### PR TITLE
AST/Sema: Decouple potential unavailability diagnostics from platform version

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -514,7 +514,7 @@ enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagID : uint32_t {
 };
 
 class BridgedDiagnosticArgument {
-  int64_t storage[3];
+  int64_t storage[4];
 
 public:
   BRIDGED_INLINE BridgedDiagnosticArgument(const swift::DiagnosticArgument &arg);

--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -132,14 +132,10 @@ public:
   /// Returns the domain that the constraint applies to.
   AvailabilityDomain getDomain() const { return getAttr().getDomain(); }
 
-  /// Returns the platform that this constraint applies to, or
-  /// `PlatformKind::none` if it is not platform specific.
-  PlatformKind getPlatform() const;
-
   /// Returns the required range for `IntroducedInNewerVersion` requirements, or
   /// `std::nullopt` otherwise.
   std::optional<AvailabilityRange>
-  getRequiredNewerAvailabilityRange(const ASTContext &ctx) const;
+  getPotentiallyUnavailableRange(const ASTContext &ctx) const;
 
   /// Some availability constraints are active for type-checking but cannot
   /// be translated directly into an `if #available(...)` runtime query.

--- a/include/swift/AST/AvailabilityRange.h
+++ b/include/swift/AST/AvailabilityRange.h
@@ -208,6 +208,8 @@ class AvailabilityRange {
   VersionRange Range;
 
 public:
+  explicit AvailabilityRange(llvm::VersionTuple LowerEndpoint)
+      : Range(VersionRange::allGTE(LowerEndpoint)) {}
   explicit AvailabilityRange(VersionRange Range) : Range(Range) {}
 
   /// Creates a context that imposes the constraints of the ASTContext's

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -146,6 +146,7 @@ namespace swift {
     DescriptiveStmtKind,
     DeclAttribute,
     AvailabilityDomain,
+    AvailabilityRange,
     VersionTuple,
     LayoutConstraint,
     ActorIsolation,
@@ -184,6 +185,7 @@ namespace swift {
       StmtKind DescriptiveStmtKindVal;
       const DeclAttribute *DeclAttributeVal;
       AvailabilityDomain AvailabilityDomainVal;
+      AvailabilityRange AvailabilityRangeVal;
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
       ActorIsolation ActorIsolationVal;
@@ -287,6 +289,10 @@ namespace swift {
     DiagnosticArgument(const AvailabilityDomain domain)
         : Kind(DiagnosticArgumentKind::AvailabilityDomain),
           AvailabilityDomainVal(domain) {}
+
+    DiagnosticArgument(const AvailabilityRange &range)
+        : Kind(DiagnosticArgumentKind::AvailabilityRange),
+          AvailabilityRangeVal(range) {}
 
     DiagnosticArgument(llvm::VersionTuple version)
       : Kind(DiagnosticArgumentKind::VersionTuple),
@@ -416,6 +422,11 @@ namespace swift {
     const AvailabilityDomain getAsAvailabilityDomain() const {
       assert(Kind == DiagnosticArgumentKind::AvailabilityDomain);
       return AvailabilityDomainVal;
+    }
+
+    const AvailabilityRange getAsAvailabilityRange() const {
+      assert(Kind == DiagnosticArgumentKind::AvailabilityRange);
+      return AvailabilityRangeVal;
     }
 
     llvm::VersionTuple getAsVersionTuple() const {

--- a/include/swift/AST/DiagnosticsIDE.def
+++ b/include/swift/AST/DiagnosticsIDE.def
@@ -30,14 +30,14 @@ WARNING(ide_availability_softdeprecated, Deprecation,
         "%0 will be deprecated"
         " in %select{a future version|%select{a future version of %2|%2 %4}3}1"
         "%select{|: %5}5",
-        (const ValueDecl *, bool, AvailabilityDomain, bool, llvm::VersionTuple,
+        (const ValueDecl *, bool, AvailabilityDomain, bool, AvailabilityRange,
          StringRef))
 
 WARNING(ide_availability_softdeprecated_rename, Deprecation,
         "%0 will be deprecated"
         " in %select{a future version|%select{a future version of %2|%2 %4}3}1"
         ": renamed to '%5'",
-        (const ValueDecl *, bool, AvailabilityDomain, bool, llvm::VersionTuple,
+        (const ValueDecl *, bool, AvailabilityDomain, bool, AvailabilityRange,
          StringRef))
 
 WARNING(ide_recursive_accessor_reference,none,

--- a/include/swift/AST/DiagnosticsIRGen.def
+++ b/include/swift/AST/DiagnosticsIRGen.def
@@ -75,7 +75,7 @@ ERROR(attr_objc_implementation_resilient_property_deployment_target, none,
       "'@implementation' on %0 %1 does not support stored properties whose "
       "size can change due to library evolution; raise the minimum deployment "
       "target to %0 %2 or store this value in an object or 'any' type",
-      (AvailabilityDomain, const llvm::VersionTuple, const llvm::VersionTuple))
+      (AvailabilityDomain, const AvailabilityRange, const AvailabilityRange))
 
 ERROR(unable_to_load_pass_plugin,none,
       "unable to load plugin '%0': '%1'", (StringRef, StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1841,7 +1841,7 @@ ERROR(attr_objc_implementation_no_conformance,none,
 ERROR(attr_objc_implementation_raise_minimum_deployment_target,none,
       "'@implementation' of an Objective-C class requires a minimum deployment "
       "target of at least %0 %1",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 ERROR(attr_implementation_requires_language,none,
       "'@implementation' used without specifying the language being "
       "implemented",
@@ -3996,7 +3996,7 @@ ERROR(attr_not_on_decl_with_invalid_access_level,none,
 ERROR(attr_has_no_effect_decl_not_available_before,none,
       "'%0' has no effect because %1 is not "
       "available before %2 %3",
-      (DeclAttribute, const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
+      (DeclAttribute, const ValueDecl *, AvailabilityDomain, AvailabilityRange))
 
 ERROR(attr_has_no_effect_on_unavailable_decl,none,
       "'%0' has no effect because %1 is unavailable on %2",
@@ -6008,7 +6008,7 @@ ERROR(isolated_deinit_on_value_type,none,
       ())
 ERROR(isolated_deinit_unavailable,none,
       "isolated deinit is only available in %0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 //------------------------------------------------------------------------------
 // MARK: String Processing
@@ -6023,7 +6023,7 @@ ERROR(regex_capture_types_failed_to_decode,none,
 
 ERROR(regex_feature_unavailable, none,
       "%0 is only available in %1 %2 or newer",
-      (StringRef, AvailabilityDomain, llvm::VersionTuple))
+      (StringRef, AvailabilityDomain, AvailabilityRange))
 
 ERROR(must_import_regex_builder_module,none,
       "regex builder requires the 'RegexBuilder' module be imported'", ())
@@ -6373,7 +6373,7 @@ ERROR(objc_in_generic_extension,none,
       "cannot contain '@objc' members", (bool))
 ERROR(objc_in_resilient_extension,none,
       "'@objc' %0 in extension of subclass of %1 requires %2 %3",
-      (DescriptiveDeclKind, Identifier, AvailabilityDomain, llvm::VersionTuple))
+      (DescriptiveDeclKind, Identifier, AvailabilityDomain, AvailabilityRange))
 ERROR(objc_operator, none,
       "operator methods cannot be declared @objc", ())
 ERROR(objc_operator_proto, none,
@@ -6384,7 +6384,7 @@ ERROR(objc_for_generic_class,none,
       "because they are not directly visible from Objective-C", ())
 ERROR(objc_for_resilient_class,none,
       "explicit '@objc' on subclass of %0 requires %1 %2",
-      (Identifier, AvailabilityDomain, llvm::VersionTuple))
+      (Identifier, AvailabilityDomain, AvailabilityRange))
 ERROR(objc_getter_for_nonobjc_property,none,
       "'@objc' getter for non-'@objc' property", ())
 ERROR(objc_getter_for_nonobjc_subscript,none,
@@ -6784,17 +6784,17 @@ NOTE(availability_marked_unavailable, none,
 
 NOTE(availability_introduced_in_version, none,
      "%0 was introduced in %1 %2",
-     (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
+     (const ValueDecl *, AvailabilityDomain, AvailabilityRange))
 
 NOTE(availability_obsoleted, none,
      "%0 was obsoleted in %1 %2",
-     (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
+     (const ValueDecl *, AvailabilityDomain, AvailabilityRange))
 
 GROUPED_WARNING(availability_deprecated, DeprecatedDeclaration, Deprecation,
                 "%0 %select{is|%select{is|was}3}1 "
                 "deprecated%select{| in %2%select{| %4}3}1%select{|: %5}5",
                 (const ValueDecl *, bool, AvailabilityDomain, bool,
-                 llvm::VersionTuple, StringRef))
+                 AvailabilityRange, StringRef))
 
 GROUPED_WARNING(
       availability_deprecated_rename, DeprecatedDeclaration, Deprecation,
@@ -6802,7 +6802,7 @@ GROUPED_WARNING(
       "deprecated%select{| in %2%select{| %4}3}1: "
       "%select{renamed to|replaced by}5%" REPLACEMENT_DECL_KIND_SELECT "6 "
       "'%7'",
-      (const ValueDecl *, bool, AvailabilityDomain, bool, llvm::VersionTuple,
+      (const ValueDecl *, bool, AvailabilityDomain, bool, AvailabilityRange,
        bool, unsigned, StringRef))
 #undef REPLACEMENT_DECL_KIND_SELECT
 
@@ -6815,63 +6815,63 @@ ERROR(availability_decl_more_than_enclosing, none,
 
 NOTE(availability_implicit_decl_here, none,
      "%0 implicitly declared here with availability of %1 %2 or newer",
-     (DescriptiveDeclKind, AvailabilityDomain, llvm::VersionTuple))
+     (DescriptiveDeclKind, AvailabilityDomain, AvailabilityRange))
 
 NOTE(availability_decl_more_than_enclosing_here, none,
      "enclosing scope requires availability of %0 %1 or newer",
-     (AvailabilityDomain, llvm::VersionTuple))
+     (AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_decl_only_version_newer, none,
       "%0 is only available in %1 %2 or newer",
-      (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
+      (const ValueDecl *, AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_decl_only_version_newer_for_clients, none,
       "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
       " deployment target",
-      (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple, ModuleDecl *))
+      (const ValueDecl *, AvailabilityDomain, AvailabilityRange, ModuleDecl *))
 
 WARNING(availability_decl_only_version_newer_for_clients_warn, none,
         "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
         " deployment target",
-        (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple,
+        (const ValueDecl *, AvailabilityDomain, AvailabilityRange,
          ModuleDecl *))
 
 ERROR(availability_opaque_types_only_version_newer, none,
       "'some' return types are only available in %0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_concurrency_only_version_newer, none,
       "concurrency is only available in %0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_parameterized_protocol_only_version_newer, none,
       "runtime support for parameterized protocol types is only available in "
       "%0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_isolated_any_only_version_newer, none,
       "runtime support for @isolated(any) function types is only available in "
       "%0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_copyable_generics_casting_only_version_newer, none,
       "runtime support for casting types with noncopyable generic arguments "
       "is only available in %0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_escapable_generics_casting_only_version_newer, none,
       "runtime support for casting types with nonescapable generic arguments "
       "is only available in %0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_typed_throws_only_version_newer, none,
       "runtime support for typed throws function types is only available in "
       "%0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_variadic_type_only_version_newer, none,
       "parameter packs in generic types are only available in %0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 
 NOTE(availability_guard_with_version_check, none,
      "add 'if #available' version check", ())
@@ -6884,7 +6884,7 @@ FIXIT(insert_available_attr,
 
 ERROR(availability_inout_accessor_only_version_newer, none,
       "cannot pass as inout because %0 is only available in %1 %2 or newer",
-      (const ValueDecl *, AvailabilityDomain, llvm::VersionTuple))
+      (const ValueDecl *, AvailabilityDomain, AvailabilityRange))
 
 ERROR(availability_query_required_for_platform, none,
       "condition required for target platform '%0'", (StringRef))
@@ -6931,7 +6931,7 @@ WARNING(availability_enum_element_no_potential_warn,
 ERROR(availability_protocol_requires_version,
       none, "protocol %0 requires %1 to be available in %2 %3 and newer",
       (const ProtocolDecl *, const ValueDecl *, AvailabilityDomain,
-       llvm::VersionTuple))
+       AvailabilityRange))
 
 NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())
@@ -6972,22 +6972,22 @@ NOTE(conformance_availability_marked_unavailable, none,
 
 NOTE(conformance_availability_introduced_in_version, none,
      "conformance of %0 to %1 was introduced in %2 %3",
-     (Type, Type, AvailabilityDomain, llvm::VersionTuple))
+     (Type, Type, AvailabilityDomain, AvailabilityRange))
 
 NOTE(conformance_availability_obsoleted, none,
      "conformance of %0 to %1 was obsoleted in %2 %3",
-     (Type, Type, AvailabilityDomain, llvm::VersionTuple))
+     (Type, Type, AvailabilityDomain, AvailabilityRange))
 
 GROUPED_WARNING(conformance_availability_deprecated,
                 DeprecatedDeclaration, Deprecation,
                 "conformance of %0 to %1 %select{is|%select{is|was}4}2 "
                 "deprecated%select{| in %3%select{| %5}4}2%select{|: %6}6",
-                (Type, Type, bool, AvailabilityDomain, bool, llvm::VersionTuple,
+                (Type, Type, bool, AvailabilityDomain, bool, AvailabilityRange,
                  StringRef))
 
 ERROR(conformance_availability_only_version_newer, none,
       "conformance of %0 to %1 is only available in %2 %3 or newer",
-      (Type, Type, AvailabilityDomain, llvm::VersionTuple))
+      (Type, Type, AvailabilityDomain, AvailabilityRange))
 
 //------------------------------------------------------------------------------
 // MARK: if #available(...)
@@ -8257,7 +8257,7 @@ ERROR(value_generics_missing_feature,none,
       "value generics require '-enable-experimental-feature ValueGenerics'", ())
 ERROR(availability_value_generic_type_only_version_newer, none,
       "values in generic types are only available in %0 %1 or newer",
-      (AvailabilityDomain, llvm::VersionTuple))
+      (AvailabilityDomain, AvailabilityRange))
 ERROR(invalid_value_for_type_same_type,none,
       "cannot constrain type parameter %0 to be integer %1", (Type, Type))
 

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -58,17 +58,15 @@ void VersionRange::Profile(llvm::FoldingSetNodeID &id) const {
 
 AvailabilityRange
 AvailabilityRange::forDeploymentTarget(const ASTContext &Ctx) {
-  return AvailabilityRange(
-      VersionRange::allGTE(Ctx.LangOpts.getMinPlatformVersion()));
+  return AvailabilityRange(Ctx.LangOpts.getMinPlatformVersion());
 }
 
 AvailabilityRange AvailabilityRange::forInliningTarget(const ASTContext &Ctx) {
-  return AvailabilityRange(
-      VersionRange::allGTE(Ctx.LangOpts.MinimumInliningTargetVersion));
+  return AvailabilityRange(Ctx.LangOpts.MinimumInliningTargetVersion);
 }
 
 AvailabilityRange AvailabilityRange::forRuntimeTarget(const ASTContext &Ctx) {
-  return AvailabilityRange(VersionRange::allGTE(Ctx.LangOpts.RuntimeVersion));
+  return AvailabilityRange(Ctx.LangOpts.RuntimeVersion);
 }
 
 namespace {
@@ -853,7 +851,7 @@ SemanticAvailableAttr::getIntroducedRange(const ASTContext &Ctx) const {
           *this, Ctx, unusedDomain, remappedVersion))
     introducedVersion = remappedVersion;
 
-  return AvailabilityRange{VersionRange::allGTE(introducedVersion)};
+  return AvailabilityRange{introducedVersion};
 }
 
 std::optional<llvm::VersionTuple> SemanticAvailableAttr::getDeprecated() const {
@@ -877,7 +875,7 @@ SemanticAvailableAttr::getDeprecatedRange(const ASTContext &Ctx) const {
           *this, Ctx, unusedDomain, remappedVersion))
     deprecatedVersion = remappedVersion;
 
-  return AvailabilityRange{VersionRange::allGTE(deprecatedVersion)};
+  return AvailabilityRange{deprecatedVersion};
 }
 
 std::optional<llvm::VersionTuple> SemanticAvailableAttr::getObsoleted() const {
@@ -901,7 +899,7 @@ SemanticAvailableAttr::getObsoletedRange(const ASTContext &Ctx) const {
           *this, Ctx, unusedDomain, remappedVersion))
     obsoletedVersion = remappedVersion;
 
-  return AvailabilityRange{VersionRange::allGTE(obsoletedVersion)};
+  return AvailabilityRange{obsoletedVersion};
 }
 
 namespace {
@@ -931,8 +929,7 @@ AvailabilityRange ASTContext::getSwiftFutureAvailability() const {
   auto target = LangOpts.Target;
 
   auto getFutureAvailabilityRange = []() -> AvailabilityRange {
-    return AvailabilityRange(
-        VersionRange::allGTE(llvm::VersionTuple(99, 99, 0)));
+    return AvailabilityRange(llvm::VersionTuple(99, 99, 0));
   };
 
   if (target.isMacOSX()) {

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -18,12 +18,8 @@
 
 using namespace swift;
 
-PlatformKind AvailabilityConstraint::getPlatform() const {
-  return getAttr().getPlatform();
-}
-
 std::optional<AvailabilityRange>
-AvailabilityConstraint::getRequiredNewerAvailabilityRange(
+AvailabilityConstraint::getPotentiallyUnavailableRange(
     const ASTContext &ctx) const {
   switch (getReason()) {
   case Reason::UnconditionallyUnavailable:

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -126,7 +126,7 @@ getDeploymentVersion(const AvailabilityDomain &domain, const ASTContext &ctx) {
 std::optional<AvailabilityRange>
 AvailabilityDomain::getDeploymentRange(const ASTContext &ctx) const {
   if (auto version = getDeploymentVersion(*this, ctx))
-    return AvailabilityRange{VersionRange::allGTE(*version)};
+    return AvailabilityRange{*version};
   return std::nullopt;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1370,7 +1370,7 @@ AvailabilityRange Decl::getAvailabilityForLinkage() const {
   // When computing availability for linkage, use the "before" version from
   // the @backDeployed attribute, if present.
   if (auto backDeployVersion = getBackDeployedBeforeOSVersion(ctx))
-    return AvailabilityRange{VersionRange::allGTE(*backDeployVersion)};
+    return AvailabilityRange{*backDeployVersion};
 
   auto containingContext = AvailabilityInference::annotatedAvailableRange(this);
   if (containingContext.has_value()) {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1063,6 +1063,11 @@ static void formatDiagnosticArgument(StringRef Modifier,
            "Improper modifier for AvailabilityDomain argument");
     Out << Arg.getAsAvailabilityDomain().getNameForDiagnostics();
     break;
+  case DiagnosticArgumentKind::AvailabilityRange:
+    assert(Modifier.empty() &&
+           "Improper modifier for AvailabilityRange argument");
+    Out << Arg.getAsAvailabilityRange().getRawMinimumVersion().getAsString();
+    break;
   case DiagnosticArgumentKind::VersionTuple:
     assert(Modifier.empty() &&
            "Improper modifier for VersionTuple argument");

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5232,9 +5232,8 @@ diagnoseUnsupportedObjCImplLayout(IRGenModule &IGM, ClassDecl *classDecl,
         diags.diagnose(
             field.getVarDecl(),
             diag::attr_objc_implementation_resilient_property_deployment_target,
-            ctx.getTargetAvailabilityDomain(),
-            currentAvailability.getRawMinimumVersion(),
-            requiredAvailability.getRawMinimumVersion());
+            ctx.getTargetAvailabilityDomain(), currentAvailability,
+            requiredAvailability);
       else
         diags.diagnose(
             field.getVarDecl(),

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -609,7 +609,7 @@ bool Parser::parseSpecializeAttributeArguments(
                                  diag::sil_availability_expected_version))
           return false;
 
-        *SILAvailability = AvailabilityRange(VersionRange::allGTE(version));
+        *SILAvailability = AvailabilityRange(version);
       }
       if (ParamLabel == "availability") {
         SourceRange attrRange;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -758,7 +758,7 @@ static bool parseDeclSILOptional(
                                  diag::sil_availability_expected_version))
         return true;
 
-      *availability = AvailabilityRange(VersionRange::allGTE(version));
+      *availability = AvailabilityRange(version);
 
       SP.P.parseToken(tok::r_square, diag::expected_in_attribute_list);
       continue;

--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -225,8 +225,7 @@ bool SILGenModule::requiresBackDeploymentThunk(ValueDecl *decl,
   // high enough that the ABI implementation of the back deployed declaration is
   // guaranteed to be available.
   auto deploymentAvailability = AvailabilityRange::forDeploymentTarget(ctx);
-  auto declAvailability =
-      AvailabilityRange(VersionRange::allGTE(*backDeployBeforeVersion));
+  auto declAvailability = AvailabilityRange(*backDeployBeforeVersion);
   if (deploymentAvailability.isContainedIn(declAvailability))
     return false;
 

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -258,15 +258,18 @@ checkAvailability(const EnumElementDecl *elt,
   if (!constraint->isActiveForRuntimeQueries(C))
     return true;
 
-  // It's conditionally available; create a version constraint and return true.
-  auto platform = constraint->getPlatform();
-  auto range = constraint->getRequiredNewerAvailabilityRange(C);
+  auto domain = constraint->getDomain();
 
   // Only platform version constraints are supported currently.
-  ASSERT(platform != PlatformKind::none);
-  ASSERT(range);
+  // FIXME: [availability] Support non-platform domain availability checks
+  if (!domain.isPlatform())
+    return true;
 
-  versionCheck.emplace(platform, range->getRawMinimumVersion());
+  // It's conditionally available; create a version constraint and return true.
+  auto range = constraint->getPotentiallyUnavailableRange(C);
+
+  ASSERT(range);
+  versionCheck.emplace(domain.getPlatformKind(), range->getRawMinimumVersion());
   return true;
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -127,9 +127,9 @@ public:
       TypeChecker::checkAvailability(
           attr->getRange(), C.getIsolatedDeinitAvailability(),
           D->getDeclContext(),
-          [&](AvailabilityDomain domain, llvm::VersionTuple version) {
+          [&](AvailabilityDomain domain, AvailabilityRange range) {
             return diagnoseAndRemoveAttr(
-                attr, diag::isolated_deinit_unavailable, domain, version);
+                attr, diag::isolated_deinit_unavailable, domain, range);
           });
     }
   }
@@ -1898,8 +1898,7 @@ visitObjCImplementationAttr(ObjCImplementationAttr *attr) {
       auto diag = diagnose(
           attr->getLocation(),
           diag::attr_objc_implementation_raise_minimum_deployment_target,
-          Ctx.getTargetAvailabilityDomain(),
-          Ctx.getSwift50Availability().getRawMinimumVersion());
+          Ctx.getTargetAvailabilityDomain(), Ctx.getSwift50Availability());
       if (attr->isEarlyAdopter()) {
         diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
       }
@@ -2434,11 +2433,10 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *parsedAttr) {
           diagnose(enclosingDecl->getLoc(),
                    diag::availability_implicit_decl_here,
                    D->getDescriptiveKind(), Ctx.getTargetAvailabilityDomain(),
-                   AttrRange.getRawMinimumVersion());
+                   AttrRange);
         diagnose(enclosingDecl->getLoc(),
                  diag::availability_decl_more_than_enclosing_here,
-                 Ctx.getTargetAvailabilityDomain(),
-                 EnclosingAnnotatedRange->getRawMinimumVersion());
+                 Ctx.getTargetAvailabilityDomain(), *EnclosingAnnotatedRange);
       }
     }
   }
@@ -5290,10 +5288,10 @@ void AttributeChecker::checkBackDeployedAttrs(
 
       if (Attr->Version <= introVersion) {
         diagnose(AtLoc, diag::attr_has_no_effect_decl_not_available_before,
-                 Attr, VD, beforeDomain, beforeVersion);
+                 Attr, VD, beforeDomain, AvailabilityRange(beforeVersion));
         diagnose(availableAttr.getParsedAttr()->AtLoc,
                  diag::availability_introduced_in_version, VD, introDomain,
-                 introVersion)
+                 AvailabilityRange(introVersion))
             .highlight(availableAttr.getParsedAttr()->getRange());
         continue;
       }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1425,7 +1425,7 @@ private:
     llvm::VersionTuple Version =
         (GetRuntimeContext ? Spec.getRuntimeVersion() : Spec.getVersion());
 
-    return AvailabilityRange(VersionRange::allGTE(Version));
+    return AvailabilityRange(Version);
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -583,14 +583,14 @@ static bool checkObjCInExtensionContext(const ValueDecl *value,
                                             ResilienceExpansion::Maximal)) {
           auto stubAvailability = getObjCClassStubAvailability(ctx);
           auto *ancestor = getResilientAncestor(mod, classDecl);
-          softenIfAccessNote(
-              value, reason.getAttr(),
-              value
-                  ->diagnose(diag::objc_in_resilient_extension,
-                             value->getDescriptiveKind(), ancestor->getName(),
-                             ctx.getTargetAvailabilityDomain(),
-                             stubAvailability.getRawMinimumVersion())
-                  .limitBehavior(behavior));
+          softenIfAccessNote(value, reason.getAttr(),
+                             value
+                                 ->diagnose(diag::objc_in_resilient_extension,
+                                            value->getDescriptiveKind(),
+                                            ancestor->getName(),
+                                            ctx.getTargetAvailabilityDomain(),
+                                            stubAvailability)
+                                 .limitBehavior(behavior));
           reason.describe(value);
           return true;
         }
@@ -1355,10 +1355,9 @@ static std::optional<ObjCReason> shouldMarkClassAsObjC(const ClassDecl *CD) {
 
       auto stubAvailability = getObjCClassStubAvailability(ctx);
       auto *ancestor = getResilientAncestor(CD->getParentModule(), CD);
-      swift::diagnoseAndRemoveAttr(CD, attr, diag::objc_for_resilient_class,
-                                   ancestor->getName(),
-                                   ctx.getTargetAvailabilityDomain(),
-                                   stubAvailability.getRawMinimumVersion())
+      swift::diagnoseAndRemoveAttr(
+          CD, attr, diag::objc_for_resilient_class, ancestor->getName(),
+          ctx.getTargetAvailabilityDomain(), stubAvailability)
           .limitBehavior(behavior);
       reason.describe(CD);
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4533,7 +4533,7 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           diags.diagnose(diagLoc, diag::availability_protocol_requires_version,
                          conformance->getProtocol(), witness,
                          ctx.getTargetAvailabilityDomain(),
-                         check.RequiredAvailability.getRawMinimumVersion());
+                         check.RequiredAvailability);
           emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement,
                          diag::availability_protocol_requirement_here);
@@ -5037,20 +5037,18 @@ static bool diagnoseTypeWitnessAvailability(
         });
   }
 
-  auto requiredAvailability = AvailabilityRange::alwaysAvailable();
-  if (!TypeChecker::isAvailabilitySafeForConformance(conformance->getProtocol(),
-                                                     assocType, witness, dc,
-                                                     requiredAvailability)) {
-    auto requiredVersion = requiredAvailability.getRawMinimumVersion();
+  auto requiredRange = AvailabilityRange::alwaysAvailable();
+  if (!TypeChecker::isAvailabilitySafeForConformance(
+          conformance->getProtocol(), assocType, witness, dc, requiredRange)) {
     ctx.addDelayedConformanceDiag(
         conformance, shouldError,
-        [witness, requiredVersion](NormalProtocolConformance *conformance) {
+        [witness, requiredRange](NormalProtocolConformance *conformance) {
           SourceLoc loc = getLocForDiagnosingWitness(conformance, witness);
           auto &ctx = conformance->getDeclContext()->getASTContext();
           ctx.Diags
               .diagnose(loc, diag::availability_protocol_requires_version,
                         conformance->getProtocol(), witness,
-                        ctx.getTargetAvailabilityDomain(), requiredVersion)
+                        ctx.getTargetAvailabilityDomain(), requiredRange)
               .warnUntilSwiftVersion(warnBeforeVersion);
 
           emitDeclaredHereIfNeeded(ctx.Diags, loc, witness);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1067,16 +1067,22 @@ diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 /// is allowed.
 std::optional<Diagnostic> diagnosticIfDeclCannotBeUnavailable(const Decl *D);
 
+/// Checks whether the required range of versions of the compilation's target
+/// platform are available at the given `SourceRange`. If not, `Diagnose` is
+/// invoked.
 bool checkAvailability(SourceRange ReferenceRange,
                        AvailabilityRange RequiredAvailability,
                        const DeclContext *ReferenceDC,
-                       llvm::function_ref<InFlightDiagnostic(
-                           AvailabilityDomain, llvm::VersionTuple)>
+                       llvm::function_ref<InFlightDiagnostic(AvailabilityDomain,
+                                                             AvailabilityRange)>
                            Diagnose);
 
+/// Checks whether the required range of versions of the compilation's target
+/// platform are available at the given `SourceRange`. If not, `Diag` is
+/// emitted.
 bool checkAvailability(SourceRange ReferenceRange,
                        AvailabilityRange RequiredAvailability,
-                       Diag<AvailabilityDomain, llvm::VersionTuple> Diag,
+                       Diag<AvailabilityDomain, AvailabilityRange> Diag,
                        const DeclContext *ReferenceDC);
 
 void checkConcurrencyAvailability(SourceRange ReferenceRange,

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -912,9 +912,9 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
 
     llvm::VersionTuple available;
     DECODE_VER_TUPLE(available);
-    fn->setAvailabilityForLinkage(
-        available.empty() ? AvailabilityRange::alwaysAvailable()
-                          : AvailabilityRange(VersionRange::allGTE(available)));
+    fn->setAvailabilityForLinkage(available.empty()
+                                      ? AvailabilityRange::alwaysAvailable()
+                                      : AvailabilityRange(available));
 
     fn->setIsDynamic(IsDynamicallyReplaceable_t(isDynamic));
     fn->setIsExactSelfClass(IsExactSelfClass_t(isExactSelfClass));
@@ -1034,9 +1034,8 @@ llvm::Expected<SILFunction *> SILDeserializer::readSILFunctionChecked(
 
     llvm::VersionTuple available;
     DECODE_VER_TUPLE(available);
-    auto availability =
-        available.empty() ? AvailabilityRange::alwaysAvailable()
-                          : AvailabilityRange(VersionRange::allGTE(available));
+    auto availability = available.empty() ? AvailabilityRange::alwaysAvailable()
+                                          : AvailabilityRange(available);
 
     llvm::SmallVector<Type, 4> typeErasedParams;
     for (auto id : typeErasedParamsIDs) {

--- a/test/Parse/diagnose_availability_windows.swift
+++ b/test/Parse/diagnose_availability_windows.swift
@@ -11,14 +11,14 @@ unavailable()
 @available(Windows, introduced: 10.0.17763, deprecated: 10.0.19140)
 func introduced_deprecated() {}
 
-// expected-error@+1 {{'introduced_deprecated()' is only available in * 10.0.17763 or newe}}
+// expected-error@+1 {{'introduced_deprecated()' is only available in Windows 10.0.17763 or newer}}
 introduced_deprecated()
 // expected-note@-1 {{add 'if #available' version check}}
 
 @available(Windows 10, *)
 func windows10() {}
 
-// expected-error@+1 {{'windows10()' is only available in * 10 or newer}}
+// expected-error@+1 {{'windows10()' is only available in Windows 10 or newer}}
 windows10()
 // expected-note@-1 {{add 'if #available' version check}}
 

--- a/unittests/AST/AvailabilityContextTests.cpp
+++ b/unittests/AST/AvailabilityContextTests.cpp
@@ -23,8 +23,7 @@ static llvm::VersionTuple getPlatformIntro(const AvailabilityContext &context) {
 }
 
 static AvailabilityRange getAvailabilityRange(unsigned major, unsigned minor) {
-  return AvailabilityRange(
-      VersionRange::allGTE(llvm::VersionTuple(major, minor)));
+  return AvailabilityRange(llvm::VersionTuple(major, minor));
 }
 
 class AvailabilityContextTest : public ::testing::Test {


### PR DESCRIPTION
When a declaration is not guaranteed to be present on all runtimes the a program may run on, references to that declaration may be diagnosed as "potentially unavailable". Currently these diagnostics make a lot of assumptions about potential unavailability always being related to platform version availability. In the future the compiler will need to emit diagnostics for declarations which are potentially unavailable in domains besides the target platform domain. This change introduces the plumbing to emit those more general diagnostics correctly.

Additionally, support for `AvailabilityRange` arguments in diagnostics has been added for convenience.