### PR TITLE
CMake: option to disable swift in swift

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,17 +352,24 @@ option(SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS
     debugging Swift)"
     FALSE)
 
-set(BOOTSTRAPPING_MODE HOSTTOOLS CACHE STRING [=[
-How to build the swift compiler modules. Possible values are
-    HOSTTOOLS:     build with a pre-installed toolchain
-    BOOTSTRAPPING: build with a 2-stage bootstrapping process
-    BOOTSTRAPPING-WITH-HOSTLIBS:   build with a 2-stage bootstrapping process,
-                   but the compiler links against the host system swift libs (macOS only)
-    CROSSCOMPILE:  cross-compiledwith a native host compiler, provided in
-                   `SWIFT_NATIVE_SWIFT_TOOLS_PATH` (non-Darwin only)
-    CROSSCOMPILE-WITH-HOSTLIBS:    build with a bootstrapping-with-hostlibs compiled
-                                   compiler, provided in `SWIFT_NATIVE_SWIFT_TOOLS_PATH`
-]=])
+option(SWIFT_ENABLE_SWIFT_IN_SWIFT "Enable Swift sources in Swift compiler" ON)
+
+if(SWIFT_ENABLE_SWIFT_IN_SWIFT)
+  set(BOOTSTRAPPING_MODE HOSTTOOLS CACHE STRING [=[
+  How to build the swift compiler modules. Possible values are
+      HOSTTOOLS:     build with a pre-installed toolchain
+      BOOTSTRAPPING: build with a 2-stage bootstrapping process
+      BOOTSTRAPPING-WITH-HOSTLIBS:   build with a 2-stage bootstrapping process,
+                     but the compiler links against the host system swift libs (macOS only)
+      CROSSCOMPILE:  cross-compiledwith a native host compiler, provided in
+                     `SWIFT_NATIVE_SWIFT_TOOLS_PATH` (non-Darwin only)
+      CROSSCOMPILE-WITH-HOSTLIBS:    build with a bootstrapping-with-hostlibs compiled
+                                     compiler, provided in `SWIFT_NATIVE_SWIFT_TOOLS_PATH`
+  ]=])
+else()
+  set(BOOTSTRAPPING_MODE OFF)
+  set(SWIFT_BUILD_SWIFT_SYNTAX OFF)
+endif()
 
 option(BRIDGING_MODE [=[
 How swift-C++ bridging code is compiled:
@@ -939,41 +946,44 @@ set(SWIFT_MAIN_INCLUDE_DIR "${SWIFT_SOURCE_DIR}/include")
 set(SWIFT_SHIMS_INCLUDE_DIR "${SWIFT_SOURCE_DIR}/stdlib/public/SwiftShims")
 set(SWIFT_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/include")
 
-if (NOT BOOTSTRAPPING_MODE)
+if (NOT BOOTSTRAPPING_MODE AND SWIFT_ENABLE_SWIFT_IN_SWIFT)
   message(FATAL_ERROR "turning off bootstrapping is not supported anymore")
 endif()
 
 set(SWIFT_RUNTIME_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin")
 set(SWIFT_LIBRARY_OUTPUT_INTDIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib")
-if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
-  # This is the normal case. We are not cross-compiling.
-  set(SWIFT_NATIVE_SWIFT_TOOLS_PATH "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
-  set(SWIFT_EXEC_FOR_SWIFT_MODULES "${CMAKE_Swift_COMPILER}")
-  if(NOT SWIFT_EXEC_FOR_SWIFT_MODULES)
-    message(WARNING "BOOTSTRAPPING set to OFF because no Swift compiler is defined")
-    set(BOOTSTRAPPING_MODE "OFF")
+
+if(SWIFT_ENABLE_SWIFT_IN_SWIFT)
+  if(NOT SWIFT_NATIVE_SWIFT_TOOLS_PATH)
+    # This is the normal case. We are not cross-compiling.
+    set(SWIFT_NATIVE_SWIFT_TOOLS_PATH "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
+    set(SWIFT_EXEC_FOR_SWIFT_MODULES "${CMAKE_Swift_COMPILER}")
+    if(NOT SWIFT_EXEC_FOR_SWIFT_MODULES)
+      message(WARNING "BOOTSTRAPPING set to OFF because no Swift compiler is defined")
+      set(BOOTSTRAPPING_MODE "OFF")
+    endif()
+  elseif(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
+    # If cross-compiling, we don't have to bootstrap. We can just use the previously
+    # built native swiftc to build the swift compiler modules.
+    message(STATUS "Building swift modules with previously built tools instead of bootstrapping")
+    set(SWIFT_EXEC_FOR_SWIFT_MODULES "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")
+    if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
+      set(BOOTSTRAPPING_MODE "CROSSCOMPILE-WITH-HOSTLIBS")
+    elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+      set(BOOTSTRAPPING_MODE "CROSSCOMPILE")
+    else()
+      set(BOOTSTRAPPING_MODE "HOSTTOOLS")
+    endif()
+  elseif(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS" OR SWIFT_BUILD_SWIFT_SYNTAX)
+    # We are building using a pre-installed host toolchain but not bootstrapping
+    # the Swift modules. This happens when building using 'build-tooling-libs'
+    # where we haven't built a new Swift compiler. Use the Swift compiler from the
+    # pre-installed host toolchain to build the Swift modules.
+    set(SWIFT_EXEC_FOR_SWIFT_MODULES "${CMAKE_Swift_COMPILER}")
   endif()
-elseif(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
-  # If cross-compiling, we don't have to bootstrap. We can just use the previously
-  # built native swiftc to build the swift compiler modules.
-  message(STATUS "Building swift modules with previously built tools instead of bootstrapping")
-  set(SWIFT_EXEC_FOR_SWIFT_MODULES "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc")
-  if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
-    set(BOOTSTRAPPING_MODE "CROSSCOMPILE-WITH-HOSTLIBS")
-  elseif(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
-    set(BOOTSTRAPPING_MODE "CROSSCOMPILE")
-  else()
-    set(BOOTSTRAPPING_MODE "HOSTTOOLS")
-  endif()
-elseif(BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS" OR SWIFT_BUILD_SWIFT_SYNTAX)
-  # We are building using a pre-installed host toolchain but not bootstrapping
-  # the Swift modules. This happens when building using 'build-tooling-libs'
-  # where we haven't built a new Swift compiler. Use the Swift compiler from the
-  # pre-installed host toolchain to build the Swift modules.
-  set(SWIFT_EXEC_FOR_SWIFT_MODULES "${CMAKE_Swift_COMPILER}")
 endif()
 
-if(SWIFT_INCLUDE_TOOLS AND SWIFT_BUILD_SWIFT_SYNTAX)
+if(SWIFT_INCLUDE_TOOLS AND SWIFT_BUILD_SWIFT_SYNTAX AND SWIFT_ENABLE_SWIFT_IN_SWIFT)
   # Only "HOSTTOOLS" is supported in Linux when Swift parser integration is enabled.
   if(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|OPENBSD|FREEBSD" AND NOT BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
     message(WARNING "Force setting BOOTSTRAPPING=HOSTTOOLS because Swift parser integration is enabled")
@@ -1530,14 +1540,16 @@ if(SWIFT_INCLUDE_TOOLS)
   # https://github.com/apple/swift/issues/48534
   add_subdirectory(tools)
 
-  # Localization targets are configured in a way that assume the swift
-  # frontend is being built, so trying to include them for other builds
-  # (like stdlib) fail!
-  #
-  # Diagnostics information is only useful for the frontend compiler
-  # anyway, so let's only include it if the compiler is being built,
-  # which at the moment seems like if SWIFT_INCLUDE_TOOLS is defined.
-  add_subdirectory(localization)
+  if(SWIFT_NATIVE_SWIFT_TOOLS_PATH)
+    # Localization targets are configured in a way that assume the swift
+    # frontend is being built, so trying to include them for other builds
+    # (like stdlib) fail!
+    #
+    # Diagnostics information is only useful for the frontend compiler
+    # anyway, so let's only include it if the compiler is being built,
+    # which at the moment seems like if SWIFT_INCLUDE_TOOLS is defined.
+    add_subdirectory(localization)
+  endif()
 endif()
 
 add_subdirectory(utils)

--- a/lib/AST/ASTScope.cpp
+++ b/lib/AST/ASTScope.cpp
@@ -148,6 +148,7 @@ void ASTScope::unqualifiedLookup(
   if (auto *s = SF->getASTContext().Stats)
     ++s->getFrontendCounters().NumASTScopeLookups;
 
+#if SWIFT_BUILD_SWIFT_SYNTAX
   // Perform validation of SwiftLexicalLookup if option
   // Feature::UnqualifiedLookupValidation is enabled and lookup was not
   // performed in a macro.
@@ -171,6 +172,9 @@ void ASTScope::unqualifiedLookup(
   } else {
     ASTScopeImpl::unqualifiedLookup(SF, loc, consumer);
   }
+#else
+    ASTScopeImpl::unqualifiedLookup(SF, loc, consumer);
+#endif
 }
 
 llvm::SmallVector<LabeledStmt *, 4> ASTScope::lookupLabeledStmts(

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3473,6 +3473,20 @@ ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
   if (!macroNameRef)
     return status;
 
+#if !SWIFT_BUILD_SWIFT_SYNTAX
+  // If we don't have swift-syntax and therefore have no support for macros,
+  // recognize #isolation as special and route it through
+  // CurrentContextIsolationExpr.
+  if (macroNameRef.getBaseName().userFacingName() == "isolation" &&
+      genericArgs.empty() &&
+      (!argList || argList->empty())) {
+    return makeParserResult(
+      status,
+      new (Context) CurrentContextIsolationExpr(
+          macroNameLoc.getStartLoc(), Type()));
+  }
+#endif
+
   return makeParserResult(
       status,
       MacroExpansionExpr::create(

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -755,6 +755,7 @@ std::pair<bool, bool> EvaluateIfConditionRequest::evaluate(
     Evaluator &evaluator, SourceFile *sourceFile, SourceRange conditionRange,
     bool shouldEvaluate
 ) const {
+#if SWIFT_BUILD_SWIFT_SYNTAX
   // FIXME: When we migrate to SwiftParser, use the parsed syntax tree.
   ASTContext &ctx = sourceFile->getASTContext();
   auto &sourceMgr = ctx.SourceMgr;
@@ -775,4 +776,7 @@ std::pair<bool, bool> EvaluateIfConditionRequest::evaluate(
   bool isActive = (evalResult & 0x01) != 0;
   bool allowSyntaxErrors = (evalResult & 0x02) != 0;
   return std::pair(isActive, allowSyntaxErrors);
+#else
+  llvm_unreachable("Must not be used in C++-only build");
+#endif
 }

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -856,7 +856,12 @@ function(_compile_swift_files
   if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
     set(HOST_EXECUTABLE_SUFFIX .exe)
   endif()
-  if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
+  if(NOT SWIFT_ENABLE_SWIFT_IN_SWIFT)
+    # This is only for bootstrapping purposes. The just-built Swift is very
+    # limited and only built for the builder to build the next stages with
+    # hosttools.
+    set(swift_compiler_tool "${Swift_BINARY_DIR}/bin/swiftc")
+  elseif(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
     if(SWIFT_PREBUILT_SWIFT)
       set(swift_compiler_tool "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swiftc${HOST_EXECUTABLE_SUFFIX}")
     elseif(CMAKE_Swift_COMPILER)
@@ -886,8 +891,10 @@ function(_compile_swift_files
     # cross-compiling the compiler.
     list(APPEND swift_compiler_tool_dep "swift-frontend${target_suffix}")
 
-    # If we aren't cross compiling, also depend on SwiftMacros.
-    list(APPEND swift_compiler_tool_dep SwiftMacros)
+    if(SWIFT_ENABLE_SWIFT_IN_SWIFT)
+      # If we aren't cross compiling, also depend on SwiftMacros.
+      list(APPEND swift_compiler_tool_dep SwiftMacros)
+    endif()
   endif()
 
   # If there are more than one output files, we assume that they are specified

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -52,7 +52,9 @@ public func _stdlib_isOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_unavailableInEmbedded
+#if hasFeature(Macros)
 @_noLocks
+#endif
 public func _stdlib_isOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -65,7 +67,9 @@ public func _stdlib_isOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_alwaysEmitIntoClient
+#if hasFeature(Macros)
 @_noLocks
+#endif
 public func _stdlib_isOSVersionAtLeast_AEIC(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -110,7 +114,9 @@ public func _stdlib_isOSVersionAtLeast_AEIC(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @available(macOS 10.15, iOS 13.0, *)
+#if hasFeature(Macros)
 @_noLocks
+#endif
 public func _stdlib_isVariantOSVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,
@@ -153,7 +159,9 @@ public func _stdlib_isVariantOSVersionAtLeast(
 @_semantics("availability.osversion")
 @_effects(readnone)
 @_unavailableInEmbedded
+#if hasFeature(Macros)
 @_noLocks
+#endif
 public func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(
   _ major: Builtin.Word,
   _ minor: Builtin.Word,

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -441,6 +441,7 @@ extension MutableCollection where Self: BidirectionalCollection {
       swapAt(lo, hi)
       formIndex(after: &lo)
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -85,6 +85,7 @@ extension FlattenSequence.Iterator: IteratorProtocol {
       _inner = s!.makeIterator()
     }
     while true
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -387,6 +387,7 @@ extension _HashTable {
         return unsafe Bucket(word: word, bit: bit)
       }
     }
+    fatalError()
   }
 
   @inlinable
@@ -414,6 +415,7 @@ extension _HashTable {
         return unsafe Bucket(word: word, bit: bit)
       }
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -125,6 +125,7 @@ extension JoinedSequence.Iterator: IteratorProtocol {
         return nil
       }
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -193,6 +193,7 @@ public class AnyKeyPath: _AppendKeyPath {
 
         if optNextType == nil { return .some(offset) }
       }
+      fatalError()
     }
     #else
     // compiler optimizes _storedInlineOffset into a direct offset computation,
@@ -271,6 +272,7 @@ extension AnyKeyPath: Hashable {
             return true
           }
         }
+        fatalError()
       }
     }
   }
@@ -432,6 +434,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
             }
           }
         }
+        fatalError()
       }
     }
   }

--- a/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
+++ b/stdlib/public/core/ObjectIdentifier+DebugDescription.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !$Embedded
+#if !$Embedded && hasFeature(Macros)
 @DebugDescription
 extension ObjectIdentifier {
   var lldbDescription: String {

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -332,6 +332,7 @@ extension Sequence {
       case (nil, nil):           return true
       }
     }
+    fatalError()
   }
 }
 
@@ -425,6 +426,7 @@ extension Sequence {
         return false
       }
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -752,6 +752,7 @@ extension StringProtocol {
 
   public // SPI(Foundation)
   func _toUTF16Indices(_ range: Range<Int>) -> Range<Index> {
+#if hasFeature(Macros)
     if Self.self == String.self {
       let s = unsafe unsafeBitCast(self, to: String.self)
       return s.utf16._indexRange(for: range, from: s.startIndex)
@@ -760,6 +761,7 @@ extension StringProtocol {
       let s = unsafe unsafeBitCast(self, to: Substring.self)
       return s._slice._base.utf16._indexRange(for: range, from: s.startIndex)
     }
+#endif
     let lowerbound = _toUTF16Index(range.lowerBound)
     let upperbound = _toUTF16Index(range.upperBound)
     return unsafe Range(uncheckedBounds: (lower: lowerbound, upper: upperbound))

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -265,6 +265,7 @@ private func _findBoundary(
 
     unsafe idx &-= _utf8ScalarLength(utf8, endingAt: idx)
   }
+  fatalError()
 }
 
 @frozen

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -945,6 +945,7 @@ extension String.UTF16View {
 
         readIdx &+= len
       }
+      fatalError()
     }
   }
 

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -58,6 +58,8 @@ public enum _SwiftifyInfo {
 ///
 /// Parameter paramInfo: information about how the function uses the pointer passed to it. The
 /// safety of the generated wrapper function depends on this info being extensive and accurate.
+#if hasFeature(Macros)
 @attached(peer, names: overloaded)
 public macro _SwiftifyImport(_ paramInfo: _SwiftifyInfo..., typeMappings: [String: String] = [:]) =
     #externalMacro(module: "SwiftMacros", type: "SwiftifyImportMacro")
+#endif

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -256,6 +256,7 @@ extension Unicode.UTF16 {
         return (utf16Count, utf16BitUnion < 0x80)
       }
     }
+    fatalError()
   }
 }
 

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -585,6 +585,7 @@ public func transcode<
     }
     OutputEncoding.encodedReplacementCharacter.forEach(processCodeUnit)
   }
+  fatalError()
 }
 
 /// Instances of conforming types are used in internal `String`

--- a/stdlib/tools/CMakeLists.txt
+++ b/stdlib/tools/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Keep in sync with test/CMakeLists.txt: swift-reflection-test is
 # only used when testing dynamic stdlib.
-if(SWIFT_BUILD_DYNAMIC_STDLIB AND (SWIFT_INCLUDE_TESTS OR SWIFT_INCLUDE_TEST_BINARIES))
+if(SWIFT_BUILD_REMOTE_MIRROR AND
+  SWIFT_BUILD_DYNAMIC_STDLIB AND
+  (SWIFT_INCLUDE_TESTS OR SWIFT_INCLUDE_TEST_BINARIES))
   add_subdirectory(swift-reflection-test)
 endif()

--- a/tools/swift-compatibility-symbols/CMakeLists.txt
+++ b/tools/swift-compatibility-symbols/CMakeLists.txt
@@ -5,25 +5,27 @@ add_swift_host_tool(swift-compatibility-symbols
   DOES_NOT_USE_SWIFT
 )
 
-set(syms_file "${CMAKE_BINARY_DIR}/share/swift/compatibility-symbols")
+if(SWIFT_NATIVE_SWIFT_TOOLS_PATH)
+  set(syms_file "${CMAKE_BINARY_DIR}/share/swift/compatibility-symbols")
 
-add_custom_command_target(copy_compat_target
-  COMMAND
-    "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swift-compatibility-symbols"
-    --output-filename ${syms_file}
-  OUTPUT
-    ${syms_file}
-  DEPENDS
-    swift-compatibility-symbols
-)
+  add_custom_command_target(copy_compat_target
+    COMMAND
+      "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swift-compatibility-symbols"
+      --output-filename ${syms_file}
+    OUTPUT
+      ${syms_file}
+    DEPENDS
+      swift-compatibility-symbols
+  )
 
-add_dependencies(swift-frontend "${copy_compat_target}")
+  add_dependencies(swift-frontend "${copy_compat_target}")
 
-swift_install_in_component(
-  FILES
-    ${syms_file}
-  DESTINATION
-    "share/swift"
-  COMPONENT
-    compiler
-)
+  swift_install_in_component(
+    FILES
+      ${syms_file}
+    DESTINATION
+      "share/swift"
+    COMPONENT
+      compiler
+  )
+endif()


### PR DESCRIPTION
Adding `SWIFT_ENABLE_SWIFT_IN_SWIFT` option to enable or disable the parts of Swift that require a Swift compiler to build. This is meant for bootstrapping compilers on new platforms and is not guaranteed to result in a compiler that will pass the test suite.

This option is on by default so that folks won't forget. If the option is off, the resulting compiler does not include the Swift optimizer sources in SwiftCompilerSources nor does the resulting compiler have swift macro support.