### PR TITLE
[Caching] Mark `-emit-module-source-info-path` as CacheInvariant

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -730,12 +730,12 @@ def avoid_emit_module_source_info :
 def emit_module_source_info_path :
   Separate<["-"], "emit-module-source-info-path">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
-         SupplementaryOutput]>,
+         SupplementaryOutput, CacheInvariant]>,
   MetaVarName<"<path>">, HelpText<"Output module source info file to <path>">;
 def emit_variant_module_source_info_path :
   Separate<["-"], "emit-variant-module-source-info-path">,
   Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
-         SupplementaryOutput, NewDriverOnlyOption]>,
+         SupplementaryOutput, NewDriverOnlyOption, CacheInvariant]>,
   MetaVarName<"<path>">, HelpText<"Output module source info file for the target variant to <path>">;
 
 def emit_parseable_module_interface :

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -24,6 +24,7 @@ add_swift_unittest(SwiftBasicTests
   ImmutablePointerSetTest.cpp
   JSONSerialization.cpp
   OptionSetTest.cpp
+  Options.cpp
   OwnedStringTest.cpp
   MultiMapCacheTest.cpp
   PointerIntEnumTest.cpp
@@ -48,8 +49,10 @@ add_dependencies(SwiftBasicTests "${gyb_dependency_targets}")
 target_link_libraries(SwiftBasicTests
   PRIVATE
   swiftBasic
+  swiftOption
   swiftThreading
   clangBasic
+  LLVMOption
   LLVMTestingSupport
   )
 

--- a/unittests/Basic/Options.cpp
+++ b/unittests/Basic/Options.cpp
@@ -1,0 +1,40 @@
+//===--- Options.cpp ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Option/Options.h"
+#include "llvm/Option/Option.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::options;
+
+TEST(Options, outputPathCacheInvariant) {
+  auto optTable = createSwiftOptTable();
+  // 0 is OP_INVALD
+  for (auto id = 1; id < LastOption; ++id) {
+    auto opt = optTable->getOption(id);
+    // Only check the flag accepted by swift-frontend.
+    if (!opt.hasFlag(SwiftFlags::FrontendOption))
+      continue;
+
+    // The following two options are only accepted by migrator.
+    if (id == OPT_emit_migrated_file_path || id == OPT_emit_remap_file_path)
+      continue;
+
+    auto name = opt.getName();
+    // Check that if a flag matches the convention `-emit-*-path{=}`, it should
+    // be a path to an output file and should be marked as cache invariant.
+    if (name.starts_with("emit") &&
+        (name.ends_with("-path") || name.ends_with("-path=")))
+      ASSERT_TRUE(opt.hasFlag(SwiftFlags::CacheInvariant));
+  }
+}


### PR DESCRIPTION
For the options that specifies the output, it should be cache invariant. Fix the one remaining option that is not correctly labelled and add an unittest to make sure all the options with output path naming convertion are correctly marked as CacheInvariant.

rdar://146155049

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
