### PR TITLE
AST: Request-ify retrieval of `SemanticAvailabilitySpec`

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -330,6 +330,12 @@ class AvailabilityDomainOrIdentifier {
   std::optional<AvailabilityDomain>
   lookUpInDeclContext(SourceLoc loc, const DeclContext *declContext) const;
 
+  void setResolved(std::optional<AvailabilityDomain> domain) {
+    if (domain)
+      storage.setPointer(*domain);
+    storage.setInt(true);
+  }
+
 public:
   AvailabilityDomainOrIdentifier(Identifier identifier)
       : storage(identifier) {};
@@ -359,18 +365,19 @@ public:
     return std::nullopt;
   }
 
+  /// Returns true if either a resolved domain is available or if the attempt
+  /// to look up the domain from the identifier was unsuccessful.
+  bool isResolved() const { return storage.getInt() || isDomain(); }
+
   std::optional<AvailabilityDomain>
   resolveInDeclContext(SourceLoc loc, const DeclContext *declContext) {
     // Return the domain directly if already resolved.
-    if (storage.getInt() || isDomain())
+    if (isResolved())
       return getAsDomain();
 
     // Look up the domain and cache the result.
     auto result = lookUpInDeclContext(loc, declContext);
-    if (result)
-      storage.setPointer(*result);
-    storage.setInt(true);
-
+    setResolved(result);
     return result;
   }
 

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -50,11 +50,13 @@ class AvailabilitySpec : public ASTAllocated<AvailabilitySpec> {
   // Location of the availability macro expanded to create this spec.
   SourceLoc MacroLoc;
 
+  unsigned IsInvalid : 1;
+
   AvailabilitySpec(AvailabilityDomainOrIdentifier DomainOrIdentifier,
                    SourceRange SrcRange, llvm::VersionTuple Version,
                    SourceLoc VersionStartLoc)
       : DomainOrIdentifier(DomainOrIdentifier), SrcRange(SrcRange),
-        Version(Version), VersionStartLoc(VersionStartLoc) {}
+        Version(Version), VersionStartLoc(VersionStartLoc), IsInvalid(false) {}
 
 public:
   /// Creates a wildcard availability specification that guards execution
@@ -91,6 +93,9 @@ public:
   SourceRange getSourceRange() const { return SrcRange; }
   SourceLoc getStartLoc() const { return SrcRange.Start; }
 
+  /// Returns true if this spec did not type-check successfully.
+  bool isInvalid() const { return IsInvalid; }
+
   AvailabilityDomainOrIdentifier getDomainOrIdentifier() const {
     return DomainOrIdentifier;
   }
@@ -115,6 +120,14 @@ public:
   void setMacroLoc(SourceLoc loc) { MacroLoc = loc; }
 
   void print(llvm::raw_ostream &os) const;
+
+private:
+  friend class SemanticAvailabilitySpecRequest;
+
+  std::optional<AvailabilityDomain>
+  resolveInDeclContext(const DeclContext *declContext);
+
+  void setInvalid() { IsInvalid = true; }
 };
 
 inline void simple_display(llvm::raw_ostream &os,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTTypeIDs.h"
 #include "swift/AST/ActorIsolation.h"
 #include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/AvailabilitySpec.h"
 #include "swift/AST/CatchNode.h"
 #include "swift/AST/Effects.h"
 #include "swift/AST/Evaluator.h"
@@ -5226,6 +5227,28 @@ public:
   bool isCached() const { return true; }
   std::optional<std::optional<SemanticAvailableAttr>> getCachedResult() const;
   void cacheResult(std::optional<SemanticAvailableAttr> value) const;
+};
+
+class SemanticAvailabilitySpecRequest
+    : public SimpleRequest<SemanticAvailabilitySpecRequest,
+                           std::optional<SemanticAvailabilitySpec>(
+                               const AvailabilitySpec *, const DeclContext *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  std::optional<SemanticAvailabilitySpec>
+  evaluate(Evaluator &evaluator, const AvailabilitySpec *spec,
+           const DeclContext *declContext) const;
+
+public:
+  bool isCached() const { return true; }
+  std::optional<std::optional<SemanticAvailabilitySpec>>
+  getCachedResult() const;
+  void cacheResult(std::optional<SemanticAvailabilitySpec> value) const;
 };
 
 #define SWIFT_TYPEID_ZONE TypeChecker

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -616,3 +616,7 @@ SWIFT_REQUEST(TypeChecker, SemanticAvailableAttrRequest,
               std::optional<SemanticAvailableAttr>
               (const AvailableAttr *, const Decl *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SemanticAvailabilitySpecRequest,
+              std::optional<SemanticAvailabilitySpec>
+              (const AvailabilitySpec *, const DeclContext *),
+              SeparatelyCached, NoLocationInfo)


### PR DESCRIPTION
Introduced `SemanticAvailabilitySpecRequest` to retrieve the semantic spec for an `AvailabilitySpec`. Add an `isInvalid` bit to `AvailabilitySpec` to track whether the request failed. Unfortunately, there aren't any easily accessible spare bits in the layout of `AvailabilitySpec` so it had to be a new field.
