### PR TITLE
LifetimeDependenceScopeFixup: handle indirect yields & fix bugs

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
@@ -53,6 +53,8 @@ struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
     self.inExclusiveRange.insert(beginInst)
   }
 
+  // Note: 'ends' are simply the instructions to insert in the range. 'self.ends' might not return the same sequence
+  // as this 'ends' argument because 'self.ends' will not include block exits.
   init<S: Sequence>(begin beginInst: Instruction, ends: S, _ context: some Context) where S.Element: Instruction {
     self = InstructionRange(begin: beginInst, context)
     insert(contentsOf: ends)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -350,6 +350,8 @@ extension LifetimeDependence.Scope {
       self = .initialized(.yield(result))
       return
     }
+    // @inout arguments belong to the coroutine because they are valid for the duration of the yield, and, if local
+    // mutation or reassignment were relevant, then the dependence would be on an access scope instead.
     self = .yield(result)
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1333,6 +1333,8 @@ final public class AllocExistentialBoxInst : SingleValueInstruction, Allocation 
 /// scope ending instruction such as `begin_access` (ending with `end_access`) and `begin_borrow` (ending with
 /// `end_borrow`).
 public protocol ScopedInstruction {
+  var instruction: Instruction { get }
+
   var endOperands: LazyFilterSequence<UseList> { get }
 
   var endInstructions: EndInstructions { get }
@@ -1349,7 +1351,12 @@ extension Instruction {
 }
 
 /// Instructions beginning a borrow-scope which must be ended by `end_borrow`.
-public protocol BorrowIntroducingInstruction : SingleValueInstruction, ScopedInstruction {}
+public protocol BorrowIntroducingInstruction : SingleValueInstruction, ScopedInstruction {
+}
+
+extension BorrowIntroducingInstruction {
+  public var instruction: Instruction { get { self } }
+}
 
 final public class EndBorrowInst : Instruction, UnaryInstruction {
   public var borrow: Value { operand.value }
@@ -1428,6 +1435,8 @@ final public class EndAccessInst : Instruction, UnaryInstruction {
 }
 
 extension BeginAccessInst : ScopedInstruction {
+  public var instruction: Instruction { get { self } }
+
   public var endOperands: LazyFilterSequence<UseList> {
     return uses.lazy.filter { $0.instruction is EndAccessInst }
   }
@@ -1462,6 +1471,8 @@ final public class AbortApplyInst : Instruction, UnaryInstruction {
 }
 
 extension BeginApplyInst : ScopedInstruction {
+  public var instruction: Instruction { get { self } }
+
   public var endOperands: LazyFilterSequence<UseList> {
     return token.uses.lazy.filter { $0.isScopeEndingUse }
   }

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -153,31 +153,87 @@ sil [ossa] @addressableArg : $@convention(thin) (@in_guaranteed Holder) -> @life
 
 // CHECK-LABEL: sil hidden [ossa] @testAddressableArg : $@convention(thin) (@guaranteed Holder) -> () {
 // CHECK: bb0(%0 : @guaranteed $Holder):
+// CHECK: [[BORROWA:%.*]] = begin_borrow %0
+// CHECK: [[BORROWB:%.*]] = begin_borrow [[BORROWA]]
 // CHECK: [[ALLOC:%.*]] = alloc_stack $Holder
-// CHECK: [[SB:%.*]] = store_borrow %0 to [[ALLOC]]
+// CHECK: [[SB:%.*]] = store_borrow [[BORROWB]] to [[ALLOC]]
 // CHECK: [[APPLY:%.*]] = apply %{{.*}}([[SB]]) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
 // CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[APPLY]] on [[SB]]
 // CHECK: [[MV:%.*]] = move_value [var_decl] [[MD]]
 // CHECK: apply %{{.*}}([[MV]]) : $@convention(thin) (@guaranteed NE) -> ()
 // CHECK: destroy_value [[MV]]
 // CHECK: end_borrow [[SB]]
+// CHECK: end_borrow [[BORROWB]]
+// CHECK: end_borrow [[BORROWA]]
 // CHECK: dealloc_stack [[ALLOC]]
 // CHECK-LABEL: } // end sil function 'testAddressableArg'
 sil hidden [ossa] @testAddressableArg : $@convention(thin) (@guaranteed Holder) -> () {
 bb0(%0 : @guaranteed $Holder):
   debug_value %0, let, name "arg", argno 1
-  %2 = alloc_stack $Holder
-  %3 = store_borrow %0 to %2
-  %4 = function_ref @addressableArg : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
-  %5 = apply %4(%3) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
-  %6 = mark_dependence [unresolved] %5 on %3
-  end_borrow %3
-  %8 = move_value [var_decl] %6
-  debug_value %8, let, name "ne"
-  %useNE = function_ref @useNE : $@convention(thin) (@guaranteed NE) -> ()
-  %18 = apply %useNE(%8) : $@convention(thin) (@guaranteed NE) -> ()
-  destroy_value %8
-  dealloc_stack %2
+  %borrow0a = begin_borrow %0 : $Holder
+  %borrow0b = begin_borrow %borrow0a : $Holder
+  // store-borrow
+  %sballoc = alloc_stack $Holder
+  %sb = store_borrow %borrow0b to %sballoc
+  %fdep = function_ref @addressableArg : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
+  %ne = apply %fdep(%sb) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
+  %nedep = mark_dependence [unresolved] %ne on %sb
+  end_borrow %sb
+  end_borrow %borrow0b : $Holder
+  end_borrow %borrow0a : $Holder
+  %nevar = move_value [var_decl] %nedep
+  debug_value %nevar, let, name "ne"
+  %fuse = function_ref @useNE : $@convention(thin) (@guaranteed NE) -> ()
+  %user = apply %fuse(%nevar) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %nevar
+  dealloc_stack %sballoc
+  %99 = tuple ()
+  return %99 : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @testIndirectYield : $@convention(thin) (@guaranteed Holder) -> () {
+// CHECK: bb0(%0 : @guaranteed $Holder):
+// CHECK: [[BORROW0A:%.*]] = begin_borrow %0
+// CHECK: [[BORROW0B:%.*]] = begin_borrow %0
+// CHECK: [[BORROW0C:%.*]] = begin_borrow %0
+// CHECK: ([[YIELD1:%.*]], [[TOKEN1:%.*]]) = begin_apply undef([[BORROW0A:%.*]], [[BORROW0B:%.*]]) : $@yield_once @convention(thin) (@guaranteed Holder, @guaranteed Holder) -> @lifetime(borrow 0, borrow 1) @yields @guaranteed Holder
+// CHECK: ([[YIELD2:%.*]], [[TOKEN2:%.*]]) = begin_apply undef([[BORROW0C:%.*]], [[YIELD1:%.*]]) : $@yield_once @convention(thin) (@guaranteed Holder, @guaranteed Holder) -> @lifetime(borrow 0, borrow 1) @yields @inout Holder
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[YIELD2]]
+// CHECK: apply %{{.*}}([[ACCESS]]) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
+// CHECK: mark_dependence [unresolved]
+// CHECK: [[NE:%.*]] = move_value [var_decl]
+// CHECK: apply %{{.*}}(%{{.*}}) : $@convention(thin) (@guaranteed NE) -> ()
+// CHECK: destroy_value [[NE]]
+// CHECK: end_access [[ACCESS]]
+// CHECK: end_apply [[TOKEN2]] as $()
+// CHECK: end_apply [[TOKEN1]] as $()
+// CHECK-DAG: end_borrow [[BORROW0C]]
+// CHECK-DAG: end_borrow [[BORROW0B]]
+// CHECK-DAG: end_borrow [[BORROW0A]]
+// CHECK-LABEL: } // end sil function 'testIndirectYield'
+sil hidden [ossa] @testIndirectYield : $@convention(thin) (@guaranteed Holder) -> () {
+bb0(%0 : @guaranteed $Holder):
+  debug_value %0, let, name "arg", argno 1
+  %borrow0a = begin_borrow %0 : $Holder
+  %borrow0b = begin_borrow %0 : $Holder
+  %borrow0c = begin_borrow %0 : $Holder
+  (%yieldval, %tokena) = begin_apply undef(%borrow0a, %borrow0b) : $@yield_once @convention(thin) (@guaranteed Holder, @guaranteed Holder) -> @lifetime(borrow 0, borrow 1) @yields @guaranteed Holder
+  (%yieldaddr, %tokenb) = begin_apply undef(%borrow0c, %yieldval) : $@yield_once @convention(thin) (@guaranteed Holder, @guaranteed Holder) -> @lifetime(borrow 0, borrow 1) @yields @inout Holder
+  %access = begin_access [read] [dynamic] %yieldaddr
+  %fdep = function_ref @addressableArg : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
+  %ne = apply %fdep(%access) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
+  %nedep = mark_dependence [unresolved] %ne on %access
+  end_access %access
+  end_apply %tokenb as $()
+  end_apply %tokena as $()
+  end_borrow %borrow0c : $Holder
+  end_borrow %borrow0b : $Holder
+  end_borrow %borrow0a : $Holder
+  %nevar = move_value [var_decl] %nedep
+  debug_value %nevar, let, name "ne"
+  %fuse = function_ref @useNE : $@convention(thin) (@guaranteed NE) -> ()
+  %user = apply %fuse(%nevar) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %nevar
   %99 = tuple ()
   return %99 : $()
 }


### PR DESCRIPTION
Handle coroutines that yield an address. Fix bugs involving extension of  multiple nested scopes that depend on multiple coroutine operands.

Add ScopedInstruction.instruction so we can use existentials of this type. This seems really inefficient, but I don't have another solution.
