### PR TITLE
[Concurrency] Implement isIsolatingCurrentContext requirement and mode

### DIFF
--- a/include/swift/Runtime/Bincompat.h
+++ b/include/swift/Runtime/Bincompat.h
@@ -67,15 +67,20 @@ bool useLegacySwiftObjCHashing();
 /// - `swift_task_isCurrentExecutorImpl` does not invoke `checkIsolated`
 /// - logging a warning on concurrency violation is allowed
 ///
-/// New behavior:
+/// Swift 6.0 behavior:
 /// - always fatal error in `swift_task_reportUnexpectedExecutor`
 /// - `swift_task_isCurrentExecutorImpl` will crash when it would have returned
 ///     false
 /// - `swift_task_isCurrentExecutorImpl` does invoke `checkIsolated` when other
 ///     checks failed
 ///
+/// Swift 6.2 behavior:
+/// - `swift_task_isCurrentExecutorImpl` will attempt to call the *non-crashing*
+///   `isIsolatingCurrentContext` and return its result
+/// - if not available, it will invoke the the *crashing* 'checkIsolated'
+///
 /// This can be overridden by using `SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=1`
-/// or `SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=crash|nocrash`
+/// or `SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=crash|nocrash|swift6|swift6.2`
 SWIFT_RUNTIME_STDLIB_SPI
 bool swift_bincompat_useLegacyNonCrashingExecutorChecks();
 

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -773,8 +773,8 @@ void swift_task_enqueue(Job *job, SerialExecutorRef executor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobal(Job *job);
 
-/// Invoke an executor's `checkIsolated` or otherwise equivalent API,
-/// that will crash if the current executor is NOT the passed executor.
+/// Invoke an executor's `checkIsolated` implementation;
+/// It will crash if the current executor is NOT the passed executor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_checkIsolated(SerialExecutorRef executor);
 
@@ -784,6 +784,15 @@ void swift_task_checkIsolated(SerialExecutorRef executor);
 /// implementation.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_task_invokeSwiftCheckIsolated(SerialExecutorRef executor);
+
+/// Invoke an executor's `isIsolatingCurrentContext` implementation;
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_isIsolatingCurrentContext(SerialExecutorRef executor);
+
+/// Invoke a Swift executor's `isIsolatingCurrentContext` implementation; returns
+/// `true` if it invoked the Swift implementation, `false` otherwise.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+bool swift_task_invokeSwiftIsIsolatingCurrentContext(SerialExecutorRef executor);
 
 /// A count in nanoseconds.
 using JobDelay = unsigned long long;
@@ -1037,6 +1046,10 @@ enum swift_task_is_current_executor_flag : uint64_t {
 
   /// The routine should assert on failure.
   Assert = 0x8,
+
+  /// The routine should use 'isIsolatingCurrentContext' function on the
+  /// 'expected' executor instead of `checkIsolated`.
+  HasIsIsolatingCurrentContext = 0x10,
 };
 
 SWIFT_EXPORT_FROM(swift_Concurrency)

--- a/include/swift/Runtime/ConcurrencyHooks.def
+++ b/include/swift/Runtime/ConcurrencyHooks.def
@@ -44,7 +44,11 @@ SWIFT_CONCURRENCY_HOOK(void, swift_task_enqueueGlobalWithDeadline,
     long long tnsec,
     int clock, Job *job);
 
-SWIFT_CONCURRENCY_HOOK(void, swift_task_checkIsolated, SerialExecutorRef executor);
+SWIFT_CONCURRENCY_HOOK(void, swift_task_checkIsolated,
+    SerialExecutorRef executor);
+
+SWIFT_CONCURRENCY_HOOK(bool, swift_task_isIsolatingCurrentContext,
+    SerialExecutorRef executor);
 
 SWIFT_CONCURRENCY_HOOK(bool, swift_task_isOnExecutor,
     HeapObject *executor,

--- a/stdlib/public/Concurrency/ConcurrencyHooks.cpp
+++ b/stdlib/public/Concurrency/ConcurrencyHooks.cpp
@@ -100,7 +100,8 @@ swift::swift_task_enqueueGlobalWithDeadline(
 
 SWIFT_CC(swift) static void
 swift_task_checkIsolatedOrig(SerialExecutorRef executor) {
-  swift_task_checkIsolatedImpl(*reinterpret_cast<SwiftExecutorRef *>(&executor));}
+  swift_task_checkIsolatedImpl(*reinterpret_cast<SwiftExecutorRef *>(&executor));
+}
 
 void
 swift::swift_task_checkIsolated(SerialExecutorRef executor) {
@@ -108,6 +109,20 @@ swift::swift_task_checkIsolated(SerialExecutorRef executor) {
     swift_task_checkIsolated_hook(executor, swift_task_checkIsolatedOrig);
   else
     swift_task_checkIsolatedOrig(executor);
+}
+
+SWIFT_CC(swift) static bool
+swift_task_isIsolatingCurrentContextOrig(SerialExecutorRef executor) {
+  return swift_task_isIsolatingCurrentContextImpl(
+      *reinterpret_cast<SwiftExecutorRef *>(&executor));
+}
+
+bool
+swift::swift_task_isIsolatingCurrentContext(SerialExecutorRef executor) {
+  if (SWIFT_UNLIKELY(swift_task_isIsolatingCurrentContext_hook))
+    return swift_task_isIsolatingCurrentContext_hook(executor, swift_task_isIsolatingCurrentContextOrig);
+  else
+    return swift_task_isIsolatingCurrentContextOrig(executor);
 }
 
 // Implemented in Swift because we need to obtain the user-defined flags on the executor ref.

--- a/stdlib/public/Concurrency/CooperativeGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/CooperativeGlobalExecutor.cpp
@@ -154,6 +154,11 @@ void swift_task_checkIsolatedImpl(SwiftExecutorRef executor) {
   swift_executor_invokeSwiftCheckIsolated(executor);
 }
 
+SWIFT_CC(swift)
+bool swift_task_isIsolatingCurrentContextImpl(SwiftExecutorRef executor) {
+  return swift_executor_invokeSwiftIsIsolatingCurrentContext(executor);
+}
+
 /// Insert a job into the cooperative global queue with a delay.
 SWIFT_CC(swift)
 void swift_task_enqueueGlobalWithDelayImpl(SwiftJobDelay delay,

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -449,6 +449,12 @@ void swift_task_checkIsolatedImpl(SwiftExecutorRef executor) {
 }
 
 SWIFT_CC(swift)
+bool swift_task_isIsolatingCurrentContextImpl(SwiftExecutorRef executor) {
+  return swift_executor_invokeSwiftIsIsolatingCurrentContext(executor);
+}
+
+
+SWIFT_CC(swift)
 SwiftExecutorRef swift_task_getMainExecutorImpl() {
   return swift_executor_ordinary(
            reinterpret_cast<SwiftHeapObject*>(&_dispatch_main_q),

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -195,6 +195,9 @@ public protocol SerialExecutor: Executor {
   @available(SwiftStdlib 6.0, *)
   func checkIsolated()
 
+  @available(SwiftStdlib 6.2, *)
+  func isIsolatingCurrentContext() -> Bool
+
 }
 
 @available(SwiftStdlib 6.0, *)
@@ -207,6 +210,16 @@ extension SerialExecutor {
     #else
     Builtin.int_trap()
     #endif
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+extension SerialExecutor {
+
+  @available(SwiftStdlib 6.2, *)
+  public func isIsolatingCurrentContext() -> Bool {
+    self.checkIsolated()
+    return true
   }
 }
 
@@ -465,6 +478,13 @@ internal func _task_serialExecutor_isSameExclusiveExecutionContext<E>(current cu
 internal func _task_serialExecutor_checkIsolated<E>(executor: E)
     where E: SerialExecutor {
   executor.checkIsolated()
+}
+
+@available(SwiftStdlib 6.2, *)
+@_silgen_name("_task_serialExecutor_isIsolatingCurrentContext")
+internal func _task_serialExecutor_isIsolatingCurrentContext<E>(executor: E) -> Bool
+    where E: SerialExecutor {
+  return executor.isIsolatingCurrentContext()
 }
 
 /// Obtain the executor ref by calling the executor's `asUnownedSerialExecutor()`.

--- a/stdlib/public/Concurrency/ExecutorImpl.h
+++ b/stdlib/public/Concurrency/ExecutorImpl.h
@@ -221,6 +221,14 @@ swift_executor_invokeSwiftCheckIsolated(SwiftExecutorRef executor) {
   return _swift_task_invokeSwiftCheckIsolated_c(executor);
 }
 
+/// Check if the current context is isolated by the specified executor.
+static inline bool
+swift_executor_invokeSwiftIsIsolatingCurrentContext(SwiftExecutorRef executor) {
+  extern bool _swift_task_invokeSwiftIsIsolatingCurrentContext_c(SwiftExecutorRef executor);
+
+  return _swift_task_invokeSwiftIsIsolatingCurrentContext_c(executor);
+}
+
 /// Execute the specified job while running on the specified executor.
 static inline void swift_job_run(SwiftJob *job, SwiftExecutorRef executor) {
   extern void _swift_job_run_c(SwiftJob *job, SwiftExecutorRef executor);
@@ -275,6 +283,9 @@ SWIFT_CC(swift) void swift_task_enqueueMainExecutorImpl(SwiftJob *job);
 
 /// Assert that the specified executor is the current executor.
 SWIFT_CC(swift) void swift_task_checkIsolatedImpl(SwiftExecutorRef executor);
+
+/// Check if the specified executor isolates the current context.
+SWIFT_CC(swift) bool swift_task_isIsolatingCurrentContextImpl(SwiftExecutorRef executor);
 
 /// Get a reference to the main executor.
 SWIFT_CC(swift) SwiftExecutorRef swift_task_getMainExecutorImpl(void);

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -63,10 +63,10 @@
 using namespace swift;
 
 extern "C" SWIFT_CC(swift)
-    void _task_serialExecutor_checkIsolated(
-        HeapObject *executor,
-        const Metadata *selfType,
-        const SerialExecutorWitnessTable *wtable);
+void _task_serialExecutor_checkIsolated(
+    HeapObject *executor,
+    const Metadata *selfType,
+    const SerialExecutorWitnessTable *wtable);
 
 SWIFT_CC(swift)
 bool swift::swift_task_invokeSwiftCheckIsolated(SerialExecutorRef executor)
@@ -84,6 +84,29 @@ bool swift::swift_task_invokeSwiftCheckIsolated(SerialExecutorRef executor)
 extern "C" bool _swift_task_invokeSwiftCheckIsolated_c(SwiftExecutorRef executor)
 {
   return swift_task_invokeSwiftCheckIsolated(*reinterpret_cast<SerialExecutorRef *>(&executor));
+}
+
+
+extern "C" SWIFT_CC(swift)
+bool _task_serialExecutor_isIsolatingCurrentContext(
+    HeapObject *executor,
+    const Metadata *selfType,
+    const SerialExecutorWitnessTable *wtable);
+
+SWIFT_CC(swift)
+bool swift::swift_task_invokeSwiftIsIsolatingCurrentContext(SerialExecutorRef executor)
+{
+  if (!executor.hasSerialExecutorWitnessTable())
+    return false;
+
+  return _task_serialExecutor_isIsolatingCurrentContext(
+        executor.getIdentity(), swift_getObjectType(executor.getIdentity()),
+        executor.getSerialExecutorWitnessTable());
+}
+
+extern "C" bool _swift_task_invokeSwiftIsIsolatingCurrentContext_c(SwiftExecutorRef executor)
+{
+  return swift_task_invokeSwiftIsIsolatingCurrentContext(*reinterpret_cast<SerialExecutorRef *>(&executor));
 }
 
 extern "C" void _swift_job_run_c(SwiftJob *job, SwiftExecutorRef executor)

--- a/stdlib/public/Concurrency/NonDispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/NonDispatchGlobalExecutor.cpp
@@ -80,6 +80,11 @@ void swift_task_checkIsolatedImpl(SwiftExecutorRef executor) {
 }
 
 SWIFT_CC(swift)
+bool swift_task_isIsolatingCurrentContextImpl(SwiftExecutorRef executor) {
+  return swift_executor_invokeSwiftIsIsolatingCurrentContext(executor);
+}
+
+SWIFT_CC(swift)
 SwiftExecutorRef swift_task_getMainExecutorImpl() {
   return swift_executor_generic();
 }

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -124,9 +124,13 @@ VARIABLE(SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE, string, "",
          "isolation is not the expected one. Some old code may rely on the "
          "non-crashing behavior. This flag enables temporarily restoring the "
          "legacy 'nocrash' behavior until adopting code has been adjusted. "
+         "It is possible to force the use of Swift 6.2's "
+         "isIsolatingCurrentContext instead of checkIsolated by passing "
+         " the 'swift6.2' configuration value. "
          "Legal values are: "
          " 'legacy' (Legacy behavior), "
-         " 'swift6' (Swift 6.0+ behavior)")
+         " 'swift6' (Swift 6.0-6.1 behavior)"
+         " 'swift6.2' (Swift 6.2 behavior)")
 
 VARIABLE(SWIFT_DUMP_ACCESSIBLE_FUNCTIONS, bool, false,
          "Dump a listing of all 'AccessibleFunctionRecord's upon first access. "

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_isIsolatingCurrentContext_swift6_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_isIsolatingCurrentContext_swift6_mode.swift
@@ -1,0 +1,80 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %import-libdispatch -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=swift6.2 %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// REQUIRES: libdispatch
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+@available(SwiftStdlib 6.2, *)
+final class NaiveQueueExecutor: SerialExecutor {
+  init() {}
+
+  func enqueue(_ job: consuming ExecutorJob) {
+    job.runSynchronously(on: self.asUnownedSerialExecutor())
+  }
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+
+  func checkIsolated() {
+    fatalError("Should not call this: checkIsolated")
+  }
+
+  func isIsolatingCurrentContext() -> Bool {
+    print("pretend it is ok: isIsolatingCurrentContext")
+    return true
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+actor ActorOnNaiveQueueExecutor {
+  let executor: NaiveQueueExecutor
+
+  init() {
+    self.executor = NaiveQueueExecutor()
+  }
+
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    self.executor.asUnownedSerialExecutor()
+  }
+
+  nonisolated func checkPreconditionIsolated() async {
+    print("Before preconditionIsolated")
+    self.preconditionIsolated()
+    print("After preconditionIsolated")
+
+    print("Before assumeIsolated")
+    self.assumeIsolated { iso in
+      print("Inside assumeIsolated")
+    }
+    print("After assumeIsolated")
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    if #available(SwiftStdlib 6.2, *) {
+      let actor = ActorOnNaiveQueueExecutor()
+      await actor.checkPreconditionIsolated()
+      // CHECK: Before preconditionIsolated
+      // CHECK-NOT: Should not call this: checkIsolated
+      // CHECK-NEXT: pretend it is ok: isIsolatingCurrentContext
+      // CHECK-NEXT: After preconditionIsolated
+
+      // CHECK-NEXT: Before assumeIsolated
+      // CHECK-NOT: Should not call this: checkIsolated
+      // CHECK-NEXT: pretend it is ok: isIsolatingCurrentContext
+      // CHECK-NEXT: After assumeIsolated
+    }
+  }
+}

--- a/test/Concurrency/Runtime/data_race_detection_legacy_warning.swift
+++ b/test/Concurrency/Runtime/data_race_detection_legacy_warning.swift
@@ -6,7 +6,7 @@
 // will be able to have this behavior, however new apps will not. We use the
 // overrides to test the logic for legacy code remains functional.
 //
-// RUN: %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=1 %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out 2>&1 | %FileCheck %s
+// RUN: %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=1 %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=legacy %target-run %t/a.out 2>&1 | %FileCheck %s --dump-input=always
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -401,6 +401,13 @@ Added: _$ss27ThrowingDiscardingTaskGroupV05startC28SynchronouslyUnlessCancelled4
 
 Added: _swift_task_startSynchronously
 
+Added: _swift_task_invokeSwiftIsIsolatingCurrentContext
+Added: _swift_task_isIsolatingCurrentContext
+Added: _swift_task_isIsolatingCurrentContext_hook
+Added: _$sScf25isIsolatingCurrentContextSbyFTj
+Added: _$sScf25isIsolatingCurrentContextSbyFTq
+Added: _$sScfsE25isIsolatingCurrentContextSbyF
+
 // add callee-allocated coro entrypoints
 // TODO: CoroutineAccessors: several of these symbols should be in swiftCore
 Added: __swift_coro_malloc_allocator

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -401,6 +401,13 @@ Added: _$ss27ThrowingDiscardingTaskGroupV05startC28SynchronouslyUnlessCancelled4
 
 Added: _swift_task_startSynchronously
 
+Added: _swift_task_invokeSwiftIsIsolatingCurrentContext
+Added: _swift_task_isIsolatingCurrentContext
+Added: _swift_task_isIsolatingCurrentContext_hook
+Added: _$sScf25isIsolatingCurrentContextSbyFTj
+Added: _$sScf25isIsolatingCurrentContextSbyFTq
+Added: _$sScfsE25isIsolatingCurrentContextSbyF
+
 // add callee-allocated coro entrypoints
 // TODO: CoroutineAccessors: several of these symbols should be in swiftCore
 Added: __swift_coro_malloc_allocator

--- a/test/embedded/Inputs/executor.c
+++ b/test/embedded/Inputs/executor.c
@@ -306,6 +306,12 @@ void swift_task_checkIsolatedImpl(SwiftExecutorRef executor) {
   swift_executor_invokeSwiftCheckIsolated(executor);
 }
 
+/// Check if the specified executor is the current executor.
+SWIFT_CC(swift)
+bool swift_task_isIsolatingCurrentContextImpl(SwiftExecutorRef executor) {
+  return swift_executor_invokeSwiftIsIsolatingCurrentContext(executor);
+}
+
 /// Get a reference to the main executor.
 SWIFT_CC(swift)
 SwiftExecutorRef swift_task_getMainExecutorImpl() {

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -92,6 +92,14 @@ swift_task_checkIsolated_override(SerialExecutorRef executor,
 }
 
 SWIFT_CC(swift)
+static bool
+swift_task_isIsolatingCurrentContext_override(SerialExecutorRef executor,
+                                      swift_task_isIsolatingCurrentContext_original original) {
+  Ran = true;
+  return true;
+}
+
+SWIFT_CC(swift)
 static void swift_task_enqueueGlobalWithDelay_override(
     unsigned long long delay, Job *job,
     swift_task_enqueueGlobalWithDelay_original original) {
@@ -144,6 +152,8 @@ protected:
         swift_task_enqueueMainExecutor_override;
     swift_task_checkIsolated_hook =
         swift_task_checkIsolated_override;
+    swift_task_isIsolatingCurrentContext_hook =
+        swift_task_isIsolatingCurrentContext_override;
 #ifdef RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
     swift_task_asyncMainDrainQueue_hook =
         swift_task_asyncMainDrainQueue_override_fn;
@@ -199,6 +209,11 @@ TEST_F(CompatibilityOverrideConcurrencyTest,
 TEST_F(CompatibilityOverrideConcurrencyTest,
        test_swift_task_checkIsolated) {
   swift_task_checkIsolated(SerialExecutorRef::generic());
+}
+
+TEST_F(CompatibilityOverrideConcurrencyTest,
+       test_swift_task_isIsolatingCurrentContext) {
+  swift_task_isIsolatingCurrentContext(SerialExecutorRef::generic());
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest,


### PR DESCRIPTION
This implements the `isIsolatingCurrentContext` function form https://github.com/swiftlang/swift-evolution/pull/2716

It is not yet enabled.