### PR TITLE
[Completion] Avoid type parameters in expected types

### DIFF
--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -139,7 +139,7 @@ void ArgumentTypeCheckCompletionCallback::sawSolutionImpl(const Solution &S) {
   Type ExpectedCallType;
   if (auto ArgLoc = S.getConstraintSystem().getArgumentLocator(ParentCall)) {
     if (auto FuncArgApplyInfo = S.getFunctionArgApplyInfo(ArgLoc)) {
-      Type ParamType = FuncArgApplyInfo->getParamInterfaceType();
+      Type ParamType = FuncArgApplyInfo->getParamType();
       ExpectedCallType = S.simplifyTypeForCodeCompletion(ParamType);
     }
   }

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -393,11 +393,16 @@ static TypeRelation calculateTypeRelation(Type Ty, Type ExpectedTy,
     return TypeRelation::Unknown;
   }
 
-  // Equality/Conversion of GenericTypeParameterType won't account for
-  // requirements – ignore them
-  if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter()) {
-    if (Ty->isEqual(ExpectedTy))
-      return TypeRelation::Convertible;
+  ASSERT(!Ty->hasUnboundGenericType() && !ExpectedTy->hasUnboundGenericType());
+  ASSERT(!ExpectedTy->hasTypeParameter());
+
+  if (Ty->isEqual(ExpectedTy))
+    return TypeRelation::Convertible;
+
+  // FIXME: We ought to be opening generic parameters present in completion
+  // results for generic decls, and mapping into context types for non-generic
+  // decls. For now, avoid attempting to compare.
+  if (!Ty->hasTypeParameter()) {
     bool isAny = false;
     isAny |= ExpectedTy->isAny();
     isAny |= ExpectedTy->is<ArchetypeType>() &&

--- a/test/IDE/complete_rdar127844278.swift
+++ b/test/IDE/complete_rdar127844278.swift
@@ -31,5 +31,5 @@ func foo<T>(@Builder _: () -> T) where T: Q {}
 foo {
   S(#^COMPLETE^#)
 }
-// COMPLETE-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#a: Void#}[')'][#S<()>#]; name=a:
-// COMPLETE-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#b: String#}[')'][#S<String>#]; name=b:
+// COMPLETE-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#a: Void#}[')'][#S<()>#]; name=a:
+// COMPLETE-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#b: String#}[')'][#S<String>#]; name=b:


### PR DESCRIPTION
There actually only appears to be a single place where we were letting interface types into the expected type for a completion, fix it up to use a contextual type.