### PR TITLE
[cxx-interop] Always import the lifetime annotations

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2036,12 +2036,9 @@ namespace {
     }
 
     void markReturnsUnsafeNonescapable(AbstractFunctionDecl *fd) {
-      if (Impl.SwiftContext.LangOpts.hasFeature(Feature::LifetimeDependence)) {
-        fd->getAttrs().add(new (Impl.SwiftContext)
-                               UnsafeNonEscapableResultAttr(/*Implicit=*/true));
-        fd->getAttrs().add(new (Impl.SwiftContext)
-                               UnsafeAttr(/*Implicit=*/true));
-      }
+      fd->getAttrs().add(new (Impl.SwiftContext)
+                             UnsafeNonEscapableResultAttr(/*Implicit=*/true));
+      fd->getAttrs().add(new (Impl.SwiftContext) UnsafeAttr(/*Implicit=*/true));
     }
 
     Decl *VisitRecordDecl(const clang::RecordDecl *decl) {
@@ -2417,9 +2414,7 @@ namespace {
       // TODO: builtin "zeroInitializer" does not work with non-escapable
       // types yet. Don't generate an initializer.
       if (hasZeroInitializableStorage && needsEmptyInitializer &&
-          (!Impl.SwiftContext.LangOpts.hasFeature(
-               Feature::LifetimeDependence) ||
-           !isNonEscapable)) {
+          !isNonEscapable) {
         // Add default constructor for the struct if compiling in C mode.
         // If we're compiling for C++:
         // 1. If a default constructor is declared, don't synthesize one.
@@ -4045,21 +4040,29 @@ namespace {
       if (decl->getTemplatedKind() == clang::FunctionDecl::TK_FunctionTemplate)
         return;
 
-      auto &ASTContext = result->getASTContext();
-      if (!ASTContext.LangOpts.hasFeature(Feature::LifetimeDependence))
+      // FIXME: support C functions imported as members.
+      if (result->getImportAsMemberStatus().isImportAsMember() &&
+          !isa<clang::CXXMethodDecl, clang::ObjCMethodDecl>(decl))
         return;
 
+      auto isEscapable = [this](clang::QualType ty) {
+        return evaluateOrDefault(
+                   Impl.SwiftContext.evaluator,
+                   ClangTypeEscapability({ty.getTypePtr(), &Impl}),
+                   CxxEscapability::Unknown) != CxxEscapability::NonEscapable;
+      };
+
+      auto &ASTContext = result->getASTContext();
       SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
       LifetimeDependenceInfo immortalLifetime(nullptr, nullptr, 0,
                                               /*isImmortal*/ true);
-      if (const auto *funDecl = dyn_cast<FuncDecl>(result))
-        if (hasUnsafeAPIAttr(decl) && !funDecl->getResultInterfaceType()->isEscapable()) {
-          lifetimeDependencies.push_back(immortalLifetime);
-          Impl.SwiftContext.evaluator.cacheOutput(
-              LifetimeDependenceInfoRequest{result},
-              Impl.SwiftContext.AllocateCopy(lifetimeDependencies));
-          return;
-        }
+      if (hasUnsafeAPIAttr(decl) && !isEscapable(decl->getReturnType())) {
+        lifetimeDependencies.push_back(immortalLifetime);
+        Impl.SwiftContext.evaluator.cacheOutput(
+            LifetimeDependenceInfoRequest{result},
+            Impl.SwiftContext.AllocateCopy(lifetimeDependencies));
+        return;
+      }
 
       auto retType = decl->getReturnType();
       auto warnForEscapableReturnType = [&] {
@@ -4080,23 +4083,24 @@ namespace {
       SmallBitVector scopedLifetimeParamIndicesForReturn(dependencyVecSize);
       SmallBitVector paramHasAnnotation(dependencyVecSize);
       std::map<unsigned, SmallBitVector> inheritedArgDependences;
-      auto processLifetimeBound = [&](unsigned idx, Type ty) {
+      auto processLifetimeBound = [&](unsigned idx, clang::QualType ty) {
         warnForEscapableReturnType();
         paramHasAnnotation[idx] = true;
-        if (ty->isEscapable())
+        if (isEscapable(ty))
           scopedLifetimeParamIndicesForReturn[idx] = true;
         else
           inheritLifetimeParamIndicesForReturn[idx] = true;
       };
       auto processLifetimeCaptureBy =
-          [&](const clang::LifetimeCaptureByAttr *attr, unsigned idx, Type ty) {
+          [&](const clang::LifetimeCaptureByAttr *attr, unsigned idx,
+              clang::QualType ty) {
             // FIXME: support scoped lifetimes. This is not straightforward as
             // const T& is imported as taking a value
             //        and we assume the address of T would not escape. An
             //        annotation in this case contradicts our assumptions. We
             //        should diagnose that, and support this for the non-const
             //        case.
-            if (ty->isEscapable())
+            if (isEscapable(ty))
               return;
             for (auto param : attr->params()) {
               // FIXME: Swift assumes no escaping to globals. We should diagnose
@@ -4122,20 +4126,20 @@ namespace {
           };
       for (auto [idx, param] : llvm::enumerate(decl->parameters())) {
         if (param->hasAttr<clang::LifetimeBoundAttr>())
-          processLifetimeBound(idx, swiftParams->get(idx)->getInterfaceType());
+          processLifetimeBound(idx, param->getType());
         if (const auto *attr = param->getAttr<clang::LifetimeCaptureByAttr>())
-          processLifetimeCaptureBy(attr, idx,
-                                   swiftParams->get(idx)->getInterfaceType());
+          processLifetimeCaptureBy(attr, idx, param->getType());
       }
       if (getImplicitObjectParamAnnotation<clang::LifetimeBoundAttr>(decl))
-        processLifetimeBound(result->getSelfIndex(),
-                             result->getImplicitSelfDecl()->getInterfaceType());
+        processLifetimeBound(
+            result->getSelfIndex(),
+            cast<clang::CXXMethodDecl>(decl)->getThisType()->getPointeeType());
       if (auto attr =
               getImplicitObjectParamAnnotation<clang::LifetimeCaptureByAttr>(
                   decl))
         processLifetimeCaptureBy(
             attr, result->getSelfIndex(),
-            result->getImplicitSelfDecl()->getInterfaceType());
+            cast<clang::CXXMethodDecl>(decl)->getThisType()->getPointeeType());
 
       for (auto& [idx, inheritedDepVec]: inheritedArgDependences) {
         lifetimeDependencies.push_back(LifetimeDependenceInfo(inheritedDepVec.any() ? IndexSubset::get(Impl.SwiftContext,
@@ -4180,7 +4184,7 @@ namespace {
       }
 
       for (auto [idx, param] : llvm::enumerate(decl->parameters())) {
-        if (swiftParams->get(idx)->getInterfaceType()->isEscapable())
+        if (isEscapable(param->getType()))
           continue;
         if (param->hasAttr<clang::NoEscapeAttr>() || paramHasAnnotation[idx])
           continue;

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -103,13 +103,16 @@ import CxxStdlib
 // CHECK-NO-LIFETIMES: test.swift:6:32: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
 public func noAnnotations() -> View {
     // CHECK: nonescapable.h:16:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies
+    // CHECK-NO-LIFETIMES: nonescapable.h:16:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies
     f(nil)
     // CHECK: nonescapable.h:20:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies
+    // CHECK-NO-LIFETIMES: nonescapable.h:20:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies
     // No duplicate warning for f2:
     // CHECK-NOT: nonescapable.h:20
     f2(nil, nil)
     // CHECK: nonescapable.h:24:6: warning: the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated
     // CHECK: nonescapable.h:24:6: error: cannot infer lifetime dependence, no parameters found that are either ~Escapable or Escapable with a borrowing ownership
+    // CHECK-NO-LIFETIMES: nonescapable.h:24:6: warning: the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated
     // CHECK-NO-LIFETIMES: nonescapable.h:24:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
     g(nil)
     h1(nil)
@@ -144,8 +147,6 @@ public func noAnnotations() -> View {
     // CHECK-NO-LIFETIMES: nonescapable.h:77:12: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
     l2();
     return View()
-    // CHECK-NO-LIFETIMES: nonescapable.h:5:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-    // CHECK-NO-LIFETIMES: nonescapable.h:6:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
 }
 
 public func test3(_ x: inout View) {

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -1,7 +1,7 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
-// RUN: not %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-NO-LIFETIMES
+// RUN: %target-swift-frontend -I %swift_src_root/lib/ClangImporter/SwiftBridging  -I %t/Inputs -emit-sil %t/test.swift -cxx-interoperability-mode=default -diagnostic-style llvm 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
 
@@ -123,22 +123,6 @@ struct SWIFT_NONESCAPABLE AggregateView {
 // CHECK: sil [clang getCaptureView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @owned CaptureView
 // CHECK: sil [clang CaptureView.captureView] {{.*}} : $@convention(cxx_method) (View, @lifetime(copy 0) @inout CaptureView) -> ()
 // CHECK: sil [clang CaptureView.handOut] {{.*}} : $@convention(cxx_method) (@lifetime(copy 1) @inout View, @in_guaranteed CaptureView) -> ()
-
-// CHECK-NO-LIFETIMES: nonescapable.h:35:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:39:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:45:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:52:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:22:10: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:26:10: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:4:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:5:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:13:5: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:12:27: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:67:6: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:90:13: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:94:27: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES: nonescapable.h:94:27: error: returning ~Escapable type requires '-enable-experimental-feature LifetimeDependence'
-// CHECK-NO-LIFETIMES-NOT: error
 
 //--- test.swift
 


### PR DESCRIPTION
Importing these annotations were behind the LifetimeDependence experimental flag. However, this feature flag is intended to guard the use of @lifetime annotations on the Swift side and lifetime inference. The checking of imported lifetime contracts should work even when this flag is off. Removing the flag from the importer caused some fallout. This was mostly due to calling getInterfaceType functions before the import of some Swift declarations were fully done so the code was slightly improved to make decisions only based on the C++ types. There was also a crash when on-member functions imported as methods into Swift. That is worked around in this PR.

There is one last feature check that we cannot remove yet, we generate @lifetime annotations in the SwiftifyImport macro.

rdar://146289994