### PR TITLE
Add a flag to enable-new-runtime-build that enables the new runtime build

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -669,7 +669,7 @@ skip-test-sourcekit-lsp
 skip-test-swiftpm
 skip-test-llbuild
 
-extra-cmake-options=-DSWIFT_ENABLE_NEW_RUNTIME_BUILD=YES
+enable-new-runtime-build
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -703,6 +703,9 @@ def create_argument_parser():
     option('--swift-freestanding-is-darwin', toggle_true,
            help='True if the freestanding platform is a Darwin one.')
 
+    option('--enable-new-runtime-build', toggle_true,
+           help='True to enable the new runtime build.')
+
     # -------------------------------------------------------------------------
     in_group('Options to select projects')
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -336,6 +336,7 @@ EXPECTED_DEFAULTS = {
     'llvm_install_components': defaults.llvm_install_components(),
     'clean_install_destdir': False,
     'use_linker': None,
+    'enable_new_runtime_build': False,
 }
 
 
@@ -893,4 +894,5 @@ EXPECTED_OPTIONS = [
 
     StrOption('--llvm-install-components'),
     ChoicesOption('--use-linker', dest='use_linker', choices=['gold', 'lld']),
+    EnableOption('--enable-new-runtime-build', dest='enable_new_runtime_build'),
 ]

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -101,6 +101,9 @@ class Swift(product.Product):
 
         self._handle_swift_debuginfo_non_lto_args()
 
+        self.cmake_options.extend(
+            self._enable_new_runtime_build)
+
     @classmethod
     def product_source_name(cls):
         """product_source_name() -> str
@@ -287,6 +290,11 @@ updated without updating swift.py?")
     def _enable_stdlib_symbol_graphs(self):
         return [('SWIFT_STDLIB_BUILD_SYMBOL_GRAPHS:BOOL',
                  self.args.build_stdlib_docs)]
+
+    @property
+    def _enable_new_runtime_build(self):
+        return [('SWIFT_ENABLE_NEW_RUNTIME_BUILD:BOOL',
+                 self.args.enable_new_runtime_build)]
 
     def _handle_swift_debuginfo_non_lto_args(self):
         if ('swift_debuginfo_non_lto_args' not in self.args

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -72,7 +72,8 @@ class SwiftTestCase(unittest.TestCase):
             swift_freestanding_is_darwin=False,
             build_swift_private_stdlib=True,
             swift_tools_ld64_lto_codegen_only_for_supporting_targets=False,
-            build_stdlib_docs=False)
+            build_stdlib_docs=False,
+            enable_new_runtime_build=False)
 
         # Setup shell
         shell.dry_run = True
@@ -122,7 +123,8 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING=FALSE',
             '-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL=FALSE',
             '-USWIFT_DEBUGINFO_NON_LTO_ARGS',
-            '-DSWIFT_STDLIB_BUILD_SYMBOL_GRAPHS:BOOL=FALSE'
+            '-DSWIFT_STDLIB_BUILD_SYMBOL_GRAPHS:BOOL=FALSE',
+            '-DSWIFT_ENABLE_NEW_RUNTIME_BUILD:BOOL=FALSE',
         ]
         self.assertEqual(set(swift.cmake_options), set(expected))
 
@@ -157,7 +159,8 @@ class SwiftTestCase(unittest.TestCase):
             '-DSWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING=FALSE',
             '-DSWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS:BOOL=FALSE',
             '-USWIFT_DEBUGINFO_NON_LTO_ARGS',
-            '-DSWIFT_STDLIB_BUILD_SYMBOL_GRAPHS:BOOL=FALSE'
+            '-DSWIFT_STDLIB_BUILD_SYMBOL_GRAPHS:BOOL=FALSE',
+            '-DSWIFT_ENABLE_NEW_RUNTIME_BUILD:BOOL=FALSE',
         ]
         self.assertEqual(set(swift.cmake_options), set(flags_set))
 


### PR DESCRIPTION
What is nice about this is that by not using extra-cmake-args, we can avoid passing this into LLVM as well when attempting to reproduce failures on the bots (thus avoiding having to rebuild LLVM as well).
