### PR TITLE
Add to README.txt that Resync.cmake script does not update CMakeLists.txt and that must be updated manually.

### DIFF
--- a/Runtimes/Readme.md
+++ b/Runtimes/Readme.md
@@ -20,6 +20,11 @@ Once the migration is completed, we will be deleting this script. It
 is a temporary workaround to avoid trying to keep multiple sets of files in
 sync.
 
+> [!NOTE]
+> This script does not add new files to any CMakeLists.txt. Any new files
+> that are copied over will need to be added manually to ensure that
+> they will be built by CMake.
+
 ## Layering
 
 ```


### PR DESCRIPTION
The reason I am doing this is that it can be misleading to say that one only needs to run a "magic script" if there is also a manual step involved afterwards. This just makes it verbosely clear for people (like me) who take things too literally.