### PR TITLE
AST: Teach AvailabilityContext to represent version-less availability

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3308,9 +3308,13 @@ public:
   /// The source range of the `introduced:` version component.
   SourceRange getIntroducedSourceRange() const { return attr->IntroducedRange; }
 
-  /// Returns the effective availability range for the attribute's `introduced:`
-  /// component (remapping or canonicalizing if necessary).
-  AvailabilityRange getIntroducedRange(const ASTContext &Ctx) const;
+  /// Returns the effective introduction range indicated by this attribute.
+  /// This may correspond to the version specified by the `introduced:`
+  /// component (remapped or canonicalized if necessary) or it may be "always"
+  /// for an attribute indicating availability in a version-less domain. Returns
+  /// `std::nullopt` if the attribute does not indicate introduction.
+  std::optional<AvailabilityRange>
+  getIntroducedRange(const ASTContext &Ctx) const;
 
   /// The version tuple for the `deprecated:` component.
   std::optional<llvm::VersionTuple> getDeprecated() const;
@@ -3318,9 +3322,13 @@ public:
   /// The source range of the `deprecated:` version component.
   SourceRange getDeprecatedSourceRange() const { return attr->DeprecatedRange; }
 
-  /// Returns the effective availability range for the attribute's `deprecated:`
-  /// component (remapping or canonicalizing if necessary).
-  AvailabilityRange getDeprecatedRange(const ASTContext &Ctx) const;
+  /// Returns the effective deprecation range indicated by this attribute.
+  /// This may correspond to the version specified by the `deprecated:`
+  /// component (remapped or canonicalized if necessary) or it may be "always"
+  /// for an unconditional deprecation attribute. Returns `std::nullopt` if the
+  /// attribute does not indicate deprecation.
+  std::optional<AvailabilityRange>
+  getDeprecatedRange(const ASTContext &Ctx) const;
 
   /// The version tuple for the `obsoleted:` component.
   std::optional<llvm::VersionTuple> getObsoleted() const;
@@ -3328,9 +3336,13 @@ public:
   /// The source range of the `obsoleted:` version component.
   SourceRange getObsoletedSourceRange() const { return attr->ObsoletedRange; }
 
-  /// Returns the effective availability range for the attribute's `obsoleted:`
-  /// component (remapping or canonicalizing if necessary).
-  AvailabilityRange getObsoletedRange(const ASTContext &Ctx) const;
+  /// Returns the effective obsoletion range indicated by this attribute.
+  /// This always corresponds to the version specified by the `obsoleted:`
+  /// component (remapped or canonicalized if necessary). Returns `std::nullopt`
+  /// if the attribute does not indicate obsoletion (note that unavailability is
+  /// separate from obsoletion.
+  std::optional<AvailabilityRange>
+  getObsoletedRange(const ASTContext &Ctx) const;
 
   /// Returns the `message:` field of the attribute, or an empty string.
   StringRef getMessage() const { return attr->Message; }

--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -64,7 +64,14 @@ public:
 
   /// Returns the range of platform versions which may execute code in the
   /// availability context, starting at its introduction version.
+  // FIXME: [availability] Remove; superseded by getAvailableRange().
   AvailabilityRange getPlatformRange() const;
+
+  /// Returns the range which is available for `domain` in this context. If
+  /// there are not any constraints established for `domain`, returns
+  /// `std::nullopt`.
+  std::optional<AvailabilityRange>
+  getAvailabilityRange(AvailabilityDomain domain, const ASTContext &ctx) const;
 
   /// Returns true if this context contains any unavailable domains.
   bool isUnavailable() const;
@@ -80,8 +87,14 @@ public:
                             const ASTContext &ctx);
 
   /// Constrain the platform availability range with `platformRange`.
+  // FIXME: [availability] Remove; superseded by constrainWithAvailableRange().
   void constrainWithPlatformRange(const AvailabilityRange &platformRange,
                                   const ASTContext &ctx);
+
+  /// Constrain the available range for `domain` by `range`.
+  void constrainWithAvailabilityRange(const AvailabilityRange &range,
+                                      AvailabilityDomain domain,
+                                      const ASTContext &ctx);
 
   /// Constrain the context by adding \p domain to the set of unavailable
   /// domains.

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -43,6 +43,8 @@ public:
   AvailabilityRange getRange() const { return range; }
   bool isUnavailable() const { return range.isKnownUnreachable(); }
 
+  bool constrainRange(const AvailabilityRange &range);
+
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddPointer(domain.getOpaqueValue());
     range.getRawVersionRange().Profile(ID);

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -209,12 +209,23 @@ public:
   /// version ranges.
   bool isVersioned() const;
 
+  /// Returns true if availability of the domain can be refined using
+  /// `@available` attributes and `if #available` queries. If not, then the
+  /// domain's availability is fixed by compilation settings. For example,
+  /// macOS platform availability supports contextual refinement, whereas Swift
+  /// language availability does not.
+  bool supportsContextRefinement() const;
+
   /// Returns true if the domain supports `#available`/`#unavailable` queries.
   bool supportsQueries() const;
 
   /// Returns true if this domain is considered active in the current
   /// compilation context.
   bool isActive(const ASTContext &ctx) const;
+
+  /// Returns true if this domain is a platform domain that is contained by the
+  /// set of active platform-specific domains.
+  bool isActiveForTargetPlatform(const ASTContext &ctx) const;
 
   /// Returns the minimum available range for the attribute's domain. For
   /// example, for the domain of the platform that compilation is targeting,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6823,20 +6823,15 @@ NOTE(availability_decl_more_than_enclosing_here, none,
      "enclosing scope requires availability of %0 %1 or newer",
      (AvailabilityDomain, AvailabilityRange))
 
-ERROR(availability_decl_only_version_newer, none,
-      "%0 is only available in %1 %2 or newer",
-      (const ValueDecl *, AvailabilityDomain, AvailabilityRange))
+ERROR(availability_decl_only_in, none,
+      "%0 is only available in %1%select{| %3 or newer}2",
+      (const ValueDecl *, AvailabilityDomain, bool, AvailabilityRange))
 
-ERROR(availability_decl_only_version_newer_for_clients, none,
-      "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
-      " deployment target",
-      (const ValueDecl *, AvailabilityDomain, AvailabilityRange, ModuleDecl *))
-
-WARNING(availability_decl_only_version_newer_for_clients_warn, none,
-        "%0 is only available in %1 %2 or newer; clients of %3 may have a lower"
-        " deployment target",
-        (const ValueDecl *, AvailabilityDomain, AvailabilityRange,
-         ModuleDecl *))
+ERROR(availability_decl_only_in_for_clients, none,
+      "%0 is only available in %1%select{| %3 or newer}2"
+      "%select{|; clients of %4 may have a lower deployment target}2",
+      (const ValueDecl *, AvailabilityDomain, bool, AvailabilityRange,
+       ModuleDecl *))
 
 ERROR(availability_opaque_types_only_version_newer, none,
       "'some' return types are only available in %0 %1 or newer",
@@ -6884,9 +6879,10 @@ FIXIT(insert_available_attr,
       "@available(%0 %1, *)\n%2",
       (StringRef, StringRef, StringRef))
 
-ERROR(availability_inout_accessor_only_version_newer, none,
-      "cannot pass as inout because %0 is only available in %1 %2 or newer",
-      (const ValueDecl *, AvailabilityDomain, AvailabilityRange))
+ERROR(availability_inout_accessor_only_in, none,
+      "cannot pass as inout because %0 is only available in %1"
+      "%select{| %3 or newer}2",
+      (const ValueDecl *, AvailabilityDomain, bool, AvailabilityRange))
 
 ERROR(availability_query_required_for_platform, none,
       "condition required for target platform '%0'", (StringRef))

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -453,13 +453,13 @@ std::optional<SemanticAvailableAttr> Decl::getDeprecatedAttr() const {
       return attr;
 
     auto deprecatedRange = attr.getDeprecatedRange(ctx);
-    if (deprecatedRange.isKnownUnreachable())
+    if (!deprecatedRange)
       continue;
 
     // We treat the declaration as deprecated if it is deprecated on
     // all deployment targets.
     auto deploymentRange = attr.getDomain().getDeploymentRange(ctx);
-    if (deploymentRange && deploymentRange->isContainedIn(deprecatedRange))
+    if (deploymentRange && deploymentRange->isContainedIn(*deprecatedRange))
       result.emplace(attr);
   }
   return result;
@@ -475,13 +475,13 @@ std::optional<SemanticAvailableAttr> Decl::getSoftDeprecatedAttr() const {
       continue;
 
     auto deprecatedRange = attr.getDeprecatedRange(ctx);
-    if (deprecatedRange.isKnownUnreachable())
+    if (!deprecatedRange)
       continue;
 
     // We treat the declaration as soft-deprecated if it is deprecated in a
     // future version.
     auto deploymentRange = attr.getDomain().getDeploymentRange(ctx);
-    if (!deploymentRange || !deploymentRange->isContainedIn(deprecatedRange))
+    if (!deploymentRange || !deploymentRange->isContainedIn(*deprecatedRange))
       result.emplace(attr);
   }
   return result;
@@ -705,7 +705,8 @@ AvailabilityRange AvailabilityInference::annotatedAvailableRangeForAttr(
   }
 
   if (bestAvailAttr)
-    return bestAvailAttr->getIntroducedRange(ctx);
+    return bestAvailAttr->getIntroducedRange(ctx).value_or(
+        AvailabilityRange::alwaysAvailable());
 
   return AvailabilityRange::alwaysAvailable();
 }
@@ -737,8 +738,10 @@ Decl::getAvailableAttrForPlatformIntroduction(bool checkExtension) const {
 }
 
 AvailabilityRange AvailabilityInference::availableRange(const Decl *D) {
+  // ALLANXXX
   if (auto attr = D->getAvailableAttrForPlatformIntroduction())
-    return attr->getIntroducedRange(D->getASTContext());
+    return attr->getIntroducedRange(D->getASTContext())
+        .value_or(AvailabilityRange::alwaysAvailable());
 
   return AvailabilityRange::alwaysAvailable();
 }
@@ -854,13 +857,29 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getIntroduced() const {
   return std::nullopt;
 }
 
-AvailabilityRange
+std::optional<AvailabilityRange>
 SemanticAvailableAttr::getIntroducedRange(const ASTContext &Ctx) const {
   DEBUG_ASSERT(getDomain().isActive(Ctx));
 
   auto *attr = getParsedAttr();
-  if (!attr->getRawIntroduced().has_value())
-    return AvailabilityRange::alwaysAvailable();
+  if (!attr->getRawIntroduced().has_value()) {
+    // For versioned domains, an "introduced:" version is always required to
+    // indicate introduction.
+    if (getDomain().isVersioned())
+      return std::nullopt;
+
+    // For version-less domains, an attribute that does not indicate some other
+    // kind of unconditional availability constraint implicitly specifies that
+    // the decl is available in all versions of the domain.
+    switch (attr->getKind()) {
+    case AvailableAttr::Kind::Default:
+      return AvailabilityRange::alwaysAvailable();
+    case AvailableAttr::Kind::Deprecated:
+    case AvailableAttr::Kind::Unavailable:
+    case AvailableAttr::Kind::NoAsync:
+      return std::nullopt;
+    }
+  }
 
   llvm::VersionTuple introducedVersion = getIntroduced().value();
   AvailabilityDomain unusedDomain;
@@ -878,13 +897,20 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getDeprecated() const {
   return std::nullopt;
 }
 
-AvailabilityRange
+std::optional<AvailabilityRange>
 SemanticAvailableAttr::getDeprecatedRange(const ASTContext &Ctx) const {
   DEBUG_ASSERT(getDomain().isActive(Ctx));
 
   auto *attr = getParsedAttr();
-  if (!attr->getRawDeprecated().has_value())
-    return AvailabilityRange::neverAvailable();
+  if (!attr->getRawDeprecated().has_value()) {
+    // Regardless of the whether the domain supports versions or not, an
+    // unconditional deprecation attribute indicates the decl is always
+    // deprecated.
+    if (isUnconditionallyDeprecated())
+      return AvailabilityRange::alwaysAvailable();
+
+    return std::nullopt;
+  }
 
   llvm::VersionTuple deprecatedVersion = getDeprecated().value();
   AvailabilityDomain unusedDomain;
@@ -902,13 +928,15 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getObsoleted() const {
   return std::nullopt;
 }
 
-AvailabilityRange
+std::optional<AvailabilityRange>
 SemanticAvailableAttr::getObsoletedRange(const ASTContext &Ctx) const {
   DEBUG_ASSERT(getDomain().isActive(Ctx));
 
   auto *attr = getParsedAttr();
+
+  // Obsoletion always requires a version.
   if (!attr->getRawObsoleted().has_value())
-    return AvailabilityRange::neverAvailable();
+    return std::nullopt;
 
   llvm::VersionTuple obsoletedVersion = getObsoleted().value();
   AvailabilityDomain unusedDomain;

--- a/lib/AST/AvailabilityConstraint.cpp
+++ b/lib/AST/AvailabilityConstraint.cpp
@@ -146,21 +146,24 @@ getAvailabilityConstraintForAttr(const Decl *decl,
   auto &ctx = decl->getASTContext();
   auto deploymentRange = attr.getDomain().getDeploymentRange(ctx);
 
-  auto obsoletedRange = attr.getObsoletedRange(ctx);
-  if (deploymentRange && deploymentRange->isContainedIn(obsoletedRange))
-    return AvailabilityConstraint::obsoleted(attr);
-
-  AvailabilityRange introducedRange = attr.getIntroducedRange(ctx);
-
-  // FIXME: [availability] Expand this to cover custom versioned domains
-  if (attr.isPlatformSpecific()) {
-    if (!context.getPlatformRange().isContainedIn(introducedRange))
-      return AvailabilityConstraint::potentiallyUnavailable(attr);
-  } else if (deploymentRange &&
-             !deploymentRange->isContainedIn(introducedRange)) {
-    return AvailabilityConstraint::unavailableForDeployment(attr);
+  // Is the decl obsoleted in the deployment context?
+  if (auto obsoletedRange = attr.getObsoletedRange(ctx)) {
+    if (deploymentRange && deploymentRange->isContainedIn(*obsoletedRange))
+      return AvailabilityConstraint::obsoleted(attr);
   }
 
+  if (auto introducedRange = attr.getIntroducedRange(ctx)) {
+    // FIXME: [availability] Expand this to cover custom versioned domains
+    if (attr.isPlatformSpecific()) {
+      if (!context.getPlatformRange().isContainedIn(*introducedRange))
+        return AvailabilityConstraint::potentiallyUnavailable(attr);
+    } else if (deploymentRange &&
+               !deploymentRange->isContainedIn(*introducedRange)) {
+      return AvailabilityConstraint::unavailableForDeployment(attr);
+    }
+  }
+
+  // FIXME: [availability] Model deprecation as an availability constraint.
   return std::nullopt;
 }
 

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -44,58 +44,94 @@ static bool constrainRange(AvailabilityRange &existing,
   return true;
 }
 
-/// Returns true if `domain` is not already contained in `domainInfos` as an
-/// unavailable domain. Also, removes domains from `unavailableDomains` that are
-/// contained in `domain`.
-static bool shouldConstrainUnavailableDomains(
-    AvailabilityDomain domain,
-    llvm::SmallVectorImpl<AvailabilityContext::DomainInfo> &domainInfos) {
-  bool didRemove = false;
-  for (auto iter = domainInfos.rbegin(), end = domainInfos.rend(); iter != end;
-       ++iter) {
-    auto const &domainInfo = *iter;
-    auto existingDomain = domainInfo.getDomain();
+/// Returns true if `domainInfos` will be constrained by merging the domain
+/// availability represented by `otherDomainInfo`. Additionally, this function
+/// has a couple of side-effects:
+///
+///   - If any existing domain availability ought to be constrained by
+///     `otherDomainInfo` then that value will be updated in place.
+///   - If any existing value in `domainInfos` should be replaced when
+///     `otherDomainInfo` is added, then that existing value is removed
+///     and `otherDomainInfo` is appended to `domainInfosToAdd`.
+///
+static bool constrainDomainInfos(
+    AvailabilityContext::DomainInfo otherDomainInfo,
+    llvm::SmallVectorImpl<AvailabilityContext::DomainInfo> &domainInfos,
+    llvm::SmallVectorImpl<AvailabilityContext::DomainInfo> &domainInfosToAdd) {
+  bool isConstrained = false;
+  bool shouldAdd = true;
+  auto otherDomain = otherDomainInfo.getDomain();
+  auto end = domainInfos.rend();
 
-    if (!domainInfo.isUnavailable())
+  // Iterate over domainInfos in reverse order to allow items to be removed
+  // during iteration.
+  for (auto iter = domainInfos.rbegin(); iter != end; ++iter) {
+    auto &domainInfo = *iter;
+    auto domain = domainInfo.getDomain();
+
+    // We found an existing available range for the domain. Constrain it if
+    // necessary.
+    if (domain == otherDomain) {
+      shouldAdd = false;
+      isConstrained |= domainInfo.constrainRange(otherDomainInfo.getRange());
       continue;
+    }
 
-    // Check if the domain is already unavailable.
-    if (existingDomain.contains(domain)) {
-      ASSERT(!didRemove); // This would indicate that the context is malformed.
+    // Check whether an existing unavailable domain contains the domain that
+    // would be added. If so, there's nothing to do because the availability of
+    // the domain is already as constrained as it can be.
+    if (domainInfo.isUnavailable() && domain.contains(otherDomain)) {
+      DEBUG_ASSERT(!isConstrained);
       return false;
     }
 
-    // Check if the existing domain would be absorbed by the new domain.
-    if (domain.contains(existingDomain)) {
+    // If the domain that will be added is unavailable, check whether the
+    // existing domain is contained within it. If it is, availability for the
+    // existing domain should be removed because it has been superseded.
+    if (otherDomainInfo.isUnavailable() && otherDomain.contains(domain)) {
       domainInfos.erase((iter + 1).base());
-      didRemove = true;
+      isConstrained = true;
     }
   }
 
-  return true;
+  // If the new domain availability isn't already covered by an item in
+  // `domainInfos`, then it needs to be added. Defer adding the new domain
+  // availability until later when the entire set of domain infos can be
+  // re-sorted once.
+  if (shouldAdd) {
+    domainInfosToAdd.push_back(otherDomainInfo);
+    return true;
+  }
+
+  return isConstrained;
 }
 
+/// Constrains `domainInfos` by merging them with `otherDomainInfos`. Returns
+/// true if any changes were made to `domainInfos`.
 static bool constrainDomainInfos(
     llvm::SmallVectorImpl<AvailabilityContext::DomainInfo> &domainInfos,
     llvm::ArrayRef<AvailabilityContext::DomainInfo> otherDomainInfos) {
+  bool isConstrained = false;
   llvm::SmallVector<AvailabilityContext::DomainInfo, 4> domainInfosToAdd;
-
   for (auto otherDomainInfo : otherDomainInfos) {
-    if (otherDomainInfo.isUnavailable())
-      if (shouldConstrainUnavailableDomains(otherDomainInfo.getDomain(),
-                                            domainInfos))
-        domainInfosToAdd.push_back(otherDomainInfo);
+    isConstrained |=
+        constrainDomainInfos(otherDomainInfo, domainInfos, domainInfosToAdd);
   }
 
-  if (domainInfosToAdd.size() < 1)
+  if (!isConstrained)
     return false;
 
-  // Add the candidate domain and then re-sort.
+  // Add the new domains and then re-sort.
   for (auto domainInfo : domainInfosToAdd)
     domainInfos.push_back(domainInfo);
 
   llvm::sort(domainInfos, AvailabilityDomainInfoComparator());
   return true;
+}
+
+bool AvailabilityContext::DomainInfo::constrainRange(
+    const AvailabilityRange &otherRange) {
+  return ::constrainRange(range, otherRange);
 }
 
 AvailabilityContext
@@ -119,6 +155,23 @@ AvailabilityContext::forDeploymentTarget(const ASTContext &ctx) {
 
 AvailabilityRange AvailabilityContext::getPlatformRange() const {
   return storage->platformRange;
+}
+
+std::optional<AvailabilityRange>
+AvailabilityContext::getAvailabilityRange(AvailabilityDomain domain,
+                                          const ASTContext &ctx) const {
+  DEBUG_ASSERT(domain.supportsContextRefinement());
+
+  if (domain.isActiveForTargetPlatform(ctx)) {
+    return storage->platformRange;
+  }
+
+  for (auto domainInfo : storage->getDomainInfos()) {
+    if (domain == domainInfo.getDomain() && !domainInfo.isUnavailable())
+      return domainInfo.getRange();
+  }
+
+  return std::nullopt;
 }
 
 bool AvailabilityContext::isUnavailable() const {
@@ -162,14 +215,30 @@ void AvailabilityContext::constrainWithContext(const AvailabilityContext &other,
 }
 
 void AvailabilityContext::constrainWithPlatformRange(
-    const AvailabilityRange &otherPlatformRange, const ASTContext &ctx) {
-
+    const AvailabilityRange &range, const ASTContext &ctx) {
   auto platformRange = storage->platformRange;
-  if (!constrainRange(platformRange, otherPlatformRange))
+  if (!constrainRange(platformRange, range))
     return;
 
   storage = Storage::get(platformRange, storage->isDeprecated,
                          storage->getDomainInfos(), ctx);
+}
+
+void AvailabilityContext::constrainWithAvailabilityRange(
+    const AvailabilityRange &range, AvailabilityDomain domain,
+    const ASTContext &ctx) {
+
+  if (domain.isActiveForTargetPlatform(ctx)) {
+    constrainWithPlatformRange(range, ctx);
+    return;
+  }
+
+  auto domainInfos = storage->copyDomainInfos();
+  if (!constrainDomainInfos(domainInfos, {DomainInfo(domain, range)}))
+    return;
+
+  storage = Storage::get(storage->platformRange, storage->isDeprecated,
+                         domainInfos, ctx);
 }
 
 void AvailabilityContext::constrainWithUnavailableDomain(
@@ -196,6 +265,9 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
   bool isDeprecated = storage->isDeprecated;
   isConstrained |= constrainBool(isDeprecated, decl->isDeprecated());
 
+  // Compute the availability constraints for the decl when used in this context
+  // and then map those constraints to domain infos. The result will be merged
+  // into the existing domain infos for this context.
   llvm::SmallVector<DomainInfo, 4> declDomainInfos;
   AvailabilityConstraintFlags flags =
       AvailabilityConstraintFlag::SkipEnclosingExtension;
@@ -211,13 +283,13 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
       declDomainInfos.push_back(DomainInfo::unavailable(domain));
       break;
     case AvailabilityConstraint::Reason::PotentiallyUnavailable:
-      DEBUG_ASSERT(domain.isPlatform());
-      if (domain.isPlatform()) {
-        if (auto introducedRange = attr.getIntroducedRange(ctx))
+      if (auto introducedRange = attr.getIntroducedRange(ctx)) {
+        if (domain.isActiveForTargetPlatform(ctx)) {
           isConstrained |= constrainRange(platformRange, *introducedRange);
+        } else {
+          declDomainInfos.push_back({domain, *introducedRange});
+        }
       }
-      // FIXME: [availability] Store other potentially unavailable domains in
-      // domainInfos.
       break;
     }
   }
@@ -285,14 +357,36 @@ void AvailabilityContext::print(llvm::raw_ostream &os) const {
 
 void AvailabilityContext::dump() const { print(llvm::errs()); }
 
-bool AvailabilityContext::verify(const ASTContext &ctx) const {
-  // Domain infos must be sorted to ensure folding set node lookups yield
-  // consistent results.
-  if (!llvm::is_sorted(storage->getDomainInfos(),
-                       AvailabilityDomainInfoComparator()))
-    return false;
+bool verifyDomainInfos(
+    llvm::ArrayRef<AvailabilityContext::DomainInfo> domainInfos) {
+  // Checks that the following invariants hold:
+  //   - The domain infos are sorted using AvailabilityDomainInfoComparator.
+  //   - There is not more than one info per-domain.
+  if (domainInfos.empty())
+    return true;
+
+  AvailabilityDomainInfoComparator compare;
+  auto prev = domainInfos.begin();
+  auto next = prev;
+  auto end = domainInfos.end();
+  for (++next; next != end; prev = next, ++next) {
+    const auto &prevInfo = *prev;
+    const auto &nextInfo = *next;
+
+    if (compare(nextInfo, prevInfo))
+      return false;
+
+    // Since the infos are sorted by domain, infos with the same domain should
+    // be adjacent.
+    if (prevInfo.getDomain() == nextInfo.getDomain())
+      return false;
+  }
 
   return true;
+}
+
+bool AvailabilityContext::verify(const ASTContext &ctx) const {
+  return verifyDomainInfos(storage->getDomainInfos());
 }
 
 void AvailabilityContext::Storage::Profile(

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -212,9 +212,10 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
       break;
     case AvailabilityConstraint::Reason::PotentiallyUnavailable:
       DEBUG_ASSERT(domain.isPlatform());
-      if (domain.isPlatform())
-        isConstrained |=
-            constrainRange(platformRange, attr.getIntroducedRange(ctx));
+      if (domain.isPlatform()) {
+        if (auto introducedRange = attr.getIntroducedRange(ctx))
+          isConstrained |= constrainRange(platformRange, *introducedRange);
+      }
       // FIXME: [availability] Store other potentially unavailable domains in
       // domainInfos.
       break;

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -76,6 +76,19 @@ bool AvailabilityDomain::isVersioned() const {
   }
 }
 
+bool AvailabilityDomain::supportsContextRefinement() const {
+  switch (getKind()) {
+  case Kind::Universal:
+  case Kind::Embedded:
+  case Kind::SwiftLanguage:
+  case Kind::PackageDescription:
+    return false;
+  case Kind::Platform:
+  case Kind::Custom:
+    return true;
+  }
+}
+
 bool AvailabilityDomain::supportsQueries() const {
   switch (getKind()) {
   case Kind::Universal:
@@ -103,6 +116,17 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
     // the future someone might want to define a domain but leave it inactive.
     return true;
   }
+}
+
+bool AvailabilityDomain::isActiveForTargetPlatform(
+    const ASTContext &ctx) const {
+  if (isPlatform()) {
+    if (auto targetDomain = AvailabilityDomain::forTargetPlatform(ctx)) {
+      auto compatibleDomain = targetDomain->getABICompatibilityDomain();
+      return compatibleDomain.contains(*this);
+    }
+  }
+  return false;
 }
 
 static std::optional<llvm::VersionTuple>

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1747,6 +1747,7 @@ bool DeclContext::isAlwaysAvailableConformanceContext() const {
 
   auto &ctx = getASTContext();
 
+  // FIXME: [availability] Query AvailabilityContext, not platform range.
   AvailabilityRange conformanceAvailability{
       AvailabilityInference::availableRange(ext)};
 

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -88,7 +88,7 @@ bool CodeCompletionDiagnostics::getDiagnosticForDeprecated(
   // So getter/setter specific availability doesn't work in code completion.
 
   auto Domain = Attr.getDomain();
-  auto DeprecatedRange = Attr.getDeprecatedRange(Ctx);
+  auto DeprecatedRange = Attr.getDeprecatedRange(Ctx).value();
   auto Message = Attr.getMessage();
   auto NewName = Attr.getRename();
   if (!isSoftDeprecated) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2840,7 +2840,7 @@ static void diagnoseIfDeprecated(SourceRange ReferenceRange,
     return;
 
   auto Domain = Attr->getDomain();
-  auto DeprecatedRange = Attr->getDeprecatedRange(Context);
+  auto DeprecatedRange = Attr->getDeprecatedRange(Context).value();
   auto Message = Attr->getMessage();
   auto NewName = Attr->getRename();
   if (Message.empty() && NewName.empty()) {
@@ -2919,7 +2919,7 @@ static bool diagnoseIfDeprecated(SourceLoc loc,
   auto proto = rootConf->getProtocol()->getDeclaredInterfaceType();
 
   auto domain = attr->getDomain();
-  auto deprecatedRange = attr->getDeprecatedRange(ctx);
+  auto deprecatedRange = attr->getDeprecatedRange(ctx).value();
   auto message = attr->getMessage();
   if (message.empty()) {
     ctx.Diags
@@ -3071,12 +3071,12 @@ bool diagnoseExplicitUnavailability(SourceLoc loc,
     break;
   case AvailabilityConstraint::Reason::UnavailableForDeployment:
     diags.diagnose(ext, diag::conformance_availability_introduced_in_version,
-                   type, proto, domain, attr.getIntroducedRange(ctx));
+                   type, proto, domain, attr.getIntroducedRange(ctx).value());
     break;
   case AvailabilityConstraint::Reason::Obsoleted:
     diags
         .diagnose(ext, diag::conformance_availability_obsoleted, type, proto,
-                  domain, attr.getObsoletedRange(ctx))
+                  domain, attr.getObsoletedRange(ctx).value())
         .highlight(attr.getParsedAttr()->getRange());
     break;
   case AvailabilityConstraint::Reason::PotentiallyUnavailable:
@@ -3492,13 +3492,13 @@ bool diagnoseExplicitUnavailability(
   case AvailabilityConstraint::Reason::UnavailableForDeployment:
     diags
         .diagnose(D, diag::availability_introduced_in_version, D, domain,
-                  Attr.getIntroducedRange(ctx))
+                  Attr.getIntroducedRange(ctx).value())
         .highlight(sourceRange);
     break;
   case AvailabilityConstraint::Reason::Obsoleted:
     diags
         .diagnose(D, diag::availability_obsoleted, D, domain,
-                  Attr.getObsoletedRange(ctx))
+                  Attr.getObsoletedRange(ctx).value())
         .highlight(sourceRange);
     break;
   case AvailabilityConstraint::Reason::PotentiallyUnavailable:

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2248,27 +2248,23 @@ static Diagnostic getPotentialUnavailabilityDiagnostic(
     bool WarnBeforeDeploymentTarget, bool &IsError) {
   ASTContext &Context = ReferenceDC->getASTContext();
 
-  if (!Availability.hasMinimumVersion()) {
-    // FIXME: [availability] Need a version-less diagnostic.
-    return Diagnostic(diag::availability_decl_only_version_newer, D, Domain,
-                      AvailabilityRange(llvm::VersionTuple()));
-  }
-
   if (requiresDeploymentTargetOrEarlier(Domain, Availability, Context)) {
     // The required OS version is at or before the deployment target so this
     // diagnostic should indicate that the decl could be unavailable to clients
     // of the module containing the reference.
     IsError = !WarnBeforeDeploymentTarget;
 
-    return Diagnostic(
-        IsError ? diag::availability_decl_only_version_newer_for_clients
-                : diag::availability_decl_only_version_newer_for_clients_warn,
-        D, Domain, Availability, ReferenceDC->getParentModule());
+    auto diag = Diagnostic(diag::availability_decl_only_in_for_clients, D,
+                           Domain, Availability.hasMinimumVersion(),
+                           Availability, ReferenceDC->getParentModule());
+    if (!IsError)
+      diag.setBehaviorLimit(DiagnosticBehavior::Warning);
+    return diag;
   }
 
   IsError = true;
-  return Diagnostic(diag::availability_decl_only_version_newer, D, Domain,
-                    Availability);
+  return Diagnostic(diag::availability_decl_only_in, D, Domain,
+                    Availability.hasMinimumVersion(), Availability);
 }
 
 // Emits a diagnostic for a reference to a declaration that is potentially
@@ -2311,13 +2307,14 @@ static void diagnosePotentialAccessorUnavailability(
 
   assert(Accessor->isGetterOrSetter());
 
-  auto &diag = ForInout ? diag::availability_inout_accessor_only_version_newer
-                        : diag::availability_decl_only_version_newer;
+  auto &diag = ForInout ? diag::availability_inout_accessor_only_in
+                        : diag::availability_decl_only_in;
 
   {
-    auto Err = Context.Diags.diagnose(ReferenceRange.Start, diag, Accessor,
-                                      Context.getTargetAvailabilityDomain(),
-                                      Availability);
+    auto Err =
+        Context.Diags.diagnose(ReferenceRange.Start, diag, Accessor,
+                               Context.getTargetAvailabilityDomain(),
+                               Availability.hasMinimumVersion(), Availability);
 
     // Direct a fixit to the error if an existing guard is nearly-correct
     if (fixAvailabilityByNarrowingNearbyVersionCheck(

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3128,6 +3128,7 @@ public:
 
     // An associated type that was introduced after the protocol
     auto module = AT->getDeclContext()->getParentModule();
+    // FIXME: [availability] Query AvailabilityContext, not platform range.
     if (!defaultType &&
         module->getResilienceStrategy() == ResilienceStrategy::Resilient &&
         AvailabilityInference::availableRange(proto).isSupersetOf(

--- a/test/Parse/diagnose_availability_windows.swift
+++ b/test/Parse/diagnose_availability_windows.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift
-// REQUIRES: OS=windows-msvc
+// RUN: %target-typecheck-verify-swift -target x86_64-unknown-windows-msvc -parse-stdlib
 
 // expected-note@+2{{'unavailable()' has been explicitly marked unavailable here}}
 @available(Windows, unavailable, message: "unsupported")

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -137,6 +137,34 @@ overloadedFunction()
 overloadedFunction(0) // expected-error {{'overloadedFunction' is only available in macOS 51 or newer}}
     // expected-note@-1 {{add 'if #available' version check}}
 
+@available(OSX, deprecated, introduced: 51)
+func globalFuncDeprecatedAndAvailableOn51() -> Int { return 51 }
+
+@available(OSX, introduced: 51, deprecated: 52)
+func globalFuncAvailableOn51Deprecated52() -> Int { return 51 }
+
+@available(OSX, introduced: 51, obsoleted: 52)
+func globalFuncAvailableOn51Obsoleted52() -> Int { return 51 }
+
+@available(OSX, unavailable, introduced: 51)
+func globalFuncUnavailableAndIntroducedOn51() -> Int { return 51 } // expected-note 2 {{'globalFuncUnavailableAndIntroducedOn51()' has been explicitly marked unavailable here}}
+
+let _ = globalFuncDeprecatedAndAvailableOn51() // expected-error {{'globalFuncDeprecatedAndAvailableOn51()' is only available in macOS 51 or newer}}
+// expected-note@-1 {{add 'if #available' version check}}
+// expected-warning@-2 {{'globalFuncDeprecatedAndAvailableOn51()' is deprecated in macOS}}
+let _ = globalFuncAvailableOn51Deprecated52() // expected-error {{'globalFuncAvailableOn51Deprecated52()' is only available in macOS 51 or newer}}
+// expected-note@-1 {{add 'if #available' version check}}
+let _ = globalFuncAvailableOn51Obsoleted52() // expected-error {{'globalFuncAvailableOn51Obsoleted52()' is only available in macOS 51 or newer}}
+// expected-note@-1 {{add 'if #available' version check}}
+let _ = globalFuncUnavailableAndIntroducedOn51() // expected-error {{'globalFuncUnavailableAndIntroducedOn51()' is unavailable in macOS}}
+
+if #available(OSX 51, *) {
+  let _ = globalFuncDeprecatedAndAvailableOn51() // expected-warning {{'globalFuncDeprecatedAndAvailableOn51()' is deprecated in macOS}}
+  let _ = globalFuncAvailableOn51Deprecated52()
+  let _ = globalFuncAvailableOn51Obsoleted52()
+  let _ = globalFuncUnavailableAndIntroducedOn51() // expected-error {{'globalFuncUnavailableAndIntroducedOn51()' is unavailable in macOS}}
+}
+
 // Potentially unavailable methods
 
 class ClassWithPotentiallyUnavailableMethod {


### PR DESCRIPTION
This enables potential unavailability diagnostics to be emitted for decls that are only available in a version-less domain.