### PR TITLE
Fix copy-to-borrow optimization's end_borrow insertion

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CopyToBorrowOptimization.swift
@@ -124,10 +124,6 @@ private struct Uses {
   // E.g. the none-case of a switch_enum of an Optional.
   private(set) var nonDestroyingLiverangeExits: Stack<Instruction>
 
-  var allLifetimeEndingInstructions: [Instruction] {
-    Array(destroys.lazy.map { $0 }) + Array(nonDestroyingLiverangeExits)
-  }
-
   private(set) var usersInDeadEndBlocks: Stack<Instruction>
 
   init(_ context: FunctionPassContext) {
@@ -323,7 +319,16 @@ private func createEndBorrows(for beginBorrow: Value, atEndOf liverange: Instruc
   //   destroy_value %2
   //   destroy_value %3  // The final destroy. Here we need to create the `end_borrow`(s)
   //
-  for endInst in collectedUses.allLifetimeEndingInstructions {
+
+  var allLifetimeEndingInstructions = InstructionWorklist(context)
+  allLifetimeEndingInstructions.pushIfNotVisited(contentsOf: collectedUses.destroys.lazy.map { $0 })
+  allLifetimeEndingInstructions.pushIfNotVisited(contentsOf: collectedUses.nonDestroyingLiverangeExits)
+
+  defer {
+    allLifetimeEndingInstructions.deinitialize()
+  }
+
+  while let endInst = allLifetimeEndingInstructions.pop() {
     if !liverange.contains(endInst) {
       let builder = Builder(before: endInst, context)
       builder.createEndBorrow(of: beginBorrow)

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -2156,3 +2156,49 @@ bb0(%0 : $*MultiPayload):
   return %2
 }
 
+// CHECK-LABEL: sil [ossa] @duplicate_lifetime_end1 :
+// CHECK:         load_borrow %0
+// CHECK:       } // end sil function 'duplicate_lifetime_end1'
+sil [ossa] @duplicate_lifetime_end1 : $@convention(thin) (@in_guaranteed (C, Optional<C>)) -> () {
+bb0(%0 : $*(C, Optional<C>)):
+  %1 = load [copy] %0
+  (%2, %3) = destructure_tuple %1
+  switch_enum %3, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%4 : @owned $C):
+  destroy_value %2
+  destroy_value %4
+  br bb3
+
+bb2:
+  debug_value %2
+  destroy_value %2
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL: sil [ossa] @duplicate_lifetime_end2 :
+// CHECK:         load_borrow %0
+// CHECK:       } // end sil function 'duplicate_lifetime_end2'
+sil [ossa] @duplicate_lifetime_end2 : $@convention(thin) (@in_guaranteed (C, Optional<C>)) -> () {
+bb0(%0 : $*(C, Optional<C>)):
+  %1 = load [copy] %0
+  (%2, %3) = destructure_tuple %1
+  switch_enum %3, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%4 : @owned $C):
+  destroy_value %2
+  destroy_value %4
+  br bb3
+
+bb2:
+  destroy_value %2
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r
+}


### PR DESCRIPTION
allLifetimeEndingInstructions collects insertion points for end_borrows, and can end up having duplicate entries in the case of enums with non payloaded cases.

Unique the entries so we don't end up with multiple end_borrows

Fixes rdar://146212574

