### PR TITLE
[DiagnosticBridge] Make sure that diagnostic queues up its child notes

### DIFF
--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -77,6 +77,13 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
                                    documentationPath.size(),
                                    highlightRanges.data(),
                                    highlightRanges.size() / 2);
+
+  // TODO: A better way to do this would be to pass the notes as an
+  // argument to `swift_ASTGen_addQueuedDiagnostic` but that requires
+  // bridging of `Note` structure and new serialization.
+  for (auto *childNote : info.ChildDiagnosticInfo) {
+    addQueueDiagnostic(queuedDiagnostics, *childNote, SM);
+  }
 }
 
 void DiagnosticBridge::enqueueDiagnostic(SourceManager &SM,

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -339,12 +339,19 @@ public func addQueuedDiagnostic(
     }
   }
 
-  let category: DiagnosticCategory? = categoryName.map { categoryNamePtr in
+  let category: DiagnosticCategory? = categoryName.flatMap { categoryNamePtr in
     let categoryNameBuffer = UnsafeBufferPointer(
       start: categoryNamePtr,
       count: categoryLength
     )
     let categoryName = String(decoding: categoryNameBuffer, as: UTF8.self)
+
+    // If the data comes from serialized diagnostics, it's possible that
+    // the category name is empty because StringRef() is serialized into
+    // an empty string.
+    guard !categoryName.isEmpty else {
+      return nil
+    }
 
     let documentationURL = documentationPath.map { documentationPathPtr in
       let documentationPathBuffer = UnsafeBufferPointer(

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -617,7 +617,7 @@ llvm::Error DiagnosticSerializer::deserializeDiagnosticInfo(
                                   Kind,
                                   Info.FormatString,
                                   {},
-                                  Info.Category,
+                                  Info.Category.empty() ? StringRef() : Info.Category,
                                   *BICD,
                                   ChildDiagPtrs,
                                   Ranges,

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -617,7 +617,7 @@ llvm::Error DiagnosticSerializer::deserializeDiagnosticInfo(
                                   Kind,
                                   Info.FormatString,
                                   {},
-                                  Info.Category.empty() ? StringRef() : Info.Category,
+                                  Info.Category,
                                   *BICD,
                                   ChildDiagPtrs,
                                   Ranges,

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -66,6 +66,9 @@ foo(b:
     1,
     a: 2)
 
+// Test for child notes attached directly to a "primary" error/warning diagnostic
+func test(a: Int) {}
+func test(a: Int) {}
 
 // Test fallback for non-ASCII characters.
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:11
@@ -85,3 +88,9 @@ foo(b:
 // CHECK:  [[#LINE]] | foo(b: 1, a: 2)
 // CHECK:              |         `- error: argument 'a' must precede argument 'b'
 // CHECK: [[#LINE+1]]  |
+
+// CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:6
+// CHECK:  [[#LINE-1]] | func test(a: Int) {}
+// CHECK:              |      `- note: 'test(a:)' previously declared here
+// CHECK:  [[#LINE]]   |  func test(a: Int) {}
+// CHECL:  [[#LINE+1]] |       `- error: invalid redeclaration of 'test(a:)'


### PR DESCRIPTION
`DiagnosticEngine` has an API that allows to attach notes to a "primary" diagnostic (an error or a warning). This works well with old formatting (`llvm`) but `swift` formatter doesn't display attached notes which makes some diagnostics very hard to work with i.e. `invalid_redecl`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
