### PR TITLE
CapturePropagation: handle existential keypaths

### DIFF
--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -71,6 +71,9 @@ static SILInstruction *getConstant(SILValue V) {
   if (auto *uc = dyn_cast<UpcastInst>(V))
     V = uc->getOperand();
 
+  if (auto *oer = dyn_cast<OpenExistentialRefInst>(V))
+    V = oer->getOperand();
+
   if (auto *kp = dyn_cast<KeyPathInst>(V)) {
     // We could support operands, if they are constants, to enable propagation
     // of subscript keypaths. This would require to add the operands in the
@@ -566,11 +569,13 @@ bool CapturePropagation::optimizePartialApply(PartialApplyInst *PAI) {
       // instruction.
       //
       // For non-escaping closures:
-      // The keypath is not consumed by the PAI. We don't need todelete the
+      // The keypath is not consumed by the PAI. We don't need to delete the
       // keypath instruction in this pass, but let dead-object-elimination clean
       // it up later.
       if (!PAI->isOnStack()) {
         SILInstruction *user = getSingleNonDebugUser(kp);
+        if (auto *oer = dyn_cast_or_null<OpenExistentialRefInst>(user))
+          user = getSingleNonDebugUser(oer);
         if (auto *uc = dyn_cast_or_null<UpcastInst>(user))
           user = getSingleNonDebugUser(uc);
 

--- a/test/SILOptimizer/capture_propagate_keypath.swift
+++ b/test/SILOptimizer/capture_propagate_keypath.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend  -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend  -primary-file %s -swift-version 6 -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
 
 // Also do an end-to-end test to check if the generated code is correct.
 // RUN: %empty-directory(%t) 

--- a/test/SILOptimizer/capture_propagation.sil
+++ b/test/SILOptimizer/capture_propagation.sil
@@ -601,6 +601,25 @@ bb0:
   return %7 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @testCastKeypathOSSA2 :
+// CHECK-NOT:     keypath
+// CHECK:       } // end sil function 'testCastKeypathOSSA2'
+sil [ossa] @testCastKeypathOSSA2 : $@convention(thin) () -> () {
+bb0:
+  %0 = keypath $any WritableKeyPath<Str, Int> & Sendable, (root $Str; stored_property #Str.a : $Int)
+  %o = open_existential_ref %0 to $@opened("E66BBE78-FA9E-11EF-B968-0EA13E3AABB4", any WritableKeyPath<Str, Int> & Sendable) Self
+  %c = upcast %o to $KeyPath<Str, Int>
+  %1 = function_ref @closureWithKeypathOSSA : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int
+  %2 = partial_apply [callee_guaranteed] %1(%c) : $@convention(thin) (Str, @guaranteed KeyPath<Str, Int>) -> Int
+  %3 = convert_escape_to_noescape %2 : $@callee_guaranteed (Str) -> Int to $@noescape @callee_guaranteed (Str) -> Int
+  %4 = function_ref @calleeWithKeypath : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Int) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@noescape @callee_guaranteed (Str) -> Int) -> ()
+  destroy_value %3 : $@noescape @callee_guaranteed (Str) -> Int
+  destroy_value %2 : $@callee_guaranteed (Str) -> Int
+  %7 = tuple ()
+  return %7 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @testKeypathNoescapeOSSA
 // CHECK:         [[K:%[0-9]+]] = keypath
 // CHECK:         [[C:%[0-9]+]] = function_ref @$s22closureWithKeypathOSSA{{.*}}main3StrVSiTf3npk_n


### PR DESCRIPTION
Handle open_existential_ref instructions which cast keypath instructions before they are passed to a partial_apply. In Swift language mode 6 keypaths are existentials (e.g. `any WritableKeyPath<Str, Int> & Sendable`) and we need to deal with that in CapturePropagation.

rdar://141370412

This is a follow-up of https://github.com/swiftlang/swift/pull/78160