### PR TITLE
[cxx-interop] Allow AppKit & UIKit to be rebuilt with C++ interop enabled

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2106,10 +2106,7 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   // interop enabled by the Swift CI because it uses an old host SDK.
   // FIXME: Hack for CoreGraphics.swiftmodule, which cannot be rebuilt because
   // of a CF_OPTIONS bug (rdar://142762174).
-  // FIXME: Hack for AppKit.swiftmodule / UIKit.swiftmodule, which cannot be
-  // rebuilt because of an NS_OPTIONS bug (rdar://143033209)
-  if (moduleName == "Darwin" || moduleName == "CoreGraphics"
-      || moduleName == "AppKit" || moduleName == "UIKit") {
+  if (moduleName == "Darwin" || moduleName == "CoreGraphics") {
     subInvocation.getLangOptions().EnableCXXInterop = false;
     subInvocation.getLangOptions().cxxInteropCompatVersion = {};
     BuildArgs.erase(llvm::remove_if(BuildArgs,

--- a/test/Interop/Cxx/enum/Inputs/CFAvailability.h
+++ b/test/Interop/Cxx/enum/Inputs/CFAvailability.h
@@ -10,13 +10,9 @@
 #endif
 
 #if (__cplusplus)
-#define CF_OPTIONS(_type, _name)                                               \
-  _type __attribute__((availability(swift, unavailable))) _name;               \
-  enum __CF_OPTIONS_ATTRIBUTES : _name
+#define CF_OPTIONS(_type, _name) __attribute__((availability(swift,unavailable))) _type _name; enum __CF_OPTIONS_ATTRIBUTES : _name
 #else
-#define CF_OPTIONS(_type, _name)                                               \
-  enum __CF_OPTIONS_ATTRIBUTES _name : _type _name;                            \
-  enum _name : _type
+#define CF_OPTIONS(_type, _name) enum __CF_OPTIONS_ATTRIBUTES _name : _type _name; enum _name : _type
 #endif
 
 #define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)

--- a/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
+++ b/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
@@ -27,8 +27,7 @@
 // CHECK:   static var All: SOColorMask { get }
 // CHECK: }
 
-// CHECK: @available(*, unavailable, message: "Not available in Swift")
-// CHECK: typealias CFColorMask = UInt32
+// CHECK-NOT: typealias CFColorMask = UInt32
 
 // CHECK: struct CFColorMask : OptionSet {
 // CHECK:   init(rawValue: UInt32)

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-NS_REFINED_FOR_SWIFT.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-NS_REFINED_FOR_SWIFT.swift
@@ -3,8 +3,9 @@
 
 import CenumsNSOptions
 
-// CHECK:      typealias NSAttributedStringFormattingOptions = UInt
-// CHECK-NEXT: struct __NSAttributedStringFormattingOptions : OptionSet, @unchecked Sendable {
+// CHECK-NOT: typealias NSAttributedStringFormattingOptions = UInt
+
+// CHECK: struct __NSAttributedStringFormattingOptions : OptionSet, @unchecked Sendable {
 // CHECK-NEXT:   init(rawValue: UInt)
 // CHECK-NEXT:   let rawValue: UInt
 // CHECK-NEXT:   typealias RawValue = UInt

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
@@ -3,8 +3,9 @@
 
 import CenumsNSOptions
 
-// CHECK: typealias NSBinarySearchingOptions = UInt
-// CHECK-NEXT: struct NSBinarySearchingOptions : OptionSet, @unchecked Sendable {
+// CHECK-NOT: typealias NSBinarySearchingOptions = UInt
+
+// CHECK: struct NSBinarySearchingOptions : OptionSet, @unchecked Sendable {
 // CHECK-NEXT:   init(rawValue: UInt)
 // CHECK-NEXT:   let rawValue: UInt
 // CHECK-NEXT:   typealias RawValue = UInt


### PR DESCRIPTION
This removes a workaround from the module interface loader, which was forcing AppKit and UIKit to be rebuilt from their textual interfaces with C++ interop disabled, even if the current compilation explicitly enables it.

The workaround was previously put in place because of a compiler error:
```
error: type 'AttributeScopes.AppKitAttributes.StrikethroughStyleAttribute' does not conform to protocol 'AttributedStringKey'
note: possibly intended match 'AttributeScopes.AppKitAttributes.StrikethroughStyleAttribute.Value' (aka 'NSUnderlineStyle') does not conform to 'Hashable'
```

`NSUnderlineStyle` is a C/C++ type from AppKit that is declared using `NS_OPTIONS` macro. `NS_OPTIONS`/`CF_OPTIONS` macros have different expansions in C vs C++ language modes. The C++ expansions weren't handled correctly by ClangImporter, resulting in two distinct Swift types being created: a `typealias NSUnderlineStyle` which was marked as unavailable in Swift, and `enum NSUnderlineStyle`. This mostly worked fine, since the lookup logic was picking the enum during regular name lookup. However, this silently broke down when rebuilding the explicit conformance from `AppKit.swiftinterface`:
```
extension AppKit.NSUnderlineStyle : Swift.Hashable {}
```
Swift was picking the (unavailable) typealias when rebuilding this extension, which means the (available) enum wasn't getting the conformance.

This is verified by an existing test (`test/Interop/Cxx/objc-correctness/appkit-uikit.swift`).

rdar://142961112

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
