### PR TITLE
[Observation] ensure event triggers on deinitialization passes as if all properties that are being observed have changed (for weak storage)

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -110,7 +110,7 @@ public struct ObservationRegistrar: Sendable {
       }
     }
 
-    internal mutating func cancelAll() {
+    internal mutating func deinitialize() {
       observations.removeAll()
       lookups.removeAll()
     }
@@ -157,8 +157,11 @@ public struct ObservationRegistrar: Sendable {
       state.withCriticalRegion { $0.cancel(id) }
     }
 
-    internal func cancelAll() {
-      state.withCriticalRegion { $0.cancelAll() }
+    internal func deinitialize() {
+      let tracking = state.withCriticalRegion { $0.deinitialize() }
+      for action in tracking {
+        action()
+      }
     }
     
     internal func willSet<Subject: Observable, Member>(
@@ -189,7 +192,7 @@ public struct ObservationRegistrar: Sendable {
     }
 
     deinit {
-      context.cancelAll()
+      context.deinitialize()
     }
   }
   

--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -110,9 +110,18 @@ public struct ObservationRegistrar: Sendable {
       }
     }
 
-    internal mutating func deinitialize() {
+    internal mutating func deinitialize() -> [@Sendable () -> Void] {
+      var trackers = [@Sendable () -> Void]()
+      for (keyPath, ids) in lookups {
+        if let tracker = observations[id]?.willSetTracker {
+           trackers.append({
+             tracker(keyPath)
+           })
+        }
+      }
       observations.removeAll()
       lookups.removeAll()
+      return trackers
     }
     
     internal mutating func willSet(keyPath: AnyKeyPath) -> [@Sendable (AnyKeyPath) -> Void] {

--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -113,10 +113,12 @@ public struct ObservationRegistrar: Sendable {
     internal mutating func deinitialize() -> [@Sendable () -> Void] {
       var trackers = [@Sendable () -> Void]()
       for (keyPath, ids) in lookups {
-        if let tracker = observations[id]?.willSetTracker {
-           trackers.append({
-             tracker(keyPath)
-           })
+        for id in ids {
+          if let tracker = observations[id]?.willSetTracker {
+             trackers.append({
+               tracker(keyPath)
+             })
+          }
         }
       }
       observations.removeAll()

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -511,6 +511,28 @@ struct Validator {
       expectEqual(subject.container.id, startId)
     }
 
+    suite.test("weak container observation") {
+      let changed = CapturedState(state: false)
+      var contents: HasIgnoredProperty? = HasIgnoredProperty()
+      class Container {
+        var contents: weak HasIgnoredProperty?
+        init(contents: HasIgnoredProperty) {
+          self.contents = contents
+        }
+      }
+
+      let test = Container(contents: contents!)
+      withObservationTracking {
+        _blackHole(test.contents?.ignored)
+        _blackHole(test.contents?.field)
+      } onChange: {
+        changed.state = true
+      }
+      
+      contents = nil
+      expectEqual(changed.state, true)
+    }
+
     runAllTests()
   }
 }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -537,7 +537,7 @@ struct Validator {
       } onChange: {
         changed.state = true
       }
-      test = DeinitTriggeredObserver()
+      test = DeinitTriggeredObserver { }
       expectEqual(deinitialized.state, true)
       expectEqual(changed.state, true)
     }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -515,7 +515,7 @@ struct Validator {
       let changed = CapturedState(state: false)
       var contents: HasIgnoredProperty? = HasIgnoredProperty()
       class Container {
-        var contents: weak HasIgnoredProperty?
+        weak var contents: HasIgnoredProperty?
         init(contents: HasIgnoredProperty) {
           self.contents = contents
         }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -287,6 +287,12 @@ final class CowTest {
   var container = CowContainer()
 }
 
+@Observable
+final class DeinitTriggeredObserver {
+  var property: Int = 3
+}
+
+
 @main
 struct Validator {
   @MainActor
@@ -513,23 +519,13 @@ struct Validator {
 
     suite.test("weak container observation") {
       let changed = CapturedState(state: false)
-      var contents: HasIgnoredProperty? = HasIgnoredProperty()
-      class Container {
-        weak var contents: HasIgnoredProperty?
-        init(contents: HasIgnoredProperty) {
-          self.contents = contents
-        }
-      }
-
-      let test = Container(contents: contents!)
+      var test: DeinitTriggeredObserver? = DeinitTriggeredObserver()
       withObservationTracking {
-        _blackHole(test.contents?.ignored)
-        _blackHole(test.contents?.field)
+        _blackHole(test?.property)
       } onChange: {
         changed.state = true
       }
-      
-      contents = nil
+      test = nil
       expectEqual(changed.state, true)
     }
 


### PR DESCRIPTION
It was the case that `@Observable` types would participate in weak storage but not trigger change events when deallocating, that deinitialization pass would leave incorrect state in views or other systems that would track those values via `withObservationTracking`.  This now lets that deinit post as if all tracked properties are inferring a willSet (but no didSet will occur).