### PR TITLE
[CSBindings] Don't delay inferred loeading-dot base inference if sour…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -129,9 +129,15 @@ bool BindingSet::isDelayed() const {
       if (Bindings.empty())
         return true;
 
-
-      if (Bindings[0].BindingType->is<ProtocolType>())
-        return true;
+      if (Bindings[0].BindingType->is<ProtocolType>()) {
+        auto *locator = Bindings[0].getLocator();
+        // If the binding got inferred from a contextual type
+        // this set shouldn't be delayed because there won't
+        // be any other inference sources for this leading-dot
+        // syntax member.
+        if (!locator->findLast<LocatorPathElt::ContextualType>())
+          return true;
+      }
     }
 
     // Since force unwrap preserves l-valueness, resulting

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -1402,3 +1402,33 @@ func testBuildFinalResultDependentOnContextualType() {
 
 testBuildFinalResultDependentOnContextualType()
 // CHECK: Optional(42)
+
+protocol TestLeadingDot {
+}
+
+@resultBuilder
+struct IntBuilder {
+  static func buildBlock(_ v: Int) -> Int {
+    print("buildBlock: \(v)")
+    return v
+  }
+}
+
+extension TestLeadingDot where Self == NoopImpl {
+  static func test(@IntBuilder builder: () -> Int) -> NoopImpl {
+    builder()
+    return NoopImpl()
+  }
+}
+
+struct NoopImpl : TestLeadingDot {
+}
+
+func testLeadingDotSyntax(v: Int) {
+  let x: some TestLeadingDot = .test {
+    v
+  }
+}
+
+testLeadingDotSyntax(v: -42)
+// CHECK: buildBlock: -42


### PR DESCRIPTION
…ce is a contextual type

Transitively inferring a protocol type binding from a contextual type means that the binding set for a leading-dot member reference is complete because there could be no other sources of bindings when expression is connected directly to a contextual type.

Resolves: rdar://145103149

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
