### PR TITLE
utils: work towards splitting up build + test invocations

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1034,7 +1034,6 @@ function Build-CMakeProject {
     [string[]] $UseMSVCCompilers = @(), # C,CXX
     [string[]] $UseBuiltCompilers = @(), # ASM,C,CXX,Swift
     [string[]] $UsePinnedCompilers = @(), # ASM,C,CXX,Swift
-    [switch] $UseSwiftSwiftDriver = $false,
     [switch] $AddAndroidCMakeEnv = $false,
     [switch] $UseGNUDriver = $false,
     [string] $SwiftSDK = "",
@@ -1072,14 +1071,6 @@ function Build-CMakeProject {
       } else {
         $env:SCCACHE_DIR = $Cache
       }
-    }
-    if ($UseSwiftSwiftDriver) {
-      $env:SWIFT_DRIVER_SWIFT_FRONTEND_EXEC = ([IO.Path]::Combine($CompilersBinaryCache, "bin", "swift-frontend.exe"))
-    }
-
-    # TODO(compnerd) workaround swiftc.exe symlink not existing.
-    if ($UseSwiftSwiftDriver) {
-      Copy-Item -Force ([IO.Path]::Combine($DriverBinaryCache, "bin", "swift-driver.exe")) ([IO.Path]::Combine($DriverBinaryCache, "bin", "swiftc.exe"))
     }
 
     # Add additional defines (unless already present)
@@ -1218,9 +1209,7 @@ function Build-CMakeProject {
     if ($UsePinnedCompilers.Contains("Swift") -Or $UseBuiltCompilers.Contains("Swift")) {
       $SwiftArgs = @()
 
-      if ($UseSwiftSwiftDriver) {
-        TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER ([IO.Path]::Combine($DriverBinaryCache, "bin", "swiftc.exe"))
-      } elseif ($UseBuiltCompilers.Contains("Swift")) {
+      if ($UseBuiltCompilers.Contains("Swift")) {
         TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER ([IO.Path]::Combine($CompilersBinaryCache, "bin", "swiftc.exe"))
       } else {
         TryAdd-KeyValue $Defines CMAKE_Swift_COMPILER (Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath  "swiftc.exe")

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3085,8 +3085,8 @@ function Test-PackageManager {
   Build-SPMProject `
     -Action Test `
     -Src $SrcDir `
-    -Bin "$BinaryCache\$($HostArch.LLVMTarget)\PackageManagerTests" `
-    -Arch $HostArch `
+    -Bin "$BinaryCache\$($BuildArch.LLVMTarget)\PackageManagerTests" `
+    -Arch $BuildArch `
     -Xcc "-I$LibraryRoot\sqlite-3.46.0\usr\include" -Xlinker "-L$LibraryRoot\sqlite-3.46.0\usr\lib"
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3075,7 +3075,7 @@ function Build-DocC() {
     --product docc
 }
 
-function Test-PackageManager() {
+function Test-PackageManager {
   $SrcDir = if (Test-Path -Path "$SourceCache\swift-package-manager" -PathType Container) {
     "$SourceCache\swift-package-manager"
   } else {
@@ -3329,7 +3329,7 @@ if (-not $IsCrossCompiling) {
     Build-Testing Windows $HostArch -Test
   }
   if ($Test -contains "llbuild") { Test-LLBuild }
-  if ($Test -contains "swiftpm") { Test-PackageManager $HostArch }
+  if ($Test -contains "swiftpm") { Test-PackageManager }
   if ($Test -contains "swift-format") { Test-Format }
   if ($Test -contains "sourcekit-lsp") { Test-SourceKitLSP }
 }


### PR DESCRIPTION
Split up the test routine from the build routine. While we largely share the logic between the two phases, this reduces conditional logic and makes the script more linear. Incidentally, this actually comes out shorter!