### PR TITLE
utils: Cleanup timing functions in build.ps1.

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -498,9 +498,6 @@ function Invoke-BuildStep([string] $Name) {
     Add-TimingData $BuildArch.LLVMName "Windows" ($Name -replace "Build-","") $Stopwatch.Elapsed
   }
   if ($Name.Replace("Build-", "") -eq $BuildTo) {
-    if ($Summary) {
-      Write-Summary
-    }
     exit 0
   }
 }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -386,7 +386,8 @@ $IsCrossCompiling = $HostArchName -ne $BuildArchName
 $TimingData = New-Object System.Collections.Generic.List[System.Object]
 
 function Add-TimingData {
-  param(
+  param
+  (
     [Parameter(Mandatory)]
     [string] $Arch,
     [Parameter(Mandatory)]

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -391,7 +391,7 @@ function Add-TimingData {
     [Parameter(Mandatory)]
     [string] $Arch,
     [Parameter(Mandatory)]
-    [string] $Platform,
+    [Platform] $Platform,
     [Parameter(Mandatory)]
     [string] $BuildStep,
     [Parameter(Mandatory)]

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1112,6 +1112,8 @@ function Build-CMakeProject {
     Write-Host -ForegroundColor Cyan "[$([DateTime]::Now.ToString("yyyy-MM-dd HH:mm:ss"))] Building '$Src' to '$Bin' ..."
   }
 
+  $Stopwatch = [Diagnostics.Stopwatch]::StartNew()
+
   # Enter the developer command shell early so we can resolve cmake.exe
   # for version checks.
   Invoke-IsolatingEnvVars {


### PR DESCRIPTION
Create centralized functions for adding timing data and displaying the summary.
Automatically log each build step via Invoke-BuildStep.