### PR TITLE
[DebugInfo] Use Stmt EndLoc if SILLocation passed in is the Stmt EndLoc.

### DIFF
--- a/lib/SIL/IR/SILLocation.cpp
+++ b/lib/SIL/IR/SILLocation.cpp
@@ -290,8 +290,14 @@ RegularLocation::getDebugOnlyExtendedASTNodeLoc(SILLocation L,
     return new (Module) ExtendedASTNodeLoc(Empty, {D, 0});
   if (auto E = L.getAsASTNode<Expr>())
     return new (Module) ExtendedASTNodeLoc(Empty, {E, 0});
-  if (auto S = L.getAsASTNode<Stmt>())
+  if (auto S = L.getAsASTNode<Stmt>()) {
+    // If the source location of the SILLocation passed in matches the EndLoc of
+    // the Stmt, set the primary ASTNodeTy integer to 1, so that
+    // SILLocation::getSourceLoc returns the EndLoc when queried.
+    if (L.getSourceLocForDebugging() == S->getEndLoc())
+      Empty.setInt(1);
     return new (Module) ExtendedASTNodeLoc(Empty, {S, 0});
+  }
   auto P = L.getAsASTNode<Pattern>();
   return new (Module) ExtendedASTNodeLoc(Empty, {P, 0});
 }

--- a/test/DebugInfo/hop_to_executor.swift
+++ b/test/DebugInfo/hop_to_executor.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swiftc_driver %s -c -g -Onone -o - -Xllvm -sil-print-debuginfo -emit-sil -parse-as-library -module-name m |  %FileCheck %s
+
+// This test ensures that the hop_to_executor source location matches the end of the do block
+
+func getTimestamp(x: Int) async -> Int {
+  return 40 + x
+}
+func work() {}
+func foo() async {
+  do {
+    work()
+    async let timestamp2 = getTimestamp(x:2)
+    print(await timestamp2)
+  // CHECK: %[[REG:[0-9]+]] = function_ref @swift_asyncLet_finish : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> (), loc {{.*}}:[[@LINE+3]]
+  // CHECK-NEXT: %{{[0-9]+}} = apply %[[REG]](%{{[0-9]+}}, %{{[0-9]+}}) : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> (), loc{{.*}}:[[@LINE+2]]
+  // CHECK-NEXT: hop_to_executor %0, loc * {{.*}}:[[@LINE+1]]
+  }
+  work()
+}
+@main enum entry {
+  static func main() async {
+    await foo()
+  }
+}


### PR DESCRIPTION
When creating an ExtendedASTNodeLoc from a SILLocation, if the SILLocation passed in belongs to a swift::Stmt, we only ever use the Stmt's StartLoc for the SourceLocation. If the SILLocation passed in, has a SourceLocation that matches the EndLoc of the Stmt, we should correctly set the primary ASTNodeTy PointerIntPair's integer to 1, to denote that the SourceLocation dervied from the Stmt points to the EndLoc.

To explain a little more:

When we emit a `hop_to_execution` instruction in SIL, we call ` RegularLocation::getDebugOnlyLocation` on the SILLocation being passed in, which calls `RegularLocation::getDebugOnlyExtendedASTNodeLoc`. This function will create an `ExtendedASTNodeLoc` which has two AST locations, a primary location and one used for debugging:

```
struct ExtendedASTNodeLoc : public SILAllocated<ExtendedASTNodeLoc> {
    /// Primary AST location, always used for diagnostics.
    ASTNodeTy primary;
    /// Sometimes the location for diagnostics needs to be different than the
    /// one used to emit the line table for debugging.
    ASTNodeTy forDebugging;
    
    ExtendedASTNodeLoc(ASTNodeTy primary, ASTNodeTy forDebugging) :
      primary(primary), forDebugging(forDebugging) {}
  };
  ```
  
If we look at how a `SourceLoc` is derived from a `SILLocation` we can see that the `SILLocation::getSourceLoc` always calls `getStartLoc` if the pointer the `ASTNodeTy` holds is a `swift::Stmt*`, unless the `SILLocation::pointsToEnd` function returns true. 
  
The `SILLocation::pointsToEnd` function checks the primary location to see if it has a 1 as it's PointerIntPair's integer value. 

```
bool SILLocation::pointsToEnd() const {
  switch (getStorageKind()) {
  case ASTNodeKind:
    return storage.ASTNodeLoc.getInt();
  case ExtendedASTNodeKind:
    return storage.extendedASTNodeLoc->primary.getInt();
  default:
    return false;
  }
}
```

Therefore, if we know that the `SILLocation` being passed in when creating our `ExtendedASTNodeLoc` is pointing to the `EndLoc` of the `swift::Stmt`, we need to set the primary `ASTNodeTy`'s integer to 1.