### PR TITLE
GenericSpecializer: avoid an infinite loop when looking up GenericSpecializationInformation

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -3625,8 +3625,8 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::visitKeyPathInst(KeyPathInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   SmallVector<SILValue, 4> opValues;
-  for (auto &op : Inst->getAllOperands())
-    opValues.push_back(getOpValue(op.get()));
+  for (Operand *op : Inst->getRealOperands())
+    opValues.push_back(getOpValue(op->get()));
 
   recordClonedInstruction(Inst,
                           getBuilder().createKeyPath(

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -3176,7 +3176,7 @@ KeyPathInst::create(SILDebugLocation Loc,
                     ArrayRef<SILValue> Args,
                     SILType Ty,
                     SILFunction &F) {
-  assert(Args.size() == Pattern->getNumOperands()
+  ASSERT(Args.size() == Pattern->getNumOperands()
          && "number of key path args doesn't match pattern");
 
   SmallVector<SILValue, 8> allOperands(Args.begin(), Args.end());

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -370,6 +370,8 @@ static bool createsInfiniteSpecializationLoop(ApplySite Apply) {
     LLVM_DEBUG(llvm::dbgs() << "Scan caller's specialization history\n");
   }
 
+  llvm::SmallSet<const GenericSpecializationInformation *, 8> visited;
+
   while (CurSpecializationInfo) {
     LLVM_DEBUG(llvm::dbgs() << "Current caller is a specialization:\n"
                             << "Caller: "
@@ -384,6 +386,10 @@ static bool createsInfiniteSpecializationLoop(ApplySite Apply) {
                        .getReplacementTypes()) {
                  Replacement->dump(llvm::dbgs());
                });
+
+    if (!visited.insert(CurSpecializationInfo).second) {
+      return true;
+    }
 
     if (CurSpecializationInfo->getParent() == GenericFunc) {
       LLVM_DEBUG(llvm::dbgs() << "Found a call graph loop, checking "


### PR DESCRIPTION
Also, fix a bug with cloning keypath instructions, which I found while investigating the specializer problem.

Unfortunately I couldn't come up with an isolated test case for those problems.

fixes a compiler hang
rdar://146330284