### PR TITLE
Add a StdlibUnitTest modifier for requiring a stdlib version

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2112,6 +2112,11 @@ public final class TestSuite {
       return self
     }
 
+    public func require(_ stdlibVersion: StdLibVersion) -> _TestBuilder {
+      _data._skip.append(.minimumStdlib(stdlibVersion))
+      return self
+    }
+
     public func stdin(_ stdinText: String, eof: Bool = false) -> _TestBuilder {
       _data._stdinText = stdinText
       _data._stdinEndsWithEOF = eof
@@ -2202,6 +2207,35 @@ func _getSystemVersionPlistProperty(_ propertyName: String) -> String? {
 }
 #endif
 #endif
+
+public enum StdLibVersion: String {
+  case stdlib_5_7  = "5.7"
+  case stdlib_5_8  = "5.8"
+  case stdlib_5_9  = "5.9"
+  case stdlib_5_10 = "5.10"
+  case stdlib_6_0  = "6.0"
+  case stdlib_6_1  = "6.1"
+  case stdlib_6_2  = "6.2"
+  
+  var isAvailable: Bool {
+    switch self {
+    case .stdlib_5_7:
+      return if #available(SwiftStdlib 5.7, *)  { true } else { false }
+    case .stdlib_5_8:
+      return if #available(SwiftStdlib 5.8, *)  { true } else { false }
+    case .stdlib_5_9:
+      return if #available(SwiftStdlib 5.9, *)  { true } else { false }
+    case .stdlib_5_10:
+      return if #available(SwiftStdlib 5.10, *) { true } else { false }
+    case .stdlib_6_0:
+      return if #available(SwiftStdlib 6.0, *)  { true } else { false }
+    case .stdlib_6_1:
+      return if #available(SwiftStdlib 6.1, *)  { true } else { false }
+    case .stdlib_6_2:
+      return if #available(SwiftStdlib 6.2, *)  { true } else { false }
+    }
+  }
+}
 
 public enum OSVersion : CustomStringConvertible {
   case osx(major: Int, minor: Int, bugFix: Int)
@@ -2413,6 +2447,8 @@ public enum TestRunPredicate : CustomStringConvertible {
   case objCRuntime(/*reason:*/ String)
   case nativeRuntime(/*reason:*/ String)
 
+  case minimumStdlib(StdLibVersion)
+  
   public var description: String {
     switch self {
     case .custom(_, let reason):
@@ -2533,6 +2569,9 @@ public enum TestRunPredicate : CustomStringConvertible {
       return "Objective-C runtime, reason: \(reason))"
     case .nativeRuntime(let reason):
       return "Native runtime (no ObjC), reason: \(reason))"
+      
+    case .minimumStdlib(let version):
+      return "Requires Swift \(version.rawValue)'s standard library"
     }
   }
 
@@ -2921,6 +2960,9 @@ public enum TestRunPredicate : CustomStringConvertible {
 #else
       return true
 #endif
+      
+    case .minimumStdlib(let version):
+      return !version.isAvailable
     }
   }
 }

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -981,9 +981,7 @@ CastsTests.test("Recursive AnyHashable") {
 // https://github.com/apple/swift/issues/56987
 #if _runtime(_ObjC)
 CastsTests.test("Do not overuse __SwiftValue")
-.skip(.custom({
-  if #available(SwiftStdlib 5.9, *) { return false } else { return true }
-}, reason: "Requires stdlib from Swift 5.9 or later"))
+.require(.stdlib_5_9)
 .code {
   struct Bar {}
   // This used to succeed because of overeager __SwiftValue

--- a/test/stdlib/StringCreate.swift
+++ b/test/stdlib/StringCreate.swift
@@ -148,10 +148,7 @@ let s1 = "Long string containing the characters é, ß, 🦆, and 👨‍👧‍
 let s2 = "Long ascii string with no accented characters (obviously)."
 
 StringCreateTests.test("Validating.utf8")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.0, *) { false } else { true } },
-  reason: "Requires Swift 6.0's standard library"
-))
+.require(.stdlib_6_0)
 .code {
   guard #available(SwiftStdlib 6.0, *) else { return }
 
@@ -182,10 +179,7 @@ StringCreateTests.test("Validating.utf8")
 }
 
 StringCreateTests.test("Validating.utf8.from.int8")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.0, *) { false } else { true } },
-  reason: "Requires Swift 6.0's standard library"
-))
+.require(.stdlib_6_0)
 .code {
   guard #available(SwiftStdlib 6.0, *) else { return }
 
@@ -209,10 +203,7 @@ StringCreateTests.test("Validating.utf8.from.int8")
 }
 
 StringCreateTests.test("Validating.ascii")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.0, *) { false } else { true } },
-  reason: "Requires Swift 6.0's standard library"
-))
+.require(.stdlib_6_0)
 .code {
   guard #available(SwiftStdlib 6.0, *) else { return }
 
@@ -236,10 +227,7 @@ StringCreateTests.test("Validating.ascii")
 }
 
 StringCreateTests.test("Validating.utf16")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.0, *) { false } else { true } },
-  reason: "Requires Swift 6.0's standard library"
-))
+.require(.stdlib_6_0)
 .code {
   guard #available(SwiftStdlib 6.0, *) else { return }
 
@@ -263,10 +251,7 @@ StringCreateTests.test("Validating.utf16")
 }
 
 StringCreateTests.test("Validating.utf32")
-.skip(.custom(
-  { if #available(SwiftStdlib 6.0, *) { false } else { true } },
-  reason: "Requires Swift 6.0's standard library"
-))
+.require(.stdlib_6_0)
 .code {
   guard #available(SwiftStdlib 6.0, *) else { return }
 

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -578,9 +578,7 @@ UnsafeRawBufferPointerTestSuite.test("load.invalid")
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.unaligned")
-.skip(.custom({ // require SwiftStdlib 5.7
-  if #available(SwiftStdlib 5.7, *) { return false } else { return true }
-}, reason: "Requires stdlib from Swift 5.7"))
+.require(.stdlib_5_7)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var data: [UInt8] = [0, 0, 0, .max, .max, .max, .max, 0]
@@ -619,10 +617,7 @@ UnsafeRawBufferPointerTestSuite.test("store.after")
 }
 
 UnsafeRawBufferPointerTestSuite.test("store.unaligned")
-.skip(.custom({
-  if #available(SwiftStdlib 5.7, *) { return false }
-  return true
-}, reason: "Requires Swift 5.7's stdlib"))
+.require(.stdlib_5_7)
 .code {
   let count = MemoryLayout<UInt>.stride * 2
   let p1 = UnsafeMutableRawBufferPointer.allocate(
@@ -648,9 +643,7 @@ UnsafeRawBufferPointerTestSuite.test("store.unaligned")
 UnsafeRawBufferPointerTestSuite.test("store.invalid")
 .skip(.custom({ !_isDebugAssertConfiguration() }, // require debugAssert
               reason: "This tests a debug precondition.."))
-.skip(.custom({ // require SwiftStdlib 5.7
-  if #available(SwiftStdlib 5.7, *) { return false } else { return true }
-}, reason: "Requires stdlib from Swift 5.7"))
+.require(.stdlib_5_7)
 .code {
   let t = "Text that is longer than fits in a small String."
   let p1 = UnsafeMutableRawPointer.allocate(

--- a/test/stdlib/UnsafeRawPointer.swift
+++ b/test/stdlib/UnsafeRawPointer.swift
@@ -55,9 +55,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("initializeMemory") {
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("initializeMemorySingleElement")
-.skip(.custom({
-   if #available(SwiftStdlib 5.8, *) { return false } else { return true }
- }, reason: "Requires standard library from Swift 5.8"))
+.require(.stdlib_5_8)
 .code {
   Missile.missilesLaunched = 0
   let p1 = UnsafeMutableRawPointer.allocate(
@@ -112,10 +110,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load/store") {
 }
 
 UnsafeMutableRawPointerExtraTestSuite.test("load.unaligned")
-.skip(.custom({
-  if #available(SwiftStdlib 5.7, *) { return false }
-  return true
-}, reason: "Requires Swift 5.7's stdlib"))
+.require(.stdlib_5_7)
 .code {
   guard #available(SwiftStdlib 5.7, *) else { return }
   var data: [UInt8] = [0x0, 0x0, 0x0, 0xff, 0xff, 0xff, 0xff, 0x0]
@@ -158,10 +153,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("load.invalid.mutable")
 #endif
 
 UnsafeMutableRawPointerExtraTestSuite.test("store.unaligned")
-.skip(.custom({
-  if #available(SwiftStdlib 5.7, *) { return false }
-  return true
-}, reason: "Requires Swift 5.7's stdlib"))
+.require(.stdlib_5_7)
 .code {
   let count = MemoryLayout<UInt>.stride * 2
   let p1 = UnsafeMutableRawPointer.allocate(
@@ -190,10 +182,7 @@ UnsafeMutableRawPointerExtraTestSuite.test("store.unaligned")
 UnsafeMutableRawPointerExtraTestSuite.test("store.invalid")
 .skip(.custom({ !_isDebugAssertConfiguration() },
               reason: "This tests a debug precondition.."))
-.skip(.custom({
-  if #available(SwiftStdlib 5.7, *) { return false }
-  return true
-}, reason: "Requires Swift 5.7's stdlib"))
+.require(.stdlib_5_7)
 .code {
   Missile.missilesLaunched = 0
   let m = Missile(0)


### PR DESCRIPTION
It would be great if this could also set the availability for the `code:` block, but this at least cuts out some boilerplate.
