### PR TITLE
utils: remove swiftinterfaces from the build image

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3162,6 +3162,10 @@ if (-not $SkipBuild) {
 
     # Build platform: SDK, Redist and XCTest
     Invoke-BuildStep Build-Runtime Windows $Arch
+
+    # FIXME(swiftlang/swift#79839)
+    Get-ChildItem -Recurse -Path "$(Get-SwiftSDK Windows)\usr\lib\swift\windows" -Filter "*.swiftinterface" | Remove-Item -Force | Out-Null
+
     Invoke-BuildStep Build-Dispatch Windows $Arch
     # FIXME(compnerd) ensure that the _build_ is the first arch and don't rebuild on each arch
     Invoke-BuildStep Build-FoundationMacros -Build Windows $BuildArch
@@ -3195,6 +3199,10 @@ if (-not $SkipBuild) {
 
       # Build platform: SDK, Redist and XCTest
       Invoke-BuildStep Build-Runtime Android $Arch
+
+      # FIXME(swiftlang/swift#79839)
+      Get-ChildItem -Recurse -Path "$(Get-SwiftSDK Windows)\usr\lib\swift\android" -Filter "*.swiftinterface" | Remove-Item -Force | Out-Null
+
       Invoke-BuildStep Build-Dispatch Android $Arch
       Invoke-BuildStep Build-Foundation Android $Arch
       Invoke-BuildStep Build-Sanitizers Android $Arch


### PR DESCRIPTION
These cannot be reserialized due to a bug in the serialization logic where we do not inject the VFS Ovelay for the system modules.

Bug: #79839