### PR TITLE
SE-0458: Disambiguate postfix expressions vs. unsafe expressions more generally

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -441,7 +441,9 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
         peekToken().isAny(tok::r_paren, tok::r_brace, tok::r_square,
                           tok::equal, tok::colon, tok::comma) ||
         (isExprBasic && peekToken().is(tok::l_brace)) ||
-        peekToken().is(tok::period))) {
+        peekToken().is(tok::period) ||
+        (peekToken().isAny(tok::l_paren, tok::l_square) &&
+         peekToken().getRange().getStart() == Tok.getRange().getEnd()))) {
     Tok.setKind(tok::contextual_keyword);
     SourceLoc unsafeLoc = consumeToken();
     ParserResult<Expr> sub =

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -183,6 +183,8 @@ func acceptBools(_: Bool, _: Bool) { }
 
 func acceptBoolsUnsafeLabel(unsafe _: Bool, _: Bool) { }
 
+func unsafe(_: Int) { }
+
 func unsafeFun() {
   var unsafe = true
   unsafe = false
@@ -198,6 +200,20 @@ func unsafeFun() {
   _ = color
 
   if unsafe { }
+}
+
+func moreUnsafeFunc(unsafe: [Int]) {
+  let _: [Int] = unsafe []
+  // expected-warning@-1{{no unsafe operations occur within 'unsafe' expression}}
+
+  _ = unsafe[1]
+}
+
+func yetMoreUnsafeFunc(unsafe: () -> Void) {
+  unsafe()
+
+  _ = unsafe ()
+  // expected-warning@-1{{no unsafe operations occur within 'unsafe' expression}}
 }
 
 // @safe suppresses unsafe-type-related diagnostics on an entity


### PR DESCRIPTION
Handle call-vs-tuple and subscript-vs-collection-expr disambiguation using the same "no trivia" rule that we used to disambiguite "unsafe.x" (which we treat as a member access) from "unsafe .x" (which we treat as an unsafe expression with a leading-dot member access).

Fixes rdar://146459104.