### PR TITLE
[ASTGen] Misc fixes

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -2885,29 +2885,27 @@ struct BridgedRequirementRepr {
   BridgedNullableTypeRepr SecondType;
   BridgedLayoutConstraint LayoutConstraint;
   BridgedSourceLoc LayoutConstraintLoc;
-
-  // TODO: bool IsExpansionPattern;
+  bool IsExpansionPattern;
 
   swift::RequirementRepr unbridged() const;
 };
 
-SWIFT_NAME(
-    "BridgedRequirementRepr.createTypeConstraint(subject:colonLoc:constraint:)")
-BridgedRequirementRepr
-BridgedRequirementRepr_createTypeConstraint(BridgedTypeRepr cSubject,
-                                            BridgedSourceLoc cColonLoc,
-                                            BridgedTypeRepr cConstraint);
-SWIFT_NAME(
-    "BridgedRequirementRepr.createSameType(firstType:equalLoc:secondType:)")
-BridgedRequirementRepr
-BridgedRequirementRepr_createSameType(BridgedTypeRepr cFirstType,
-                                      BridgedSourceLoc cEqualLoc,
-                                      BridgedTypeRepr cSecondType);
+SWIFT_NAME("BridgedRequirementRepr.createTypeConstraint(subject:colonLoc:"
+           "constraint:isExpansionPattern:)")
+BridgedRequirementRepr BridgedRequirementRepr_createTypeConstraint(
+    BridgedTypeRepr cSubject, BridgedSourceLoc cColonLoc,
+    BridgedTypeRepr cConstraint, bool isExpansionPattern);
+SWIFT_NAME("BridgedRequirementRepr.createSameType(firstType:equalLoc:"
+           "secondType:isExpansionPattern:)")
+BridgedRequirementRepr BridgedRequirementRepr_createSameType(
+    BridgedTypeRepr cFirstType, BridgedSourceLoc cEqualLoc,
+    BridgedTypeRepr cSecondType, bool isExpansionPattern);
 SWIFT_NAME("BridgedRequirementRepr.createLayoutConstraint(subject:colonLoc:"
-           "layout:layoutLoc:)")
+           "layout:layoutLoc:isExpansionPattern:)")
 BridgedRequirementRepr BridgedRequirementRepr_createLayoutConstraint(
     BridgedTypeRepr cSubject, BridgedSourceLoc cColonLoc,
-    BridgedLayoutConstraint cLayout, BridgedSourceLoc cLayoutLoc);
+    BridgedLayoutConstraint cLayout, BridgedSourceLoc cLayoutLoc,
+    bool isExpansionPattern);
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedGenericTypeParamKind : size_t {
   /// A regular generic type parameter: 'T'

--- a/lib/AST/Bridging/GenericsBridging.cpp
+++ b/lib/AST/Bridging/GenericsBridging.cpp
@@ -101,23 +101,22 @@ RequirementRepr BridgedRequirementRepr::unbridged() const {
   case BridgedRequirementReprKindTypeConstraint:
     return RequirementRepr::getTypeConstraint(
         FirstType.unbridged(), SeparatorLoc.unbridged(), SecondType.unbridged(),
-        /*IsExpansionPattern=*/false);
+        IsExpansionPattern);
   case BridgedRequirementReprKindSameType:
     return RequirementRepr::getSameType(
         FirstType.unbridged(), SeparatorLoc.unbridged(), SecondType.unbridged(),
-        /*IsExpansionPattern=*/false);
+        IsExpansionPattern);
   case BridgedRequirementReprKindLayoutConstraint:
     return RequirementRepr::getLayoutConstraint(
         FirstType.unbridged(), SeparatorLoc.unbridged(),
         {LayoutConstraint.unbridged(), LayoutConstraintLoc.unbridged()},
-        /*IsExpansionPattern=*/false);
+        IsExpansionPattern);
   }
 }
 
-BridgedRequirementRepr
-BridgedRequirementRepr_createTypeConstraint(BridgedTypeRepr cSubject,
-                                            BridgedSourceLoc cColonLoc,
-                                            BridgedTypeRepr cConstraint) {
+BridgedRequirementRepr BridgedRequirementRepr_createTypeConstraint(
+    BridgedTypeRepr cSubject, BridgedSourceLoc cColonLoc,
+    BridgedTypeRepr cConstraint, bool isExpansionPattern) {
   return {
       /*SeparatorLoc=*/cColonLoc,
       /*Kind=*/BridgedRequirementReprKindTypeConstraint,
@@ -125,13 +124,13 @@ BridgedRequirementRepr_createTypeConstraint(BridgedTypeRepr cSubject,
       /*SecondType=*/cConstraint.unbridged(),
       /*LayoutConstraint=*/{},
       /*LayoutConstraintLoc=*/{},
+      /*IsExpansionPattern=*/isExpansionPattern,
   };
 }
 
-BridgedRequirementRepr
-BridgedRequirementRepr_createSameType(BridgedTypeRepr cFirstType,
-                                      BridgedSourceLoc cEqualLoc,
-                                      BridgedTypeRepr cSecondType) {
+BridgedRequirementRepr BridgedRequirementRepr_createSameType(
+    BridgedTypeRepr cFirstType, BridgedSourceLoc cEqualLoc,
+    BridgedTypeRepr cSecondType, bool isExpansionPattern) {
   return {
       /*SeparatorLoc=*/cEqualLoc,
       /*Kind=*/BridgedRequirementReprKindSameType,
@@ -139,12 +138,14 @@ BridgedRequirementRepr_createSameType(BridgedTypeRepr cFirstType,
       /*SecondType=*/cSecondType.unbridged(),
       /*LayoutConstraint=*/{},
       /*LayoutConstraintLoc=*/{},
+      /*IsExpansionPattern=*/isExpansionPattern,
   };
 }
 
 BridgedRequirementRepr BridgedRequirementRepr_createLayoutConstraint(
     BridgedTypeRepr cSubject, BridgedSourceLoc cColonLoc,
-    BridgedLayoutConstraint cLayout, BridgedSourceLoc cLayoutLoc) {
+    BridgedLayoutConstraint cLayout, BridgedSourceLoc cLayoutLoc,
+    bool isExpansionPattern) {
   return {
       /*SeparatorLoc=*/cColonLoc,
       /*Kind=*/BridgedRequirementReprKindLayoutConstraint,
@@ -152,6 +153,7 @@ BridgedRequirementRepr BridgedRequirementRepr_createLayoutConstraint(
       /*SecondType=*/nullptr,
       /*LayoutConstraint=*/cLayout,
       /*LayoutConstraintLoc=*/cLayoutLoc,
+      /*IsExpansionPattern=*/isExpansionPattern,
   };
 }
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -1682,7 +1682,7 @@ extension ASTGenVisitor {
           return nil
         }
 
-        guard let moveAsLike = args.isEmpty ? false : generateConsumingMoveAsLike() else {
+        guard let moveAsLike = args.isEmpty ? false : generateConsumingMovesAsLike() else {
           return nil
         }
 
@@ -1711,7 +1711,7 @@ extension ASTGenVisitor {
           return nil
         }
 
-        guard let moveAsLike = args.isEmpty ? false : generateConsumingMoveAsLike() else {
+        guard let moveAsLike = args.isEmpty ? false : generateConsumingMovesAsLike() else {
           return nil
         }
 
@@ -1738,10 +1738,10 @@ extension ASTGenVisitor {
         }
       }
 
-      func generateConsumingMoveAsLike() -> Bool? {
+      func generateConsumingMovesAsLike() -> Bool? {
         self.generateConsumingPlainIdentifierAttrOption(args: &args) {
           switch $0.rawText {
-          case "moveAsLike":
+          case "movesAsLike":
             return true
           default:
             // TODO: Diagnose.

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -189,6 +189,10 @@ extension ASTGenVisitor {
         return handle(self.generateUnavailableFromAsyncAttr(attribute: node)?.asDeclAttribute)
       case .none where attrName == "_unavailableInEmbedded":
         return handle(self.generateUnavailableInEmbeddedAttr(attribute: node)?.asDeclAttribute)
+      case .none where attrName == "_functionBuilder":
+        // TODO: Diagnostics. '_functionBuilder' is renamed to 'resultBuilder'
+        return handle(self.generateSimpleDeclAttr(attribute: node, kind: .resultBuilder))
+
 
       // Simple attributes.
       case .addressableSelf,

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -240,6 +240,7 @@ struct ReferenceOwnershipModifierTest<X: AnyObject> {
 }
 
 @_rawLayout(like: T) struct RawStorage<T>: ~Copyable {}
+@_rawLayout(like: T, movesAsLike) struct RawStorage2<T>: ~Copyable {}
 @_rawLayout(likeArrayOf: T, count: 4) struct RawSmallArray<T>: ~Copyable {}
 @_rawLayout(size: 4, alignment: 4) struct Lock: ~Copyable {}
 

--- a/test/ASTGen/decls.swift
+++ b/test/ASTGen/decls.swift
@@ -346,3 +346,5 @@ func testBuilder() {
     1
   }
 }
+
+struct ExpansionRequirementTest<each T> where repeat each T: Comparable {}

--- a/test/ASTGen/diagnostics.swift
+++ b/test/ASTGen/diagnostics.swift
@@ -33,3 +33,6 @@ struct S {
     subscript(x: Int) { _ = 1 } // expected-error@:23 {{expected '->' and return type in subscript}}
                                 // expected-note@-1:23 {{insert '->' and return type}}
 }
+
+struct ExpansionRequirementTest<each T> {}
+extension ExpansionRequirementTest where repeat each T == Int {} // expected-error {{same-element requirements are not yet supported}}


### PR DESCRIPTION
* Fix a typo `moveAsLike` -> `movesAsLike`
* Generate `@_functionBuilder` as `@resultBuilder`
* Handle `repeat each T` in generic requirements