### PR TITLE
MemoryLifetimeVerifier: verify `inject_enum_addr`

### DIFF
--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -732,11 +732,15 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
       case SILInstructionKind::InjectEnumAddrInst: {
         auto *IEAI = cast<InjectEnumAddrInst>(&I);
         int enumIdx = locations.getLocationIdx(IEAI->getOperand());
-        if (enumIdx >= 0 && injectsNoPayloadCase(IEAI)) {
-          // Again, an injected no-payload case is treated like a "full"
-          // initialization. See initDataflowInBlock().
-          requireBitsClear(bits & nonTrivialLocations, IEAI->getOperand(), &I);
-          locations.setBits(bits, IEAI->getOperand());
+        if (enumIdx >= 0) {
+          if (injectsNoPayloadCase(IEAI)) {
+            // Again, an injected no-payload case is treated like a "full"
+            // initialization. See initDataflowInBlock().
+            requireBitsClear(bits & nonTrivialLocations, IEAI->getOperand(), &I);
+            locations.setBits(bits, IEAI->getOperand());
+          } else {
+            requireBitsSet(bits, IEAI->getOperand(), &I);
+          }
         }
         requireNoStoreBorrowLocation(IEAI->getOperand(), &I);
         break;

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -850,3 +850,19 @@ bb0(%0 : @owned $T, %1 : @owned $Inner):
   return %8
 }
 
+sil @initfn : $@convention(thin) () -> @out T 
+
+sil [ossa] @inject_enum_case : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Optional<T>
+  %1 = function_ref @initfn : $@convention(thin) () -> @out T 
+  %2 = init_enum_data_addr %0, #Optional.some!enumelt 
+  %3 = apply %1(%2) : $@convention(thin) () -> @out T
+  inject_enum_addr %0, #Optional.some!enumelt
+  destroy_addr %0
+  dealloc_stack %0
+  %10 = tuple ()                                  
+  return %10                                      
+} 
+
+

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -809,3 +809,20 @@ bb0(%0 : @owned $T, %1 : @owned $Inner):
   return %8
 }
 
+sil @initfn : $@convention(thin) () -> @out T 
+
+// CHECK: SIL memory lifetime failure in @inject_enum_case: memory is not initialized, but should be
+sil [ossa] @inject_enum_case : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Optional<T>
+  %1 = function_ref @initfn : $@convention(thin) () -> @out T 
+  %2 = init_enum_data_addr %0, #Optional.some!enumelt 
+  %3 = apply %1(%2) : $@convention(thin) () -> @out T
+  destroy_addr %0
+  inject_enum_addr %0, #Optional.some!enumelt
+  dealloc_stack %0
+  %10 = tuple ()                                  
+  return %10                                      
+} 
+
+


### PR DESCRIPTION
Verify that the enum case payload is alive at the point of an `inject_enum_addr`
rdar://146315214
