### PR TITLE
[silgen] Place hop_to_executor emission for an apply within a formal evaluation scope.

### DIFF
--- a/test/SILGen/async_initializer.swift
+++ b/test/SILGen/async_initializer.swift
@@ -142,7 +142,8 @@ enum Birb {
 // CHECK-LABEL:  sil hidden [ossa] @$s12initializers7makeCatyyYaF : $@convention(thin) @async () -> () {
 // CHECK:          [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-NEXT:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
-// CHECK:          hop_to_executor {{%[0-9]+}} : $MainActor
+// CHECK:          hop_to_executor [[BORROWED_EXECUTOR:%[0-9]+]]
+// CHECK:          end_borrow [[BORROWED_EXECUTOR]]
 // CHECK-NEXT:     {{%[0-9]+}} = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (@owned String, @thick Cat.Type) -> @owned Cat
 // CHECK:          hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
 // CHECK:        } // end sil function '$s12initializers7makeCatyyYaF'
@@ -153,7 +154,8 @@ func makeCat() async {
 // CHECK-LABEL:  sil hidden [ossa] @$s12initializers7makeDogyyYaF : $@convention(thin) @async () -> () {
 // CHECK:          [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-NEXT:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
-// CHECK:          hop_to_executor {{%[0-9]+}} : $MainActor
+// CHECK:          hop_to_executor [[BORROWED_EXEC:%.*]] :
+// CHECK-NEXT:     end_borrow [[BORROWED_EXEC]]
 // CHECK-NEXT:     {{%[0-9]+}} = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (@owned String, @thin Dog.Type) -> Dog
 // CHECK:          hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
 // CHECK:        } // end sil function '$s12initializers7makeDogyyYaF'
@@ -164,7 +166,8 @@ func makeDog() async {
 // CHECK-LABEL:  sil hidden [ossa] @$s12initializers8makeBirbyyYaF : $@convention(thin) @async () -> () {
 // CHECK:          [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-NEXT:     hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
-// CHECK:          hop_to_executor {{%[0-9]+}} : $MainActor
+// CHECK:          hop_to_executor [[BORROWED_EXEC:%.*]] : $MainActor
+// CHECK-NEXT:     end_borrow [[BORROWED_EXEC]]
 // CHECK-NEXT:     {{%[0-9]+}} = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (@owned String, @thin Birb.Type) -> Birb
 // CHECK:          hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
 // CHECK:        } // end sil function '$s12initializers8makeBirbyyYaF'

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -270,9 +270,9 @@ struct BlueActor {
 // CHECK:       [[R:%[0-9]+]] = apply [[GETTER]]([[REDMT]]) : $@convention(method) (@thin RedActor.Type) -> @owned RedActorImpl
 // CHECK:       [[REDEXE:%[0-9]+]] = begin_borrow [[R]] : $RedActorImpl
 // CHECK:       hop_to_executor [[REDEXE]] : $RedActorImpl
+// CHECK-NEXT:  end_borrow [[REDEXE]]
       // ---- now invoke redFn, hop back to Blue, and clean-up ----
 // CHECK-NEXT:  {{%[0-9]+}} = apply [[CALLEE]]([[ARG]]) : $@convention(thin) (Int) -> ()
-// CHECK-NEXT:  end_borrow [[REDEXE]] : $RedActorImpl
 // CHECK-NEXT:  destroy_value [[R]] : $RedActorImpl
 // CHECK-NEXT:  hop_to_executor [[BLUEEXE]] : $BlueActorImpl
 // CHECK:       end_borrow [[BLUEEXE]] : $BlueActorImpl
@@ -287,8 +287,8 @@ struct BlueActor {
 // CHECK-NEXT:    hop_to_executor [[GENERIC_EXEC]] :
 // CHECK:         [[BORROW:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $RedActorImpl
 // CHECK-NEXT:    hop_to_executor [[BORROW]] : $RedActorImpl
-// CHECK-NEXT:    {{%[0-9]+}} = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(thin) (Int) -> ()
 // CHECK-NEXT:    end_borrow [[BORROW]] : $RedActorImpl
+// CHECK-NEXT:    {{%[0-9]+}} = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(thin) (Int) -> ()
 // CHECK-NEXT:    destroy_value
 // CHECK-NEXT:    hop_to_executor [[GENERIC_EXEC]]
 // CHECK: } // end sil function '$s4test20unspecifiedAsyncFuncyyYaF'
@@ -315,6 +315,7 @@ func anotherUnspecifiedAsyncFunc(_ red : RedActorImpl) async {
 // CHECK: hop_to_executor [[GENERIC_EXEC]] :
 // CHECK: function_ref @$s4test8RedActorV6sharedAA0bC4ImplCvgZ
 // CHECK: hop_to_executor [[RED:%[0-9]+]] : $RedActorImpl
+// CHECK-NEXT: end_borrow [[RED]]
 // CHECK-NEXT: begin_borrow
 // CHECK-NEXT: apply
 // CHECK:      hop_to_executor [[GENERIC_EXEC:%[0-9]+]] : $Optional<Builtin.Executor>
@@ -464,10 +465,37 @@ func asyncWithUnsafeInheritance_hopback() async {
   // CHECK-NEXT: [[ACTOR:%.*]] = apply [[ACTOR_GETTER]]([[METATYPE]])
   // CHECK-NEXT: [[BORROWED_ACTOR:%.*]] = begin_borrow [[ACTOR]]
   // CHECK-NEXT: hop_to_executor [[BORROWED_ACTOR]]
-  // CHECK-NEXT: apply [[FN]]({{%.*}})
   // CHECK-NEXT: end_borrow [[BORROWED_ACTOR]]
+  // CHECK-NEXT: apply [[FN]]({{%.*}})
   // CHECK-NEXT: destroy_value [[ACTOR]]
   // CHECK-NEXT: tuple
   // CHECK-NEXT: return
   await redFn(0)
+}
+
+// Previously we would break Ownership SSA when passing a below since when we
+// emitted the hop_to_executor, we would unnecessarily borrow a over the entire
+// apply (we only needed it to call hop_to_executor). This would cause an OSSA
+// violation since we are going to consume it as part of calling Klass's
+// initializer.
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test40validateHopToExecutorLifetimeShortEnoughyyYaF : $@convention(thin) @async () -> () {
+// CHECK: hop_to_executor %0
+// CHECK: [[ACTOR:%.*]] = init_existential_ref {{%.*}}
+// CHECK: [[INIT_FN:%.*]] = function_ref @$s4test40validateHopToExecutorLifetimeShortEnoughyyYaF5KlassL_C2onADScA_pYi_tcfC : $@convention(method) (@sil_isolated @owned any Actor, @thick Klass.Type) -> @owned Klass
+// CHECK: [[BORROW:%.*]] = begin_borrow [[ACTOR]]
+// CHECK: hop_to_executor [[BORROW]]
+// CHECK: end_borrow [[BORROW]]
+// CHECK: apply [[INIT_FN]]([[ACTOR]],
+// CHECK: hop_to_executor %0
+// CHECK: } // end sil function '$s4test40validateHopToExecutorLifetimeShortEnoughyyYaF'
+func validateHopToExecutorLifetimeShortEnough() async {
+  class Klass {
+    init(
+      on isolation: isolated Actor,
+    ) { }
+  }
+
+  let a = MyActor()
+  _ = await Klass(on: a)
 }

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -122,8 +122,8 @@ func accessSweaterOfSweater(cat : Cat) async -> Sweater {
 // CHECK:    [[GLOBAL_CAT:%[0-9]+]] = begin_borrow [[GLOBAL_CAT_REF]] : $Cat
 
 // CHECK:    hop_to_executor [[GLOBAL_CAT]] : $Cat
-// CHECK:    [[THE_STRING:%[0-9]+]] = apply [[GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned String
 // CHECK:    end_borrow [[GLOBAL_CAT]] : $Cat
+// CHECK:    [[THE_STRING:%[0-9]+]] = apply [[GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned String
 // CHECK:    destroy_value [[GLOBAL_CAT_REF]] : $Cat
 // CHECK:    hop_to_executor [[GENERIC_EXEC]]
 // CHECK:    return [[THE_STRING]] : $String

--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -65,8 +65,8 @@ await printFromMyActor(value: a)
 // CHECK: [[PRINTFROMMYACTOR_FUNC:%[0-9]+]] = function_ref @$s24toplevel_globalactorvars16printFromMyActor5valueySi_tF
 // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
 // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
-// CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
 // CHECK: end_borrow [[ACTORREF]]
+// CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
 // CHECK: hop_to_executor [[MAIN_OPTIONAL]]
 
 if a < 10 {
@@ -119,7 +119,7 @@ if a < 10 {
     // CHECK: [[PRINTFROMMYACTOR_FUNC:%[0-9]+]] = function_ref @$s24toplevel_globalactorvars16printFromMyActor5valueySi_tF
     // CHECK: [[ACTORREF:%[0-9]+]] = begin_borrow {{%[0-9]+}} : $MyActorImpl
     // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
-    // CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
     // CHECK: end_borrow [[ACTORREF]]
+    // CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
     // CHECK: hop_to_executor [[MAIN_OPTIONAL]]
 }


### PR DESCRIPTION
Without this, the borrow of the hop_to_executor lasts after the apply. Beyond being unnecessary this results in an OSSA violation if we are passing an actor as an isolated parameter to an initializer since we hop_to_executor the actor and then pass it as a +1 parameter to the initializer causing the actor to be consumed before its borrow ends.

rdar://144994837
