### PR TITLE
Sema: Downgrade diagnostics about unavailable requirements in swiftinterfaces

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5106,7 +5106,10 @@ void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> attrs) {
         if (VD->isProtocolRequirement() && !PD->isObjC()) {
           diagnoseAndRemoveAttr(
               const_cast<AvailableAttr *>(attr.getParsedAttr()),
-              diag::unavailable_method_non_objc_protocol);
+              diag::unavailable_method_non_objc_protocol)
+              .warnInSwiftInterface(D->getDeclContext());
+          // Be lenient in interfaces to accomodate @_spi_available, which has
+          // been accepted historically.
           return;
         }
       }

--- a/test/ModuleInterface/availability-macos.swift
+++ b/test/ModuleInterface/availability-macos.swift
@@ -64,3 +64,16 @@ public enum EnumWithAssociatedValues {
   @available(macOS 51, *)
   case introducedAtDeploymentWithAssoc(Int)
 }
+
+// CHECK-LABEL: public protocol Proto
+public protocol Proto {
+  // CHECK:      @available(macOS 99, *)
+  // CHECK-NEXT: func reqIntroducedAfterDeployment()
+  @available(macOS 99, *)
+  func reqIntroducedAfterDeployment()
+
+  // CHECK:      @available(macOS, unavailable)
+  // CHECK-NEXT: func reqIntroducedAsSPIAfterDeployment()
+  @_spi_available(macOS 99, *)
+  func reqIntroducedAsSPIAfterDeployment()
+}


### PR DESCRIPTION
Historically, we've allowed protocol requirements to be written with `@_spi_available` which makes them unavailable to clients of the public `.swiftinterface`. Don't diagnose this when checking a `.swiftinterface` since there's nothing the client can do about it.

Resolves rdar://146334181.
