### PR TITLE
Serialization: Diagnose broken conformances from stale swiftmodule files

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -381,11 +381,10 @@ public:
   /// files?
   bool IgnoreAdjacentModules = false;
 
-  /// Override to accept reading errors from swiftmodules and being generally
-  /// more tolerant to inconsistencies. This is enabled for
-  /// index-while-building as it runs last and it can afford to read an AST
-  /// with inconsistencies.
-  bool ForceAllowModuleWithCompilerErrors = false;
+  /// Accept recovering from more issues at deserialization, even if it can
+  /// lead to an inconsistent state. This is enabled for index-while-building
+  /// as it runs last and it can afford to read an AST with inconsistencies.
+  bool ForceExtendedDeserializationRecovery = false;
 
   // Define the set of known identifiers.
 #define IDENTIFIER_WITH_NAME(Name, IdStr) Identifier Id_##Name;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1037,6 +1037,12 @@ NOTE(modularization_issue_worked_around,none,
      "-experimental-force-workaround-broken-modules",
      ())
 
+ERROR(modularization_issue_conformance_xref_error,none,
+      "Conformance of %0 to %1 not found in referenced module %2",
+      (DeclName, DeclName, DeclName))
+NOTE(modularization_issue_conformance_xref_note,none,
+     "Breaks conformances of '%0' to %1",
+     (StringRef, DeclName))
 ERROR(reserved_member_name,none,
       "type member must not be named %0, since it would conflict with the"
       " 'foo.%1' expression", (const ValueDecl *, StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1043,6 +1043,12 @@ ERROR(modularization_issue_conformance_xref_error,none,
 NOTE(modularization_issue_conformance_xref_note,none,
      "Breaks conformances of '%0' to %1",
      (StringRef, DeclName))
+ERROR(modularization_issue_conformance_error,none,
+      "Conformances of '%0' "
+      "do not match requirement signature of %1; "
+      "%2 conformances for %3 requirements",
+      (StringRef, DeclName, unsigned int, unsigned int))
+
 ERROR(reserved_member_name,none,
       "type member must not be named %0, since it would conflict with the"
       " 'foo.%1' expression", (const ValueDecl *, StringRef))

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -2168,7 +2168,7 @@ void index::indexModule(ModuleDecl *module, IndexDataConsumer &consumer) {
     return;
   }
 
-  llvm::SaveAndRestore<bool> S(ctx.ForceAllowModuleWithCompilerErrors, true);
+  llvm::SaveAndRestore<bool> S(ctx.ForceExtendedDeserializationRecovery, true);
 
   IndexSwiftASTWalker walker(consumer, ctx);
   walker.visitModule(*module);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -179,6 +179,8 @@ const char ModularizationError::ID = '\0';
 void ModularizationError::anchor() {}
 const char InvalidEnumValueError::ID = '\0';
 void InvalidEnumValueError::anchor() {}
+const char ConformanceXRefError::ID = '\0';
+void ConformanceXRefError::anchor() {}
 
 /// Skips a single record in the bitstream.
 ///
@@ -402,6 +404,16 @@ ModuleFile::diagnoseModularizationError(llvm::Error error,
         });
 
   return outError;
+}
+
+void
+ConformanceXRefError::diagnose(const ModuleFile *MF,
+                               DiagnosticBehavior limit) const {
+  auto &diags = MF->getContext().Diags;
+  diags.diagnose(MF->getSourceLoc(),
+                 diag::modularization_issue_conformance_xref_error,
+                 name, protoName, expectedModule->getName())
+    .limitBehavior(limit);
 }
 
 llvm::Error ModuleFile::diagnoseFatal(llvm::Error error) const {
@@ -860,7 +872,8 @@ ProtocolConformanceDeserializer::readSpecializedProtocolConformance(
     return subMapOrError.takeError();
   auto subMap = subMapOrError.get();
 
-  auto genericConformance = MF.getConformance(conformanceID);
+  ProtocolConformanceRef genericConformance;
+  UNWRAP(MF.getConformanceChecked(conformanceID), genericConformance);
 
   PrettyStackTraceDecl traceTo("... to", genericConformance.getRequirement());
   ++NumNormalProtocolConformancesLoaded;
@@ -892,8 +905,8 @@ ProtocolConformanceDeserializer::readInheritedProtocolConformance(
   PrettyStackTraceType trace(ctx, "reading inherited conformance for",
                              conformingType);
 
-  ProtocolConformanceRef inheritedConformance =
-    MF.getConformance(conformanceID);
+  ProtocolConformanceRef inheritedConformance;
+  UNWRAP(MF.getConformanceChecked(conformanceID), inheritedConformance);
   PrettyStackTraceDecl traceTo("... to",
                                inheritedConformance.getRequirement());
 
@@ -943,14 +956,16 @@ ProtocolConformanceDeserializer::readNormalProtocolConformanceXRef(
   ProtocolConformanceXrefLayout::readRecord(scratch, protoID, nominalID,
                                             moduleID);
 
-  auto maybeNominal = MF.getDeclChecked(nominalID);
-  if (!maybeNominal)
-    return maybeNominal.takeError();
-
-  auto nominal = cast<NominalTypeDecl>(maybeNominal.get());
+  Decl *maybeNominal;
+  UNWRAP(MF.getDeclChecked(nominalID), maybeNominal);
+  auto nominal = cast<NominalTypeDecl>(maybeNominal);
   PrettyStackTraceDecl trace("cross-referencing conformance for", nominal);
-  auto proto = cast<ProtocolDecl>(MF.getDecl(protoID));
+
+  Decl *maybeProto;
+  UNWRAP(MF.getDeclChecked(protoID), maybeProto);
+  auto proto = cast<ProtocolDecl>(maybeProto);
   PrettyStackTraceDecl traceTo("... to", proto);
+
   auto module = MF.getModule(moduleID);
 
   // FIXME: If the module hasn't been loaded, we probably don't want to fall
@@ -971,16 +986,26 @@ ProtocolConformanceDeserializer::readNormalProtocolConformanceXRef(
   // TODO: Sink Sendable derivation into the conformance lookup table
   if (proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
     auto conformanceRef = lookupConformance(nominal->getDeclaredInterfaceType(), proto);
-    if (!conformanceRef.isConcrete())
-      abort();
-    return conformanceRef.getConcrete();
+    if (conformanceRef.isConcrete())
+      return conformanceRef.getConcrete();
   } else {
     SmallVector<ProtocolConformance *, 2> conformances;
     nominal->lookupConformance(proto, conformances);
-    if (conformances.empty())
-      abort();
-    return conformances.front();
+    if (!conformances.empty())
+      return conformances.front();
   }
+
+  auto error = llvm::make_error<ConformanceXRefError>(
+                 nominal->getName(), proto->getName(), module);
+
+  if (!MF.enableExtendedDeserializationRecovery()) {
+    error = llvm::handleErrors(std::move(error),
+      [&](const ConformanceXRefError &error) -> llvm::Error {
+        error.diagnose(&MF);
+        return llvm::make_error<ConformanceXRefError>(std::move(error));
+      });
+  }
+  return error;
 }
 
 Expected<ProtocolConformance *>
@@ -7863,7 +7888,7 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
   ProtocolConformanceRef witnessMethodConformance;
   if (*representation == swift::SILFunctionTypeRepresentation::WitnessMethod) {
     auto conformanceID = variableData[nextVariableDataIndex++];
-    witnessMethodConformance = MF.getConformance(conformanceID);
+    UNWRAP(MF.getConformanceChecked(conformanceID), witnessMethodConformance);
   }
 
   GenericSignature invocationSig =
@@ -8643,6 +8668,8 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       scratch, protoID, contextID, typeCount, valueCount, conformanceCount,
       rawOptions, rawIDs);
 
+  const ProtocolDecl *proto = conformance->getProtocol();
+
   // Read requirement signature conformances.
   SmallVector<ProtocolConformanceRef, 4> reqConformances;
   for (auto conformanceID : rawIDs.slice(0, conformanceCount)) {
@@ -8650,14 +8677,28 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     if (maybeConformance) {
       reqConformances.push_back(maybeConformance.get());
     } else if (getContext().LangOpts.EnableDeserializationRecovery) {
-      diagnoseAndConsumeError(maybeConformance.takeError());
+      llvm::Error error = maybeConformance.takeError();
+      if (error.isA<ConformanceXRefError>() &&
+          !enableExtendedDeserializationRecovery()) {
+
+        std::string typeStr = conformance->getType()->getString();
+        auto &diags = getContext().Diags;
+        diags.diagnose(getSourceLoc(),
+                       diag::modularization_issue_conformance_xref_note,
+                       typeStr, proto->getName());
+
+        consumeError(std::move(error));
+        conformance->setInvalid();
+        return;
+      }
+
+      diagnoseAndConsumeError(std::move(error));
       reqConformances.push_back(ProtocolConformanceRef::forInvalid());
     } else {
       fatal(maybeConformance.takeError());
     }
   }
 
-  const ProtocolDecl *proto = conformance->getProtocol();
   if (proto->isObjC() && getContext().LangOpts.EnableDeserializationRecovery) {
     // Don't crash if inherited protocols are added or removed.
     // This is limited to Objective-C protocols because we know their only

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -677,6 +677,36 @@ public:
   }
 };
 
+// Cross-reference to a conformance was not found where it was expected.
+class ConformanceXRefError : public llvm::ErrorInfo<ConformanceXRefError,
+                                                    DeclDeserializationError> {
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+  DeclName protoName;
+  const ModuleDecl *expectedModule;
+
+public:
+  ConformanceXRefError(Identifier name, Identifier protoName,
+                       const ModuleDecl *expectedModule):
+                     protoName(protoName), expectedModule(expectedModule) {
+    this->name = name;
+  }
+
+  void diagnose(const ModuleFile *MF,
+                DiagnosticBehavior limit = DiagnosticBehavior::Fatal) const;
+
+  void log(raw_ostream &OS) const override {
+    OS << "Conformance of '" << name << "' to '" << protoName
+       << "' not found in module '" << expectedModule->getName() << "'";
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
 class PrettyStackTraceModuleFile : public llvm::PrettyStackTraceEntry {
   const char *Action;
   const ModuleFile &MF;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -135,8 +135,15 @@ ModuleFile::ModuleFile(std::shared_ptr<const ModuleFileSharedCore> core)
 }
 
 bool ModuleFile::allowCompilerErrors() const {
-  return getContext().LangOpts.AllowModuleWithCompilerErrors ||
-         getContext().ForceAllowModuleWithCompilerErrors;
+  return getContext().LangOpts.AllowModuleWithCompilerErrors;
+}
+
+bool ModuleFile::enableExtendedDeserializationRecovery() const {
+  ASTContext &ctx = getContext();
+  return ctx.LangOpts.EnableDeserializationRecovery &&
+         (allowCompilerErrors() ||
+          ctx.LangOpts.DebuggerSupport ||
+          ctx.ForceExtendedDeserializationRecovery);
 }
 
 Status

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -691,6 +691,10 @@ public:
   /// '-experimental-allow-module-with-compiler-errors' is currently enabled).
   bool allowCompilerErrors() const;
 
+  /// Allow recovering from errors that could be unsafe when compiling
+  /// the binary. Useful for the debugger and IDE support tools.
+  bool enableExtendedDeserializationRecovery() const;
+
   /// \c true if this module has incremental dependency information.
   bool hasIncrementalInfo() const { return Core->hasIncrementalInfo(); }
 

--- a/test/Serialization/Recovery/conformance-xref.swift
+++ b/test/Serialization/Recovery/conformance-xref.swift
@@ -22,6 +22,29 @@
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
 // RUN:   -experimental-allow-module-with-compiler-errors -verify
 
+/// Case 2: Remove a requirement from one lib, leave the other as stale and
+/// rebuild client. Error on the mismatch.
+// RUN: %target-swift-frontend -emit-module %t/ChangingLib.swift -I %t \
+// RUN:   -emit-module-path %t/ChangingLib.swiftmodule \
+// RUN:   -D DROP_REQUIREMENT
+// RUN: not %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   2> %t/errors.log
+// RUN: %FileCheck %s --input-file=%t/errors.log \
+// RUN:   --check-prefix CHECK-REMARK-REQUIREMENT
+
+/// No errors when extended recovery is enabled.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -experimental-allow-module-with-compiler-errors -verify
+
+/// Combined case: Remove both the conformance and the requirement.
+/// Fail on the removed conformance only as it was first.
+// RUN: %target-swift-frontend -emit-module %t/ChangingLib.swift -I %t \
+// RUN:   -emit-module-path %t/ChangingLib.swiftmodule \
+// RUN:   -D DROP_CONFORMANCE -D DROP_REQUIREMENT
+// RUN: not %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   2> %t/errors.log
+// RUN: %FileCheck %s --input-file=%t/errors.log \
+// RUN:   --check-prefixes CHECK-REMARK-CONFORMANCE
 
 //--- ChangingLib.swift
 
@@ -37,7 +60,19 @@ extension Counter: SimpleProto {}
 #endif
 
 public protocol ProtoUser {
+  associatedtype Element
+#if DROP_REQUIREMENT
+// CHECK-REMARK-REQUIREMENT: MiddleLib.swiftmodule:1:1: error: Conformances of 'OneToAThousand' do not match requirement signature of 'ProtoUser'; 5 conformances for 6 requirements
+// CHECK-REMARK-REQUIREMENT: Requirements:
+// Skipping implicits.
+// CHECK-REMARK-REQUIREMENT: Conformances:
+// Skipping implicits.
+// CHECK-REMARK-REQUIREMENT: (specialized_conformance type="OneToAThousand.Impl" protocol="SimpleProto"
+// CHECK-REMARK-REQUIREMENT:   (normal_conformance type="Counter<T>" protocol="SimpleProto" lazy))
+  associatedtype Impl
+#else
   associatedtype Impl: SimpleProto
+#endif
 
   var start: Impl { get }
 

--- a/test/Serialization/Recovery/conformance-xref.swift
+++ b/test/Serialization/Recovery/conformance-xref.swift
@@ -1,0 +1,82 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Reference build: Build libs and client for a normal build.
+// RUN: %target-swift-frontend -emit-module %t/ChangingLib.swift -I %t \
+// RUN:   -emit-module-path %t/ChangingLib.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/MiddleLib.swift -I %t \
+// RUN:   -emit-module-path %t/MiddleLib.swiftmodule
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t
+
+/// Case 1: Remove a conformance from one lib, leave the other as stale and
+/// rebuild client. Error on the missing conformance.
+// RUN: %target-swift-frontend -emit-module %t/ChangingLib.swift -I %t \
+// RUN:   -emit-module-path %t/ChangingLib.swiftmodule \
+// RUN:   -D DROP_CONFORMANCE
+// RUN: not %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   2> %t/errors.log
+// RUN: %FileCheck %s --input-file=%t/errors.log \
+// RUN:    --check-prefix CHECK-REMARK-CONFORMANCE
+
+/// No errors when extended recovery is enabled.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -experimental-allow-module-with-compiler-errors -verify
+
+
+//--- ChangingLib.swift
+
+public protocol SimpleProto {
+  func successor() -> Self
+}
+
+#if DROP_CONFORMANCE
+// CHECK-REMARK-CONFORMANCE: MiddleLib.swiftmodule:1:1: error: Conformance of 'Counter' to 'SimpleProto' not found in referenced module 'ChangingLib'
+// CHECK-REMARK-CONFORMANCE: note: Breaks conformances of 'OneToAThousand' to 'ProtoUser'
+#else
+extension Counter: SimpleProto {}
+#endif
+
+public protocol ProtoUser {
+  associatedtype Impl: SimpleProto
+
+  var start: Impl { get }
+
+  subscript(_: Impl) -> Element { get }
+}
+
+public struct Counter<T> {
+  public var value = 0
+
+  public init(value: Int) { self.value = value }
+
+  public func successor() -> Counter {
+    return Counter(value: value + 1)
+  }
+}
+
+//--- MiddleLib.swift
+
+import ChangingLib
+
+// Instantiate Counter<Int>, relying on Counter's adoption of SimpleProto.
+public struct OneToAThousand : ProtoUser {
+  public typealias Impl = Counter<Int>
+
+  public var start: Impl {
+    return Impl(value: 1)
+  }
+
+  public subscript(i: Impl) -> Int {
+    return i.value
+  }
+
+  public init() {}
+}
+
+//--- Client.swift
+
+import MiddleLib
+
+var test = OneToAThousand()
+var s = test.start
+print(test[s])


### PR DESCRIPTION
Diagnose failures in `readNormalProtocolConformanceXRef` and `finishNormalConformance`. These are usually caused by a change in one library without the required rebuild of its dependents, leaving stale swiftmodule files behind.

If a single conformance is missing, show an error with the type and protocol and note indirect effects. When there's a mismatch between the number of requirements and the number of conformances found, show an error with the types and list the requirements and conformances to stderr for visual inspection.

Display a proper error instead of crashing when the compiler hit these issues during normal compilation. Or recover silently during indexing or in LLDB. This recovery is gated behind the new `enableExtendedDeserializationRecovery` which should only be enabled when we can afford reading inconsistent information from swiftmodule files.

rdar://125995448&145019988