### PR TITLE
Build Preset: Bootstrap Stage-0 Toolchain

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3105,3 +3105,45 @@ skip-test-foundation
 
 llvm-cmake-options=
   -DCLANG_DEFAULT_LINKER=gold
+
+#===------------------------------------------------------------------------===#
+# Toolchain Bootstrapping Stages
+#===------------------------------------------------------------------------===#
+# Build Requirements:
+#   - C and C++ compiler
+# Toolchain Outputs:
+#   - Swift Compiler
+#     C++ Driver
+#     No Macro Support
+#     No Swift Compiler Sources
+# Runtime Outputs:
+#   - Swift Standard Library
+#     swiftCore
+#     OnoneSupport
+#     Concurrency
+[preset: bootstrap_stage0]
+mixin-preset=
+  mixin_buildbot_linux,no_test
+
+swift-include-tests=0
+llvm-include-tests=0
+
+release
+
+skip-early-swiftsyntax
+skip-early-swift-driver
+skip-build-benchmarks
+
+build-runtime-with-host-compiler=0
+build-swift-libexec=0
+build-swift-remote-mirror=0
+
+swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;toolchain-tools
+llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;compiler-rt;clang-features-file;llvm-symbolizer
+
+extra-cmake-options=
+  -DLLVM_TARGETS_TO_BUILD=AArch64;X86
+
+swift-cmake-options=
+  -DSWIFT_ENABLE_SWIFT_IN_SWIFT:BOOL=NO
+  -DSWIFT_INCLUDE_DOCS:BOOL=NO


### PR DESCRIPTION
This preset builds the compiler and standard library on a system without an existing Swift.

Note, there are many issues with it and it won't be able to pass tests. It is an intermediate product that will need to build a compiler with the Swift sources. The stage-0 compiler won't be able to build the driver as the driver depends on Foundation, which requires macro support and the stage-0 compiler does not have macro support. It will need to build swiftsyntax though to give the stage-1 compiler macro support. The stage-1 compiler then can build a stage-2 toolchain with most of the libraries and runtimes. That stage-2 toolchain should then be capable of building the full nightly toolchain package.