### PR TITLE
Sema: Diagnose `@_spi_available` on declarations that cannot be unavailable

### DIFF
--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -20,6 +20,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/AnyFunctionRef.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/AvailabilityRange.h"
 #include "swift/AST/AvailabilityScope.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -1065,7 +1066,8 @@ diagnosticIfDeclCannotBePotentiallyUnavailable(const Decl *D);
 /// Returns a diagnostic indicating why the declaration cannot be annotated
 /// with an @available() attribute indicating it is unavailable or None if this
 /// is allowed.
-std::optional<Diagnostic> diagnosticIfDeclCannotBeUnavailable(const Decl *D);
+std::optional<Diagnostic>
+diagnosticIfDeclCannotBeUnavailable(const Decl *D, SemanticAvailableAttr attr);
 
 /// Checks whether the required range of versions of the compilation's target
 /// platform are available at the given `SourceRange`. If not, `Diagnose` is

--- a/test/Sema/availability_accessors.swift
+++ b/test/Sema/availability_accessors.swift
@@ -569,5 +569,4 @@ struct BadAccessorAvailability<T> {
     @available(swift, introduced: 99) // expected-error {{didSet observer for property cannot be marked unavailable with '@available'}}
     didSet { }
   }
-
 }

--- a/test/Sema/availability_deinit.swift
+++ b/test/Sema/availability_deinit.swift
@@ -31,6 +31,11 @@ class DeinitUnavailableMacOS {
   deinit {}
 }
 
+class DeinitSPIAvailableMacOS {
+  @_spi_available(macOS, introduced: 50) // expected-error {{deinitializer cannot be marked unavailable with '@available'}}
+  deinit {}
+}
+
 class AvailableAtDeploymentTargetDeinit {
   @available(macOS 50, *)
   deinit {}

--- a/test/Sema/availability_script_mode.swift
+++ b/test/Sema/availability_script_mode.swift
@@ -11,10 +11,10 @@ struct Available50 {}
 struct Available51 {}
 
 @available(macOS, unavailable)
-struct UnavailableOnMacOS {}
+struct UnavailableOnMacOS {} // expected-note {{'UnavailableOnMacOS' has been explicitly marked unavailable here}}
 
 @available(*, unavailable)
-struct UnavailableUnconditionally {}
+struct UnavailableUnconditionally {} // expected-note {{'UnavailableUnconditionally' has been explicitly marked unavailable here}}
 
 var alwaysAvailableVar: AlwaysAvailable = .init() // Ok
 
@@ -28,7 +28,7 @@ var availableOn50Var: Available50 = .init() // Ok
 var potentiallyUnavailableVar: Available51 = .init()
 
 @available(macOS, unavailable) // expected-error {{global variable cannot be marked unavailable with '@available' in script mode}}
-var unavailableOnMacOSVar: UnavailableOnMacOS = .init()
+var unavailableOnMacOSVar: UnavailableOnMacOS = .init() // expected-error {{'UnavailableOnMacOS' is unavailable in macOS}}
 
 @available(*, unavailable) // expected-error {{global variable cannot be marked unavailable with '@available' in script mode}}
-var unconditionallyUnavailableVar: UnavailableUnconditionally = .init()
+var unconditionallyUnavailableVar: UnavailableUnconditionally = .init() // expected-error {{'UnavailableUnconditionally' is unavailable}}

--- a/test/Sema/availability_stored_unavailable.swift
+++ b/test/Sema/availability_stored_unavailable.swift
@@ -3,10 +3,10 @@
 // REQUIRES: OS=macosx
 
 @available(macOS, unavailable)
-struct UnavailableMacOSStruct {}
+struct UnavailableMacOSStruct {} // expected-note 2 {{'UnavailableMacOSStruct' has been explicitly marked unavailable here}}
 
 @available(*, unavailable)
-public struct UniversallyUnavailableStruct {}
+public struct UniversallyUnavailableStruct {} // expected-note {{'UniversallyUnavailableStruct' has been explicitly marked unavailable here}}
 
 // Ok, initialization of globals is lazy and boxed.
 @available(macOS, unavailable)
@@ -61,15 +61,15 @@ struct GoodUniversallyUnavailableStruct {
 struct BadStruct {
   // expected-error@+1 {{stored properties cannot be marked unavailable with '@available'}}
   @available(macOS, unavailable)
-  var unavailableMacOS: UnavailableMacOSStruct = .init()
+  var unavailableMacOS: UnavailableMacOSStruct = .init() // expected-error {{'UnavailableMacOSStruct' is unavailable in macOS}}
 
   // expected-error@+1 {{stored properties cannot be marked unavailable with '@available'}}
   @available(macOS, unavailable)
-  lazy var lazyUnavailableMacOS: UnavailableMacOSStruct = .init()
+  lazy var lazyUnavailableMacOS: UnavailableMacOSStruct = .init() // expected-error {{'UnavailableMacOSStruct' is unavailable in macOS}}
 
   // expected-error@+1 {{stored properties cannot be marked unavailable with '@available'}}
   @available(*, unavailable)
-  var universallyUnavailable: UniversallyUnavailableStruct = .init()
+  var universallyUnavailable: UniversallyUnavailableStruct = .init() // expected-error {{'UniversallyUnavailableStruct' is unavailable}}
 }
 
 enum GoodAvailableEnum {

--- a/test/Sema/availability_stored_unavailable.swift
+++ b/test/Sema/availability_stored_unavailable.swift
@@ -5,12 +5,20 @@
 @available(macOS, unavailable)
 struct UnavailableMacOSStruct {} // expected-note 2 {{'UnavailableMacOSStruct' has been explicitly marked unavailable here}}
 
+@available(iOS, introduced: 8.0)
+@_spi_available(macOS, introduced: 10.9)
+public struct SPIAvailableMacOSStruct {}
+
 @available(*, unavailable)
 public struct UniversallyUnavailableStruct {} // expected-note {{'UniversallyUnavailableStruct' has been explicitly marked unavailable here}}
 
 // Ok, initialization of globals is lazy and boxed.
 @available(macOS, unavailable)
 var unavailableMacOSGlobal: UnavailableMacOSStruct = .init()
+
+@available(iOS, introduced: 8.0)
+@_spi_available(macOS, introduced: 10.9)
+var spiAvailableMacOSGlobal: SPIAvailableMacOSStruct = .init()
 
 @available(*, unavailable)
 var universallyUnavailableGlobal: UniversallyUnavailableStruct = .init()
@@ -21,6 +29,10 @@ struct GoodAvailableStruct {
   var unavailableMacOS: UnavailableMacOSStruct {
     get { UnavailableMacOSStruct() }
   }
+
+  // Ok, storage is available to implementation at runtime.
+  @_spi_available(macOS, introduced: 10.9)
+  var spiAvailableMacOS: SPIAvailableMacOSStruct
 
   // Ok, initialization of static vars is lazy and boxed.
   @available(macOS, unavailable)
@@ -75,4 +87,7 @@ struct BadStruct {
 enum GoodAvailableEnum {
   @available(macOS, unavailable)
   case unavailableMacOS(UnavailableMacOSStruct)
+
+  @_spi_available(macOS, introduced: 10.9)
+  case spiAvailableMacOS(SPIAvailableMacOSStruct)
 }

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1934,4 +1934,13 @@ struct PropertyObservers {
     @available(macOS, obsoleted: 10.9) // expected-error {{didSet observer for property cannot be marked unavailable with '@available'}}
     didSet { }
   }
+
+  var hasSPIAvailableObservers: Int {
+    @_spi_available(macOS, introduced: 10.9) // expected-error {{willSet observer for property cannot be marked unavailable with '@available'}}
+    willSet { }
+
+    @_spi_available(macOS, introduced: 10.9) // expected-error {{didSet observer for property cannot be marked unavailable with '@available'}}
+    didSet { }
+  }
+
 }

--- a/test/decl/protocol/req/unavailable.swift
+++ b/test/decl/protocol/req/unavailable.swift
@@ -15,8 +15,13 @@ class Foo : Proto {
 // Reject protocols with 'unavailable' requirements
 // if a protocol is not marked @objc.
 protocol NonObjCProto {
-  @available(*,unavailable) func bad() // expected-error {{protocol members can only be marked unavailable in an @objc protocol}} expected-note {{protocol requires function 'bad()'}}
+  @available(*,unavailable) // expected-error {{protocol members can only be marked unavailable in an @objc protocol}}
+  func bad() // expected-note {{protocol requires function 'bad()'}}
+
   func good()
+
+  @_spi_available(macOS, introduced: 10.9) // expected-warning {{protocol members can only be marked unavailable in an @objc protocol}}
+  func kindaBad() // expected-note {{protocol requires function 'kindaBad()'}}
 }
 
 class Bar : NonObjCProto { // expected-error {{type 'Bar' does not conform to protocol 'NonObjCProto'}} expected-note {{add stubs for conformance}}
@@ -115,4 +120,7 @@ protocol UnavailableAssoc {
 
   @available(swift, obsoleted: 99)
   associatedtype A5
+
+  @_spi_available(macOS, introduced: 11) // expected-error {{associated type cannot be marked unavailable with '@available'}}
+  associatedtype A6
 }


### PR DESCRIPTION
The attribute makes the declaration unavailable from the perspective of clients of the module's public interface and was creating a loophole that admitted inappropriate unavailability.