### PR TITLE
[docs] Fix typo in PartialAsyncTask

### DIFF
--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -658,7 +658,7 @@ internal func _resumeUnsafeThrowingContinuationWithError<T>(
 #endif
 
 
-/// Invokes the passed in closure with a unsafe continuation for the current task.
+/// Invokes the passed in closure with an unsafe continuation for the current task.
 ///
 /// The body of the closure executes synchronously on the calling task, and once it returns
 /// the calling task is suspended. It is possible to immediately resume the task, or escape the
@@ -693,7 +693,7 @@ public func withUnsafeContinuation<T>(
   }
 }
 
-/// Invokes the passed in closure with a unsafe continuation for the current task.
+/// Invokes the passed in closure with an unsafe continuation for the current task.
 ///
 /// The body of the closure executes synchronously on the calling task, and once it returns
 /// the calling task is suspended. It is possible to immediately resume the task, or escape the


### PR DESCRIPTION
Fixed a small grammatical typo in the documentation for `withUnsafeContinuation `. 
Cheers :)