### PR TITLE
Runtimes: tweak incorrect case (NFC)

### DIFF
--- a/Runtimes/Core/cmake/modules/CompilerSettings.cmake
+++ b/Runtimes/Core/cmake/modules/CompilerSettings.cmake
@@ -48,9 +48,10 @@ if(NOT HAVE_SWIFT_ASYNC_CALL)
   message(SEND_ERROR "CXX Compiler must support Swift async calling conventions")
 endif()
 
-check_compiler_flag(CXX "-mcx16" HAVE_CXX_MCX16)
-if(HAVE_CXX_MCX16 AND
-    (CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "(X86)|(X64)" OR
-     CMAKE_SYSTEM_PROCESSOR MATCHES "(i[3-6]86)|(x86_64)|(amd64)|(AMD64)"))
-  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-mcx16>)
+if(CMAKE_CXX_COMPILER_ARCHITECTURE_ID MATCHES "(x86)|(x64)" OR
+   CMAKE_SYSTEM_PROCESSOR MATCHES "(i[3-6]86)|(x86_64)|(amd64)|(AMD64)")
+  check_compiler_flag(CXX "-mcx16" HAVE_CXX_MCX16)
+  if(HAVE_CXX_MCX16)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-mcx16>)
+  endif()
 endif()


### PR DESCRIPTION
This adjusts the spelling for the architecture specifier for the Windows compilers. Take the opportunity to further restrict the compiler check to micro-optimize the CMake configure phase.
