### PR TITLE
[AST] Avoid setting `questionLoc` for implicit OptionalSomePatterns

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -687,12 +687,15 @@ public:
   static OptionalSomePattern *create(ASTContext &ctx, Pattern *subPattern,
                                      SourceLoc questionLoc);
 
-  static OptionalSomePattern *
-  createImplicit(ASTContext &ctx, Pattern *subPattern,
-                 SourceLoc questionLoc = SourceLoc());
+  static OptionalSomePattern *createImplicit(ASTContext &ctx,
+                                             Pattern *subPattern);
 
   SourceLoc getQuestionLoc() const { return QuestionLoc; }
+
   SourceRange getSourceRange() const {
+    if (QuestionLoc.isInvalid())
+      return SubPattern->getSourceRange();
+
     return SourceRange(SubPattern->getStartLoc(), QuestionLoc);
   }
 

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -367,10 +367,10 @@ OptionalSomePattern *OptionalSomePattern::create(ASTContext &ctx,
   return new (ctx) OptionalSomePattern(ctx, subPattern, questionLoc);
 }
 
-OptionalSomePattern *
-OptionalSomePattern::createImplicit(ASTContext &ctx, Pattern *subPattern,
-                                    SourceLoc questionLoc) {
-  auto *P = OptionalSomePattern::create(ctx, subPattern, questionLoc);
+OptionalSomePattern *OptionalSomePattern::createImplicit(ASTContext &ctx,
+                                                         Pattern *subPattern) {
+  auto *P = OptionalSomePattern::create(ctx, subPattern,
+                                        /*questionLoc*/ SourceLoc());
   P->setImplicit();
   return P;
 }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -645,7 +645,7 @@ Pattern *ResolvePatternRequest::evaluate(Evaluator &evaluator, Pattern *P,
 
     // "if let" implicitly looks inside of an optional, so wrap it in an
     // OptionalSome pattern.
-    P = OptionalSomePattern::createImplicit(Context, P, P->getEndLoc());
+    P = OptionalSomePattern::createImplicit(Context, P);
   }
 
   return P;
@@ -1029,7 +1029,7 @@ static NullablePtr<Pattern> simplifyToBoolPattern(ASTContext &Ctx,
   if (auto wrappedType = patternTy->getOptionalObjectType()) {
     if (auto P =
             simplifyToBoolPattern(Ctx, EP, BLE, wrappedType).getPtrOrNull()) {
-      auto OP = OptionalSomePattern::createImplicit(Ctx, P, P->getEndLoc());
+      auto OP = OptionalSomePattern::createImplicit(Ctx, P);
       OP->setType(patternTy);
       return OP;
     }
@@ -1475,8 +1475,7 @@ Pattern *TypeChecker::coercePatternToType(
             if (lookupEnumMemberElement(dc,
                                         baseType->lookThroughAllOptionalTypes(),
                                         EEP->getName(), EEP->getLoc())) {
-              P = OptionalSomePattern::createImplicit(Context, EEP,
-                                                      EEP->getEndLoc());
+              P = OptionalSomePattern::createImplicit(Context, EEP);
               return coercePatternToType(
                   pattern.forSubPattern(P, /*retainTopLevel=*/true), type,
                   options, tryRewritePattern);


### PR DESCRIPTION
Instead fix `getSourceRange` to handle cases where the question location is missing.