### PR TITLE
Match freestanding macros in vim syntax

### DIFF
--- a/utils/vim/syntax/swift.vim
+++ b/utils/vim/syntax/swift.vim
@@ -207,6 +207,9 @@ syn match swiftTupleIndexNumber contains=swiftDecimal
 syn match swiftDecimal contained
       \ /[0-9]\+/
 
+" This is a superset of the Preproc macros below, so it must come FIRST
+syn match swiftFreestandingMacro
+      \ /#\<[A-Za-z_][A-Za-z_0-9]*\>/
 syn match swiftPreproc
       \ /#\(\<column\>\|\<dsohandle\>\|\<file\>\|\<line\>\|\<function\>\)/
 syn match swiftPreproc
@@ -271,6 +274,7 @@ hi def link swiftLabel Operator
 hi def link swiftMutating Statement
 hi def link swiftPreproc PreCondit
 hi def link swiftPreprocFalse Comment
+hi def link swiftFreestandingMacro Macro
 hi def link swiftAttribute Type
 hi def link swiftTodo Todo
 hi def link swiftNil Constant


### PR DESCRIPTION
Any valid name beginning with `#` that isn't already a preprocessor macro is now considered a freestanding macro. Previously, only preprocessor macros were handled in the vim syntax file, e.g. `#if`.

For example, this properly handles the syntax for the `#expect` and the `#require` macros used in Swift Testing.

Attached a screenshot of the before and after:
<img width="2039" alt="before-and-after" src="https://github.com/user-attachments/assets/8e310d4f-aa49-4696-9df0-b6d82339285d" />

Resolves rdar://135162741.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
