### PR TITLE
6.1: Check file type better in this verifier.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3196,19 +3196,17 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
 
   if (auto *nominal = substType.getAnyNominal()) {
     auto *module = nominal->getModuleContext();
-    if (module) {
-      if (module->isBuiltFromInterface()) {
+    if (module && module->isBuiltFromInterface()) {
         // Don't verify for types in modules built from interfaces; the feature
         // may not have been enabled in them.
         return;
-      }
-      auto *file = dyn_cast_or_null<FileUnit>(module->getModuleScopeContext());
-      if (file && file->getKind() == FileUnitKind::Source) {
-        auto sourceFile = nominal->getParentSourceFile();
-        if (sourceFile && sourceFile->Kind == SourceFileKind::SIL) {
-          // Don't verify for types in SIL files.
-          return;
-        }
+    }
+    auto *file = nominal->getParentSourceFile();
+    if (file && file->getKind() == FileUnitKind::Source) {
+      auto sourceFile = nominal->getParentSourceFile();
+      if (sourceFile && sourceFile->Kind == SourceFileKind::SIL) {
+        // Don't verify for types in SIL files.
+        return;
       }
     }
   }

--- a/test/IRGen/enum_value_semantics_future.sil
+++ b/test/IRGen/enum_value_semantics_future.sil
@@ -8,6 +8,7 @@
 // UNSUPPORTED: CPU=armv7s && OS=ios
 
 import Builtin
+import Swift
 
 enum NoPayload {
   case a


### PR DESCRIPTION
**Explanation**: Fix check in asserts-only verifier that determines whether a decl comes from a SIL source file.
**Scope**: Affects test files written in textual SIL tested using an asserts compiler.
**Issue**: rdar://147359465
**Original PR**: https://github.com/swiftlang/swift/pull/79586
**Risk**: None.  
**Testing**: CI.
**Reviewer**: Arnold Schwaighofer ( @aschwaighofer )