### PR TITLE
[ASTGen] Stub out support for method keypaths

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -736,6 +736,9 @@ extension ASTGenVisitor {
           additionalTrailingClosures: nil
         )
       ).asExpr
+
+    case .method(_):
+      fatalError("unimplemented")
     }
   }
 


### PR DESCRIPTION
The merge of https://github.com/swiftlang/swift-syntax/pull/2950 broke ASTGen. This stubs out the missing case while https://github.com/swiftlang/swift/pull/78823 is still in progress.