### PR TITLE
[Diagnostics] Print category footnotes at the end of translation

### DIFF
--- a/include/swift/AST/DiagnosticBridge.h
+++ b/include/swift/AST/DiagnosticBridge.h
@@ -31,6 +31,9 @@ class DiagnosticBridge {
   /// A queued up source file known to the queued diagnostics.
   using QueuedBuffer = void *;
 
+  /// Per-frontend state maintained on the Swift side.
+  void *perFrontendState = nullptr;
+
   /// The queued diagnostics structure.
   void *queuedDiagnostics = nullptr;
   llvm::DenseMap<unsigned, QueuedBuffer> queuedBuffers;
@@ -55,6 +58,9 @@ public:
   /// initial location is invalid, the result will be empty.
   static SmallVector<unsigned, 1> getSourceBufferStack(SourceManager &sourceMgr,
                                                        SourceLoc loc);
+
+  /// Print the category footnotes as part of teardown.
+  void printCategoryFootnotes(llvm::raw_ostream &os, bool forceColors);
 
   DiagnosticBridge() = default;
   ~DiagnosticBridge();

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -26,7 +26,8 @@ void swift_ASTGen_addQueuedSourceFile(
     void *_Nonnull sourceFile, const uint8_t *_Nonnull displayNamePtr,
     intptr_t displayNameLength, ssize_t parentID, ssize_t positionInParent);
 void swift_ASTGen_addQueuedDiagnostic(
-    void *_Nonnull queued, const char *_Nonnull text, ptrdiff_t textLength,
+    void *_Nonnull queued, void *_Nonnull state,
+    const char *_Nonnull text, ptrdiff_t textLength,
     BridgedDiagnosticSeverity severity, const void *_Nullable sourceLoc,
     const char *_Nullable categoryName, ptrdiff_t categoryNameLength,
     const char *_Nullable documentationPath,
@@ -35,6 +36,12 @@ void swift_ASTGen_addQueuedDiagnostic(
     ptrdiff_t numHighlightRanges);
 void swift_ASTGen_renderQueuedDiagnostics(
     void *_Nonnull queued, ssize_t contextSize, ssize_t colorize,
+    BridgedStringRef *_Nonnull renderedString);
+
+void *_Nonnull swift_ASTGen_createPerFrontendDiagnosticState();
+void swift_ASTGen_destroyPerFrontendDiagnosticState(void * _Nonnull state);
+void swift_ASTGen_renderCategoryFootnotes(
+    void * _Nonnull state, ssize_t colorize,
     BridgedStringRef *_Nonnull renderedString);
 
 // FIXME: Hack because we cannot easily get to the already-parsed source

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -736,6 +736,9 @@ extension ASTGenVisitor {
           additionalTrailingClosures: nil
         )
       ).asExpr
+
+    case .method(_):
+      fatalError("unimplemented")
     }
   }
 

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -295,6 +295,12 @@ void PrintingDiagnosticConsumer::flush(bool includeTrailingBreak) {
 bool PrintingDiagnosticConsumer::finishProcessing() {
   // If there's an in-flight snippet, flush it.
   flush(false);
+
+#if SWIFT_BUILD_SWIFT_SYNTAX
+  // Print out footnotes for any category that was referenced.
+  DiagBridge.printCategoryFootnotes(Stream, ForceColors);
+#endif
+
   return false;
 }
 

--- a/test/diagnostics/print-diagnostic-groups.swift
+++ b/test/diagnostics/print-diagnostic-groups.swift
@@ -1,19 +1,16 @@
-// RUN: %target-swift-frontend -typecheck -diagnostic-style llvm -print-diagnostic-groups %s 2>&1 | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -typecheck %s 2>&1 | %FileCheck %s --check-prefix=CHECK
+// REQUIRES: swift_swift_parser
 
+// CHECK: warning: file 'print-diagnostic-groups.swift' is part of module 'main'; ignoring import{{$}}
+import main
 
-// This test checks that "-print-diagnostic-groups" prints the diagnostic group
-// if it exists, and prints nothing if it does not.
-
+// This test checks that we get diagnostic groups as part of the printed output.
 
 @available(*, deprecated, renamed: "bar2")
 func bar() {
 }
 
-// CHECK: warning: 'bar()' is deprecated: renamed to 'bar2' [DeprecatedDeclaration]{{$}}
+// CHECK: warning: 'bar()' is deprecated: renamed to 'bar2' [#DeprecatedDeclaration]{{$}}
 bar()
 
-
-func foo() {
-  // CHECK: warning: initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it{{$}}
-  let x = 42
-}
+// CHECK: [#DeprecatedDeclarations]: <{{.*}}deprecated-declaration.md>


### PR DESCRIPTION
When printing diagnostics, category names are printed as [#<category-name>]
at the end of a diagnostic. For all of the category names that are mentioned
in this manner, print "footnotes" at the end of compilation providing
documentation references to each category, e.g.,

    [#deprecated]: <http://example.com/deprecated>
    [#StrictMemorySafety]: <http://example.com/memory-safety>

Right now, these point into the markdown files in the installed toolchain,
same as the URLs behind references. That is subject to change in the future.