### PR TITLE
[CS] Deep-equality match OpenedArchetypeTypes

### DIFF
--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -784,3 +784,17 @@ do {
     }
   }
 }
+
+// https://github.com/swiftlang/swift/issues/79623
+do {
+  protocol P<T>: Hashable {
+    associatedtype T
+  }
+
+  struct S<each T> {
+    var x: any P<(repeat each T)>
+    var hashable: AnyHashable {
+      AnyHashable(x)
+    }
+  }
+}


### PR DESCRIPTION
Resolves: [swiftlang/swift#79623](https://github.com/swiftlang/swift/issues/79623)

When comparing two distinct `OpenedArchetypeType`s, `matchTypes` currently does not check for deep equality. Because the types are not trivially equal, this results in incorrect mismatches.

This change resolves the issue by introducing a deep equality check when the two types have the same interface type and UUID.
