### PR TITLE
Sema: Optimize Constraint layout to save 24 bytes 

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -872,7 +872,7 @@ public:
 
   /// Retrieve the overload choice for an overload-binding constraint.
   OverloadChoice getOverloadChoice() const {
-    assert(Kind == ConstraintKind::BindOverload);
+    ASSERT(Kind == ConstraintKind::BindOverload);
     return *getTrailingObjects<OverloadChoice>();
   }
 
@@ -903,7 +903,7 @@ public:
 
   /// Retrieve the DC in which the overload was used.
   DeclContext *getDeclContext() const {
-    assert(HasDeclContext);
+    ASSERT(HasDeclContext);
     return *getTrailingObjects<DeclContext *>();
   }
 

--- a/include/swift/Sema/ConstraintSolverStats.def
+++ b/include/swift/Sema/ConstraintSolverStats.def
@@ -18,6 +18,7 @@
 #  error #define CS_STATISTIC(Name, Description) before including
 #endif
 
+CS_STATISTIC(ASTBytesAllocated, "bytes allocated in solver arena")
 CS_STATISTIC(NumTypeVariablesBound, "# of type variables bound")
 CS_STATISTIC(NumTypeVariableBindings, "# of type variable bindings attempted")
 CS_STATISTIC(NumDisjunctions, "# of disjunctions explored")

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13089,7 +13089,7 @@ retry_after_fail:
         // Determine the type that this choice will have.
         Type choiceType = getEffectiveOverloadType(
             constraint->getLocator(), choice, /*allowMembers=*/true,
-            constraint->getOverloadUseDC());
+            constraint->getDeclContext());
         if (!choiceType) {
           hasUnhandledConstraints = true;
           return true;
@@ -16335,7 +16335,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
     return simplifyApplicableFnConstraint(
         constraint.getAppliedFunctionType(), constraint.getCalleeType(),
         constraint.getTrailingClosureMatching(),
-        constraint.getApplicationDC(), /*flags=*/std::nullopt,
+        constraint.getDeclContext(), /*flags=*/std::nullopt,
         constraint.getLocator());
 
   case ConstraintKind::DynamicCallableApplicableFunction:
@@ -16382,7 +16382,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
 
     resolveOverload(constraint.getLocator(), constraint.getFirstType(),
                     constraint.getOverloadChoice(),
-                    constraint.getOverloadUseDC());
+                    constraint.getDeclContext());
     return SolutionKind::Solved;
 
   case ConstraintKind::SubclassOf:
@@ -16429,7 +16429,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   case ConstraintKind::UnresolvedValueMember:
     return simplifyMemberConstraint(
         constraint.getKind(), constraint.getFirstType(), constraint.getMember(),
-        constraint.getSecondType(), constraint.getMemberUseDC(),
+        constraint.getSecondType(), constraint.getDeclContext(),
         constraint.getFunctionRefInfo(),
         /*outerAlternatives=*/{},
         /*flags*/ std::nullopt, constraint.getLocator());
@@ -16438,7 +16438,7 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
     return simplifyValueWitnessConstraint(
         constraint.getKind(), constraint.getFirstType(),
         constraint.getRequirement(), constraint.getSecondType(),
-        constraint.getMemberUseDC(), constraint.getFunctionRefInfo(),
+        constraint.getDeclContext(), constraint.getFunctionRefInfo(),
         /*flags*/ std::nullopt, constraint.getLocator());
 
   case ConstraintKind::Defaultable:

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -669,6 +669,10 @@ ConstraintSystem::SolverState::~SolverState() {
     CS.Options -= ConstraintSystemFlags::DebugConstraints;
   }
 
+  // This statistic is special because it's not a counter; we just update
+  // it in one shot at the end.
+  ASTBytesAllocated = CS.getASTContext().getSolverMemory();
+
   // Write our local statistics back to the overall statistics.
   #define CS_STATISTIC(Name, Description) JOIN2(Overall,Name) += Name;
   #include "swift/Sema/ConstraintSolverStats.def"

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -30,9 +30,10 @@ using namespace constraints;
 Constraint::Constraint(ConstraintKind kind, ArrayRef<Constraint *> constraints,
                        bool isIsolated, ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(kind), HasFix(false), HasRestriction(false), IsActive(false),
-      IsDisabled(false), IsDisabledForPerformance(false), RememberChoice(false),
-      IsFavored(false), IsIsolated(isIsolated), NumTypeVariables(typeVars.size()),
+    : Kind(kind), NumTypeVariables(typeVars.size()),
+      HasFix(false), HasRestriction(false), IsActive(false),
+      IsDisabled(false), IsDisabledForPerformance(false),
+      RememberChoice(false), IsFavored(false), IsIsolated(isIsolated),
       Nested(constraints), Locator(locator) {
   assert(kind == ConstraintKind::Disjunction ||
          kind == ConstraintKind::Conjunction);
@@ -54,10 +55,11 @@ static bool isAdmissibleType(Type type) {
 Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
                        ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(Kind), HasFix(false), HasRestriction(false), IsActive(false),
-      IsDisabled(false), IsDisabledForPerformance(false), RememberChoice(false),
-      IsFavored(false), IsIsolated(false),
-      NumTypeVariables(typeVars.size()), Types{First, Second, Type()},
+    : Kind(Kind), NumTypeVariables(typeVars.size()),
+      HasFix(false), HasRestriction(false), IsActive(false),
+      IsDisabled(false), IsDisabledForPerformance(false),
+      RememberChoice(false), IsFavored(false), IsIsolated(false),
+      Types{First, Second, Type()},
       Locator(locator) {
   ASSERT(isAdmissibleType(First));
   ASSERT(isAdmissibleType(Second));
@@ -135,10 +137,11 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
 Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
                        ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(Kind), HasFix(false), HasRestriction(false), IsActive(false),
-      IsDisabled(false), IsDisabledForPerformance(false), RememberChoice(false),
-      IsFavored(false), IsIsolated(false),
-      NumTypeVariables(typeVars.size()), Types{First, Second, Third},
+    : Kind(Kind), NumTypeVariables(typeVars.size()),
+      HasFix(false), HasRestriction(false), IsActive(false),
+      IsDisabled(false), IsDisabledForPerformance(false),
+      RememberChoice(false), IsFavored(false), IsIsolated(false),
+      Types{First, Second, Third},
       Locator(locator) {
   ASSERT(isAdmissibleType(First));
   ASSERT(isAdmissibleType(Second));
@@ -201,10 +204,11 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
                        FunctionRefInfo functionRefInfo,
                        ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(kind), HasFix(false), HasRestriction(false), IsActive(false),
-      IsDisabled(false), IsDisabledForPerformance(false), RememberChoice(false),
-      IsFavored(false), IsIsolated(false),
-      NumTypeVariables(typeVars.size()), Member{first, second, {member}, useDC},
+    : Kind(kind), NumTypeVariables(typeVars.size()),
+      HasFix(false), HasRestriction(false), IsActive(false),
+      IsDisabled(false), IsDisabledForPerformance(false),
+      RememberChoice(false), IsFavored(false), IsIsolated(false),
+      Member{first, second, {member}, useDC},
       Locator(locator) {
   assert(kind == ConstraintKind::ValueMember ||
          kind == ConstraintKind::UnresolvedValueMember);
@@ -221,9 +225,10 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
                        FunctionRefInfo functionRefInfo,
                        ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(kind), HasFix(false), HasRestriction(false), IsActive(false),
-      IsDisabled(false), IsDisabledForPerformance(false), RememberChoice(false),
-      IsFavored(false), IsIsolated(false), NumTypeVariables(typeVars.size()),
+    : Kind(kind), NumTypeVariables(typeVars.size()),
+      HasFix(false), HasRestriction(false), IsActive(false),
+      IsDisabled(false), IsDisabledForPerformance(false),
+      RememberChoice(false), IsFavored(false), IsIsolated(false),
       Locator(locator) {
   Member.First = first;
   Member.Second = second;
@@ -242,10 +247,11 @@ Constraint::Constraint(ConstraintKind kind, Type first, Type second,
 Constraint::Constraint(Type type, OverloadChoice choice, DeclContext *useDC,
                        ConstraintFix *fix, ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(ConstraintKind::BindOverload), HasFix(fix != nullptr), HasRestriction(false),
-      IsActive(false), IsDisabled(bool(fix)), IsDisabledForPerformance(false),
+    : Kind(ConstraintKind::BindOverload), NumTypeVariables(typeVars.size()),
+      HasFix(fix != nullptr), HasRestriction(false), IsActive(false),
+      IsDisabled(bool(fix)), IsDisabledForPerformance(false),
       RememberChoice(false), IsFavored(false), IsIsolated(false),
-      NumTypeVariables(typeVars.size()), Overload{type, useDC},
+      Overload{type, useDC},
       Locator(locator) {
   std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
   if (fix)
@@ -257,10 +263,10 @@ Constraint::Constraint(ConstraintKind kind,
                        ConversionRestrictionKind restriction, Type first,
                        Type second, ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(kind), Restriction(restriction), HasFix(false), HasRestriction(true),
-      IsActive(false), IsDisabled(false), IsDisabledForPerformance(false),
-      RememberChoice(false), IsFavored(false), IsIsolated(false),
-      NumTypeVariables(typeVars.size()), Types{first, second, Type()},
+    : Kind(kind), Restriction(restriction), NumTypeVariables(typeVars.size()),
+      HasFix(false), HasRestriction(true), IsActive(false), IsDisabled(false),
+      IsDisabledForPerformance(false), RememberChoice(false), IsFavored(false),
+      IsIsolated(false), Types{first, second, Type()},
       Locator(locator) {
   ASSERT(isAdmissibleType(first));
   ASSERT(isAdmissibleType(second));
@@ -270,10 +276,11 @@ Constraint::Constraint(ConstraintKind kind,
 Constraint::Constraint(ConstraintKind kind, ConstraintFix *fix, Type first,
                        Type second, ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(kind), HasFix(fix != nullptr), HasRestriction(false), IsActive(false),
+    : Kind(kind), NumTypeVariables(typeVars.size()),
+      HasFix(fix != nullptr), HasRestriction(false), IsActive(false),
       IsDisabled(false), IsDisabledForPerformance(false), RememberChoice(false),
       IsFavored(false), IsIsolated(false),
-      NumTypeVariables(typeVars.size()), Types{first, second, Type()},
+      Types{first, second, Type()},
       Locator(locator) {
   ASSERT(isAdmissibleType(first));
   ASSERT(isAdmissibleType(second));
@@ -285,24 +292,25 @@ Constraint::Constraint(ConstraintKind kind, ConstraintFix *fix, Type first,
 Constraint::Constraint(ASTNode node, ContextualTypeInfo context,
                        bool isDiscarded, ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(ConstraintKind::SyntacticElement), HasFix(false),
-      HasRestriction(false), IsActive(false), IsDisabled(false),
-      IsDisabledForPerformance(false), RememberChoice(false), IsFavored(false),
-      IsIsolated(false),
-      NumTypeVariables(typeVars.size()), SyntacticElement{node, context,
-                                                          isDiscarded},
+    : Kind(ConstraintKind::SyntacticElement), NumTypeVariables(typeVars.size()),
+      HasFix(false), HasRestriction(false), IsActive(false),
+      IsDisabled(false), IsDisabledForPerformance(false), RememberChoice(false),
+      IsFavored(false), IsIsolated(false), isDiscarded(isDiscarded),
+      SyntacticElement{node},
       Locator(locator) {
   std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
+  *getTrailingObjects<ContextualTypeInfo>() = context;
 }
 
 Constraint::Constraint(FunctionType *appliedFn, Type calleeType,
                        unsigned trailingClosureMatching, DeclContext *useDC,
                        ConstraintLocator *locator,
                        SmallPtrSetImpl<TypeVariableType *> &typeVars)
-    : Kind(ConstraintKind::ApplicableFunction), HasFix(false),
-      HasRestriction(false), IsActive(false), IsDisabled(false),
+    : Kind(ConstraintKind::ApplicableFunction), NumTypeVariables(typeVars.size()),
+      HasFix(false), HasRestriction(false), IsActive(false), IsDisabled(false),
       IsDisabledForPerformance(false), RememberChoice(false), IsFavored(false),
-      IsIsolated(false), NumTypeVariables(typeVars.size()), Locator(locator) {
+      IsIsolated(false), trailingClosureMatching(trailingClosureMatching),
+      Locator(locator) {
   ASSERT(isAdmissibleType(appliedFn));
   ASSERT(isAdmissibleType(calleeType));
   assert(trailingClosureMatching >= 0 && trailingClosureMatching <= 2);
@@ -310,7 +318,6 @@ Constraint::Constraint(FunctionType *appliedFn, Type calleeType,
 
   Apply.AppliedFn = appliedFn;
   Apply.Callee = calleeType;
-  Apply.TrailingClosureMatching = trailingClosureMatching;
   Apply.UseDC = useDC;
 
   std::copy(typeVars.begin(), typeVars.end(), getTypeVariablesBuffer().begin());
@@ -782,8 +789,10 @@ Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind,
 
   // Create the constraint.
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return ::new (mem) Constraint(kind, first, second, locator, typeVars);
 }
@@ -803,8 +812,10 @@ Constraint *Constraint::create(ConstraintSystem &cs, ConstraintKind kind,
     third->getTypeVariables(typeVars);
 
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return ::new (mem) Constraint(kind,
                                 first, second, third,
@@ -846,8 +857,10 @@ Constraint *Constraint::createMember(ConstraintSystem &cs, ConstraintKind kind,
 
   // Create the constraint.
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, first, second, member, useDC,
                               functionRefInfo, locator, typeVars);
@@ -868,8 +881,10 @@ Constraint *Constraint::createValueWitness(
 
   // Create the constraint.
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, first, second, requirement, useDC,
                               functionRefInfo, locator, typeVars);
@@ -890,8 +905,10 @@ Constraint *Constraint::createBindOverload(ConstraintSystem &cs, Type type,
 
   // Create the constraint.
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), fix ? 1 : 0, /*hasOverloadChoice=*/1);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), fix ? 1 : 0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/1);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(type, choice, useDC, fix, locator, typeVars);
 }
@@ -910,8 +927,10 @@ Constraint *Constraint::createRestricted(ConstraintSystem &cs,
 
   // Create the constraint.
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, restriction, first, second, locator,
                               typeVars);
@@ -929,8 +948,10 @@ Constraint *Constraint::createFixed(ConstraintSystem &cs, ConstraintKind kind,
 
   // Create the constraint.
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), fix ? 1 : 0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), fix ? 1 : 0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(kind, fix, first, second, locator, typeVars);
 }
@@ -1001,8 +1022,10 @@ Constraint *Constraint::createDisjunction(ConstraintSystem &cs,
 
   // Create the disjunction constraint.
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   auto disjunction = new (mem)
       Constraint(ConstraintKind::Disjunction, cs.allocateCopy(constraints),
@@ -1022,8 +1045,10 @@ Constraint *Constraint::createConjunction(
 
   assert(!constraints.empty() && "Empty conjunction constraint");
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   auto conjunction = new (mem)
       Constraint(ConstraintKind::Conjunction, cs.allocateCopy(constraints),
@@ -1058,8 +1083,10 @@ Constraint *Constraint::createApplicableFunction(
 
     // Create the constraint.
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/0, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   auto constraint = new (mem)
       Constraint(argumentFnType, calleeType, rawTrailingClosureMatching, useDC,
@@ -1087,8 +1114,10 @@ Constraint *Constraint::createSyntacticElement(ConstraintSystem &cs,
     contextTy->getTypeVariables(typeVars);
 
   auto size =
-    totalSizeToAlloc<TypeVariableType *, ConstraintFix *, OverloadChoice>(
-      typeVars.size(), /*hasFix=*/0, /*hasOverloadChoice=*/0);
+    totalSizeToAlloc<TypeVariableType *, ConstraintFix *,
+                     ContextualTypeInfo, OverloadChoice>(
+      typeVars.size(), /*hasFix=*/0,
+      /*hasContextualTypeInfo=*/1, /*hasOverloadChoice=*/0);
   void *mem = cs.getAllocator().Allocate(size, alignof(Constraint));
   return new (mem) Constraint(node, context, isDiscarded, locator, typeVars);
 }
@@ -1096,7 +1125,7 @@ Constraint *Constraint::createSyntacticElement(ConstraintSystem &cs,
 std::optional<TrailingClosureMatching>
 Constraint::getTrailingClosureMatching() const {
   assert(Kind == ConstraintKind::ApplicableFunction);
-  switch (Apply.TrailingClosureMatching) {
+  switch (trailingClosureMatching) {
   case 0:
     return std::nullopt;
   case 1: return TrailingClosureMatching::Forward;

--- a/unittests/Sema/ConstraintSimplificationTests.cpp
+++ b/unittests/Sema/ConstraintSimplificationTests.cpp
@@ -218,7 +218,7 @@ TEST_F(SemaTest, TestInitializerUseDCIsSetCorrectlyInClosure) {
                       ->isLastElement<LocatorPathElt::ConstructorMember>());
 
       for (auto *choice : constraint->getNestedConstraints())
-        ASSERT_EQ(choice->getOverloadUseDC(), closure);
+        ASSERT_EQ(choice->getDeclContext(), closure);
     }
   }
 }


### PR DESCRIPTION
While building the standard library, the total size of all constraint solver arenas allocated goes down from 638Mb to 596Mb.

Fixes rdar://146459456