### PR TITLE
[CMake] Fix package CMO capability chekcing logic

### DIFF
--- a/cmake/modules/SwiftCompilerCapability.cmake
+++ b/cmake/modules/SwiftCompilerCapability.cmake
@@ -39,6 +39,7 @@ function(swift_get_package_cmo_support out_var)
   # > 6.0 : Fixed feature.
   swift_supports_compiler_arguments(result
     -package-name my-package
+    -enable-library-evolution
     -Xfrontend -package-cmo
     -Xfrontend -allow-non-resilient-access
   )


### PR DESCRIPTION
Package CMO requires '-enable-library-evolution' in 6.1+ compilers. Otherwise:
```
  <unknown>:0: error: Library evolution must be enabled for Package CMO
```
rdar://146673779