### PR TITLE
[Region analysis] Remove an assertion that doesn't always hold

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3752,11 +3752,6 @@ static bool canComputeRegionsForFunction(SILFunction *fn) {
   if (!fn->getASTContext().LangOpts.hasFeature(Feature::RegionBasedIsolation))
     return false;
 
-  assert(fn->getASTContext().LangOpts.StrictConcurrencyLevel ==
-             StrictConcurrency::Complete &&
-         "Need strict concurrency to be enabled for RegionBasedIsolation to be "
-         "enabled as well");
-
   // If this function does not correspond to a syntactic declContext and it
   // doesn't have a parent module, don't check it since we cannot check if a
   // type is sendable.


### PR DESCRIPTION
It appears that we can end up breaking this assertion when inlining SIL from modules with strict concurrency enabled into modules that don't. That's not a assertion-worth condition.

