### PR TITLE
[SUA][IRGen] Add stub for swift_coroFrameAlloc that weakly links against the runtime function

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -646,7 +646,7 @@ public:
         DisableReadonlyStaticObjects(false), CollocatedMetadataFunctions(false),
         ColocateTypeDescriptors(true), UseRelativeProtocolWitnessTables(false),
         UseFragileResilientProtocolWitnesses(false), EnableHotColdSplit(false),
-        EmitAsyncFramePushPopMetadata(true), EmitTypeMallocForCoroFrame(false),
+        EmitAsyncFramePushPopMetadata(true), EmitTypeMallocForCoroFrame(true),
         AsyncFramePointerAll(false), UseProfilingMarkerThunks(false),
         UseCoroCCX8664(false), UseCoroCCArm64(false),
         MergeableTraps(false),

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2105,6 +2105,12 @@ FUNCTION(CoroFrameAlloc, Swift, swift_coroFrameAlloc, C_CC, AlwaysAvailable,
          NO_ATTRS,
          EFFECT(RuntimeEffect::Allocating),
          UNKNOWN_MEMEFFECTS)
+FUNCTION(coroFrameAllocStub, Swift, swift_coroFrameAllocStub, C_CC,
+         AlwaysAvailable, RETURNS(Int8PtrTy),
+         ARGS(SizeTy, Int64Ty),
+         ATTRS(NoUnwind),
+         EFFECT(RuntimeEffect::Allocating),
+         UNKNOWN_MEMEFFECTS)
 
 // void *_Block_copy(void *block);
 FUNCTION(BlockCopy, BlocksRuntime, _Block_copy, C_CC, AlwaysAvailable,

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5090,7 +5090,9 @@ void irgen::emitYieldOnceCoroutineEntry(
   auto *buffer = emission.getCoroutineBuffer();
   llvm::SmallVector<llvm::Value *, 2> finalArgs;
   llvm::Constant *allocFn = nullptr;
-  if (IGF.getOptions().EmitTypeMallocForCoroFrame) {
+  if (IGF.getOptions().EmitTypeMallocForCoroFrame
+      && !llvm::Triple(IGF.IGM.Triple).isOSLinux()
+      && !llvm::Triple(IGF.IGM.Triple).isOSWindows()) {
     auto mallocTypeId = IGF.getMallocTypeId();
     finalArgs.push_back(mallocTypeId);
     // Use swift_coroFrameAllocStub to emit our allocator.

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5099,11 +5099,14 @@ void irgen::emitYieldOnceCoroutineEntry(
     // Use malloc as our allocator.
     allocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getMallocFn());
   }
+
+  ArtificialLocation Loc(IGF.getDebugScope(), IGF.IGM.DebugInfo.get(), IGF.Builder);
   emitRetconCoroutineEntry(IGF, fnType, buffer,
                            llvm::Intrinsic::coro_id_retcon_once,
                            getYieldOnceCoroutineBufferSize(IGF.IGM),
                            getYieldOnceCoroutineBufferAlignment(IGF.IGM), {},
                            allocFn, deallocFn, finalArgs);
+
 }
 
 void irgen::emitYieldManyCoroutineEntry(

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1466,9 +1466,9 @@ public:
     llvm::Value *buffer = origParams.claimNext();
     llvm::Value *id;
     if (subIGF.IGM.getOptions().EmitTypeMallocForCoroFrame) {
-      // Use swift_coroFrameAlloc as our allocator.
-    auto coroAllocFn = subIGF.IGM.getOpaquePtr(subIGF.IGM.getCoroFrameAllocFn());
-    auto mallocTypeId = subIGF.getMallocTypeId();
+      // Use swift_coroFrameAllocStub to emit our allocator.
+      auto coroAllocFn = subIGF.IGM.getOpaquePtr(getCoroFrameAllocStubFn(subIGF.IGM));
+      auto mallocTypeId = subIGF.getMallocTypeId();
       id = subIGF.Builder.CreateIntrinsicCall(
         llvm::Intrinsic::coro_id_retcon_once,
         {llvm::ConstantInt::get(

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1465,7 +1465,9 @@ public:
     // Call the right 'llvm.coro.id.retcon' variant.
     llvm::Value *buffer = origParams.claimNext();
     llvm::Value *id;
-    if (subIGF.IGM.getOptions().EmitTypeMallocForCoroFrame) {
+    if (subIGF.IGM.getOptions().EmitTypeMallocForCoroFrame
+        && !llvm::Triple(subIGF.IGM.Triple).isOSLinux()
+        && !llvm::Triple(subIGF.IGM.Triple).isOSWindows()) {
       // Use swift_coroFrameAllocStub to emit our allocator.
       auto coroAllocFn = subIGF.IGM.getOpaquePtr(getCoroFrameAllocStubFn(subIGF.IGM));
       auto mallocTypeId = subIGF.getMallocTypeId();

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -61,6 +61,42 @@ namespace irgen {
       CanSILFunctionType outType, Explosion &out, bool isOutlined);
   CanType getArgumentLoweringType(CanType type, SILParameterInfo paramInfo,
                                   bool isNoEscape);
+
+  /// Stub function that weakly links againt the swift_coroFrameAlloc
+  /// function. This is required for back-deployment.
+  static llvm::Constant *getCoroFrameAllocStubFn(IRGenModule &IGM) {
+  return IGM.getOrCreateHelperFunction(
+    "__swift_coroFrameAllocStub", IGM.Int8PtrTy,
+    {IGM.SizeTy, IGM.Int64Ty},
+    [&](IRGenFunction &IGF) {
+      auto parameters = IGF.collectParameters();
+      auto *size = parameters.claimNext();
+      auto coroAllocPtr = IGF.IGM.getCoroFrameAllocFn();
+      auto coroAllocFn = dyn_cast<llvm::Function>(coroAllocPtr);
+      coroAllocFn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
+      auto *coroFrameAllocFn = IGF.IGM.getOpaquePtr(coroAllocPtr);
+      auto *nullSwiftCoroFrameAlloc = IGF.Builder.CreateCmp(
+        llvm::CmpInst::Predicate::ICMP_NE, coroFrameAllocFn,
+        llvm::ConstantPointerNull::get(
+            cast<llvm::PointerType>(coroFrameAllocFn->getType())));
+      auto *coroFrameAllocReturn = IGF.createBasicBlock("return-coroFrameAlloc");
+      auto *mallocReturn = IGF.createBasicBlock("return-malloc");
+      IGF.Builder.CreateCondBr(nullSwiftCoroFrameAlloc, coroFrameAllocReturn, mallocReturn);
+
+      IGF.Builder.emitBlock(coroFrameAllocReturn);
+      auto *mallocTypeId = parameters.claimNext();
+      auto *coroFrameAllocCall = IGF.Builder.CreateCall(IGF.IGM.getCoroFrameAllocFunctionPointer(), {size, mallocTypeId});
+      IGF.Builder.CreateRet(coroFrameAllocCall);
+
+      IGF.Builder.emitBlock(mallocReturn);
+      auto *mallocCall = IGF.Builder.CreateCall(IGF.IGM.getMallocFunctionPointer(), {size});
+      IGF.Builder.CreateRet(mallocCall);
+    },
+    /*setIsNoInline=*/false,
+    /*forPrologue=*/false,
+    /*isPerformanceConstraint=*/false,
+    /*optionalLinkageOverride=*/nullptr, llvm::CallingConv::C);
+  }
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -73,8 +73,8 @@ namespace irgen {
       auto *size = parameters.claimNext();
       auto coroAllocPtr = IGF.IGM.getCoroFrameAllocFn();
       auto coroAllocFn = dyn_cast<llvm::Function>(coroAllocPtr);
-      if (!llvm::Triple(IGM.Triple).isOSWindows())
-        coroAllocFn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
+      // if (!llvm::Triple(IGM.Triple).isOSWindows())
+      coroAllocFn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
       auto *coroFrameAllocFn = IGF.IGM.getOpaquePtr(coroAllocPtr);
       auto *nullSwiftCoroFrameAlloc = IGF.Builder.CreateCmp(
         llvm::CmpInst::Predicate::ICMP_NE, coroFrameAllocFn,

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -73,7 +73,8 @@ namespace irgen {
       auto *size = parameters.claimNext();
       auto coroAllocPtr = IGF.IGM.getCoroFrameAllocFn();
       auto coroAllocFn = dyn_cast<llvm::Function>(coroAllocPtr);
-      coroAllocFn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
+      if (!llvm::Triple(IGM.Triple).isOSWindows())
+        coroAllocFn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
       auto *coroFrameAllocFn = IGF.IGM.getOpaquePtr(coroAllocPtr);
       auto *nullSwiftCoroFrameAlloc = IGF.Builder.CreateCmp(
         llvm::CmpInst::Predicate::ICMP_NE, coroFrameAllocFn,

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -73,7 +73,6 @@ namespace irgen {
       auto *size = parameters.claimNext();
       auto coroAllocPtr = IGF.IGM.getCoroFrameAllocFn();
       auto coroAllocFn = dyn_cast<llvm::Function>(coroAllocPtr);
-      // if (!llvm::Triple(IGM.Triple).isOSWindows())
       coroAllocFn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
       auto *coroFrameAllocFn = IGF.IGM.getOpaquePtr(coroAllocPtr);
       auto *nullSwiftCoroFrameAlloc = IGF.Builder.CreateCmp(

--- a/test/IRGen/partial_apply_coro.sil
+++ b/test/IRGen/partial_apply_coro.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=OnoneSimplification -I %t -emit-ir %s -o - | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
+// RUN: %target-swift-frontend -Xllvm -sil-disable-pass=OnoneSimplification -I %t -emit-ir -disable-emit-type-malloc-for-coro-frame %s -o - | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-cpu
 
 // REQUIRES: concurrency
 

--- a/test/IRGen/yield_once.sil
+++ b/test/IRGen/yield_once.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth
+// RUN: %target-swift-frontend -emit-irgen -disable-emit-type-malloc-for-coro-frame %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth
 
 import Builtin
 

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen -disable-emit-type-malloc-for-coro-frame %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
 // UNSUPPORTED: CPU=arm64_32
 
 import Builtin

--- a/test/IRGen/yield_once_biggish.sil
+++ b/test/IRGen/yield_once_biggish.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen -disable-emit-type-malloc-for-coro-frame %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
 
 // i386 uses a scalar result count of 3 instead of 4, so this test would need
 // to be substantially different to test the functionality there.  It's easier

--- a/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
+++ b/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
@@ -44,17 +44,16 @@ unwind:
 }
 
 // CHECK:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i64 %0, i64 %1) #1 {
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:  %2 = icmp ne ptr @swift_coroFrameAlloc, null
-// CHECK-NEXT:  br i1 %2, label %return-coroFrameAlloc, label %return-malloc
+// CHECK:       %2 = icmp ne ptr @swift_coroFrameAlloc, null
+// CHECK:       br i1 %2, label %return-coroFrameAlloc, label %return-malloc
 
 // CHECK-LABEL: return-coroFrameAlloc:
-// CHECK-NEXT:  %3 = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1) #2
-// CHECK-NEXT:  ret ptr %3
+// CHECK:         %3 = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1) #2
+// CHECK:         ret ptr %3
 
 // CHECK-LABEL: return-malloc:
-// CHECK-NEXT:  %4 = call ptr @malloc(i64 %0)
-// CHECK-NEXT:  ret ptr %4
+// CHECK:         %4 = call ptr @malloc(i64 %0)
+// CHECK:         ret ptr %4
 
 // CHECK:       declare extern_weak ptr @swift_coroFrameAlloc(i64, i64)
 

--- a/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
+++ b/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
@@ -49,8 +49,8 @@ unwind:
 // CHECK:       br i1 %2, label %return-coroFrameAlloc, label %return-malloc
 
 // CHECK-LABEL: return-coroFrameAlloc:
-// CHECK-32:         %3 = call ptr @swift_coroFrameAlloc(i32 %0, i64 %1) #2
-// CHECK-64:         %3 = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1) #2
+// CHECK-32:         %3 = call ptr @swift_coroFrameAlloc(i32 %0, i64 %1)
+// CHECK-64:         %3 = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1)
 // CHECK:         ret ptr %3
 
 // CHECK-LABEL: return-malloc:

--- a/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
+++ b/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
@@ -10,8 +10,8 @@ sil @marker : $(Builtin.Int32) -> ()
 // CHECK-SAME:  [[CORO_ATTRIBUTES:#[0-9]+]]
 sil @test_simple : $@yield_once () -> () {
 entry:
-  // CHECK-32: [[ID:%.*]] = call token (i32, i32, ptr, ptr, ptr, ptr, ...) @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:4]], ptr %0, ptr @"$sIetA_TC", ptr @swift_coroFrameAlloc, ptr @free, i64 38223)
-  // CHECK-64: [[ID:%.*]] = call token (i32, i32, ptr, ptr, ptr, ptr, ...) @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:8]], ptr %0, ptr @"$sIetA_TC", ptr @swift_coroFrameAlloc, ptr @free, i64 38223)
+  // CHECK-32: [[ID:%.*]] = call token (i32, i32, ptr, ptr, ptr, ptr, ...) @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:4]], ptr %0, ptr @"$sIetA_TC", ptr @__swift_coroFrameAllocStub, ptr @free, i64 38223)
+  // CHECK-64: [[ID:%.*]] = call token (i32, i32, ptr, ptr, ptr, ptr, ...) @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:8]], ptr %0, ptr @"$sIetA_TC", ptr @__swift_coroFrameAllocStub, ptr @free, i64 38223)
   // CHECK-NEXT:    [[BEGIN:%.*]] = call ptr @llvm.coro.begin(token [[ID]], ptr null)
 
   // CHECK-NEXT:    call swiftcc void @marker(i32 1000)
@@ -42,6 +42,21 @@ unwind:
   // CHECK:         call i1 @llvm.coro.end(ptr [[BEGIN]], i1 false, token none)
   // CHECK-NEXT:    unreachable
 }
+
+// CHECK:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i64 %0, i64 %1) #1 {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:  %2 = icmp ne ptr @swift_coroFrameAlloc, null
+// CHECK-NEXT:  br i1 %2, label %return-coroFrameAlloc, label %return-malloc
+
+// CHECK-LABEL: return-coroFrameAlloc:
+// CHECK-NEXT:  %3 = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1) #2
+// CHECK-NEXT:  ret ptr %3
+
+// CHECK-LABEL: return-malloc:
+// CHECK-NEXT:  %4 = call ptr @malloc(i64 %0)
+// CHECK-NEXT:  ret ptr %4
+
+// CHECK:       declare extern_weak ptr @swift_coroFrameAlloc(i64, i64)
 
 // CHECK-LABEL:     declare{{( dllimport)?}}{{( protected)?}} swiftcc void @"$sIetA_TC"
 // CHECK-SAME:      (ptr noalias dereferenceable([[BUFFER_SIZE]]), i1)

--- a/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
+++ b/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-irgen -enable-emit-type-malloc-for-coro-frame %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth
+// REQUIRES: OS=macosx || OS=iOS
+// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth
 
 import Builtin
 

--- a/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
+++ b/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
@@ -43,16 +43,19 @@ unwind:
   // CHECK-NEXT:    unreachable
 }
 
-// CHECK:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i64 %0, i64 %1) #1 {
+// CHECK-32:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i32 %0, i64 %1) #1 {
+// CHECK-64:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i64 %0, i64 %1) #1 {
 // CHECK:       %2 = icmp ne ptr @swift_coroFrameAlloc, null
 // CHECK:       br i1 %2, label %return-coroFrameAlloc, label %return-malloc
 
 // CHECK-LABEL: return-coroFrameAlloc:
-// CHECK:         %3 = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1) #2
+// CHECK-32:         %3 = call ptr @swift_coroFrameAlloc(i32 %0, i64 %1) #2
+// CHECK-64:         %3 = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1) #2
 // CHECK:         ret ptr %3
 
 // CHECK-LABEL: return-malloc:
-// CHECK:         %4 = call ptr @malloc(i64 %0)
+// CHECK-32:         %4 = call ptr @malloc(i32 %0)
+// CHECK-64:         %4 = call ptr @malloc(i64 %0)
 // CHECK:         ret ptr %4
 
 // CHECK:       declare extern_weak ptr @swift_coroFrameAlloc(i64, i64)

--- a/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
+++ b/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
@@ -43,7 +43,7 @@ unwind:
   // CHECK-NEXT:    unreachable
 }
 
-// CHECK-32:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i32 %0, i64 %1) #1 {
+// CHECK-32:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i32 %0, i64 %1) #1{{( comdat)?}} {
 // CHECK-64:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i64 %0, i64 %1) #1 {
 // CHECK:       %2 = icmp ne ptr @swift_coroFrameAlloc, null
 // CHECK:       br i1 %2, label %return-coroFrameAlloc, label %return-malloc
@@ -58,7 +58,8 @@ unwind:
 // CHECK-64:         %4 = call ptr @malloc(i64 %0)
 // CHECK:         ret ptr %4
 
-// CHECK:       declare extern_weak ptr @swift_coroFrameAlloc(i64, i64)
+// CHECK-32:       declare extern_weak ptr @swift_coroFrameAlloc(i32, i64)
+// CHECK-64:       declare extern_weak ptr @swift_coroFrameAlloc(i64, i64)
 
 // CHECK-LABEL:     declare{{( dllimport)?}}{{( protected)?}} swiftcc void @"$sIetA_TC"
 // CHECK-SAME:      (ptr noalias dereferenceable([[BUFFER_SIZE]]), i1)

--- a/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
+++ b/test/IRGen/yield_once_enable_emit_type_malloc_coro_frame.sil
@@ -44,19 +44,19 @@ unwind:
 }
 
 // CHECK-32:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i32 %0, i64 %1) #1{{( comdat)?}} {
-// CHECK-64:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i64 %0, i64 %1) #1 {
-// CHECK:       %2 = icmp ne ptr @swift_coroFrameAlloc, null
-// CHECK:       br i1 %2, label %return-coroFrameAlloc, label %return-malloc
+// CHECK-64:       define linkonce_odr hidden ptr @__swift_coroFrameAllocStub(i64 %0, i64 %1) #1{{( comdat)?}} {
+// CHECK:       [[T0:%.*]] = icmp ne ptr @swift_coroFrameAlloc, null
+// CHECK:       br i1 [[T0]], label %return-coroFrameAlloc, label %return-malloc
 
 // CHECK-LABEL: return-coroFrameAlloc:
-// CHECK-32:         %3 = call ptr @swift_coroFrameAlloc(i32 %0, i64 %1)
-// CHECK-64:         %3 = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1)
-// CHECK:         ret ptr %3
+// CHECK-32:         [[T1:%.*]] = call ptr @swift_coroFrameAlloc(i32 %0, i64 %1)
+// CHECK-64:         [[T1:%.*]] = call ptr @swift_coroFrameAlloc(i64 %0, i64 %1)
+// CHECK:         ret ptr [[T1]]
 
 // CHECK-LABEL: return-malloc:
-// CHECK-32:         %4 = call ptr @malloc(i32 %0)
-// CHECK-64:         %4 = call ptr @malloc(i64 %0)
-// CHECK:         ret ptr %4
+// CHECK-32:         [[T2:%.*]] = call ptr @malloc(i32 %0)
+// CHECK-64:         [[T2:%.*]] = call ptr @malloc(i64 %0)
+// CHECK:         ret ptr [[T2]]
 
 // CHECK-32:       declare extern_weak ptr @swift_coroFrameAlloc(i32, i64)
 // CHECK-64:       declare extern_weak ptr @swift_coroFrameAlloc(i64, i64)

--- a/test/IRGen/yield_once_indirect.sil
+++ b/test/IRGen/yield_once_indirect.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen -disable-emit-type-malloc-for-coro-frame %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-ptrsize-%target-ptrauth -DINT=i%target-ptrsize
 
 import Builtin
 import Swift

--- a/test/IRGen/yield_result.sil
+++ b/test/IRGen/yield_result.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-irgen %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -emit-irgen -disable-emit-type-malloc-for-coro-frame %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
 
 import Builtin
 


### PR DESCRIPTION
This PR modifies IRGen to emit a stub function `__swift_coroFrameAllocStub` instead of the
newly introduced swift-rt function `swift_coroFrameAlloc`. The stub checks whether the runtime has the symbol
`swift_coroFrameAlloc` and dispatches to it if it exists, uses `malloc` otherwise. This ensures the
ability to back deploy the feature to older OS targets.

rdar://145239850