### PR TITLE
[cxx-interop] Remove workarounds for `CF_OPTIONS` default arguments

### DIFF
--- a/lib/ClangImporter/ImportEnumInfo.h
+++ b/lib/ClangImporter/ImportEnumInfo.h
@@ -163,6 +163,14 @@ StringRef getCommonPluralPrefix(StringRef singular, StringRef plural);
 /// Returns the underlying integer type of an enum. If clang treats the type as
 /// an elaborated type, an unwrapped type is returned.
 const clang::Type *getUnderlyingType(const clang::EnumDecl *decl);
+
+inline bool isCFOptionsMacro(StringRef macroName) {
+  return llvm::StringSwitch<bool>(macroName)
+      .Case("CF_OPTIONS", true)
+      .Case("NS_OPTIONS", true)
+      .Default(false);
+}
+
 }
 }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1875,7 +1875,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     if (loc.isMacroID()) {
       StringRef macroName =
           clangSema.getPreprocessor().getImmediateMacroName(loc);
-      if (macroName == "CF_OPTIONS" || macroName == "NS_OPTIONS")
+      if (isCFOptionsMacro(macroName))
         return ImportedName();
     }
   }

--- a/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
@@ -1,43 +1,57 @@
+#include "CFAvailability.h"
+
+typedef unsigned long NSUInteger;
+
 // Enum usage that is bitwise-able and assignable in C++, aka how CF_OPTIONS
 // does things.
-typedef int __attribute__((availability(swift, unavailable))) NSEnumerationOptions;
-enum : NSEnumerationOptions { NSEnumerationConcurrent, NSEnumerationReverse };
+typedef CF_OPTIONS(NSUInteger, NSEnumerationOptions) {
+  NSEnumerationConcurrent = (1UL << 0),
+  NSEnumerationReverse = (1UL << 1),
+};
 
 @interface NSSet
 - (void)enumerateObjectsWithOptions:(NSEnumerationOptions)opts ;
 @end
 
-typedef int __attribute__((availability(swift, unavailable))) NSOrderedCollectionDifferenceCalculationOptions;
-enum : NSOrderedCollectionDifferenceCalculationOptions {
+typedef CF_OPTIONS(NSUInteger, NSOrderedCollectionDifferenceCalculationOptions) {
   NSOrderedCollectionDifferenceCalculationOptions1,
   NSOrderedCollectionDifferenceCalculationOptions2
 };
 
-typedef int __attribute__((availability(swift, unavailable))) NSCalendarUnit;
-enum : NSCalendarUnit { NSCalendarUnit1, NSCalendarUnit2 };
+typedef CF_OPTIONS(NSUInteger, NSCalendarUnit) {
+  NSCalendarUnit1,
+  NSCalendarUnit2
+};
 
-typedef int __attribute__((availability(swift, unavailable))) NSSearchPathDomainMask;
-enum : NSSearchPathDomainMask { NSSearchPathDomainMask1, NSSearchPathDomainMask2 };
+typedef CF_OPTIONS(NSUInteger, NSSearchPathDomainMask) {
+  NSSearchPathDomainMask1,
+  NSSearchPathDomainMask2
+};
 
-typedef int __attribute__((availability(swift, unavailable))) NSControlCharacterAction;
-enum : NSControlCharacterAction { NSControlCharacterAction1, NSControlCharacterAction2 };
+typedef CF_OPTIONS(NSUInteger, NSControlCharacterAction) {
+  NSControlCharacterAction1,
+  NSControlCharacterAction2
+};
 
-typedef int __attribute__((availability(swift, unavailable))) UIControlState;
-enum : UIControlState { UIControlState1, UIControlState2 };
+typedef CF_OPTIONS(NSUInteger, UIControlState) {
+  UIControlState1,
+  UIControlState2
+};
 
-typedef int __attribute__((availability(swift, unavailable))) UITableViewCellStateMask;
-enum : UITableViewCellStateMask { UITableViewCellStateMask1, UITableViewCellStateMask2 };
+typedef CF_OPTIONS(NSUInteger, UITableViewCellStateMask) {
+  UITableViewCellStateMask1,
+  UITableViewCellStateMask2
+};
 
-typedef int __attribute__((availability(swift, unavailable))) UIControlEvents;
-enum : UIControlEvents { UIControlEvents1, UIControlEvents2 };
+typedef CF_OPTIONS(NSUInteger, UIControlEvents) {
+  UIControlEvents1,
+  UIControlEvents2
+};
 
-typedef int __attribute__((availability(swift, unavailable)))
-UITableViewScrollPosition;
-enum : UITableViewScrollPosition {
+typedef CF_OPTIONS(NSUInteger, UITableViewScrollPosition) {
   UITableViewScrollPosition1,
   UITableViewScrollPosition2
 };
-
 @interface NSIndexPath
 @end
 


### PR DESCRIPTION
ClangImporter has logic that infers default arguments of certain C/C++ types, such as the types declared via `CF_OPTIONS`/`NS_OPTIONS` macros.

There were some workarounds in place which triggered for C++ interop mode specifically. The workarounds were applying a heuristic based on the name of the type, which tried to match the behavior to non-C++ interop mode for certain types from the OS SDK. That was not working well for user-defined types, causing source compatibility breakages when enabling C++ interop.

This change replaces the name-based heuristic with a more robust criteria.

See also 3791ccb6.

rdar://142961112

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
