### PR TITLE
[Concurrency] Look for explicit 'nonisolated' when getting isolation from protocol conformances.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5282,7 +5282,10 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
       llvm_unreachable("protocol cannot have erased isolation");
 
     case ActorIsolation::GlobalActor:
-      if (!foundIsolation) {
+      // If we encountered an explicit globally isolated conformance, allow it
+      // to override the nonisolated isolation kind.
+      if (!foundIsolation ||
+          conformance->getSourceKind() == ConformanceEntryKind::Explicit) {
         foundIsolation = {
           protoIsolation,
           IsolationSource(proto, IsolationSource::Conformance)

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -100,6 +100,10 @@ nonisolated struct S1: GloballyIsolated {
 nonisolated protocol Refined: GloballyIsolated {}
 nonisolated protocol WhyNot {}
 
+nonisolated protocol NonisolatedWithMembers {
+  func test()
+}
+
 struct A: Refined {
   var x: NonSendable
   init(x: NonSendable) {
@@ -166,6 +170,16 @@ struct NonisolatedStruct {
   func callK2() {
     // expected-error@+1 {{call to main actor-isolated instance method 'k2()' in a synchronous nonisolated context}}
     return IsolatedCFlipped().k2()
+  }
+}
+
+@MainActor
+struct TestIsolated : NonisolatedWithMembers {
+  var x: NonSendable // expected-note {{property declared here}}
+
+  // requirement behaves as if it's explicitly `nonisolated` which gets inferred onto the witness
+  func test() {
+    _ = x // expected-error {{main actor-isolated property 'x' can not be referenced from a nonisolated context}}
   }
 }
 

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -183,6 +183,27 @@ struct TestIsolated : NonisolatedWithMembers {
   }
 }
 
+@MainActor
+protocol Root {
+  func testRoot()
+}
+
+nonisolated protocol Child : Root {
+  func testChild()
+}
+
+struct TestDifferentLevels : Child {
+  func testRoot() {}
+  func testChild() {}
+  func testNonWitness() {}
+}
+
+nonisolated func testRequirementsOnMultipleNestingLevels(t: TestDifferentLevels) {
+  t.testRoot() // okay
+  t.testChild() // okay
+  t.testNonWitness() // okay
+}
+
 // MARK: - Extensions
 
 nonisolated extension GloballyIsolated {

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -98,6 +98,7 @@ nonisolated struct S1: GloballyIsolated {
 // MARK: - Protocols
 
 nonisolated protocol Refined: GloballyIsolated {}
+nonisolated protocol WhyNot {}
 
 struct A: Refined {
   var x: NonSendable
@@ -114,10 +115,28 @@ struct A: Refined {
 
 @MainActor protocol ExplicitGlobalActor: Refined {}
 
-struct IsolatedStruct: ExplicitGlobalActor {
+struct IsolatedA: ExplicitGlobalActor {
   // expected-note@+2 {{main actor isolation inferred from conformance to protocol 'ExplicitGlobalActor'}}
   // expected-note@+1 {{calls to instance method 'g()' from outside of its actor context are implicitly asynchronous}}
   func g() {}
+}
+
+struct IsolatedB: Refined, ExplicitGlobalActor {
+  // expected-note@+2 {{calls to instance method 'h()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@+1 {{main actor isolation inferred from conformance to protocol 'ExplicitGlobalActor'}}
+  func h() {}
+}
+
+struct IsolatedC: WhyNot, GloballyIsolated {
+  // expected-note@+2 {{calls to instance method 'k()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@+1 {{main actor isolation inferred from conformance to protocol 'GloballyIsolated'}}
+  func k() {}
+}
+
+struct IsolatedCFlipped: GloballyIsolated, WhyNot {
+  // expected-note@+2 {{calls to instance method 'k2()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@+1 {{main actor isolation inferred from conformance to protocol 'GloballyIsolated'}}
+  func k2() {}
 }
 
 struct NonisolatedStruct {
@@ -128,7 +147,25 @@ struct NonisolatedStruct {
   // expected-note@+1 {{add '@MainActor' to make instance method 'callG()' part of global actor 'MainActor'}}
   func callG() {
     // expected-error@+1{{call to main actor-isolated instance method 'g()' in a synchronous nonisolated context}}
-    return IsolatedStruct().g()
+    return IsolatedA().g()
+  }
+
+  // expected-note@+1 {{add '@MainActor' to make instance method 'callH()' part of global actor 'MainActor'}}
+  func callH() {
+    // expected-error@+1 {{call to main actor-isolated instance method 'h()' in a synchronous nonisolated context}}
+    return IsolatedB().h()
+  }
+
+  // expected-note@+1 {{add '@MainActor' to make instance method 'callK()' part of global actor 'MainActor'}}
+  func callK() {
+    // expected-error@+1 {{call to main actor-isolated instance method 'k()' in a synchronous nonisolated context}}
+    return IsolatedC().k()
+  }
+
+  // expected-note@+1 {{add '@MainActor' to make instance method 'callK2()' part of global actor 'MainActor'}}
+  func callK2() {
+    // expected-error@+1 {{call to main actor-isolated instance method 'k2()' in a synchronous nonisolated context}}
+    return IsolatedCFlipped().k2()
   }
 }
 

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -63,7 +63,7 @@ public struct PublicNonSendable {
 }
 
 
-nonisolated struct NonisolatedStruct: GloballyIsolated {
+nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
   var x: NonSendable
   var y: Int = 1
 
@@ -103,6 +103,32 @@ struct A: Refined {
   var x: NonSendable
   init(x: NonSendable) {
     self.x = x // okay
+  }
+
+  init() {
+    self.x = NonSendable()
+  }
+
+  func f() {}
+}
+
+@MainActor protocol ExplicitGlobalActor: Refined {}
+
+struct IsolatedStruct: ExplicitGlobalActor {
+  // expected-note@+2 {{main actor isolation inferred from conformance to protocol 'ExplicitGlobalActor'}}
+  // expected-note@+1 {{calls to instance method 'g()' from outside of its actor context are implicitly asynchronous}}
+  func g() {}
+}
+
+struct NonisolatedStruct {
+  func callF() {
+    return A().f() // okay, 'A' is non-isolated.
+  }
+
+  // expected-note@+1 {{add '@MainActor' to make instance method 'callG()' part of global actor 'MainActor'}}
+  func callG() {
+    // expected-error@+1{{call to main actor-isolated instance method 'g()' in a synchronous nonisolated context}}
+    return IsolatedStruct().g()
   }
 }
 


### PR DESCRIPTION
If the protocol from the conformance list explicitly strips off global actor with `nonisolated`, make sure to look for this explicit isolation source when computing the resulting isolation; to prevent accidental global actor inference on the conforming type.

Resolves rdar://144798727.
