### PR TITLE
[Concurrency] Allow explicit 'nonisolated' on lazy properties and properties with property wrappers if they are a member of a non-'Sendable' type.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6068,12 +6068,6 @@ ERROR(nonisolated_local_var,none,
 ERROR(nonisolated_actor_sync_init,none,
       "'nonisolated' on an actor's synchronous initializer is invalid",
       ())
-ERROR(nonisolated_wrapped_property,none,
-      "'nonisolated' is not supported on properties with property wrappers",
-      ())
-ERROR(nonisolated_lazy,none,
-      "'nonisolated' is not supported on lazy properties",
-      ())
 
 ERROR(non_sendable_from_deinit,none,
         "cannot access %kind1 with a non-Sendable type %0 from nonisolated "

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -813,31 +813,29 @@ actor LazyActor {
     lazy var l25: Int = { [unowned self] in self.l }()
 
     nonisolated lazy var l31: Int = { v }()
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l32: Int = v
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
-    // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l33: Int = { self.v }()
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l34: Int = self.v
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
-    // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     // expected-warning@-2 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 
     nonisolated lazy var l41: Int = { l }()
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l42: Int = l
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l43: Int = { self.l }()
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l44: Int = self.l
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l45: Int = { [unowned self] in self.l }()
-    // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+    // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
 }
 
 // Infer global actors from context only for instance members.

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -65,5 +65,7 @@ actor Pumpkin: NSObject {}
 
 actor Bad {
   @objc nonisolated lazy var invalid = 0
-  // expected-warning@-1 {{'nonisolated' is not supported on lazy properties; this is an error in the Swift 6 language mode}}
+  // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
+  // expected-error@-2 {{actor-isolated setter for property 'invalid' cannot be @objc}}
+  // expected-error@-3 {{actor-isolated getter for property 'invalid' cannot be @objc}}
 }

--- a/test/Concurrency/actor_isolation_objc.swift
+++ b/test/Concurrency/actor_isolation_objc.swift
@@ -66,6 +66,6 @@ actor Pumpkin: NSObject {}
 actor Bad {
   @objc nonisolated lazy var invalid = 0
   // expected-warning@-1 {{'nonisolated' cannot be applied to mutable stored properties; this is an error in the Swift 6 language mode}}
-  // expected-error@-2 {{actor-isolated setter for property 'invalid' cannot be @objc}}
-  // expected-error@-3 {{actor-isolated getter for property 'invalid' cannot be @objc}}
+  // expected-error@-2 {{actor-isolated setter for property 'invalid' cannot be '@objc'}}
+  // expected-error@-3 {{actor-isolated getter for property 'invalid' cannot be '@objc'}}
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -400,8 +400,7 @@ struct HasWrapperOnActor {
     synced = 17
   }
 
-  @WrapperActor var actorSynced: Int = 0 // expected-warning{{'nonisolated' is not supported on properties with property wrappers}}
-
+  @WrapperActor var actorSynced: Int = 0 // expected-warning {{'nonisolated' cannot be applied to mutable stored properties}}
   func testActorSynced() {
     _ = actorSynced
     _ = $actorSynced
@@ -499,9 +498,8 @@ struct SimplePropertyWrapper {
 
 @MainActor
 class WrappedContainsNonisolatedAttr {
-  @SimplePropertyWrapper nonisolated var value 
-  // expected-error@-1 {{'nonisolated' is not supported on properties with property wrappers}}
-  // expected-note@-2 {{property declared here}}
+  @SimplePropertyWrapper nonisolated var value
+  // expected-note@-1 {{property declared here}}
 
   nonisolated func test() {
     _ = value

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -115,7 +115,7 @@ struct HasWrapperOnActor {
     synced = 17
   }
 
-  @WrapperActor var actorSynced: Int = 0 // expected-error{{'nonisolated' is not supported on properties with property wrappers}}
+  @WrapperActor var actorSynced: Int = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
 
   func testActorSynced() {
     _ = actorSynced

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -36,8 +36,8 @@ struct ImplicitlySendable {
   nonisolated var d = 0
 
   // never okay
-  nonisolated lazy var e = 0  // expected-error {{'nonisolated' is not supported on lazy properties}}
-  @P nonisolated var f = 0  // expected-error {{'nonisolated' is not supported on properties with property wrappers}}
+  nonisolated lazy var e = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
 }
 
 struct ImplicitlyNonSendable {
@@ -48,9 +48,9 @@ struct ImplicitlyNonSendable {
   nonisolated var c: Int { 0 }
   nonisolated var d = 0
 
-  // never okay
-  nonisolated lazy var e = 0  // expected-error {{'nonisolated' is not supported on lazy properties}}
-  @P nonisolated var f = 0  // expected-error {{'nonisolated' is not supported on properties with property wrappers}}
+  // okay, the type is non-'Sendable'
+  nonisolated lazy var e = 0
+  @P nonisolated var f = 0
 }
 
 public struct PublicSendable: Sendable {
@@ -60,8 +60,8 @@ public struct PublicSendable: Sendable {
   nonisolated var d = 0
 
   // never okay
-  nonisolated lazy var e = 0  // expected-error {{'nonisolated' is not supported on lazy properties}}
-  @P nonisolated var f = 0  // expected-error {{'nonisolated' is not supported on properties with property wrappers}}
+  nonisolated lazy var e = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  @P nonisolated var f = 0  // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
 }
 
 public struct PublicNonSendable {
@@ -70,9 +70,9 @@ public struct PublicNonSendable {
   nonisolated var c: Int { 0 }
   nonisolated var d = 0
 
-  // never okay
-  nonisolated lazy var e = 0  // expected-error {{'nonisolated' is not supported on lazy properties}}
-  @P nonisolated var f = 0  // expected-error {{'nonisolated' is not supported on properties with property wrappers}}
+  // okay, the type is non-'Sendable'
+  nonisolated lazy var e = 0
+  @P nonisolated var f = 0
 }
 
 
@@ -96,6 +96,8 @@ nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
 
 @MainActor struct S {
   var value: NonSendable // globally-isolated
+  @P nonisolated var x = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  nonisolated lazy var y = 1 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
   struct Nested {} // 'Nested' is not @MainActor-isolated
 }
 
@@ -104,6 +106,8 @@ nonisolated struct StructRemovesGlobalActor: GloballyIsolated {
 
 nonisolated struct S1: GloballyIsolated {
   var x: NonSendable
+  @P nonisolated var y = 0 // okay
+  nonisolated lazy var z = 1 // okay
   func f() {
     // expected-error@+1 {{call to main actor-isolated global function 'requireMain()' in a synchronous nonisolated context}}
     requireMain()

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -53,8 +53,8 @@ distributed actor DA {
     fatalError()
   }
 
-  nonisolated lazy var a = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
-  @P nonisolated var b = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  nonisolated lazy var a = 0 // expected-error {{'nonisolated' can not be applied to distributed actor stored properties}}
+  @P nonisolated var b = 0 // expected-error {{'nonisolated' can not be applied to distributed actor stored properties}}
 
 }
 

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -10,6 +10,10 @@ import FakeDistributedActorSystems
 @available(SwiftStdlib 5.5, *)
 typealias DefaultDistributedActorSystem = FakeActorSystem
 
+@propertyWrapper struct P {
+  var wrappedValue = 0
+}
+
 distributed actor DA {
 
   let local: Int = 42
@@ -48,6 +52,9 @@ distributed actor DA {
     // expected-error@-1{{cannot declare method 'distributedNonisolated()' as both 'nonisolated' and 'distributed'}}{{15-27=}}
     fatalError()
   }
+
+  nonisolated lazy var a = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
+  @P nonisolated var b = 0 // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}
 
 }
 


### PR DESCRIPTION
Allow spelling the `nonisolated` modifier for lazy properties and properties with property wrappers if the property is a member of a non-`Sendable` type. In general, `nonisolated` is not supported on such properties, but it should be under the rule proposed in [SE-0449](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0449-nonisolated-for-global-actor-cutoff.md#stored-properties-of-non-sendable-types) which allowed spelling the implicit `nonisolated` on a property of a non-`Sendable` type. This PR also removes the lazy property/property-wrapper specific diagnostic and allows such properties to go through the normal `nonisolated` attribute checking.

Resolves rdar://144659578.