### PR TITLE
[6.1][CMake] Fix package CMO capability checking logic

### DIFF
--- a/cmake/modules/SwiftCompilerCapability.cmake
+++ b/cmake/modules/SwiftCompilerCapability.cmake
@@ -39,6 +39,7 @@ function(swift_get_package_cmo_support out_var)
   # > 6.0 : Fixed feature.
   swift_supports_compiler_arguments(result
     -package-name my-package
+    -enable-library-evolution
     -Xfrontend -package-cmo
     -Xfrontend -allow-non-resilient-access
   )


### PR DESCRIPTION
  - **Explanation**: The host swift-syntax is missing package CMO since https://github.com/swiftlang/swift/pull/76278, which results in a significant regression to build performance for anything using these libraries.
  - **Scope**: Host swift-syntax libraries
  - **Issues**: rdar://146673779
  - **Original PRs**: https://github.com/swiftlang/swift/pull/79884
  - **Risk**: Very low, we were already building in this configuration for all of release/6.0 (and still do for any 6.0 compiler)
  - **Testing**: Build + compiler tests with 6.1 host
  - **Reviewers**: @hborla 