### PR TITLE
[Strict memory safety] Eliminate false cycle when checking nonisolated(unsafe)

### DIFF
--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -165,11 +165,6 @@ void swift::diagnoseUnsafeUse(const UnsafeUse &use) {
 /// Determine whether a reference to the given variable is treated as
 /// nonisolated(unsafe).
 static bool isReferenceToNonisolatedUnsafe(ValueDecl *decl) {
-  auto isolation = getActorIsolationForReference(
-      decl, decl->getDeclContext());
-  if (!isolation.isNonisolated())
-    return false;
-
   auto attr = decl->getAttrs().getAttribute<NonisolatedAttr>();
   return attr && attr->isUnsafe();
 }

--- a/test/Unsafe/unsafe_concurrency.swift
+++ b/test/Unsafe/unsafe_concurrency.swift
@@ -43,3 +43,15 @@ final class MyExecutor: SerialExecutor {
   func enqueue(_ job: consuming ExecutorJob) { fatalError("boom") }
   @unsafe func asUnownedSerialExecutor() -> UnownedSerialExecutor { fatalError("boom") }
 }
+
+// Ensure that this does not cause a reference cycle.
+public struct TokenSyntax { }
+public struct Syntax { }
+
+open class SyntaxVisitor {
+  open func visit(_ token: TokenSyntax) { }
+}
+
+open class SyntaxAnyVisitor: SyntaxVisitor {
+  override open func visit(_ token: TokenSyntax) { }
+}


### PR DESCRIPTION
When checking for nonisolated(unsafe), don't evaluate the full isolation of the entity, because doing so causes a reference cycle.
