### PR TITLE
utils: Move libs to arch-specific SDK dirs to avoid multi-lib error with lld

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3211,8 +3211,8 @@ if (-not $SkipBuild) {
       Invoke-BuildStep Build-ExperimentalRuntime -Static Android $Arch
       Invoke-BuildStep Build-Foundation -Static Android $Arch
 
-      Copy-File "$(Get-SwiftSDK Android)\usr\lib\swift\android\*.a" "$(Get-SwiftSDK Android)\usr\lib\swift\android\$($Arch.LLVMName)\"
-      Copy-File "$(Get-SwiftSDK Android)\usr\lib\swift\android\*.so" "$(Get-SwiftSDK Android)\usr\lib\swift\android\$($Arch.LLVMName)\"
+      Move-Item "$(Get-SwiftSDK Android)\usr\lib\swift\android\*.a" "$(Get-SwiftSDK Android)\usr\lib\swift\android\$($Arch.LLVMName)\"
+      Move-Item "$(Get-SwiftSDK Android)\usr\lib\swift\android\*.so" "$(Get-SwiftSDK Android)\usr\lib\swift\android\$($Arch.LLVMName)\"
     }
     Install-Platform Android $AndroidSDKArchs
     Invoke-BuildStep Write-PlatformInfoPlist Android


### PR DESCRIPTION
Android SDK builds with the Windows toolchain fail right now, because lld traverses arch-agnostic libs first. Make sure we leave no copies of arch-specific artifacts in arch-agnostic folders. Otherwise they get picked up for the next arch, but aren't compatible.