### PR TITLE
Sema: Mostly remove one-way constraints

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -859,7 +859,7 @@ public:
 
   /// Whether this is a one-way constraint.
   bool isOneWayConstraint() const {
-    return Kind == ConstraintKind::OneWayEqual;
+    return false;
   }
 
   /// Retrieve the overload choice for an overload-binding constraint.

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -857,11 +857,6 @@ public:
   /// from the rest of the constraint system.
   bool isIsolated() const { return IsIsolated; }
 
-  /// Whether this is a one-way constraint.
-  bool isOneWayConstraint() const {
-    return false;
-  }
-
   /// Retrieve the overload choice for an overload-binding constraint.
   OverloadChoice getOverloadChoice() const {
     assert(Kind == ConstraintKind::BindOverload);

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -295,25 +295,18 @@ public:
   /// to a type variable.
   void introduceToInference(TypeVariableType *typeVar, Type fixedType);
 
-  /// Describes which constraints \c gatherConstraints should gather.
-  enum class GatheringKind {
-    /// Gather constraints associated with all of the variables within the
-    /// same equivalence class as the given type variable, as well as its
-    /// immediate fixed bindings.
-    EquivalenceClass,
-    /// Gather all constraints that mention this type variable or type variables
-    /// that it is a fixed binding of. Unlike EquivalenceClass, this looks
-    /// through transitive fixed bindings. This can be used to find all the
-    /// constraints that may be affected when binding a type variable.
-    AllMentions,
-  };
-
-  /// Gather the set of constraints that involve the given type variable,
-  /// i.e., those constraints that will be affected when the type variable
-  /// gets merged or bound to a fixed type.
+  /// Gather constraints associated with all of the variables within the
+  /// same equivalence class as the given type variable, as well as its
+  /// immediate fixed bindings.
   llvm::TinyPtrVector<Constraint *>
-  gatherConstraints(TypeVariableType *typeVar,
-                    GatheringKind kind,
+  gatherAllConstraints(TypeVariableType *typeVar);
+
+  /// Gather all constraints that mention this type variable or type variables
+  /// that it is a fixed binding of. Unlike EquivalenceClass, this looks
+  /// through transitive fixed bindings. This can be used to find all the
+  /// constraints that may be affected when binding a type variable.
+  llvm::TinyPtrVector<Constraint *>
+  gatherNearbyConstraints(TypeVariableType *typeVar,
                     llvm::function_ref<bool(Constraint *)> acceptConstraint =
                         [](Constraint *constraint) { return true; });
 

--- a/include/swift/Sema/ConstraintGraph.h
+++ b/include/swift/Sema/ConstraintGraph.h
@@ -338,12 +338,6 @@ public:
     /// The constraints in this component.
     TinyPtrVector<Constraint *> constraints;
 
-    /// The set of components that this component depends on, such that
-    /// the partial solutions of the those components need to be available
-    /// before this component can be solved.
-    ///
-    SmallVector<unsigned, 2> dependencies;
-
   public:
     Component(unsigned solutionIndex) : solutionIndex(solutionIndex) { }
 
@@ -358,11 +352,6 @@ public:
     const TinyPtrVector<Constraint *> &getConstraints() const {
       return constraints;
     }
-
-    /// Records a component which this component depends on.
-    void recordDependency(const Component &component);
-
-    ArrayRef<unsigned> getDependencies() const { return dependencies; }
 
     unsigned getNumDisjunctions() const { return numDisjunctions; }
   };

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -400,8 +400,8 @@ namespace {
 
     llvm::SmallSetVector<ProtocolDecl *, 2> literalProtos;
     if (auto argTypeVar = argTy->getAs<TypeVariableType>()) {
-      auto constraints = CS.getConstraintGraph().gatherConstraints(
-          argTypeVar, ConstraintGraph::GatheringKind::EquivalenceClass,
+      auto constraints = CS.getConstraintGraph().gatherNearbyConstraints(
+          argTypeVar,
           [](Constraint *constraint) {
             return constraint->getKind() == ConstraintKind::LiteralConformsTo;
           });

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15953,8 +15953,8 @@ ConstraintSystem::addKeyPathApplicationRootConstraint(Type root, ConstraintLocat
   if (!typeVar)
     return;
 
-  auto constraints = CG.gatherConstraints(
-      typeVar, ConstraintGraph::GatheringKind::EquivalenceClass,
+  auto constraints = CG.gatherNearbyConstraints(
+      typeVar,
       [&keyPathExpr](Constraint *constraint) -> bool {
         if (constraint->getKind() != ConstraintKind::KeyPath)
           return false;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1876,8 +1876,8 @@ static Constraint *selectBestBindingDisjunction(
     if (!firstBindDisjunction)
       firstBindDisjunction = disjunction;
 
-    auto constraints = cs.getConstraintGraph().gatherConstraints(
-        typeVar, ConstraintGraph::GatheringKind::EquivalenceClass,
+    auto constraints = cs.getConstraintGraph().gatherNearbyConstraints(
+        typeVar,
         [](Constraint *constraint) {
           return constraint->getKind() == ConstraintKind::Conversion;
         });
@@ -1906,8 +1906,8 @@ ConstraintSystem::findConstraintThroughOptionals(
   while (visitedVars.insert(rep).second) {
     // Look for a disjunction that binds this type variable to an overload set.
     TypeVariableType *optionalObjectTypeVar = nullptr;
-    auto constraints = getConstraintGraph().gatherConstraints(
-        rep, ConstraintGraph::GatheringKind::EquivalenceClass,
+    auto constraints = getConstraintGraph().gatherNearbyConstraints(
+        rep,
         [&](Constraint *match) {
           // If we have an "optional object of" constraint, we may need to
           // look through it to find the constraint we're looking for.
@@ -2549,9 +2549,8 @@ void DisjunctionChoice::propagateConversionInfo(ConstraintSystem &cs) const {
     }
   }
 
-  auto constraints = cs.CG.gatherConstraints(
+  auto constraints = cs.CG.gatherNearbyConstraints(
       typeVar,
-      ConstraintGraph::GatheringKind::EquivalenceClass,
       [](Constraint *constraint) -> bool {
         switch (constraint->getKind()) {
         case ConstraintKind::Conversion:

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -126,7 +126,6 @@ void SplitterStep::computeFollowupSteps(
   // Take the orphaned constraints, because they'll go into a component now.
   OrphanedConstraints = CG.takeOrphanedConstraints();
 
-  IncludeInMergedResults.resize(numComponents, true);
   Components.resize(numComponents);
   PartialSolutions = std::unique_ptr<SmallVector<Solution, 4>[]>(
       new SmallVector<Solution, 4>[numComponents]);
@@ -135,26 +134,9 @@ void SplitterStep::computeFollowupSteps(
   for (unsigned i : indices(components)) {
     unsigned solutionIndex = components[i].solutionIndex;
 
-    // If there are no dependencies, build a normal component step.
-    if (components[i].getDependencies().empty()) {
-      steps.push_back(std::make_unique<ComponentStep>(
-          CS, solutionIndex, &Components[i], std::move(components[i]),
-          PartialSolutions[solutionIndex]));
-      continue;
-    }
-
-    // Note that the partial results from any dependencies of this component
-    // need not be included in the final merged results, because they'll
-    // already be part of the partial results for this component.
-    for (auto dependsOn : components[i].getDependencies()) {
-      IncludeInMergedResults[dependsOn] = false;
-    }
-
-    // Otherwise, build a dependent component "splitter" step, which
-    // handles all combinations of incoming partial solutions.
-    steps.push_back(std::make_unique<DependentComponentSplitterStep>(
-        CS, &Components[i], solutionIndex, std::move(components[i]),
-        llvm::MutableArrayRef(PartialSolutions.get(), numComponents)));
+    steps.push_back(std::make_unique<ComponentStep>(
+        CS, solutionIndex, &Components[i], std::move(components[i]),
+        PartialSolutions[solutionIndex]));
   }
 
   assert(CS.InactiveConstraints.empty() && "Missed a constraint");
@@ -223,8 +205,7 @@ bool SplitterStep::mergePartialSolutions() const {
   SmallVector<unsigned, 2> countsVec;
   countsVec.reserve(numComponents);
   for (unsigned idx : range(numComponents)) {
-    countsVec.push_back(
-        IncludeInMergedResults[idx] ? PartialSolutions[idx].size() : 1);
+    countsVec.push_back(PartialSolutions[idx].size());
   }
 
   // Produce all combinations of partial solutions.
@@ -237,9 +218,6 @@ bool SplitterStep::mergePartialSolutions() const {
     // solutions.
     ConstraintSystem::SolverScope scope(CS);
     for (unsigned i : range(numComponents)) {
-      if (!IncludeInMergedResults[i])
-        continue;
-
       CS.replaySolution(PartialSolutions[i][indices[i]]);
     }
 
@@ -271,76 +249,14 @@ bool SplitterStep::mergePartialSolutions() const {
   return anySolutions;
 }
 
-StepResult DependentComponentSplitterStep::take(bool prevFailed) {
-  // "split" is considered a failure if previous step failed,
-  // or there is a failure recorded by constraint system, or
-  // system can't be simplified.
-  if (prevFailed || CS.getFailedConstraint() || CS.simplify())
-    return done(/*isSuccess=*/false);
-
-  // Figure out the sets of partial solutions that this component depends on.
-  SmallVector<const SmallVector<Solution, 4> *, 2> dependsOnSets;
-  for (auto index : Component.getDependencies()) {
-    dependsOnSets.push_back(&AllPartialSolutions[index]);
-  }
-
-  // Produce all combinations of partial solutions for the inputs.
-  SmallVector<std::unique_ptr<SolverStep>, 4> followup;
-  SmallVector<unsigned, 2> indices(Component.getDependencies().size(), 0);
-  auto dependsOnSetsRef = llvm::ArrayRef(dependsOnSets);
-  do {
-    // Form the set of input partial solutions.
-    SmallVector<const Solution *, 2> dependsOnSolutions;
-    for (auto index : swift::indices(indices)) {
-      dependsOnSolutions.push_back(&(*dependsOnSets[index])[indices[index]]);
-    }
-    ContextualSolutions.push_back(std::make_unique<SmallVector<Solution, 2>>());
-
-    followup.push_back(std::make_unique<ComponentStep>(
-        CS, Index, Constraints, Component, std::move(dependsOnSolutions),
-        *ContextualSolutions.back()));
-  } while (nextCombination(dependsOnSetsRef, indices));
-
-  /// Wait until all of the component steps are done.
-  return suspend(followup);
-}
-
-StepResult DependentComponentSplitterStep::resume(bool prevFailed) {
-  for (auto &ComponentStepSolutions : ContextualSolutions) {
-    Solutions.append(std::make_move_iterator(ComponentStepSolutions->begin()),
-                     std::make_move_iterator(ComponentStepSolutions->end()));
-  }
-  return done(/*isSuccess=*/!Solutions.empty());
-}
-
-void DependentComponentSplitterStep::print(llvm::raw_ostream &Out) {
-  Out << "DependentComponentSplitterStep for dependencies on [";
-  interleave(
-      Component.getDependencies(), [&](unsigned index) { Out << index; },
-      [&] { Out << ", "; });
-  Out << "]\n";
-}
-
 StepResult ComponentStep::take(bool prevFailed) {
   // One of the previous components created by "split"
   // failed, it means that we can't solve this component.
-  if ((prevFailed && DependsOnPartialSolutions.empty()) ||
-      CS.isTooComplex(Solutions) || CS.worseThanBestSolution())
+  if (prevFailed || CS.isTooComplex(Solutions) || CS.worseThanBestSolution())
     return done(/*isSuccess=*/false);
 
   // Setup active scope, only if previous component didn't fail.
   setupScope();
-
-  // If there are any dependent partial solutions to compose, do so now.
-  if (!DependsOnPartialSolutions.empty()) {
-    for (auto partial : DependsOnPartialSolutions) {
-      CS.replaySolution(*partial);
-    }
-
-    // Simplify again.
-    if (CS.failedConstraint || CS.simplify())
-      return done(/*isSuccess=*/false);
-  }
 
   /// Try to figure out what this step is going to be,
   /// after the scope has been established.

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -337,16 +337,6 @@ StepResult ComponentStep::take(bool prevFailed) {
       CS.replaySolution(*partial);
     }
 
-    // Activate all of the one-way constraints.
-    SmallVector<Constraint *, 4> oneWayConstraints;
-    for (auto &constraint : CS.InactiveConstraints) {
-      if (constraint.isOneWayConstraint())
-        oneWayConstraints.push_back(&constraint);
-    }
-    for (auto constraint : oneWayConstraints) {
-      CS.activateConstraint(constraint);
-    }
-
     // Simplify again.
     if (CS.failedConstraint || CS.simplify())
       return done(/*isSuccess=*/false);

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -240,10 +240,6 @@ class SplitterStep final : public SolverStep {
 
   SmallVector<Constraint *, 4> OrphanedConstraints;
 
-  /// Whether to include the partial results of this component in the final
-  /// merged results.
-  SmallVector<bool, 4> IncludeInMergedResults;
-
 public:
   SplitterStep(ConstraintSystem &cs, SmallVectorImpl<Solution> &solutions)
       : SolverStep(cs, solutions) {}
@@ -267,56 +263,6 @@ private:
   ///
   /// \returns true if there are any solutions, false otherwise.
   bool mergePartialSolutions() const;
-};
-
-/// `DependentComponentSplitterStep` is responsible for composing the partial
-/// solutions from other components (on which this component depends) into
-/// the inputs based on which we can solve a particular component.
-class DependentComponentSplitterStep final : public SolverStep {
-  /// Constraints "in scope" of this step.
-  ConstraintList *Constraints;
-
-  /// Index into the parent splitter step.
-  unsigned Index;
-
-  /// The component that has dependencies.
-  ConstraintGraph::Component Component;
-
-  /// Array containing all of the partial solutions for the parent split.
-  MutableArrayRef<SmallVector<Solution, 4>> AllPartialSolutions;
-
-  /// The solutions computed the \c ComponentSteps created for each partial
-  /// solution combinations. Will be merged into the final \c Solutions vector
-  /// in \c resume.
-  std::vector<std::unique_ptr<SmallVector<Solution, 2>>> ContextualSolutions;
-
-  /// Take all of the constraints in this component and put them into
-  /// \c Constraints.
-  void injectConstraints() {
-    for (auto constraint : Component.getConstraints()) {
-      Constraints->erase(constraint);
-      Constraints->push_back(constraint);
-    }
-  }
-
-public:
-  DependentComponentSplitterStep(
-      ConstraintSystem &cs,
-      ConstraintList *constraints,
-      unsigned index,
-      ConstraintGraph::Component &&component,
-      MutableArrayRef<SmallVector<Solution, 4>> allPartialSolutions)
-    : SolverStep(cs, allPartialSolutions[index]), Constraints(constraints),
-      Index(index), Component(std::move(component)),
-      AllPartialSolutions(allPartialSolutions) {
-    assert(!Component.getDependencies().empty() && "Should use ComponentStep");
-    injectConstraints();
-  }
-
-  StepResult take(bool prevFailed) override;
-  StepResult resume(bool prevFailed) override;
-
-  void print(llvm::raw_ostream &Out) override;
 };
 
 
@@ -381,10 +327,6 @@ class ComponentStep final : public SolverStep {
   /// Constraints "in scope" of this step.
   ConstraintList *Constraints;
 
-  /// The set of partial solutions that should be composed before evaluating
-  /// this component.
-  SmallVector<const Solution *, 2> DependsOnPartialSolutions;
-
   /// Constraint which doesn't have any free type variables associated
   /// with it, which makes it disconnected in the graph.
   Constraint *OrphanedConstraint = nullptr;
@@ -419,8 +361,6 @@ public:
       constraints->erase(constraint);
       Constraints->push_back(constraint);
     }
-
-    assert(component.getDependencies().empty());
   }
 
   /// Create a component step that composes existing partial solutions before
@@ -429,15 +369,11 @@ public:
       ConstraintSystem &cs, unsigned index,
       ConstraintList *constraints,
       const ConstraintGraph::Component &component,
-      llvm::SmallVectorImpl<const Solution *> &&dependsOnPartialSolutions,
       SmallVectorImpl<Solution> &solutions)
         : SolverStep(cs, solutions), Index(index), IsSingle(false),
           OriginalScore(getCurrentScore()), OriginalBestScore(getBestScore()),
-          Constraints(constraints),
-          DependsOnPartialSolutions(std::move(dependsOnPartialSolutions)) {
+          Constraints(constraints) {
     TypeVars = component.typeVars;
-    assert(DependsOnPartialSolutions.size() ==
-           component.getDependencies().size());
 
     for (auto constraint : component.getConstraints()) {
       constraints->erase(constraint);

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -545,18 +545,11 @@ void ConstraintGraph::retractBindings(TypeVariableType *typeVar,
 
 #pragma mark Algorithms
 
-/// Perform a depth-first search.
-///
-/// \param cg The constraint graph.
-/// \param typeVar The type variable we're searching from.
-/// \param visitConstraint Called before considering a constraint.
-/// \param visitedConstraints Set of already-visited constraints, used
-/// internally to avoid duplicated work.
 static void depthFirstSearch(
     ConstraintGraph &cg,
     TypeVariableType *typeVar,
-    llvm::function_ref<void(Constraint *)> visitConstraint,
     llvm::SmallPtrSet<TypeVariableType *, 4> &typeVars,
+    llvm::TinyPtrVector<Constraint *> &constraints,
     llvm::SmallPtrSet<Constraint *, 8> &visitedConstraints) {
   // If we're not looking at this type variable right now because we're
   // solving a conjunction element, don't consider its adjacencies.
@@ -570,11 +563,8 @@ static void depthFirstSearch(
   // Local function to visit adjacent type variables.
   auto visitAdjacencies = [&](ArrayRef<TypeVariableType *> adjTypeVars) {
     for (auto adj : adjTypeVars) {
-      if (adj == typeVar)
-        continue;
-
-      // Recurse into this node.
-      depthFirstSearch(cg, adj, visitConstraint, typeVars, visitedConstraints);
+      if (adj != typeVar)
+        depthFirstSearch(cg, adj, typeVars, constraints, visitedConstraints);
     }
   };
 
@@ -585,7 +575,7 @@ static void depthFirstSearch(
     if (!visitedConstraints.insert(constraint).second)
       continue;
 
-    visitConstraint(constraint);
+    constraints.push_back(constraint);
   }
 
   // Visit all of the other nodes in the equivalence class.
@@ -604,28 +594,22 @@ static void depthFirstSearch(
   visitAdjacencies(node.getReferencedVars());
 }
 
-llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
-    TypeVariableType *typeVar, GatheringKind kind,
-    llvm::function_ref<bool(Constraint *)> acceptConstraintFn) {
+llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherAllConstraints(
+    TypeVariableType *typeVar) {
   llvm::TinyPtrVector<Constraint *> constraints;
   llvm::SmallPtrSet<TypeVariableType *, 4> typeVars;
   llvm::SmallPtrSet<Constraint *, 8> visitedConstraints;
 
-  if (kind == GatheringKind::AllMentions) {
-    // If we've been asked for "all mentions" of a type variable, search for
-    // constraints involving both it and its fixed bindings.
-    depthFirstSearch(
-        *this, typeVar,
-        [&](Constraint *constraint) {
-          if (acceptConstraintFn(constraint))
-            constraints.push_back(constraint);
-        },
-        typeVars, visitedConstraints);
-    return constraints;
-  }
+  depthFirstSearch(*this, typeVar, typeVars, constraints, visitedConstraints);
+  return constraints;
+}
 
-  // Otherwise only search in the type var's equivalence class and immediate
-  // fixed bindings.
+llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherNearbyConstraints(
+    TypeVariableType *typeVar, 
+    llvm::function_ref<bool(Constraint *)> acceptConstraintFn) {
+  llvm::TinyPtrVector<Constraint *> constraints;
+  llvm::SmallPtrSet<TypeVariableType *, 4> typeVars;
+  llvm::SmallPtrSet<Constraint *, 8> visitedConstraints;
 
   // Local function to add constraints.
   auto addTypeVarConstraints = [&](TypeVariableType *adjTypeVar) {

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -549,17 +549,14 @@ void ConstraintGraph::retractBindings(TypeVariableType *typeVar,
 ///
 /// \param cg The constraint graph.
 /// \param typeVar The type variable we're searching from.
-/// \param preVisitNode Called before traversing a node. Must return \c
-/// false when the node has already been visited.
-/// \param visitConstraint Called before considering a constraint. If it
-/// returns \c false, that constraint will be skipped.
+/// \param visitConstraint Called before considering a constraint.
 /// \param visitedConstraints Set of already-visited constraints, used
 /// internally to avoid duplicated work.
 static void depthFirstSearch(
     ConstraintGraph &cg,
     TypeVariableType *typeVar,
-    llvm::function_ref<bool(TypeVariableType *)> preVisitNode,
-    llvm::function_ref<bool(Constraint *)> visitConstraint,
+    llvm::function_ref<void(Constraint *)> visitConstraint,
+    llvm::SmallPtrSet<TypeVariableType *, 4> &typeVars,
     llvm::SmallPtrSet<Constraint *, 8> &visitedConstraints) {
   // If we're not looking at this type variable right now because we're
   // solving a conjunction element, don't consider its adjacencies.
@@ -567,7 +564,7 @@ static void depthFirstSearch(
     return;
 
   // Visit this node. If we've already seen it, bail out.
-  if (!preVisitNode(typeVar))
+  if (!typeVars.insert(typeVar).second)
     return;
 
   // Local function to visit adjacent type variables.
@@ -577,21 +574,18 @@ static void depthFirstSearch(
         continue;
 
       // Recurse into this node.
-      depthFirstSearch(cg, adj, preVisitNode, visitConstraint,
-                       visitedConstraints);
+      depthFirstSearch(cg, adj, visitConstraint, typeVars, visitedConstraints);
     }
   };
 
-  // Walk all of the constraints associated with this node to find related
-  // nodes.
+  // Walk all of the constraints associated with this node.
   auto &node = cg[typeVar];
   for (auto constraint : node.getConstraints()) {
     // If we've already seen this constraint, skip it.
     if (!visitedConstraints.insert(constraint).second)
       continue;
 
-    if (visitConstraint(constraint))
-      visitAdjacencies(constraint->getTypeVariables());
+    visitConstraint(constraint);
   }
 
   // Visit all of the other nodes in the equivalence class.
@@ -622,17 +616,11 @@ llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
     // constraints involving both it and its fixed bindings.
     depthFirstSearch(
         *this, typeVar,
-        [&](TypeVariableType *typeVar) {
-          return typeVars.insert(typeVar).second;
-        },
         [&](Constraint *constraint) {
           if (acceptConstraintFn(constraint))
             constraints.push_back(constraint);
-
-          // Don't recurse into the constraint's type variables.
-          return false;
         },
-        visitedConstraints);
+        typeVars, visitedConstraints);
     return constraints;
   }
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -865,10 +865,6 @@ void ConstraintGraph::Component::addConstraint(Constraint *constraint) {
   constraints.push_back(constraint);
 }
 
-void ConstraintGraph::Component::recordDependency(const Component &component) {
-  dependencies.push_back(component.solutionIndex);
-}
-
 SmallVector<ConstraintGraph::Component, 1>
 ConstraintGraph::computeConnectedComponents(
            ArrayRef<TypeVariableType *> typeVars) {
@@ -1122,20 +1118,6 @@ void ConstraintGraph::printConnectedComponents(
                [&] {
                  out << ' ';
                });
-
-    auto dependencies = component.getDependencies();
-    if (dependencies.empty())
-      continue;
-
-    SmallVector<unsigned, 4> indices{dependencies.begin(), dependencies.end()};
-    // Sort dependencies so output is stable.
-    llvm::sort(indices);
-
-    // Print all of the one-way components.
-    out << " depends on ";
-    llvm::interleave(
-        indices, [&out](unsigned index) { out << index; },
-        [&out] { out << ", "; });
   }
 }
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -614,26 +614,6 @@ llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
     TypeVariableType *typeVar, GatheringKind kind,
     llvm::function_ref<bool(Constraint *)> acceptConstraintFn) {
   llvm::TinyPtrVector<Constraint *> constraints;
-  // Whether we should consider this constraint at all.
-  auto shouldConsiderConstraint = [&](Constraint *constraint) {
-    // For a one-way constraint, only consider it when the left-hand side of
-    // the binding is one of the type variables currently under consideration,
-    // as only such constraints need solving for this component. Note that we
-    // don't perform any other filtering, as the constraint system should be
-    // responsible for checking any other conditions.
-    if (constraint->isOneWayConstraint()) {
-      auto lhsTypeVar = constraint->getFirstType()->castTo<TypeVariableType>();
-      return CS.isActiveTypeVariable(lhsTypeVar);
-    }
-
-    return true;
-  };
-
-  auto acceptConstraint = [&](Constraint *constraint) {
-    return shouldConsiderConstraint(constraint) &&
-        acceptConstraintFn(constraint);
-  };
-
   llvm::SmallPtrSet<TypeVariableType *, 4> typeVars;
   llvm::SmallPtrSet<Constraint *, 8> visitedConstraints;
 
@@ -646,7 +626,7 @@ llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
           return typeVars.insert(typeVar).second;
         },
         [&](Constraint *constraint) {
-          if (acceptConstraint(constraint))
+          if (acceptConstraintFn(constraint))
             constraints.push_back(constraint);
 
           // Don't recurse into the constraint's type variables.
@@ -666,7 +646,7 @@ llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
 
     for (auto constraint : (*this)[adjTypeVar].getConstraints()) {
       if (visitedConstraints.insert(constraint).second &&
-          acceptConstraint(constraint))
+          acceptConstraintFn(constraint))
         constraints.push_back(constraint);
     }
   };
@@ -681,7 +661,7 @@ llvm::TinyPtrVector<Constraint *> ConstraintGraph::gatherConstraints(
 
     for (auto constraint : node.getConstraints()) {
       if (visitedConstraints.insert(constraint).second &&
-          acceptConstraint(constraint))
+          acceptConstraintFn(constraint))
         constraints.push_back(constraint);
     }
 
@@ -708,23 +688,6 @@ namespace {
     /// we merge equivalence classes.
     unsigned validComponentCount = 0;
 
-    /// Describes the one-way incoming and outcoming adjacencies of
-    /// a component within the directed graph of one-way constraints.
-    struct OneWayComponent {
-      /// The (uniqued) set of type variable representatives to which this
-      /// component has an outgoing edge.
-      TinyPtrVector<TypeVariableType *> outAdjacencies;
-
-      /// The (uniqued) set of type variable representatives from which this
-      /// component has an incoming edge.
-      TinyPtrVector<TypeVariableType *> inAdjacencies;
-    };
-
-    // Adjacency list representation of the directed graph of edges for
-    // one-way constraints, using type variable representatives as the
-    // nodes.
-    llvm::SmallDenseMap<TypeVariableType *, OneWayComponent> oneWayDigraph;
-
   public:
     using Component = ConstraintGraph::Component;
 
@@ -734,14 +697,7 @@ namespace {
                         ArrayRef<TypeVariableType *> typeVars)
         : cg(cg), typeVars(typeVars)
     {
-      auto oneWayConstraints = connectedComponents();
-
-      // If there were no one-way constraints, we're done.
-      if (oneWayConstraints.empty())
-        return;
-
-      // Build the directed one-way constraint graph.
-      buildOneWayConstraintGraph(oneWayConstraints);
+      connectedComponents();
     }
 
     /// Retrieve the set of components.
@@ -792,49 +748,9 @@ namespace {
         if (constraintTypeVars.empty())
           continue;
 
-        TypeVariableType *typeVar;
-        if (constraint.isOneWayConstraint()) {
-          // For one-way constraints, associate the constraint with the
-          // left-hand type variable.
-          typeVar = constraint.getFirstType()->castTo<TypeVariableType>();
-        } else {
-          typeVar = constraintTypeVars.front();
-        }
-
+        TypeVariableType *typeVar = constraintTypeVars.front();
         auto rep = typeVar->getImpl().getComponent();
         getComponent(rep).addConstraint(&constraint);
-      }
-
-      // If we have any one-way constraint information, compute the ordering
-      // of representative type variables needed to respect one-way
-      // constraints while solving.
-      if (!oneWayDigraph.empty()) {
-        // Sort the representative type variables based on the disjunction
-        // count, so
-        std::sort(representativeTypeVars.begin(), representativeTypeVars.end(),
-                  [&](TypeVariableType *lhs, TypeVariableType *rhs) {
-                    return getComponent(lhs).getNumDisjunctions() >
-                        getComponent(rhs).getNumDisjunctions();
-                  });
-        
-        representativeTypeVars =
-            computeOneWayComponentOrdering(representativeTypeVars);
-
-        // Fill in one-way dependency information for all of the components.
-        for (auto typeVar : representativeTypeVars) {
-          auto knownOneWayComponent = oneWayDigraph.find(typeVar);
-          if (knownOneWayComponent == oneWayDigraph.end())
-            continue;
-
-          auto &oneWayComponent = knownOneWayComponent->second;
-          auto &component = getComponent(typeVar);
-          for (auto inAdj : oneWayComponent.inAdjacencies) {
-            if (!inAdj->getImpl().isValidComponent())
-              continue;
-
-            component.recordDependency(getComponent(inAdj));
-          }
-        }
       }
 
       // Flatten the set of components.
@@ -859,10 +775,7 @@ namespace {
       // sort the orphaned constraints at the back. In the absence of
       // one-way constraints, sort everything.
       if (components.size() > 1) {
-        auto sortStart = oneWayDigraph.empty()
-            ? flatComponents.begin()
-            : flatComponents.end() - cg.getOrphanedConstraints().size();
-        std::sort(sortStart, flatComponents.end(),
+        std::sort(flatComponents.begin(), flatComponents.end(),
                   [&](const Component &lhs, const Component &rhs) {
                     return lhs.getNumDisjunctions() > rhs.getNumDisjunctions();
                   });
@@ -902,13 +815,8 @@ namespace {
       return true;
     }
 
-    /// Perform the connected components algorithm, skipping one-way
-    /// constraints.
-    ///
-    /// \returns the set of one-way constraints that were skipped.
-    TinyPtrVector<Constraint *> connectedComponents() {
-      TinyPtrVector<Constraint *> oneWayConstraints;
-
+    /// Compute the connected components of the graph.
+    void connectedComponents() {
       auto &cs = cg.getConstraintSystem();
 
       for (auto typeVar : typeVars) {
@@ -935,15 +843,6 @@ namespace {
       }
 
       for (auto &constraint : cs.getConstraints()) {
-        if (constraint.isOneWayConstraint()) {
-          oneWayConstraints.push_back(&constraint);
-          auto *typeVar = constraint.getFirstType()->castTo<TypeVariableType>();
-          typeVar = typeVar->getImpl().getComponent();
-          if (typeVar->getImpl().markValidComponent())
-            ++validComponentCount;
-          continue;
-        }
-
         auto typeVars = constraint.getTypeVariables();
         if (typeVars.empty())
           continue;
@@ -955,258 +854,6 @@ namespace {
         for (auto *otherTypeVar : typeVars.slice(1))
           unionSets(firstTypeVar, otherTypeVar);
       }
-
-      return oneWayConstraints;
-    }
-
-    /// Insert the given type variable into the given vector if it isn't
-    /// already present.
-    static void insertIfUnique(TinyPtrVector<TypeVariableType *> &vector,
-                               TypeVariableType *typeVar) {
-      if (std::find(vector.begin(), vector.end(), typeVar) == vector.end())
-        vector.push_back(typeVar);
-    }
-
-    /// Retrieve the (uniqued) set of type variable representations that occur
-    /// within the given type.
-    TinyPtrVector<TypeVariableType *>
-    getRepresentativesInType(Type type) const {
-      TinyPtrVector<TypeVariableType *> results;
-
-      SmallPtrSet<TypeVariableType *, 2> typeVars;
-      type->getTypeVariables(typeVars);
-      for (auto typeVar : typeVars) {
-        auto rep = typeVar->getImpl().getComponent();
-        insertIfUnique(results, rep);
-      }
-
-      return results;
-    }
-
-    /// Add all of the one-way constraints to the one-way digraph
-    void addOneWayConstraintEdges(ArrayRef<Constraint *> oneWayConstraints) {
-      for (auto constraint : oneWayConstraints) {
-        auto lhsTypeReps =
-            getRepresentativesInType(constraint->getFirstType());
-        auto rhsTypeReps =
-            getRepresentativesInType(constraint->getSecondType());
-
-        // Add an edge from the type representatives on the right-hand side
-        // of the one-way constraint to the type representatives on the
-        // left-hand side, because the right-hand type variables need to
-        // be solved before the left-hand type variables.
-        for (auto lhsTypeRep : lhsTypeReps) {
-          for (auto rhsTypeRep : rhsTypeReps) {
-            if (lhsTypeRep == rhsTypeRep)
-              continue;
-
-            insertIfUnique(oneWayDigraph[rhsTypeRep].outAdjacencies,lhsTypeRep);
-            insertIfUnique(oneWayDigraph[lhsTypeRep].inAdjacencies,rhsTypeRep);
-          }
-        }
-      }
-    }
-
-    using TypeVariablePair = std::pair<TypeVariableType *, TypeVariableType *>;
-
-    /// Build the directed graph of one-way constraints among components.
-    void buildOneWayConstraintGraph(ArrayRef<Constraint *> oneWayConstraints) {
-      auto &cs = cg.getConstraintSystem();
-      auto &ctx = cs.getASTContext();
-      bool contractedCycle = false;
-      do {
-        // Construct the one-way digraph from scratch.
-        oneWayDigraph.clear();
-        addOneWayConstraintEdges(oneWayConstraints);
-
-        // Minimize the in-adjacencies, detecting cycles along the way.
-        SmallVector<TypeVariablePair, 4> cycleEdges;
-        removeIndirectOneWayInAdjacencies(cycleEdges);
-
-        // For any contractions we need to perform due to cycles, perform a
-        // union the connected components based on the type variable pairs.
-        contractedCycle = false;
-        for (const auto &edge : cycleEdges) {
-          if (unionSets(edge.first, edge.second)) {
-            if (cs.isDebugMode()) {
-              auto &log = llvm::errs();
-              if (cs.solverState)
-                log.indent(cs.solverState->getCurrentIndent());
-
-              log << "Collapsing one-way components for $T"
-                  << edge.first->getID() << " and $T" << edge.second->getID()
-                  << " due to cycle.\n";
-            }
-
-            if (ctx.Stats) {
-              ++ctx.Stats->getFrontendCounters()
-                  .NumCyclicOneWayComponentsCollapsed;
-            }
-
-            contractedCycle = true;
-          }
-        }
-      } while (contractedCycle);
-    }
-
-    /// Perform a depth-first search to produce a from the given type variable,
-    /// notifying the function object.
-    ///
-    /// \param getAdjacencies Called to retrieve the set of type variables
-    /// that are adjacent to the given type variable.
-    ///
-    /// \param preVisit Called before visiting the adjacencies of the given
-    /// type variable. When it returns \c true, the adjacencies of this type
-    /// variable will be visited. When \c false, the adjacencies will not be
-    /// visited and \c postVisit will not be called.
-    ///
-    /// \param postVisit Called after visiting the adjacencies of the given
-    /// type variable.
-    static void postorderDepthFirstSearchRec(
-        TypeVariableType *typeVar,
-        llvm::function_ref<
-          ArrayRef<TypeVariableType *>(TypeVariableType *)> getAdjacencies,
-        llvm::function_ref<bool(TypeVariableType *)> preVisit,
-        llvm::function_ref<void(TypeVariableType *)> postVisit) {
-      if (!preVisit(typeVar))
-        return;
-
-      for (auto adj : getAdjacencies(typeVar)) {
-        postorderDepthFirstSearchRec(adj, getAdjacencies, preVisit, postVisit);
-      }
-
-      postVisit(typeVar);
-    }
-
-    /// Minimize the incoming adjacencies for one of the nodes in the one-way
-    /// directed graph by eliminating any in-adjacencies that can also be
-    /// found indirectly.
-    void removeIndirectOneWayInAdjacencies(
-        TypeVariableType *typeVar,
-        OneWayComponent &component,
-        SmallVectorImpl<TypeVariablePair> &cycleEdges) {
-      // Perform a depth-first search from each of the in adjacencies to
-      // this type variable, traversing each of the one-way edges backwards
-      // to find all of the components whose type variables must be
-      // bound before this component can be solved.
-      SmallPtrSet<TypeVariableType *, 4> visited;
-      SmallPtrSet<TypeVariableType *, 4> indirectlyReachable;
-      SmallVector<TypeVariableType *, 4> currentPath;
-      for (auto inAdj : component.inAdjacencies) {
-        postorderDepthFirstSearchRec(
-            inAdj,
-            [&](TypeVariableType *typeVar) -> ArrayRef<TypeVariableType *> {
-              // Traverse the outgoing adjacencies for the subcomponent
-              auto oneWayComponent = oneWayDigraph.find(typeVar);
-              if (oneWayComponent == oneWayDigraph.end()) {
-                return { };
-              }
-
-              return oneWayComponent->second.inAdjacencies;
-            },
-            [&](TypeVariableType *typeVar) {
-              // If we haven't seen this type variable yet, add it to the
-              // path.
-              if (visited.insert(typeVar).second) {
-                currentPath.push_back(typeVar);
-                return true;
-              }
-
-              // Add edges between this type variable and every other type
-              // variable in the path.
-              for (auto otherTypeVar : llvm::reverse(currentPath)) {
-                // When we run into our own type variable, we're done.
-                if (otherTypeVar == typeVar)
-                  break;
-
-                cycleEdges.push_back({typeVar, otherTypeVar});
-              }
-
-              return false;
-            },
-            [&](TypeVariableType *dependsOn) {
-              // Remove this type variable from the path.
-              assert(currentPath.back() == dependsOn);
-              currentPath.pop_back();
-
-              // Don't record dependency on ourselves.
-              if (dependsOn == inAdj)
-                return;
-
-              indirectlyReachable.insert(dependsOn);
-            });
-
-        // Remove any in-adjacency of this component that is indirectly
-        // reachable.
-        component.inAdjacencies.erase(
-            std::remove_if(component.inAdjacencies.begin(),
-                           component.inAdjacencies.end(),
-                           [&](TypeVariableType *inAdj) {
-                             return indirectlyReachable.count(inAdj) > 0;
-                           }),
-            component.inAdjacencies.end());
-      }
-    }
-
-    /// Minimize the incoming adjacencies for all of the nodes in the one-way
-    /// directed graph by eliminating any in-adjacencies that can also be
-    /// found indirectly.
-    void removeIndirectOneWayInAdjacencies(
-        SmallVectorImpl<TypeVariablePair> &cycleEdges)  {
-      for (auto &oneWayEntry : oneWayDigraph) {
-        auto typeVar = oneWayEntry.first;
-        auto &component = oneWayEntry.second;
-        removeIndirectOneWayInAdjacencies(typeVar, component, cycleEdges);
-      }
-    }
-
-    /// Compute the order in which the components should be visited to respect
-    /// one-way constraints.
-    ///
-    /// \param representativeTypeVars the set of type variables that
-    /// represent the components, in a preferred ordering that does not
-    /// account for one-way constraints.
-    /// \returns the set of type variables that represent the components, in
-    /// an ordering that ensures that components containing type variables
-    /// that occur on the left-hand side of a one-way constraint will be
-    /// solved after the components for type variables on the right-hand
-    /// side of that constraint.
-    SmallVector<TypeVariableType *, 4> computeOneWayComponentOrdering(
-        ArrayRef<TypeVariableType *> representativeTypeVars) const {
-      SmallVector<TypeVariableType *, 4> orderedReps;
-      orderedReps.reserve(representativeTypeVars.size());
-      SmallPtrSet<TypeVariableType *, 4> visited;
-      for (auto rep : llvm::reverse(representativeTypeVars)) {
-        // Perform a postorder depth-first search through the one-way digraph,
-        // starting at this representative, to establish the dependency
-        // ordering amongst components that are reachable
-        // to establish the dependency ordering for the representative type
-        // variables.
-        postorderDepthFirstSearchRec(
-            rep,
-            [&](TypeVariableType *typeVar) -> ArrayRef<TypeVariableType *> {
-              // Traverse the outgoing adjacencies for the subcomponent
-              assert(typeVar == typeVar->getImpl().getComponent());
-              auto oneWayComponent = oneWayDigraph.find(typeVar);
-              if (oneWayComponent == oneWayDigraph.end()) {
-                return { };
-              }
-
-              return oneWayComponent->second.outAdjacencies;
-            },
-            [&](TypeVariableType *typeVar) {
-              return visited.insert(typeVar).second;
-            },
-            [&](TypeVariableType *typeVar) {
-              // Record this type variable, if it's one of the representative
-              // type variables.
-              if (typeVar->getImpl().isValidComponent())
-                orderedReps.push_back(typeVar);
-            });
-      }
-
-      assert(orderedReps.size() == representativeTypeVars.size());
-      return orderedReps;
     }
   };
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -267,8 +267,7 @@ void ConstraintSystem::assignFixedType(TypeVariableType *typeVar, Type type,
 void ConstraintSystem::addTypeVariableConstraintsToWorkList(
        TypeVariableType *typeVar) {
   // Activate the constraints affected by a change to this type variable.
-  auto gatheringKind = ConstraintGraph::GatheringKind::AllMentions;
-  for (auto *constraint : CG.gatherConstraints(typeVar, gatheringKind))
+  for (auto *constraint : CG.gatherAllConstraints(typeVar))
     if (!constraint->isActive())
       activateConstraint(constraint);
 }

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2058,8 +2058,8 @@ void ConstraintSystem::bindOverloadType(
       increaseScore(SK_KeyPathSubscript, locator);
 
       auto boundTypeVar = boundType->castTo<TypeVariableType>();
-      auto constraints = getConstraintGraph().gatherConstraints(
-          boundTypeVar, ConstraintGraph::GatheringKind::EquivalenceClass,
+      auto constraints = getConstraintGraph().gatherNearbyConstraints(
+          boundTypeVar,
           [](Constraint *constraint) {
             return constraint->getKind() == ConstraintKind::ApplicableFunction;
           });

--- a/test/expr/closure/closures_swift6.swift
+++ b/test/expr/closure/closures_swift6.swift
@@ -501,14 +501,18 @@ class TestGithubIssue70089 {
       }
 
       doVoidStuff { [weak self] in
-        doVoidStuff { [self] in
-          x += 1 // expected-error {{explicit use of 'self' is required when 'self' is optional, to make control flow explicit}} expected-note{{reference 'self?.' explicitly}}
+        doVoidStuff { [self] in // expected-error {{value of optional type 'TestGithubIssue70089?' must be unwrapped to a value of type 'TestGithubIssue70089'}}
+          // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+          // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+          x += 1
         }
       }
 
       doVoidStuff { [weak self] in
-        doVoidStuff { [self] in
-          self.x += 1 // expected-error {{value of optional type 'TestGithubIssue70089?' must be unwrapped to refer to member 'x' of wrapped base type 'TestGithubIssue70089'}} expected-note {{chain the optional using '?' to access member 'x' only for non-'nil' base values}} expected-note{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} 
+        doVoidStuff { [self] in // expected-error {{value of optional type 'TestGithubIssue70089?' must be unwrapped to a value of type 'TestGithubIssue70089'}}
+          // expected-note@-1 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+          // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+          self.x += 1
         }
       }
 


### PR DESCRIPTION
I had to revert this last time (https://github.com/swiftlang/swift/pull/79105) because it broke observable behavior in some cases involving capture list expressions. For now, there doesn't appear to be an easy way to simulate the current behavior of capture lists without one-way constraints.

However, since one-way constraints are no longer needed for performance, we can still rip out the special handling they received in the connected components algorithm. This still changes behavior in a diagnostics test, but the existing expression there appears to be already invalid. The test case from rdar://problem/143338891 still passes:

```
func rdar143338891() {
  func takesAny(_: Any?) {}

  class Test {
    func test() {
      _ = { [weak self] in takesAny(self) }
    }
  }
}
```