### PR TITLE
[Test][Dependency Scanning] Restrict macos-only test

### DIFF
--- a/test/ScanDependencies/Incremental/module_deps_invalidate.swift
+++ b/test/ScanDependencies/Incremental/module_deps_invalidate.swift
@@ -1,3 +1,5 @@
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/module-cache)
 // RUN: %empty-directory(%t/Modules)


### PR DESCRIPTION
The headers this test is relying on have some macos-specific dependency behavior. Restrict the test for now, to unblock testing on other platforms.

Resolves rdar://146771469