### PR TITLE
[CMake] '-no-emit-module-separately-wmo' for swift modules

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -28,6 +28,10 @@ function(_add_host_swift_compile_options name)
       "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
   endif()
 
+  # Emitting module seprately doesn't give us any benefit.
+  target_compile_options(${name} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:-no-emit-module-separately-wmo>")
+
   if(SWIFT_ANALYZE_CODE_COVERAGE)
      set(_cov_flags $<$<COMPILE_LANGUAGE:Swift>:-profile-generate -profile-coverage-mapping>)
      target_compile_options(${name} PRIVATE ${_cov_flags})


### PR DESCRIPTION
Emitting modules in separate frontend job doesn't give any benefits because single add_library is just a single job from CMake's point of view. Clients need to wait for `.dylib`/`.so` being emitted before using the `.swiftmodule`. *Not* emitting modules separately is actually faster in CMake because it doesn't parse and typecheck the source code twice.
