### PR TITLE
[ASTGen][NFC] Remove unused variable

### DIFF
--- a/lib/AST/Bridging/StmtBridging.cpp
+++ b/lib/AST/Bridging/StmtBridging.cpp
@@ -100,7 +100,7 @@ BridgedBreakStmt BridgedBreakStmt_createParsed(BridgedDeclContext cDeclContext,
                 cTargetLoc.unbridged(), cDeclContext.unbridged());
 }
 
-void getCaseLabelItems(BridgedArrayRef cItems,
+static void getCaseLabelItems(BridgedArrayRef cItems,
                        SmallVectorImpl<CaseLabelItem> &output) {
   for (auto &elem : cItems.unbridged<BridgedCaseLabelItemInfo>()) {
     if (!elem.IsDefault) {
@@ -250,7 +250,6 @@ BridgedSwitchStmt BridgedSwitchStmt_createParsed(
     BridgedSourceLoc cSwitchLoc, BridgedExpr cSubjectExpr,
     BridgedSourceLoc cLBraceLoc, BridgedArrayRef cCases,
     BridgedSourceLoc cRBraceLoc) {
-  auto &context = cContext.unbridged();
   SmallVector<CaseStmt *, 16> cases;
   for (auto cCase : cCases.unbridged<BridgedCaseStmt>())
     cases.push_back(cCase.unbridged());


### PR DESCRIPTION
There was a compiler warning `unused variable 'context'`
