### PR TITLE
[Tests] Mark 2 tests require 'embedded_stdlib'

### DIFF
--- a/test/DebugInfo/value-generics-embedded.swift
+++ b/test/DebugInfo/value-generics-embedded.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend %s -target %target-cpu-apple-macos14 -emit-ir -g -enable-experimental-feature Embedded -wmo -disable-availability-checking -o - | %FileCheck %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
 
 // REQUIRES: swift_feature_Embedded
 

--- a/test/Macros/macro_unique_name_embedded.swift
+++ b/test/Macros/macro_unique_name_embedded.swift
@@ -1,6 +1,7 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_Embedded
 // REQUIRES: OS=macosx
+// REQUIRES: embedded_stdlib
 
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t


### PR DESCRIPTION
These tests require Embedded stdlib:

```
  DebugInfo/value-generics-embedded.swift
  Macros/macro_unique_name_embedded.swift
```