### PR TITLE
[Compile Time Values] Add parsing of @constInitialized attribute under CompileTimeValues experimental feature

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5898,6 +5898,7 @@ public:
     Bits.AbstractStorageDecl.IsStatic = IsStatic;
   }
   bool isCompileTimeLiteral() const;
+  bool isConstVal() const;
 
   /// \returns the way 'static'/'class' should be spelled for this declaration.
   StaticSpellingKind getCorrectStaticSpelling() const;

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -872,8 +872,13 @@ SIMPLE_DECL_ATTR(const, ConstVal,
   ABIStableToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
   167)
 DECL_ATTR_FEATURE_REQUIREMENT(ConstVal, CompileTimeValues)
+SIMPLE_DECL_ATTR(constInitialized, ConstInitialized,
+  OnVar,
+  ABIStableToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove,
+  168)
+DECL_ATTR_FEATURE_REQUIREMENT(ConstInitialized, CompileTimeValues)
 
-LAST_DECL_ATTR(ConstVal)
+LAST_DECL_ATTR(ConstInitialized)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -77,14 +77,20 @@ ERROR(class_subscript_not_in_class,none,
       "class subscripts are only allowed within classes; "
       "use 'static' to declare a %select{static|requirement fulfilled by either a static or class}0 subscript", (bool))
 
-ERROR(require_static_for_const,none,
+ERROR(require_static_for_literal,none,
       "'static' is required for _const variable declaration", ())
 
-ERROR(require_let_for_const,none,
+ERROR(require_let_for_literal,none,
       "let is required for a _const variable declaration", ())
 
+ERROR(require_literal_initializer_for_literal,none,
+      "_const let should be initialized with a literal value", ())
+      
 ERROR(require_const_initializer_for_const,none,
-      "_const let should be initialized with a compile-time literal", ())
+      "@const value should be initialized with a compile-time value", ())
+
+ERROR(require_const_arg_for_parameter,none,
+      "expected a compile-time value for a '@const' parameter", ())
 
 // FIXME: Used by both the parser and the type-checker.
 ERROR(func_decl_without_brace,PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2149,7 +2149,7 @@ ERROR(attr_only_at_non_local_scope, none,
 ERROR(attr_only_at_non_generic_scope, none,
       "attribute '%0' cannot be used in a generic context", (StringRef))
 ERROR(attr_only_on_static_properties, none,
-      "properties with attribute '_section' must be static", (StringRef))
+      "properties with attribute '%0' must be static", (StringRef))
 
 ERROR(weak_unowned_in_embedded_swift, none,
       "attribute %0 cannot be used in embedded Swift", (ReferenceOwnership))
@@ -4045,6 +4045,10 @@ ERROR(attr_incompatible_with_override,none,
 ERROR(attr_incompatible_with_objc,none,
       "'%0' must not be used on an '@objc' %1",
       (DeclAttribute, DescriptiveDeclKind))
+
+ERROR(attr_unusable_in_protocol,none,
+      "'%0' cannot be used inside a protocol declaration",
+      (DeclAttribute))
 
 ERROR(final_not_on_accessors,none,
       "only the %select{property|subscript}0 itself can be marked as 'final'"

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4819,6 +4819,7 @@ public:
   TRIVIAL_ATTR_PRINTER(Borrowing, borrowing)
   TRIVIAL_ATTR_PRINTER(CompileTimeLiteral, compile_time_literal)
   TRIVIAL_ATTR_PRINTER(ConstVal, compile_time_value)
+  TRIVIAL_ATTR_PRINTER(ConstInitialized, const_initialized)
   TRIVIAL_ATTR_PRINTER(CompilerInitialized, compiler_initialized)
   TRIVIAL_ATTR_PRINTER(Consuming, consuming)
   TRIVIAL_ATTR_PRINTER(Convenience, convenience)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1294,6 +1294,10 @@ bool AbstractStorageDecl::isCompileTimeLiteral() const {
   return getAttrs().hasAttribute<CompileTimeLiteralAttr>();
 }
 
+bool AbstractStorageDecl::isConstVal() const {
+  return getAttrs().hasAttribute<ConstValAttr>();
+}
+
 bool AbstractStorageDecl::isTransparent() const {
   return getAttrs().hasAttribute<TransparentAttr>();
 }

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -363,7 +363,8 @@ static bool usesFeatureConcurrencySyntaxSugar(Decl *decl) {
 }
 
 static bool usesFeatureCompileTimeValues(Decl *decl) {
-  return decl->getAttrs().hasAttribute<ConstValAttr>();
+  return decl->getAttrs().hasAttribute<ConstValAttr>() ||
+         decl->getAttrs().hasAttribute<ConstInitializedAttr>();
 }
 
 static bool usesFeatureClosureBodyMacro(Decl *decl) {

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -224,6 +224,7 @@ extension ASTGenVisitor {
         .borrowed,
         .compilerInitialized,
         .constVal,
+        .constInitialized,
         .dynamicCallable,
         .eagerMove,
         .exported,

--- a/lib/SIL/IR/SILGlobalVariable.cpp
+++ b/lib/SIL/IR/SILGlobalVariable.cpp
@@ -106,8 +106,14 @@ bool SILGlobalVariable::mustBeInitializedStatically() const {
   if (getSectionAttr())
     return true;
 
-  auto *decl = getDecl();
+  auto *decl = getDecl();  
   if (decl && isDefinition() && decl->getAttrs().hasAttribute<SILGenNameAttr>())
+    return true;
+
+  if (decl && isDefinition() && decl->getAttrs().hasAttribute<ConstValAttr>())
+    return true;
+
+  if (decl && isDefinition() && decl->getAttrs().hasAttribute<ConstInitializedAttr>())
     return true;
 
   return false;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2847,6 +2847,8 @@ void AttributeChecker::visitMoveOnlyAttr(MoveOnlyAttr *attr) {
 void AttributeChecker::visitConstValAttr(ConstValAttr *attr) {
   auto *VD = dyn_cast<VarDecl>(D);
   if (VD) {
+    // FIXME: Do not allow 'var' on @const protocol requirements, only allow
+    // 'let' (once that's implemented to be allowed at all).
     if (!VD->isLet() && !isa<ProtocolDecl>(D->getDeclContext())) {
       diagnose(D->getStartLoc(), diag::attr_only_one_decl_kind,
                attr, "let");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -435,7 +435,8 @@ public:
   void visitFinalAttr(FinalAttr *attr);
   void visitMoveOnlyAttr(MoveOnlyAttr *attr);
   void visitCompileTimeLiteralAttr(CompileTimeLiteralAttr *attr) {}
-  void visitConstValAttr(ConstValAttr *attr) {}
+  void visitConstValAttr(ConstValAttr *attr);
+  void visitConstInitializedAttr(ConstInitializedAttr *attr);
   void visitIBActionAttr(IBActionAttr *attr);
   void visitIBSegueActionAttr(IBSegueActionAttr *attr);
   void visitLazyAttr(LazyAttr *attr);
@@ -2841,6 +2842,39 @@ void AttributeChecker::visitMoveOnlyAttr(MoveOnlyAttr *attr) {
 
   diagnose(attr->getLocation(), diag::moveOnly_not_allowed_here)
     .fixItRemove(attr->getRange());
+}
+
+void AttributeChecker::visitConstValAttr(ConstValAttr *attr) {
+  auto *VD = dyn_cast<VarDecl>(D);
+  if (VD) {
+    if (!VD->isLet() && !isa<ProtocolDecl>(D->getDeclContext())) {
+      diagnose(D->getStartLoc(), diag::attr_only_one_decl_kind,
+               attr, "let");
+      attr->setInvalid();
+      return;
+    }
+  }
+}
+
+void AttributeChecker::visitConstInitializedAttr(ConstInitializedAttr *attr) {
+  auto *VD = cast<VarDecl>(D);
+  
+  if (D->getDeclContext()->isLocalContext()) {
+    diagnose(attr->getLocation(), diag::attr_only_at_non_local_scope,
+             attr->getAttrName());
+  } else
+  if (isa<ProtocolDecl>(D->getDeclContext())) {
+    diagnose(attr->getLocation(), diag::attr_unusable_in_protocol,
+             attr);
+  } else
+  if (!VD->isStatic() && !D->getDeclContext()->isModuleScopeContext()) {
+    diagnose(attr->getLocation(), diag::attr_only_on_static_properties,
+             attr->getAttrName());
+  } else
+  if (!VD->hasStorageOrWrapsStorage()) {
+    diagnose(attr->getLocation(), diag::attr_not_on_computed_properties,
+             attr);
+  }
 }
 
 /// Return true if this is a builtin operator that cannot be defined in user

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1726,6 +1726,7 @@ namespace  {
     UNINTERESTING_ATTR(NoMetadata)
     UNINTERESTING_ATTR(CompileTimeLiteral)
     UNINTERESTING_ATTR(ConstVal)
+    UNINTERESTING_ATTR(ConstInitialized)
 
     UNINTERESTING_ATTR(BackDeployed)
     UNINTERESTING_ATTR(KnownToBeLocal)

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -473,7 +473,7 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
     bool hasStatic = StaticSpelling != StaticSpellingKind::None;
     // only static _const let/var is supported
     if (shouldRequireStatic && !hasStatic) {
-      binding->diagnose(diag::require_static_for_const);
+      binding->diagnose(diag::require_static_for_literal);
       continue;
     }
     if (isReq) {
@@ -485,15 +485,15 @@ const PatternBindingEntry *PatternBindingEntryRequest::evaluate(
     }
     // var is only allowed in a protocol.
     if (!sv->isLet()) {
-      binding->diagnose(diag::require_let_for_const);
+      binding->diagnose(diag::require_let_for_literal);
     }
     // Diagnose when an init isn't given and it's not a compile-time constant
     if (auto *init = binding->getInit(entryNumber)) {
       if (!init->isSemanticallyConstExpr()) {
-        binding->diagnose(diag::require_const_initializer_for_const);
+        binding->diagnose(diag::require_literal_initializer_for_literal);
       }
     } else {
-      binding->diagnose(diag::require_const_initializer_for_const);
+      binding->diagnose(diag::require_literal_initializer_for_literal);
     }
   }
 

--- a/test/Parse/const.swift
+++ b/test/Parse/const.swift
@@ -1,16 +1,17 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature CompileTimeValues
 // REQUIRES: swift_feature_CompileTimeValues
 @const let x: Int = 42
+@const var y: Int = 42 // expected-error{{@const may only be used on 'let' declarations}}
 
 // FIXME: Only allow 'let' for `@const` properties, even in protocol requirements
 protocol ConstUserProto {
-	@const static var v: String { get }
+  @const static var v: String { get }
 }
 
 class ConstFanClassWrong: ConstUserProto {
-	  @const static let v: String = ""
-    // FIXME: Only allow 'let' for `@const` properties
-    @const static var B: String = ""
+  @const static let v: String = ""
+  @const static var B: String = "" // expected-error{{@const may only be used on 'let' declarations}}
+  @const static let C: String = ""
 }
 
 func takeIntConst(@const _ a: Int) {}
@@ -23,8 +24,8 @@ struct Article {
 @const let keypath = \Article.id
 
 func LocalConstVarUser() -> Int {
-		@const let localConst = 3
-		return localConst + 1
+  @const let localConst = 3
+  return localConst + 1
 }
 
 // FIXME: This should be diagnosed

--- a/test/Parse/constinitialized.swift
+++ b/test/Parse/constinitialized.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature CompileTimeValues
+// REQUIRES: swift_feature_CompileTimeValues
+
+@constInitialized let x: Int = 42
+@constInitialized var y: Int = 42
+
+protocol ConstUserProto {
+	@constInitialized var v: String { get } // expected-error{{'@constInitialized' cannot be used inside a protocol declaration}}
+}
+
+class ConstFanClassWrong: ConstUserProto {
+	@constInitialized var v: String = "" // expected-error{{properties with attribute 'constInitialized' must be static}}
+  @constInitialized static var B: String = ""
+  @constInitialized static var Computed: String { get { return "" } } // expected-error{{'@constInitialized' must not be used on computed properties}}
+}
+
+func takeIntConst(@constInitialized _ a: Int) {} // expected-error{{@constInitialized may only be used on 'var' declarations}}
+
+@constInitialized func constFunc(_ a: Int) {} // expected-error{{@constInitialized may only be used on 'var' declarations}}
+
+func LocalConstVarUser() -> Int {
+		@constInitialized let localConst = 3 // expected-error{{attribute 'constInitialized' can only be used in a non-local scope}}
+		return localConst + 1
+}

--- a/test/Parse/constinitialized_no_feature.swift
+++ b/test/Parse/constinitialized_no_feature.swift
@@ -1,0 +1,2 @@
+// RUN: %target-typecheck-verify-swift
+@constInitialized let x: Int = 42 // expected-error{{'constInitialized' attribute is only valid when experimental feature CompileTimeValues is enabled}}

--- a/test/Sema/const_pass_as_arguments.swift
+++ b/test/Sema/const_pass_as_arguments.swift
@@ -54,13 +54,13 @@ class ConstFanClassCorrect: ConstFan {
 }
 
 class ConstFanClassWrong1: ConstFan {
-	static _const let v: String // expected-error {{_const let should be initialized with a compile-time literal}}
+	static _const let v: String // expected-error {{_const let should be initialized with a literal value}}
 	// expected-error@-1 {{'static let' declaration requires an initializer expression or an explicitly stated getter}}
 	// expected-note@-2 {{add an initializer to silence this error}}
 }
 
 class ConstFanClassWrong2: ConstFan {
-	static _const let v: String = "\(v)" // expected-error {{_const let should be initialized with a compile-time literal}}
+	static _const let v: String = "\(v)" // expected-error {{_const let should be initialized with a literal value}}
 }
 
 class ConstFanClassWrong3: ConstFan {
@@ -69,7 +69,7 @@ class ConstFanClassWrong3: ConstFan {
 
 class ConstFanClassWrong4: ConstFan {
 	static func giveMeString() -> String { return "" }
-	static _const let v: String = giveMeString() // expected-error {{_const let should be initialized with a compile-time literal}}
+	static _const let v: String = giveMeString() // expected-error {{_const let should be initialized with a literal value}}
 }
 
 _const let globalConst = 3


### PR DESCRIPTION
This extends the work from https://github.com/swiftlang/swift/pull/79753 (which is groundwork for implementation of this proposal: https://forums.swift.org/t/pitch-3-swift-compile-time-values/77434) to also add the `@constInitialized` attribute (proposal: https://forums.swift.org/t/pitch-3-section-placement-control/77435).

All under `-enable-experimental-feature CompileTimeValues`.

This PR just adds the basic parsing of the attribute, actual semantics will be done in follow-up PRs.