### PR TITLE
Fix bug in dropped variable statistics for SIL.

### DIFF
--- a/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerStatsUtils.cpp
@@ -782,7 +782,7 @@ int computeLostVariables(SILFunction *F, FunctionStat &Old, FunctionStat &New) {
     auto &DbgValScope = std::get<0>(Var);
     for (auto &BB : *F) {
       for (auto &I : BB) {
-        if (I.isDebugInstruction()) {
+        if (!I.isDebugInstruction()) {
           auto DbgLoc = I.getDebugLocation();
           auto Scope = DbgLoc.getScope();
           // If the Scope is a child of, or equal to the DbgValScope and is


### PR DESCRIPTION
When checking for false positives, we want to make sure that if a debug_value is dropped, we also find a real instruction that shares the same scope as the debug_value or has a scope that is a child of the scope of the debug_value, and has an inlinedAt equal to the inlinedAt of the debug_value or it's inlinedAt chain contains the inlinedAt of the debug_value. However, this instruction shouldn't be another debug_value.

The check was supossed to check `if(!I.isDebugInstruction())` but it checked `if(I.isDebugInstruction())`

This patch fixes that bug.
