### PR TITLE
Serialization: Don't crash in loadAllConformances in extended recovery

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -8584,9 +8584,9 @@ ModuleFile::loadAllConformances(const Decl *D, uint64_t contextData,
       auto unconsumedError =
         consumeExpectedError(conformance.takeError());
       if (unconsumedError) {
-        // Ignore if allowing errors, it's just doing a best effort to produce
-        // *some* module anyway.
-        if (allowCompilerErrors())
+        // Ignore when we're not building a binary, it's just doing a best
+        // effort to produce *some* module anyway.
+        if (enableExtendedDeserializationRecovery())
           diagnoseAndConsumeError(std::move(unconsumedError));
         else
           fatal(std::move(unconsumedError));


### PR DESCRIPTION
In extended recovery mode we should recover from all errors without crashing. Protect `loadAllConformances` and drop all conformance errors in this mode.

This was already the logic applied in background indexing, also apply it in index-while-building and LLDB.

rdar://81811394