### PR TITLE
[Explicit Module Builds] Add '-clang-target-variant' flag

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -149,6 +149,7 @@ namespace swift {
     /// The lowering triple may result in multiple versions of the same Clang
     /// modules being built.
     std::optional<llvm::Triple> ClangTarget;
+    std::optional<llvm::Triple> ClangTargetVariant;
 
     /// The SDK version, if known.
     std::optional<llvm::VersionTuple> SDKVersion;
@@ -808,6 +809,8 @@ namespace swift {
         hashValue = llvm::hash_combine(hashValue, TargetVariant.value().str());
       if (ClangTarget.has_value())
         hashValue = llvm::hash_combine(hashValue, ClangTarget.value().str());
+      if (ClangTargetVariant.has_value())
+        hashValue = llvm::hash_combine(hashValue, ClangTargetVariant.value().str());
       if (SDKVersion.has_value())
         hashValue = llvm::hash_combine(hashValue, SDKVersion.value().getAsString());
       if (VariantSDKVersion.has_value())

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1533,6 +1533,11 @@ def clang_target : Separate<["-"], "clang-target">,
   Flags<[FrontendOption, SwiftSymbolGraphExtractOption,
          SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
   HelpText<"Separately set the target we should use for internal Clang instance">;
+def clang_target_variant : Separate<["-"], "clang-target-variant">,
+  Flags<[FrontendOption, SwiftSymbolGraphExtractOption,
+         SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
+  HelpText<"Separately set the target we should use for internal Clang instance"
+           " for the 'zippered' code for macCatalyst">;
 
 def disable_clang_target : Flag<["-"], "disable-clang-target">,
   Flags<[NewDriverOnlyOption]>,

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -866,6 +866,8 @@ importer::addCommonInvocationArguments(
       // Passing the -target-variant along to clang causes clang's
       // CodeGenerator to emit zippered .o files.
       invocationArgStrs.push_back("-darwin-target-variant");
+      if (ctx.LangOpts.ClangTargetVariant.has_value() && !ignoreClangTarget)
+        variantTriple = ctx.LangOpts.ClangTargetVariant.value();
       invocationArgStrs.push_back(variantTriple->str());
     }
 
@@ -1202,8 +1204,11 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
     }
 
     // If clang target is ignored, using swift target.
-    if (ignoreClangTarget)
+    if (ignoreClangTarget) {
       CI->getTargetOpts().Triple = ctx.LangOpts.Target.str();
+      if (ctx.LangOpts.TargetVariant.has_value())
+        CI->getTargetOpts().DarwinTargetVariantTriple = ctx.LangOpts.TargetVariant->str();
+    }
 
     // Forward the index store path. That information is not passed to scanner
     // and it is cached invariant so we don't want to re-scan if that changed.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1433,9 +1433,10 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   // necessary because the textual interface hardcoded the proper target triple
   // to use. Inferring -clang-target there will always give us the default
   // target triple.
-  if (const Arg *A = Args.getLastArg(OPT_clang_target)) {
+  if (const Arg *A = Args.getLastArg(OPT_clang_target))
     Opts.ClangTarget = llvm::Triple(A->getValue());
-  }
+  if (const Arg *A = Args.getLastArg(OPT_clang_target_variant))
+    Opts.ClangTargetVariant = llvm::Triple(A->getValue());
 
   Opts.setCxxInteropFromArgs(Args, Diags);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -246,6 +246,11 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.ExtraClangOptions.push_back("--target=" +
                                                   LangOpts.ClangTarget->str());
   }
+  if (LangOpts.ClangTargetVariant &&
+      !getClangImporterOptions().DirectClangCC1ModuleBuild) {
+    serializationOpts.ExtraClangOptions.push_back("-darwin-target-variant");
+    serializationOpts.ExtraClangOptions.push_back(LangOpts.ClangTargetVariant->str());
+  }
   if (LangOpts.EnableAppExtensionRestrictions) {
     serializationOpts.ExtraClangOptions.push_back("-fapplication-extension");
   }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1668,6 +1668,15 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     GenericArgs.push_back(triple);
   }
 
+  if (LangOpts.ClangTargetVariant.has_value()) {
+    genericSubInvocation.getLangOptions().ClangTargetVariant = LangOpts.ClangTargetVariant;
+    auto variantTriple = ArgSaver.save(genericSubInvocation.getLangOptions()
+      .ClangTargetVariant->getTriple());
+    assert(!variantTriple.empty());
+    GenericArgs.push_back("-clang-target-variant");
+    GenericArgs.push_back(variantTriple);
+  }
+
   // Inherit the target SDK name and version
   if (!LangOpts.SDKName.empty()) {
     genericSubInvocation.getLangOptions().SDKName = LangOpts.SDKName;

--- a/test/ScanDependencies/clang-target-variant.swift
+++ b/test/ScanDependencies/clang-target-variant.swift
@@ -1,0 +1,23 @@
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -enable-objc-interop -module-load-mode prefer-interface -module-cache-path %t.module-cache %s -o %t.deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -target arm64e-apple-ios16.4-macabi -clang-target arm64e-apple-ios17.0-macabi -target-variant arm64e-apple-macosx14.4 -clang-target-variant arm64e-apple-macosx15.0
+
+// RUN: %validate-json %t.deps.json | %FileCheck %s
+
+// Ensure the flag affects Clang dependencies in the expected way
+// CHECK: "clang": "X"
+// CHECK: "modulePath": "{{.*}}X-{{.*}}.pcm"
+// CHECK: "-darwin-target-variant-triple"
+// CHECK-NEXT: "-Xcc"
+// CHECK-NEXT: "arm64e-apple-macosx15.0"
+
+// Ensure the flag is propagated to Swift dependencies
+// CHECK: "-clang-target-variant"
+// CHECK-NEXT: "arm64e-apple-macosx15.0"
+
+import X
+


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/37774 added '-clang-target' which allows us to specify a target triple that only differs from '-target' by the OS version, when we want to provide a different OS version for API availability and type-checking, in order to set a common/unified target triple for the entire Clang module dependency graph, for presenting a unified API surface to the Swift client, serving as a maximum type-checking epoch.

This change adds an equivalent flag for the '-target-variant' configuration, as a mechanism to ensure that the entire module dependency graph presents a consistent os version. 
