### PR TITLE
Fix call to templated readFullContextDescriptor method

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -1521,7 +1521,7 @@ public:
                                  MemoryReader::ReadBytesResult &ptr) {
     // Read the full base descriptor if it's bigger than what we have so far.
     if (sizeof(DescriptorTy) > sizeof(TargetContextDescriptor<Runtime>)) {
-      ptr = Reader->readObj<DescriptorTy>(address);
+      ptr = Reader->template readObj<DescriptorTy>(address);
       if (!ptr)
         return false;
     }


### PR DESCRIPTION
This function call was causing an error in my local builds:

```c++
In file included from /Users/j-hui/Documents/open2/swift/stdlib/public/RemoteInspection/TypeLowering.cpp:27:
In file included from /Users/j-hui/Documents/open2/swift/include/swift/RemoteInspection/TypeLowering.h:24:
/Users/j-hui/Documents/open2/swift/include/swift/Remote/MetadataReader.h:1524:21: error: use 'template' keyword to treat 'readObj' as a dependent template name
 1524 |       ptr = Reader->readObj<DescriptorTy>(address);
      |                     ^
      |                     template
1 error generated.
```

Applying the suggested fix seemed to resolve the issue.