### PR TITLE
Adopt `@abi` in the standard library

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -1131,15 +1131,17 @@ ways to misuse it:
   be reliably recovered through C interfaces like `dlsym`. If you want to
   implement a plugin-style interface, use `Bundle`/`NSBundle` if available, or
   export your plugin entry points as C entry points using `@_cdecl`.
-  
+- Don't use `@_silgen_name` when you need to make a change to an ABI-stable
+  declaration's signature that would normally alter its mangled name, but you
+  need to preserve the old mangled name for ABI compatibility. We used to use it
+  for this task, but `@abi` can do it with fewer limitations, more safety, and
+  better readability. If for some reason you do need `@_silgen_name`, you will
+  need to be careful that the change doesn't materially affect the actual
+  calling convention of the function in an incompatible way.
+
 Legitimate uses may include:
 
 - Use `@_silgen_name` if you're implementing the Swift runtime.
-- Use `@_silgen_name` if you need to make a change to an ABI-stable
-  declaration's signature that would normally alter its mangled name, but you
-  need to preserve the old mangled name for ABI compatibility. You will need
-  to be careful that the change doesn't materially affect the actual calling
-  convention of the function in an incompatible way.
 - Use `@_silgen_name` if certain declarations need to have predictable symbol
   names, such as to be easily referenced by linker scripts or other highly
   customized build environments (and it's OK for those predictable symbols to

--- a/docs/StandardLibraryProgrammersManual.md
+++ b/docs/StandardLibraryProgrammersManual.md
@@ -455,6 +455,8 @@ This attribute specifies the name that a declaration will have at link time. It 
 1. To specify the symbol name of a Swift function so that it can be called from Swift-aware C. Such functions have bodies.
 2. To provide a Swift declaration which really represents a C declaration. Such functions do not have bodies.
 
+In the past it was sometimes used for ABI backwards compatibility hacks, but `@abi` does this job better.
+
 ##### Using `@_silgen_name` to call Swift from Swift-aware C
 
 Rather than hard-code Swift mangling into C code, `@_silgen_name` is used to provide a stable and known symbol name for linking. Note that C code still must understand and use the Swift calling convention (available in swift-clang) for such Swift functions (if they use Swift's CC). Example:

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -637,6 +637,7 @@ function(_compile_swift_files
   list(APPEND swift_flags "-enable-experimental-feature" "LifetimeDependence")
   list(APPEND swift_flags "-enable-experimental-feature" "InoutLifetimeDependence")
   list(APPEND swift_flags "-enable-experimental-feature" "LifetimeDependenceMutableAccessors")
+  list(APPEND swift_flags "-enable-experimental-feature" "ABIAttribute")
 
   list(APPEND swift_flags "-enable-upcoming-feature" "MemberImportVisibility")
 

--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -330,7 +330,12 @@ public struct AsyncStream<Element> {
   ///     }
   ///
   ///
-  @_silgen_name("$sScS9unfolding8onCancelScSyxGxSgyYac_yyYbcSgtcfC")
+  @abi(
+    init(
+      unfolding produce: @escaping /* not @Sendable*/ () async -> Element?,
+      onCancel: (@Sendable () -> Void)?
+    )
+  )
   @preconcurrency // Original API had `@Sendable` only on `onCancel`
   public init(
     unfolding produce: @escaping @Sendable () async -> Element?,

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -313,9 +313,14 @@ public func withCheckedContinuation<T>(
 //
 // This function also doubles as an ABI-compatibility shim predating the
 // introduction of #isolation.
+@abi(
+  func withCheckedContinuation<T>(
+    function: String,
+    _ body: (CheckedContinuation<T, Never>) -> Void
+  ) async -> T
+)
 @available(SwiftStdlib 5.1, *)
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
-@_silgen_name("$ss23withCheckedContinuation8function_xSS_yScCyxs5NeverOGXEtYalF")
 public func _unsafeInheritExecutor_withCheckedContinuation<T>(
   function: String = #function,
   _ body: (CheckedContinuation<T, Never>) -> Void
@@ -377,9 +382,14 @@ public func withCheckedThrowingContinuation<T>(
 //
 // This function also doubles as an ABI-compatibility shim predating the
 // introduction of #isolation.
+@abi(
+  func withCheckedThrowingContinuation<T>(
+    function: String,
+    _ body: (CheckedContinuation<T, Error>) -> Void
+  ) async throws -> T
+)
 @available(SwiftStdlib 5.1, *)
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
-@_silgen_name("$ss31withCheckedThrowingContinuation8function_xSS_yScCyxs5Error_pGXEtYaKlF")
 public func _unsafeInheritExecutor_withCheckedThrowingContinuation<T>(
   function: String = #function,
   _ body: (CheckedContinuation<T, Error>) -> Void

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -127,8 +127,12 @@ extension Clock {
   //
   // This function also doubles as an ABI-compatibility shim predating the
   // introduction of #isolation.
+  @abi(
+    func measure(
+        _ work: () async throws -> Void
+    ) async rethrows -> Instant.Duration
+  )
   @available(SwiftStdlib 5.7, *)
-  @_silgen_name("$ss5ClockPsE7measurey8DurationQzyyYaKXEYaKF")
   @_unsafeInheritExecutor // for ABI compatibility
   public func _unsafeInheritExecutor_measure(
     _ work: () async throws -> Void

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -97,9 +97,14 @@ public func withDiscardingTaskGroup<GroupResult>(
 //
 // This function also doubles as an ABI-compatibility shim predating the
 // introduction of #isolation.
+@abi(
+  func withDiscardingTaskGroup<GroupResult>(
+    returning returnType: GroupResult.Type,
+    body: (inout DiscardingTaskGroup) async -> GroupResult
+  ) async -> GroupResult
+)
 @available(SwiftStdlib 5.9, *)
 @_unsafeInheritExecutor // for ABI compatibility
-@_silgen_name("$ss23withDiscardingTaskGroup9returning4bodyxxm_xs0bcD0VzYaXEtYalF")
 public func _unsafeInheritExecutor_withDiscardingTaskGroup<GroupResult>(
   returning returnType: GroupResult.Type = GroupResult.self,
   body: (inout DiscardingTaskGroup) async -> GroupResult
@@ -367,9 +372,14 @@ public func withThrowingDiscardingTaskGroup<GroupResult>(
   return result
 }
 
+@abi(
+  func withThrowingDiscardingTaskGroup<GroupResult>(
+      returning returnType: GroupResult.Type,
+      body: (inout ThrowingDiscardingTaskGroup<Error>) async throws -> GroupResult
+  ) async throws -> GroupResult
+)
 @available(SwiftStdlib 5.9, *)
 @_unsafeInheritExecutor // for ABI compatibility
-@_silgen_name("$ss31withThrowingDiscardingTaskGroup9returning4bodyxxm_xs0bcdE0Vys5Error_pGzYaKXEtYaKlF")
 public func _unsafeInheritExecutor_withThrowingDiscardingTaskGroup<GroupResult>(
     returning returnType: GroupResult.Type = GroupResult.self,
     body: (inout ThrowingDiscardingTaskGroup<Error>) async throws -> GroupResult

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -368,11 +368,16 @@ extension Actor {
     }
   }
 
+  @abi(
+    nonisolated func assumeIsolated<T /* not ': Sendable' */>(
+        _ operation: (isolated Self) throws -> T,
+        file: StaticString, line: UInt
+    ) rethrows -> T
+  )
   @available(SwiftStdlib 5.9, *)
   @usableFromInline
   @_unavailableInEmbedded
-  @_silgen_name("$sScAsE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKlF")
-  internal nonisolated func __abi__assumeIsolated<T : Sendable>(
+  internal nonisolated func __nonsendable_assumeIsolated<T : Sendable>(
       _ operation: (isolated Self) throws -> T,
       _ file: StaticString, _ line: UInt
   ) rethrows -> T {

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -152,10 +152,15 @@ extension MainActor {
     }
   }
 
+  @abi(
+    static func assumeIsolated<T /* not ': Sendable' */>(
+        _ operation: @MainActor () throws -> T,
+        file: StaticString, line: UInt
+    ) rethrows -> T
+  )
   @available(SwiftStdlib 5.9, *)
   @usableFromInline
-  @_silgen_name("$sScM14assumeIsolated_4file4linexxyKScMYcXE_s12StaticStringVSutKlFZ")
-  internal static func __abi__assumeIsolated<T : Sendable>(
+  internal static func __nonsendable_assumeIsolated<T : Sendable>(
       _ operation: @MainActor () throws -> T,
       _ file: StaticString, _ line: UInt
   ) rethrows -> T {

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -164,10 +164,15 @@ public func withTaskExecutorPreference<T, Failure>(
 //
 // This function also doubles as an ABI-compatibility shim predating the
 // introduction of #isolation.
+@abi(
+  func withTaskExecutorPreference<T: Sendable>(
+    _ taskExecutor: (any TaskExecutor)?,
+    operation: @Sendable () async throws -> T
+  ) async rethrows -> T
+)
 @_unavailableInEmbedded
 @available(SwiftStdlib 6.0, *)
 @_unsafeInheritExecutor // for ABI compatibility
-@_silgen_name("$ss26withTaskExecutorPreference_9operationxSch_pSg_xyYaYbKXEtYaKs8SendableRzlF")
 public func _unsafeInheritExecutor_withTaskExecutorPreference<T: Sendable>(
   _ taskExecutor: (any TaskExecutor)?,
   operation: @Sendable () async throws -> T

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -89,9 +89,14 @@ public func withTaskCancellationHandler<T>(
 //
 // This function also doubles as an ABI-compatibility shim predating the
 // introduction of #isolation.
+@abi(
+  func withTaskCancellationHandler<T>(
+    operation: () async throws -> T,
+    onCancel handler: @Sendable () -> Void
+  ) async rethrows -> T
+)
 @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 @available(SwiftStdlib 5.1, *)
-@_silgen_name("$ss27withTaskCancellationHandler9operation8onCancelxxyYaKXE_yyYbXEtYaKlF")
 public func _unsafeInheritExecutor_withTaskCancellationHandler<T>(
   operation: () async throws -> T,
   onCancel handler: @Sendable () -> Void

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -97,8 +97,15 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 //
 // This function also doubles as an ABI-compatibility shim predating the
 // introduction of #isolation.
+@abi(
+  @preconcurrency   // TaskGroup.ChildTaskResult: Sendable
+  func withTaskGroup<ChildTaskResult, GroupResult>(
+    of childTaskResultType: ChildTaskResult.Type,
+    returning returnType: GroupResult.Type,
+    body: (inout TaskGroup<ChildTaskResult>) async -> GroupResult
+  ) async -> GroupResult
+)
 @available(SwiftStdlib 5.1, *)
-@_silgen_name("$ss13withTaskGroup2of9returning4bodyq_xm_q_mq_ScGyxGzYaXEtYar0_lF")
 @_unsafeInheritExecutor // for ABI compatibility
 @inlinable
 public func _unsafeInheritExecutor_withTaskGroup<ChildTaskResult, GroupResult>(
@@ -243,8 +250,15 @@ public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
 //
 // This function also doubles as an ABI-compatibility shim predating the
 // introduction of #isolation.
+@abi(
+  @preconcurrency   // ThrowingTaskGroup.ChildTaskResult: Sendable
+  func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
+    of childTaskResultType: ChildTaskResult.Type,
+    returning returnType: GroupResult.Type,
+    body: (inout ThrowingTaskGroup<ChildTaskResult, Error>) async throws -> GroupResult
+  ) async rethrows -> GroupResult
+)
 @available(SwiftStdlib 5.1, *)
-@_silgen_name("$ss21withThrowingTaskGroup2of9returning4bodyq_xm_q_mq_Scgyxs5Error_pGzYaKXEtYaKr0_lF")
 @_unsafeInheritExecutor // for ABI compatibility
 public func _unsafeInheritExecutor_withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
@@ -690,7 +704,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
     return try await _taskGroupWaitNext(group: _group)
   }
 
-  @_silgen_name("$sScg10nextResults0B0Oyxq_GSgyYaKF")
+  @abi(mutating func nextResult() async throws -> Result<ChildTaskResult, Failure>?)
   @usableFromInline
   mutating func nextResultForABI() async throws -> Result<ChildTaskResult, Failure>? {
     do {

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -221,10 +221,16 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   //
   // This function also doubles as an ABI-compatibility shim predating the
   // introduction of #isolation.
+  @abi(
+    func withValue<R>(
+      _ valueDuringOperation: Value,
+      operation: () async throws -> R,
+      file: String, line: UInt
+    ) async rethrows -> R
+  )
   @discardableResult
   @_unsafeInheritExecutor // ABI compatibility with Swift 5.1
   @available(SwiftStdlib 5.1, *)
-  @_silgen_name("$ss9TaskLocalC9withValue_9operation4file4lineqd__x_qd__yYaKXESSSutYaKlF")
   public func _unsafeInheritExecutor_withValue<R>(
     _ valueDuringOperation: Value,
     operation: () async throws -> R,
@@ -265,7 +271,13 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     return try await operation()
   }
 
-  @_silgen_name("$ss9TaskLocalC13withValueImpl_9operation4file4lineqd__xn_qd__yYaKXESSSutYaKlF")
+  @abi(
+    func withValueImpl<R>(
+      _ valueDuringOperation: __owned Value,
+      operation: () async throws -> R,
+      file: String, line: UInt
+    ) async rethrows -> R
+  )
   @inlinable
   @discardableResult
   @_unsafeInheritExecutor // internal for backwards compatibility; though may be able to be removed safely?

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -362,10 +362,15 @@ extension DistributedActor {
   /// state.
   ///
   /// When the actor is remote, the closure won't be executed and this function will return nil.
+  @abi(
+    // We need to @abi here because the signature is the same as
+    // `__separately_compiled_typed_throws_whenLocal(_:)`, and even though this
+    // is @AEIC, the symbol name would conflict.
+    nonisolated func __typed_throws_whenLocal<T: Sendable, E>(
+      _ body: @Sendable (isolated Self) async throws(E) -> T
+    ) async throws(E) -> T?
+  )
   @_alwaysEmitIntoClient
-  // we need to silgen_name here because the signature is the same as __abi_whenLocal,
-  // and even though this is @AEIC, the symbol name would conflict.
-  @_silgen_name("$s11Distributed0A5ActorPAAE20whenLocalTypedThrowsyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF")
   public nonisolated func whenLocal<T: Sendable, E>(
     _ body: @Sendable (isolated Self) async throws(E) -> T
   ) async throws(E) -> T? {
@@ -380,18 +385,26 @@ extension DistributedActor {
   // ABI: This is a workaround when in Swift 6 this method was introduced
   // in order to support typed-throws, but missed to add @_aeic.
   // In practice, this method should not ever be used by anyone, ever.
+  @abi(
+    nonisolated func whenLocal<T: Sendable, E>(
+      _ body: @Sendable (isolated Self) async throws(E) -> T
+    ) async throws(E) -> T?
+  )
   @usableFromInline
-  @_silgen_name("$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbqd_0_YKXEYaqd_0_YKs8SendableRd__s5ErrorRd_0_r0_lF")
-  internal nonisolated func __abi_whenLocal<T: Sendable, E>(
+  nonisolated func __separately_compiled_typed_throws_whenLocal<T: Sendable, E>(
     _ body: @Sendable (isolated Self) async throws(E) -> T
   ) async throws(E) -> T? {
     try await whenLocal(body)
   }
 
   // ABI: Historical whenLocal, rethrows was changed to typed throws `throws(E)`
-  @_silgen_name("$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbKXEYaKs8SendableRd__lF")
+  @abi(
+    nonisolated func whenLocal<T: Sendable>(
+      _ body: @Sendable (isolated Self) async throws -> T
+    ) async rethrows -> T?
+  )
   @usableFromInline
-  nonisolated func __abi_whenLocal<T: Sendable>(
+  nonisolated func __rethrows_whenLocal<T: Sendable>(
     _ body: @Sendable (isolated Self) async throws -> T
   ) async rethrows -> T? {
     try await whenLocal(body)

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -179,10 +179,15 @@ extension DistributedActor {
     }
   }
 
+  @abi(
+    nonisolated func assumeIsolated<T /* not ': Sendable' */>(
+      _ operation: (isolated Self) throws -> T,
+      file: StaticString, line: UInt
+    ) rethrows -> T
+  )
   @available(SwiftStdlib 5.9, *)
   @usableFromInline
-  @_silgen_name("$s11Distributed0A5ActorPAAE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKlF")
-  internal nonisolated func __abi__assumeIsolated<T : Sendable>(
+  internal nonisolated func __nonsendable_assumeIsolated<T : Sendable>(
       _ operation: (isolated Self) throws -> T,
       _ file: StaticString, _ line: UInt
   ) rethrows -> T {

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1634,12 +1634,16 @@ extension Array {
 
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    mutating func withUnsafeMutableBufferPointer<R>(
+      _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @_semantics("array.withUnsafeMutableBufferPointer")
   @_effects(notEscaping self.value**)
   @usableFromInline
   @inline(__always)
-  @_silgen_name("$sSa30withUnsafeMutableBufferPointeryqd__qd__SryxGzKXEKlF")
-  mutating func __abi_withUnsafeMutableBufferPointer<R>(
+  mutating func __rethrows_withUnsafeMutableBufferPointer<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     _makeMutableAndUnique()

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -649,9 +649,13 @@ extension _ArrayBuffer {
   /// created on-demand.
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    func withUnsafeBufferPointer<R>(
+      _ body: (UnsafeBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @usableFromInline
-  @_silgen_name("$ss12_ArrayBufferV010withUnsafeB7Pointeryqd__qd__SRyxGKXEKlF")
-  internal func __abi_withUnsafeBufferPointer<R>(
+  internal func __rethrows_withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     if _fastPath(_isNative) {
@@ -679,9 +683,13 @@ extension _ArrayBuffer {
 
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    mutating func withUnsafeMutableBufferPointer<R>(
+      _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @usableFromInline
-  @_silgen_name("$ss12_ArrayBufferV017withUnsafeMutableB7Pointeryqd__qd__SryxGKXEKlF")
-  internal mutating func __abi_withUnsafeMutableBufferPointer<R>(
+  internal mutating func __rethrows_withUnsafeMutableBufferPointer<R>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     return try unsafe withUnsafeMutableBufferPointer(body)

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1223,11 +1223,15 @@ extension ArraySlice {
 
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    mutating func withUnsafeMutableBufferPointer<R>(
+      _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @_semantics("array.withUnsafeMutableBufferPointer")
   @usableFromInline
   @inline(__always)
-  @_silgen_name("$ss10ArraySliceV30withUnsafeMutableBufferPointeryqd__qd__SryxGzKXEKlF")
-  mutating func __abi_withUnsafeMutableBufferPointer<R>(
+  mutating func __rethrows_withUnsafeMutableBufferPointer<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     return try unsafe withUnsafeMutableBufferPointer(body)

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -983,8 +983,8 @@ public func type<T: ~Copyable & ~Escapable, Metatype>(
   Builtin.unreachable()
 }
 
+@abi(func type<T, Metatype>(of _: T) -> Metatype)
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss4type2ofq_x_tr0_lF")
 @usableFromInline
 func __abi_type<T, Metatype>(of value: T) -> Metatype {
   // This is a legacy entry point for the original definition of `type(of:)`
@@ -1091,9 +1091,14 @@ public func withoutActuallyEscaping<ClosureType, ResultType, Failure>(
   Builtin.unreachable()
 }
 
-@_silgen_name("$ss23withoutActuallyEscaping_2doq_x_q_xKXEtKr0_lF")
+@abi(
+  func withoutActuallyEscaping<ClosureType, ResultType>(
+    _ closure: ClosureType,
+    do body: (_ escapingClosure: ClosureType) throws -> ResultType
+  ) throws -> ResultType
+)
 @usableFromInline
-func __abi_withoutActuallyEscaping<ClosureType, ResultType>(
+func __rethrows_withoutActuallyEscaping<ClosureType, ResultType>(
   _ closure: ClosureType,
   do body: (_ escapingClosure: ClosureType) throws -> ResultType
 ) throws -> ResultType {
@@ -1122,9 +1127,14 @@ public func _openExistential<ExistentialType, ContainedType, ResultType, Failure
   Builtin.unreachable()
 }
 
+@abi(
+  func _openExistential<ExistentialType, ContainedType, ResultType>(
+    _ existential: ExistentialType,
+    do body: (_ escapingClosure: ContainedType) throws -> ResultType
+  ) throws -> ResultType
+)
 @usableFromInline
-@_silgen_name("$ss16_openExistential_2doq0_x_q0_q_KXEtKr1_lF")
-func __abi_openExistential<ExistentialType, ContainedType, ResultType>(
+func __rethrows_openExistential<ExistentialType, ContainedType, ResultType>(
   _ existential: ExistentialType,
   do body: (_ escapingClosure: ContainedType) throws -> ResultType
 ) throws -> ResultType {

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -334,6 +334,7 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "ValueGene
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "AddressableParameters")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "AddressableTypes")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "AllowUnsafeAttribute")
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "ABIAttribute")
 list(APPEND swift_stdlib_compile_flags "-strict-memory-safety")
 
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")

--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -186,7 +186,7 @@ extension String {
   ///
   /// - Parameter nullTerminatedUTF8:
   ///     A pointer to a null-terminated sequence of UTF-8 code units.
-  @_silgen_name("$sSS14validatingUTF8SSSgSPys4Int8VG_tcfC")
+  @abi(init?(validatingUTF8 nullTerminatedUTF8: UnsafePointer<CChar>))
   public init?(validatingCString nullTerminatedUTF8: UnsafePointer<CChar>) {
     let len = unsafe UTF8._nullCodeUnitOffset(in: nullTerminatedUTF8)
     let validated = unsafe nullTerminatedUTF8.withMemoryRebound(
@@ -231,7 +231,7 @@ extension String {
   @inlinable
   @_alwaysEmitIntoClient
   @available(swift, deprecated: 6, renamed: "String.init(validatingCString:)")
-  @_silgen_name("_swift_se0405_String_validatingUTF8")
+  @abi(init?(validatingCString nullTerminatedUTF8: UnsafePointer<CChar>))
   public init?(validatingUTF8 cString: UnsafePointer<CChar>) {
     unsafe self.init(validatingCString: cString)
   }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1214,11 +1214,14 @@ extension Collection {
   }
 
   // ABI-only entrypoint for the rethrows version of map, which has been
-  // superseded by the typed-throws version. Expressed as "throws", which is
-  // ABI-compatible with "rethrows".
+  // superseded by the typed-throws version.
+  @abi(
+    func map<T>(
+      _ transform: (Element) throws -> T
+    ) rethrows -> [T]
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
-  @_silgen_name("$sSlsE3mapySayqd__Gqd__7ElementQzKXEKlF")
   func __rethrows_map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1166,11 +1166,15 @@ extension ContiguousArray {
 
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    mutating func withUnsafeMutableBufferPointer<R>(
+      _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @_semantics("array.withUnsafeMutableBufferPointer")
   @usableFromInline
   @inline(__always)
-  @_silgen_name("$ss15ContiguousArrayV30withUnsafeMutableBufferPointeryqd__qd__SryxGzKXEKlF")
-  mutating func __abi_withUnsafeMutableBufferPointer<R>(
+  mutating func __rethrows_withUnsafeMutableBufferPointer<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     return try unsafe withUnsafeMutableBufferPointer(body)

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -447,9 +447,13 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
 
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    func withUnsafeBufferPointer<R>(
+      _ body: (UnsafeBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @usableFromInline
-  @_silgen_name("$ss22_ContiguousArrayBufferV010withUnsafeC7Pointeryqd__qd__SRyxGKXEKlF")
-  internal func __abi_withUnsafeBufferPointer<R>(
+  internal func __rethrows_withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     defer { _fixLifetime(self) }
@@ -470,9 +474,13 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
 
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    mutating func withUnsafeMutableBufferPointer<R>(
+      _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @usableFromInline
-  @_silgen_name("$ss22_ContiguousArrayBufferV017withUnsafeMutableC7Pointeryqd__qd__SryxGKXEKlF")
-  internal mutating func __abi_withUnsafeMutableBufferPointer<R>(
+  internal mutating func __rethrows_withUnsafeMutableBufferPointer<R>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     defer { _fixLifetime(self) }

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -1335,11 +1335,14 @@ extension AnySequence {
   }
 
   // ABI-only entrypoint for the rethrows version of map, which has been
-  // superseded by the typed-throws version. Expressed as "throws", which is
-  // ABI-compatible with "rethrows".
+  // superseded by the typed-throws version.
+  @abi(
+    func map<T>(
+      _ transform: (Element) throws -> T
+    ) rethrows -> [T]
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
-  @_silgen_name("$ss11AnySequenceV3mapySayqd__Gqd__xKXEKlF")
   func __rethrows_map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
@@ -1439,11 +1442,14 @@ extension AnyCollection {
   }
 
   // ABI-only entrypoint for the rethrows version of map, which has been
-  // superseded by the typed-throws version. Expressed as "throws", which is
-  // ABI-compatible with "rethrows".
+  // superseded by the typed-throws version.
+  @abi(
+    func map<T>(
+      _ transform: (Element) throws -> T
+    ) rethrows -> [T]
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
-  @_silgen_name("$ss13AnyCollectionV3mapySayqd__Gqd__xKXEKlF")
   func __rethrows_map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
@@ -1549,11 +1555,14 @@ extension AnyBidirectionalCollection {
   }
 
   // ABI-only entrypoint for the rethrows version of map, which has been
-  // superseded by the typed-throws version. Expressed as "throws", which is
-  // ABI-compatible with "rethrows".
+  // superseded by the typed-throws version.
+  @abi(
+    func map<T>(
+      _ transform: (Element) throws -> T
+    ) rethrows -> [T]
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
-  @_silgen_name("$ss26AnyBidirectionalCollectionV3mapySayqd__Gqd__xKXEKlF")
   func __rethrows_map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
@@ -1663,9 +1672,13 @@ extension AnyRandomAccessCollection {
   // ABI-only entrypoint for the rethrows version of map, which has been
   // superseded by the typed-throws version. Expressed as "throws", which is
   // ABI-compatible with "rethrows".
+  @abi(
+    func map<T>(
+      _ transform: (Element) throws -> T
+    ) rethrows -> [T]
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
-  @_silgen_name("$ss25AnyRandomAccessCollectionV3mapySayqd__Gqd__xKXEKlF")
   func __rethrows_map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -43,10 +43,14 @@ public func withExtendedLifetime<
   return try body()
 }
 
+@abi(
+  func withExtendedLifetime<T, Result>(
+    _ x: T, _ body: () throws -> Result
+  ) rethrows -> Result
+)
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss20withExtendedLifetimeyq_x_q_yKXEtKr0_lF")
 @usableFromInline
-internal func __abi_withExtendedLifetime<T, Result>(
+internal func __rethrows_withExtendedLifetime<T, Result>(
   _ x: T,
   _ body: () throws -> Result
 ) rethrows -> Result {
@@ -76,10 +80,14 @@ public func withExtendedLifetime<
   return try body(x)
 }
 
+@abi(
+  func withExtendedLifetime<T, Result>(
+    _ x: T, _ body: (T) throws -> Result
+  ) rethrows -> Result
+)
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss20withExtendedLifetimeyq_x_q_xKXEtKr0_lF")
 @usableFromInline
-internal func __abi_withExtendedLifetime<T, Result>(
+internal func __rethrows_withExtendedLifetime<T, Result>(
   _ x: T, _ body: (T) throws -> Result
 ) rethrows -> Result {
   defer { _fixLifetime(x) }
@@ -126,8 +134,13 @@ public func withUnsafeMutablePointer<
   try unsafe body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
 }
 
+@abi(
+  func withUnsafeMutablePointer<T, Result>(
+    to value: inout T,
+    _ body: (UnsafeMutablePointer<T>) throws -> Result
+  ) throws -> Result
+)
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss24withUnsafeMutablePointer2to_q_xz_q_SpyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_se0413_withUnsafeMutablePointer<T, Result>(
   to value: inout T,
@@ -186,10 +199,15 @@ public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafePointer(to:_:) rethrows, expressed as "throws",
 /// which is ABI-compatible with "rethrows".
+@abi(
+  func withUnsafePointer<T, Result>(
+    to value: T,
+    _ body: (UnsafePointer<T>) throws -> Result
+  ) throws -> Result
+)
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss17withUnsafePointer2to_q_x_q_SPyxGKXEtKr0_lF")
 @usableFromInline
-internal func __abi_withUnsafePointer<T, Result>(
+internal func __rethrows_withUnsafePointer<T, Result>(
   to value: T,
   _ body: (UnsafePointer<T>) throws -> Result
 ) throws -> Result
@@ -231,8 +249,13 @@ public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafePointer(to:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
+@abi(
+  func withUnsafePointer<T, Result>(
+    to value: inout T,
+    _ body: (UnsafePointer<T>) throws -> Result
+  ) throws -> Result
+)
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss17withUnsafePointer2to_q_xz_q_SPyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_se0413_withUnsafePointer<T, Result>(
   to value: inout T,

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -174,8 +174,12 @@ extension ManagedBuffer where Element: ~Copyable {
 }
 
 extension ManagedBuffer {
+  @abi(
+    final func withUnsafeMutablePointerToHeader<R>(
+      _ body: (UnsafeMutablePointer<Header>) throws -> R
+    ) rethrows -> R
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss13ManagedBufferC32withUnsafeMutablePointerToHeaderyqd__qd__SpyxGKXEKlF")
   @usableFromInline
   internal final func __legacy_withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
@@ -183,8 +187,12 @@ extension ManagedBuffer {
     return try unsafe withUnsafeMutablePointers { (v, _) in return try unsafe body(v) }
   }
 
+  @abi(
+    final func withUnsafeMutablePointerToElements<R>(
+      _ body: (UnsafeMutablePointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss13ManagedBufferC34withUnsafeMutablePointerToElementsyqd__qd__Spyq_GKXEKlF")
   @usableFromInline
   internal final func __legacy_withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
@@ -192,8 +200,14 @@ extension ManagedBuffer {
     return try unsafe withUnsafeMutablePointers { return try unsafe body($1) }
   }
 
+  @abi(
+    final func withUnsafeMutablePointers<R>(
+      _ body: (
+        UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>
+      ) throws -> R
+    ) rethrows -> R
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss13ManagedBufferC25withUnsafeMutablePointersyqd__qd__SpyxG_Spyq_GtKXEKlF")
   @usableFromInline
   internal final func __legacy_withUnsafeMutablePointers<R>(
     _ body: (
@@ -473,27 +487,41 @@ extension ManagedBufferPointer where Element: ~Copyable {
   }
 }
 
-extension ManagedBufferPointer {
+extension ManagedBufferPointer /* where Element: Copyable */ {
+  @abi(
+    func withUnsafeMutablePointerToHeader<R>(
+      _ body: (UnsafeMutablePointer<Header>) throws -> R
+    ) rethrows -> R
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss20ManagedBufferPointerV017withUnsafeMutableC8ToHeaderyqd__qd__SpyxGKXEKlF")
   @usableFromInline
-  internal func withUnsafeMutablePointerToHeader<R>(
+  internal func __rethrows_withUnsafeMutablePointerToHeader<R>(
     _ body: (UnsafeMutablePointer<Header>) throws -> R
   ) rethrows -> R {
     try unsafe withUnsafeMutablePointers { (v, _) in try unsafe body(v) }
   }
 
+  @abi(
+    func withUnsafeMutablePointerToElements<R>(
+      _ body: (UnsafeMutablePointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss20ManagedBufferPointerV017withUnsafeMutableC10ToElementsyqd__qd__Spyq_GKXEKlF")
   @usableFromInline
-  internal func withUnsafeMutablePointerToElements<R>(
+  internal func __rethrows_withUnsafeMutablePointerToElements<R>(
     _ body: (UnsafeMutablePointer<Element>) throws -> R
   ) rethrows -> R {
     try unsafe withUnsafeMutablePointers { (_, v) in try unsafe body(v) }
   }
 
+  @abi(
+    func withUnsafeMutablePointers<R>(
+      _ body: (
+        UnsafeMutablePointer<Header>, UnsafeMutablePointer<Element>
+      ) throws -> R
+    ) rethrows -> R
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss20ManagedBufferPointerV25withUnsafeMutablePointersyqd__qd__SpyxG_Spyq_GtKXEKlF")
   @usableFromInline
   internal func withUnsafeMutablePointers<R>(
     _ body: (

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -848,10 +848,15 @@ public func ?? <T: ~Copyable>(
   }
 }
 
+@abi(
+  func ?? <T>(
+    optional: T?,
+    defaultValue: @autoclosure () throws -> T
+  ) rethrows -> T
+)
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss2qqoiyxxSg_xyKXKtKlF")
 @usableFromInline
-internal func _legacy_abi_optionalNilCoalescingOperator <T>(
+internal func _copyable_optionalNilCoalescingOperator <T>(
   optional: T?,
   defaultValue: @autoclosure () throws -> T
 ) rethrows -> T {
@@ -924,9 +929,15 @@ public func ?? <T: ~Copyable>(
   }
 }
 
+@abi(
+  func ?? <T>(
+    optional: T?,
+    defaultValue: @autoclosure () throws -> T?
+  ) rethrows -> T?
+)
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @usableFromInline
-internal func ?? <T>(
+internal func _copyable_optionalNilCoalescingOperator <T>(
   optional: T?,
   defaultValue: @autoclosure () throws -> T?
 ) rethrows -> T? {

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -67,10 +67,14 @@ extension Result {
 }
 
 extension Result {
+  @abi(
+    func map<NewSuccess>(
+      _ transform: (Success) -> NewSuccess
+    ) -> Result<NewSuccess, Failure>
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss6ResultO3mapyAByqd__q_Gqd__xXElF")
   @usableFromInline
-  internal func __abi_map<NewSuccess>(
+  internal func __copyable_map<NewSuccess>(
     _ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
     switch self {
@@ -210,10 +214,14 @@ extension Result {
 }
 
 extension Result {
+  @abi(
+    func flatMap<NewSuccess>(
+      _ transform: (Success) -> Result<NewSuccess, Failure>
+    ) -> Result<NewSuccess, Failure>
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss6ResultO7flatMapyAByqd__q_GADxXElF")
   @usableFromInline
-  internal func __abi_flatMap<NewSuccess>(
+  internal func __copyable_flatMap<NewSuccess>(
     _ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
     switch self {
@@ -278,10 +286,14 @@ extension Result where Success: ~Copyable {
 }
 
 extension Result {
+  @abi(
+    func flatMapError<NewFailure>(
+      _ transform: (Failure) -> Result<Success, NewFailure>
+    ) -> Result<Success, NewFailure>
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss6ResultO12flatMapErroryAByxqd__GADq_XEs0D0Rd__lF")
   @usableFromInline
-  internal func __abi_flatMapError<NewFailure>(
+  internal func __copyable_flatMapError<NewFailure>(
     _ transform: (Failure) -> Result<Success, NewFailure>
   ) -> Result<Success, NewFailure> {
     switch self {
@@ -324,10 +336,10 @@ extension Result where Success: ~Copyable & ~Escapable {
 
 extension Result {
   /// ABI: Historical get() throws
+  @abi(func get() throws -> Success)
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss6ResultO3getxyKF")
   @usableFromInline
-  func __abi_get() throws -> Success {
+  func __untyped_throws_get() throws -> Success {
     switch self {
     case let .success(success):
       return success
@@ -355,11 +367,12 @@ extension Result where Success: ~Copyable {
 }
 
 extension Result where Failure == Swift.Error {
-  /// ABI: Historical init(catching:)
+  // ABI: Historical `init(catching:)`; this gets the old ABI because of the
+  // `where` clause on the extension.
+  @abi(init(catching body: () throws -> Success))
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$ss6ResultOss5Error_pRs_rlE8catchingAByxsAC_pGxyKXE_tcfC")
   @usableFromInline
-  init(__abi_catching body: () throws(Failure) -> Success) {
+  init(__untyped_throws_catching body: () throws(Failure) -> Success) {
     do {
       self = .success(try body())
     } catch {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -706,11 +706,14 @@ extension Sequence {
   }
 
   // ABI-only entrypoint for the rethrows version of map, which has been
-  // superseded by the typed-throws version. Expressed as "throws", which is
-  // ABI-compatible with "rethrows".
+  // superseded by the typed-throws version.
+  @abi(
+    func map<T>(
+      _ transform: (Element) throws -> T
+    ) rethrows -> [T]
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
-  @_silgen_name("$sSTsE3mapySayqd__Gqd__7ElementQzKXEKlF")
   func __rethrows_map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -433,9 +433,13 @@ internal struct _SliceBuffer<Element>
   //===--- misc -----------------------------------------------------------===//
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    func withUnsafeBufferPointer<R>(
+      _ body: (UnsafeBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @usableFromInline
-  @_silgen_name("$ss12_SliceBufferV010withUnsafeB7Pointeryqd__qd__SRyxGKXEKlF")
-  internal func __abi_withUnsafeBufferPointer<R>(
+  internal func __rethrows_withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     defer { _fixLifetime(self) }
@@ -456,9 +460,13 @@ internal struct _SliceBuffer<Element>
 
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
+  @abi(
+    mutating func withUnsafeMutableBufferPointer<R>(
+      _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
+    ) rethrows -> R
+  )
   @usableFromInline
-  @_silgen_name("$ss12_SliceBufferV017withUnsafeMutableB7Pointeryqd__qd__SryxGKXEKlF")
-  internal mutating func __abi_withUnsafeMutableBufferPointer<R>(
+  internal mutating func __rethrows_withUnsafeMutableBufferPointer<R>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
     defer { _fixLifetime(self) }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -937,8 +937,13 @@ extension UnsafeMutableBufferPointer {
   ///   buffer.
   /// - Returns: An iterator to any elements of `source` that didn't fit in the
   ///   buffer, and an index to the next uninitialized element in the buffer.
+  @abi(
+    func initialize<S: Sequence>(
+      from source: S
+    ) -> (/* not 'unwritten:' */ S.Iterator, /* not 'index:' */ Index)
+      where S.Element == Element
+  )
   @inlinable // unsafe-performance
-  @_silgen_name("$sSr10initialize4from8IteratorQyd___Sitqd___t7ElementQyd__RszSTRd__lF")
   public func initialize<S: Sequence>(
     from source: S
   ) -> (unwritten: S.Iterator, index: Index) where S.Element == Element {
@@ -1009,8 +1014,8 @@ extension UnsafeMutableBufferPointer {
   ///
   /// - Parameters:
   ///   - repeatedValue: The value used when updating this pointer's memory.
+  @abi(func assign(repeating repeatedValue: Element))
   @inlinable // unsafe-performance
-  @_silgen_name("$sSr6assign9repeatingyx_tF")
   public func update(repeating repeatedValue: Element) {
     guard let dstBase = _position else {
       return
@@ -1019,9 +1024,9 @@ extension UnsafeMutableBufferPointer {
     unsafe dstBase.update(repeating: repeatedValue, count: count)
   }
 
+  @abi(func update(repeating repeatedValue: Element))
   @_alwaysEmitIntoClient
   @available(*, deprecated, renamed: "update(repeating:)")
-  @_silgen_name("_swift_se0370_UnsafeMutableBufferPointer_assign_repeating")
   public func assign(repeating repeatedValue: Element) {
     unsafe update(repeating: repeatedValue)
   }
@@ -1431,12 +1436,13 @@ extension Unsafe${Mutable}BufferPointer {
   // of `withMemoryRebound<T, Result>(to:_:)`, and provides
   // an entry point for any binary linked against the stdlib binary
   // for Swift 5.6 and older.
+  @abi(
+    func withMemoryRebound<T, Result>(
+      to type: T.Type,
+      _ body: (${Self}<T>) throws -> Result
+    ) rethrows -> Result
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-% if Mutable:
-  @_silgen_name("$sSr17withMemoryRebound2to_qd_0_qd__m_qd_0_Sryqd__GKXEtKr0_lF")
-% else:
-  @_silgen_name("$sSR17withMemoryRebound2to_qd_0_qd__m_qd_0_SRyqd__GKXEtKr0_lF")
-% end
   @usableFromInline
   internal func _legacy_se0333_withMemoryRebound<T, Result>(
     to type: T.Type,

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -421,8 +421,14 @@ extension UnsafePointer {
   // of `withMemoryRebound<T, Result>(to:capacity:_:)`, and provides
   // an entry point for any binary linked against the stdlib binary
   // for Swift 5.6 and older.
+  @abi(
+    func withMemoryRebound<T, Result>(
+      to type: T.Type,
+      capacity count: Int,
+      _ body: (UnsafePointer<T>) throws -> Result
+    ) rethrows -> Result
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$sSP17withMemoryRebound2to8capacity_qd_0_qd__m_Siqd_0_SPyqd__GKXEtKr0_lF")
   @usableFromInline
   internal func _legacy_se0333_withMemoryRebound<T, Result>(
     to type: T.Type,
@@ -954,8 +960,8 @@ extension UnsafeMutablePointer {
   ///   - repeatedValue: The value used when updating this pointer's memory.
   ///   - count: The number of consecutive elements to update.
   ///     `count` must not be negative.
+  @abi(func assign(repeating repeatedValue: Pointee, count: Int))
   @inlinable
-  @_silgen_name("$sSp6assign9repeating5countyx_SitF")
   public func update(repeating repeatedValue: Pointee, count: Int) {
     _debugPrecondition(count >= 0, "UnsafeMutablePointer.update(repeating:count:) with negative count")
     for i in 0..<count {
@@ -963,9 +969,9 @@ extension UnsafeMutablePointer {
     }
   }
 
+  @abi(func update(repeating repeatedValue: Pointee, count: Int))
   @_alwaysEmitIntoClient
   @available(*, deprecated, renamed: "update(repeating:count:)")
-  @_silgen_name("_swift_se0370_UnsafeMutablePointer_assign_repeating_count")
   public func assign(repeating repeatedValue: Pointee, count: Int) {
     unsafe update(repeating: repeatedValue, count: count)
   }
@@ -988,8 +994,8 @@ extension UnsafeMutablePointer {
   ///     pointer may overlap.
   ///   - count: The number of instances to copy from the memory referenced by
   ///     `source` to this pointer's memory. `count` must not be negative.
+  @abi(func assign(from source: UnsafePointer<Pointee>, count: Int))
   @inlinable
-  @_silgen_name("$sSp6assign4from5countySPyxG_SitF")
   public func update(from source: UnsafePointer<Pointee>, count: Int) {
     _debugPrecondition(
       count >= 0, "UnsafeMutablePointer.update with negative count")
@@ -1015,9 +1021,9 @@ extension UnsafeMutablePointer {
     }
   }
 
+  @abi(func update(from source: UnsafePointer<Pointee>, count: Int))
   @_alwaysEmitIntoClient
   @available(*, deprecated, renamed: "update(from:count:)")
-  @_silgen_name("_swift_se0370_UnsafeMutablePointer_assign_from_count")
   @unsafe
   public func assign(from source: UnsafePointer<Pointee>, count: Int) {
     unsafe update(from: source, count: count)
@@ -1126,8 +1132,13 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   ///     referenced by `source` and this pointer must not overlap.
   ///   - count: The number of instances to move from `source` to this
   ///     pointer's memory. `count` must not be negative.
+  @abi(
+    @_preInverseGenerics
+    func moveAssign(
+      from source: UnsafeMutablePointer, count: Int
+    )
+  )
   @inlinable
-  @_silgen_name("$sSp10moveAssign4from5countySpyxG_SitF")
   @_preInverseGenerics
   public func moveUpdate(
     @_nonEphemeral from source: UnsafeMutablePointer, count: Int
@@ -1147,9 +1158,13 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
 }
 
 extension UnsafeMutablePointer {
+  @abi(
+    func moveUpdate(
+      from source: UnsafeMutablePointer, count: Int
+    )
+  )
   @_alwaysEmitIntoClient
   @available(*, deprecated, renamed: "moveUpdate(from:count:)")
-  @_silgen_name("_swift_se0370_UnsafeMutablePointer_moveAssign_from_count")
   public func moveAssign(
     @_nonEphemeral from source: UnsafeMutablePointer, count: Int
   ) {
@@ -1268,8 +1283,14 @@ extension UnsafeMutablePointer {
   // This obsolete implementation uses the expected mangled name of
   // `withMemoryRebound<T, Result>(to:capacity:_:)`, and provides an entry point
   // for any binary linked against the stdlib binary for Swift 5.6 and older.
+  @abi(
+    func withMemoryRebound<T, Result>(
+      to type: T.Type,
+      capacity count: Int,
+      _ body: (UnsafeMutablePointer<T>) throws -> Result
+    ) rethrows -> Result
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$sSp17withMemoryRebound2to8capacity_qd_0_qd__m_Siqd_0_Spyqd__GKXEtKr0_lF")
   @usableFromInline
   internal func _legacy_se0333_withMemoryRebound<T, Result>(
     to type: T.Type,

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -504,9 +504,13 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   - type: The type to use for the newly constructed instance. The memory
   ///     must be initialized to a value of a type that is layout compatible
   ///     with `type`.
+  @abi(
+    // This is chosen to not interfere with the old ABI
+    func _new_se0349_storeBytes<T>(
+      of value: T, toByteOffset offset: Int, as type: T.Type
+    )
+  )
   @_alwaysEmitIntoClient
-  // This custom silgen name is chosen to not interfere with the old ABI
-  @_silgen_name("_swift_se0349_UnsafeMutableRawBufferPointer_storeBytes")
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
@@ -521,8 +525,12 @@ extension Unsafe${Mutable}RawBufferPointer {
   // This unavailable implementation uses the expected mangled name
   // of `storeBytes<T>(of:toByteOffset:as:)`, and provides an entry point for
   // any binary linked against the stdlib binary for Swift 5.6 and older.
+  @abi(
+    func storeBytes<T>(
+      of value: T, toByteOffset offset: Int, as type: T.Type
+    )
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$sSw10storeBytes2of12toByteOffset2asyx_SixmtlF")
   @usableFromInline
   func _legacy_se0349_storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
@@ -1245,10 +1253,14 @@ public func withUnsafeMutableBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
   return try unsafe body(unsafe .init(start: pointer, count: MemoryLayout<T>.size))
 }
 
-/// ABI: Historical withUnsafeMutableBytes(of:_:) rethrows,
-/// expressed as "throws", which is ABI-compatible with "rethrows".
+/// ABI: Historical withUnsafeMutableBytes(of:_:) rethrows.
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss22withUnsafeMutableBytes2of_q_xz_q_SwKXEtKr0_lF")
+@abi(
+  func withUnsafeMutableBytes<T, Result>(
+    of value: inout T,
+    _ body: (UnsafeMutableRawBufferPointer) throws -> Result
+  ) rethrows -> Result
+)
 @usableFromInline
 func __abi_se0413_withUnsafeMutableBytes<T, Result>(
   of value: inout T,
@@ -1312,10 +1324,14 @@ public func withUnsafeBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
   return try unsafe body(unsafe .init(start: address, count: MemoryLayout<T>.size))
 }
 
-/// ABI: Historical withUnsafeBytes(of:_:) rethrows,
-/// expressed as "throws", which is ABI-compatible with "rethrows".
+/// ABI: Historical withUnsafeBytes(of:_:) rethrows.
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss15withUnsafeBytes2of_q_xz_q_SWKXEtKr0_lF")
+@abi(
+  func withUnsafeBytes<T, Result>(
+    of value: inout T,
+    _ body: (UnsafeRawBufferPointer) throws -> Result
+  ) rethrows -> Result
+)
 @usableFromInline
 func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: inout T,
@@ -1379,7 +1395,12 @@ public func withUnsafeBytes<
 /// ABI: Historical withUnsafeBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
 @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-@_silgen_name("$ss15withUnsafeBytes2of_q_x_q_SWKXEtKr0_lF")
+@abi(
+  func withUnsafeBytes<T, Result>(
+    of value: T,
+    _ body: (UnsafeRawBufferPointer) throws -> Result
+  ) throws -> Result
+)
 @usableFromInline
 func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: T,

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1457,10 +1457,14 @@ extension UnsafeMutableRawPointer {
   ///   - offset: The offset from this pointer, in bytes. `offset` must be
   ///     nonnegative. The default is zero.
   ///   - type: The type of `value`.
+  @abi(
+    // This custom ABI is chosen to not interfere with the old ABI
+    func _new_se0349_storeBytes<T>(
+      of value: T, toByteOffset offset: Int, as type: T.Type
+    )
+  )
   @inlinable
   @_alwaysEmitIntoClient
-  // This custom silgen name is chosen to not interfere with the old ABI
-  @_silgen_name("_swift_se0349_UnsafeMutableRawPointer_storeBytes")
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
@@ -1483,8 +1487,12 @@ extension UnsafeMutableRawPointer {
   // This obsolete implementation uses the expected mangled name
   // of `storeBytes<T>(of:toByteOffset:as:)`, and provides an entry point for
   // any binary compiled against the stdlib binary for Swift 5.6 and older.
+  @abi(
+    func storeBytes<T>(
+      of value: T, toByteOffset offset: Int, as type: T.Type
+    )
+  )
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
-  @_silgen_name("$sSv10storeBytes2of12toByteOffset2asyx_SixmtlF")
   @usableFromInline
   func _legacy_se0349_storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -375,3 +375,15 @@ Accessor UnsafeMutableBufferPointer.indices.Get() has generic signature change f
 
 Func type(of:) has generic signature change from <T, Metatype> to <T, Metatype where T : ~Copyable, T : ~Escapable>
 Func type(of:) has parameter 0 changing from Default to Shared
+
+// Renames made by SE-0370. There are also new deprecated methods to preserve
+// source compatibility. These only started being flagged when the ABI magic
+// switched from @_silgen_name to @abi.
+Func UnsafeMutableBufferPointer.assign(repeating:) has been renamed to Func update(repeating:)
+Func UnsafeMutablePointer.assign(from:count:) has been renamed to Func update(from:count:)
+Func UnsafeMutablePointer.assign(repeating:count:) has been renamed to Func update(repeating:count:)
+
+// False positive: this is a new overload of a method with some @abi trickery
+// that confuses the API checker into losing track of the old overload.
+// FIXME: It'd be nice if this didn't happen.
+Func UnsafeMutableRawPointer.storeBytes(of:toByteOffset:as:) has generic signature change from <T> to <T where T : Swift.BitwiseCopyable>

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -80,24 +80,13 @@ Protocol Executor has added inherited protocol SendableMetatype
 Protocol SerialExecutor has added inherited protocol SendableMetatype
 
 // #isolated adoption in with...Continuation
-// api-digester is not aware of silgen_name trickery we do to keep this ABI compatible
-Func withCheckedContinuation(function:_:) has parameter 0 type change from Swift.String to (any _Concurrency.Actor)?
-Func withCheckedContinuation(function:_:) has parameter 1 type change from (_Concurrency.CheckedContinuation<τ_0_0, Swift.Never>) -> () to Swift.String
-Func withCheckedThrowingContinuation(function:_:) has been renamed to Func withCheckedThrowingContinuation(isolation:function:_:)
-Func withCheckedThrowingContinuation(function:_:) has mangled name changing from '_Concurrency.withCheckedThrowingContinuation<A>(function: Swift.String, _: (Swift.CheckedContinuation<A, Swift.Error>) -> ()) async throws -> A' to '_Concurrency.withCheckedThrowingContinuation<A>(isolation: isolated Swift.Optional<Swift.Actor>, function: Swift.String, _: (Swift.CheckedContinuation<A, Swift.Error>) -> ()) async throws -> A'
-Func withCheckedThrowingContinuation(function:_:) has parameter 0 type change from Swift.String to (any _Concurrency.Actor)?
-Func withCheckedThrowingContinuation(function:_:) has parameter 1 type change from (_Concurrency.CheckedContinuation<τ_0_0, any Swift.Error>) -> () to Swift.String
+// There are new @_alwaysEmitIntoClient functions to preserve source compatibility
+Func withCheckedContinuation(function:_:) has been renamed to Func _unsafeInheritExecutor_withCheckedContinuation(function:_:)
+Func withCheckedThrowingContinuation(function:_:) has been renamed to Func _unsafeInheritExecutor_withCheckedThrowingContinuation(function:_:)
 
 // #isolation adoption for cancellation handlers; old APIs are kept ABI compatible
-Func withTaskCancellationHandler(operation:onCancel:) has been renamed to Func withTaskCancellationHandler(operation:onCancel:isolation:)
-Func withTaskCancellationHandler(operation:onCancel:) has mangled name changing from '_Concurrency.withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> ()) async throws -> A' to '_Concurrency.withTaskCancellationHandler<A>(operation: () async throws -> A, onCancel: @Sendable () -> (), isolation: isolated Swift.Optional<Swift.Actor>) async throws -> A'
-
-// #isolated was adopted and the old methods kept: $ss31withCheckedThrowingContinuation8function_xSS_yScCyxs5Error_pGXEtYaKlF
-Func withCheckedContinuation(function:_:) has been renamed to Func withCheckedContinuation(isolation:function:_:)
-Func withCheckedContinuation(function:_:) has mangled name changing from '_Concurrency.withCheckedContinuation<A>(function: Swift.String, _: (Swift.CheckedContinuation<A, Swift.Never>) -> ()) async -> A' to '_Concurrency.withCheckedContinuation<A>(isolation: isolated Swift.Optional<Swift.Actor>, function: Swift.String, _: (Swift.CheckedContinuation<A, Swift.Never>) -> ()) async -> A'
-
-// AsyncStream.init(unfolding:onCancel:) uses @_silgen_name to preserve mangling after adding @preconcurrency.
-Constructor AsyncStream.init(unfolding:onCancel:) has mangled name changing from 'Swift.AsyncStream.init(unfolding: () async -> Swift.Optional<A>, onCancel: Swift.Optional<@Sendable () -> ()>) -> Swift.AsyncStream<A>' to 'Swift.AsyncStream.init(unfolding: () async -> Swift.Optional<A>, onCancel: Swift.Optional<() -> ()>) -> Swift.AsyncStream<A>'
+// There's a new @_alwaysEmitIntoClient function to preserve source compatibility
+Func withTaskCancellationHandler(operation:onCancel:) has been renamed to Func _unsafeInheritExecutor_withTaskCancellationHandler(operation:onCancel:)
 
 // We did not change the mangling, we did change from Default to Shared. Both
 // took their arg at +0, so there is no actual ABI difference.
@@ -114,19 +103,18 @@ Func SerialExecutor.enqueue(_:) has been added as a protocol requirement
 Func Executor.enqueue(_:) is a new API without @available attribute
 
 // Adopt #isolation in TaskLocal.withValue APIs
-Func TaskLocal.withValue(_:operation:file:line:) has been renamed to Func withValue(_:operation:isolation:file:line:)
-Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, file: Swift.String, line: Swift.UInt) async throws -> A1' to '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1'
-Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1' to '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Optional<Swift.Actor>, file: Swift.String, line: Swift.UInt) async throws -> A1'
-Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change from () async throws -> τ_1_0 to () throws -> τ_1_0
-Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change from () throws -> τ_1_0 to () async throws -> τ_1_0
-Func TaskLocal.withValue(_:operation:file:line:) has parameter 2 type change from Swift.String to (any _Concurrency.Actor)?
-Func TaskLocal.withValue(_:operation:file:line:) has parameter 3 type change from Swift.UInt to Swift.String
+Func TaskLocal.withValue(_:operation:file:line:) has been renamed to Func _unsafeInheritExecutor_withValue(_:operation:file:line:)
 Func withTaskGroup(of:returning:body:) has parameter 2 type change from (inout _Concurrency.TaskGroup<τ_0_0>) async -> τ_0_1 to (any _Concurrency.Actor)?
 Func withThrowingTaskGroup(of:returning:body:) has been renamed to Func withThrowingTaskGroup(of:returning:isolation:body:)
 Func withThrowingTaskGroup(of:returning:body:) has mangled name changing from '_Concurrency.withThrowingTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, body: (inout Swift.ThrowingTaskGroup<A, Swift.Error>) async throws -> B) async throws -> B' to '_Concurrency.withThrowingTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, isolation: isolated Swift.Optional<Swift.Actor>, body: (inout Swift.ThrowingTaskGroup<A, Swift.Error>) async throws -> B) async throws -> B'
 Func withThrowingTaskGroup(of:returning:body:) has parameter 2 type change from (inout _Concurrency.ThrowingTaskGroup<τ_0_0, any Swift.Error>) async throws -> τ_0_1 to (any _Concurrency.Actor)?
 Func withTaskGroup(of:returning:body:) has been renamed to Func withTaskGroup(of:returning:isolation:body:)
 Func withTaskGroup(of:returning:body:) has mangled name changing from '_Concurrency.withTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, body: (inout Swift.TaskGroup<A>) async -> B) async -> B' to '_Concurrency.withTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, isolation: isolated Swift.Optional<Swift.Actor>, body: (inout Swift.TaskGroup<A>) async -> B) async -> B'
+
+// False ABI digester positive caused by replacement of @_silgen_name hack with
+// @abi; the USR isn't affected by @_silgen_name but is affected by @abi, so the
+// baseline has data in it that doesn't reflect the actual mangled name.
+Func ThrowingTaskGroup.nextResultForABI() has mangled name changing from 'Swift.ThrowingTaskGroup.nextResultForABI() async throws -> Swift.Optional<Swift.Result<A, B>>' to 'Swift.ThrowingTaskGroup.nextResult() async throws -> Swift.Optional<Swift.Result<A, B>>'
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -84,7 +84,7 @@ Enum Never has added a conformance to an existing protocol Decodable
 Enum Never has added a conformance to an existing protocol Encodable
 Enum Never has added a conformance to an existing protocol Identifiable
 
-// These functions haven't actually changed ABI, but are using @_silgen_name tricks to maintain the old ABI while moving to typed throws.
+// These functions haven't actually changed ABI, but are using @abi tricks to maintain the old ABI while moving to typed throws.
 Func AnyBidirectionalCollection.map(_:) has been removed
 Func AnyCollection.map(_:) has been removed
 Func AnyRandomAccessCollection.map(_:) has been removed
@@ -92,13 +92,10 @@ Func AnySequence.map(_:) has been removed
 Func Collection.map(_:) has been removed
 Func Sequence.map(_:) has been removed
 Constructor Result.init(catching:) has been removed
-Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)
-Func withoutActuallyEscaping(_:do:) has mangled name changing from 'Swift.withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B' to 'Swift.__abi_withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B'
+Func withoutActuallyEscaping(_:do:) has been renamed to Func __rethrows_withoutActuallyEscaping(_:do:)
 Func withoutActuallyEscaping(_:do:) is now without rethrows
-Func _openExistential(_:do:) has been renamed to Func __abi_openExistential(_:do:)
-Func _openExistential(_:do:) has mangled name changing from 'Swift._openExistential<A, B, C>(_: A, do: (B) throws -> C) throws -> C' to 'Swift.__abi_openExistential<A, B, C>(_: A, do: (B) throws -> C) throws -> C'
+Func _openExistential(_:do:) has been renamed to Func __rethrows_openExistential(_:do:)
 Func _openExistential(_:do:) is now without rethrows
-
 
 // These haven't actually been removed; they are simply marked unavailable.
 // This seems to be a false positive in the ABI checker. This is not an ABI
@@ -129,25 +126,20 @@ Func _RandomAccessCollectionBox._map(_:) is now without rethrows
 Func _SequenceBox._map(_:) is now without rethrows
 Func UnsafeMutableRawBufferPointer.storeBytes(of:toByteOffset:as:) has been removed
 Func UnsafeMutableRawPointer.storeBytes(of:toByteOffset:as:) has been removed
-Func UnsafeMutableBufferPointer.assign(repeating:) has been removed
-Func UnsafeMutableBufferPointer.update(repeating:) is a new API without @available attribute
-Func UnsafeMutablePointer.assign(from:count:) has been removed
-Func UnsafeMutablePointer.update(from:count:) is a new API without @available attribute
-Func UnsafeMutablePointer.assign(repeating:count:) has been removed
-Func UnsafeMutablePointer.update(repeating:count:) is a new API without @available attribute
+Func UnsafeMutableBufferPointer.assign(repeating:) has been renamed to Func update(repeating:)
+Func UnsafeMutablePointer.assign(from:count:) has been renamed to Func update(from:count:)
+Func UnsafeMutablePointer.assign(repeating:count:) has been renamed to Func update(repeating:count:)
 Func UnsafeMutablePointer.moveAssign(from:count:) has been removed
 Func UnsafeMutablePointer.moveUpdate(from:count:) is a new API without @available attribute
 
 // These haven't actually been removed; they were renamed at the source level while
 // retaining their old mangled name. The source break was accepted as part of se-0370.
-Func UnsafeMutableBufferPointer.initialize(from:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.initialize<A where A == A1.Element, A1: Swift.Sequence>(from: A1) -> (A1.Iterator, Swift.Int)' to 'Swift.UnsafeMutableBufferPointer.initialize<A where A == A1.Element, A1: Swift.Sequence>(from: A1) -> (unwritten: A1.Iterator, index: Swift.Int)'
 Func UnsafeMutableBufferPointer.initialize(from:) has return type change from (τ_1_0.Iterator, Swift.Int) to (unwritten: τ_1_0.Iterator, index: Swift.Int)
 
-// This hasn't actually been removed; it was renamed at the source level while
-// retaining its old mangled/silgen name. The old source-level name is preserved
-// as an @_alwaysEmitIntoClient function. The source break was accepted as part of se-0405.
-Constructor String.init(validatingCString:) is a new API without @available attribute
-Constructor String.init(validatingUTF8:) has been removed
+// This was renamed at the source level while preserving its ABI using @abi.
+// The old source-level name is preserved as an @_alwaysEmitIntoClient function.
+// The source break was accepted as part of se-0405.
+Constructor String.init(validatingUTF8:) has been renamed to Constructor init(validatingCString:)
 
 // These haven't actually been removed; they are simply marked unavailable.
 // This seems to be a false positive in the ABI checker. This is not an ABI
@@ -801,26 +793,17 @@ Func _isPOD(_:) is now with @_preInverseGenerics
 
 Func FixedWidthInteger.&*(_:_:) has been added as a protocol requirement
 
-Func Array.withUnsafeMutableBufferPointer(_:) has been renamed to Func __abi_withUnsafeMutableBufferPointer(_:)
-Func Array.withUnsafeMutableBufferPointer(_:) has mangled name changing from 'Swift.Array.withUnsafeMutableBufferPointer<A>((inout Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift.Array.__abi_withUnsafeMutableBufferPointer<A>((inout Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1'
-Func ArraySlice.withUnsafeMutableBufferPointer(_:) has been renamed to Func __abi_withUnsafeMutableBufferPointer(_:)
-Func ArraySlice.withUnsafeMutableBufferPointer(_:) has mangled name changing from 'Swift.ArraySlice.withUnsafeMutableBufferPointer<A>((inout Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift.ArraySlice.__abi_withUnsafeMutableBufferPointer<A>((inout Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1'
-Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has been renamed to Func __abi_withUnsafeMutableBufferPointer(_:)
-Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has mangled name changing from 'Swift.ContiguousArray.withUnsafeMutableBufferPointer<A>((inout Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift.ContiguousArray.__abi_withUnsafeMutableBufferPointer<A>((inout Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1'
-Func _ArrayBuffer.withUnsafeBufferPointer(_:) has been renamed to Func __abi_withUnsafeBufferPointer(_:)
-Func _ArrayBuffer.withUnsafeBufferPointer(_:) has mangled name changing from 'Swift._ArrayBuffer.withUnsafeBufferPointer<A>((Swift.UnsafeBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift._ArrayBuffer.__abi_withUnsafeBufferPointer<A>((Swift.UnsafeBufferPointer<A>) throws -> A1) throws -> A1'
-Func _ArrayBuffer.withUnsafeMutableBufferPointer(_:) has been renamed to Func __abi_withUnsafeMutableBufferPointer(_:)
-Func _ArrayBuffer.withUnsafeMutableBufferPointer(_:) has mangled name changing from 'Swift._ArrayBuffer.withUnsafeMutableBufferPointer<A>((Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift._ArrayBuffer.__abi_withUnsafeMutableBufferPointer<A>((Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1'
+Func Array.withUnsafeMutableBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeMutableBufferPointer(_:)
+Func ArraySlice.withUnsafeMutableBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeMutableBufferPointer(_:)
+Func ContiguousArray.withUnsafeMutableBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeMutableBufferPointer(_:)
+Func _ArrayBuffer.withUnsafeBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeBufferPointer(_:)
+Func _ArrayBuffer.withUnsafeMutableBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeMutableBufferPointer(_:)
 Func _ArrayBufferProtocol.withUnsafeBufferPointer(_:) has been added as a protocol requirement
 Func _ArrayBufferProtocol.withUnsafeMutableBufferPointer(_:) has been added as a protocol requirement
-Func _ContiguousArrayBuffer.withUnsafeBufferPointer(_:) has been renamed to Func __abi_withUnsafeBufferPointer(_:)
-Func _ContiguousArrayBuffer.withUnsafeBufferPointer(_:) has mangled name changing from 'Swift._ContiguousArrayBuffer.withUnsafeBufferPointer<A>((Swift.UnsafeBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift._ContiguousArrayBuffer.__abi_withUnsafeBufferPointer<A>((Swift.UnsafeBufferPointer<A>) throws -> A1) throws -> A1'
-Func _ContiguousArrayBuffer.withUnsafeMutableBufferPointer(_:) has been renamed to Func __abi_withUnsafeMutableBufferPointer(_:)
-Func _ContiguousArrayBuffer.withUnsafeMutableBufferPointer(_:) has mangled name changing from 'Swift._ContiguousArrayBuffer.withUnsafeMutableBufferPointer<A>((Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift._ContiguousArrayBuffer.__abi_withUnsafeMutableBufferPointer<A>((Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1'
-Func _SliceBuffer.withUnsafeBufferPointer(_:) has been renamed to Func __abi_withUnsafeBufferPointer(_:)
-Func _SliceBuffer.withUnsafeBufferPointer(_:) has mangled name changing from 'Swift._SliceBuffer.withUnsafeBufferPointer<A>((Swift.UnsafeBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift._SliceBuffer.__abi_withUnsafeBufferPointer<A>((Swift.UnsafeBufferPointer<A>) throws -> A1) throws -> A1'
-Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has been renamed to Func __abi_withUnsafeMutableBufferPointer(_:)
-Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has mangled name changing from 'Swift._SliceBuffer.withUnsafeMutableBufferPointer<A>((Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1' to 'Swift._SliceBuffer.__abi_withUnsafeMutableBufferPointer<A>((Swift.UnsafeMutableBufferPointer<A>) throws -> A1) throws -> A1'
+Func _ContiguousArrayBuffer.withUnsafeBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeBufferPointer(_:)
+Func _ContiguousArrayBuffer.withUnsafeMutableBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeMutableBufferPointer(_:)
+Func _SliceBuffer.withUnsafeBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeBufferPointer(_:)
+Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has been renamed to Func __rethrows_withUnsafeMutableBufferPointer(_:)
 
 Struct String.Index has added a conformance to an existing protocol CustomDebugStringConvertible
 


### PR DESCRIPTION
This PR replaces eligible uses of `@_silgen_name` in `stdlib/` with `@abi`. Because the API digester has a better understanding of `@abi` than `@_silgen_name`, this also affects the output of API digester tests run on the standard library; it should typically describe changes more accurately than it did before.

This PR also includes two commits with macro-related tests that were originally part of #80383 but cannot be merged without a SwiftSyntax change (either swiftlang/swift-syntax#3026 or the changes that will be made if [SE-0476](https://forums.swift.org/t/se-0476-controlling-the-abi-of-a-function-initializer-property-or-subscript/79233) is accepted).

**Standard library reviewers**: Review the final commit; ignore the others. You might also want to search the standard library for uses of `@_silgen_name` that I might have missed. (Remember, `@abi` is not designed to replace uses of `@_silgen_name` to assign an arbitrary string symbol, like `swift_stdlib_getDescription`.)