### PR TITLE
[cxx-interop] Remove last LifetimeDependence guard in C++ interop

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8950,11 +8950,8 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
       attachMacro = true;
     }
     bool returnHasLifetimeInfo = false;
-    bool lifetimeDependenceOn =
-        SwiftContext.LangOpts.hasFeature(Feature::LifetimeDependence);
     if (SwiftDeclConverter::getImplicitObjectParamAnnotation<
-            clang::LifetimeBoundAttr>(ClangDecl) &&
-        lifetimeDependenceOn) {
+            clang::LifetimeBoundAttr>(ClangDecl)) {
       printer.printLifetimeboundReturn(SwiftifyInfoPrinter::SELF_PARAM_INDEX,
                                        true);
       returnHasLifetimeInfo = true;
@@ -8976,8 +8973,7 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
         printer.printNonEscaping(index);
         paramHasLifetimeInfo = true;
       }
-      if (clangParam->hasAttr<clang::LifetimeBoundAttr>() &&
-          lifetimeDependenceOn) {
+      if (clangParam->hasAttr<clang::LifetimeBoundAttr>()) {
         printer.printLifetimeboundReturn(
             index, !paramHasBoundsInfo &&
                        swiftParam->getInterfaceType()->isEscapable());

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=StdSpan -source-filename=x -enable-experimental-cxx-interop -Xcc -std=c++20 -module-cache-path %t > %t/interface.swift
+// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=StdSpan -source-filename=x -enable-experimental-cxx-interop -Xcc -std=c++20 -module-cache-path %t > %t/interface.swift
 // RUN: %FileCheck %s < %t/interface.swift
 
 // REQUIRES: swift_feature_SafeInteropWrappers
-// REQUIRES: swift_feature_LifetimeDependence
 
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu


### PR DESCRIPTION
We now accept @lifetime annotations in the import macro generated code so no longer need to guard the emission of these attributes with this feature flag.
