### PR TITLE
utils: Update default Android SDKs in build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -212,9 +212,11 @@ $WiXVersion = "4.0.6"
 $UnixToolsBinDir = "$env:SystemDrive\Program Files\Git\usr\bin"
 
 if ($Android -and ($AndroidSDKs.Length -eq 0)) {
-  # Enable all android SDKs by default.
-  $AndroidSDKs = @("aarch64","armv7","i686","x86_64")
+  # By default, build and test the arm64 Android SDK. That choice might change
+  # once we can run executable tests in CI.
+  $AndroidSDKs = @("aarch64")
 }
+
 # Work around limitations of cmd passing in array arguments via powershell.exe -File
 if ($AndroidSDKs.Length -eq 1) { $AndroidSDKs = $AndroidSDKs[0].Split(",") }
 if ($WindowsSDKs.Length -eq 1) { $WindowsSDKs = $WindowsSDKs[0].Split(",") }


### PR DESCRIPTION
Building all the Android SDKs might not be the ideal default, since it takes a lot of time. We might want to focus on the one we can test best. In the future we want to run executable tests for the Swift runtime on Android and the emulator only works for the native architecture. It might be a better default to build that one, because we will have the best options for testing.