### PR TITLE
[cxx-interop] Fix transforming spans that are not behind type aliases

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -203,7 +203,12 @@ struct TemplateArgumentPrinter
     if (arg.getIntegralType()->isBuiltinType()) {
       buffer << typePrinter.Visit(arg.getIntegralType().getTypePtr()) << "_";
     }
-    arg.getAsIntegral().print(buffer, true);
+    auto value = arg.getAsIntegral();
+    if (value.isNegative()) {
+      value.negate();
+      buffer << "Neg_";
+    }
+    value.print(buffer, arg.getIntegralType()->isSignedIntegerType());
   }
 
   void VisitPackTemplateArgument(const clang::TemplateArgument &arg,

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -168,6 +168,13 @@ enum Mutability {
   case Mutable
 }
 
+func getUnattributedType(_ type: TypeSyntax) -> TypeSyntax {
+  if let attributedType = type.as(AttributedTypeSyntax.self) {
+    return attributedType.baseType.trimmed
+  }
+  return type.trimmed
+}
+
 func getTypeName(_ type: TypeSyntax) throws -> TokenSyntax {
   switch type.kind {
   case .memberType:
@@ -410,7 +417,7 @@ struct CxxSpanThunkBuilder: ParamPointerBoundsThunkBuilder {
   func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
     -> (FunctionSignatureSyntax, Bool) {
     var types = argTypes
-    let typeName = try getTypeName(oldType).text
+    let typeName = getUnattributedType(oldType).description
     guard let desugaredType = typeMappings[typeName] else {
       throw DiagnosticError(
         "unable to desugar type with name '\(typeName)'", node: node)
@@ -426,7 +433,7 @@ struct CxxSpanThunkBuilder: ParamPointerBoundsThunkBuilder {
 
   func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
     var args = pointerArgs
-    let typeName = try getTypeName(oldType).text
+    let typeName = getUnattributedType(oldType).description
     assert(args[index] == nil)
     args[index] = ExprSyntax("\(raw: typeName)(\(raw: name))")
     return try base.buildFunctionCall(args)
@@ -446,7 +453,7 @@ struct CxxSpanReturnThunkBuilder: BoundsCheckedThunkBuilder {
   func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
     -> (FunctionSignatureSyntax, Bool) {
     assert(returnType == nil)
-    let typeName = try getTypeName(signature.returnClause!.type).text
+    let typeName = getUnattributedType(signature.returnClause!.type).description
     guard let desugaredType = typeMappings[typeName] else {
       throw DiagnosticError(
         "unable to desugar type with name '\(typeName)'", node: node)
@@ -923,19 +930,15 @@ public struct SwiftifyImportMacro: PeerMacro {
       return []
     }
     var result : [ParamInfo] = []
-    let process = { type, expr, orig in
-      do {
-        let typeName = try getTypeName(type).text
-        if let desugaredType = typeMappings[typeName] {
-          if let unqualifiedDesugaredType = getUnqualifiedStdName(desugaredType) {
-            if unqualifiedDesugaredType.starts(with: "span<") {
-              result.append(CxxSpan(pointerIndex: expr, nonescaping: false,
-                dependencies: [], typeMappings: typeMappings, original: orig))
-            }
+    let process : (TypeSyntax, SwiftifyExpr, SyntaxProtocol) throws -> () = { type, expr, orig in
+      let typeName = getUnattributedType(type).description
+      if let desugaredType = typeMappings[typeName] {
+        if let unqualifiedDesugaredType = getUnqualifiedStdName(desugaredType) {
+          if unqualifiedDesugaredType.starts(with: "span<") {
+            result.append(CxxSpan(pointerIndex: expr, nonescaping: false,
+              dependencies: [], typeMappings: typeMappings, original: orig))
           }
         }
-      } catch is DiagnosticError {
-        // type doesn't match expected pattern
       }
     }
     for (idx, param) in signature.parameterClause.parameters.enumerated() {

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -121,4 +121,9 @@ inline ConstSpanOfInt mixedFuncWithSafeWrapper7(const int * __counted_by(len) p,
   return ConstSpanOfInt(p, len);
 }
 
+struct SpanWithoutTypeAlias {
+  std::span<const int> bar() [[clang::lifetimebound]];
+  void foo(std::span<const int> s [[clang::noescape]]);
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -27,6 +27,14 @@ import CxxStdlib
 // CHECK-NEXT:   @_alwaysEmitIntoClient public mutating func methodWithSafeWrapper(_ s: Span<CInt>)
 // CHECK-NEXT:   mutating func methodWithSafeWrapper(_ s: ConstSpanOfInt)
 // CHECK-NEXT: }
+// CHECK: struct SpanWithoutTypeAlias {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   @lifetime(borrow self)
+// CHECK-NEXT:   @_alwaysEmitIntoClient @_disfavoredOverload public mutating func bar() -> Span<CInt>
+// CHECK-NEXT:   mutating func bar() -> std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>
+// CHECK-NEXT:   @_alwaysEmitIntoClient public mutating func foo(_ s: Span<CInt>)
+// CHECK-NEXT:   mutating func foo(_ s: std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>)
+// CHECK-NEXT: }
 // CHECK: @_alwaysEmitIntoClient public func funcWithSafeWrapper(_ s: Span<CInt>)
 // CHECK-NEXT: @lifetime(s)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper2(_ s: Span<CInt>) -> Span<CInt>

--- a/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-non-type-parameter.h
@@ -10,4 +10,11 @@ template <class T, size_t Size> struct MagicArray { T t[Size]; };
 typedef MagicArray<int, 2> MagicIntPair;
 typedef MagicArray<int, 3> MagicIntTriple;
 
+template <typename T, T Val>
+struct integral_constant {
+  constexpr static T value = Val;
+};
+
+typedef integral_constant<int, -3> NegativeThree;
+
 #endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_NON_TYPE_PARAMETER_H

--- a/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-non-type-parameter-module-interface.swift
@@ -17,3 +17,4 @@
 
 // CHECK: typealias MagicIntPair = MagicArray<CInt, _C{{.*}}_2>
 // CHECK: typealias MagicIntTriple = MagicArray<CInt, _C{{.*}}_3>
+// CHECK: typealias NegativeThree = integral_constant<CInt, _C{{.*}}_Neg_3>


### PR DESCRIPTION
While we expect our users to use type aliases for template instantiations, there are some contexts when we import instantiations without aliases. Unfortunately, in case of C++ span we generated a name for the instantiation that cannot be a syntactically valid Swift type due to unary negation appearing in the type name. This PR replaces the unary negation with "Neg" in the type name and also fixed a bug that ended up printing certain unsigned values as signed. Moreover, this PR also fixes some other fallouts in the SwiftifyImport macro.

rdar://146833480