### PR TITLE
[Tests] NFC: Re-enable rdar://57201781 and rdar://70880670

### DIFF
--- a/validation-test/Sema/SwiftUI/rdar57201781.swift
+++ b/validation-test/Sema/SwiftUI/rdar57201781.swift
@@ -3,7 +3,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 // https://github.com/swiftlang/swift/issues/79255
-// REQUIRES: rdar141262107
+
 import SwiftUI
 
 struct ContentView : View {

--- a/validation-test/Sema/SwiftUI/rdar70880670.swift
+++ b/validation-test/Sema/SwiftUI/rdar70880670.swift
@@ -2,7 +2,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 // https://github.com/swiftlang/swift/issues/79255
-// REQUIRES: rdar141262107
+
 import SwiftUI
 
 var foo = doesntExist // expected-error {{cannot find 'doesntExist' in scope}}


### PR DESCRIPTION
A crash that was causing these tests to fail has been resolved.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
