### PR TITLE
Revert "IRGen: convert two `assert`s to `ASSERT` to check the conditions also in a release-built compiler"

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1123,7 +1123,7 @@ public:
 
   static LinkEntity forProtocolWitnessTable(const ProtocolConformance *C) {
     if (isEmbedded(C)) {
-      ASSERT(C->getProtocol()->requiresClass());
+      assert(C->getProtocol()->requiresClass());
     }
 
     LinkEntity entity;

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3752,7 +3752,7 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
 
   // In Embedded Swift, only class-bound wtables are allowed.
   if (srcType->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
-    ASSERT(proto->requiresClass());
+    assert(proto->requiresClass());
   }
 
   assert(Lowering::TypeConverter::protocolRequiresWitnessTable(proto)


### PR DESCRIPTION
This fails in TBD generation in embedded swift.
A temporary workaround until we disable TBD generation in embedded swift.
rdar://146864959
