### PR TITLE
AST: remove the temporary TypeKind::OpenedArchetype enum case

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -114,9 +114,6 @@ enum class TypeKind : uint8_t {
 #define TYPE_RANGE(Id, FirstId, LastId) \
   First_##Id##Type = FirstId, Last_##Id##Type = LastId,
 #include "swift/AST/TypeNodes.def"
-  // For backward compatibility in LLDB sources.
-  // TODO: remove this once OpenedArchetype is renamed in LLDB sources.
-  OpenedArchetype = ExistentialArchetype
 };
 
 enum : unsigned {


### PR DESCRIPTION
Since it's not used in lldb sources anymore (https://github.com/swiftlang/llvm-project/pull/10237)
