### PR TITLE
[gardening] adjust Span availability in more tests

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -659,10 +659,10 @@ StdSpanTestSuite.test("Span as arg to generic func") {
   accessSpanAsSomeGenericParam(sspan)
 }
 
-StdSpanTestSuite.test("Convert between Swift and C++ span types") {
-  guard #available(SwiftStdlib 6.1, *) else {
-    return
-  }
+StdSpanTestSuite.test("Convert between Swift and C++ span types")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
   do {
     var arr: [Int32] = [1, 2, 3]
     arr.withUnsafeMutableBufferPointer{ ubpointer in

--- a/test/SILOptimizer/lifetime_dependence/stdlib_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/stdlib_span.swift
@@ -16,7 +16,7 @@
 // =============================================================================
 
 extension UnsafeRawBufferPointer {
-  @available(SwiftStdlib 6.1, *)
+  @available(SwiftStdlib 6.2, *)
   public var storage: RawSpan {
     @lifetime(borrow self)
     get {
@@ -26,24 +26,24 @@ extension UnsafeRawBufferPointer {
   }
 }
 
-@available(SwiftStdlib 6.1, *)
+@available(SwiftStdlib 6.2, *)
 func read(_ span: RawSpan) {}
 
-@available(SwiftStdlib 6.1, *)
+@available(SwiftStdlib 6.2, *)
 func testUBPStorage(ubp: UnsafeRawBufferPointer) {
   // 'span' is valid within the lexical scope of variable 'ubp', which is the entire function.
   let span = ubp.storage
   read(span)
 }
 
-@available(SwiftStdlib 6.1, *)
+@available(SwiftStdlib 6.2, *)
 @lifetime(borrow ubp)
 func testUBPStorageReturn(ubp: UnsafeRawBufferPointer) -> RawSpan {
   // 'storage' can be returned since the function's return value also has a dependence on 'ubp'.
   return ubp.storage
 }
 
-@available(SwiftStdlib 6.1, *)
+@available(SwiftStdlib 6.2, *)
 @lifetime(borrow ubp)
 func testUBPStorageCopy(ubp: UnsafeRawBufferPointer) -> RawSpan {
   let localBuffer = ubp
@@ -52,7 +52,7 @@ func testUBPStorageCopy(ubp: UnsafeRawBufferPointer) -> RawSpan {
                              // expected-note  @-2{{this use causes the lifetime-dependent value to escape}}
 }
 
-@available(SwiftStdlib 6.1, *)
+@available(SwiftStdlib 6.2, *)
 func testUBPStorageEscape(array: [Int64]) {
   var span = RawSpan()
   array.withUnsafeBytes {


### PR DESCRIPTION
Adjusts more tests to require SwiftStdlib 6.2 availability when using `Span`

Addresses these test failures in rdar://146792412