### PR TITLE
[WIP] [CMAKE] link libc++ explicitly on darwin

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -114,6 +114,7 @@ target_link_libraries(swift_Concurrency PRIVATE
   $<$<BOOL:${BUILD_SHARED_LIBS}>:swiftThreading>
   $<$<PLATFORM_ID:Windows>:Synchronization>
   $<$<PLATFORM_ID:Windows>:mincore>
+  $<$<PLATFORM_ID:Darwin>:c++>
   # Link to the runtime that we are just building.
   swiftCore
   $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftrt>)

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -310,6 +310,7 @@ target_link_libraries(swiftCore
     swiftStdlibStubs
     swiftThreading
     $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftrt$<$<PLATFORM_ID:Windows>:T>>
+    $<$<PLATFORM_ID:Darwin>:c++>
   PUBLIC
     swiftShims)
 target_link_options(swiftCore PRIVATE


### PR DESCRIPTION
This is more of a PR for discussion. On Darwin these libraries require libc++, and rather than rely on the compiler to add the libc++ argument (which may be platform dependent) or relying on a flag added in a [given source file](https://github.com/swiftlang/swift/blob/main/stdlib/public/runtime/Metadata.cpp#L8133) as is with swift Core, It would be better to explicitly link in the c++ stdlib.


Outstanding question: Does it make sense to do the same for other platforms? Can we make assumptions about which C++ stdlib is being used on a given platform? Perhaps there's a more CMAKE native way to say "link in the C++ stdlib" on a given platform?