### PR TITLE
[IDE] Complete `nonisolated`, `unowned`, and access control attribute parameter

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -612,7 +612,7 @@ public:
 
   void getAttributeDeclCompletions(bool IsInSil, std::optional<DeclKind> DK);
 
-  void getAttributeDeclParamCompletions(CustomSyntaxAttributeKind AttrKind,
+  void getAttributeDeclParamCompletions(ParameterizedDeclAttributeKind AttrKind,
                                         int ParamIndex, bool HasLabel);
 
   void getTypeAttributeKeywordCompletions(CompletionKind completionKind);

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -32,7 +32,7 @@ enum class ObjCSelectorContext {
 /// Attributes that have syntax which can't be modelled using a function call.
 /// This can't be \c DeclAttrKind because '@freestandig' and '@attached' have
 /// the same attribute kind but take different macro roles as arguemnts.
-enum class CustomSyntaxAttributeKind {
+enum class ParameterizedDeclAttributeKind {
   Available,
   FreestandingMacro,
   AttachedMacro,
@@ -228,7 +228,7 @@ public:
   /// @available.
   /// If `HasLabel` is `true`, then the argument already has a label specified,
   /// e.g. we're completing after `names: ` in a macro declaration.
-  virtual void completeDeclAttrParam(CustomSyntaxAttributeKind DK, int Index,
+  virtual void completeDeclAttrParam(ParameterizedDeclAttributeKind DK, int Index,
                                      bool HasLabel){};
 
   /// Complete 'async' and 'throws' at effects specifier position.

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -29,10 +29,13 @@ enum class ObjCSelectorContext {
   SetterSelector
 };
 
-/// Attributes that have syntax which can't be modelled using a function call.
-/// This can't be \c DeclAttrKind because '@freestandig' and '@attached' have
+/// Parameterized attributes that have code completion.
+/// This can't be \c DeclAttrKind because '@freestanding' and '@attached' have
 /// the same attribute kind but take different macro roles as arguemnts.
 enum class ParameterizedDeclAttributeKind {
+  AccessControl,
+  Nonisolated,
+  Unowned,
   Available,
   FreestandingMacro,
   AttachedMacro,

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -461,8 +461,6 @@ void CodeCompletionCallbacksImpl::completeTypeSimpleBeginning() {
 
 void CodeCompletionCallbacksImpl::completeDeclAttrParam(
     ParameterizedDeclAttributeKind DK, int Index, bool HasLabel) {
-  assert(P.Tok.is(tok::code_complete));
-  
   Kind = CompletionKind::AttributeDeclParen;
   AttrKind = DK;
   AttrParamIndex = Index;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -114,7 +114,7 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks,
   SourceLoc DotLoc;
   TypeLoc ParsedTypeLoc;
   DeclContext *CurDeclContext = nullptr;
-  CustomSyntaxAttributeKind AttrKind;
+  ParameterizedDeclAttributeKind AttrKind;
 
   /// When the code completion token occurs in a custom attribute, the attribute
   /// it occurs in. Used so we can complete inside the attribute even if it's
@@ -272,7 +272,7 @@ public:
   void completeCaseStmtKeyword() override;
   void completeCaseStmtBeginning(CodeCompletionExpr *E) override;
   void completeDeclAttrBeginning(bool Sil, bool isIndependent) override;
-  void completeDeclAttrParam(CustomSyntaxAttributeKind DK, int Index,
+  void completeDeclAttrParam(ParameterizedDeclAttributeKind DK, int Index,
                              bool HasLabel) override;
   void completeEffectsSpecifier(bool hasAsync, bool hasThrows) override;
   void completeInPrecedenceGroup(
@@ -460,7 +460,9 @@ void CodeCompletionCallbacksImpl::completeTypeSimpleBeginning() {
 }
 
 void CodeCompletionCallbacksImpl::completeDeclAttrParam(
-    CustomSyntaxAttributeKind DK, int Index, bool HasLabel) {
+    ParameterizedDeclAttributeKind DK, int Index, bool HasLabel) {
+  assert(P.Tok.is(tok::code_complete));
+  
   Kind = CompletionKind::AttributeDeclParen;
   AttrKind = DK;
   AttrParamIndex = Index;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3105,6 +3105,16 @@ void CompletionLookup::getAttributeDeclCompletions(bool IsInSil,
 void CompletionLookup::getAttributeDeclParamCompletions(
     ParameterizedDeclAttributeKind AttrKind, int ParamIndex, bool HasLabel) {
   switch (AttrKind) {
+  case ParameterizedDeclAttributeKind::Unowned:
+    addDeclAttrParamKeyword("safe", /*Parameters=*/{}, "", false);
+    addDeclAttrParamKeyword("unsafe", /*Parameters=*/{}, "", false);
+    break;
+  case ParameterizedDeclAttributeKind::Nonisolated:
+    addDeclAttrParamKeyword("unsafe", /*Parameters=*/{}, "", false);
+    break;
+  case ParameterizedDeclAttributeKind::AccessControl:
+    addDeclAttrParamKeyword("set", /*Parameters=*/{}, "", false);
+    break;
   case ParameterizedDeclAttributeKind::Available:
     if (ParamIndex == 0) {
       addDeclAttrParamKeyword("*", /*Parameters=*/{}, "Platform", false);

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3103,9 +3103,9 @@ void CompletionLookup::getAttributeDeclCompletions(bool IsInSil,
 }
 
 void CompletionLookup::getAttributeDeclParamCompletions(
-    CustomSyntaxAttributeKind AttrKind, int ParamIndex, bool HasLabel) {
+    ParameterizedDeclAttributeKind AttrKind, int ParamIndex, bool HasLabel) {
   switch (AttrKind) {
-  case CustomSyntaxAttributeKind::Available:
+  case ParameterizedDeclAttributeKind::Available:
     if (ParamIndex == 0) {
       addDeclAttrParamKeyword("*", /*Parameters=*/{}, "Platform", false);
 
@@ -3126,15 +3126,15 @@ void CompletionLookup::getAttributeDeclParamCompletions(
                               "Specify version number", true);
     }
     break;
-  case CustomSyntaxAttributeKind::FreestandingMacro:
-  case CustomSyntaxAttributeKind::AttachedMacro:
+  case ParameterizedDeclAttributeKind::FreestandingMacro:
+  case ParameterizedDeclAttributeKind::AttachedMacro:
     switch (ParamIndex) {
     case 0:
       for (auto role : getAllMacroRoles()) {
         bool isRoleSupported = isMacroSupported(role, Ctx);
-        if (AttrKind == CustomSyntaxAttributeKind::FreestandingMacro) {
+        if (AttrKind == ParameterizedDeclAttributeKind::FreestandingMacro) {
           isRoleSupported &= isFreestandingMacro(role);
-        } else if (AttrKind == CustomSyntaxAttributeKind::AttachedMacro) {
+        } else if (AttrKind == ParameterizedDeclAttributeKind::AttachedMacro) {
           isRoleSupported &= isAttachedMacro(role);
         }
         if (isRoleSupported) {
@@ -3162,7 +3162,7 @@ void CompletionLookup::getAttributeDeclParamCompletions(
       break;
     }
     break;
-  case CustomSyntaxAttributeKind::StorageRestrictions: {
+  case ParameterizedDeclAttributeKind::StorageRestrictions: {
     bool suggestInitializesLabel = false;
     bool suggestAccessesLabel = false;
     bool suggestArgument = false;
@@ -3295,7 +3295,7 @@ void CompletionLookup::getPrecedenceGroupCompletions(
 void CompletionLookup::getPoundAvailablePlatformCompletions() {
 
   // The platform names should be identical to those in @available.
-  getAttributeDeclParamCompletions(CustomSyntaxAttributeKind::Available, 0,
+  getAttributeDeclParamCompletions(ParameterizedDeclAttributeKind::Available, 0,
                                    /*HasLabel=*/false);
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -396,7 +396,7 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
           .highlight(SourceRange(ArgumentLoc));
       if (Tok.is(tok::code_complete) && CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeDeclAttrParam(
-            CustomSyntaxAttributeKind::Available, ParamIndex,
+            ParameterizedDeclAttributeKind::Available, ParamIndex,
             /*HasLabel=*/false);
         consumeToken(tok::code_complete);
       } else {
@@ -737,7 +737,7 @@ bool Parser::parseAvailability(
       !(Tok.isAnyOperator() && Tok.getText() == "*")) {
     if (Tok.is(tok::code_complete) && CodeCompletionCallbacks) {
       CodeCompletionCallbacks->completeDeclAttrParam(
-          CustomSyntaxAttributeKind::Available, 0, /*HasLabel=*/false);
+          ParameterizedDeclAttributeKind::Available, 0, /*HasLabel=*/false);
       consumeToken(tok::code_complete);
     }
     diagnose(Tok.getLoc(), diag::attr_availability_platform, AttrName)
@@ -993,7 +993,7 @@ Parser::parseStorageRestrictionsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
             }
           }
           this->CodeCompletionCallbacks->completeDeclAttrParam(
-              CustomSyntaxAttributeKind::StorageRestrictions,
+              ParameterizedDeclAttributeKind::StorageRestrictions,
               static_cast<int>(completionKind), /*HasLabel=*/false);
         }
       } else if (parseIdentifier(propertyName, propertyNameLoc,
@@ -1026,7 +1026,7 @@ Parser::parseStorageRestrictionsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
       if (consumeIf(tok::code_complete)) {
         if (this->CodeCompletionCallbacks) {
           this->CodeCompletionCallbacks->completeDeclAttrParam(
-              CustomSyntaxAttributeKind::StorageRestrictions,
+              ParameterizedDeclAttributeKind::StorageRestrictions,
               static_cast<int>(StorageRestrictionsCompletionKind::Label),
               /*HasLabel=*/false);
         }
@@ -2214,11 +2214,11 @@ std::optional<MacroRole> getMacroRole(StringRef roleName) {
       .Default(std::nullopt);
 }
 
-static CustomSyntaxAttributeKind getCustomSyntaxAttributeKind(bool isAttached) {
+static ParameterizedDeclAttributeKind getParameterizedDeclAttributeKind(bool isAttached) {
   if (isAttached) {
-    return CustomSyntaxAttributeKind::AttachedMacro;
+    return ParameterizedDeclAttributeKind::AttachedMacro;
   } else {
-    return CustomSyntaxAttributeKind::FreestandingMacro;
+    return ParameterizedDeclAttributeKind::FreestandingMacro;
   }
 }
 
@@ -2265,13 +2265,13 @@ Parser::parseMacroRoleAttribute(
             sawRole = true;
             if (this->CodeCompletionCallbacks) {
               this->CodeCompletionCallbacks->completeDeclAttrParam(
-                  getCustomSyntaxAttributeKind(isAttached), 0,
+                  getParameterizedDeclAttributeKind(isAttached), 0,
                   /*HasLabel=*/false);
             }
           } else if (!sawNames) {
             if (this->CodeCompletionCallbacks) {
               this->CodeCompletionCallbacks->completeDeclAttrParam(
-                  getCustomSyntaxAttributeKind(isAttached), 1,
+                  getParameterizedDeclAttributeKind(isAttached), 1,
                   /*HasLabel=*/false);
             }
           }
@@ -2373,7 +2373,7 @@ Parser::parseMacroRoleAttribute(
           status.setHasCodeCompletionAndIsError();
           if (this->CodeCompletionCallbacks) {
             this->CodeCompletionCallbacks->completeDeclAttrParam(
-                getCustomSyntaxAttributeKind(isAttached), 1, /*HasLabel=*/true);
+                getParameterizedDeclAttributeKind(isAttached), 1, /*HasLabel=*/true);
           }
         } else if (parseIdentifier(introducedNameKind, introducedNameKindLoc,
                                    diag::macro_attribute_unknown_argument_form,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2911,9 +2911,9 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeDeclAttrParam(
             ParameterizedDeclAttributeKind::AccessControl, 0, false);
+        consumeToken(tok::code_complete);
       }
-      consumeToken(tok::code_complete);
-      return makeParserCodeCompletionStatus();
+      return makeParserSuccess();
     }
     
     // Parse the subject.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2504,11 +2504,6 @@ static std::optional<Identifier> parseSingleAttrOptionImpl(
     return std::nullopt;
   }
   
-  if (P.Tok.is(tok::code_complete)) {
-    Status.setHasCodeCompletion();
-    codeCompletionCallback();
-  }
-  
   if (!P.consumeIf(tok::r_paren)) {
     Status.setIsParseError();
     P.diagnose(Loc, diag::attr_expected_rparen, AttrName, isDeclModifier);
@@ -2926,20 +2921,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       consumeToken();
     } else {
       diagnose(Loc, diag::attr_access_expected_set, AttrName);
-      
-      const Token &Tok2 = peekToken();
-      
-      if (Tok2.is(tok::code_complete) && Tok.is(tok::identifier) &&
-                 !Tok.isContextualDeclKeyword()) {
-        consumeToken(tok::identifier);
-        if (CodeCompletionCallbacks) {
-          CodeCompletionCallbacks->completeDeclAttrParam(
-              ParameterizedDeclAttributeKind::AccessControl, 0, false);
-        }
-        consumeToken(tok::code_complete);
-        return makeParserCodeCompletionStatus();
-      }
-      
+
       // Minimal recovery: if there's a single token and then an r_paren,
       // consume them both. If there's just an r_paren, consume that.
       if (!consumeIf(tok::r_paren)) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5718,8 +5718,8 @@ consumeIfParenthesizedModifier(Parser &P, StringRef name,
       std::find(allowedArguments.begin(), allowedArguments.end(),
                 P.Tok.getText()) != allowedArguments.end();
   
-  if (argumentIsAllowed && P.Tok.is(tok::identifier) &&
-      P.peekToken().is(tok::r_paren)) {
+  if (argumentIsAllowed && P.consumeIf(tok::identifier) &&
+      P.consumeIf(tok::r_paren)) {
     backtrack.cancelBacktrack();
     return true;
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2837,7 +2837,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
           [&] () {
             if (CodeCompletionCallbacks) {
               CodeCompletionCallbacks->completeDeclAttrParam(
-                  ParameterizedDeclAttributeKind::Unowned, 0, false);
+                  ParameterizedDeclAttributeKind::Unowned, 0, /*HasLabel=*/false);
               consumeToken(tok::code_complete);
             }
           })
@@ -2928,15 +2928,6 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       diagnose(Loc, diag::attr_access_expected_set, AttrName);
       
       const Token &Tok2 = peekToken();
-      
-      if (Tok.is(tok::code_complete)) {
-        if (CodeCompletionCallbacks) {
-          CodeCompletionCallbacks->completeDeclAttrParam(
-              ParameterizedDeclAttributeKind::AccessControl, 0, false);
-        }
-        consumeToken(tok::code_complete);
-        return makeParserCodeCompletionStatus();
-      }
       
       if (Tok2.is(tok::code_complete) && Tok.is(tok::identifier) &&
                  !Tok.isContextualDeclKeyword()) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2910,7 +2910,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     if (Tok.is(tok::code_complete)) {
       if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeDeclAttrParam(
-            ParameterizedDeclAttributeKind::AccessControl, 0, false);
+            ParameterizedDeclAttributeKind::AccessControl, 0, /*HasLabel=*/false);
         consumeToken(tok::code_complete);
       }
       return makeParserSuccess();
@@ -3765,7 +3765,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
                                       *isUnsafe, [&] () {
             if (CodeCompletionCallbacks) {
               CodeCompletionCallbacks->completeDeclAttrParam(
-                  ParameterizedDeclAttributeKind::Nonisolated, 0, false);
+                  ParameterizedDeclAttributeKind::Nonisolated, 0, /*HasLabel=*/false);
               consumeToken(tok::code_complete);
             }
           });

--- a/test/IDE/complete_access_control_set.swift
+++ b/test/IDE/complete_access_control_set.swift
@@ -1,0 +1,27 @@
+// RUN: %batch-code-completion
+
+// ACCESS_CONTROL_SET: Keyword/None:                       set; name=set
+
+public(#^PUBLIC_TOP_LEVEL?check=ACCESS_CONTROL_SET^#) var var1 = 0
+
+private(#^PRIVATE_TOP_LEVEL?check=ACCESS_CONTROL_SET^#) var var2 = 0
+
+internal(#^INTERNAL_TOP_LEVEL?check=ACCESS_CONTROL_SET^#) var var3 = 0
+
+fileprivate(#^FILEPRIVATE_TOP_LEVEL?check=ACCESS_CONTROL_SET^#) var var4 = 0
+
+package(#^PACKAGE_TOP_LEVEL?check=ACCESS_CONTROL_SET^#) var var5 = 0
+
+struct MyStruct {
+  public(#^PUBLIC_IN_STRUCT?check=ACCESS_CONTROL_SET^#) var prop1: Int = 0
+
+  private(#^PRIVATE_IN_STRUCT?check=ACCESS_CONTROL_SET^#) var prop2: Int = 0
+
+  open(#^OPEN_IN_STRUCT?check=ACCESS_CONTROL_SET^#) var prop3: Int = 0
+
+  internal(#^INTERNAL_IN_STRUCT?check=ACCESS_CONTROL_SET^#) var prop4: Int = 0
+
+  fileprivate(#^FILEPRIVATE_IN_STRUCT?check=ACCESS_CONTROL_SET^#) var prop5: Int = 0
+
+  package(#^PACKAGE_IN_STRUCT?check=ACCESS_CONTROL_SET^#) var prop6: Int = 0
+}

--- a/test/IDE/complete_nonisolated_unsafe.swift
+++ b/test/IDE/complete_nonisolated_unsafe.swift
@@ -1,0 +1,9 @@
+// RUN: %batch-code-completion
+
+// NONISOLATED_UNSAFE: Keyword/None:                       unsafe; name=unsafe
+
+nonisolated(#^NONISOLATED_UNSAFE_TOP_LEVEL?check=NONISOLATED_UNSAFE^#) var count = 0
+
+struct MyStruct {
+  nonisolated(#^NONISOLATED_UNSAFE_IN_STRUCT?check=NONISOLATED_UNSAFE^#) var prop = 0
+}

--- a/test/IDE/complete_unowned_parameter.swift
+++ b/test/IDE/complete_unowned_parameter.swift
@@ -1,0 +1,10 @@
+// RUN: %batch-code-completion
+
+// UNOWNED_PARAMETER-DAG: Keyword/None:                       safe; name=safe
+// UNOWNED_PARAMETER-DAG: Keyword/None:                       unsafe; name=unsafe
+
+unowned(#^UNOWNED_TOP_LEVEL?check=UNOWNED_PARAMETER^#) var count = 0
+
+struct MyStruct {
+  unowned(#^UNOWNED_IN_STRUCT?check=UNOWNED_PARAMETER^#) var prop: Int = 0
+}


### PR DESCRIPTION
## Description

Added code completion support for:

- `nonisolated(unsafe)`
- `unowned(safe)`
- `unowned(unsafe)`
- `<access-control>(set)` (e.g. `private(set)`)
