### PR TITLE
[Concurrency] Extend `@execution(...)` attribute support to closures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8343,6 +8343,10 @@ ERROR(attr_execution_only_on_async,none,
       "cannot use '@execution' on non-async %kind0",
       (ValueDecl *))
 
+ERROR(attr_execution_only_on_async_closure,none,
+      "cannot use '@execution' on non-async closure",
+      ())
+
 ERROR(attr_execution_type_attr_only_on_async,none,
       "cannot use '@execution' on non-async function type",
       ())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2542,6 +2542,16 @@ namespace {
             return FunctionTypeIsolation::forGlobalActor(actorType);
         }
 
+        if (auto *execution =
+                closure->getAttrs().getAttribute<ExecutionAttr>()) {
+          switch (execution->getBehavior()) {
+          case ExecutionKind::Caller:
+            return FunctionTypeIsolation::forNonIsolatedCaller();
+          case ExecutionKind::Concurrent:
+            return FunctionTypeIsolation::forNonIsolated();
+          }
+        }
+
         return FunctionTypeIsolation::forNonIsolated();
       }();
       extInfo = extInfo.withIsolation(isolation);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1400,6 +1400,12 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
   bool throws = expr->getThrowsLoc().isValid();
   bool async = expr->getAsyncLoc().isValid();
   bool sendable = expr->getAttrs().hasAttribute<SendableAttr>();
+
+  // `@execution(...)` attribute is only valid on asynchronous function types.
+  if (expr->getAttrs().hasAttribute<ExecutionAttr>()) {
+    async = true;
+  }
+
   if (throws || async) {
     return ASTExtInfoBuilder()
       .withThrows(throws, /*FIXME:*/Type())

--- a/test/Concurrency/attr_execution_conversions.swift
+++ b/test/Concurrency/attr_execution_conversions.swift
@@ -82,6 +82,17 @@ do {
   // expected-error@-1 {{cannot convert value of type '(@execution(caller) () async -> ()).Type' to expected argument type '(@isolated(any) () async -> Void).Type'}}
 }
 
+do {
+  let _: () -> Void = { @execution(concurrent) in
+    // expected-error@-1 {{invalid conversion from 'async' function of type '() async -> Void' to synchronous function type '() -> Void'}}
+  }
+
+  func test(_: () -> Void) {}
+
+  test { @execution(caller) in
+    // expected-error@-1 {{cannot pass function of type '@execution(caller) () async -> ()' to parameter expecting synchronous function type}}
+  }
+}
 
 // Converting to `@execution(caller)` function
 class NonSendable {}

--- a/test/attr/attr_execution.swift
+++ b/test/attr/attr_execution.swift
@@ -75,3 +75,21 @@ struct InfersMainActor : P {
 struct IsolatedType {
   @execution(concurrent) func test() async {}
 }
+
+_ = { @execution(caller) in // Ok
+}
+
+_ = { @execution(concurrent) in // Ok
+}
+
+_ = { @MainActor @execution(concurrent) in
+  // expected-error@-1 {{cannot use '@execution' because function type is isolated to a global actor 'MainActor'}}
+}
+
+_ = { @execution(concurrent) () -> Int in
+  // expected-error@-1 {{'@execution' on non-async closure}}
+}
+
+_ = { @execution(caller) (x: isolated (any Actor)?) in
+  // expected-error@-1 {{cannot use '@execution' together with an isolated parameter}}
+}


### PR DESCRIPTION
- Update `ClosureAttributeChecker` to allow and verify `@execution(...)` attribute.
- Update closure effects checker and type inference to account for `@execution(...)` and the fact that it implies `async`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
