### PR TITLE
AST: Unique `CustomAvailabilityDomain` instances

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -351,7 +351,7 @@ private:
   bool BypassResilience = false;
 
   using AvailabilityDomainMap =
-      llvm::SmallDenseMap<Identifier, CustomAvailabilityDomain *>;
+      llvm::SmallDenseMap<Identifier, const CustomAvailabilityDomain *>;
   AvailabilityDomainMap AvailabilityDomains;
 
 public:

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -738,7 +738,6 @@ Decl::getAvailableAttrForPlatformIntroduction(bool checkExtension) const {
 }
 
 AvailabilityRange AvailabilityInference::availableRange(const Decl *D) {
-  // ALLANXXX
   if (auto attr = D->getAvailableAttrForPlatformIntroduction())
     return attr->getIntroducedRange(D->getASTContext())
         .value_or(AvailabilityRange::alwaysAvailable());

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -280,10 +280,12 @@ CustomAvailabilityDomain::CustomAvailabilityDomain(Identifier name,
   ASSERT(mod);
 }
 
-CustomAvailabilityDomain *
-CustomAvailabilityDomain::create(const ASTContext &ctx, StringRef name,
-                                 ModuleDecl *mod, Kind kind) {
-  return new (ctx) CustomAvailabilityDomain(ctx.getIdentifier(name), mod, kind);
+void CustomAvailabilityDomain::Profile(llvm::FoldingSetNodeID &ID,
+                                       Identifier name, ModuleDecl *mod,
+                                       Kind kind) {
+  ID.AddPointer(name.getAsOpaquePointer());
+  ID.AddPointer(mod);
+  ID.AddInteger(static_cast<unsigned>(kind));
 }
 
 static std::optional<AvailabilityDomain>

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1390,11 +1390,11 @@ bool CompilerInstance::createFilesForMainModule(
 static void configureAvailabilityDomains(const ASTContext &ctx,
                                          const FrontendOptions &opts,
                                          ModuleDecl *mainModule) {
-  llvm::SmallDenseMap<Identifier, CustomAvailabilityDomain *> domainMap;
+  llvm::SmallDenseMap<Identifier, const CustomAvailabilityDomain *> domainMap;
   auto createAndInsertDomain = [&](const std::string &name,
                                    CustomAvailabilityDomain::Kind kind) {
-    auto *domain = CustomAvailabilityDomain::create(
-        ctx, name, mainModule, CustomAvailabilityDomain::Kind::Enabled);
+    auto *domain = CustomAvailabilityDomain::get(
+        name, mainModule, CustomAvailabilityDomain::Kind::Enabled, ctx);
     bool inserted = domainMap.insert({domain->getName(), domain}).second;
     ASSERT(inserted); // Domains must be unique.
   };


### PR DESCRIPTION
Store `CustomAvailabilityDomain` instances in a folding set on `ASTContext`. This allows instances of custom domains to be created without needing to cache them in disparate locations.