### PR TITLE
utils: repair the XCTest build configuration

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2151,6 +2151,8 @@ mixin-preset=
 llbuild
 swiftpm
 xctest
+swift-testing
+swift-testing-macros
 foundation
 libdispatch
 indexstore-db
@@ -2171,6 +2173,8 @@ install-llbuild
 install-swiftpm
 install-swiftsyntax
 install-xctest
+install-swift-testing
+install-swift-testing-macros
 install-sourcekit-lsp
 install-swiftformat
 


### PR DESCRIPTION
Swift Package Manager has grown a dependency on swift-testing and swift-testing-macros. Ensure that we build these dependencies when testing.