### PR TITLE
[Macros] Implement support for function body macros on closures.

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -408,10 +408,18 @@ public:
   std::string mangleMacroExpansion(const FreestandingMacroExpansion *expansion);
   std::string mangleAttachedMacroExpansion(
       const Decl *decl, CustomAttr *attr, MacroRole role);
+  std::string mangleAttachedMacroExpansion(
+      ClosureExpr *attachedTo, CustomAttr *attr, MacroDecl *macro);
 
   void appendMacroExpansion(const FreestandingMacroExpansion *expansion);
   void appendMacroExpansionContext(SourceLoc loc, DeclContext *origDC,
-                                   const FreestandingMacroExpansion *expansion);
+                                   Identifier macroName,
+                                   unsigned discriminator);
+
+  void appendMacroExpansion(ClosureExpr *attachedTo,
+                            CustomAttr *attr,
+                            MacroDecl *macro);
+
   void appendMacroExpansionOperator(
       StringRef macroName, MacroRole role, unsigned discriminator);
 

--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -243,6 +243,54 @@ public:
     llvm_unreachable("unexpected AnyFunctionRef representation");
   }
 
+  DeclAttributes getDeclAttributes() const {
+    if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      return afd->getExpandedAttrs();
+    }
+
+    if (auto ace = TheFunction.dyn_cast<AbstractClosureExpr *>()) {
+      if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
+        return ce->getAttrs();
+      }
+    }
+
+    return DeclAttributes();
+  }
+
+  MacroDecl *getResolvedMacro(CustomAttr *attr) const {
+    if (auto afd = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
+      return afd->getResolvedMacro(attr);
+    }
+
+    if (auto ace = TheFunction.dyn_cast<AbstractClosureExpr *>()) {
+      if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
+        return ce->getResolvedMacro(attr);
+      }
+    }
+
+    return nullptr;
+  }
+
+  using MacroCallback = llvm::function_ref<void(CustomAttr *, MacroDecl *)>;
+
+  void
+  forEachAttachedMacro(MacroRole role,
+                       MacroCallback macroCallback) const {
+    auto attrs = getDeclAttributes();
+    for (auto customAttrConst : attrs.getAttributes<CustomAttr>()) {
+      auto customAttr = const_cast<CustomAttr *>(customAttrConst);
+      auto *macroDecl = getResolvedMacro(customAttr);
+
+      if (!macroDecl)
+        continue;
+
+      if (!macroDecl->getMacroRoles().contains(role))
+        continue;
+
+      macroCallback(customAttr, macroDecl);
+    }
+  }
+
   friend bool operator==(AnyFunctionRef lhs, AnyFunctionRef rhs) {
      return lhs.TheFunction == rhs.TheFunction;
    }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7833,6 +7833,9 @@ ERROR(conformance_macro,none,
 ERROR(experimental_macro,none,
       "macro %0 is experimental",
       (DeclName))
+ERROR(experimental_closure_body_macro,none,
+      "function body macros on closures is experimental",
+      ())
 
 ERROR(macro_resolve_circular_reference, none,
       "circular reference resolving %select{freestanding|attached}0 macro %1",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4305,6 +4305,8 @@ public:
   BraceStmt *getBody() const { return Body; }
   void setBody(BraceStmt *S) { Body = S; }
 
+  BraceStmt *getExpandedBody();
+
   DeclAttributes &getAttrs() { return Attributes; }
   const DeclAttributes &getAttrs() const { return Attributes; }
 
@@ -4421,6 +4423,10 @@ public:
     assert(hasExplicitResultType() && "No explicit result type");
     return ExplicitResultTypeAndBodyState.getPointer()->getTypeRepr();
   }
+
+  /// Returns the resolved macro for the given custom attribute
+  /// attached to this closure expression.
+  MacroDecl *getResolvedMacro(CustomAttr *customAttr);
 
   /// Determine whether the closure has a single expression for its
   /// body.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4708,7 +4708,7 @@ public:
 
 class ExpandBodyMacroRequest
     : public SimpleRequest<ExpandBodyMacroRequest,
-                           std::optional<unsigned>(AbstractFunctionDecl *),
+                           std::optional<unsigned>(AnyFunctionRef),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -4717,7 +4717,7 @@ private:
   friend SimpleRequest;
 
   std::optional<unsigned> evaluate(Evaluator &evaluator,
-                                   AbstractFunctionDecl *fn) const;
+                                   AnyFunctionRef fn) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -531,7 +531,7 @@ SWIFT_REQUEST(TypeChecker, ExpandPreambleMacroRequest,
               ArrayRef<unsigned>(AbstractFunctionDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExpandBodyMacroRequest,
-              std::optional<unsigned>(AbstractFunctionDecl *),
+              std::optional<unsigned>(AnyFunctionRef),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, LocalDiscriminatorsRequest,
               unsigned(DeclContext *),

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -511,6 +511,9 @@ EXPERIMENTAL_FEATURE(ConcurrencySyntaxSugar, true)
 /// Allow declaration of compile-time values
 EXPERIMENTAL_FEATURE(CompileTimeValues, true)
 
+/// Allow function body macros applied to closures.
+EXPERIMENTAL_FEATURE(ClosureBodyMacro, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4759,7 +4759,8 @@ static Identifier encodeLocalPrecheckedDiscriminator(
 
 void ASTMangler::appendMacroExpansionContext(
     SourceLoc loc, DeclContext *origDC,
-    const FreestandingMacroExpansion *expansion
+    Identifier macroName,
+    unsigned macroDiscriminator
 ) {
   origDC = MacroDiscriminatorContext::getInnermostMacroContext(origDC);
   BaseEntitySignature nullBase(nullptr);
@@ -4768,9 +4769,9 @@ void ASTMangler::appendMacroExpansionContext(
     if (auto outermostLocalDC = getOutermostLocalContext(origDC)) {
       auto innermostNonlocalDC = outermostLocalDC->getParent();
       appendContext(innermostNonlocalDC, nullBase, StringRef());
-      Identifier name = expansion->getMacroName().getBaseIdentifier();
+      Identifier name = macroName;
       ASTContext &ctx = origDC->getASTContext();
-      unsigned discriminator = expansion->getDiscriminator();
+      unsigned discriminator = macroDiscriminator;
       name = encodeLocalPrecheckedDiscriminator(ctx, name, discriminator);
       appendIdentifier(name.str());
     } else {
@@ -4875,7 +4876,10 @@ void ASTMangler::appendMacroExpansionContext(
     return appendMacroExpansionLoc();
 
   // Append our own context and discriminator.
-  appendMacroExpansionContext(outerExpansionLoc, origDC, expansion);
+  appendMacroExpansionContext(
+      outerExpansionLoc, origDC,
+      macroName,
+      macroDiscriminator);
   appendMacroExpansionOperator(
       baseName.userFacingName(), role, discriminator);
 }
@@ -4902,16 +4906,14 @@ void ASTMangler::appendMacroExpansionOperator(
 }
 
 static StringRef getPrivateDiscriminatorIfNecessary(
-      const MacroExpansionExpr *expansion) {
-  auto dc = MacroDiscriminatorContext::getInnermostMacroContext(
-      expansion->getDeclContext());
-  auto decl = dc->getAsDecl();
+      const DeclContext *macroDC) {
+  auto decl = macroDC->getAsDecl();
   if (decl && !decl->isOutermostPrivateOrFilePrivateScope())
     return StringRef();
 
   // Mangle non-local private declarations with a textual discriminator
   // based on their enclosing file.
-  auto topLevelSubcontext = dc->getModuleScopeContext();
+  auto topLevelSubcontext = macroDC->getModuleScopeContext();
   SourceFile *sf = dyn_cast<SourceFile>(topLevelSubcontext);
   if (!sf)
     return StringRef();
@@ -4925,6 +4927,13 @@ static StringRef getPrivateDiscriminatorIfNecessary(
   assert(!clang::isDigit(discriminator.str().front()) &&
          "not a valid identifier");
   return discriminator.str();
+}
+
+static StringRef getPrivateDiscriminatorIfNecessary(
+    const MacroExpansionExpr *expansion) {
+  auto dc = MacroDiscriminatorContext::getInnermostMacroContext(
+      expansion->getDeclContext());
+  return getPrivateDiscriminatorIfNecessary(dc);
 }
 
 static StringRef getPrivateDiscriminatorIfNecessary(
@@ -4943,7 +4952,8 @@ void
 ASTMangler::appendMacroExpansion(const FreestandingMacroExpansion *expansion) {
   appendMacroExpansionContext(expansion->getPoundLoc(),
                               expansion->getDeclContext(),
-                              expansion);
+                              expansion->getMacroName().getBaseIdentifier(),
+                              expansion->getDiscriminator());
   auto privateDiscriminator = getPrivateDiscriminatorIfNecessary(expansion);
   if (!privateDiscriminator.empty()) {
     appendIdentifier(privateDiscriminator);
@@ -4953,6 +4963,42 @@ ASTMangler::appendMacroExpansion(const FreestandingMacroExpansion *expansion) {
       expansion->getMacroName().getBaseName().userFacingName(),
       MacroRole::Declaration,
       expansion->getDiscriminator());
+}
+
+void ASTMangler::appendMacroExpansion(ClosureExpr *attachedTo,
+                                      CustomAttr *attr,
+                                      MacroDecl *macro) {
+  auto &ctx = attachedTo->getASTContext();
+  auto discriminator =
+      ctx.getNextMacroDiscriminator(attachedTo,
+                                    macro->getBaseName());
+
+  appendMacroExpansionContext(
+      attr->getLocation(),
+      attachedTo,
+      macro->getBaseName().getIdentifier(),
+      discriminator);
+
+  auto privateDiscriminator =
+      getPrivateDiscriminatorIfNecessary(attachedTo);
+  if (!privateDiscriminator.empty()) {
+    appendIdentifier(privateDiscriminator);
+    appendOperator("Ll");
+  }
+
+  appendMacroExpansionOperator(
+      macro->getBaseName().userFacingName(),
+      MacroRole::Body,
+      discriminator);
+}
+
+std::string
+ASTMangler::mangleAttachedMacroExpansion(ClosureExpr *attachedTo,
+                                         CustomAttr *attr,
+                                         MacroDecl *macro) {
+  beginMangling();
+  appendMacroExpansion(attachedTo, attr, macro);
+  return finalize();
 }
 
 std::string

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -359,6 +359,10 @@ static bool usesFeatureCompileTimeValues(Decl *decl) {
   return decl->getAttrs().hasAttribute<ConstValAttr>();
 }
 
+static bool usesFeatureClosureBodyMacro(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureMemorySafetyAttributes(Decl *decl) {
   if (decl->getAttrs().hasAttribute<SafeAttr>() ||
       decl->getAttrs().hasAttribute<UnsafeAttr>())

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2681,19 +2681,17 @@ void ExpandPreambleMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
 //----------------------------------------------------------------------------//
 
 void ExpandBodyMacroRequest::diagnoseCycle(DiagnosticEngine &diags) const {
-  auto decl = std::get<0>(getStorage());
-  diags.diagnose(decl->getLoc(),
-                 diag::macro_expand_circular_reference_entity,
-                 "body",
-                 decl->getName());
+  auto fn = std::get<0>(getStorage());
+  diags.diagnose(fn.getLoc(),
+                 diag::macro_expand_circular_reference_unnamed,
+                 "body");
 }
 
 void ExpandBodyMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
-  auto decl = std::get<0>(getStorage());
-  diags.diagnose(decl->getLoc(),
-                 diag::macro_expand_circular_reference_entity_through,
-                 "body",
-                 decl->getName());
+  auto fn = std::get<0>(getStorage());
+  diags.diagnose(fn.getLoc(),
+                 diag::macro_expand_circular_reference_unnamed_through,
+                 "body");
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -287,9 +287,8 @@ public func findSyntaxNodeInSourceFile<Node: SyntaxProtocol>(
     }
   }
 
-  // If we didn't find anything, complain and fail.
+  // If we didn't find anything, return nil.
   guard var resultSyntax else {
-    print("unable to find node: \(token.debugDescription)")
     return nil
   }
 

--- a/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
@@ -583,15 +583,22 @@ func expandAttachedMacro(
     return 1
   }
 
-  // Dig out the node for the declaration to which the custom attribute is
-  // attached.
-  guard
-    let declarationNode = findSyntaxNodeInSourceFile(
+  func findNode<T: SyntaxProtocol>(type: T.Type) -> T? {
+    findSyntaxNodeInSourceFile(
       sourceFilePtr: declarationSourceFilePtr,
       sourceLocationPtr: declarationSourceLocPointer,
-      type: Syntax.self
+      type: T.self
     )
-  else {
+  }
+
+  // Dig out the node for the closure or declaration to which the custom
+  // attribute is attached.
+  let node: Syntax
+  if let closureNode = findNode(type: ClosureExprSyntax.self) {
+    node = Syntax(closureNode)
+  } else if let declNode = findNode(type: DeclSyntax.self) {
+    node = Syntax(declNode)
+  } else {
     return 1
   }
 
@@ -622,7 +629,7 @@ func expandAttachedMacro(
     customAttrSourceFilePtr: customAttrSourceFilePtr,
     customAttrNode: customAttrNode,
     declarationSourceFilePtr: declarationSourceFilePtr,
-    attachedTo: declarationNode,
+    attachedTo: node,
     parentDeclSourceFilePtr: parentDeclSourceFilePtr,
     parentDeclNode: parentDeclNode
   )

--- a/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
@@ -589,7 +589,7 @@ func expandAttachedMacro(
     let declarationNode = findSyntaxNodeInSourceFile(
       sourceFilePtr: declarationSourceFilePtr,
       sourceLocationPtr: declarationSourceLocPointer,
-      type: DeclSyntax.self
+      type: Syntax.self
     )
   else {
     return 1
@@ -657,7 +657,7 @@ func expandAttachedMacroImpl(
   customAttrSourceFilePtr: UnsafePointer<ExportedSourceFile>,
   customAttrNode: AttributeSyntax,
   declarationSourceFilePtr: UnsafePointer<ExportedSourceFile>,
-  attachedTo declarationNode: DeclSyntax,
+  attachedTo declarationNode: Syntax,
   parentDeclSourceFilePtr: UnsafePointer<ExportedSourceFile>?,
   parentDeclNode: DeclSyntax?
 ) -> String? {
@@ -689,7 +689,7 @@ func expandAttachedMacroImpl(
   )!
 
   let declSyntax = PluginMessage.Syntax(
-    syntax: Syntax(declarationNode),
+    syntax: declarationNode,
     in: declarationSourceFilePtr
   )!
 

--- a/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/Macros.swift
@@ -583,22 +583,15 @@ func expandAttachedMacro(
     return 1
   }
 
-  func findNode<T: SyntaxProtocol>(type: T.Type) -> T? {
-    findSyntaxNodeInSourceFile(
-      sourceFilePtr: declarationSourceFilePtr,
-      sourceLocationPtr: declarationSourceLocPointer,
-      type: T.self
-    )
-  }
-
   // Dig out the node for the closure or declaration to which the custom
   // attribute is attached.
-  let node: Syntax
-  if let closureNode = findNode(type: ClosureExprSyntax.self) {
-    node = Syntax(closureNode)
-  } else if let declNode = findNode(type: DeclSyntax.self) {
-    node = Syntax(declNode)
-  } else {
+  let node = findSyntaxNodeInSourceFile(
+    sourceFilePtr: declarationSourceFilePtr,
+    sourceLocationPtr: declarationSourceLocPointer,
+    where: { $0.is(DeclSyntax.self) || $0.is(ClosureExprSyntax.self) }
+  )
+
+  guard let node else {
     return 1
   }
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -4478,7 +4478,7 @@ NodePointer Demangler::demangleMacroExpansion() {
     context = popContext();
   NodePointer discriminator = demangleIndexAsNode();
   NodePointer result;
-  if (isAttached) {
+  if (isAttached && attachedName) {
     result = createWithChildren(
         kind, context, attachedName, macroName, discriminator);
   } else {

--- a/lib/Macros/Sources/SwiftMacros/StartTaskMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/StartTaskMacro.swift
@@ -50,4 +50,18 @@ public struct StartTaskMacro: BodyMacro {
       """
     ]
   }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingBodyFor closure: ClosureExprSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [CodeBlockItemSyntax] {
+    return [
+      """
+      Task {
+      \(closure.statements)
+      }
+      """
+    ]
+  }
 }

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -1149,7 +1149,7 @@ public:
 
   ASTContext &getASTContext() const { return Ctx; }
 
-  bool walkToClosureExprPre(ClosureExpr *expr);
+  bool walkToClosureExprPre(ClosureExpr *expr, ParentTy &parent);
 
   MacroWalking getMacroWalkingBehavior() const override {
     return MacroWalking::Arguments;
@@ -1251,7 +1251,7 @@ public:
     // but do not walk into the body. That will be type-checked after
     // we've determine the complete function type.
     if (auto closure = dyn_cast<ClosureExpr>(expr))
-      return finish(walkToClosureExprPre(closure), expr);
+      return finish(walkToClosureExprPre(closure, Parent), expr);
 
     if (auto *unresolved = dyn_cast<UnresolvedDeclRefExpr>(expr))
       return finish(true, TypeChecker::resolveDeclRefExpr(unresolved, DC));
@@ -1533,7 +1533,27 @@ public:
 
 /// Perform prechecking of a ClosureExpr before we dive into it.  This returns
 /// true when we want the body to be considered part of this larger expression.
-bool PreCheckTarget::walkToClosureExprPre(ClosureExpr *closure) {
+bool PreCheckTarget::walkToClosureExprPre(ClosureExpr *closure,
+                                          ParentTy &parent) {
+  if (auto *expandedBody = closure->getExpandedBody()) {
+    if (Parent.getAsExpr()) {
+      // We cannot simply replace the body when closure i.e. is passed
+      // as an argument to a call or is a source of an assignment
+      // because the source range of the argument list would cross
+      // buffer boundaries. One way to avoid that is to inject
+      // elements into a new implicit brace statement with the original
+      // source locations. Brace statement has to be implicit because its
+      // elements are in a different buffer.
+      auto sourceRange = closure->getSourceRange();
+      closure->setBody(BraceStmt::create(getASTContext(), sourceRange.Start,
+                                         expandedBody->getElements(),
+                                         sourceRange.End,
+                                         /*implicit=*/true));
+    } else {
+      closure->setBody(expandedBody);
+    }
+  }
+
   // Pre-check the closure body.
   (void)evaluateOrDefault(Ctx.evaluator, PreCheckClosureBodyRequest{closure},
                           nullptr);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8319,6 +8319,12 @@ public:
     auto *decl = declRef.getDecl();
     if (auto *macro = dyn_cast_or_null<MacroDecl>(decl)) {
       if (macro->getMacroRoles().contains(MacroRole::Body)) {
+        if (!ctx.LangOpts.hasFeature(Feature::ClosureBodyMacro)) {
+          ctx.Diags.diagnose(
+              attr->getLocation(),
+              diag::experimental_closure_body_macro);
+        }
+
         // Function body macros are allowed on closures.
         return;
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -33,6 +33,7 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ImportCache.h"
+#include "swift/AST/MacroDefinition.h"
 #include "swift/AST/ModuleNameLookup.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
@@ -8308,6 +8309,19 @@ public:
       }
 
       return; // it's OK
+    }
+
+    auto declRef = evaluateOrDefault(
+      ctx.evaluator,
+      ResolveMacroRequest{attr, closure},
+      ConcreteDeclRef());
+
+    auto *decl = declRef.getDecl();
+    if (auto *macro = dyn_cast_or_null<MacroDecl>(decl)) {
+      if (macro->getMacroRoles().contains(MacroRole::Body)) {
+        // Function body macros are allowed on closures.
+        return;
+      }
     }
 
     // Otherwise, it's an error.

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -971,6 +971,13 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
   }
 
   case MacroRole::Body: {
+    if (target.is<Expr *>()) {
+      // A closure body macro expansion replaces the full source
+      // range of the closure.
+      return Lexer::getCharSourceRangeFromSourceRange(
+          sourceMgr, target.getSourceRange());
+    }
+
     SourceLoc afterDeclLoc =
         Lexer::getLocForEndOfToken(sourceMgr, target.getEndLoc());
     return CharSourceRange(afterDeclLoc, 0);
@@ -1568,6 +1575,142 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
   return macroSourceFile;
 }
 
+static SourceFile *evaluateAttachedMacro(MacroDecl *macro,
+                                         ClosureExpr *attachedTo,
+                                         CustomAttr *attr,
+                                         MacroRole role,
+                                         StringRef discriminatorStr = "") {
+  assert(role == MacroRole::Body);
+
+  DeclContext *dc = attachedTo;
+  ASTContext &ctx = dc->getASTContext();
+  auto moduleDecl = dc->getParentModule();
+
+  auto attrSourceFile =
+    moduleDecl->getSourceFileContainingLocation(attr->AtLoc);
+  if (!attrSourceFile)
+    return nullptr;
+
+  SourceLoc attachedToLoc = attachedTo->getLoc();
+  SourceFile *closureSourceFile =
+      moduleDecl->getSourceFileContainingLocation(attachedToLoc);
+  if (!closureSourceFile)
+    return nullptr;
+
+  if (isFromExpansionOfMacro(attrSourceFile, macro, role) ||
+      isFromExpansionOfMacro(closureSourceFile, macro, role)) {
+    ctx.Diags.diagnose(attr->getLocation(),
+                       diag::macro_recursive,
+                       macro->getName());
+    return nullptr;
+  }
+
+  // Evaluate the macro.
+  std::unique_ptr<llvm::MemoryBuffer> evaluatedSource;
+
+  /// The discriminator used for the macro.
+  LazyValue<std::string> discriminator([&]() -> std::string {
+    if (!discriminatorStr.empty())
+      return discriminatorStr.str();
+#if SWIFT_BUILD_SWIFT_SYNTAX
+    Mangle::ASTMangler mangler(attachedTo->getASTContext());
+    return mangler.mangleAttachedMacroExpansion(
+        attachedTo, attr, macro);
+#else
+    return "";
+#endif
+  });
+
+  auto macroDef = macro->getDefinition();
+  switch (macroDef.kind) {
+  case MacroDefinition::Kind::Undefined:
+  case MacroDefinition::Kind::Invalid:
+    // Already diagnosed as an error elsewhere.
+    return nullptr;
+
+  case MacroDefinition::Kind::Builtin: {
+    switch (macroDef.getBuiltinKind()) {
+    case BuiltinMacroKind::ExternalMacro:
+    case BuiltinMacroKind::IsolationMacro:
+    case BuiltinMacroKind::SwiftSettingsMacro:
+      // FIXME: Error here.
+      return nullptr;
+    }
+  }
+
+  case MacroDefinition::Kind::Expanded: {
+    // Expand the definition with the given arguments.
+    auto result = expandMacroDefinition(
+        macroDef.getExpanded(), macro,
+        /*genericArgs=*/{}, // attached macros don't have generic parameters
+        attr->getArgs());
+    evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
+        result, adjustMacroExpansionBufferName(*discriminator));
+    break;
+  }
+
+  case MacroDefinition::Kind::External: {
+    // Retrieve the external definition of the macro.
+    auto external = macroDef.getExternalMacro();
+    ExternalMacroDefinitionRequest request{
+        &ctx, external.moduleName, external.macroTypeName
+    };
+    auto externalDef =
+        evaluateOrDefault(ctx.evaluator, request,
+                          ExternalMacroDefinition::error("failed request"));
+    if (externalDef.isError()) {
+      ctx.Diags.diagnose(attr->getLocation(),
+                         diag::external_macro_not_found,
+                         external.moduleName.str(),
+                         external.macroTypeName.str(), macro->getName(),
+                         externalDef.getErrorMessage());
+      macro->diagnose(diag::decl_declared_here, macro);
+      return nullptr;
+    }
+
+#if SWIFT_BUILD_SWIFT_SYNTAX
+    PrettyStackTraceExpr debugStack(
+      ctx, "expanding attached macro", attachedTo);
+
+    auto *astGenAttrSourceFile = attrSourceFile->getExportedSourceFile();
+    if (!astGenAttrSourceFile)
+      return nullptr;
+
+    auto *astGenClosureSourceFile = closureSourceFile->getExportedSourceFile();
+    if (!astGenClosureSourceFile)
+      return nullptr;
+
+    auto startLoc = attachedTo->getStartLoc();
+    BridgedStringRef evaluatedSourceOut{nullptr, 0};
+    assert(!externalDef.isError());
+    swift_Macros_expandAttachedMacro(
+        &ctx.Diags, externalDef.get(), discriminator->c_str(),
+        "", "", getRawMacroRole(role),
+        astGenAttrSourceFile, attr->AtLoc.getOpaquePointerValue(),
+        astGenClosureSourceFile, startLoc.getOpaquePointerValue(),
+        /*parentDeclSourceFile*/nullptr, /*parentDeclLoc*/nullptr,
+        &evaluatedSourceOut);
+    if (!evaluatedSourceOut.unbridged().data())
+      return nullptr;
+    evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
+        evaluatedSourceOut.unbridged(),
+        adjustMacroExpansionBufferName(*discriminator));
+    swift_ASTGen_freeBridgedString(evaluatedSourceOut);
+    break;
+#else
+    ctx.Diags.diagnose(attachedTo->getLoc(),
+                       diag::macro_unsupported);
+    return nullptr;
+#endif
+  }
+  }
+
+  SourceFile *macroSourceFile = createMacroSourceFile(
+      std::move(evaluatedSource), role, attachedTo, dc, attr);
+
+  return macroSourceFile;
+}
+
 bool swift::accessorMacroOnlyIntroducesObservers(
     MacroDecl *macro,
     const MacroRoleAttr *attr
@@ -1743,9 +1886,12 @@ ArrayRef<unsigned> ExpandPreambleMacroRequest::evaluate(
 
 std::optional<unsigned>
 ExpandBodyMacroRequest::evaluate(Evaluator &evaluator,
-                                 AbstractFunctionDecl *fn) const {
+                                 AnyFunctionRef fn) const {
+  auto *dc = fn.getAsDeclContext();
+  auto &ctx = dc->getASTContext();
   std::optional<unsigned> bufferID;
-  fn->forEachAttachedMacro(MacroRole::Body,
+  fn.forEachAttachedMacro(
+      MacroRole::Body,
       [&](CustomAttr *customAttr, MacroDecl *macro) {
         // FIXME: Should we complain if we already expanded a body macro?
         if (bufferID)
@@ -1753,7 +1899,6 @@ ExpandBodyMacroRequest::evaluate(Evaluator &evaluator,
 
         // '@StartTask' is gated behind the 'ConcurrencySyntaxSugar'
         // experimental feature.
-        auto &ctx = fn->getASTContext();
         if (macro->getParentModule()->getName().is("_Concurrency") &&
             macro->getBaseIdentifier().is("StartTask") &&
             !ctx.LangOpts.hasFeature(Feature::ConcurrencySyntaxSugar)) {
@@ -1764,8 +1909,16 @@ ExpandBodyMacroRequest::evaluate(Evaluator &evaluator,
           return;
         }
 
-        auto macroSourceFile = ::evaluateAttachedMacro(
-            macro, fn, customAttr, false, MacroRole::Body);
+        SourceFile * macroSourceFile = nullptr;
+        if (auto *fnDecl = fn.getAbstractFunctionDecl()) {
+          macroSourceFile = ::evaluateAttachedMacro(
+              macro, fnDecl, customAttr, false, MacroRole::Body);
+        } else if (auto *closure =
+            dyn_cast_or_null<ClosureExpr>(fn.getAbstractClosureExpr())) {
+          macroSourceFile = ::evaluateAttachedMacro(
+              macro, closure, customAttr, MacroRole::Body);
+        }
+
         if (!macroSourceFile)
           return;
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2764,12 +2764,6 @@ PreCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
 
 BraceStmt *PreCheckClosureBodyRequest::evaluate(Evaluator &evaluator,
                                                 ClosureExpr *closure) const {
-  // If this closure has an attached body macro, expand it now before
-  // type checking the body.
-  if (auto *expandedBody = closure->getExpandedBody()) {
-    closure->setBody(expandedBody);
-  }
-
   auto *body = closure->getBody();
 
   // If we have a single statement 'return', synthesize 'return ()' to ensure

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2764,6 +2764,12 @@ PreCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
 
 BraceStmt *PreCheckClosureBodyRequest::evaluate(Evaluator &evaluator,
                                                 ClosureExpr *closure) const {
+  // If this closure has an attached body macro, expand it now before
+  // type checking the body.
+  if (auto *expandedBody = closure->getExpandedBody()) {
+    closure->setBody(expandedBody);
+  }
+
   auto *body = closure->getBody();
 
   // If we have a single statement 'return', synthesize 'return ()' to ensure

--- a/test/Macros/start_task.swift
+++ b/test/Macros/start_task.swift
@@ -14,5 +14,15 @@ func sync() {
   await f()
 }
 
+func takeClosure(
+  _ closure: @escaping @Sendable () -> Void
+) {
+  closure()
+}
 
 
+func onClosure() {
+  takeClosure { @StartTask in
+    await f()
+  }
+}

--- a/test/Macros/start_task.swift
+++ b/test/Macros/start_task.swift
@@ -15,14 +15,107 @@ func sync() {
 }
 
 func takeClosure(
-  _ closure: @escaping @Sendable () -> Void
+  _ closure: @escaping @Sendable () -> Void,
+  v: Int = 42
 ) {
   closure()
 }
 
+func multipleClosures(
+  a: @escaping @Sendable () -> Void,
+  b: @escaping @Sendable () -> Void) {
+}
 
 func onClosure() {
+  // CHECK-LABEL: @__swiftmacro_10start_task0021start_taskswift_IfFDefMX35_16_33_EEC79532ED9A2723128F952F754D3F84Ll9StartTaskfMb_.swift
+  // CHECK: {
+  // CHECK:     Task {
+  // CHECK:         await f()
+  // CHECK:     }
+  // CHECK: }
   takeClosure { @StartTask in
     await f()
+  }
+
+  // CHECK-LABEL: @__swiftmacro_10start_task0021start_taskswift_IfFDefMX45_16_33_EEC79532ED9A2723128F952F754D3F84Ll9StartTaskfMb_.swift
+  // CHECK: {
+  // CHECK:     Task {
+  // CHECK:         await f()
+  // CHECK:     }
+  // CHECK: }
+  takeClosure({ @StartTask in
+    await f()
+  }, v: 0)
+
+  // CHECK-LABEL: @__swiftmacro_10start_task0021start_taskswift_IfFDefMX55_21_33_EEC79532ED9A2723128F952F754D3F84Ll9StartTaskfMb_.swift
+  // CHECK: {
+  // CHECK:     Task {
+  // CHECK:         await f()
+  // CHECK:     }
+  // CHECK: }
+  multipleClosures { @StartTask in
+    await f()
+  } b: {
+  }
+
+  // CHECK-LABEL: @__swiftmacro_10start_task0021start_taskswift_IfFDefMX68_9_33_EEC79532ED9A2723128F952F754D3F84Ll9StartTaskfMb_.swift
+  // CHECK: {
+  // CHECK:     Task {
+  // CHECK:         await f()
+  // CHECK:     }
+  // CHECK: }
+  multipleClosures {
+    _ = 42
+  } b: { @StartTask in
+    await f()
+  }
+
+  // CHECK-LABEL: @__swiftmacro_10start_task0021start_taskswift_IfFDefMX86_4_33_EEC79532ED9A2723128F952F754D3F84Ll9StartTaskfMb_.swift
+  // CHECK: {
+  // CHECK:     Task {
+  // CHECK:         _ = 42
+  // CHECK:     }
+  // CHECK: }
+  
+  // CHECK-LABEL: @__swiftmacro_10start_task0021start_taskswift_IfFDefMX88_9_33_EEC79532ED9A2723128F952F754D3F84Ll9StartTaskfMb_.swift
+  // CHECK: {
+  // CHECK:     Task {
+  // CHECK:         await f()
+  // CHECK:     }
+  // CHECK: }
+  multipleClosures {
+    @StartTask in
+    _ = 42
+  } b: { @StartTask in
+    await f()
+  }
+
+  // CHECK-LABEL: @__swiftmacro_10start_task0021start_taskswift_IfFDefMX100_12_33_EEC79532ED9A2723128F952F754D3F84Ll9StartTaskfMb_.swift
+  // CHECK: {
+  // CHECK:     Task {
+  // CHECK:         await f()
+  // CHECK:     }
+  // CHECK: }
+  let _ = {
+    func test() {
+      _ = { @StartTask in await f() }
+    }
+  }
+
+  // CHECK-LABEL: @__swiftmacro_10start_task0021start_taskswift_IfFDefMX114_54_33_EEC79532ED9A2723128F952F754D3F84Ll9StartTaskfMb_.swift
+  // CHECK: {
+  // CHECK:     Task {
+  // CHECK:         await test()
+  // CHECK:     }
+  // CHECK: }
+  let _ = {
+    let y = 42
+    func test() async { print(y) }
+    
+    if case let (_, closure) = (otherValue: 42, fn: { @StartTask in
+         await test()
+      }) {
+      let _: Task<(), Never> = closure()
+    }
   }
 }

--- a/test/Macros/start_task.swift
+++ b/test/Macros/start_task.swift
@@ -1,6 +1,6 @@
-// REQUIRES: swift_swift_parser, swift_feature_ConcurrencySyntaxSugar
+// REQUIRES: swift_swift_parser, swift_feature_ConcurrencySyntaxSugar, swift_feature_ClosureBodyMacro
 
-// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature ConcurrencySyntaxSugar -language-mode 6 %s -dump-macro-expansions 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature ConcurrencySyntaxSugar -enable-experimental-feature ClosureBodyMacro -language-mode 6 %s -dump-macro-expansions 2>&1 | %FileCheck %s
 
 func f() async {}
 


### PR DESCRIPTION
This change adds support for function body macros on closure expressions, gated behind the `ClosureBodyMacro` experimental feature.

This is pitched at https://forums.swift.org/t/pre-pitch-closure-body-macros/78534. The implementation does not match the current pitch for type checking behavior of macro arguments and expansions; I'll make that change in a follow up PR.