### PR TITLE
Align isolated conformances with the current proposal

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -279,6 +279,14 @@ public:
   struct Implementation;
   Implementation &getImpl() const;
 
+  struct GlobalCache;
+
+  /// Retrieve a reference to the global cache within this ASTContext,
+  /// which is a place where we can stash side tables without having to
+  /// recompile the world every time we add a side table. See
+  /// "swift/AST/ASTContextGlobalCache.h"
+  GlobalCache &getGlobalCache() const;
+
   friend ConstraintCheckerArenaRAII;
 
   void operator delete(void *Data) throw();

--- a/include/swift/AST/ASTContextGlobalCache.h
+++ b/include/swift/AST/ASTContextGlobalCache.h
@@ -1,0 +1,34 @@
+//===--- ASTContextGlobalCache.h - AST Context Cache ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the ASTContext::GlobalCache type. DO NOT include this
+// header from any other header: it should only be included in those .cpp
+// files that need to access the side tables. There are no include guards to
+// force the issue.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTContext.h"
+
+namespace swift {
+
+/// A collection of side tables associated with the ASTContext itself, meant
+// as
+struct ASTContext::GlobalCache {
+  /// Mapping from normal protocol conformances to the explicitly-specified
+  /// global actor isolations, e.g., when the conformance was spelled
+  /// `@MainActor P` or similar.
+  llvm::DenseMap<const NormalProtocolConformance *, TypeExpr *>
+      conformanceExplicitGlobalActorIsolation;
+};
+
+} // end namespace 

--- a/include/swift/AST/ConformanceAttributes.h
+++ b/include/swift/AST/ConformanceAttributes.h
@@ -17,6 +17,8 @@
 
 namespace swift {
 
+class TypeExpr;
+
 /// Describes all of the attributes that can occur on a conformance.
 struct ConformanceAttributes {
   /// The location of the "unchecked" attribute, if present.
@@ -28,9 +30,15 @@ struct ConformanceAttributes {
   /// The location of the "unsafe" attribute if present.
   SourceLoc unsafeLoc;
 
-  /// The location of the "@isolated" attribute if present.
-  SourceLoc isolatedLoc;
-  
+  /// The location of the "nonisolated" modifier, if present.
+  SourceLoc nonisolatedLoc;
+
+  /// The location of the '@' prior to the global actor type.
+  SourceLoc globalActorAtLoc;
+
+  /// The global actor type to which this conformance is isolated.
+  TypeExpr *globalActorType = nullptr;
+
   /// Merge other conformance attributes into this set.
   ConformanceAttributes &
   operator |=(const ConformanceAttributes &other) {
@@ -40,8 +48,12 @@ struct ConformanceAttributes {
       preconcurrencyLoc = other.preconcurrencyLoc;
     if (other.unsafeLoc.isValid())
       unsafeLoc = other.unsafeLoc;
-    if (other.isolatedLoc.isValid())
-      isolatedLoc = other.isolatedLoc;
+    if (other.nonisolatedLoc.isValid())
+      nonisolatedLoc = other.nonisolatedLoc;
+    if (other.globalActorType && !globalActorType) {
+      globalActorAtLoc = other.globalActorAtLoc;
+      globalActorType = other.globalActorType;
+    }
     return *this;
   }
 };

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1806,16 +1806,20 @@ private:
   /// This is true in cases like ~Copyable but not (P & ~Copyable).
   bool IsSuppressed : 1;
 
+  /// The global actor isolation provided (for a conformance).
+  TypeExpr *globalActorIsolationType = nullptr;
+
 public:
   InheritedEntry(const TypeLoc &typeLoc);
 
   InheritedEntry(const TypeLoc &typeLoc, ProtocolConformanceOptions options,
                  bool isSuppressed = false)
       : TypeLoc(typeLoc), RawOptions(options.toRaw()),
-        IsSuppressed(isSuppressed) {}
+        IsSuppressed(isSuppressed),
+        globalActorIsolationType(options.getGlobalActorIsolationType()) {}
 
   ProtocolConformanceOptions getOptions() const {
-    return ProtocolConformanceOptions(RawOptions);
+    return ProtocolConformanceOptions(RawOptions, globalActorIsolationType);
   }
 
   bool isUnchecked() const {
@@ -1827,8 +1831,12 @@ public:
   bool isPreconcurrency() const {
     return getOptions().contains(ProtocolConformanceFlags::Preconcurrency);
   }
-  bool isIsolated() const {
-    return getOptions().contains(ProtocolConformanceFlags::Isolated);
+  bool isNonisolated() const {
+    return getOptions().contains(ProtocolConformanceFlags::Nonisolated);
+  }
+
+  TypeExpr *getGlobalActorIsolationType() const {
+    return globalActorIsolationType;
   }
 
   ExplicitSafety getExplicitSafety() const {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8319,15 +8319,12 @@ ERROR(attr_abi_incompatible_with_silgen_name,none,
 //===----------------------------------------------------------------------===//
 // MARK: Isolated conformances
 //===----------------------------------------------------------------------===//
-ERROR(isolated_conformance_not_global_actor_isolated,none,
-      "isolated conformance is only permitted on global-actor-isolated types",
-      ())
 ERROR(isolated_conformance_experimental_feature,none,
       "isolated conformances require experimental feature "
       " 'IsolatedConformances'", ())
 ERROR(nonisolated_conformance_depends_on_isolated_conformance,none,
-      "conformance of %0 to %1 depends on %2 conformance of %3 to %4; mark it as 'isolated'",
-      (Type, DeclName, ActorIsolation, Type, DeclName))
+      "conformance of %0 to %1 depends on %2 conformance of %3 to %4; mark it as '%5'",
+      (Type, DeclName, ActorIsolation, Type, DeclName, StringRef))
 ERROR(isolated_conformance_mismatch_with_associated_isolation,none,
       "%0 conformance of %1 to %2 cannot depend on %3 conformance of %4 to %5",
       (ActorIsolation, Type, DeclName, ActorIsolation, Type, DeclName))
@@ -8335,15 +8332,15 @@ NOTE(add_isolated_to_conformance,none,
      "add '%0' to the %1 conformance to restrict it to %2 code",
     (StringRef, DeclName, ActorIsolation))
 ERROR(isolated_conformance_with_sendable,none,
-      "isolated conformance of %0 to %1 cannot be used to satisfy conformance "
+      "%4 conformance of %0 to %1 cannot be used to satisfy conformance "
       "requirement for a %select{`Sendable`|`SendableMetatype`}2 type "
-      "parameter %3", (Type, DeclName, bool, Type))
+      "parameter %3", (Type, DeclName, bool, Type, ActorIsolation))
 ERROR(isolated_conformance_with_sendable_simple,none,
-      "isolated conformance of %0 to %1 cannot be used to satisfy conformance "
-      "requirement for a `Sendable` type parameter ",
-      (Type, DeclName))
+      "%2 conformance of %0 to %1 cannot be used to satisfy "
+      "conformance requirement for a `Sendable` type parameter ",
+      (Type, DeclName, ActorIsolation))
 ERROR(isolated_conformance_wrong_domain,none,
-      "%0 isolated conformance of %1 to %2 cannot be used in %3 context",
+      "%0 conformance of %1 to %2 cannot be used in %3 context",
       (ActorIsolation, Type, DeclName, ActorIsolation))
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8332,8 +8332,8 @@ ERROR(isolated_conformance_mismatch_with_associated_isolation,none,
       "%0 conformance of %1 to %2 cannot depend on %3 conformance of %4 to %5",
       (ActorIsolation, Type, DeclName, ActorIsolation, Type, DeclName))
 NOTE(add_isolated_to_conformance,none,
-     "add 'isolated' to the %0 conformance to restrict it to %1 code",
-    (DeclName, ActorIsolation))
+     "add '%0' to the %1 conformance to restrict it to %2 code",
+    (StringRef, DeclName, ActorIsolation))
 ERROR(isolated_conformance_with_sendable,none,
       "isolated conformance of %0 to %1 cannot be used to satisfy conformance "
       "requirement for a %select{`Sendable`|`SendableMetatype`}2 type "

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -240,6 +240,14 @@ public:
   /// Otherwise a new conformance will be created.
   ProtocolConformance *getCanonicalConformance();
 
+  /// Determine the actor isolation of this conformance.
+  ActorIsolation getIsolation() const;
+
+  /// Determine whether this conformance is isolated to an actor.
+  bool isIsolated() const {
+    return getIsolation().isActorIsolated();
+  }
+
   /// Return true if the conformance has a witness for the given associated
   /// type.
   bool hasTypeWitness(AssociatedTypeDecl *assocType) const;
@@ -529,6 +537,7 @@ class NormalProtocolConformance : public RootProtocolConformance,
 {
   friend class ValueWitnessRequest;
   friend class TypeWitnessRequest;
+  friend class ConformanceIsolationRequest;
 
   /// The protocol being conformed to.
   ProtocolDecl *Protocol;
@@ -572,6 +581,9 @@ class NormalProtocolConformance : public RootProtocolConformance,
   friend class ASTContext;
 
   void resolveLazyInfo() const;
+
+  /// Set up global actor isolation for this conformance.
+  void setGlobalActorIsolation(Type globalActorType);
 
 public:
   NormalProtocolConformance(Type conformingType, ProtocolDecl *protocol,
@@ -672,16 +684,6 @@ public:
   /// Whether this is an preconcurrency conformance.
   bool isPreconcurrency() const {
     return getOptions().contains(ProtocolConformanceFlags::Preconcurrency);
-  }
-
-  /// Whether this is a global-actor isolated conformance.
-  bool isGlobalActorIsolated() const {
-    return getOptions().contains(
-        ProtocolConformanceFlags::GlobalActorIsolated);
-  }
-
-  TypeExpr *getGlobalActorIsolation() const {
-    return globalActorIsolation;
   }
 
   /// Retrieve the location of `@preconcurrency`, if there is one and it is

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -546,6 +546,9 @@ class NormalProtocolConformance : public RootProtocolConformance,
   /// NominalTypeDecl that declared the conformance.
   DeclContext *Context;
 
+  /// The global actor isolation for this conformance, if there is one.
+  TypeExpr *globalActorIsolation = nullptr;
+
   NormalProtocolConformance *ImplyingConformance = nullptr;
 
   /// The mapping of individual requirements in the protocol over to
@@ -593,6 +596,7 @@ public:
     Bits.NormalProtocolConformance.HasComputedAssociatedConformances = false;
     Bits.NormalProtocolConformance.SourceKind =
         unsigned(ConformanceEntryKind::Explicit);
+    globalActorIsolation = options.getGlobalActorIsolationType();
   }
 
   /// Get the protocol being conformed to.
@@ -634,7 +638,8 @@ public:
   void setInvalid() { Bits.NormalProtocolConformance.IsInvalid = true; }
 
   ProtocolConformanceOptions getOptions() const {
-    return ProtocolConformanceOptions(Bits.NormalProtocolConformance.Options);
+    return ProtocolConformanceOptions(Bits.NormalProtocolConformance.Options,
+                                      globalActorIsolation);
   }
 
   /// Whether this is an "unchecked" conformance.
@@ -669,9 +674,14 @@ public:
     return getOptions().contains(ProtocolConformanceFlags::Preconcurrency);
   }
 
-  /// Whether this is an isolated conformance.
-  bool isIsolated() const {
-    return getOptions().contains(ProtocolConformanceFlags::Isolated);
+  /// Whether this is a global-actor isolated conformance.
+  bool isGlobalActorIsolated() const {
+    return getOptions().contains(
+        ProtocolConformanceFlags::GlobalActorIsolated);
+  }
+
+  TypeExpr *getGlobalActorIsolation() const {
+    return globalActorIsolation;
   }
 
   /// Retrieve the location of `@preconcurrency`, if there is one and it is

--- a/include/swift/AST/ProtocolConformanceOptions.h
+++ b/include/swift/AST/ProtocolConformanceOptions.h
@@ -20,6 +20,8 @@
 
 namespace swift {
 
+class TypeExpr;
+
   /// Flags that describe extra attributes on protocol conformances.
 enum class ProtocolConformanceFlags {
   /// @unchecked conformance
@@ -34,16 +36,107 @@ enum class ProtocolConformanceFlags {
   /// @retroactive conformance
   Retroactive = 0x08,
 
-  /// @isolated conformance
-  Isolated = 0x10,
+  /// nonisolated, which suppresses and inferred global actor isolation
+  Nonisolated = 0x10,
+
+  /// The conformance is global-actor-isolated; the global actor will be
+  /// stored separately.
+  GlobalActorIsolated = 0x20,
 
   // Note: whenever you add a bit here, update
   // NumProtocolConformanceOptions below.
 };
 
+template<typename TheOptionSet>
+struct OptionSetStorageType;
+
+template<typename Flags, typename StorageType>
+struct OptionSetStorageType<OptionSet<Flags, StorageType>> {
+  using Type = StorageType;
+};
+
 /// Options that describe extra attributes on protocol conformances.
-using ProtocolConformanceOptions =
-    OptionSet<ProtocolConformanceFlags>;
+class ProtocolConformanceOptions {
+  /// The set of options.
+  OptionSet<ProtocolConformanceFlags> options;
+
+  /// Global actor isolation for this conformance.
+  TypeExpr *globalActorIsolationType = nullptr;
+
+public:
+  using StorageType =
+      OptionSetStorageType<OptionSet<ProtocolConformanceFlags>>::Type;
+
+  ProtocolConformanceOptions() { }
+
+  ProtocolConformanceOptions(ProtocolConformanceFlags flag)
+    : ProtocolConformanceOptions(static_cast<StorageType>(flag), nullptr) { }
+
+  ProtocolConformanceOptions(StorageType flagBits,
+                             TypeExpr *globalActorIsolationType)
+      : options(flagBits), globalActorIsolationType(globalActorIsolationType) {
+    assert(options.contains(ProtocolConformanceFlags::GlobalActorIsolated) ==
+           (bool)globalActorIsolationType);
+  }
+
+  bool contains(ProtocolConformanceFlags flag) const {
+    return options.contains(flag);
+  }
+
+  TypeExpr *getGlobalActorIsolationType() const {
+    return globalActorIsolationType;
+  }
+
+  void setGlobalActorIsolation(TypeExpr *globalActorIsolationType) {
+    options |= ProtocolConformanceFlags::GlobalActorIsolated;
+    this->globalActorIsolationType = globalActorIsolationType;
+  }
+
+  /// Retrieve the raw bits for just the flags part of the options. You also
+  /// need to get the global actor isolation (separately) to reconstitute the
+  /// options.
+  StorageType toRaw() const {
+    return options.toRaw();
+  }
+
+  ProtocolConformanceOptions &operator|=(ProtocolConformanceFlags flag) {
+    assert(flag != ProtocolConformanceFlags::GlobalActorIsolated &&
+           "global actor isolation requires a type; use setGlobalActorIsolation");
+    options |= flag;
+    return *this;
+  }
+
+  ProtocolConformanceOptions &
+  operator|=(const ProtocolConformanceOptions &other) {
+    options |= other.options;
+    if (other.globalActorIsolationType && !globalActorIsolationType)
+      globalActorIsolationType = other.globalActorIsolationType;
+    return *this;
+  }
+
+  ProtocolConformanceOptions &operator-=(ProtocolConformanceFlags flag) {
+    options -= flag;
+    if (flag == ProtocolConformanceFlags::GlobalActorIsolated)
+      globalActorIsolationType = nullptr;
+    return *this;
+  }
+
+  friend ProtocolConformanceOptions operator|(
+      const ProtocolConformanceOptions &lhs,
+      const ProtocolConformanceOptions &rhs) {
+    ProtocolConformanceOptions result(lhs);
+    result |= rhs;
+    return result;
+  }
+
+  friend ProtocolConformanceOptions operator-(
+      const ProtocolConformanceOptions &lhs,
+      ProtocolConformanceFlags flag) {
+    ProtocolConformanceOptions result(lhs);
+    result -= flag;
+    return result;
+  }
+};
 
 inline ProtocolConformanceOptions operator|(
     ProtocolConformanceFlags flag1,
@@ -52,7 +145,7 @@ inline ProtocolConformanceOptions operator|(
 }
 
 enum : unsigned {
-  NumProtocolConformanceOptions = 5
+  NumProtocolConformanceOptions = 6
 };
 
 } // end namespace swift

--- a/include/swift/AST/TypeAttr.def
+++ b/include/swift/AST/TypeAttr.def
@@ -65,6 +65,7 @@ SIMPLE_TYPE_ATTR(_local, Local)
 SIMPLE_TYPE_ATTR(_noMetadata, NoMetadata)
 TYPE_ATTR(_opaqueReturnTypeOf, OpaqueReturnTypeOf)
 TYPE_ATTR(isolated, Isolated)
+SIMPLE_TYPE_ATTR(nonisolated, Nonisolated)
 SIMPLE_TYPE_ATTR(_addressable, Addressable)
 TYPE_ATTR(execution, Execution)
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -478,7 +478,8 @@ public:
 class ConformanceIsolationRequest :
     public SimpleRequest<ConformanceIsolationRequest,
                          ActorIsolation(ProtocolConformance *),
-                         RequestFlags::Cached> {
+                         RequestFlags::SeparatelyCached |
+                         RequestFlags::SplitCached> {
 public:
   using SimpleRequest::SimpleRequest;
 
@@ -490,8 +491,10 @@ private:
   evaluate(Evaluator &evaluator, ProtocolConformance *conformance) const;
 
 public:
-  // Caching.
-  bool isCached() const;
+  // Separate caching.
+  bool isCached() const { return true; }
+  std::optional<ActorIsolation> getCachedResult() const;
+  void cacheResult(ActorIsolation result) const;
 };
 
 /// Determine whether the given declaration is 'final'.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -475,6 +475,25 @@ public:
   bool isCached() const { return true; }
 };
 
+class ConformanceIsolationRequest :
+    public SimpleRequest<ConformanceIsolationRequest,
+                         ActorIsolation(ProtocolConformance *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ActorIsolation
+  evaluate(Evaluator &evaluator, ProtocolConformance *conformance) const;
+
+public:
+  // Caching.
+  bool isCached() const;
+};
+
 /// Determine whether the given declaration is 'final'.
 class IsFinalRequest :
     public SimpleRequest<IsFinalRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -407,6 +407,9 @@ SWIFT_REQUEST(TypeChecker, PolymorphicEffectRequirementsRequest,
 SWIFT_REQUEST(TypeChecker, ConformanceHasEffectRequest,
               bool(EffectKind, ProtocolConformanceRef),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ConformanceIsolationRequest,
+              ActorIsolation(ProtocolConformance *), Cached,
+              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeRequest,
               Type (const TypeResolution *, TypeRepr *, GenericParamList *),
               Uncached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -408,7 +408,8 @@ SWIFT_REQUEST(TypeChecker, ConformanceHasEffectRequest,
               bool(EffectKind, ProtocolConformanceRef),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ConformanceIsolationRequest,
-              ActorIsolation(ProtocolConformance *), Cached,
+              ActorIsolation(ProtocolConformance *),
+              SeparatelyCached | SplitCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeRequest,
               Type (const TypeResolution *, TypeRepr *, GenericParamList *),

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -154,6 +154,10 @@ public:
   /// or return an invalid source location if there is no such attribute.
   SourceLoc findAttrLoc(TypeAttrKind kind) const;
 
+  /// Find a custom attribute within this type, or return NULL if there is
+  /// no such attribute.
+  CustomAttr *findCustomAttr() const;
+
   /// Is this type grammatically a type-simple?
   inline bool isSimple() const; // bottom of this file
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -18,6 +18,7 @@
 #include "ClangTypeConverter.h"
 #include "ForeignRepresentationInfo.h"
 #include "SubstitutionMapStorage.h"
+#include "swift/AST/ASTContextGlobalCache.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/AvailabilityContextStorage.h"
 #include "swift/AST/ClangModuleLoader.h"
@@ -269,6 +270,9 @@ struct ASTContext::Implementation {
   ~Implementation();
 
   llvm::BumpPtrAllocator Allocator; // used in later initializations
+
+  /// The global cache of side tables for random things.
+  GlobalCache globalCache;
 
   /// The set of cleanups to be called when the ASTContext is destroyed.
   std::vector<std::function<void(void)>> Cleanups;
@@ -745,6 +749,10 @@ inline ASTContext::Implementation &ASTContext::getImpl() const {
   auto offset = llvm::alignAddr((void *)sizeof(*this),
                                 llvm::Align(alignof(Implementation)));
   return *reinterpret_cast<Implementation*>(pointer + offset);
+}
+
+ASTContext::GlobalCache &ASTContext::getGlobalCache() const {
+  return getImpl().globalCache;
 }
 
 void ASTContext::operator delete(void *Data) throw() {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2924,6 +2924,18 @@ void PrintAST::printInherited(const Decl *decl) {
           Printer << "@unsafe ";
         break;
       }
+
+      if (auto globalActor = inherited.getGlobalActorIsolationType()) {
+        TypeLoc globalActorTL(globalActor->getTypeRepr(),
+                              globalActor->getInstanceType());
+        Printer << "@";
+        printTypeLoc(globalActorTL);
+        Printer << " ";
+      }
+
+      if (inherited.isNonisolated())
+        Printer << "nonisolated ";
+
       if (inherited.isSuppressed())
         Printer << "~";
     });

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7915,8 +7915,7 @@ static void getSyntacticInheritanceClause(const ProtocolDecl *proto,
   if (auto superclassTy = genericSig->getSuperclassBound(
         proto->getSelfInterfaceType())) {
     Results.emplace_back(TypeLoc::withoutLoc(superclassTy),
-                         ProtocolConformanceOptions(),
-                         /*isPreconcurrency=*/false);
+                         ProtocolConformanceOptions());
   }
 
   InvertibleProtocolSet inverses = InvertibleProtocolSet::allKnown();

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -154,8 +154,10 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
         options |= ProtocolConformanceFlags::Preconcurrency;
       if (getUnsafeLoc().isValid())
         options |= ProtocolConformanceFlags::Unsafe;
-      if (getIsolatedLoc().isValid())
-        options |= ProtocolConformanceFlags::Isolated;
+      if (getNonisolatedLoc().isValid())
+        options |= ProtocolConformanceFlags::Nonisolated;
+      if (attributes.globalActorType)
+        options.setGlobalActorIsolation(attributes.globalActorType);
       return options;
     }
 
@@ -211,9 +213,9 @@ class ConformanceLookupTable : public ASTAllocated<ConformanceLookupTable> {
       return attributes.unsafeLoc;
     }
 
-    /// The location of the @isolated attribute, if any.
-    SourceLoc getIsolatedLoc() const {
-      return attributes.isolatedLoc;
+    /// The location of the isolated modifier, if any.
+    SourceLoc getNonisolatedLoc() const {
+      return attributes.nonisolatedLoc;
     }
 
     /// For an inherited conformance, retrieve the class declaration

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -474,6 +474,17 @@ void NormalProtocolConformance::resolveLazyInfo() const {
   loader->finishNormalConformance(mutableThis, LoaderContextData);
 }
 
+void NormalProtocolConformance::setGlobalActorIsolation(Type globalActorType) {
+  ASTContext &ctx = getDeclContext()->getASTContext();
+  if (globalActorIsolation)
+    globalActorIsolation->setType(MetatypeType::get(globalActorType));
+  else
+    globalActorIsolation = TypeExpr::createImplicit(globalActorType, ctx);
+
+  Bits.NormalProtocolConformance.Options |=
+      static_cast<unsigned>(ProtocolConformanceFlags::GlobalActorIsolated);
+}
+
 void NormalProtocolConformance::setLazyLoader(LazyConformanceLoader *loader,
                                               uint64_t contextData) {
   assert(!Loader && "already has a loader");

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "ConformanceLookupTable.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ASTContextGlobalCache.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DistributedDecl.h"
@@ -474,22 +475,31 @@ void NormalProtocolConformance::resolveLazyInfo() const {
   loader->finishNormalConformance(mutableThis, LoaderContextData);
 }
 
-void NormalProtocolConformance::setGlobalActorIsolation(Type globalActorType) {
-  ASTContext &ctx = getDeclContext()->getASTContext();
-  if (globalActorIsolation)
-    globalActorIsolation->setType(MetatypeType::get(globalActorType));
-  else
-    globalActorIsolation = TypeExpr::createImplicit(globalActorType, ctx);
-
-  Bits.NormalProtocolConformance.Options |=
-      static_cast<unsigned>(ProtocolConformanceFlags::GlobalActorIsolated);
-}
-
 void NormalProtocolConformance::setLazyLoader(LazyConformanceLoader *loader,
                                               uint64_t contextData) {
   assert(!Loader && "already has a loader");
   Loader = loader;
   LoaderContextData = contextData;
+}
+
+TypeExpr *NormalProtocolConformance::getExplicitGlobalActorIsolation() const {
+  if (!Bits.NormalProtocolConformance.HasExplicitGlobalActor)
+    return nullptr;
+
+  ASTContext &ctx = getDeclContext()->getASTContext();
+  return ctx.getGlobalCache().conformanceExplicitGlobalActorIsolation[this];
+}
+
+void
+NormalProtocolConformance::setExplicitGlobalActorIsolation(TypeExpr *typeExpr) {
+  if (!typeExpr) {
+    Bits.NormalProtocolConformance.HasExplicitGlobalActor = false;
+    return;
+  }
+
+  Bits.NormalProtocolConformance.HasExplicitGlobalActor = true;
+  ASTContext &ctx = getDeclContext()->getASTContext();
+  ctx.getGlobalCache().conformanceExplicitGlobalActorIsolation[this] = typeExpr;
 }
 
 namespace {

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -406,7 +406,7 @@ bool ProtocolConformanceRef::forEachIsolatedConformance(
   auto concrete = getConcrete();
   if (auto normal =
           dyn_cast<NormalProtocolConformance>(concrete->getRootConformance())) {
-    if (normal->isIsolated()) {
+    if (normal->isGlobalActorIsolated()) {
       if (body(concrete))
         return true;
     }

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -406,7 +406,7 @@ bool ProtocolConformanceRef::forEachIsolatedConformance(
   auto concrete = getConcrete();
   if (auto normal =
           dyn_cast<NormalProtocolConformance>(concrete->getRootConformance())) {
-    if (normal->isGlobalActorIsolated()) {
+    if (normal->isIsolated()) {
       if (body(concrete))
         return true;
     }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1381,7 +1381,18 @@ bool ConformanceIsolationRequest::isCached() const {
   if (!rootNormal)
     return false;
 
-  return rootNormal->isGlobalActorIsolated();
+  if (rootNormal->globalActorIsolation)
+    return true;
+
+  // If we might infer conformance isolation, then we should cache the result.
+  auto dc = rootNormal->getDeclContext();
+  auto nominal = dc->getSelfNominalTypeDecl();
+  if (nominal &&
+      ((isa<ClassDecl>(nominal) && cast<ClassDecl>(nominal)->isActor()) ||
+       nominal->getSemanticAttrs().hasAttribute<NonisolatedAttr>()))
+    return false;
+
+  return true;
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1369,6 +1369,22 @@ void AssociatedConformanceRequest::cacheResult(
 }
 
 //----------------------------------------------------------------------------//
+// ConformanceIsolationRequest computation.
+//----------------------------------------------------------------------------//
+bool ConformanceIsolationRequest::isCached() const {
+  // We only want to cache for global-actor-isolated conformances. For
+  // everything else, which is nearly every conformance, this request quickly
+  // returns "nonisolated" so there is no point in caching it.
+  auto conformance = std::get<0>(getStorage());
+  auto rootNormal =
+      dyn_cast<NormalProtocolConformance>(conformance->getRootConformance());
+  if (!rootNormal)
+    return false;
+
+  return rootNormal->isGlobalActorIsolated();
+}
+
+//----------------------------------------------------------------------------//
 // HasCircularInheritedProtocolsRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1381,6 +1381,11 @@ bool ConformanceIsolationRequest::isCached() const {
   if (!rootNormal)
     return false;
 
+  // We know this is nonisolated.
+  if (rootNormal->getOptions().contains(ProtocolConformanceFlags::Nonisolated))
+    return false;
+
+  // Explicit global actor isolation needs to be checked.
   if (rootNormal->globalActorIsolation)
     return true;
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -151,8 +151,13 @@ SourceLoc TypeRepr::findAttrLoc(TypeAttrKind kind) const {
   while (auto attrTypeRepr = dyn_cast<AttributedTypeRepr>(typeRepr)) {
     for (auto attr : attrTypeRepr->getAttrs()) {
       if (auto typeAttr = attr.dyn_cast<TypeAttribute*>())
-        if (typeAttr->getKind() == kind)
-          return typeAttr->getStartLoc();
+        if (typeAttr->getKind() == kind) {
+          auto startLoc = typeAttr->getStartLoc();
+          if (startLoc.isValid())
+            return startLoc;
+
+          return typeAttr->getAttrLoc();
+        }
     }
 
     typeRepr = attrTypeRepr->getTypeRepr();

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -161,6 +161,20 @@ SourceLoc TypeRepr::findAttrLoc(TypeAttrKind kind) const {
   return SourceLoc();
 }
 
+CustomAttr *TypeRepr::findCustomAttr() const {
+  auto typeRepr = this;
+  while (auto attrTypeRepr = dyn_cast<AttributedTypeRepr>(typeRepr)) {
+    for (auto attr : attrTypeRepr->getAttrs()) {
+      if (auto typeAttr = attr.dyn_cast<CustomAttr*>())
+        return typeAttr;
+    }
+
+    typeRepr = attrTypeRepr->getTypeRepr();
+  }
+
+  return nullptr;
+}
+
 DeclRefTypeRepr::DeclRefTypeRepr(TypeReprKind K, DeclNameRef Name,
                                  DeclNameLoc NameLoc, unsigned NumGenericArgs,
                                  bool HasAngleBrackets)

--- a/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
@@ -53,6 +53,7 @@ extension ASTGenVisitor {
         .preconcurrency,
         .local,
         .noMetadata,
+        .nonisolated,
         .packGuaranteed,
         .packInout,
         .packOut,

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3209,6 +3209,7 @@ void CompletionLookup::getTypeAttributeKeywordCompletions(
       switch (Kind) {
       case TypeAttrKind::Retroactive:
       case TypeAttrKind::Preconcurrency:
+      case TypeAttrKind::Nonisolated:
       case TypeAttrKind::Unchecked:
       case TypeAttrKind::Unsafe:
         // These attributes are only available in inheritance clasuses.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -94,11 +94,6 @@
 using namespace swift;
 using namespace irgen;
 
-namespace swift {
-  // FIXME: Move this on to ProtocolConformance?
-  ActorIsolation getConformanceIsolation(ProtocolConformance *conformance);
-}
-
 namespace {
 
 /// A class for computing how to pass arguments to a polymorphic
@@ -2238,10 +2233,11 @@ namespace {
     void addFlags() {
       // Miscellaneous flags.
       if (auto conf = dyn_cast<NormalProtocolConformance>(Conformance)) {
+        auto isolation = conf->getIsolation();
         Flags = Flags.withIsRetroactive(conf->isRetroactive());
         Flags = Flags.withIsSynthesizedNonUnique(conf->isSynthesizedNonUnique());
         Flags = Flags.withIsConformanceOfProtocol(conf->isConformanceOfProtocol());
-        Flags = Flags.withHasGlobalActorIsolation(conf->isGlobalActorIsolated());
+        Flags = Flags.withHasGlobalActorIsolation(isolation.isGlobalActor());
       } else {
         Flags = Flags.withIsRetroactive(false)
                      .withIsSynthesizedNonUnique(false);
@@ -2435,13 +2431,11 @@ namespace {
         return;
 
       auto normal = cast<NormalProtocolConformance>(Conformance);
-      assert(normal->isGlobalActorIsolated());
       auto nominal = normal->getDeclContext()->getSelfNominalTypeDecl();
 
       // Add global actor type.
       auto sig = nominal->getGenericSignatureOfContext();
-      auto isolation = getConformanceIsolation(
-          const_cast<RootProtocolConformance *>(Conformance));
+      auto isolation = Conformance->getIsolation();
       assert(isolation.isGlobalActor());
       Type globalActorType = isolation.getGlobalActor();
       auto globalActorTypeName = IGM.getTypeRef(

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2241,7 +2241,7 @@ namespace {
         Flags = Flags.withIsRetroactive(conf->isRetroactive());
         Flags = Flags.withIsSynthesizedNonUnique(conf->isSynthesizedNonUnique());
         Flags = Flags.withIsConformanceOfProtocol(conf->isConformanceOfProtocol());
-        Flags = Flags.withHasGlobalActorIsolation(conf->isIsolated());
+        Flags = Flags.withHasGlobalActorIsolation(conf->isGlobalActorIsolated());
       } else {
         Flags = Flags.withIsRetroactive(false)
                      .withIsSynthesizedNonUnique(false);
@@ -2435,7 +2435,7 @@ namespace {
         return;
 
       auto normal = cast<NormalProtocolConformance>(Conformance);
-      assert(normal->isIsolated());
+      assert(normal->isGlobalActorIsolated());
       auto nominal = normal->getDeclContext()->getSelfNominalTypeDecl();
 
       // Add global actor type.

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -413,6 +413,15 @@ ParserResult<TypeRepr> Parser::parseTypeScalar(
     return makeParserCodeCompletionResult<TypeRepr>(ET);
   }
 
+  // "nonisolated" for attribute lists.
+  if (reason == ParseTypeReason::InheritanceClause &&
+      Tok.isContextualKeyword("nonisolated")) {
+    SourceLoc nonisolatedLoc = consumeToken();
+    parsedAttributeList.Attributes.push_back(
+        TypeAttribute::createSimple(Context, TypeAttrKind::Nonisolated,
+                                    SourceLoc(), nonisolatedLoc));
+  }
+
   // Parse generic parameters in SIL mode.
   GenericParamList *generics = nullptr;
   SourceLoc substitutedLoc;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -16,6 +16,7 @@
 
 #include "CSDiagnostics.h"
 #include "MiscDiagnostics.h"
+#include "TypeCheckConcurrency.h"
 #include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
 #include "TypoCorrection.h"
@@ -9566,7 +9567,8 @@ bool IncorrectInlineArrayLiteralCount::diagnoseAsError() {
 bool DisallowedIsolatedConformance::diagnoseAsError() {
   emitDiagnostic(diag::isolated_conformance_with_sendable_simple,
                  conformance->getType(),
-                 conformance->getProtocol()->getName());
+                 conformance->getProtocol()->getName(),
+                 getConformanceIsolation(conformance));
 
   auto selectedOverload = getCalleeOverloadChoiceIfAvailable(getLocator());
   if (!selectedOverload)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -9568,7 +9568,7 @@ bool DisallowedIsolatedConformance::diagnoseAsError() {
   emitDiagnostic(diag::isolated_conformance_with_sendable_simple,
                  conformance->getType(),
                  conformance->getProtocol()->getName(),
-                 getConformanceIsolation(conformance));
+                 conformance->getIsolation());
 
   auto selectedOverload = getCalleeOverloadChoiceIfAvailable(getLocator());
   if (!selectedOverload)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7913,10 +7913,13 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
     return ActorIsolation::forGlobalActor(globalActorType);
   }
 
-  // In a context where we are inferring @MainActor, if the conforming type
-  // is on the main actor, then the conformance is, too.
   auto dc = rootNormal->getDeclContext();
   ASTContext &ctx = dc->getASTContext();
+  if (!ctx.LangOpts.hasFeature(Feature::IsolatedConformances))
+    return ActorIsolation::forNonisolated(false);
+
+  // In a context where we are inferring @MainActor, if the conforming type
+  // is on the main actor, then the conformance is, too.
   auto nominal = dc->getSelfNominalTypeDecl();
   if (ctx.LangOpts.hasFeature(Feature::UnspecifiedMeansMainActorIsolated) &&
       nominal) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7918,6 +7918,11 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
   if (!ctx.LangOpts.hasFeature(Feature::IsolatedConformances))
     return ActorIsolation::forNonisolated(false);
 
+  // If the protocol itself is isolated, don't infer isolation for the
+  // conformance.
+  if (getActorIsolation(rootNormal->getProtocol()).isActorIsolated())
+    return ActorIsolation::forNonisolated(false);
+
   // In a context where we are inferring @MainActor, if the conforming type
   // is on the main actor, then the conformance is, too.
   auto nominal = dc->getSelfNominalTypeDecl();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7890,7 +7890,7 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
 
   // If there is an explicitly-specified global actor on the isolation,
   // resolve it and report it.
-  if (auto globalActorTypeExpr = rootNormal->globalActorIsolation) {
+  if (auto globalActorTypeExpr = rootNormal->getExplicitGlobalActorIsolation()) {
     // If we don't already have a resolved global actor type, resolve it now.
     Type globalActorType = globalActorTypeExpr->getInstanceType();
     if (!globalActorType) {
@@ -7925,7 +7925,6 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
       nominal) {
     auto nominalIsolation = getActorIsolation(nominal);
     if (nominalIsolation.isMainActor()) {
-      rootNormal->setGlobalActorIsolation(nominalIsolation.getGlobalActor());
       return nominalIsolation;
     }
   }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -699,10 +699,6 @@ void introduceUnsafeInheritExecutorReplacements(
 void introduceUnsafeInheritExecutorReplacements(
     const DeclContext *dc, Type base, SourceLoc loc, LookupResult &result);
 
-/// Determine the isolation of the given conformance. This only applies to
-/// the immediate conformance, not any conformances on which it depends.
-ActorIsolation getConformanceIsolation(ProtocolConformance *conformance);
-
 /// Check for correct use of isolated conformances in the given reference.
 ///
 /// This checks that any isolated conformances that occur in the given

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -938,7 +938,7 @@ void TypeChecker::diagnoseRequirementFailure(
             .IsolatedConformanceProto->isSpecificProtocol(
               KnownProtocolKind::SendableMetatype),
           req.getFirstType(),
-          getConformanceIsolation(isolatedConformance));
+          isolatedConformance->getIsolation());
       diagnosticNote = diag::type_does_not_inherit_or_conform_requirement;
       break;
     }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -13,6 +13,7 @@
 // This file implements support for generics.
 //
 //===----------------------------------------------------------------------===//
+#include "TypeCheckConcurrency.h"
 #include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
@@ -936,7 +937,8 @@ void TypeChecker::diagnoseRequirementFailure(
           reqFailureInfo
             .IsolatedConformanceProto->isSpecificProtocol(
               KnownProtocolKind::SendableMetatype),
-          req.getFirstType());
+          req.getFirstType(),
+          getConformanceIsolation(isolatedConformance));
       diagnosticNote = diag::type_does_not_inherit_or_conform_requirement;
       break;
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2544,7 +2544,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
 
   // Complain if the conformance is isolated but the conforming type is
   // not global-actor-isolated.
-  if (conformance->isIsolated()) {
+  if (conformance->isGlobalActorIsolated()) {
     auto enclosingNominal = DC->getSelfNominalTypeDecl();
     if (!enclosingNominal ||
         !getActorIsolation(enclosingNominal).isGlobalActor()) {
@@ -3403,7 +3403,7 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
     // If the conformance itself is isolated, and the witness isolation
     // matches the enclosing type's isolation, treat this as being in the
     // same concurrency domain.
-    if (Conformance->isIsolated() &&
+    if (Conformance->isGlobalActorIsolated() &&
         refResult.isolation.isGlobalActor() &&
         isolationMatchesEnclosingType(
             refResult.isolation, DC->getSelfNominalTypeDecl())) {
@@ -3592,7 +3592,8 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
     // Another way to address the issue is to mark the conformance as
     // "isolated" or "@preconcurrency".
     if (Conformance->getSourceKind() == ConformanceEntryKind::Explicit &&
-        !Conformance->isIsolated() && !Conformance->isPreconcurrency() &&
+        !Conformance->isGlobalActorIsolated() &&
+        !Conformance->isPreconcurrency() &&
         !suggestedPreconcurrencyOrIsolated &&
         !requirementIsolation.isActorIsolated()) {
       if (Context.LangOpts.hasFeature(Feature::IsolatedConformances)) {
@@ -5237,7 +5238,7 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
             [&](ProtocolConformance *isolatedConformance) {
               // If the conformance we're checking isn't isolated at all, it
               // needs "isolated".
-              if (!conformance->isIsolated()) {
+              if (!conformance->isGlobalActorIsolated()) {
                 ctx.Diags.diagnose(
                     conformance->getLoc(),
                     diag::nonisolated_conformance_depends_on_isolated_conformance,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3574,12 +3574,12 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
     // Another way to address the issue is to mark the conformance as
     // isolated to the global actor or "@preconcurrency".
     if (Conformance->getSourceKind() == ConformanceEntryKind::Explicit &&
-        !Conformance->getIsolation().isGlobalActor() &&
+        !Conformance->isIsolated() &&
         !Conformance->isPreconcurrency() &&
         !suggestedPreconcurrencyOrIsolated &&
-        !requirementIsolation.isActorIsolated() &&
-        refResult.isolation.isGlobalActor()) {
-      if (Context.LangOpts.hasFeature(Feature::IsolatedConformances)) {
+        !requirementIsolation.isActorIsolated()) {
+      if (Context.LangOpts.hasFeature(Feature::IsolatedConformances) &&
+          refResult.isolation.isGlobalActor()) {
         std::string globalActorStr = "@" +
             refResult.isolation.getGlobalActor().getString();
         Context.Diags.diagnose(Conformance->getProtocolNameLoc(),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3590,17 +3590,22 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
     }
     
     // Another way to address the issue is to mark the conformance as
-    // "isolated" or "@preconcurrency".
+    // isolated to the global actor or "@preconcurrency".
     if (Conformance->getSourceKind() == ConformanceEntryKind::Explicit &&
         !Conformance->isGlobalActorIsolated() &&
         !Conformance->isPreconcurrency() &&
         !suggestedPreconcurrencyOrIsolated &&
-        !requirementIsolation.isActorIsolated()) {
+        !requirementIsolation.isActorIsolated() &&
+        refResult.isolation.isGlobalActor()) {
       if (Context.LangOpts.hasFeature(Feature::IsolatedConformances)) {
+        std::string globalActorStr = "@" +
+            refResult.isolation.getGlobalActor().getString();
         Context.Diags.diagnose(Conformance->getProtocolNameLoc(),
                                diag::add_isolated_to_conformance,
+                               globalActorStr,
                                Proto->getName(), refResult.isolation)
-            .fixItInsert(Conformance->getProtocolNameLoc(), "isolated ");
+            .fixItInsert(Conformance->getProtocolNameLoc(),
+                         globalActorStr + " ");
       }
 
       Context.Diags.diagnose(Conformance->getProtocolNameLoc(),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3495,6 +3495,13 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
     return false;
   };
 
+  // If we're in an inheritance clause, check for a global actor.
+  if (options.is(TypeResolverContext::Inherited)) {
+    CustomAttr *customAttr = nullptr;
+    (void)resolveGlobalActor(repr->getLoc(), options,
+                             customAttr, attrs);
+  }
+
   if (handleInheritedOnly(claim<UncheckedTypeAttr>(attrs)) ||
       handleInheritedOnly(claim<PreconcurrencyTypeAttr>(attrs)) ||
       handleInheritedOnly(claim<UnsafeTypeAttr>(attrs)))

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3504,7 +3504,8 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
 
   if (handleInheritedOnly(claim<UncheckedTypeAttr>(attrs)) ||
       handleInheritedOnly(claim<PreconcurrencyTypeAttr>(attrs)) ||
-      handleInheritedOnly(claim<UnsafeTypeAttr>(attrs)))
+      handleInheritedOnly(claim<UnsafeTypeAttr>(attrs)) ||
+      handleInheritedOnly(claim<NonisolatedTypeAttr>(attrs)))
     return ty;
 
   if (auto retroactiveAttr = claim<RetroactiveTypeAttr>(attrs)) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 924; // ExtensibleEnums feature
+const uint16_t SWIFTMODULE_VERSION_MINOR = 925; // isolated conformances
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2086,6 +2086,7 @@ namespace decls_block {
     BCVBR<5>, // value mapping count
     BCVBR<5>, // requirement signature conformance count
     BCVBR<5>, // options
+    TypeIDField, // global actor isolation of conformance
     BCArray<DeclIDField>
     // The array contains requirement signature conformances, then
     // type witnesses, then value witnesses.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1929,10 +1929,7 @@ void Serializer::writeLocalNormalProtocolConformance(
 
   // Figure out the isolation of the conformance.
   Type globalActorType;
-  auto isolation = evaluateOrDefault(
-      getASTContext().evaluator,
-      ConformanceIsolationRequest{conformance}, swift::ActorIsolation());
-  switch (isolation) {
+  switch (auto isolation = conformance->getIsolation()) {
   case swift::ActorIsolation::Unspecified:
   case swift::ActorIsolation::Nonisolated:
     break;

--- a/test/Concurrency/Runtime/isolated_conformance.swift
+++ b/test/Concurrency/Runtime/isolated_conformance.swift
@@ -16,13 +16,32 @@ protocol P {
   func f()
 }
 
-@MainActor
-class MyClass: @MainActor P {
+protocol Q {
+  func g()
+}
+
+nonisolated class MyClass: @MainActor P {
   func f() {
     print("MyClass.f()")
 
     // Make sure we're on the main actor.
     MainActor.assumeIsolated { }
+  }
+}
+
+actor SomeActor { }
+
+@globalActor
+struct SomeGlobalActor {
+  static let shared = SomeActor()
+}
+
+extension MyClass: @SomeGlobalActor Q {
+  @SomeGlobalActor func g() {
+    print("MyClass.g()")
+
+    // Make sure we're on this actor.
+    SomeGlobalActor.shared.assumeIsolated { _ in }
   }
 }
 
@@ -34,6 +53,13 @@ extension Wrapper: P where T: P {
   func f() {
     print("Wrapper for ", terminator: "")
     wrapped.f()
+  }
+}
+
+extension Wrapper: Q where T: Q {
+  func g() {
+    print("Wrapper for ", terminator: "")
+    wrapped.g()
   }
 }
 
@@ -49,12 +75,21 @@ extension WrapMany: P where repeat each T: P {
   }
 }
 
-extension Int: P {
-  func f() { }
+@available(SwiftStdlib 5.9, *)
+extension WrapMany: Q where repeat each T: Q {
+  func g() {
+    print("Wrapper for many")
+  }
 }
 
-extension String: P {
+extension Int: P, Q {
   func f() { }
+  func g() { }
+}
+
+extension String: P, Q {
+  func f() { }
+  func g() { }
 }
 
 func tryCastToP(_ value: any Sendable) -> Bool {
@@ -67,12 +102,22 @@ func tryCastToP(_ value: any Sendable) -> Bool {
   return false
 }
 
+func tryCastToQ(_ value: any Sendable) -> Bool {
+  if let q = value as? any Q {
+    q.g()
+    return true
+  }
+
+  print("Conformance did not match")
+  return false
+}
+
 // CHECK: Testing on the main actor
 // CHECK-NEXT: MyClass.f()
 // CHECK-NEXT: Wrapper for MyClass.f()
 print("Testing on the main actor")
-let mc = MyClass()
-let wrappedMC = Wrapper(wrapped: mc)
+nonisolated let mc = MyClass()
+nonisolated let wrappedMC = Wrapper(wrapped: mc)
 precondition(tryCastToP(mc))
 precondition(tryCastToP(wrappedMC))
 
@@ -96,12 +141,33 @@ await Task.detached { @MainActor in
 
 }.value
 
+// CHECK: Testing a separate task on a different global actor
+// CHECK-NEXT: MyClass.g()
+// CHECK-NEXT: Wrapper for MyClass.g()
+print("Testing a separate task on a different global actor")
+await Task.detached { @SomeGlobalActor in
+  precondition(tryCastToQ(mc))
+  precondition(tryCastToQ(wrappedMC))
+
+  if #available(SwiftStdlib 5.9, *) {
+    let wrappedMany = WrapMany(wrapped: (17, mc, "Pack"))
+    precondition(tryCastToQ(wrappedMany))
+  }
+
+  // Not on the main actor any more.
+  precondition(!tryCastToP(mc))
+  precondition(!tryCastToP(wrappedMC))
+}.value
+
 // CHECK: Testing a separate task off the main actor
 print("Testing a separate task off the main actor")
 await Task.detached {
   if #available(SwiftStdlib 6.2, *) {
     precondition(!tryCastToP(mc))
     precondition(!tryCastToP(wrappedMC))
+
+    precondition(!tryCastToQ(mc))
+    precondition(!tryCastToQ(wrappedMC))
 
     let wrappedMany = WrapMany(wrapped: (17, mc, "Pack"))
     precondition(!tryCastToP(wrappedMany))

--- a/test/Concurrency/Runtime/isolated_conformance.swift
+++ b/test/Concurrency/Runtime/isolated_conformance.swift
@@ -17,7 +17,7 @@ protocol P {
 }
 
 @MainActor
-class MyClass: isolated P {
+class MyClass: @MainActor P {
   func f() {
     print("MyClass.f()")
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -12,7 +12,7 @@ protocol P {
 // ----------------------------------------------------------------------------
 
 // expected-note@+3{{add '@preconcurrency' to the 'P' conformance to defer isolation checking to run time}}{{25-25=@preconcurrency }}
-// expected-note@+2{{add 'isolated' to the 'P' conformance to restrict it to main actor-isolated code}}{{25-25=isolated }}
+// expected-note@+2{{add '@MainActor' to the 'P' conformance to restrict it to main actor-isolated code}}{{25-25=@MainActor }}
 @MainActor
 class CWithNonIsolated: P {
   func f() { } // expected-error{{main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -22,11 +22,11 @@ class CWithNonIsolated: P {
 actor SomeActor { }
 
 // Isolated conformances need a global-actor-constrained type.
-class CNonIsolated: isolated P { // expected-error{{isolated conformance is only permitted on global-actor-isolated types}}
+class CNonIsolated: @MainActor P { // expected-error{{isolated conformance is only permitted on global-actor-isolated types}}
   func f() { }
 }
 
-extension SomeActor: isolated P { // expected-error{{isolated conformance is only permitted on global-actor-isolated types}}
+extension SomeActor: @MainActor P { // expected-error{{isolated conformance is only permitted on global-actor-isolated types}}
   nonisolated func f() { }
 }
 
@@ -35,14 +35,14 @@ struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
-// Isolation of the function needs to match that of the enclosing type.
+// Isolation of the conformance needs to match that of the enclosing type.
 @MainActor
-class CMismatchedIsolation: isolated P {
+class CMismatchedIsolation: @SomeGlobalActor P {
   @SomeGlobalActor func f() { } // expected-error{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
 }
 
 @MainActor
-class C: isolated P {
+class C: @MainActor P {
   func f() { } // okay
 }
 
@@ -69,18 +69,18 @@ struct SMissingIsolationViaWrapper: Q {
 }
 
 @SomeGlobalActor
-class C2: isolated P {
+class C2: @SomeGlobalActor P {
   func f() { }
 }
 
 @MainActor
-struct S: isolated Q {
+struct S: @MainActor Q {
   typealias A = C
 }
 
 // expected-error@+2{{main actor-isolated conformance of 'SMismatchedActors' to 'Q' cannot depend on global actor 'SomeGlobalActor'-isolated conformance of 'C2' to 'P'}}
 @MainActor
-struct SMismatchedActors: isolated Q {
+struct SMismatchedActors: @MainActor Q {
   typealias A = C2
 }
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -4,7 +4,7 @@
 // REQUIRES: concurrency
 
 protocol P {
-  func f() // expected-note 2{{mark the protocol requirement 'f()' 'async' to allow actor-isolated conformances}}
+  func f() // expected-note{{mark the protocol requirement 'f()' 'async' to allow actor-isolated conformances}}
 }
 
 // ----------------------------------------------------------------------------
@@ -22,12 +22,12 @@ class CWithNonIsolated: P {
 actor SomeActor { }
 
 // Isolated conformances need a global-actor-constrained type.
-class CNonIsolated: @MainActor P { // expected-error{{isolated conformance is only permitted on global-actor-isolated types}}
+class CNonIsolated: @MainActor P {
   func f() { }
 }
 
-extension SomeActor: @MainActor P { // expected-error{{isolated conformance is only permitted on global-actor-isolated types}}
-  nonisolated func f() { }
+extension SomeActor: @MainActor P {
+  @MainActor func f() { }
 }
 
 @globalActor
@@ -35,10 +35,11 @@ struct SomeGlobalActor {
   static let shared = SomeActor()
 }
 
-// Isolation of the conformance needs to match that of the enclosing type.
+// Isolation of the conformance can be different from that of the enclosing
+// type, so long as the witnesses match up.
 @MainActor
 class CMismatchedIsolation: @SomeGlobalActor P {
-  @SomeGlobalActor func f() { } // expected-error{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+  @SomeGlobalActor func f() { }
 }
 
 @MainActor
@@ -52,7 +53,7 @@ protocol Q {
   associatedtype A: P
 }
 
-// expected-error@+2{{conformance of 'SMissingIsolation' to 'Q' depends on main actor-isolated conformance of 'C' to 'P'; mark it as 'isolated'}}{{27-27=isolated }}
+// expected-error@+2{{conformance of 'SMissingIsolation' to 'Q' depends on main actor-isolated conformance of 'C' to 'P'; mark it as '@MainActor'}}{{27-27=@MainActor }}
 @MainActor
 struct SMissingIsolation: Q {
   typealias A = C
@@ -62,7 +63,7 @@ struct PWrapper<T: P>: P {
   func f() { }
 }
 
-// expected-error@+2{{conformance of 'SMissingIsolationViaWrapper' to 'Q' depends on main actor-isolated conformance of 'C' to 'P'; mark it as 'isolated'}}
+// expected-error@+2{{conformance of 'SMissingIsolationViaWrapper' to 'Q' depends on main actor-isolated conformance of 'C' to 'P'; mark it as '@MainActor'}}
 @MainActor
 struct SMissingIsolationViaWrapper: Q {
   typealias A = PWrapper<C>
@@ -111,18 +112,30 @@ func acceptSendableP<T: Sendable & P>(_: T) { }
 // expected-note@-1{{'acceptSendableP' declared here}}
 
 func acceptSendableMetaP<T: SendableMetatype & P>(_: T) { }
-// expected-note@-1{{'acceptSendableMetaP' declared here}}
+// expected-note@-1 3{{'acceptSendableMetaP' declared here}}
 
 @MainActor
 func testIsolationConformancesInCall(c: C) {
   acceptP(c) // okay
 
-  acceptSendableP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
+  acceptSendableP(c) // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
   acceptSendableMetaP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
 }
 
+@MainActor
+func testIsolatedConformancesOfActor(a: SomeActor) {
+  acceptP(a)
+  acceptSendableMetaP(a) // expected-error{{main actor-isolated conformance of 'SomeActor' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
+}
+
+@SomeGlobalActor
+func testIsolatedConformancesOfOtherGlobalActor(c: CMismatchedIsolation) {
+  acceptP(c)
+  acceptSendableMetaP(c)  // expected-error{{global actor 'SomeGlobalActor'-isolated conformance of 'CMismatchedIsolation' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
+}
+
 func testIsolationConformancesFromOutside(c: C) {
-  acceptP(c) // expected-error{{main actor-isolated isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
-  let _: any P = c // expected-error{{main actor-isolated isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
-  let _ = PWrapper<C>() // expected-error{{main actor-isolated isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  acceptP(c) // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  let _: any P = c // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  let _ = PWrapper<C>() // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
 }

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -1,0 +1,40 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances -enable-experimental-feature UnspecifiedMeansMainActorIsolated %s
+
+// REQUIRES: swift_feature_IsolatedConformances
+// REQUIRES: swift_feature_UnspecifiedMeansMainActorIsolated
+// REQUIRES: concurrency
+
+nonisolated
+protocol P {
+  func f() // expected-note{{mark the protocol requirement 'f()' 'async' to allow actor-isolated conformances}}
+}
+
+class CImplicitMainActorNonisolatedConformance: nonisolated P {
+  func f() { } // error: explicitly nonisolated conformance
+}
+
+
+@MainActor
+class CExplicitMainActor: P {
+  func f() { } // okay! conformance above is isolated
+}
+
+class CImplicitMainActor: P {
+  func f() { } // okay! conformance above is isolated
+}
+
+// expected-note@+2{{add '@preconcurrency' to the 'P' conformance to defer isolation checking to run time}}
+// expected-note@+1{{add '@MainActor' to the 'P' conformance to restrict it to main actor-isolated code}}
+nonisolated class CNonIsolated: P {
+  @MainActor func f() { } // expected-error{{main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+}
+
+func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }
+
+nonisolated func testConformancesFromNonisolated() {
+  let _: any P = CExplicitMainActor() // expected-error{{main actor-isolated conformance of 'CExplicitMainActor' to 'P' cannot be used in nonisolated context}}
+  let _: any P = CImplicitMainActor() // expected-error{{main actor-isolated conformance of 'CImplicitMainActor' to 'P' cannot be used in nonisolated context}}
+
+  let _: any P = CNonIsolated()
+  let _: any P = CImplicitMainActorNonisolatedConformance()
+}

--- a/test/IRGen/isolated_conformance.swift
+++ b/test/IRGen/isolated_conformance.swift
@@ -17,6 +17,6 @@ protocol P {
 // CHECK-SAME: ScM
 // CHECK-SAME: $sScMs11GlobalActorsMc"
 @MainActor
-struct X<T>: isolated P {
+struct X<T>: @MainActor P {
   func f() { }
 }

--- a/test/ModuleInterface/isolated_conformance.swift
+++ b/test/ModuleInterface/isolated_conformance.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -swift-version 6 -enable-library-evolution -module-name isolated_conformance -enable-experimental-feature IsolatedConformances -emit-module-interface-path - %s | %FileCheck %s
+
+// REQUIRES: swift_feature_IsolatedConformances
+// REQUIRES: concurrency
+
+public protocol MyProtocol {
+  func f()
+}
+
+@MainActor
+public class MyClass { }
+
+// CHECK: extension isolated_conformance.MyClass : @MainActor isolated_conformance.MyProtocol {
+extension MyClass: @MainActor MyProtocol {
+  @MainActor public func f() { }
+}

--- a/test/ModuleInterface/isolated_conformance.swift
+++ b/test/ModuleInterface/isolated_conformance.swift
@@ -10,7 +10,7 @@ public protocol MyProtocol {
 @MainActor
 public class MyClass { }
 
-// CHECK: extension isolated_conformance.MyClass : @MainActor isolated_conformance.MyProtocol {
+// CHECK: extension isolated_conformance.MyClass : @{{.*}}MainActor isolated_conformance.MyProtocol {
 extension MyClass: @MainActor MyProtocol {
   @MainActor public func f() { }
 }

--- a/test/ModuleInterface/isolated_conformance.swift
+++ b/test/ModuleInterface/isolated_conformance.swift
@@ -14,3 +14,9 @@ public class MyClass { }
 extension MyClass: @MainActor MyProtocol {
   @MainActor public func f() { }
 }
+
+extension MyClass: nonisolated Equatable {
+  nonisolated public static func ==(lhs: MyClass, rhs: MyClass) -> Bool {
+    false
+  }
+}

--- a/test/Serialization/Inputs/def_isolated_conformance.swift
+++ b/test/Serialization/Inputs/def_isolated_conformance.swift
@@ -1,0 +1,10 @@
+public protocol MyProtocol {
+  func f()
+}
+
+@MainActor
+public class MyClass { }
+
+extension MyClass: @MainActor MyProtocol {
+  @MainActor public func f() { }
+}

--- a/test/Serialization/isolated_conformance.swift
+++ b/test/Serialization/isolated_conformance.swift
@@ -12,5 +12,5 @@ func acceptMyProtocol(_: some MyProtocol) { }
 
 nonisolated func f(mc: MyClass) {
   acceptMyProtocol(mc)
-  // expected-error@-1{{main actor-isolated isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
+  // expected-error@-1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
 }

--- a/test/Serialization/isolated_conformance.swift
+++ b/test/Serialization/isolated_conformance.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances -o %t/def_isolated_conformance.swiftmodule %S/Inputs/def_isolated_conformance.swift
+
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances %s -I %t
+
+// REQUIRES: swift_feature_IsolatedConformances
+// REQUIRES: concurrency
+
+import def_isolated_conformance
+
+func acceptMyProtocol(_: some MyProtocol) { }
+
+nonisolated func f(mc: MyClass) {
+  acceptMyProtocol(mc)
+  // expected-error@-1{{main actor-isolated isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
+}


### PR DESCRIPTION
Make several changes to bring the isolated conformances implementation into alignment with the latest proposal:
* Use global-actor syntax to specify isolation conformances, e.g., `@MainActor P`, rather than `isolated P`
* Allow conformance isolation to differ from that of the conforming type
* Infer `@MainActor` on conformances when SE-0466 is enabled, which can be suppressed by `nonisolated`
* Test printing of conformance isolation