### PR TITLE
[cxx-interop] Import default public ctor of C++ foreign ref types as Swift Initializer

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -464,6 +464,10 @@ EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)
 /// Import inherited non-public members when importing C++ classes.
 EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 
+/// Synthesize static factory methods for C++ foreign reference types and import
+/// them as Swift initializers.
+EXPERIMENTAL_FEATURE(CXXForeignReferenceTypeInitializers, true)
+
 // Isolated deinit
 SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedDeinit, 371, "isolated deinit")
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -392,6 +392,7 @@ UNINTERESTING_FEATURE(StrictMemorySafety)
 UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
+UNINTERESTING_FEATURE(CXXForeignReferenceTypeInitializers)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
 
 static bool usesFeatureSwiftSettings(const Decl *decl) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7686,17 +7686,6 @@ static bool hasImportAsRefAttr(const clang::RecordDecl *decl) {
          });
 }
 
-// TODO: Move all these utility functions in a new file ClangImporterUtils.h
-// rdar://138803759
-static bool hasImmortalAtts(const clang::RecordDecl *decl) {
-  return decl->hasAttrs() && llvm::any_of(decl->getAttrs(), [](auto *attr) {
-           if (auto swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
-             return swiftAttr->getAttribute() == "retain:immortal" ||
-                    swiftAttr->getAttribute() == "release:immortal";
-           return false;
-         });
-}
-
 // Is this a pointer to a foreign reference type.
 bool importer::isForeignReferenceTypeWithoutImmortalAttrs(const clang::QualType type) {
   if (!type->isPointerType())
@@ -7708,7 +7697,7 @@ bool importer::isForeignReferenceTypeWithoutImmortalAttrs(const clang::QualType 
     return false;
 
   return hasImportAsRefAttr(pointeeType->getDecl()) &&
-         !hasImmortalAtts(pointeeType->getDecl());
+         !hasImmortalAttrs(pointeeType->getDecl());
 }
 
 static bool hasDiamondInheritanceRefType(const clang::CXXRecordDecl *decl) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1890,6 +1890,10 @@ namespace importer {
 bool recordHasReferenceSemantics(const clang::RecordDecl *decl,
                                  ClangImporter::Implementation *importerImpl);
 
+/// Returns true if the given C/C++ reference type uses "immortal"
+/// retain/release functions.
+bool hasImmortalAttrs(const clang::RecordDecl *decl);
+
 /// Whether this is a forward declaration of a type. We ignore forward
 /// declarations in certain cases, and instead process the real declarations.
 bool isForwardDeclOfType(const clang::Decl *decl);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2529,3 +2529,131 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
 
   return callExpr;
 }
+
+// MARK: C++ foreign reference type constructors
+
+clang::CXXMethodDecl *
+SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
+    const clang::CXXRecordDecl *cxxRecordDecl) {
+
+  clang::ASTContext &clangCtx = cxxRecordDecl->getASTContext();
+  clang::Sema &clangSema = ImporterImpl.getClangSema();
+
+  clang::QualType cxxRecordTy = clangCtx.getRecordType(cxxRecordDecl);
+
+  clang::CXXConstructorDecl *defaultCtorDecl = nullptr;
+  for (clang::CXXConstructorDecl *ctor : cxxRecordDecl->ctors()) {
+    if (ctor->parameters().empty() && !ctor->isDeleted() &&
+        ctor->getAccess() != clang::AS_private &&
+        ctor->getAccess() != clang::AS_protected) {
+      defaultCtorDecl = ctor;
+      break;
+    }
+  }
+  if (!defaultCtorDecl)
+    return nullptr;
+
+  clang::FunctionDecl *operatorNew = nullptr;
+  clang::FunctionDecl *operatorDelete = nullptr;
+  bool passAlignment = false;
+  bool findingAllocFuncFailed = clangSema.FindAllocationFunctions(
+      cxxRecordDecl->getLocation(), clang::SourceRange(), clang::Sema::AFS_Both,
+      clang::Sema::AFS_Both, cxxRecordTy,
+      /*IsArray*/ false, passAlignment, clang::MultiExprArg(), operatorNew,
+      operatorDelete, /*Diagnose*/ false);
+  if (findingAllocFuncFailed || !operatorNew || operatorNew->isDeleted() ||
+      operatorNew->getAccess() == clang::AS_private ||
+      operatorNew->getAccess() == clang::AS_protected)
+    return nullptr;
+
+  clang::QualType cxxRecordPtrTy = clangCtx.getPointerType(cxxRecordTy);
+  // Adding `_Nonnull` to the return type of synthesized static factory
+  bool nullabilityCannotBeAdded =
+      clangSema.CheckImplicitNullabilityTypeSpecifier(
+          cxxRecordPtrTy, clang::NullabilityKind::NonNull,
+          cxxRecordDecl->getLocation(),
+          /*isParam=*/false,
+          /*OverrideExisting=*/true);
+  assert(!nullabilityCannotBeAdded &&
+         "Failed to add _Nonnull specifier to synthesized "
+         "static factory's return type");
+
+  clang::IdentifierTable &clangIdents = clangCtx.Idents;
+  clang::IdentifierInfo *funcNameToSynthesize = &clangIdents.get(
+      ("__returns_" + cxxRecordDecl->getNameAsString()).c_str());
+  clang::FunctionProtoType::ExtProtoInfo EPI;
+  clang::QualType funcTypeToSynthesize =
+      clangCtx.getFunctionType(cxxRecordPtrTy, {}, EPI);
+
+  clang::CXXMethodDecl *synthesizedCxxMethodDecl = clang::CXXMethodDecl::Create(
+      clangCtx, const_cast<clang::CXXRecordDecl *>(cxxRecordDecl),
+      cxxRecordDecl->getLocation(),
+      clang::DeclarationNameInfo(funcNameToSynthesize,
+                                 cxxRecordDecl->getLocation()),
+      funcTypeToSynthesize,
+      clangCtx.getTrivialTypeSourceInfo(funcTypeToSynthesize), clang::SC_Static,
+      /*UsesFPIntrin=*/false, /*isInline=*/true,
+      clang::ConstexprSpecKind::Unspecified, cxxRecordDecl->getLocation());
+  assert(synthesizedCxxMethodDecl &&
+         "Unable to synthesize static factory for c++ foreign reference type");
+  synthesizedCxxMethodDecl->setAccess(clang::AccessSpecifier::AS_public);
+
+  if (!hasImmortalAttrs(cxxRecordDecl)) {
+    clang::SwiftAttrAttr *returnsRetainedAttrForSynthesizedCxxMethodDecl =
+        clang::SwiftAttrAttr::Create(clangCtx, "returns_retained");
+    synthesizedCxxMethodDecl->addAttr(
+        returnsRetainedAttrForSynthesizedCxxMethodDecl);
+  }
+
+  clang::SwiftNameAttr *swiftNameInitAttrForSynthesizedCxxMethodDecl =
+      clang::SwiftNameAttr::Create(clangCtx, "init()");
+  synthesizedCxxMethodDecl->addAttr(
+      swiftNameInitAttrForSynthesizedCxxMethodDecl);
+
+  clang::ExprResult synthesizedConstructExprResult =
+      clangSema.BuildCXXConstructExpr(
+          clang::SourceLocation(), cxxRecordTy, defaultCtorDecl,
+          /*Elidable=*/false, clang::MultiExprArg(),
+          /*HadMultipleCandidates=*/false,
+          /*IsListInitialization=*/false,
+          /*IsStdInitListInitialization=*/false,
+          /*RequiresZeroInit=*/false, clang::CXXConstructionKind::Complete,
+          clang::SourceRange());
+  assert(!synthesizedConstructExprResult.isInvalid() &&
+         "Unable to synthesize constructor expression for c++ foreign "
+         "reference type");
+  clang::CXXConstructExpr *synthesizedConstructExpr =
+      cast<clang::CXXConstructExpr>(synthesizedConstructExprResult.get());
+
+  clang::ExprResult synthesizedNewExprResult = clangSema.BuildCXXNew(
+      clang::SourceRange(), /*UseGlobal=*/false, clang::SourceLocation(), {},
+      clang::SourceLocation(), clang::SourceRange(), cxxRecordTy,
+      clangCtx.getTrivialTypeSourceInfo(cxxRecordTy), std::nullopt,
+      clang::SourceRange(), synthesizedConstructExpr);
+  assert(
+      !synthesizedNewExprResult.isInvalid() &&
+      "Unable to synthesize `new` expression for c++ foreign reference type");
+  clang::CXXNewExpr *synthesizedNewExpr =
+      cast<clang::CXXNewExpr>(synthesizedNewExprResult.get());
+
+  clang::ReturnStmt *synthesizedRetStmt =
+      clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
+                                synthesizedNewExpr, /*VarDecl=*/nullptr);
+  assert(synthesizedRetStmt && "Unable to synthesize return statement for "
+                               "static factory of c++ foreign reference type");
+
+  clang::CompoundStmt *synthesizedFuncBody = clang::CompoundStmt::Create(
+      clangCtx, {synthesizedRetStmt}, clang::FPOptionsOverride(),
+      clang::SourceLocation(), clang::SourceLocation());
+  assert(synthesizedRetStmt && "Unable to synthesize function body for static "
+                               "factory of c++ foreign reference type");
+
+  synthesizedCxxMethodDecl->setBody(synthesizedFuncBody);
+  synthesizedCxxMethodDecl->addAttr(
+      clang::NoDebugAttr::CreateImplicit(clangCtx));
+
+  synthesizedCxxMethodDecl->setImplicit();
+  synthesizedCxxMethodDecl->setImplicitlyInline();
+
+  return synthesizedCxxMethodDecl;
+}

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -334,6 +334,12 @@ public:
                                 const swift::Type &swiftParamTy,
                                 SourceLoc paramLoc);
 
+  /// Synthesize a static factory method for a C++ foreign reference type,
+  /// returning a `CXXMethodDecl*` or `nullptr` if the required constructor or
+  /// allocation function is not found.
+  clang::CXXMethodDecl *synthesizeStaticFactoryForCXXForeignRef(
+      const clang::CXXRecordDecl *cxxRecordDecl);
+
 private:
   Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
 };

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -1,6 +1,17 @@
 #ifndef TEST_INTEROP_CXX_CLASS_INPUTS_CONSTRUCTORS_H
 #define TEST_INTEROP_CXX_CLASS_INPUTS_CONSTRUCTORS_H
 
+#ifndef __SIZE_T_DEFINED_CUSTOM__
+#define __SIZE_T_DEFINED_CUSTOM__
+
+#if defined(_WIN32) || defined(_WIN64)
+typedef unsigned long long size_t;
+#else
+typedef unsigned long size_t;
+#endif
+
+#endif // __SIZE_T_DEFINED_CUSTOM__
+
 struct ExplicitDefaultConstructor {
   ExplicitDefaultConstructor() : x(42) {}
   int x;
@@ -122,6 +133,7 @@ struct MoveConstructorWithOneParameterWithDefaultArg {
       : value(other.value + 1) {}
 };
 
+namespace UserFactoriesForCXXRefTypeInit {
 struct __attribute__((swift_attr("import_reference")))
 __attribute__((swift_attr("retain:retain")))
 __attribute__((swift_attr("release:release"))) ImportWithCtor {
@@ -129,51 +141,261 @@ __attribute__((swift_attr("release:release"))) ImportWithCtor {
   int param1 = 0;
   int param2 = 0;
 
-  __attribute__((swift_name("init()")))
-  __attribute__((swift_attr("returns_retained")))
-  static ImportWithCtor * _Nonnull create() {
+  __attribute__((swift_name("init()"))) __attribute__((swift_attr(
+      "returns_retained"))) static ImportWithCtor *_Nonnull create() {
     return new ImportWithCtor{1};
   }
 
-  __attribute__((swift_name("init(_:)")))
-  __attribute__((swift_attr("returns_retained")))
-  static ImportWithCtor * _Nonnull create(int x) {
+  __attribute__((swift_name("init(_:)"))) __attribute__((swift_attr(
+      "returns_retained"))) static ImportWithCtor *_Nonnull create(int x) {
     return new ImportWithCtor{1, x};
   }
 
   __attribute__((swift_name("init(_:_:)")))
-  __attribute__((swift_attr("returns_retained")))
-  static ImportWithCtor * _Nonnull create(int x, int y) {
+  __attribute__((swift_attr("returns_retained"))) static ImportWithCtor
+      *_Nonnull create(int x, int y) {
     return new ImportWithCtor{1, x, y};
   }
 
   __attribute__((swift_name("init(_:_:_:)")))
-  __attribute__((swift_attr("returns_unretained")))
-  static ImportWithCtor * _Nonnull create(int x, int y, int z) {
+  __attribute__((swift_attr("returns_unretained"))) static ImportWithCtor
+      *_Nonnull create(int x, int y, int z) {
     return new ImportWithCtor{0, x, y};
   }
 };
 
-inline void retain(ImportWithCtor * _Nonnull x) {
+class Value {
+public:
+  __attribute__((swift_name("init(x:)"))) static Value forFoo(int x) {
+    Value ret;
+    ret.x = x;
+    return ret;
+  }
+  int getX() const { return x; }
+
+private:
+  int x;
+};
+} // namespace UserFactoriesForCXXRefTypeInit
+
+inline void retain(UserFactoriesForCXXRefTypeInit::ImportWithCtor *_Nonnull x) {
   x->value++;
 }
 
-inline void release(ImportWithCtor * _Nonnull x) {
+inline void
+release(UserFactoriesForCXXRefTypeInit::ImportWithCtor *_Nonnull x) {
   if (!--x->value)
     delete x;
 }
 
-class Value {
+namespace SwiftInitSynthesisForCXXRefTypes {
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain1")))
+__attribute__((swift_attr("release:Release1"))) CompilerGeneratedDefaultCtor {
 public:
-  __attribute__((swift_name("init(x:)")))
-  static Value forFoo(int x) {
-      Value ret;
-      ret.x = x;
-      return ret; 
-  }
-  int getX() const { return x; }
-private:
-  int x;
+  int val = 1;
 };
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain3"))) __attribute__((
+    swift_attr("release:Release3"))) ExplicitCompilerGeneratedDefaultCtor {
+public:
+  int val = 1;
+  ExplicitCompilerGeneratedDefaultCtor() = default;
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal"))) ImmortalReference {
+public:
+  int val = 1;
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain2")))
+__attribute__((swift_attr("release:Release2"))) UserProvidedDefaultCtor {
+public:
+  int val = 1;
+  UserProvidedDefaultCtor() { val = 2; }
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain15")))
+__attribute__((swift_attr("release:Release15"))) UserProvidedStaticFactory {
+public:
+  int val = 1;
+
+  UserProvidedStaticFactory() = default;
+
+  __attribute__((swift_name("init()"))) __attribute__((
+      swift_attr("returns_retained"))) static UserProvidedStaticFactory
+      *_Nonnull create() {
+    UserProvidedStaticFactory *_Nonnull returnPtr =
+        new UserProvidedStaticFactory();
+    returnPtr->val = 2;
+    return returnPtr;
+  }
+
+  __attribute__((swift_name("init(_:)"))) __attribute__((
+      swift_attr("returns_retained"))) static UserProvidedStaticFactory
+      *_Nonnull create(int x) {
+    UserProvidedStaticFactory *returnPtr = new UserProvidedStaticFactory();
+    returnPtr->val = x;
+    return returnPtr;
+  }
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain4")))
+__attribute__((swift_attr("release:Release4"))) PlacementOperatorNew {
+public:
+  int val = 1;
+  void *operator new(size_t, void *ptr) { return ptr; }
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain5")))
+__attribute__((swift_attr("release:Release5"))) PrivateOperatorNew { // expected-error {{'operator new' is a private member of 'SwiftInitSynthesisForCXXRefTypes::PrivateOperatorNew}}
+public:
+  int val = 1;
+
+private:
+  void *operator new(size_t); // expected-note {{declared private here}}
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain6")))
+__attribute__((swift_attr("release:Release6"))) ProtectedOperatorNew { // expected-error {{'operator new' is a protected member of 'SwiftInitSynthesisForCXXRefTypes::ProtectedOperatorNew'}}
+public:
+  int val = 1;
+
+protected:
+  void *operator new(size_t); // expected-note {{declared protected here}}
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain7")))
+__attribute__((swift_attr("release:Release7"))) DeletedOperatorNew {
+public:
+  int val = 1;
+  void *operator new(size_t) = delete;
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain8")))
+__attribute__((swift_attr("release:Release8"))) PrivateCtor {
+private:
+  int val = 1;
+  PrivateCtor() {}
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain9")))
+__attribute__((swift_attr("release:Release9"))) ProtectedCtor {
+protected:
+  int val = 1;
+  ProtectedCtor() {}
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain10")))
+__attribute__((swift_attr("release:Release10"))) DeletedCtor {
+public:
+  int val = 90;
+  DeletedCtor() = delete;
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain11")))
+__attribute__((swift_attr("release:Release11"))) CtorWithDefaultArg {
+public:
+  int val = 1;
+  CtorWithDefaultArg(int x = 2) : val(x) {}
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain12"))) __attribute__((
+    swift_attr("release:Release12"))) CtorWithDefaultAndNonDefaultArg {
+public:
+  int val;
+  CtorWithDefaultAndNonDefaultArg(int x, int y = 42) : val(x + y) {}
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain13")))
+__attribute__((swift_attr("release:Release13"))) DefaulltAndNonDefaultCtors {
+public:
+  int val = 1;
+  DefaulltAndNonDefaultCtors() = default;
+  DefaulltAndNonDefaultCtors(int x) : val(x) {}
+};
+
+struct __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:Retain14")))
+__attribute__((swift_attr("release:Release14"))) ParameterizedCtor {
+public:
+  int val = 1;
+  ParameterizedCtor(int x) : val(x) {}
+};
+} // namespace SwiftInitSynthesisForCXXRefTypes
+
+void Retain1(SwiftInitSynthesisForCXXRefTypes::CompilerGeneratedDefaultCtor
+                  *_Nonnull v) {};
+void Release1(SwiftInitSynthesisForCXXRefTypes::CompilerGeneratedDefaultCtor
+                  *_Nonnull v) {};
+void Retain2(
+    SwiftInitSynthesisForCXXRefTypes::UserProvidedDefaultCtor *_Nonnull v) {};
+void Release2(
+    SwiftInitSynthesisForCXXRefTypes::UserProvidedDefaultCtor *_Nonnull v) {};
+void Retain3(
+    SwiftInitSynthesisForCXXRefTypes::ExplicitCompilerGeneratedDefaultCtor
+        *_Nonnull v) {};
+void Release3(
+    SwiftInitSynthesisForCXXRefTypes::ExplicitCompilerGeneratedDefaultCtor
+        *_Nonnull v) {};
+void Retain4(
+    SwiftInitSynthesisForCXXRefTypes::PlacementOperatorNew *_Nonnull v) {};
+void Release4(
+    SwiftInitSynthesisForCXXRefTypes::PlacementOperatorNew *_Nonnull v) {};
+void Retain5(SwiftInitSynthesisForCXXRefTypes::PrivateOperatorNew *_Nonnull v) {
+};
+void Release5(
+    SwiftInitSynthesisForCXXRefTypes::PrivateOperatorNew *_Nonnull v) {};
+void Retain6(
+    SwiftInitSynthesisForCXXRefTypes::ProtectedOperatorNew *_Nonnull v) {};
+void Release6(
+    SwiftInitSynthesisForCXXRefTypes::ProtectedOperatorNew *_Nonnull v) {};
+void Retain7(SwiftInitSynthesisForCXXRefTypes::DeletedOperatorNew *_Nonnull v) {
+};
+void Release7(
+    SwiftInitSynthesisForCXXRefTypes::DeletedOperatorNew *_Nonnull v) {};
+void Retain8(SwiftInitSynthesisForCXXRefTypes::PrivateCtor *_Nonnull v) {};
+void Release8(SwiftInitSynthesisForCXXRefTypes::PrivateCtor *_Nonnull v) {};
+void Retain9(SwiftInitSynthesisForCXXRefTypes::ProtectedCtor *_Nonnull v) {};
+void Release9(SwiftInitSynthesisForCXXRefTypes::ProtectedCtor *_Nonnull v) {};
+void Retain10(SwiftInitSynthesisForCXXRefTypes::DeletedCtor *_Nonnull v) {};
+void Release10(SwiftInitSynthesisForCXXRefTypes::DeletedCtor *_Nonnull v) {};
+void Retain11(
+    SwiftInitSynthesisForCXXRefTypes::CtorWithDefaultArg *_Nonnull v) {};
+void Release11(
+    SwiftInitSynthesisForCXXRefTypes::CtorWithDefaultArg *_Nonnull v) {};
+void Retain12(SwiftInitSynthesisForCXXRefTypes::CtorWithDefaultAndNonDefaultArg
+                  *_Nonnull v) {};
+void Release12(SwiftInitSynthesisForCXXRefTypes::CtorWithDefaultAndNonDefaultArg
+                    *_Nonnull v) {};
+void Retain13(
+    SwiftInitSynthesisForCXXRefTypes::DefaulltAndNonDefaultCtors *_Nonnull v) {
+};
+void Release13(
+    SwiftInitSynthesisForCXXRefTypes::DefaulltAndNonDefaultCtors *_Nonnull v) {
+};
+void Retain14(SwiftInitSynthesisForCXXRefTypes::ParameterizedCtor *_Nonnull v) {
+};
+void Release14(
+    SwiftInitSynthesisForCXXRefTypes::ParameterizedCtor *_Nonnull v) {};
+void Retain15(
+    SwiftInitSynthesisForCXXRefTypes::UserProvidedStaticFactory *_Nonnull v) {};
+void Release15(
+    SwiftInitSynthesisForCXXRefTypes::UserProvidedStaticFactory *_Nonnull v) {};
 
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_CONSTRUCTORS_H

--- a/test/Interop/Cxx/class/constructors-diagnostics.swift
+++ b/test/Interop/Cxx/class/constructors-diagnostics.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=default -enable-experimental-feature CXXForeignReferenceTypeInitializers -disable-availability-checking -verify-additional-file %S/Inputs/constructors.h -Xcc -Wno-nullability-completeness
+
+// This test uses -verify-additional-file, which do not work well on Windows:
+// UNSUPPORTED: OS=windows-msvc
+// REQUIRES: swift_feature_CXXForeignReferenceTypeInitializers
+
+import Constructors
+
+let _ = SwiftInitSynthesisForCXXRefTypes.PlacementOperatorNew()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.PlacementOperatorNew' cannot be constructed because it has no accessible initializers}}
+
+let _ = SwiftInitSynthesisForCXXRefTypes.PrivateOperatorNew()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.PrivateOperatorNew' cannot be constructed because it has no accessible initializers}}
+let _ = SwiftInitSynthesisForCXXRefTypes.ProtectedOperatorNew()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.ProtectedOperatorNew' cannot be constructed because it has no accessible initializers}}
+let _ = SwiftInitSynthesisForCXXRefTypes.DeletedOperatorNew()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.DeletedOperatorNew' cannot be constructed because it has no accessible initializers}}
+
+let _ = SwiftInitSynthesisForCXXRefTypes.PrivateCtor()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.PrivateCtor' cannot be constructed because it has no accessible initializers}}
+let _ = SwiftInitSynthesisForCXXRefTypes.ProtectedCtor()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.ProtectedCtor' cannot be constructed because it has no accessible initializers}}
+let _ = SwiftInitSynthesisForCXXRefTypes.DeletedCtor()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.DeletedCtor' cannot be constructed because it has no accessible initializers}}
+
+let _ = SwiftInitSynthesisForCXXRefTypes.CtorWithDefaultArg()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.CtorWithDefaultArg' cannot be constructed because it has no accessible initializers}}
+let _ = SwiftInitSynthesisForCXXRefTypes.CtorWithDefaultAndNonDefaultArg()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.CtorWithDefaultAndNonDefaultArg' cannot be constructed because it has no accessible initializers}}
+
+let _ = SwiftInitSynthesisForCXXRefTypes.DefaulltAndNonDefaultCtors()
+// TODO: change the error message when we start supporting parameterised ctors
+let _ = SwiftInitSynthesisForCXXRefTypes.DefaulltAndNonDefaultCtors(2)  // expected-error {{argument passed to call that takes no arguments}}
+
+let _ = SwiftInitSynthesisForCXXRefTypes.ParameterizedCtor()  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.ParameterizedCtor' cannot be constructed because it has no accessible initializers}}
+let _ = SwiftInitSynthesisForCXXRefTypes.ParameterizedCtor(3)  // expected-error {{'SwiftInitSynthesisForCXXRefTypes.ParameterizedCtor' cannot be constructed because it has no accessible initializers}}

--- a/test/Interop/Cxx/class/constructors-executable.swift
+++ b/test/Interop/Cxx/class/constructors-executable.swift
@@ -1,9 +1,10 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xfrontend -disable-availability-checking)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature CXXForeignReferenceTypeInitializers -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_CXXForeignReferenceTypeInitializers
 
-import StdlibUnittest
 import Constructors
+import StdlibUnittest
 
 var CxxConstructorTestSuite = TestSuite("CxxConstructors")
 
@@ -71,21 +72,47 @@ CxxConstructorTestSuite.test("MoveConstructorWithOneParamWithDefaultArg") {
 }
 
 CxxConstructorTestSuite.test("ImportStaticFactoryAsInitializer") {
-  let x = ImportWithCtor()
+  let x = UserFactoriesForCXXRefTypeInit.ImportWithCtor()
   expectEqual(x.param1, 0)
   expectEqual(x.param2, 0)
   let y = x
-  let z = ImportWithCtor(1)
+  let z = UserFactoriesForCXXRefTypeInit.ImportWithCtor(1)
   expectEqual(z.param1, 1)
   expectEqual(z.param2, 0)
-  let z2 = ImportWithCtor(2, 3)
+  let z2 = UserFactoriesForCXXRefTypeInit.ImportWithCtor(2, 3)
   expectEqual(z2.param1, 2)
   expectEqual(z2.param2, 3)
-  let z3 = ImportWithCtor(2, 3, 4)
+  let z3 = UserFactoriesForCXXRefTypeInit.ImportWithCtor(2, 3, 4)
   expectEqual(z3.param1, 2)
   expectEqual(z3.param2, 3)
-  let v = Value(x: 2)
+  let v = UserFactoriesForCXXRefTypeInit.Value(x: 2)
   expectEqual(v.getX(), 2)
+}
+
+CxxConstructorTestSuite.test("SynthesizeAndImportStaticFactoryAsInitializer") {
+  let x1 = SwiftInitSynthesisForCXXRefTypes.CompilerGeneratedDefaultCtor()
+  expectEqual(x1.val, 1)
+  x1.val = 2
+  expectEqual(x1.val, 2)
+
+  let x2 = SwiftInitSynthesisForCXXRefTypes.ExplicitCompilerGeneratedDefaultCtor()
+  expectEqual(x2.val, 1)
+  x2.val = 2
+  expectEqual(x2.val, 2)
+
+  let x3 = SwiftInitSynthesisForCXXRefTypes.ImmortalReference()
+  expectEqual(x3.val, 1)
+  x3.val = 2
+  expectEqual(x3.val, 2)
+
+  let x4 = SwiftInitSynthesisForCXXRefTypes.UserProvidedDefaultCtor()
+  expectEqual(x4.val, 2)
+
+  let x5 = SwiftInitSynthesisForCXXRefTypes.UserProvidedStaticFactory()
+  expectEqual(x5.val, 2)
+
+  let x6 = SwiftInitSynthesisForCXXRefTypes.UserProvidedStaticFactory(3)
+  expectEqual(x6.val, 3)
 }
 
 runAllTests()


### PR DESCRIPTION
Building on top of [PR #79288](https://github.com/swiftlang/swift/pull/79288), this update synthesizes a static factory method using the default new operator, with a call to the default constructor expression for C++ foreign reference types, and imports them as Swift initializers.

rdar://147529406