### PR TITLE
[Distributed] Carry SPI attribute to stub types

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -137,8 +137,14 @@ extension DistributedResolvableMacro {
     var isGenericOverActorSystem = false
     var specificActorSystemRequirement: TypeSyntax?
 
-    let attributes = proto.attributes.filter { attr in
-      attr.as(AttributeSyntax.self)?.attributeName.trimmed.description == "_spi"
+    let attributes = proto.attributes.filter {
+      guard let attr = $0.as(AttributeSyntax.self) else {
+        return false
+      }
+      guard let ident = attr.attributeName.as(IdentifierTypeSyntax.self) else {
+        return false
+      }
+      return ident.name.text == "_spi"
     }
     let accessModifiers = proto.accessControlModifiers
 
@@ -239,7 +245,7 @@ extension DistributedResolvableMacro {
 
     return [
       """
-      \(raw: attributes.map({ $0.description }).joined(separator: "\n"))
+      \(attributes)
       \(proto.modifiers) distributed actor $\(proto.name.trimmed)\(raw: typeParamsClause): \(proto.name.trimmed), 
         Distributed._DistributedActorStub \(raw: whereClause)
       {

--- a/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedResolvableMacro.swift
@@ -45,6 +45,9 @@ extension DistributedResolvableMacro {
       return []
     }
 
+    let attributes = proto.attributes.filter { attr in
+      attr.as(AttributeSyntax.self)?.attributeName.trimmed.description == "_spi"
+    }
     let accessModifiers = proto.accessControlModifiers
 
     let requirementStubs =
@@ -64,6 +67,7 @@ extension DistributedResolvableMacro {
 
     let extensionDecl: DeclSyntax =
       """
+      \(raw: attributes.map({$0.description}).joined(separator: "\n"))
       extension \(proto.name.trimmed) where Self: Distributed._DistributedActorStub {
         \(raw: requirementStubs)
       }
@@ -133,6 +137,9 @@ extension DistributedResolvableMacro {
     var isGenericOverActorSystem = false
     var specificActorSystemRequirement: TypeSyntax?
 
+    let attributes = proto.attributes.filter { attr in
+      attr.as(AttributeSyntax.self)?.attributeName.trimmed.description == "_spi"
+    }
     let accessModifiers = proto.accessControlModifiers
 
     for req in proto.genericWhereClause?.requirements ?? [] {
@@ -232,6 +239,7 @@ extension DistributedResolvableMacro {
 
     return [
       """
+      \(raw: attributes.map({ $0.description }).joined(separator: "\n"))
       \(proto.modifiers) distributed actor $\(proto.name.trimmed)\(raw: typeParamsClause): \(proto.name.trimmed), 
         Distributed._DistributedActorStub \(raw: whereClause)
       {

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_spi.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_spi.swift
@@ -7,7 +7,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
 
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -I %t -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s --dump-input=always
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -I %t -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s
 
 import Distributed
 

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_spi.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_spi.swift
@@ -1,0 +1,38 @@
+// REQUIRES: swift_swift_parser, asserts
+//
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t-scratch)
+
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-6.0-abi-triple -plugin-path %swift-plugin-dir -I %t -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s --dump-input=always
+
+import Distributed
+
+@Resolvable
+@_spi(CoolFeatures)
+public protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  distributed func greet(name: String) -> String
+}
+
+// @Resolvable ->
+
+// CHECK: @_spi(CoolFeatures)
+// CHECK: distributed actor $Greeter<ActorSystem>: Greeter,
+// CHECK-NEXT: Distributed._DistributedActorStub
+// CHECK-NEXT: where ActorSystem: DistributedActorSystem<any Codable>
+// CHECK-NEXT: {
+// CHECK: }
+
+// CHECK: @_spi(CoolFeatures)
+// CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
+// CHECK:       distributed func greet(name: String) -> String {
+// CHECK-NEXT:     if #available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *) {
+// CHECK-NEXT:       Distributed._distributedStubFatalError()
+// CHECK-NEXT:     } else {
+// CHECK-NEXT:       fatalError()
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }


### PR DESCRIPTION
The distributed macro must carry forward the @_spi attribute

resolves rdar://146940405

I need to cleanup how we detect the attr; 