### PR TITLE
utils: Enable Android in Windows PR tests

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -77,6 +77,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -ImageRoot %BuildRoot% ^
   %SkipPackagingArg% ^
   %TestArg% ^
+  -Android ^
   -Stage %PackageRoot% ^
   -Summary || (exit /b 1)
 


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/79185 contains the preparations for Android Swift Runtime tests on Windows. Once it lands, they will be running in https://ci-external.swift.org/job/swift-main-windows-toolchain/. This PR illustrates how to enable them in PR-testing as well. Depending on the runtime impact, we might decide for or against it.