### PR TITLE
Use target-specific substitutions for target-specific RUN-lines

### DIFF
--- a/test/FixCode/batch-mode.swift
+++ b/test/FixCode/batch-mode.swift
@@ -1,4 +1,4 @@
-// RUN: not %swift -typecheck -target %target-triple -primary-file %s  -emit-fixits-path %t.main.remap -primary-file %S/Inputs/batch-mode-helper.swift -emit-fixits-path %t.helper.remap
+// RUN: not %target-swift-frontend -typecheck -primary-file %s  -emit-fixits-path %t.main.remap -primary-file %S/Inputs/batch-mode-helper.swift -emit-fixits-path %t.helper.remap
 // RUN: %FileCheck -check-prefix=CHECK-MAIN %s < %t.main.remap
 // RUN: %FileCheck -check-prefix=NEGATIVE-MAIN %s < %t.main.remap
 // RUN: %FileCheck -check-prefix=CHECK-HELPER %s < %t.helper.remap

--- a/test/IDE/module_api_smoketest.swift
+++ b/test/IDE/module_api_smoketest.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %swift-ide-test -generate-module-api-description -- -target %target-triple -module-cache-path %t %s | %FileCheck %s
+// RUN: %target-swift-ide-test -generate-module-api-description -module-cache-path %t %s | %FileCheck %s
 
 public struct Struct1 {}
 

--- a/test/IDE/rdar141440011.swift
+++ b/test/IDE/rdar141440011.swift
@@ -2,7 +2,7 @@ public protocol MyProto {}
 public struct MyStruct: MyProto {}
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/swift_mod.swiftmodule %s -parse-as-library -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -experimental-lazy-typecheck -target %target-triple
-// RUN: %target-swift-synthesize-interface -module-name swift_mod -I %t -o - -target %target-triple | %FileCheck %s
+// RUN: %target-swift-frontend -emit-module -o %t/swift_mod.swiftmodule %s -parse-as-library -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -experimental-lazy-typecheck
+// RUN: %target-swift-synthesize-interface -module-name swift_mod -I %t -o - | %FileCheck %s
 
 // CHECK: public struct MyStruct : swift_mod.MyProto

--- a/test/IDE/rdar141440011.swift
+++ b/test/IDE/rdar141440011.swift
@@ -2,7 +2,7 @@ public protocol MyProto {}
 public struct MyStruct: MyProto {}
 
 // RUN: %empty-directory(%t)
-// RUN: %swift -emit-module -o %t/swift_mod.swiftmodule %s -parse-as-library -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -experimental-lazy-typecheck -target %target-triple
+// RUN: %target-swift-frontend -emit-module -o %t/swift_mod.swiftmodule %s -parse-as-library -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -experimental-lazy-typecheck -target %target-triple
 // RUN: %target-swift-synthesize-interface -module-name swift_mod -I %t -o - -target %target-triple | %FileCheck %s
 
 // CHECK: public struct MyStruct : swift_mod.MyProto

--- a/test/Sema/fixits-derived-conformances.swift
+++ b/test/Sema/fixits-derived-conformances.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-module -emit-library -module-name Types %S/Inputs/fixits-derived-conformances-multifile.swift -o %t/%target-library-name(Types)
-// RUN: %target-swift-frontend -typecheck -I %t -verify %s
+// RUN: %target-typecheck-verify-swift %s -I %t
 
 import Types
 

--- a/test/Sema/fixits-derived-conformances.swift
+++ b/test/Sema/fixits-derived-conformances.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -emit-module -emit-library -module-name Types %S/Inputs/fixits-derived-conformances-multifile.swift -o %t/%target-library-name(Types)
-// RUN: %swift -typecheck -target %target-triple -I %t -verify %s
+// RUN: %target-swift-frontend -typecheck -I %t -verify %s
 
 import Types
 


### PR DESCRIPTION
In most environments there is no difference between the two. However, when we test the Swift Runtime for Android on Windows, we pass extra parameters, like the location of the Android SDK on disk, which only works with the target-specific substitutions.