### PR TITLE
[Runtime] Allow ~Escapable types in _getMangledTypeName.

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -98,7 +98,7 @@ func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
 @available(SwiftStdlib 5.3, *)
 @_silgen_name("swift_getMangledTypeName")
 @_preInverseGenerics
-public func _getMangledTypeName(_ type: any ~Copyable.Type)
+public func _getMangledTypeName(_ type: any (~Copyable & ~Escapable).Type)
   -> (UnsafePointer<UInt8>, Int)
 
 /// Returns the mangled name for a given type.
@@ -106,7 +106,7 @@ public func _getMangledTypeName(_ type: any ~Copyable.Type)
 @_unavailableInEmbedded
 @_preInverseGenerics
 public // SPI
-func _mangledTypeName(_ type: any ~Copyable.Type) -> String? {
+func _mangledTypeName(_ type: any (~Copyable & ~Escapable).Type) -> String? {
   let (stringPtr, count) = unsafe _getMangledTypeName(type)
   guard count > 0 else {
     return nil

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -494,6 +494,7 @@ DemangleToMetadataTests.test("Nested types in same-type-constrained extensions")
 }
 
 struct NonCopyable: ~Copyable {}
+struct NonEscapable: ~Escapable {}
 
 if #available(SwiftStdlib 5.3, *) {
   DemangleToMetadataTests.test("Round-trip with _mangledTypeName and _typeByName") {
@@ -530,6 +531,11 @@ if #available(SwiftStdlib 5.3, *) {
   DemangleToMetadataTests.test("Check _MangledTypeName with any ~Copyable.Type") {
     let type: any ~Copyable.Type = NonCopyable.self
     expectEqual("4main11NonCopyableV", _mangledTypeName(type))
+  }
+
+  DemangleToMetadataTests.test("Check _MangledTypeName with any ~Escapable.Type") {
+    let type: any ~Escapable.Type = NonEscapable.self
+    expectEqual("4main12NonEscapableV", _mangledTypeName(type))
   }
 }
 


### PR DESCRIPTION
Resolves rdar://145945680.