### PR TITLE
[stdlib] fix `Span`'s `Sendable` conformance

### DIFF
--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -84,7 +84,7 @@ public struct Span<Element: ~Copyable & ~Escapable>
 }
 
 @available(SwiftStdlib 6.2, *)
-extension Span: @unchecked Sendable where Element: Sendable {}
+extension Span: @unchecked Sendable where Element: Sendable & ~Copyable {}
 
 @available(SwiftStdlib 6.2, *)
 extension Span where Element: ~Copyable {

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -589,3 +589,20 @@ suite.test("initialize from raw memory")
   let first = test(span)
   expectEqual(first, 0x07060504)
 }
+
+private func send(_: some Sendable & ~Escapable) {}
+
+private struct NCSendable: ~Copyable, Sendable {}
+
+suite.test("Span Sendability")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let buffer = UnsafeMutableBufferPointer<NCSendable>.allocate(capacity: 1)
+  defer { buffer.deallocate() }
+  buffer.initializeElement(at: 0, to: NCSendable())
+  defer { buffer.deinitialize() }
+
+  let span = Span(_unsafeElements: buffer)
+  send(span)
+}


### PR DESCRIPTION
It accidentally required `Copyable` elements. This fix allows sending spans of non-copyable elements.

Thanks to @benrimmington for pointing this out.