### PR TITLE
Serialization: Ignore lookup shadowing when resolving cross-references

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2075,7 +2075,7 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                getIdentifier(privateDiscriminator));
     } else {
       baseModule->lookupQualified(baseModule, DeclNameRef(name),
-                                  SourceLoc(), NL_QualifiedDefault,
+                                  SourceLoc(), NL_RemoveOverridden,
                                   values);
     }
     filterValues(filterTy, nullptr, nullptr, isType, inProtocolExt,
@@ -2285,8 +2285,8 @@ ModuleFile::resolveCrossReference(ModuleID MID, uint32_t pathLen) {
                                    getIdentifier(privateDiscriminator));
         } else {
           otherModule->lookupQualified(otherModule, DeclNameRef(name),
-                                      SourceLoc(), NL_QualifiedDefault,
-                                      values);
+                                       SourceLoc(), NL_RemoveOverridden,
+                                       values);
         }
 
         std::optional<ValueDecl*> matchBeforeFiltering = std::nullopt;

--- a/test/Serialization/inlined-shadowed-clang-vs-swift.swift
+++ b/test/Serialization/inlined-shadowed-clang-vs-swift.swift
@@ -1,0 +1,64 @@
+/// Ensure inlined code in swiftmodules differentiates between shadowed Swift
+/// and clang decls.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// REQUIRES: objc_interop
+
+/// Reference build: Build libs and client for a normal build.
+// RUN: %target-swift-frontend -emit-module %t/RootLib.swift -I %t \
+// RUN:   -emit-module-path %t/RootLib.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/MiddleLib.swift -I %t \
+// RUN:   -emit-module-path %t/MiddleLib.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -O %t/Client.swift -I %t > %t/Client.sil
+// RUN: %FileCheck %s --input-file=%t/Client.sil
+
+//--- module.modulemap
+module RootLib {
+  header "RootLib.h"
+}
+
+//--- RootLib.h
+#include <stdio.h>
+void ShadowedFunc() {
+    printf("Clang\n");
+}
+
+//--- RootLib.swift
+@_exported import RootLib
+
+@usableFromInline
+internal func ShadowedFunc() {
+    print("Swift")
+}
+
+@inlinable
+@inline(__always)
+public func swiftUser() {
+    ShadowedFunc() // Swift one
+}
+
+//--- MiddleLib.swift
+
+import RootLib
+
+@inlinable
+@inline(__always)
+public func clangUser() {
+    ShadowedFunc() // Clang one
+}
+
+//--- Client.swift
+
+import RootLib
+import MiddleLib
+
+swiftUser()
+// CHECK: [[SWIFT_FUNC:%.*]] = function_ref @$s7RootLib12ShadowedFuncyyF : $@convention(thin) () -> ()
+// CHECK: apply [[SWIFT_FUNC]]() : $@convention(thin) () -> ()
+// CHECK-NOT: apply [[SWIFT_FUNC]]() : $@convention(thin) () -> ()
+
+clangUser()
+// CHECK: [[CLANG_FUNC:%.*]] = function_ref @ShadowedFunc : $@convention(c) () -> ()
+// CHECK: apply [[CLANG_FUNC]]() : $@convention(c) () -> ()
+// CHECK-NOT: apply [[CLANG_FUNC]]() : $@convention(c) () -> ()

--- a/test/Serialization/inlined-shadowed-layered-modules.swift
+++ b/test/Serialization/inlined-shadowed-layered-modules.swift
@@ -1,0 +1,127 @@
+/// Ensure inlined code in swiftmodules picks the right shadowed decl
+/// relative to where they were inlined from, no matter if other imported
+/// modules define more shadowers at the inlining site.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// REQUIRES: objc_interop
+
+/// Reference build: Build libs and client for a normal build.
+// RUN: %target-swift-frontend -emit-module %t/RootLib.swift -I %t \
+// RUN:   -emit-module-path %t/RootLib.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/MiddleLib.swift -I %t \
+// RUN:   -emit-module-path %t/MiddleLib.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/HighLib.swift -I %t \
+// RUN:   -emit-module-path %t/HighLib.swiftmodule
+// RUN: %target-swift-frontend -emit-sil -O %t/Client.swift -I %t > %t/Client.sil
+// RUN: %FileCheck %s --input-file=%t/Client.sil
+
+//--- module.modulemap
+module RootLib {
+  header "RootLib.h"
+}
+module ClangMiddleLib {
+  header "ClangMiddleLib.h"
+}
+
+//--- RootLib.h
+#include <stdio.h>
+void ShadowedFunc() { // Never picked as it's shadowed by Swift's.
+    printf("Clang\n");
+}
+
+void ShadowedFuncClang();
+
+//--- ClangMiddleLib.h
+#include "RootLib.h"
+void ShadowedFuncClang();
+
+//--- RootLib.swift
+@_exported import RootLib
+@_exported import ClangMiddleLib
+
+public func ShadowedFunc() {
+    print("Swift Root")
+}
+
+@inlinable
+@inline(__always)
+public func userFromRoot() {
+    ShadowedFunc() // RootLib Swift one
+}
+
+@inlinable
+@inline(__always)
+public func clangUserFromRoot() {
+    ShadowedFuncClang()
+}
+
+//--- MiddleLib.swift
+@_exported import RootLib
+
+public func ShadowedFunc() {
+    print("Swift Middle")
+}
+
+@inlinable
+@inline(__always)
+public func userFromMiddle() {
+    ShadowedFunc() // MiddleLib one
+}
+
+@inlinable
+@inline(__always)
+public func clangUserFromMiddle() {
+    ShadowedFuncClang()
+}
+
+//--- HighLib.swift
+@_exported import MiddleLib
+
+@inlinable
+@inline(__always)
+public func userFromHigh() {
+    ShadowedFunc() // MiddleLib one
+}
+
+@inlinable
+@inline(__always)
+public func explicitUserFromHigh() {
+    RootLib.ShadowedFunc() // MRootLib.iddleLib one
+}
+
+@inlinable
+@inline(__always)
+public func clangUserFromHigh() {
+    ShadowedFuncClang()
+}
+
+//--- Client.swift
+import HighLib
+import ClangMiddleLib
+
+// RootLib call its own Swift ShadowedFunc.
+userFromRoot()
+// CHECK: [[ROOT_FUNC:%.*]] = function_ref @$s7RootLib12ShadowedFuncyyF : $@convention(thin) () -> ()
+// CHECK: apply [[ROOT_FUNC]]() : $@convention(thin) () -> ()
+explicitUserFromHigh()
+// CHECK: apply [[ROOT_FUNC]]() : $@convention(thin) () -> ()
+// CHECK-NOT: apply [[ROOT_FUNC]]() : $@convention(thin) () -> ()
+
+// MiddleLib and HighLib call the last ShadowedFunc from MiddleLib.
+userFromMiddle()
+// CHECK: [[MIDDLE_FUNC:%.*]] = function_ref @$s9MiddleLib12ShadowedFuncyyF : $@convention(thin) () -> ()
+// CHECK: apply [[MIDDLE_FUNC]]() : $@convention(thin) () -> ()
+userFromHigh()
+// CHECK: apply [[MIDDLE_FUNC]]() : $@convention(thin) () -> ()
+// CHECK-NOT: apply [[MIDDLE_FUNC]]() : $@convention(thin) () -> ()
+
+// All callers of the clang func use the merged one anyway.
+clangUserFromRoot()
+clangUserFromMiddle()
+clangUserFromHigh()
+// CHECK: [[CLANG_FUNC:%.*]] = function_ref @ShadowedFuncClang : $@convention(c) () -> ()
+// CHECK: apply [[CLANG_FUNC]]() : $@convention(c) () -> ()
+// CHECK: apply [[CLANG_FUNC]]() : $@convention(c) () -> ()
+// CHECK: apply [[CLANG_FUNC]]() : $@convention(c) () -> ()
+// CHECK-NOT: apply [[CLANG_FUNC]]() : $@convention(c) () -> ()


### PR DESCRIPTION
When a Swift function shadows a clang function of the same name, the assumption was that Swift code would refer only to the Swift one. However, if the Swift function is `@usableFromInline internal` it can be called only from the local module and inlined automatically in other clients. Outside of that module, sources see only the clang function, so their inlinable code calls only the clang function and ignores the Swift one. This configuration passed type checking but it could crash the compiler at inlining the call as the compiler couldn't see the clang function.

Let's update the deserialization logic to support inlined calls to the shadowed or the shadower. Typical shadowing is already handled by the custom deserialization cross-reference filtering logic which looks for the defining module, scope and whether it's a Swift or clang decl. We can disable the lookup shadowing logic and rely only on the deserialization filtering.

rdar://146320871
#79801