### PR TITLE
[Tests] ExistentialArchetypeType matching

### DIFF
--- a/test/Constraints/opened_existentials.swift
+++ b/test/Constraints/opened_existentials.swift
@@ -565,3 +565,19 @@ do {
     types.assertTypesAreEqual()
   }
 }
+
+protocol Env {
+  associatedtype A
+  associatedtype B
+}
+
+func testExistentialArchetypeMismatch(existential: any Env) {
+  // Different generic environments.
+  func f<T: Env, U: Env>(_ t: T, _ u: U) where T.B == U.B {}
+  // Different interface types.
+  func g<T: Env>(_ t: T) where T.A == T.B {}
+  f(existential, existential)
+  // expected-error@-1 {{local function 'f' requires the types 'T.B' and 'U.B' be equivalent}}
+  g(existential)
+  // expected-error@-1 {{local function 'g' requires the types 'T.A' and 'T.B' be equivalent}}
+}


### PR DESCRIPTION
This is a follow-up to a [previous PR](https://github.com/swiftlang/swift/pull/79876), adding two tests for `ExistentialArchetypeType` mismatches to ensure the compiler emits the correct diagnostic. These tests cover cases where:

1) Type1 and Type2 are opened in different generic environments.
2) Type1 and Type2 share the same generic environment but have different interface types.

Note: A potentially uncovered case is when Type1 and Type2 share the same generic environment and interface type but have different generic arguments. A similar case is tested for opaques [here](https://github.com/swiftlang/swift/blob/f6c9177120a7ed81165b17957cf83d87394773c2/test/type/opaque.swift#L471) using assignment. However, for opened existentials, the values are erased back to existentials upon returning, so assignment likely won't work as a test case. 