### PR TITLE
[Concurrency] task names dont need default nil arg

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -651,7 +651,7 @@ extension Task where Failure == Never {
   @_alwaysEmitIntoClient
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public init(
-    name: String? = nil,
+    name: String?,
     priority: TaskPriority? = nil,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async -> Success
   ) {
@@ -662,7 +662,7 @@ extension Task where Failure == Never {
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 6.2, *)
   public init(
-    name: String? = nil,
+    name: String?,
     // TaskExecutor is unavailable in embedded
     priority: TaskPriority? = nil,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping () async -> Success
@@ -712,7 +712,7 @@ extension Task where Failure == Never {
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 6.2, *)
   public init(
-    name: String? = nil,
+    name: String?,
     priority: TaskPriority? = nil,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async -> Success
   ) {
@@ -824,7 +824,7 @@ extension Task where Failure == Error {
   @_alwaysEmitIntoClient
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public init(
-    name: String? = nil,
+    name: String?,
     priority: TaskPriority? = nil,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async throws -> Success
 ) {
@@ -835,7 +835,7 @@ extension Task where Failure == Error {
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 6.2, *)
   public init(
-    name: String? = nil,
+    name: String?,
     // TaskExecutor is unavailable in embedded
     priority: TaskPriority? = nil,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping () async throws -> Success
@@ -881,7 +881,7 @@ self._task = task
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 6.2, *)
   public init(
-    name: String? = nil,
+    name: String?,
     priority: TaskPriority? = nil,
     @_inheritActorContext @_implicitSelfCapture operation: sending @escaping @isolated(any) () async throws -> Success
 ) {
@@ -991,7 +991,7 @@ extension Task where Failure == Never {
   @_alwaysEmitIntoClient
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public static func detached(
-    name: String? = nil,
+    name: String?,
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async -> Success
   ) -> Task<Success, Failure> {
@@ -1022,7 +1022,7 @@ extension Task where Failure == Never {
   @discardableResult
   @_alwaysEmitIntoClient
   public static func detached(
-    name: String? = nil,
+    name: String?,
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async -> Success
   ) -> Task<Success, Failure> {
@@ -1132,7 +1132,7 @@ extension Task where Failure == Error {
   @_alwaysEmitIntoClient
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public static func detached(
-    name: String? = nil,
+    name: String?,
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async throws -> Success
   ) -> Task<Success, Failure> {
@@ -1164,7 +1164,7 @@ extension Task where Failure == Error {
   @discardableResult
   @_alwaysEmitIntoClient
   public static func detached(
-    name: String? = nil,
+    name: String?,
     priority: TaskPriority? = nil,
     operation: sending @escaping @isolated(any) () async throws -> Success
   ) -> Task<Success, Failure> {

--- a/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
+++ b/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
@@ -36,7 +36,7 @@ import Swift
 %        ],
 %        ['addTask', 'addTaskUnlessCancelled'],
 %        [
-%          'name: String? = nil',
+%          'name: String?',
 %          'executorPreference taskExecutor: (any TaskExecutor)? = nil',
 %          'priority: TaskPriority? = nil',
 %          # throws and ChildTaskResult will be adjusted per task group type


### PR DESCRIPTION
Remove default nil where we don't need it in new task name APIs.

One could discuss if those now need to be optional or not, but leaving this for the review. Personally I like the same shape in all APIs: because some would be optional and others not otherwise... Which could be annoying