### PR TITLE
AST/SIL: Refactor and cleanup `AST.Type`, `AST.CanonicalType` and `SIL.Type`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ClosureSpecialization.swift
@@ -1127,7 +1127,7 @@ private extension PartialApplyInst {
     if self.numArguments == 1, 
        let fun = self.referencedFunction,
        fun.thunkKind == .reabstractionThunk || fun.thunkKind == .thunk,
-       self.arguments[0].type.isFunction,
+       self.arguments[0].type.isLoweredFunction,
        self.arguments[0].type.isReferenceCounted(in: self.parentFunction) || self.callee.type.isThickFunction
     {
       return true

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -179,7 +179,7 @@ private extension AllocStackInst {
   ///   use %3
   /// ```
   func optimizeExistential(_ context: SimplifyContext) -> Bool {
-    guard type.astType.isExistential || type.astType.isExistentialArchetype,
+    guard type.isExistential || type.isExistentialArchetype,
           let concreteFormalType = getConcreteTypeOfExistential()
     else {
       return false
@@ -266,7 +266,7 @@ private extension AllocStackInst {
     }
     let concreteType: CanonicalType
     if let initExistential {
-      assert(self.type.astType.isExistential)
+      assert(self.type.isExistential)
       if let cft = initExistential.concreteTypeOfDependentExistentialArchetype {
         // Case 1: We will replace the alloc_stack of an existential with the concrete type.
         //         `alloc_stack $any P` -> `alloc_stack $ConcreteType`
@@ -281,9 +281,9 @@ private extension AllocStackInst {
         }
         // Case 2: We will replace the alloc_stack of an existential with the existential archetype.
         //         `alloc_stack $any P` -> `alloc_stack $@opened("...")`
-        concreteType = initExistential.type.astType
+        concreteType = initExistential.type.canonicalType
       }
-    } else if self.type.astType.isExistentialArchetype, let cft = self.concreteTypeOfDependentExistentialArchetype {
+    } else if self.type.isExistentialArchetype, let cft = self.concreteTypeOfDependentExistentialArchetype {
       // Case 3: We will replace the alloc_stack of an existential archetype with the concrete type:
       //         `alloc_stack $@opened("...")` -> `alloc_stack $ConcreteType`
       concreteType = cft

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -193,12 +193,12 @@ private extension BuiltinInst {
       return
     }
 
-    guard type.astType.representationOfMetatype == .thick else {
+    guard type.representationOfMetatype == .thick else {
       return
     }
     
     let builder = Builder(before: self, context)
-    let newMetatype = builder.createMetatype(ofInstanceType: type.astType.instanceTypeOfMetatype,
+    let newMetatype = builder.createMetatype(ofInstanceType: type.canonicalType.instanceTypeOfMetatype,
                                              representation: .thin)
     operands[argument].set(to: newMetatype, context)
   }
@@ -271,11 +271,11 @@ private func typesOfValuesAreEqual(_ lhs: Value, _ rhs: Value, in function: Func
 
   let lhsMetatype = lhsExistential.metatype.type
   let rhsMetatype = rhsExistential.metatype.type
-  if lhsMetatype.isDynamicSelfMetatype != rhsMetatype.isDynamicSelfMetatype {
-    return nil
-  }
   let lhsTy = lhsMetatype.loweredInstanceTypeOfMetatype(in: function)
   let rhsTy = rhsMetatype.loweredInstanceTypeOfMetatype(in: function)
+  if lhsTy.isDynamicSelf != rhsTy.isDynamicSelf {
+    return nil
+  }
 
   // Do we know the exact types? This is not the case e.g. if a type is passed as metatype
   // to the function.

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -269,10 +269,8 @@ private func typesOfValuesAreEqual(_ lhs: Value, _ rhs: Value, in function: Func
     return nil
   }
 
-  let lhsMetatype = lhsExistential.metatype.type
-  let rhsMetatype = rhsExistential.metatype.type
-  let lhsTy = lhsMetatype.loweredInstanceTypeOfMetatype(in: function)
-  let rhsTy = rhsMetatype.loweredInstanceTypeOfMetatype(in: function)
+  let lhsTy = lhsExistential.metatype.type.canonicalType.instanceTypeOfMetatype
+  let rhsTy = rhsExistential.metatype.type.canonicalType.instanceTypeOfMetatype
   if lhsTy.isDynamicSelf != rhsTy.isDynamicSelf {
     return nil
   }
@@ -288,12 +286,18 @@ private func typesOfValuesAreEqual(_ lhs: Value, _ rhs: Value, in function: Func
     //   ((Int, Int) -> ())
     //   (((Int, Int)) -> ())
     //
-    if lhsMetatype == rhsMetatype {
+    if lhsTy == rhsTy {
       return true
     }
     // Comparing types of different classes which are in a sub-class relation is not handled by the
     // cast optimizer (below).
     if lhsTy.isClass && rhsTy.isClass && lhsTy.nominal != rhsTy.nominal {
+      return false
+    }
+
+    // Failing function casts are not supported by the cast optimizer (below).
+    // (Reason: "Be conservative about function type relationships we may add in the future.")
+    if lhsTy.isFunction && rhsTy.isFunction && lhsTy != rhsTy && !lhsTy.hasArchetype && !rhsTy.hasArchetype {
       return false
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCheckedCast.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCheckedCast.swift
@@ -70,15 +70,12 @@ private extension UnconditionalCheckedCastInst {
   // Note that init_existential_metatype is better than unconditional_checked_cast because it does not need
   // to do any runtime casting.
   func tryOptimizeCastToExistentialMetatype(_ context: SimplifyContext) {
-    guard targetFormalType.isExistentialMetatypeType,
-          sourceFormalType.isMetatypeType,
-          !sourceFormalType.isExistentialMetatypeType
-    else {
+    guard targetFormalType.isExistentialMetatype, sourceFormalType.isMetatype else {
       return
     }
     
     let instanceTy = targetFormalType.instanceTypeOfMetatype
-    guard let nominal = instanceTy.anyNominal,
+    guard let nominal = instanceTy.nominal,
           let proto = nominal as? ProtocolDecl
     else {
       return

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyConvertEscapeToNoEscape.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyConvertEscapeToNoEscape.swift
@@ -28,10 +28,6 @@ private extension ConvertEscapeToNoEscapeInst {
   ///   %3 = thin_to_thick_function %1 to $@noescape () -> ()
 
   func tryCombineWithThinToThickOperand(_ context: SimplifyContext) {
-    // compiling bridged.getFunctionTypeWithNoEscape crashes the 5.10 Windows compiler
-#if !os(Windows)
-    // TODO: https://github.com/apple/swift/issues/73253
-
     if let thinToThick = fromFunction as? ThinToThickFunctionInst {
       let builder = Builder(before: self, context)
       let noEscapeFnType = thinToThick.type.getFunctionType(withNoEscape: true)
@@ -40,6 +36,5 @@ private extension ConvertEscapeToNoEscapeInst {
       uses.replaceAll(with: newThinToThick, context)
       context.erase(instruction: self)
     }
-#endif
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/FunctionSignatureTransforms.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/FunctionSignatureTransforms.swift
@@ -148,7 +148,7 @@ private func removeMetatypArguments(in specializedFunction: Function, _ context:
     if funcArg.type.isRemovableMetatype(in: specializedFunction) {
       // Rematerialize the metatype value in the entry block.
       let builder = Builder(atBeginOf: entryBlock, context)
-      let instanceType = funcArg.type.astType.instanceTypeOfMetatype
+      let instanceType = funcArg.type.canonicalType.instanceTypeOfMetatype
       let metatype = builder.createMetatype(ofInstanceType: instanceType, representation: .thick)
       funcArg.uses.replaceAll(with: metatype, context)
       entryBlock.eraseArgument(at: funcArgIdx, context)
@@ -232,7 +232,7 @@ private func replace(apply: FullApplySite, to specializedCallee: Function, _ con
 private extension Type {
   func isRemovableMetatype(in function: Function) -> Bool {
     if isMetatype {
-      if astType.representationOfMetatype == .thick {
+      if representationOfMetatype == .thick {
         let instanceTy = loweredInstanceTypeOfMetatype(in: function)
         // For structs and enums we know the metatype statically.
         return instanceTy.isStruct || instanceTy.isEnum

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -145,7 +145,7 @@ func specializeWitnessTable(forConformance conformance: Conformance,
       let substType = witness.subst(with: conformance.specializedSubstitutions)
       return .associatedType(requirement: requirement, witness: substType)
     case .associatedConformance(let requirement, let proto, _):
-      let concreteAssociateConf = conformance.getAssociatedConformance(ofAssociatedType: requirement.type, to: proto)
+      let concreteAssociateConf = conformance.getAssociatedConformance(ofAssociatedType: requirement.rawType, to: proto)
       if concreteAssociateConf.isSpecialized {
         specializeWitnessTable(forConformance: concreteAssociateConf,
                                errorLocation: errorLocation,

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -478,7 +478,7 @@ extension Instruction {
        let iemt = oemt.operand.value as? InitExistentialMetatypeInst,
        let mt = iemt.metatype as? MetatypeInst
     {
-      return mt.type.astType.instanceTypeOfMetatype
+      return mt.type.canonicalType.instanceTypeOfMetatype
     }
     // TODO: also handle open_existential_addr and open_existential_ref.
     // Those cases are currently handled in SILCombine's `propagateConcreteTypeOfInitExistential`.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -899,7 +899,9 @@ func getGlobalInitialization(
   return nil
 }
 
-func canDynamicallyCast(from sourceType: Type, to destType: Type, in function: Function, sourceTypeIsExact: Bool) -> Bool? {
+func canDynamicallyCast(from sourceType: CanonicalType, to destType: CanonicalType,
+                        in function: Function, sourceTypeIsExact: Bool
+) -> Bool? {
   switch classifyDynamicCastBridged(sourceType.bridged, destType.bridged, function.bridged, sourceTypeIsExact) {
     case .willSucceed: return true
     case .maySucceed:  return nil

--- a/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
+++ b/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
@@ -13,10 +13,15 @@
 import AST
 import SILBridging
 
-extension AST.`Type` {
-  // See `CanonicalType.loweredType(in:)`.
+extension TypeProperties {
+  // Lowers the AST type to a SIL type - in a specific function.
+  // In contrast to `silType` this always succeeds. Still, it's not allowed to do this for certain AST types
+  // which are not present in SIL, like an `InOut` or LValue types.
+  //
+  // If `maximallyAbstracted` is true, the lowering is done with a completely opaque abstraction pattern
+  // (see AbstractionPattern for details).
   public func loweredType(in function: Function, maximallyAbstracted: Bool = false) -> Type {
-    function.bridged.getLoweredType(bridged, maximallyAbstracted).type.objectType
+    function.bridged.getLoweredType(rawType.bridged, maximallyAbstracted).type.objectType
   }
 }
 
@@ -25,16 +30,6 @@ extension CanonicalType {
   // For example, if the AST type is a `AnyFunctionType` for which the lowered type would be a `SILFunctionType`.
   public var silType: Type? {
     BridgedType.createSILType(bridged).typeOrNil
-  }
-
-  // Lowers the AST type to a SIL type - in a specific function.
-  // In contrast to `silType` this always succeeds. Still, it's not allowed to do this for certain AST types
-  // which are not present in SIL, like an `InOut` or LValue types.
-  //
-  // If `maximallyAbstracted` is true, the lowering is done with a completely opaque abstraction pattern
-  // (see AbstractionPattern for details).
-  public func loweredType(in function: Function, maximallyAbstracted: Bool = false) -> Type {
-    type.loweredType(in: function, maximallyAbstracted: maximallyAbstracted)
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -18,8 +18,12 @@ import SILBridging
 /// A `SIL.Type` is basically an `AST.CanonicalType` with the distinction between "object" and "address" type
 /// (`*T` is the type of an address pointing at T).
 /// Note that not all `CanonicalType`s can be represented as a `SIL.Type`.
-public struct Type : CustomStringConvertible, NoReflectionChildren {
+public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildren {
   public let bridged: BridgedType
+
+  public var description: String {
+    String(taking: bridged.getDebugDescription())
+  }
 
   public var isAddress: Bool { bridged.isAddress() }
   public var isObject: Bool { !isAddress }
@@ -27,7 +31,16 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
   public var addressType: Type { bridged.getAddressType().type }
   public var objectType: Type { bridged.getObjectType().type }
 
-  public var astType: CanonicalType { CanonicalType(bridged: bridged.getCanType()) }
+  public var rawType: AST.`Type` { canonicalType.rawType }
+  public var canonicalType: CanonicalType { CanonicalType(bridged: bridged.getCanType()) }
+
+  public func getLoweredType(in function: Function) -> Type {
+    function.bridged.getLoweredType(self.bridged).type
+  }
+
+  //===--------------------------------------------------------------------===//
+  //                           Various type properties
+  //===--------------------------------------------------------------------===//
 
   public func isTrivial(in function: Function) -> Bool {
     return bridged.isTrivial(function.bridged)
@@ -38,10 +51,6 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
     return !bridged.isNonTrivialOrContainsRawPointer(function.bridged)
   }
 
-  /// True if this type is a value type (struct/enum) that requires deinitialization beyond
-  /// destruction of its members.
-  public var isValueTypeWithDeinit: Bool { bridged.isValueTypeWithDeinit() }
-
   public func isLoadable(in function: Function) -> Bool {
     return bridged.isLoadable(function.bridged)
   }
@@ -49,27 +58,6 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
   public func isReferenceCounted(in function: Function) -> Bool {
     return bridged.isReferenceCounted(function.bridged)
   }
-
-  public var isUnownedStorageType: Bool {
-    return bridged.isUnownedStorageType()
-  }
-
-  public var hasArchetype: Bool { bridged.hasArchetype() }
-
-  public var isClass: Bool { bridged.isClassOrBoundGenericClass() }
-  public var isStruct: Bool { bridged.isStructOrBoundGenericStruct() }
-  public var isTuple: Bool { bridged.isTuple() }
-  public var isEnum: Bool { bridged.isEnumOrBoundGenericEnum() }
-  public var isFunction: Bool { bridged.isFunction() }
-  public var isMetatype: Bool { bridged.isMetatype() }
-  public var isClassExistential: Bool { bridged.isClassExistential() }
-  public var isOptional: Bool { astType.isOptional }
-  public var isNoEscapeFunction: Bool { bridged.isNoEscapeFunction() }
-  public var containsNoEscapeFunction: Bool { bridged.containsNoEscapeFunction() }
-  public var isThickFunction: Bool { bridged.isThickFunction() }
-  public var isAsyncFunction: Bool { bridged.isAsyncFunction() }
-
-  public var canBeClass: AST.`Type`.TraitResult { astType.canBeClass }
 
   public var isMoveOnly: Bool { bridged.isMoveOnly() }
 
@@ -82,84 +70,81 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
     !isNoEscapeFunction && isEscapable(in: function)
   }
 
-  /// Can only be used if the type is in fact a nominal type.
-  public var nominal: NominalTypeDecl? {
-    bridged.getNominalOrBoundGenericNominal().getAs(NominalTypeDecl.self)
-  }
+  public var builtinVectorElementType: Type { canonicalType.builtinVectorElementType.silType! }
 
-  public var superClassType: Type? {
-    precondition(isClass)
-    return bridged.getSuperClassType().typeOrNil
-  }
-
-  public var contextSubstitutionMap: SubstitutionMap {
-    SubstitutionMap(bridged: bridged.getContextSubstitutionMap())
-  }
-
-  public var isGenericAtAnyLevel: Bool { bridged.isGenericAtAnyLevel() }
-
-  public var isOrContainsObjectiveCClass: Bool { bridged.isOrContainsObjectiveCClass() }
-
-  public var isBuiltinInteger: Bool { bridged.isBuiltinInteger() }
-  public var isBuiltinFloat: Bool { bridged.isBuiltinFloat() }
-  public var isBuiltinVector: Bool { bridged.isBuiltinVector() }
-  public var builtinVectorElementType: Type { bridged.getBuiltinVectorElementType().type }
-
-  public var isLegalFormalType: Bool { astType.isLegalFormalType }
-
-  public func isBuiltinInteger(withFixedWidth width: Int) -> Bool {
-    bridged.isBuiltinFixedWidthInteger(width)
-  }
+  public var superClassType: Type? { canonicalType.superClassType?.silType }
 
   public func isExactSuperclass(of type: Type) -> Bool {
     bridged.isExactSuperclassOf(type.bridged)
   }
 
-  public var isVoid: Bool {
-    bridged.isVoid()
+  public func loweredInstanceTypeOfMetatype(in function: Function) -> Type {
+    return canonicalType.instanceTypeOfMetatype.loweredType(in: function)
   }
 
+  public var isMarkedAsImmortal: Bool { bridged.isMarkedAsImmortal() }
+
+  //===--------------------------------------------------------------------===//
+  //                Properties of lowered `SILFunctionType`s
+  //===--------------------------------------------------------------------===//
+
+  public var isLoweredFunction: Bool { bridged.isFunction() }
+  public var isNoEscapeFunction: Bool { bridged.isNoEscapeFunction() }
+  public var isCalleeConsumedFunction: Bool { bridged.isCalleeConsumedFunction() }
+  public var containsNoEscapeFunction: Bool { bridged.containsNoEscapeFunction() }
+  public var isThickFunction: Bool { bridged.isThickFunction() }
+  public var isAsyncFunction: Bool { bridged.isAsyncFunction() }
+
+  public var invocationGenericSignatureOfFunction: GenericSignature {
+    GenericSignature(bridged: bridged.getInvocationGenericSignatureOfFunctionType())
+  }
+
+  // compiling bridged.getFunctionTypeWithNoEscape crashes the 5.10 Windows compiler
+  // TODO: https://github.com/apple/swift/issues/73253
+  #if !os(Windows)
+    // Returns a new SILFunctionType with changed "escapeness".
+    public func getFunctionType(withNoEscape: Bool) -> Type {
+      bridged.getFunctionTypeWithNoEscape(withNoEscape).type
+    }
+  #endif
+
+  //===--------------------------------------------------------------------===//
+  //                           Aggregates
+  //===--------------------------------------------------------------------===//
+
+  public var isVoid: Bool { isTuple && tupleElements.isEmpty }
+
+  /// True if the type has no stored properties.
+  /// For example an empty tuple or an empty struct or a combination of such.
   public func isEmpty(in function: Function) -> Bool {
     bridged.isEmpty(function.bridged)
   }
 
-  public var tupleElements: TupleElementArray { TupleElementArray(type: self) }
-
-  public func getLoweredType(in function: Function) -> Type {
-    function.bridged.getLoweredType(self.bridged).type
+  public var tupleElements: TupleElementArray {
+    precondition(isTuple)
+    return TupleElementArray(type: self)
   }
 
-  /// Can only be used if the type is in fact a nominal type.
   /// Returns nil if the nominal is a resilient type because in this case the complete list
   /// of fields is not known.
   public func getNominalFields(in function: Function) -> NominalFieldsArray? {
-    if nominal!.isResilient(in: function) {
+    guard let nominal = nominal, !nominal.isResilient(in: function) else {
       return nil
     }
     return NominalFieldsArray(type: self, function: function)
   }
 
-  /// Can only be used if the type is in fact an enum type.
   /// Returns nil if the enum is a resilient type because in this case the complete list
   /// of cases is not known.
   public func getEnumCases(in function: Function) -> EnumCases? {
-    if nominal!.isResilient(in: function) {
+    guard let nominal = nominal,
+          let en = nominal as? EnumDecl,
+          !en.isResilient(in: function)
+    else {
       return nil
     }
     return EnumCases(enumType: self, function: function)
   }
-
-  public func loweredInstanceTypeOfMetatype(in function: Function) -> Type {
-    bridged.getLoweredInstanceTypeOfMetatype(function.bridged).type
-  }
-
-  public var isDynamicSelfMetatype: Bool {
-    bridged.isDynamicSelfMetatype()
-  }
-
-  public var isCalleeConsumedFunction: Bool { bridged.isCalleeConsumedFunction() }
-
-  public var isMarkedAsImmortal: Bool { bridged.isMarkedAsImmortal() }
 
   public func getIndexOfEnumCase(withName name: String) -> Int? {
     let idx = name._withBridgedStringRef {
@@ -189,18 +174,6 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
       return cases.contains { $0.payload?.aggregateIsOrContains(otherType, in: function) ?? false }
     }
     return false
-  }
-
-// compiling bridged.getFunctionTypeWithNoEscape crashes the 5.10 Windows compiler
-#if !os(Windows)
-  // TODO: https://github.com/apple/swift/issues/73253
-  public func getFunctionType(withNoEscape: Bool) -> Type {
-    bridged.getFunctionTypeWithNoEscape(withNoEscape).type
-  }
-#endif
-
-  public var description: String {
-    String(taking: bridged.getDebugDescription())
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -99,14 +99,10 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
     GenericSignature(bridged: bridged.getInvocationGenericSignatureOfFunctionType())
   }
 
-  // compiling bridged.getFunctionTypeWithNoEscape crashes the 5.10 Windows compiler
-  // TODO: https://github.com/apple/swift/issues/73253
-  #if !os(Windows)
-    // Returns a new SILFunctionType with changed "escapeness".
-    public func getFunctionType(withNoEscape: Bool) -> Type {
-      bridged.getFunctionTypeWithNoEscape(withNoEscape).type
-    }
-  #endif
+  // Returns a new SILFunctionType with changed "escapeness".
+  public func getFunctionType(withNoEscape: Bool) -> Type {
+    bridged.getFunctionTypeWithNoEscape(withNoEscape).type
+  }
 
   //===--------------------------------------------------------------------===//
   //                           Aggregates

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1746,10 +1746,6 @@ SWIFT_NAME("BridgedNominalTypeDecl.isClass(self:)")
 BRIDGED_INLINE
 bool BridgedNominalTypeDecl_isClass(BridgedNominalTypeDecl decl);
 
-SWIFT_NAME("BridgedNominalTypeDecl.isGenericAtAnyLevel(self:)")
-BRIDGED_INLINE
-bool BridgedNominalTypeDecl_isGenericAtAnyLevel(BridgedNominalTypeDecl decl);
-
 SWIFT_NAME("BridgedNominalTypeDecl.setParsedMembers(self:_:fingerprint:)")
 void BridgedNominalTypeDecl_setParsedMembers(BridgedNominalTypeDecl decl,
                                              BridgedArrayRef members,
@@ -3012,23 +3008,37 @@ struct BridgedASTType {
   BRIDGED_INLINE swift::Type unbridged() const;
   BridgedOwnedString getDebugDescription() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getCanonicalType() const;
+  BRIDGED_INLINE bool hasArchetype() const;
   BRIDGED_INLINE bool isLegalFormalType() const;
+  BRIDGED_INLINE bool isGenericAtAnyLevel() const;
   BRIDGED_INLINE bool hasTypeParameter() const;
   BRIDGED_INLINE bool hasLocalArchetype() const;
   BRIDGED_INLINE bool isExistentialArchetype() const;
   BRIDGED_INLINE bool isExistentialArchetypeWithError() const;
   BRIDGED_INLINE bool isExistential() const;
+  BRIDGED_INLINE bool isDynamicSelf() const;
+  BRIDGED_INLINE bool isClassExistential() const;
   BRIDGED_INLINE bool isEscapable() const;
   BRIDGED_INLINE bool isNoEscape() const;
   BRIDGED_INLINE bool isInteger() const;
+  BRIDGED_INLINE bool isUnownedStorageType() const;
   BRIDGED_INLINE bool isMetatypeType() const;
   BRIDGED_INLINE bool isExistentialMetatypeType() const;
+  BRIDGED_INLINE bool isTuple() const;
+  BRIDGED_INLINE bool isFunction() const;
+  BRIDGED_INLINE bool isBuiltinInteger() const;
+  BRIDGED_INLINE bool isBuiltinFloat() const;
+  BRIDGED_INLINE bool isBuiltinVector() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getBuiltinVectorElementType() const;
+  BRIDGED_INLINE bool isBuiltinFixedWidthInteger(SwiftInt width) const;
   BRIDGED_INLINE bool isOptional() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj getNominalOrBoundGenericNominal() const;
   BRIDGED_INLINE TraitResult canBeClass() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj getAnyNominal() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getInstanceTypeOfMetatype() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getSuperClassType() const;
   BRIDGED_INLINE MetatypeRepresentation getRepresentationOfMetatype() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGenericSignature getInvocationGenericSignatureOfFunctionType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getContextSubstitutionMap() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType subst(BridgedSubstitutionMap substMap) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType subst(BridgedASTType fromType, BridgedASTType toType) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance checkConformance(BridgedDeclObj proto) const;  
@@ -3040,7 +3050,7 @@ class BridgedCanType {
 public:
   BRIDGED_INLINE BridgedCanType(swift::CanType ty);
   BRIDGED_INLINE swift::CanType unbridged() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getRawType() const;
 };
 
 struct BridgedASTTypeArray {

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -390,9 +390,18 @@ BridgedCanType BridgedASTType::getCanonicalType() const {
   return unbridged()->getCanonicalType();
 }
 
+bool BridgedASTType::hasArchetype() const {
+  return unbridged()->hasArchetype();
+}
+
 bool BridgedASTType::isLegalFormalType() const {
   return unbridged()->isLegalFormalType();
 }
+
+bool BridgedASTType::isGenericAtAnyLevel() const {
+  return unbridged()->isSpecialized();
+}
+
 
 bool BridgedASTType::hasTypeParameter() const {
   return unbridged()->hasTypeParameter();
@@ -414,6 +423,14 @@ bool BridgedASTType::isExistential() const {
   return unbridged()->is<swift::ExistentialType>();
 }
 
+bool BridgedASTType::isDynamicSelf() const {
+  return unbridged()->is<swift::DynamicSelfType>();
+}
+
+bool BridgedASTType::isClassExistential() const {
+  return unbridged()->isClassExistentialType();
+}
+
 bool BridgedASTType::isEscapable() const {
   return unbridged()->isEscapable();
 }
@@ -427,15 +444,53 @@ bool BridgedASTType::isInteger() const {
 }
 
 bool BridgedASTType::isMetatypeType() const {
-  return unbridged()->is<swift::AnyMetatypeType>();
+  return unbridged()->is<swift::MetatypeType>();
+}
+
+bool BridgedASTType::isExistentialMetatypeType() const {
+  return unbridged()->is<swift::ExistentialMetatypeType>();
+}
+
+bool BridgedASTType::isTuple() const {
+  return unbridged()->is<swift::TupleType>();
+}
+
+bool BridgedASTType::isFunction() const {
+  return unbridged()->is<swift::FunctionType>();
+}
+
+bool BridgedASTType::isBuiltinInteger() const {
+  return unbridged()->is<swift::BuiltinIntegerType>();
+}
+
+bool BridgedASTType::isBuiltinFloat() const {
+  return unbridged()->is<swift::BuiltinFloatType>();
+}
+
+bool BridgedASTType::isBuiltinVector() const {
+  return unbridged()->is<swift::BuiltinVectorType>();
+}
+
+BridgedASTType BridgedASTType::getBuiltinVectorElementType() const {
+  return {unbridged()->castTo<swift::BuiltinVectorType>()->getElementType().getPointer()};
+}
+
+bool BridgedASTType::isBuiltinFixedWidthInteger(SwiftInt width) const {
+  if (auto *intTy = unbridged()->getAs<swift::BuiltinIntegerType>())
+    return intTy->isFixedWidth((unsigned)width);
+  return false;
 }
 
 bool BridgedASTType::isOptional() const {
   return unbridged()->getCanonicalType()->isOptional();
 }
 
-bool BridgedASTType::isExistentialMetatypeType() const {
-  return unbridged()->is<swift::ExistentialMetatypeType>();
+bool BridgedASTType::isUnownedStorageType() const {
+  return unbridged()->is<swift::UnownedStorageType>();
+}
+
+OptionalBridgedDeclObj BridgedASTType::getNominalOrBoundGenericNominal() const {
+  return {unbridged()->getNominalOrBoundGenericNominal()};
 }
 
 BridgedASTType::TraitResult BridgedASTType::canBeClass() const {
@@ -450,12 +505,16 @@ BridgedASTType BridgedASTType::getInstanceTypeOfMetatype() const {
   return {unbridged()->getAs<swift::AnyMetatypeType>()->getInstanceType().getPointer()};
 }
 
+BridgedASTType BridgedASTType::getSuperClassType() const {
+  return {unbridged()->getSuperclass().getPointer()};
+}
+
 BridgedASTType::MetatypeRepresentation BridgedASTType::getRepresentationOfMetatype() const {
   return MetatypeRepresentation(unbridged()->getAs<swift::AnyMetatypeType>()->getRepresentation());
 }
 
-BridgedGenericSignature BridgedASTType::getInvocationGenericSignatureOfFunctionType() const {
-  return {unbridged()->castTo<swift::SILFunctionType>()->getInvocationGenericSignature().getPointer()};
+BridgedSubstitutionMap BridgedASTType::getContextSubstitutionMap() const {
+  return unbridged()->getContextSubstitutionMap();
 }
 
 BridgedASTType BridgedASTType::subst(BridgedSubstitutionMap substMap) const {
@@ -496,7 +555,7 @@ swift::CanType BridgedCanType::unbridged() const {
   return swift::CanType(type);
 }
 
-BridgedASTType BridgedCanType::getType() const {
+BridgedASTType BridgedCanType::getRawType() const {
   return {type};
 }
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -243,44 +243,20 @@ struct BridgedType {
   BRIDGED_INLINE bool isAddress() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getAddressType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getObjectType() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getASTType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDiagnosticArgument asDiagnosticArgument() const;
   BRIDGED_INLINE bool isTrivial(BridgedFunction f) const;
   BRIDGED_INLINE bool isNonTrivialOrContainsRawPointer(BridgedFunction f) const;
-  BRIDGED_INLINE bool isValueTypeWithDeinit() const;
   BRIDGED_INLINE bool isLoadable(BridgedFunction f) const;
   BRIDGED_INLINE bool isReferenceCounted(BridgedFunction f) const;
-  BRIDGED_INLINE bool isUnownedStorageType() const;
-  BRIDGED_INLINE bool hasArchetype() const;
-  BRIDGED_INLINE bool isNominalOrBoundGenericNominal() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj getNominalOrBoundGenericNominal() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getContextSubstitutionMap() const;
-  BRIDGED_INLINE bool isGenericAtAnyLevel() const;
-  BRIDGED_INLINE bool isClassOrBoundGenericClass() const;
-  BRIDGED_INLINE bool isStructOrBoundGenericStruct() const;
-  BRIDGED_INLINE bool isTuple() const;
-  BRIDGED_INLINE bool isEnumOrBoundGenericEnum() const;
   BRIDGED_INLINE bool isFunction() const;
-  BRIDGED_INLINE bool isMetatype() const;
-  BRIDGED_INLINE bool isClassExistential() const;
-  BRIDGED_INLINE bool isOptional() const;
   BRIDGED_INLINE bool isNoEscapeFunction() const;
   BRIDGED_INLINE bool containsNoEscapeFunction() const;
   BRIDGED_INLINE bool isThickFunction() const;
   BRIDGED_INLINE bool isAsyncFunction() const;
-  BRIDGED_INLINE bool isVoid() const;
   BRIDGED_INLINE bool isEmpty(BridgedFunction f) const;
   BRIDGED_INLINE bool isMoveOnly() const;
   BRIDGED_INLINE bool isEscapable(BridgedFunction f) const;
-  BRIDGED_INLINE bool isOrContainsObjectiveCClass() const;
-  BRIDGED_INLINE bool isBuiltinInteger() const;
-  BRIDGED_INLINE bool isBuiltinFloat() const;
-  BRIDGED_INLINE bool isBuiltinVector() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getBuiltinVectorElementType() const;
-  BRIDGED_INLINE bool isBuiltinFixedWidthInteger(SwiftInt width) const;
   BRIDGED_INLINE bool isExactSuperclassOf(BridgedType t) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getLoweredInstanceTypeOfMetatype(BridgedFunction f) const;
-  BRIDGED_INLINE bool isDynamicSelfMetatype() const;
   BRIDGED_INLINE bool isCalleeConsumedFunction() const;
   BRIDGED_INLINE bool isMarkedAsImmortal() const;
   BRIDGED_INLINE SwiftInt getCaseIdxOfEnumType(BridgedStringRef name) const;
@@ -295,8 +271,8 @@ struct BridgedType {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType
   getTupleElementType(SwiftInt idx) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getFunctionTypeWithNoEscape(bool withNoEscape) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGenericSignature getInvocationGenericSignatureOfFunctionType() const;
   BRIDGED_INLINE BridgedArgumentConvention getCalleeConvention() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getSuperClassType() const;
 };
 
 // SIL Bridging

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -320,10 +320,6 @@ BridgedType BridgedType::getObjectType() const {
   return unbridged().getObjectType();
 }
 
-BridgedASTType BridgedType::getASTType() const {
-  return {unbridged().getASTType().getPointer()};
-}
-
 BridgedDiagnosticArgument BridgedType::asDiagnosticArgument() const {
   return swift::DiagnosticArgument(unbridged().getASTType());
 }
@@ -336,10 +332,6 @@ bool BridgedType::isNonTrivialOrContainsRawPointer(BridgedFunction f) const {
   return unbridged().isNonTrivialOrContainsRawPointer(f.getFunction());
 }
 
-bool BridgedType::isValueTypeWithDeinit() const {
-  return unbridged().isValueTypeWithDeinit();
-}
-
 bool BridgedType::isLoadable(BridgedFunction f) const {
   return unbridged().isLoadable(f.getFunction());
 }
@@ -348,63 +340,8 @@ bool BridgedType::isReferenceCounted(BridgedFunction f) const {
   return unbridged().isReferenceCounted(f.getFunction());
 }
 
-bool BridgedType::isUnownedStorageType() const {
-  return unbridged().isUnownedStorageType();
-}
-
-bool BridgedType::hasArchetype() const {
-  return unbridged().hasArchetype();
-}
-
-bool BridgedType::isNominalOrBoundGenericNominal() const {
-  return unbridged().getNominalOrBoundGenericNominal() != nullptr;
-}
-
-BridgedSubstitutionMap BridgedType::getContextSubstitutionMap() const {
-  swift::CanType astType = unbridged().getASTType();
-  return astType->getContextSubstitutionMap();
-}
-
-bool BridgedType::isGenericAtAnyLevel() const {
-  swift::CanType astType = unbridged().getASTType();
-  return astType->isSpecialized();
-}
-
-OptionalBridgedDeclObj BridgedType::getNominalOrBoundGenericNominal() const {
-  return {unbridged().getNominalOrBoundGenericNominal()};
-}
-
-bool BridgedType::isClassOrBoundGenericClass() const {
-  return unbridged().getClassOrBoundGenericClass() != 0;
-}
-
-bool BridgedType::isStructOrBoundGenericStruct() const {
-  return unbridged().getStructOrBoundGenericStruct() != nullptr;
-}
-
-bool BridgedType::isTuple() const {
-  return unbridged().isTuple();
-}
-
-bool BridgedType::isEnumOrBoundGenericEnum() const {
-  return unbridged().getEnumOrBoundGenericEnum() != nullptr;
-}
-
 bool BridgedType::isFunction() const {
   return unbridged().isFunction();
-}
-
-bool BridgedType::isMetatype() const {
-  return unbridged().isMetatype();
-}
-
-bool BridgedType::isClassExistential() const {
-  return unbridged().isClassExistentialType();
-}
-
-bool BridgedType::isOptional() const {
-  swift::CanType astType = unbridged().getASTType();
-  return astType->isOptional();
 }
 
 bool BridgedType::isNoEscapeFunction() const {
@@ -423,10 +360,6 @@ bool BridgedType::isAsyncFunction() const {
   return unbridged().isAsyncFunction();
 }
 
-bool BridgedType::isVoid() const {
-  return unbridged().isVoid();
-}
-
 bool BridgedType::isEmpty(BridgedFunction f) const {
   return unbridged().isEmpty(*f.getFunction());
 }
@@ -439,42 +372,8 @@ bool BridgedType::isEscapable(BridgedFunction f) const {
   return unbridged().isEscapable(*f.getFunction());
 }
 
-bool BridgedType::isOrContainsObjectiveCClass() const {
-  return unbridged().isOrContainsObjectiveCClass();
-}
-
-bool BridgedType::isBuiltinInteger() const {
-  return unbridged().isBuiltinInteger();
-}
-
-bool BridgedType::isBuiltinFloat() const {
-  return unbridged().isBuiltinFloat();
-}
-
-bool BridgedType::isBuiltinVector() const {
-  return unbridged().isBuiltinVector();
-}
-
-BridgedType BridgedType::getBuiltinVectorElementType() const {
-  return unbridged().getBuiltinVectorElementType();
-}
-
-bool BridgedType::isBuiltinFixedWidthInteger(SwiftInt width) const {
-  return unbridged().isBuiltinFixedWidthInteger((unsigned)width);
-}
-
 bool BridgedType::isExactSuperclassOf(BridgedType t) const {
   return unbridged().isExactSuperclassOf(t.unbridged());
-}
-
-BridgedType BridgedType::getLoweredInstanceTypeOfMetatype(BridgedFunction f) const {
-  return unbridged().getLoweredInstanceTypeOfMetatype(f.getFunction());
-}
-
-bool BridgedType::isDynamicSelfMetatype() const {
-  auto metaType = unbridged().castTo<swift::MetatypeType>();
-  swift::Type instTy = metaType->getInstanceType();
-  return instTy->is<swift::DynamicSelfType>();
 }
 
 bool BridgedType::isCalleeConsumedFunction() const {
@@ -537,13 +436,13 @@ BridgedType BridgedType::getFunctionTypeWithNoEscape(bool withNoEscape) const {
   return swift::SILType::getPrimitiveObjectType(newTy);
 }
 
+BridgedGenericSignature BridgedType::getInvocationGenericSignatureOfFunctionType() const {
+  return {unbridged().castTo<swift::SILFunctionType>()->getInvocationGenericSignature().getPointer()};
+}
+
 BridgedArgumentConvention BridgedType::getCalleeConvention() const {
   auto fnType = unbridged().getAs<swift::SILFunctionType>();
   return getArgumentConvention(fnType->getCalleeConvention());
-}
-
-BridgedType BridgedType::getSuperClassType() const {
-  return unbridged().getSuperclass();
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -264,23 +264,6 @@ public:
     });
   }
 
-  bool isBuiltinInteger() const {
-    return is<BuiltinIntegerType>();
-  }
-
-  bool isBuiltinFixedWidthInteger(unsigned width) const {
-    BuiltinIntegerType *bi = getAs<BuiltinIntegerType>();
-    return bi && bi->isFixedWidth(width);
-  }
-
-  bool isBuiltinFloat() const {
-    return is<BuiltinFloatType>();
-  }
-
-  bool isBuiltinVector() const {
-    return is<BuiltinVectorType>();
-  }
-
   bool isBuiltinBridgeObject() const { return is<BuiltinBridgeObjectType>(); }
 
   SILType getBuiltinVectorElementType() const {
@@ -936,8 +919,6 @@ public:
   }
 
   SILType getLoweredInstanceTypeOfMetatype(SILFunction *function) const;
-
-  bool isOrContainsObjectiveCClass() const;
 
   bool isCalleeConsumedFunction() const {
     auto funcTy = castTo<SILFunctionType>();

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -403,7 +403,7 @@ enum class BridgedDynamicCastResult {
   willFail
 };
 
-BridgedDynamicCastResult classifyDynamicCastBridged(BridgedType sourceTy, BridgedType destTy,
+BridgedDynamicCastResult classifyDynamicCastBridged(BridgedCanType sourceTy, BridgedCanType destTy,
                                                     BridgedFunction function,
                                                     bool sourceTypeIsExact);
 

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1099,18 +1099,6 @@ SILType SILType::getLoweredInstanceTypeOfMetatype(SILFunction *function) const {
   return tl.getLoweredType();
 }
 
-bool SILType::isOrContainsObjectiveCClass() const {
-  return getASTType().findIf([](Type ty) {
-    if (ClassDecl *cd = ty->getClassOrBoundGenericClass()) {
-      if (cd->isForeign() || cd->getObjectModel() == ReferenceCounting::ObjC)
-        return true;
-    }
-    if (ty->is<ProtocolCompositionType>())
-      return true;
-    return false;
-  });
-}
-
 static bool hasImmortalAttr(NominalTypeDecl *nominal) {
   if (auto *semAttr = nominal->getAttrs().getAttribute<SemanticsAttr>()) {
     if (semAttr->Value == semantics::ARC_IMMORTAL) {

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -2120,7 +2120,7 @@ bool BeginApply_canInline(BridgedInstruction beginApply) {
   return swift::SILInliner::canInlineBeginApply(beginApply.getAs<BeginApplyInst>());
 }
 
-BridgedDynamicCastResult classifyDynamicCastBridged(BridgedType sourceTy, BridgedType destTy,
+BridgedDynamicCastResult classifyDynamicCastBridged(BridgedCanType sourceTy, BridgedCanType destTy,
                                                     BridgedFunction function,
                                                     bool sourceTypeIsExact) {
   static_assert((int)DynamicCastFeasibility::WillSucceed == (int)BridgedDynamicCastResult::willSucceed);
@@ -2129,8 +2129,8 @@ BridgedDynamicCastResult classifyDynamicCastBridged(BridgedType sourceTy, Bridge
 
   return static_cast<BridgedDynamicCastResult>(
     classifyDynamicCast(function.getFunction()->getModule().getSwiftModule(),
-                        sourceTy.unbridged().getASTType(),
-                        destTy.unbridged().getASTType(),
+                        sourceTy.unbridged(),
+                        destTy.unbridged(),
                         sourceTypeIsExact));
 }
 

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -273,7 +273,7 @@ bb0:
 }
 
 // CHECK-LABEL: sil @different_function_metatype2
-// CHECK:         [[R:%.*]] = builtin "is_same_metatype"
+// CHECK:         [[R:%.*]] = integer_literal $Builtin.Int1, 0
 // CHECK:         return [[R]]
 // CHECK:       } // end sil function 'different_function_metatype2'
 sil @different_function_metatype2 : $@convention(thin) () -> Builtin.Int1 {
@@ -283,6 +283,34 @@ bb0:
   %2 = init_existential_metatype %0 : $@thick ((Int, Int) -> ()).Type, $@thick Any.Type
   %3 = init_existential_metatype %1 : $@thick (((Int, Int)) -> ()).Type, $@thick Any.Type
   %4 = builtin "is_same_metatype"(%2 : $@thick Any.Type, %3 : $@thick Any.Type) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @unknown_function_metatype1 :
+// CHECK:         [[R:%.*]] = builtin "is_same_metatype"
+// CHECK:         return [[R]]
+// CHECK:       } // end sil function 'unknown_function_metatype1'
+sil @unknown_function_metatype1 : $@convention(thin) <T> () -> Builtin.Int1 {
+bb0:
+  %0 = metatype $@thick ((T) -> Bool).Type
+  %1 = metatype $@thick ((Int) -> Bool).Type
+  %2 = init_existential_metatype %0, $@thick Any.Type
+  %3 = init_existential_metatype %1, $@thick Any.Type
+  %4 = builtin "is_same_metatype"(%2, %3) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @unknown_function_metatype2 :
+// CHECK:         [[R:%.*]] = builtin "is_same_metatype"
+// CHECK:         return [[R]]
+// CHECK:       } // end sil function 'unknown_function_metatype2'
+sil @unknown_function_metatype2 : $@convention(thin) <T> () -> Builtin.Int1 {
+bb0:
+  %0 = metatype $@thick ((Int) -> Bool).Type
+  %1 = metatype $@thick ((T) -> Bool).Type
+  %2 = init_existential_metatype %0, $@thick Any.Type
+  %3 = init_existential_metatype %1, $@thick Any.Type
+  %4 = builtin "is_same_metatype"(%2, %3) : $Builtin.Int1
   return %4 : $Builtin.Int1
 }
 


### PR DESCRIPTION
* let `SIL.Type` conform to `TypeProperties` to share the implementation of common type properties between the AST types and `SIL.Type`
* call references to an `AST.Type` `rawType` (instead of just `type`)
* remove unneeded stuff
* add comments
*  use formal types instead of SIL types for classifying dynamic casts
* remove a workaround for a Windows 5.10 host compiler crash

This is mostly a NFC.