### PR TITLE
[cxx-interop] Do not create copies of nullable pointers passed as optionals

### DIFF
--- a/test/Interop/SwiftToObjCxx/optional-objc-class-in-obj-cxx.swift
+++ b/test/Interop/SwiftToObjCxx/optional-objc-class-in-obj-cxx.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %s -module-name UseCoreFoundation -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/UseCoreFoundation.h
+// RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c -x objective-c++-header %t/UseCoreFoundation.h -o %t/o.o
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+public class TestFoundationType {
+    private let _bundle: Bundle?
+
+    public init(resourcesBundle bundle: Bundle? = nil) {
+        _bundle = bundle
+    }
+}


### PR DESCRIPTION
In reverse interop, we create copies of values that will be consumed by the Swift function. This is not necessary for pointers that are passed as swift::Optional to Swift. These are layout compatible, and consuming a pointer should not require us to do anything extra, ARC takes care of all the details.

rdar://146855233