### PR TITLE
[cxx-interop] Fix exporting Swift enums with C POD associated data

### DIFF
--- a/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/core-foundation-types-in-cxx.swift
@@ -3,6 +3,10 @@
 // RUN: %target-swift-frontend %s -module-name UseCoreFoundation -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/UseCoreFoundation.h
 // RUN: %FileCheck %s < %t/UseCoreFoundation.h
 
+// RUN: echo "#include <netinet/in.h>" > %t/full-header.h
+// RUN: cat %t/UseCoreFoundation.h >> %t/full-header.h
+// RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c -x objective-c++-header %t/full-header.h -o %t/o.o
+
 // REQUIRES: objc_interop
 
 import CoreFoundation
@@ -14,6 +18,10 @@ public func foobar(_ a: CFData) -> Bool {
 
 public func networkThing() -> in_addr? {
     return nil
+}
+
+public enum MyEnum {
+    case value(in_addr)
 }
 
 // CHECK: SWIFT_EXTERN bool $s17UseCoreFoundation6foobarySbSo9CFDataRefaF(CFDataRef _Nonnull a) SWIFT_NOEXCEPT SWIFT_CALL; // foobar(_:)


### PR DESCRIPTION
These types are OK to by copied using memcpy. Previously, the generated code assumed these types are exported swift types with all the value witness functions.

rdar://111812577
