### PR TITLE
Simplification: remove redundant array casts

### DIFF
--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -71,6 +71,7 @@ internal func _arrayDownCastConditionalIndirect<SourceValue, TargetValue>(
 ///
 /// - Complexity: O(n), because each element must be checked.
 @inlinable //for performance reasons
+@_semantics("array.conditional_cast")
 public func _arrayConditionalCast<SourceElement, TargetElement>(
   _ source: [SourceElement]
 ) -> [TargetElement]? {

--- a/test/SILOptimizer/cast_folding.swift
+++ b/test/SILOptimizer/cast_folding.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -O -Xllvm -sil-print-types -emit-sil %s | %FileCheck %s
+// RUN: %target-swift-frontend -O -Xllvm -sil-print-types -Xllvm -sil-disable-pass=function-signature-opts -emit-sil %s | %FileCheck %s
 
 // We want to check two things here:
 // - Correctness
@@ -723,6 +723,19 @@ func test33() -> Bool {
     return cast33(A())
 }
 
+func castArray<T>(from: [T]) -> [Int]? {
+  return from as? [Int]
+}
+
+// CHECK-LABEL: sil @$s12cast_folding13callCastArray1aSaySiGSgAD_tF :
+// CHECK-NOT:     apply
+// CHECK:         [[E:%.*]] = enum $Optional<Array<Int>>, #Optional.some!enumelt, %0
+// CHECK-NOT:     apply
+// CHECK:         return [[E]]
+// CHECK:       } // end sil function '$s12cast_folding13callCastArray1aSaySiGSgAD_tF'
+public func callCastArray(a: [Int]) -> [Int]? {
+  return castArray(from: a)
+}
 
 protocol PP {
   func foo() -> Int

--- a/test/SILOptimizer/simplify_apply.sil
+++ b/test/SILOptimizer/simplify_apply.sil
@@ -139,3 +139,29 @@ bb0(%0 : $Int):
   return %11
 }
 
+sil [_semantics "array.conditional_cast"] @cast_int_array : $@convention(thin) (@guaranteed Array<Int>) -> @owned Optional<Array<Int>>
+sil [_semantics "array.conditional_cast"] @cast_any_int_array : $@convention(thin) (@guaranteed Array<Any>) -> @owned Optional<Array<Int>>
+
+// CHECK-LABEL: sil [ossa] @remove_array_cast :
+// CHECK:         %1 = copy_value %0
+// CHECK:         %2 = enum $Optional<Array<Int>>, #Optional.some!enumelt, %1
+// CHECK:         return %2
+// CHECK:       } // end sil function 'remove_array_cast'
+sil [ossa] @remove_array_cast : $@convention(thin) (@guaranteed Array<Int>) -> @owned Optional<Array<Int>> {
+bb0(%0 : @guaranteed $Array<Int>):
+  %1 = function_ref @cast_int_array : $@convention(thin) (@guaranteed Array<Int>) -> @owned Optional<Array<Int>>
+  %2 = apply %1(%0) : $@convention(thin) (@guaranteed Array<Int>) -> @owned Optional<Array<Int>>
+  return %2
+}
+
+// CHECK-LABEL: sil [ossa] @dont_remove_array_cast :
+// CHECK:         %2 = apply
+// CHECK:         return %2
+// CHECK:       } // end sil function 'dont_remove_array_cast'
+sil [ossa] @dont_remove_array_cast : $@convention(thin) (@guaranteed Array<Any>) -> @owned Optional<Array<Int>> {
+bb0(%0 : @guaranteed $Array<Any>):
+  %1 = function_ref @cast_any_int_array : $@convention(thin) (@guaranteed Array<Any>) -> @owned Optional<Array<Int>>
+  %2 = apply %1(%0) : $@convention(thin) (@guaranteed Array<Any>) -> @owned Optional<Array<Int>>
+  return %2
+}
+


### PR DESCRIPTION
Remove casts between arrays of the same type.

```
  %1 = function_ref @_arrayConditionalCast : (@guaranteed Array<Int>) -> @owned Optional<Array<Int>>
  %2 = apply %1(%0) : (@guaranteed Array<Int>) -> @owned Optional<Array<Int>>
```
->
```
  %1 = copy_value %0
  %2 = enum $Optional<Array<Int>>, #Optional.some!enumelt, %1
```

This can be a result of specialization, e.g.

```
func foo<T>(from: [T]) -> [Int]? {
  return from as? [Int]
}

func bar(a: [Int]) -> [Int]? {
  return foo(from: a)
}
```

rdar://139632757