### PR TITLE
[concurrency] Make extension have the same availability as its only containing declaration.

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1545,6 +1545,7 @@ func _taskIsCurrentExecutor(_ executor: Builtin.Executor) -> Bool
 internal func _taskIsCurrentExecutor(
   executor: Builtin.Executor, flags: UInt64) -> Bool
 
+@available(SwiftStdlib 6.2, *)
 extension GlobalActor {
   @available(SwiftStdlib 6.2, *)
   @_silgen_name("_swift_task_isCurrentGlobalActor")


### PR DESCRIPTION
Otherwise in certain cases, we will run into:

```
1588 | extension GlobalActor {
     | |         `- error: 'GlobalActor' is only available in macOS 10.15 or newer
     | `- note: add @available attribute to enclosing extension
1589 |   @available(SwiftStdlib 6.2, *)
1590 |   @_silgen_name("_swift_task_isCurrentGlobalActor")
```

rdar://146848568
