### PR TITLE
[build-wrangler] Temporarily disable a test on non-macOS.

### DIFF
--- a/test/SILOptimizer/sil_combine_concrete_existential_ossa.swift
+++ b/test/SILOptimizer/sil_combine_concrete_existential_ossa.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -O -enable-ossa-modules -Xllvm -sil-print-types -emit-sil -Xllvm -sil-verify-force-analysis-around-pass=devirtualizer -Xllvm -sil-disable-pass=function-signature-opts %s | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx
 
 //===----------------------------------------------------------------------===//
 // testReturnSelf: Call to a protocol extension method with


### PR DESCRIPTION
Just until it is looked at. Testing on macOS should prevent any loss of code coverage.

rdar://147024734
