### PR TITLE
[Clang importer] Report auxiliary decls from C++ class and namespace lookup

### DIFF
--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -329,6 +329,11 @@ void swift::performImportResolutionForClangMacroBuffer(
   ImportResolver resolver(SF);
   resolver.addImplicitImport(clangModule);
 
+  // FIXME: This is a hack that we shouldn't need, but be sure that we can
+  // see the Swift standard library.
+  if (auto stdlib = SF.getASTContext().getStdlibModule())
+    resolver.addImplicitImport(stdlib);
+
   SF.setImports(resolver.getFinishedImports());
   SF.setImportedUnderlyingModule(resolver.getUnderlyingClangModule());
 

--- a/test/Interop/Cxx/swiftify-import/counted-by-in-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-in-namespace.swift
@@ -1,0 +1,28 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Namespace -source-filename=x | %FileCheck %s
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/namespace.swift -dump-macro-expansions -typecheck -verify
+
+// CHECK: enum foo {
+// CHECK:  static func bar(_ p: UnsafeMutableBufferPointer<Float>)
+
+//--- Inputs/module.modulemap
+module Namespace {
+    header "namespace.h"
+    requires cplusplus
+}
+
+//--- Inputs/namespace.h
+
+namespace foo {
+   __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))"))) void bar(float *p, int len);
+}
+
+//--- namespace.swift
+import Namespace
+  
+func test(s: UnsafeMutableBufferPointer<Float>) {
+  foo.bar(s)
+}    

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -1,0 +1,30 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUNx: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Method -source-filename=x | %FileCheck %s
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/method.swift -dump-macro-expansions -typecheck -verify
+
+// CHECK: @_alwaysEmitIntoClient 
+// CHECK:  public mutating func bar(_ p: UnsafeMutableBufferPointer<Int32>)
+
+//--- Inputs/module.modulemap
+module Method {
+    header "method.h"
+    requires cplusplus
+}
+
+//--- Inputs/method.h
+
+class Foo {
+public:
+   __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))"))) void bar(float *p, int len);
+};
+
+//--- method.swift
+import Method
+  
+func test(s: UnsafeMutableBufferPointer<Float>) {
+  var foo = Foo()
+  foo.bar(s)
+}    

--- a/test/Interop/Cxx/swiftify-import/counted-by-method.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-method.swift
@@ -2,11 +2,11 @@
 
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUNx: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Method -source-filename=x | %FileCheck %s
+// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Method -source-filename=x | %FileCheck %s
 // RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/method.swift -dump-macro-expansions -typecheck -verify
 
 // CHECK: @_alwaysEmitIntoClient 
-// CHECK:  public mutating func bar(_ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-SAME: public mutating func bar(_ p: UnsafeMutableBufferPointer<Float>)
 
 //--- Inputs/module.modulemap
 module Method {

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class.swift
@@ -1,0 +1,29 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Method -source-filename=x | %FileCheck %s
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/method.swift -dump-macro-expansions -typecheck -verify
+
+// REQUIRES: objc_interop
+
+// CHECK: class Foo {
+// CHECK:  func bar(_ p: UnsafeMutableBufferPointer<Float>)
+
+//--- Inputs/module.modulemap
+module Method {
+    header "method.h"
+}
+
+//--- Inputs/method.h
+
+@interface Foo
+-(void)bar:(float *)p count:(int)len __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))")));
+@end
+
+//--- method.swift
+import Method
+  
+func test(foo: Foo, s: UnsafeMutableBufferPointer<Float>) {
+  foo.bar(s)
+}    


### PR DESCRIPTION
When performing name lookup into a C++ class type or namespace, make sure that we also walk through auxiliary declarations (i.e., declarations that can come from peer macro expansions) to find results. This makes the results of the "swiftify import" macro show up for name lookup.

Fixes rdar://146833294.