### PR TITLE
[IRGen] Add flags to control LLVM verify-each.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -272,6 +272,9 @@ public:
   /// well-formed?
   unsigned Verify : 1;
 
+  /// Whether to verify after every optimizer change.
+  unsigned VerifyEach : 1;
+
   OptimizationMode OptMode;
 
   /// Which sanitizer is turned on.
@@ -580,7 +583,7 @@ public:
 
   IRGenOptions()
       : OutputKind(IRGenOutputKind::LLVMAssemblyAfterOptimization),
-        Verify(true), OptMode(OptimizationMode::NotSet),
+        Verify(true), VerifyEach(false), OptMode(OptimizationMode::NotSet),
         Sanitizers(OptionSet<SanitizerKind>()),
         SanitizersWithRecoveryInstrumentation(OptionSet<SanitizerKind>()),
         SanitizeAddressUseODRIndicator(false), SanitizerUseStableABI(false),

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -592,6 +592,12 @@ def disable_swift_specific_llvm_optzns : Flag<["-"], "disable-swift-specific-llv
 def disable_llvm_verify : Flag<["-"], "disable-llvm-verify">,
   HelpText<"Don't run the LLVM IR verifier.">;
 
+def enable_llvm_verify_each : Flag<["-"], "enable-llvm-verify-each">,
+  HelpText<"Run the LLVM IR verifier after every pass.">;
+
+def disable_llvm_verify_each : Flag<["-"], "disable-llvm-verify-each">,
+  HelpText<"Don't run the LLVM IR verifier after every pass.">;
+
 def disable_llvm_value_names : Flag<["-"], "disable-llvm-value-names">,
   HelpText<"Don't add names to local values in LLVM IR">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3235,6 +3235,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_disable_llvm_verify))
     Opts.Verify = false;
 
+  Opts.VerifyEach = Args.hasFlag(OPT_enable_llvm_verify_each,
+                                 OPT_disable_llvm_verify_each, Opts.VerifyEach);
+
   Opts.EmitStackPromotionChecks |= Args.hasArg(OPT_stack_promotion_checks);
   if (const Arg *A = Args.getLastArg(OPT_stack_promotion_limit)) {
     unsigned limit;

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -294,7 +294,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
   PrintPassOpts.Indent = DebugPassStructure;
   PrintPassOpts.SkipAnalyses = DebugPassStructure;
   StandardInstrumentations SI(Module->getContext(), DebugPassStructure,
-                              /*VerifyEach*/ false, PrintPassOpts);
+                              Opts.VerifyEach, PrintPassOpts);
   SI.registerCallbacks(PIC, &MAM);
 
   PassBuilder PB(TargetMachine, PTO, PGOOpt, &PIC);


### PR DESCRIPTION
Analogous to -sil-verify-all, the new flags cause LLVM verification to be run after each LLVM optimization pass.
