### PR TITLE
Revert "utils: Update default Android SDKs in build.ps1"

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -210,11 +210,9 @@ $msbuild = "$VSInstallRoot\MSBuild\Current\Bin\$BuildArchName\MSBuild.exe"
 $UnixToolsBinDir = "$env:SystemDrive\Program Files\Git\usr\bin"
 
 if ($Android -and ($AndroidSDKs.Length -eq 0)) {
-  # By default, build and test the arm64 Android SDK. That choice might change
-  # once we can run executable tests in CI.
-  $AndroidSDKs = @("aarch64")
+  # Enable all android SDKs by default.
+  $AndroidSDKs = @("aarch64","armv7","i686","x86_64")
 }
-
 # Work around limitations of cmd passing in array arguments via powershell.exe -File
 if ($AndroidSDKs.Length -eq 1) { $AndroidSDKs = $AndroidSDKs[0].Split(",") }
 if ($WindowsSDKs.Length -eq 1) { $WindowsSDKs = $WindowsSDKs[0].Split(",") }


### PR DESCRIPTION
Reverts swiftlang/swift#79944

It is safe to default to all architectures. When building in PR testing mode, we can limit the architectures through build-windows-toolchain.bat. For nightly, we should build all the architectures.