### PR TITLE
SIL: Lower fields that are conditionally addressable because of a dependency.

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2517,7 +2517,7 @@ parseLifetimeDescriptor(Parser &P,
     // In SIL, lifetimes explicitly state whether they are dependent on a
     // memory location in addition to the value stored at that location.
     if (P.isInSILMode()
-        && name.str() == "address"
+        && (name.str() == "address" || name.str() == "address_for_deps")
         && P.Tok.is(tok::integer_literal)) {
       SourceLoc orderedLoc;
       unsigned index;
@@ -2527,7 +2527,9 @@ parseLifetimeDescriptor(Parser &P,
         return std::nullopt;
       }
       return LifetimeDescriptor::forOrdered(index, lifetimeDependenceKind, loc,
-                                            /*addressable*/ true);
+        name.str() == "address_for_deps"
+          ? LifetimeDescriptor::IsConditionallyAddressable
+          : LifetimeDescriptor::IsAddressable);
     }
     
     return LifetimeDescriptor::forNamed(name, lifetimeDependenceKind, loc);

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -34,7 +34,7 @@ public func test(pview: borrowing PView) -> View {
   return pview.getDefault()
 }
 
-// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @lifetime(borrow address 0)  @out Self.E {
+// CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics1PPAAE10getDefault1EQzyF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @lifetime(borrow address_for_deps 0)  @out Self.E {
 
 // CHECK-LABEL: sil hidden @$s28lifetime_dependence_generics5PViewV4getEAA4ViewVyF : $@convention(method) (PView) -> @lifetime(immortal) @owned View {
 

--- a/test/SILGen/lifetime_dependence_lowering.swift
+++ b/test/SILGen/lifetime_dependence_lowering.swift
@@ -90,21 +90,21 @@ struct Butt {
 @_addressableForDependencies
 struct AddressableForDeps {
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test16{{.*}} : $
-    // CHECK-SAME: -> @lifetime(borrow address 3) @owned Foo
+    // CHECK-SAME: -> @lifetime(borrow address_for_deps 3) @owned Foo
     @lifetime(borrow self)
     func test16(tuple: (AddressableForDeps, AddressableForDeps),
                 other: AddressableForDeps) -> Foo {}
 
     // The dependency makes the tuple pass as a single indirect argument.
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test17{{.*}} : $
-    // CHECK-SAME: -> @lifetime(borrow address 0) @owned Foo
+    // CHECK-SAME: -> @lifetime(borrow address_for_deps 0) @owned Foo
     @lifetime(borrow tuple)
     func test17(tuple: (AddressableForDeps, AddressableForDeps),
                 other: AddressableForDeps) -> Foo {}
 
     // The tuple destructures as usual, but `other` is passed indirectly.
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test18{{.*}} : $
-    // CHECK-SAME: -> @lifetime(borrow address 2) @owned Foo
+    // CHECK-SAME: -> @lifetime(borrow address_for_deps 2) @owned Foo
     @lifetime(borrow other)
     func test18(tuple: (AddressableForDeps, AddressableForDeps),
                 other: AddressableForDeps) -> Foo {}


### PR DESCRIPTION
Parameters of generic type need to be treated as potentially addressable-for-dependencies, but we don't want callers using the generic function with concrete types that are known not to be addressable-for- dependencies to be overconstrained. In SILFunctionType lowering, lower these dependencies distinctly as conditionally addressable, meaning that the dependency on an argument depends on whether the concrete type of that argument is (potentially) addressable-for-dependencies or not.
