### PR TITLE
utils: explicitly cross-compile the experimental runtimes

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2217,7 +2217,10 @@ function Build-ExperimentalRuntime {
       -Defines @{
         BUILD_SHARED_LIBS = if ($Static) { "NO" } else { "YES" };
         CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
+        CMAKE_Swift_COMPILER_TARGET = (Get-ModuleTriple $Arch);
+        CMAKE_Swift_COMPILER_WORKS = "YES";
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
+        CMAKE_SYSTEM_NAME = $Platform.ToString();
         dispatch_DIR = "$(Get-TargetProjectBinaryCache $Arch Dispatch)\cmake\modules";
       }
   }


### PR DESCRIPTION
Pass additional parameters to setup the cross-compilation for the experimental runtime.