### PR TITLE
[swift-project-settings] require flymake-proc

### DIFF
--- a/utils/swift-project-settings.el
+++ b/utils/swift-project-settings.el
@@ -430,6 +430,7 @@ files in the same directory."
       (,@gyb-targets "--" ,swiftc ,@swiftc-arguments ,@swift-sources))))
 
 (require 'flymake)
+(require 'flymake-proc nil 'noerror)
 (add-to-list 'flymake-allowed-file-name-masks '(".+\\.swift.gyb$" flymake-swift-init))
 
 (provide 'swift-project-settings)


### PR DESCRIPTION
This appears to be necessary in newer versions.

See the description of https://github.com/swiftlang/swift/pull/79583 .

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
