### PR TITLE
[Sema] Produce expected diagnostic for invalid operator usage in loop

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4865,6 +4865,11 @@ WARNING(use_of_void_pointer,none,
 // Ambiguities
 ERROR(ambiguous_decl_ref,none,
       "ambiguous use of %0", (DeclNameRef))
+NOTE(ambiguous_because_no_candidates_were_found,none,
+     "no candidates found for specified argument %0", (DeclNameRef))
+NOTE(ambiguous_no_candidates_match_argument_type,none,
+      "cannot convert result type %0 to expected argument type %1",
+      (Type, Type))
 ERROR(ambiguous_operator_ref,none,
       "ambiguous use of operator %0", (DeclNameRef))
 NOTE(ambiguous_because_of_trailing_closure,none,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2477,6 +2477,8 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
+
   static AllowArgumentMismatch *create(ConstraintSystem &cs, Type argType,
                                        Type paramType,
                                        ConstraintLocator *locator);

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1903,6 +1903,66 @@ bool AllowArgumentMismatch::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool AllowArgumentMismatch::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  auto *primaryFix = commonFixes.front().second->getAs<AllowArgumentMismatch>();
+
+  if (llvm::all_of(
+          commonFixes,
+          [&primaryFix](
+              const std::pair<const Solution *, const ConstraintFix *> &entry) {
+            auto *fix = entry.second->getAs<AllowArgumentMismatch>();
+            return primaryFix->getToType()->isEqual(fix->getToType());
+          })) {
+    auto primarySolution = commonFixes.front().first;
+    auto &CS = getConstraintSystem();
+    auto &DE = CS.getASTContext().Diags;
+
+    auto loc = CS.getConstraintLocator(simplifyLocatorToAnchor(getLocator()));
+    auto overload = primarySolution->getOverloadChoiceIfAvailable(
+        primarySolution->getCalleeLocator(loc));
+    if (!overload)
+      return false;
+
+    DeclNameRef name = DeclNameRef(overload->choice.getName().getBaseName());
+    DE.diagnose(getLoc(getAnchor()), diag::ambiguous_decl_ref, name);
+
+    bool isPartialApplication = false;
+    for (auto &entry : commonFixes) {
+      auto &solution = entry.first;
+      auto *fix = entry.second->getAs<AllowArgumentMismatch>();
+
+      auto overload = solution->getOverloadChoiceIfAvailable(
+          solution->getCalleeLocator(loc));
+      if (!overload)
+        continue;
+
+      auto anchor = fix->getAnchor();
+      auto *callExpr = getAsExpr<CallExpr>(anchor);
+
+      if (callExpr) {
+        auto fromType = fix->getFromType();
+        if (dyn_cast<FunctionType>(fromType)) {
+          isPartialApplication = true;
+        }
+      }
+
+      if (!isPartialApplication) {
+        DE.diagnose(getLoc(getAnchor()),
+                    diag::ambiguous_no_candidates_match_argument_type,
+                    fix->getFromType(), fix->getToType());
+      }
+    }
+    if (isPartialApplication)
+      DE.diagnose(getLoc(getAnchor()),
+                  diag::ambiguous_because_no_candidates_were_found, name);
+
+    return true;
+  }
+
+  return false;
+}
+
 AllowArgumentMismatch *
 AllowArgumentMismatch::create(ConstraintSystem &cs, Type argType,
                               Type paramType, ConstraintLocator *locator) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2676,6 +2676,11 @@ static bool diagnoseAmbiguity(
       auto *primaryFix = aggregateFix.front().second;
       if (primaryFix->diagnoseForAmbiguity(aggregateFix))
         return true;
+
+      if (fixKind == FixKind::AllowArgumentTypeMismatch) {
+        auto &primaryFix = aggregateFix.front();
+        return primaryFix.second->diagnose(*primaryFix.first);
+      }
     }
   }
 


### PR DESCRIPTION
Resolves #79999

Snippet:

```
func foo(_ a: Int) -> [Int] { [] }
for _ in foo(-) {}
```