### PR TITLE
[ASTGen] map oldOwnershipOperatorSpellings feature flag

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -77,6 +77,8 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.CoroutineAccessors, to: .coroutineAccessors)
     mapFeature(.ValueGenerics, to: .valueGenerics)
     mapFeature(.ABIAttribute, to: .abiAttribute)
+    // TODO: mapFeature(.KeypathWithMethodMembers, to: .keypathWithMethodMembers)
+    mapFeature(.OldOwnershipOperatorSpellings, to: .oldOwnershipOperatorSpellings)
   }
 }
 

--- a/test/ASTGen/exprs.swift
+++ b/test/ASTGen/exprs.swift
@@ -1,16 +1,19 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-dump-parse -target %target-swift-5.1-abi-triple -enable-experimental-move-only -enable-experimental-feature ParserASTGen \
+// RUN:   -enable-experimental-feature OldOwnershipOperatorSpellings \
 // RUN:   | %sanitize-address > %t/astgen.ast
 // RUN: %target-swift-frontend-dump-parse -target %target-swift-5.1-abi-triple -enable-experimental-move-only \
+// RUN:   -enable-experimental-feature OldOwnershipOperatorSpellings \
 // RUN:   | %sanitize-address > %t/cpp-parser.ast
 
 // RUN: %diff -u %t/astgen.ast %t/cpp-parser.ast
 
-// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple -enable-experimental-feature ParserASTGen)
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple -enable-experimental-feature OldOwnershipOperatorSpellings -enable-experimental-feature ParserASTGen)
 
 // REQUIRES: executable_test
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_ParserASTGen
+// REQUIRES: swift_feature_OldOwnershipOperatorSpellings
 
 // rdar://116686158
 // UNSUPPORTED: asan


### PR DESCRIPTION
Update for https://github.com/swiftlang/swift-syntax/pull/3018