### PR TITLE
AST: Introduce `DeclRuntimeAvailability`

### DIFF
--- a/include/swift/AST/AvailabilityConstraint.h
+++ b/include/swift/AST/AvailabilityConstraint.h
@@ -170,6 +170,10 @@ enum class AvailabilityConstraintFlag : uint8_t {
   /// referencing the extension. When this flag is specified, though, only the
   /// attributes directly attached to the declaration are considered.
   SkipEnclosingExtension = 1 << 0,
+
+  /// Include constraints for all domains, regardless of whether they are active
+  /// or relevant to type checking.
+  IncludeAllDomains = 1 << 1,
 };
 using AvailabilityConstraintFlags = OptionSet<AvailabilityConstraintFlag>;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1475,11 +1475,6 @@ public:
   /// extension) that makes it unavailable.
   std::optional<SemanticAvailableAttr> getUnavailableAttr() const;
 
-  /// Returns true if the decl is effectively always unavailable in the current
-  /// compilation context. This query differs from \c isUnavailable() because it
-  /// takes the availability of parent declarations into account.
-  bool isSemanticallyUnavailable() const;
-
   /// Returns true if code associated with this declaration should be considerd
   /// unreachable at runtime because the declaration is unavailable in all
   /// execution contexts in which the code may run. This result takes the

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4128,21 +4128,31 @@ public:
   void cacheResult(ValueDecl *value) const;
 };
 
+/// Describes the runtime availability of a declaration, which is a
+/// classification of whether a decl can be used at runtime (as opposed to
+/// compile time).
+///
+/// The elements of this enumeration must be ordered from most available to
+/// least available.
 enum class SemanticDeclAvailability : uint8_t {
-  /// The decl is potentially available in some contexts and/or under certain
-  /// deployment conditions.
+  /// The decl is potentially available at runtime. If it is unavailable at
+  /// compile time in the current module, it may still be considered available
+  /// at compile time by other modules with different settings. For example, a
+  /// decl that is obsolete in Swift 5 is still available to other modules that
+  /// are compiled for an earlier language mode.
   PotentiallyAvailable,
 
-  /// The decl is always unavailable in the current compilation context.
-  /// However, it may still be used at runtime by other modules with different
-  /// settings. For example a decl that is obsolete in Swift 5 is still
-  /// available to other modules compiled for an earlier language mode.
-  ConditionallyUnavailable,
-
-  /// The decl is universally unavailable. For example, when compiling for macOS
-  /// a decl with `@available(macOS, unavailable)` can never be used (except in
-  /// contexts that are also completely unavailable on macOS).
-  CompletelyUnavailable,
+  /// The decl is always unavailable at compile time in the current module and
+  /// all other modules, but it is still required to be present at load time to
+  /// maintain ABI compatibility. For example, when compiling for macOS a decl
+  /// with an `@available(macOS, unavailable)` attribute can never be invoked,
+  /// except in contexts that are also completely unavailable on macOS. This
+  /// means the declaration is unreachable by execution at runtime, but the
+  /// decl's symbols may still have been strongly linked by other binaries built
+  /// by older versions of the compiler which may have emitted unavailable code
+  /// with strong references. To preserve ABI stability, the decl must still be
+  /// emitted.
+  AlwaysUnavailableABICompatible,
 };
 
 class SemanticDeclAvailabilityRequest

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4134,7 +4134,7 @@ public:
 ///
 /// The elements of this enumeration must be ordered from most available to
 /// least available.
-enum class SemanticDeclAvailability : uint8_t {
+enum class DeclRuntimeAvailability : uint8_t {
   /// The decl is potentially available at runtime. If it is unavailable at
   /// compile time in the current module, it may still be considered available
   /// at compile time by other modules with different settings. For example, a
@@ -4155,9 +4155,9 @@ enum class SemanticDeclAvailability : uint8_t {
   AlwaysUnavailableABICompatible,
 };
 
-class SemanticDeclAvailabilityRequest
-    : public SimpleRequest<SemanticDeclAvailabilityRequest,
-                           SemanticDeclAvailability(const Decl *decl),
+class DeclRuntimeAvailabilityRequest
+    : public SimpleRequest<DeclRuntimeAvailabilityRequest,
+                           DeclRuntimeAvailability(const Decl *decl),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -4165,8 +4165,8 @@ public:
 private:
   friend SimpleRequest;
 
-  SemanticDeclAvailability evaluate(Evaluator &evaluator,
-                                    const Decl *decl) const;
+  DeclRuntimeAvailability evaluate(Evaluator &evaluator,
+                                   const Decl *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -473,8 +473,8 @@ SWIFT_REQUEST(TypeChecker, ImplicitKnownProtocolConformanceRequest,
 SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
               ValueDecl *(const ValueDecl *, const AvailableAttr *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, SemanticDeclAvailabilityRequest,
-              SemanticDeclAvailability(const Decl *),
+SWIFT_REQUEST(TypeChecker, DeclRuntimeAvailabilityRequest,
+              DeclRuntimeAvailability(const Decl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClosureEffectsRequest,
               FunctionType::ExtInfo(ClosureExpr *),

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -541,9 +541,9 @@ std::optional<SemanticAvailableAttr> Decl::getUnavailableAttr() const {
   return std::nullopt;
 }
 
-static llvm::SmallVector<AvailabilityDomain, 2>
+static llvm::SmallSetVector<AvailabilityDomain, 2>
 availabilityDomainsForABICompatibility(const ASTContext &ctx) {
-  llvm::SmallVector<AvailabilityDomain, 2> domains;
+  llvm::SmallSetVector<AvailabilityDomain, 2> domains;
 
   // Regardless of target platform, binaries built for Embedded do not require
   // compatibility.
@@ -551,77 +551,83 @@ availabilityDomainsForABICompatibility(const ASTContext &ctx) {
     return domains;
 
   if (auto targetDomain = AvailabilityDomain::forTargetPlatform(ctx))
-    domains.push_back(targetDomain->getABICompatibilityDomain());
-  
+    domains.insert(targetDomain->getABICompatibilityDomain());
+
   if (auto variantDomain = AvailabilityDomain::forTargetVariantPlatform(ctx))
-    domains.push_back(variantDomain->getABICompatibilityDomain());
+    domains.insert(variantDomain->getABICompatibilityDomain());
 
   return domains;
 }
 
-/// Returns true if \p decl is proven to be unavailable for all platforms that
-/// external modules interacting with this module could target. A declaration
-/// that is not proven to be unavailable in this way could be reachable at
-/// runtime, even if it is unavailable to all code in this module.
-static bool isUnavailableForAllABICompatiblePlatforms(const Decl *decl) {
+static bool constraintIndicatesRuntimeUnavailability(
+    const AvailabilityConstraint &constraint, const ASTContext &ctx) {
+  switch (constraint.getReason()) {
+  case AvailabilityConstraint::Reason::UnconditionallyUnavailable: {
+    return true;
+  }
+  case AvailabilityConstraint::Reason::UnavailableForDeployment:
+  case AvailabilityConstraint::Reason::Obsoleted:
+  case AvailabilityConstraint::Reason::PotentiallyUnavailable:
+    return false;
+  }
+}
+
+/// Computes the `SemanticDeclAvailability` value for `decl`.
+static SemanticDeclAvailability getSemanticDeclAvailability(const Decl *decl) {
   // Don't trust unavailability on declarations from Clang modules.
   if (isa<ClangModuleUnit>(decl->getDeclContext()->getModuleScopeContext()))
-    return false;
+    return SemanticDeclAvailability::PotentiallyAvailable;
+
+  // Check whether the decl is unavailable at all.
+  if (!decl->isUnavailable())
+    return SemanticDeclAvailability::PotentiallyAvailable;
 
   auto &ctx = decl->getASTContext();
-  llvm::SmallVector<AvailabilityDomain, 2> compatibilityDomains =
-      availabilityDomainsForABICompatibility(ctx);
+  auto compatibilityDomains = availabilityDomainsForABICompatibility(ctx);
+  auto potentiallyAvailableDomains = compatibilityDomains;
 
-  llvm::SmallSet<AvailabilityDomain, 8> unavailableDescendantDomains;
-  llvm::SmallSet<AvailabilityDomain, 8> availableDescendantDomains;
+  AvailabilityConstraintFlags flags;
 
-  // Build up the collection of relevant available and unavailable platform
-  // domains by looking at all the @available attributes. Along the way, we
-  // may find an attribute that makes the declaration universally unavailable
-  // in which case platform availability is irrelevant.
-  for (auto attr : decl->getSemanticAvailableAttrs(/*includeInactive=*/true)) {
-    auto domain = attr.getDomain();
+  // Semantic availability was already computed separately for any enclosing
+  // extension.
+  flags |= AvailabilityConstraintFlag::SkipEnclosingExtension;
+
+  // FIXME: [availability] Inactive domains have to be included because iOS
+  // availability is considered inactive when compiling a zippered module.
+  flags |= AvailabilityConstraintFlag::IncludeAllDomains;
+
+  auto constraints = getAvailabilityConstraintsForDecl(
+      decl, AvailabilityContext::forInliningTarget(ctx), flags);
+
+  for (auto constraint : constraints) {
+    if (!constraintIndicatesRuntimeUnavailability(constraint, ctx))
+      continue;
+
+    // Check whether the constraint is from a relevant domain.
+    auto domain = constraint.getDomain();
     bool isCompabilityDomainDescendant =
         llvm::find_if(compatibilityDomains,
                       [&domain](AvailabilityDomain compatibilityDomain) {
                         return compatibilityDomain.contains(domain);
                       }) != compatibilityDomains.end();
 
+    if (!domain.isActive(ctx) && !isCompabilityDomainDescendant)
+      continue;
+
     if (isCompabilityDomainDescendant) {
-      // Record the whether the descendant domain is marked available
-      // or unavailable. Unavailability overrides availability.
-      if (attr.isUnconditionallyUnavailable()) {
-        availableDescendantDomains.erase(domain);
-        unavailableDescendantDomains.insert(domain);
-      } else if (!unavailableDescendantDomains.contains(domain)) {
-        availableDescendantDomains.insert(domain);
-      }
-    } else if (attr.isActive(ctx)) {
-      // The declaration is always unavailable if an active attribute from a
-      // domain outside the compatibility hierarchy indicates unavailability.
-      if (attr.isUnconditionallyUnavailable())
-        return true;
+      // If the decl is still potentially available in some compatibility
+      // domain, keep looking at the remaining constraints.
+      potentiallyAvailableDomains.remove(domain);
+      if (!potentiallyAvailableDomains.empty())
+        continue;
     }
+
+    // Either every compatibility domain has been proven unavailable or this
+    // constraint proves runtime unavailability on its own.
+    return SemanticDeclAvailability::AlwaysUnavailableABICompatible;
   }
 
-  // If there aren't any compatibility domains to check and we didn't find any
-  // other active attributes that make the declaration unavailable, then it must
-  // be available.
-  if (compatibilityDomains.empty())
-    return false;
-
-  // Verify that the declaration has been marked unavailable in every
-  // compatibility domain.
-  for (auto compatibilityDomain : compatibilityDomains) {
-    if (!unavailableDescendantDomains.contains(compatibilityDomain))
-      return false;
-  }
-  
-  // Verify that there aren't any explicitly available descendant domains.
-  if (availableDescendantDomains.size() > 0)
-    return false;
-
-  return true;
+  return SemanticDeclAvailability::PotentiallyAvailable;
 }
 
 SemanticDeclAvailability
@@ -634,22 +640,21 @@ SemanticDeclAvailabilityRequest::evaluate(Evaluator &evaluator,
         evaluator, SemanticDeclAvailabilityRequest{parent}, inherited);
   }
 
-  if (inherited == SemanticDeclAvailability::CompletelyUnavailable ||
-      isUnavailableForAllABICompatiblePlatforms(decl))
-    return SemanticDeclAvailability::CompletelyUnavailable;
+  // If the inherited semantic availability is already maximally unavailable
+  // then skip computing unavailability for this declaration.
+  if (inherited == SemanticDeclAvailability::AlwaysUnavailableABICompatible)
+    return SemanticDeclAvailability::AlwaysUnavailableABICompatible;
 
-  if (inherited == SemanticDeclAvailability::ConditionallyUnavailable ||
-      decl->isUnavailable())
-    return SemanticDeclAvailability::ConditionallyUnavailable;
-
-  return SemanticDeclAvailability::PotentiallyAvailable;
+  auto availability = getSemanticDeclAvailability(decl);
+  return std::max(inherited, availability);
 }
 
 bool Decl::isUnreachableAtRuntime() const {
   auto availability = evaluateOrDefault(
       getASTContext().evaluator, SemanticDeclAvailabilityRequest{this},
       SemanticDeclAvailability::PotentiallyAvailable);
-  return availability == SemanticDeclAvailability::CompletelyUnavailable;
+  return availability ==
+         SemanticDeclAvailability::AlwaysUnavailableABICompatible;
 }
 
 static UnavailableDeclOptimization
@@ -852,8 +857,6 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getIntroduced() const {
 
 std::optional<AvailabilityRange>
 SemanticAvailableAttr::getIntroducedRange(const ASTContext &Ctx) const {
-  DEBUG_ASSERT(getDomain().isActive(Ctx));
-
   auto *attr = getParsedAttr();
   if (!attr->getRawIntroduced().has_value()) {
     // For versioned domains, an "introduced:" version is always required to
@@ -892,8 +895,6 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getDeprecated() const {
 
 std::optional<AvailabilityRange>
 SemanticAvailableAttr::getDeprecatedRange(const ASTContext &Ctx) const {
-  DEBUG_ASSERT(getDomain().isActive(Ctx));
-
   auto *attr = getParsedAttr();
   if (!attr->getRawDeprecated().has_value()) {
     // Regardless of the whether the domain supports versions or not, an
@@ -923,8 +924,6 @@ std::optional<llvm::VersionTuple> SemanticAvailableAttr::getObsoleted() const {
 
 std::optional<AvailabilityRange>
 SemanticAvailableAttr::getObsoletedRange(const ASTContext &Ctx) const {
-  DEBUG_ASSERT(getDomain().isActive(Ctx));
-
   auto *attr = getParsedAttr();
 
   // Obsoletion always requires a version.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -645,13 +645,6 @@ SemanticDeclAvailabilityRequest::evaluate(Evaluator &evaluator,
   return SemanticDeclAvailability::PotentiallyAvailable;
 }
 
-bool Decl::isSemanticallyUnavailable() const {
-  auto availability = evaluateOrDefault(
-      getASTContext().evaluator, SemanticDeclAvailabilityRequest{this},
-      SemanticDeclAvailability::PotentiallyAvailable);
-  return availability != SemanticDeclAvailability::PotentiallyAvailable;
-}
-
 bool Decl::isUnreachableAtRuntime() const {
   auto availability = evaluateOrDefault(
       getASTContext().evaluator, SemanticDeclAvailabilityRequest{this},

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SIL/SILProfiler.h"
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
@@ -117,7 +118,7 @@ static bool shouldProfile(SILDeclRef Constant) {
 
   if (auto *D = DC->getInnermostDeclarationDeclContext()) {
     // Do not profile AST nodes in unavailable contexts.
-    if (D->isSemanticallyUnavailable()) {
+    if (AvailabilityContext::forDeclSignature(D).isUnavailable()) {
       LLVM_DEBUG(llvm::dbgs() << "Skipping ASTNode: unavailable context\n");
       return false;
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5455,7 +5455,7 @@ TypeChecker::diagnosticIfDeclCannotBeUnavailable(const Decl *D,
   auto parentIsUnavailable = [](const Decl *D) -> bool {
     if (auto *parent =
             AvailabilityInference::parentDeclForInferredAvailability(D)) {
-      return parent->isSemanticallyUnavailable();
+      return AvailabilityContext::forDeclSignature(parent).isUnavailable();
     }
     return false;
   };

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1933,7 +1933,7 @@ checkOverrideUnavailability(ValueDecl *override, ValueDecl *base) {
   if (auto *overrideParent = override->getDeclContext()->getAsDecl()) {
     // If the parent of the override is unavailable, then the unavailability of
     // the override decl is irrelevant.
-    if (overrideParent->isSemanticallyUnavailable())
+    if (AvailabilityContext::forDeclSignature(overrideParent).isUnavailable())
       return {OverrideUnavailabilityStatus::Ignored, std::nullopt};
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1885,7 +1885,8 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
       }
 
       if (auto adoptingNominal = DC->getSelfNominalTypeDecl()) {
-        if (adoptingNominal->isSemanticallyUnavailable())
+        if (AvailabilityContext::forDeclSignature(adoptingNominal)
+                .isUnavailable())
           return true;
       }
 

--- a/test/SILGen/unavailable_decl_optimization_stub.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub.swift
@@ -90,3 +90,9 @@ public func obsoletedInSwift1() {}
 // CHECK:       } // end sil function '$s4Test17obsoletedInSwift5yyF'
 @available(swift, obsoleted: 5)
 public func obsoletedInSwift5() {}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test19introducedInSwift99yyF : $@convention(thin) () -> () {
+// CHECK-NOT:     ss36_diagnoseUnavailableCodeReached
+// CHECK:       } // end sil function '$s4Test19introducedInSwift99yyF'
+@available(swift, introduced: 99)
+public func introducedInSwift99() {}

--- a/test/SILGen/unavailable_decl_optimization_stub_back_deployed.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_back_deployed.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-emit-silgen -target %target-swift-5.8-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_8
+// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_9
+
+// REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test15unavailableFuncyyF
+// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test15unavailableFuncyyF'
+@available(*, unavailable)
+public func unavailableFunc() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test24unavailableInlinableFuncyyF
+// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test24unavailableInlinableFuncyyF'
+@available(*, unavailable)
+@inlinable public func unavailableInlinableFunc() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test27unavailableOnOSPlatformFuncyyF
+// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test27unavailableOnOSPlatformFuncyyF'
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+public func unavailableOnOSPlatformFunc() {}
+

--- a/test/SILGen/unavailable_decl_optimization_stub_macos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK
-// RUN: %target-swift-emit-silgen -target %target-swift-5.8-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -application-extension | %FileCheck %s --check-prefixes=CHECK
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-EXTENSION
+// RUN: %target-swift-emit-silgen -target %target-swift-5.8-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -application-extension | %FileCheck %s --check-prefixes=CHECK,CHECK-EXTENSION
 
 // REQUIRES: OS=macosx
 
@@ -38,8 +38,10 @@ public func unavailableOnMacOSExtensionFunc() {}
 @available(macOSApplicationExtension, unavailable) // FIXME: Seems like this should be diagnosed as redundant
 public func unavailableOnMacOSAndMacOSExtensionFunc() {}
 
-// CHECK-LABEL:     sil{{.*}}@$s4Test33availableOnMacOSExtensionOnlyFuncyyF
-// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK-LABEL:             sil{{.*}}@$s4Test33availableOnMacOSExtensionOnlyFuncyyF
+// CHECK-NO-EXTENSION:        [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NO-EXTENSION-NEXT:   [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK-EXTENSION-NOT:       _diagnoseUnavailableCodeReached
 // CHECK:           } // end sil function '$s4Test33availableOnMacOSExtensionOnlyFuncyyF'
 @available(macOS, unavailable)
 @available(macOSApplicationExtension, introduced: 10.9)
@@ -56,3 +58,44 @@ public func unavailableOniOSFunc() {}
 // CHECK:           } // end sil function '$s4Test20obsoletedOnMacOS10_9yyF'
 @available(macOS, obsoleted: 10.9)
 public func obsoletedOnMacOS10_9() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test19introducedInMacOS99yyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test19introducedInMacOS99yyF'
+@available(macOS, introduced: 99)
+public func introducedInMacOS99() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test28unavailableIntroducedInMacOSyyF
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test28unavailableIntroducedInMacOSyyF'
+@available(macOS, unavailable, introduced: 10.9)
+public func unavailableIntroducedInMacOS() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test31unavailableAndIntroducedInMacOSyyF
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test31unavailableAndIntroducedInMacOSyyF'
+@available(macOS, unavailable)
+@available(macOS, introduced: 10.9)
+public func unavailableAndIntroducedInMacOS() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test31introducedAndUnavailableInMacOSyyF
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test31introducedAndUnavailableInMacOSyyF'
+@available(macOS, introduced: 10.9)
+@available(macOS, unavailable)
+public func introducedAndUnavailableInMacOS() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test17deprecatedInMacOSyyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test17deprecatedInMacOSyyF'
+@available(macOS, deprecated)
+public func deprecatedInMacOS() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test21deprecatedInMacOS10_9yyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test21deprecatedInMacOS10_9yyF'
+@available(macOS, deprecated: 10.9)
+public func deprecatedInMacOS10_9() {}

--- a/test/SILGen/unavailable_decl_optimization_stub_macos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos.swift
@@ -1,29 +1,24 @@
-// RUN: %target-swift-emit-silgen -target %target-swift-5.8-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_8
-// RUN: %target-swift-emit-silgen -target %target-swift-5.8-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -application-extension | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_8
-// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_9
-// RUN: %target-swift-emit-silgen -target %target-swift-5.9-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -application-extension | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_9
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK
+// RUN: %target-swift-emit-silgen -target %target-swift-5.8-abi-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -application-extension | %FileCheck %s --check-prefixes=CHECK
 
 // REQUIRES: OS=macosx
 
 // CHECK-LABEL:     sil{{.*}}@$s4Test15unavailableFuncyyF
-// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
-// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
 // CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:           } // end sil function '$s4Test15unavailableFuncyyF'
 @available(*, unavailable)
 public func unavailableFunc() {}
 
 // CHECK-LABEL:     sil{{.*}}@$s4Test24unavailableInlinableFuncyyF
-// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
-// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
 // CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:           } // end sil function '$s4Test24unavailableInlinableFuncyyF'
 @available(*, unavailable)
 @inlinable public func unavailableInlinableFunc() {}
 
 // CHECK-LABEL:     sil{{.*}}@$s4Test22unavailableOnMacOSFuncyyF
-// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
-// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
 // CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:           } // end sil function '$s4Test22unavailableOnMacOSFuncyyF'
 @available(macOS, unavailable)
@@ -36,8 +31,7 @@ public func unavailableOnMacOSFunc() {}
 public func unavailableOnMacOSExtensionFunc() {}
 
 // CHECK-LABEL:     sil{{.*}}@$s4Test021unavailableOnMacOSAndD15OSExtensionFuncyyF
-// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
-// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
 // CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:           } // end sil function '$s4Test021unavailableOnMacOSAndD15OSExtensionFuncyyF'
 @available(macOS, unavailable)


### PR DESCRIPTION
`DeclRuntimeAvailabilityRequest` is a replacement for `SemanticDeclAvailabilityRequest` and satisfies a narrower query that only determines whether a decl is reachable by execution at runtime (rather than whether it is also considered available at compile time). `DeclRuntimeAvailabilityRequest` leverages the availability constraint machinery to determine whether a decl is available at runtime, rather than re-implementing it.