### PR TITLE
utils: add one more xfail for Android tests in build.ps1

### DIFF
--- a/utils/windows-swift-android-lit-test-overrides.txt
+++ b/utils/windows-swift-android-lit-test-overrides.txt
@@ -8,6 +8,7 @@
 # Prefer `xfail` for tests that fail reliably. Use `skip` for flaky tests.
 # Test summaries call them "excluded".
 
+xfail Swift(android-aarch64) :: ClangImporter/availability_custom_domains.swift
 xfail Swift(android-aarch64) :: ClangImporter/clang_builtin_pcm.swift
 xfail Swift(android-aarch64) :: Concurrency/fail_implicit_concurrency_load.swift
 xfail Swift(android-aarch64) :: DebugInfo/file_compilation_dir.swift


### PR DESCRIPTION
Failed in https://ci-external.swift.org/job/swift-main-windows-toolchain/1155/ and https://ci-external.swift.org/job/swift-PR-windows/37773/