### PR TITLE
NFC: Fix `variable never mutated` warning in `swift-backtrace`

### DIFF
--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -587,7 +587,7 @@ Generate a backtrace for the parent process.
           // If the output path is a directory, generate a filename
           let name = target!.name
           let pid = target!.pid
-          var now = timespec(tv_sec: 0, tv_nsec: 0)
+          let now = timespec(tv_sec: 0, tv_nsec: 0)
 
           let ext: String
           switch args.format {


### PR DESCRIPTION
```
stdlib/public/libexec/swift-backtrace/main.swift:590:15: warning: variable 'now' was never mutated; consider changing to 'let' constant
 588 |           let name = target!.name
 589 |           let pid = target!.pid
 590 |           var now = timespec(tv_sec: 0, tv_nsec: 0)
     |               `- warning: variable 'now' was never mutated; consider changing to 'let' constant
 591 |
 592 |           let ext: String
```

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
