### PR TITLE
Tests: Disable ClangImporter/availability_custom_domains.swift on Android

### DIFF
--- a/test/ClangImporter/availability_custom_domains.swift
+++ b/test/ClangImporter/availability_custom_domains.swift
@@ -7,6 +7,9 @@
 // REQUIRES: swift_feature_CustomAvailability
 // UNSUPPORTED: OS=windows-msvc
 
+// https://github.com/swiftlang/swift/issues/80058
+// UNSUPPORTED: OS=linux-android
+
 import Oceans // re-exports Rivers
 
 func testClangDecls() {


### PR DESCRIPTION
Unblocks Windows CI, which apparently tests Android. The underlying issue is tracked by https://github.com/swiftlang/swift/issues/80058.
