### PR TITLE
Fully-qualify otherwise identical types in generic argument conflicts

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -23,6 +23,7 @@
 #include "TypeCheckMacros.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
+#include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
@@ -2236,6 +2237,93 @@ std::string swift::describeGenericType(ValueDecl *GP, bool includeName) {
   return OS.str().str();
 }
 
+typedef llvm::SmallDenseMap<std::pair<GenericTypeParamType *, SourceLoc>,
+                            SmallVector<Type, 4>>
+        GenericArgumentConflicts;
+
+static bool diagnoseConflictingGenericArguments(DiagnosticEngine& DE,
+                                                const GenericArgumentConflicts& conflicts) {
+  auto getGenericTypeDecl = [&](ArchetypeType *archetype) -> ValueDecl * {
+    auto type = archetype->getInterfaceType();
+
+    if (auto *GTPT = type->getAs<GenericTypeParamType>())
+      return GTPT->getDecl();
+
+    if (auto *DMT = type->getAs<DependentMemberType>())
+      return DMT->getAssocType();
+
+    return nullptr;
+  };
+
+  bool diagnosed = false;
+  for (auto &conflict : conflicts) {
+    SourceLoc loc;
+    GenericTypeParamType *GP;
+
+    std::tie(GP, loc) = conflict.first;
+    auto conflictingArguments = conflict.second;
+
+    // If there are any substitutions that are not fully resolved
+    // solutions cannot be considered conflicting for the given parameter.
+    if (llvm::any_of(conflictingArguments,
+                     [](const auto &arg) { return arg->hasPlaceholder(); }))
+      continue;
+
+    auto describeType = [&](Type argType, const PrintOptions &PO) -> std::string {
+      std::string Result;
+      llvm::raw_string_ostream OS(Result);
+
+      OS << "'";
+      argType.print(OS, PO);
+      OS << "'";
+
+      if (auto *opaque = argType->getAs<OpaqueTypeArchetypeType>()) {
+        auto *decl = opaque->getDecl()->getNamingDecl();
+        OS << " (result type of '" << decl->getBaseName().userFacingName()
+           << "')";
+      } else if (auto archetype = argType->getAs<ArchetypeType>()) {
+        if (auto *GTD = getGenericTypeDecl(archetype))
+          OS << " (ADAM" << describeGenericType(GTD) << ")";
+      }
+
+      return OS.str();
+    };
+
+    llvm::SmallDenseMap<TypeBase *, std::string> descriptions;
+    llvm::StringMap<unsigned> descriptionCounts;
+    for (const auto &type : conflictingArguments) {
+      auto description = describeType(type, PrintOptions());
+      descriptions[type.getPointer()] = description;
+      descriptionCounts[description] += 1;
+    }
+
+    llvm::SmallString<64> arguments;
+    llvm::raw_svector_ostream OS(arguments);
+
+    interleave(
+        conflictingArguments,
+        [&](Type argType) {
+          auto description = descriptions[argType.getPointer()];
+          if (descriptionCounts[description] == 1) {
+            OS << description;
+            return;
+          }
+          // Two or more types have the exact same description. Fully-qualify
+          // the types to help the user disambiguate them.
+          auto PO = PrintOptions();
+          PO.FullyQualifiedTypes = true;
+          OS << describeType(argType, PO);
+        },
+        [&OS] { OS << " vs. "; });
+
+    DE.diagnose(loc, diag::conflicting_arguments_for_generic_parameter, GP,
+                OS.str());
+    diagnosed = true;
+  }
+
+  return diagnosed;
+}
+
 /// Special handling of conflicts associated with generic arguments.
 ///
 /// func foo<T>(_: T, _: T) {}
@@ -2272,8 +2360,6 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
   if (!noFixes && !allMismatches)
     return false;
 
-  auto &DE = cs.getASTContext().Diags;
-
   llvm::SmallDenseMap<TypeVariableType *,
                       std::pair<GenericTypeParamType *, SourceLoc>, 4>
       genericParams;
@@ -2302,10 +2388,7 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
     }
   }
 
-  llvm::SmallDenseMap<std::pair<GenericTypeParamType *, SourceLoc>,
-                      SmallVector<Type, 4>>
-      conflicts;
-
+  GenericArgumentConflicts conflicts;
   for (const auto &entry : genericParams) {
     auto *typeVar = entry.first;
     auto GP = entry.second;
@@ -2340,60 +2423,7 @@ static bool diagnoseConflictingGenericArguments(ConstraintSystem &cs,
       conflicts[GP].append(arguments.begin(), arguments.end());
   }
 
-  auto getGenericTypeDecl = [&](ArchetypeType *archetype) -> ValueDecl * {
-    auto type = archetype->getInterfaceType();
-
-    if (auto *GTPT = type->getAs<GenericTypeParamType>())
-      return GTPT->getDecl();
-
-    if (auto *DMT = type->getAs<DependentMemberType>())
-      return DMT->getAssocType();
-
-    return nullptr;
-  };
-
-  bool diagnosed = false;
-  for (auto &conflict : conflicts) {
-    SourceLoc loc;
-    GenericTypeParamType *GP;
-
-    std::tie(GP, loc) = conflict.first;
-    auto conflictingArguments = conflict.second;
-
-    // If there are any substitutions that are not fully resolved
-    // solutions cannot be considered conflicting for the given parameter.
-    if (llvm::any_of(conflictingArguments,
-                     [](const auto &arg) { return arg->hasPlaceholder(); }))
-      continue;
-
-    llvm::SmallString<64> arguments;
-    llvm::raw_svector_ostream OS(arguments);
-
-    interleave(
-        conflictingArguments,
-        [&](Type argType) {
-          OS << "'" << argType << "'";
-
-          if (auto *opaque = argType->getAs<OpaqueTypeArchetypeType>()) {
-            auto *decl = opaque->getDecl()->getNamingDecl();
-            OS << " (result type of '" << decl->getBaseName().userFacingName()
-               << "')";
-            return;
-          }
-
-          if (auto archetype = argType->getAs<ArchetypeType>()) {
-            if (auto *GTD = getGenericTypeDecl(archetype))
-              OS << " (" << describeGenericType(GTD) << ")";
-          }
-        },
-        [&OS] { OS << " vs. "; });
-
-    DE.diagnose(loc, diag::conflicting_arguments_for_generic_parameter, GP,
-                OS.str());
-    diagnosed = true;
-  }
-
-  return diagnosed;
+  return diagnoseConflictingGenericArguments(cs.getASTContext().Diags, conflicts);
 }
 
 /// Diagnose ambiguity related to overloaded declarations where only
@@ -2883,14 +2913,45 @@ static bool diagnoseContextualFunctionCallGenericAmbiguity(
     if (genericParamInferredTypes.size() != 2)
       return false;
 
-    auto &DE = cs.getASTContext().Diags;
+    auto describeType = [&](Type argType, const PrintOptions &PO) -> std::string {
+      std::string Result;
+      llvm::raw_string_ostream OS(Result);
+
+      OS << "'";
+      argType.print(OS, PO);
+      OS << "'";
+
+      return OS.str();
+    };
+
+    llvm::SmallDenseMap<TypeBase *, std::string> descriptions;
+    llvm::StringMap<unsigned> descriptionCounts;
+    for (const auto &type : genericParamInferredTypes) {
+      auto description = describeType(type, PrintOptions());
+      descriptions[type.getPointer()] = description;
+      descriptionCounts[description] += 1;
+    }
+
     llvm::SmallString<64> arguments;
     llvm::raw_svector_ostream OS(arguments);
+
     interleave(
         genericParamInferredTypes,
-        [&](Type argType) { OS << "'" << argType << "'"; },
+        [&](Type argType) {
+          auto description = descriptions[argType.getPointer()];
+          if (descriptionCounts[description] == 1) {
+            OS << description;
+            return;
+          }
+          // Two or more types have the exact same description. Fully-qualify
+          // the types to help the user disambiguate them.
+          auto PO = PrintOptions();
+          PO.FullyQualifiedTypes = true;
+          OS << describeType(argType, PO);
+        },
         [&OS] { OS << " vs. "; });
 
+    auto &DE = cs.getASTContext().Diags;
     DE.diagnose(AE->getLoc(), diag::conflicting_arguments_for_generic_parameter,
                 GP, OS.str());
 

--- a/test/Constraints/Inputs/identical-type-name-module.swift
+++ b/test/Constraints/Inputs/identical-type-name-module.swift
@@ -1,0 +1,9 @@
+public protocol SomeProtocol {}
+
+public struct SomeStruct: SomeProtocol {
+  public init() {}
+}
+
+public func returnsOpaqueInstance() -> some SomeProtocol {
+  SomeStruct()
+}

--- a/test/Constraints/identical-type-name.swift
+++ b/test/Constraints/identical-type-name.swift
@@ -1,0 +1,131 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(A)) -module-name A -emit-module -emit-module-path %t/A.swiftmodule %S/Inputs/identical-type-name-module.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(B)) -module-name B -emit-module -emit-module-path %t/B.swiftmodule %S/Inputs/identical-type-name-module.swift
+// RUN: %target-typecheck-verify-swift -I %t
+
+import A
+import B
+
+func takesConcreteInstance(_ a: A.SomeStruct) {}
+func takesGenericInstance<T>(_: T) {}
+func takesSameGenericInstance<T>(_: T, _: T) {}
+func takesGenericInstanceWithSameTypeRequirement<T: Sequence, U: Sequence>(_: T, _: U) where T.Element == U.Element {}
+func takesConstrainedInstance<T: A.SomeProtocol>(_: T) {}
+// expected-note@-1 {{where 'T' = 'SomeStruct'}}
+// expected-note@-2 {{where 'T' = 'some SomeProtocol'}}
+func takesConcreteType(_: A.SomeStruct.Type) {}
+func takesGenericType<T>(_: T.Type) {}
+func takesSameGenericType<T>(_: T.Type, _: T.Type) {}
+func takesGenericTypeWithSameTypeRequirement<T: Sequence, U: Sequence>(_: T.Type, _: U.Type) where T.Element == U.Element {}
+// expected-note@-1 {{in call to function 'takesGenericTypeWithSameTypeRequirement'}}
+// expected-note@-2 {{where 'T.Element' = 'A.SomeStruct', 'U.Element' = 'B.SomeStruct'}}
+func takesConstrainedType<T: A.SomeProtocol>(_: T.Type) {} // expected-note {{where 'T' = 'SomeStruct'}}
+func returnsConcreteInstance() -> A.SomeStruct { SomeStruct() }
+func returnsGenericInstance<T>() -> T { fatalError() }
+func returnsConcreteType() -> A.SomeStruct.Type { SomeStruct.self }
+func returnsGenericType<T>() -> T.Type { T.self }
+
+func callit<T>(_ f: () -> T) -> T {
+  f()
+}
+
+func test() {
+  takesConcreteInstance(SomeStruct())
+  takesConcreteInstance(A.SomeStruct())
+  takesConcreteInstance(B.SomeStruct()) // expected-error {{cannot convert value of type 'B.SomeStruct' to expected argument type 'A.SomeStruct'}}
+
+  takesGenericInstance(SomeStruct()) // expected-error {{ambiguous use of 'init()'}}
+  takesGenericInstance(A.SomeStruct())
+  takesGenericInstance(B.SomeStruct())
+
+  takesSameGenericInstance(SomeStruct(), SomeStruct()) // expected-error {{ambiguous use of 'init()'}}
+  takesSameGenericInstance(A.SomeStruct(), A.SomeStruct())
+  takesSameGenericInstance(B.SomeStruct(), B.SomeStruct())
+  takesSameGenericInstance(A.SomeStruct(), B.SomeStruct()) // expected-error {{conflicting arguments to generic parameter 'T' ('A.SomeStruct' vs. 'B.SomeStruct')}}
+
+  takesSameGenericInstance(A.returnsOpaqueInstance(), A.returnsOpaqueInstance())
+  takesSameGenericInstance(B.returnsOpaqueInstance(), B.returnsOpaqueInstance())
+  takesSameGenericInstance(A.returnsOpaqueInstance(), B.returnsOpaqueInstance()) // expected-error {{conflicting arguments to generic parameter 'T' ('some A.SomeProtocol' (result type of 'returnsOpaqueInstance') vs. 'some B.SomeProtocol' (result type of 'returnsOpaqueInstance'))}}
+
+  takesGenericInstanceWithSameTypeRequirement(Array<SomeStruct>(), Array<SomeStruct>())
+  // expected-error@-1 {{'SomeStruct' is ambiguous for type lookup in this context}}
+  // expected-error@-2 {{'SomeStruct' is ambiguous for type lookup in this context}}
+  takesGenericInstanceWithSameTypeRequirement(Array<A.SomeStruct>(), Array<A.SomeStruct>())
+  takesGenericInstanceWithSameTypeRequirement(Array<B.SomeStruct>(), Array<B.SomeStruct>())
+  takesGenericInstanceWithSameTypeRequirement(Array<A.SomeStruct>(), Array<B.SomeStruct>()) // expected-error {{type of expression is ambiguous without a type annotation}}
+
+  takesConstrainedInstance(SomeStruct())
+  takesConstrainedInstance(A.SomeStruct())
+  takesConstrainedInstance(B.SomeStruct()) // expected-error {{global function 'takesConstrainedInstance' requires that 'SomeStruct' conform to 'SomeProtocol'}}
+
+  takesConstrainedInstance(A.returnsOpaqueInstance())
+  takesConstrainedInstance(B.returnsOpaqueInstance()) // expected-error {{global function 'takesConstrainedInstance' requires that 'some SomeProtocol' conform to 'SomeProtocol'}}
+
+  takesConcreteType(SomeStruct.self)
+  takesConcreteType(A.SomeStruct.self)
+  takesConcreteType(B.SomeStruct.self) // expected-error {{cannot convert value of type 'B.SomeStruct.Type' to expected argument type 'A.SomeStruct.Type'}}
+
+  takesGenericType(SomeStruct.self) // expected-error {{conflicting arguments to generic parameter 'T' ('A.SomeStruct' vs. 'B.SomeStruct')}}
+  takesGenericType(A.SomeStruct.self)
+  takesGenericType(B.SomeStruct.self)
+
+  takesSameGenericType(SomeStruct.self, SomeStruct.self) // expected-error {{conflicting arguments to generic parameter 'T' ('A.SomeStruct' vs. 'B.SomeStruct')}}
+  takesSameGenericType(A.SomeStruct.self, A.SomeStruct.self)
+  takesSameGenericType(B.SomeStruct.self, B.SomeStruct.self)
+  takesSameGenericType(A.SomeStruct.self, B.SomeStruct.self) // expected-error {{cannot convert value of type 'B.SomeStruct.Type' to expected argument type 'A.SomeStruct.Type'}}
+
+  takesGenericTypeWithSameTypeRequirement(Array<SomeStruct>.self, Array<SomeStruct>.self)
+  // expected-error@-1 {{'SomeStruct' is ambiguous for type lookup in this context}}
+  // expected-error@-2 {{'SomeStruct' is ambiguous for type lookup in this context}}
+  // expected-error@-3 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-4 {{generic parameter 'U' could not be inferred}}
+  takesGenericTypeWithSameTypeRequirement(Array<A.SomeStruct>.self, Array<A.SomeStruct>.self)
+  takesGenericTypeWithSameTypeRequirement(Array<B.SomeStruct>.self, Array<B.SomeStruct>.self)
+  takesGenericTypeWithSameTypeRequirement(Array<A.SomeStruct>.self, Array<B.SomeStruct>.self)
+  // expected-error@-1 {{global function 'takesGenericTypeWithSameTypeRequirement' requires the types 'A.SomeStruct' and 'B.SomeStruct' be equivalent}}
+
+  takesConstrainedType(SomeStruct.self)
+  takesConstrainedType(A.SomeStruct.self)
+  takesConstrainedType(B.SomeStruct.self) // expected-error {{global function 'takesConstrainedType' requires that 'SomeStruct' conform to 'SomeProtocol'}}
+
+  let _: SomeStruct = returnsConcreteInstance() // expected-error {{'SomeStruct' is ambiguous for type lookup in this context}}
+  let _: A.SomeStruct = returnsConcreteInstance()
+  let _: B.SomeStruct = returnsConcreteInstance() // expected-error {{cannot convert value of type 'A.SomeStruct' to specified type 'B.SomeStruct'}}
+
+  let _: SomeStruct = returnsGenericInstance() // expected-error {{'SomeStruct' is ambiguous for type lookup in this context}}
+  let _: A.SomeStruct = returnsGenericInstance()
+  let _: B.SomeStruct = returnsGenericInstance()
+
+  let _: SomeStruct.Type = returnsConcreteType() // expected-error {{'SomeStruct' is ambiguous for type lookup in this context}}
+  let _: A.SomeStruct.Type = returnsConcreteType()
+  let _: B.SomeStruct.Type = returnsConcreteType() // expected-error {{cannot convert value of type 'A.SomeStruct.Type' to specified type 'B.SomeStruct.Type'}}
+
+  let _: SomeStruct.Type = returnsGenericType() // expected-error {{'SomeStruct' is ambiguous for type lookup in this context}}
+  let _: A.SomeStruct.Type = returnsGenericType()
+  let _: B.SomeStruct.Type = returnsGenericType()
+
+  let _ = callit { SomeStruct() } // expected-error {{ambiguous use of 'init()'}}
+  let _ = callit { A.SomeStruct() }
+  let _: B.SomeStruct = callit { A.SomeStruct() } // expected-error {{conflicting arguments to generic parameter 'T' ('A.SomeStruct' vs. 'B.SomeStruct')}}
+  // expected-note@-1 {{generic parameter 'T' inferred as 'SomeStruct' from context}}
+  // expected-note@-2 {{generic parameter 'T' inferred as 'SomeStruct' from closure return expression}}
+  let _: A.SomeStruct = callit { A.SomeStruct() }
+  let _: B.SomeStruct = callit { B.SomeStruct() }
+}
+
+struct Associate {}
+func takesTopLevelAssociate(_ a: Associate) {}
+
+func takesGenericAssociate<Associate>(_ a: Associate) {
+  takesTopLevelAssociate(a) // expected-error {{cannot convert value of type 'Associate' to expected argument type 'main.Associate'}}
+}
+
+protocol P {
+  associatedtype Associate
+}
+
+extension P {
+  func f(_ a: Associate) {
+    takesTopLevelAssociate(a) // expected-error {{cannot convert value of type 'Self.Associate' to expected argument type 'Associate'}}
+  }
+}


### PR DESCRIPTION
When two conflicting generic arguments have the same base type name (e.g., due to two imported modules exporting types with the same name), the error message that's printed is quite confusing:

    _ = try JSONDecoder().decode(MyStruct.self, from: Data())
                          `- error: conflicting arguments to generic parameter 'T' ('MyStruct' vs. 'MyStruct')

In cases like this we now print the fully-qualified name of each type so that you can see which module defined each one:

    _ = try JSONDecoder().decode(MyStruct.self, from: Data())
                          `- error: conflicting arguments to generic parameter 'T' ('ModuleA.MyStruct' vs. 'ModuleB.MyStruct')