### PR TITLE
[ExplicitModule] Propagate deterministic check to explicit modules

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1425,9 +1425,6 @@ def enable_emit_generic_class_ro_t_list :
   HelpText<"Enable emission of a section with references to class_ro_t of "
            "generic class patterns">;
 
-def enable_deterministic_check :
-  Flag<["-"], "enable-deterministic-check">,
-  HelpText<"Check compiler output determinism by running it twice">;
 def always_compile_output_files :
   Flag<["-"], "always-compile-output-files">,
   HelpText<"Always compile output files even it might not change the results">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2245,4 +2245,9 @@ def disable_sandbox:
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Disable using the sandbox when executing subprocesses">;
 
+def enable_deterministic_check :
+  Flag<["-"], "enable-deterministic-check">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, CacheInvariant]>,
+  HelpText<"Check compiler output determinism by running it twice">;
+
 include "FrontendOptions.td"

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -167,6 +167,7 @@ public:
           bridgingHeaderBuildCmd.push_back(clangDep->moduleCacheKey);
         }
       }
+      addDeterministicCheckFlags(bridgingHeaderBuildCmd);
     }
 
     SwiftInterfaceModuleOutputPathResolution::ResultTy swiftInterfaceOutputPath;
@@ -183,6 +184,7 @@ public:
             remapPathsFromCommandLine(commandline, [&](StringRef path) {
               return cache.getScanService().remapPath(path);
             });
+      addDeterministicCheckFlags(commandline);
     }
 
     auto dependencyInfoCopy = resolvingDepInfo;
@@ -581,6 +583,17 @@ private:
             instance.getActionCache().put(CAS.getID(**Ref), CAS.getID(*Result)))
       return E;
     return llvm::Error::success();
+  }
+
+  void addDeterministicCheckFlags(std::vector<std::string> &cmd) {
+    // Propagate the deterministic check to explicit built module command.
+    if (!instance.getInvocation().getFrontendOptions().DeterministicCheck)
+      return;
+    cmd.push_back("-enable-deterministic-check");
+    cmd.push_back("-always-compile-output-files");
+    // disable cache replay because that defeat the purpose of the check.
+    if (instance.getInvocation().getCASOptions().EnableCaching)
+      cmd.push_back("-cache-disable-replay");
   }
 
 private:

--- a/test/CAS/deterministic_check.swift
+++ b/test/CAS/deterministic_check.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -module-load-mode prefer-serialized \
+// RUN:   %t/test.swift -o %t/deps.json -I %t -import-objc-header %t/Bridging.h \
+// RUN:   -enable-deterministic-check -cache-compile-job -cas-path %t/cas 2>&1 | %FileCheck %s
+
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
+// RUN: %FileCheck %s --check-prefix=CMD --input-file=%t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd 2>&1 | %FileCheck %s
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:B > %t/B.cmd
+// RUN: %FileCheck %s --check-prefix=CMD --input-file=%t/B.cmd
+// RUN: %swift_frontend_plain @%t/B.cmd 2>&1 | %FileCheck %s
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Test bridgingHeader | %FileCheck %s --check-prefix=CMD
+
+// CHECK: remark: produced matching output file
+// CMD: -enable-deterministic-check
+// CMD: -always-compile-output-files
+// CMD: -cache-disable-replay
+
+//--- test.swift
+import A
+import B
+public func test() {}
+
+//--- A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+public func a() { }
+
+//--- b.h
+void b(void);
+
+//--- module.modulemap
+module B {
+  header "b.h"
+  export *
+}
+
+//--- Bridging.h
+void bridge(void);

--- a/test/ScanDependencies/deterministic_check.swift
+++ b/test/ScanDependencies/deterministic_check.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -module-load-mode prefer-serialized \
+// RUN:   %t/test.swift -o %t/deps.json -I %t -enable-deterministic-check 2>&1 | %FileCheck %s
+
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
+// RUN: %FileCheck %s --check-prefix=CMD --input-file=%t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd 2>&1 | %FileCheck %s
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:B > %t/B.cmd
+// RUN: %FileCheck %s --check-prefix=CMD --input-file=%t/B.cmd
+// RUN: %swift_frontend_plain @%t/B.cmd 2>&1 | %FileCheck %s
+
+// CHECK: remark: produced matching output file
+// CMD: -enable-deterministic-check
+// CMD: -always-compile-output-files
+
+//--- test.swift
+import A
+import B
+public func test() {}
+
+//--- A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -O -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -user-module-version 1.0
+public func a() { }
+
+//--- b.h
+void b(void);
+
+//--- module.modulemap
+module B {
+  header "b.h"
+  export *
+}


### PR DESCRIPTION
Make `-enable-deterministic-check` a driver option and teach dependency scanner to propagate the option to explicit module build commmands. This allows to the option to check every build output from the compiler is deterministic.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
