### PR TITLE
[swift-settings] Only allow for a setting to be passed exactly once to #SwiftSettings.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8399,5 +8399,10 @@ ERROR(swift_settings_invalid_setting, none,
 ERROR(swift_settings_must_be_top_level, none,
       "#SwiftSettings can only be invoked as a top level declaration", ())
 
+ERROR(swift_settings_duplicate_setting, none,
+      "duplicate setting passed to #SwiftSettings", ())
+NOTE(swift_settings_duplicate_setting_original_loc, none,
+     "setting originally passed here", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -4345,7 +4345,7 @@ SwiftSettingsWalker::getSwiftSettingArgDecl(Argument arg) {
     return {};
 
   // Now lookup our swiftSettingDecl.
-  NominalTypeDecl *swiftSettingsDecl;
+  NominalTypeDecl *swiftSettingsDecl = nullptr;
   {
     SmallVector<ValueDecl *, 1> decls;
     ctx.lookupInSwiftModule("SwiftSetting", decls);

--- a/test/Sema/swiftsettings.swift
+++ b/test/Sema/swiftsettings.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-feature SwiftSettings -enable-experimental-feature Macros -c -swift-version 6 -disable-availability-checking -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature SwiftSettings -enable-experimental-feature Macros -c -swift-version 6 -disable-availability-checking -verify -Xllvm -swift-settings-allow-duplicates %s
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
@@ -15,7 +15,6 @@ actor MyActor {}
 #SwiftSettings(2) // expected-error {{Unrecognized setting passed to #SwiftSettings}}
 // expected-error @-1 {{cannot convert value of type 'Int' to expected argument type 'SwiftSetting'}}
 
-// We should for now just take the last one that is specified.
 #SwiftSettings(.defaultIsolation(MainActor.self),
                .defaultIsolation(nil))
 

--- a/test/Sema/swiftsettings_duplicates.swift
+++ b/test/Sema/swiftsettings_duplicates.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -enable-experimental-feature SwiftSettings -enable-experimental-feature Macros -c -swift-version 6 -disable-availability-checking -verify %s
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_Macros
+// REQUIRES: swift_feature_SwiftSettings
+
+// This test specifically tests the behavior of #SwiftSettings when we find
+// multiple instances of the same setting.
+
+actor MyActor {}
+
+#SwiftSettings(.defaultIsolation(MainActor.self), // expected-note 6 {{setting originally passed here}}
+               .defaultIsolation(nil)) // expected-error {{duplicate setting passed to #SwiftSettings}}
+#SwiftSettings(.defaultIsolation(nil)) // expected-error {{duplicate setting passed to #SwiftSettings}}
+#SwiftSettings(.defaultIsolation(MyActor.self)) // expected-error {{duplicate setting passed to #SwiftSettings}}
+#SwiftSettings(.defaultIsolation(1)) // expected-error {{duplicate setting passed to #SwiftSettings}}
+// expected-error @-1 {{cannot convert value of type 'Int' to expected argument type 'any Actor.Type'}}
+#SwiftSettings(2) // expected-error {{Unrecognized setting passed to #SwiftSettings}}
+// expected-error @-1 {{cannot convert value of type 'Int' to expected argument type 'SwiftSetting'}}
+
+#SwiftSettings(.defaultIsolation(MainActor.self), // expected-error {{duplicate setting passed to #SwiftSettings}}
+               .defaultIsolation(nil)) // expected-error {{duplicate setting passed to #SwiftSettings}}
+


### PR DESCRIPTION
This responds to some feedback on the forums. Most importantly this allows for
us to use variadic generics in the the type system to document whether we allow
for "appending" behavior or not. Previously, for some options we would take the
last behavior (and theoretically) for others would have silently had appending
behavior. This just makes the behavior simple and more explicit.

