### PR TITLE
[Isolated conformances] Don't check results on older runtimes

### DIFF
--- a/test/Concurrency/Runtime/isolated_conformance.swift
+++ b/test/Concurrency/Runtime/isolated_conformance.swift
@@ -173,13 +173,6 @@ await Task.detached {
     precondition(!tryCastToP(wrappedMany))
   } else {
     print("Cast succeeds, but shouldn't")
-    precondition(tryCastToP(mc))
-    precondition(tryCastToP(wrappedMC))
-
-    if #available(SwiftStdlib 5.9, *) {
-      let wrappedMany = WrapMany(wrapped: (17, mc, "Pack"))
-      precondition(tryCastToP(wrappedMany))
-    }
   }
 }.value
 


### PR DESCRIPTION
There are some configurations where we aren't able to fully determine whether isolated conformances are supported in the runtime, so don't check the negative cases.
