### PR TITLE
[tests] Run swift-(corelibs-)foundation tests in debug configuration on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -109,6 +109,9 @@ The architecture where the toolchain will execute.
 .PARAMETER Variant
 The toolchain variant to build. Defaults to `Asserts`.
 
+.PARAMETER FoundationTestConfiguration
+Whether to run swift-foundation and swift-corelibs-foundation tests in a debug or release configuration.
+
 .EXAMPLE
 PS> .\Build.ps1
 
@@ -165,6 +168,8 @@ param
   [switch] $Clean,
   [switch] $DebugInfo,
   [switch] $EnableCaching,
+  [ValidateSet("debug", "release")]
+  [string] $FoundationTestConfiguration = "debug",
   [string] $Cache = "",
   [switch] $Summary,
   [switch] $ToBatch
@@ -1478,6 +1483,7 @@ function Build-SPMProject {
     [string] $Src,
     [string] $Bin,
     [hashtable] $Arch,
+    [string] $Configuration = "release",
     [Parameter(ValueFromRemainingArguments)]
     [string[]] $AdditionalArguments
   )
@@ -1507,7 +1513,7 @@ function Build-SPMProject {
     $Arguments = @(
         "--scratch-path", $Bin,
         "--package-path", $Src,
-        "-c", "release",
+        "-c", $Configuration,
         "-Xbuild-tools-swiftc", "-I$(Get-SwiftSDK Windows)\usr\lib\swift",
         "-Xbuild-tools-swiftc", "-L$(Get-SwiftSDK Windows)\usr\lib\swift\windows",
         "-Xcc", "-I$(Get-SwiftSDK Windows)\usr\lib\swift",
@@ -2360,7 +2366,8 @@ function Build-Foundation {
       -Action Test `
       -Src $SourceCache\swift-foundation `
       -Bin "$BinaryCache\$($Arch.LLVMTarget)\CoreFoundationTests" `
-      -Arch $HostArch
+      -Arch $HostArch `
+      -Configuration $FoundationTestConfiguration
 
     $ShortArch = $Arch.LLVMName
     Invoke-IsolatingEnvVars {
@@ -2374,7 +2381,8 @@ function Build-Foundation {
         -Action Test `
         -Src $SourceCache\swift-corelibs-foundation `
         -Bin "$BinaryCache\$($Arch.LLVMTarget)\FoundationTests" `
-        -Arch $HostArch
+        -Arch $HostArch `
+        -Configuration $FoundationTestConfiguration
     }
   } else {
     $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch


### PR DESCRIPTION
This should improve CI times because building in debug configuration instead of release configuration is significantly faster. Since we don’t install the build of swift-(corelibs-)foundation using SwiftPM into the toolchain, this doesn’t have any performance impact on users of the toolchain.
