### PR TITLE
Add dump overloads to print debug info for SIL.

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -557,6 +557,9 @@ public:
   /// Pretty-print the SILBasicBlock.
   void dump() const;
 
+  /// Pretty-print the SILBasicBlock with Debug Info.
+  void dump(bool DebugInfo) const;
+
   /// Pretty-print the SILBasicBlock with the designated stream.
   void print(llvm::raw_ostream &OS) const;
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1704,7 +1704,10 @@ public:
   /// Pretty-print the SILFunction.
   void dump(bool Verbose) const;
   void dump() const;
-  
+
+  /// Pretty-print the SILFunction with DebugInfo.
+  void dump(bool Verbose, bool DebugInfo) const;
+
   /// Pretty-print the SILFunction.
   /// Useful for dumping the function when running in a debugger.
   /// Warning: no error handling is done. Fails with an assert if the file

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -911,6 +911,9 @@ public:
   void dump() const;
   void print(raw_ostream &OS) const;
 
+  /// Pretty-print the value with DebugInfo.
+  void dump(bool DebugInfo) const;
+
   /// Pretty-print the value in context, preceded by its operands (if the
   /// value represents the result of an instruction) and followed by its
   /// users.

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -975,6 +975,9 @@ public:
   /// Pretty-print the module.
   void dump(bool Verbose = false) const;
 
+  /// Pretty-print the module with DebugInfo.
+  void dump(bool Verbose, bool DebugInfo) const;
+
   /// Pretty-print the module to a file.
   /// Useful for dumping the module when running in a debugger.
   /// Warning: no error handling is done. Fails with an assert if the file

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3336,6 +3336,12 @@ void SILInstruction::dump() const {
   print(llvm::errs());
 }
 
+void SILInstruction::dump(bool DebugInfo) const {
+  SILPrintContext Ctx(llvm::errs(), /*Verbose*/ false, /*SortedSIL*/ false,
+                      DebugInfo, /*PrintFullConvention*/ false);
+  SILPrinter(Ctx).print(this);
+}
+
 void SingleValueInstruction::dump() const {
   SILInstruction::dump();
 }
@@ -3352,6 +3358,13 @@ void NonSingleValueInstruction::dump() const {
 /// Pretty-print the SILBasicBlock to errs.
 void SILBasicBlock::dump() const {
   print(llvm::errs());
+}
+
+/// Pretty-print the SILBasicBlock to errs with Debug Info.
+void SILBasicBlock::dump(bool DebugInfo) const {
+  SILPrintContext Ctx(llvm::errs(), /*Verbose*/ false, /*SortedSIL*/ false,
+                      DebugInfo, /*PrintFullConvention*/ false);
+  SILPrinter(Ctx).print(this);
 }
 
 /// Pretty-print the SILBasicBlock to the designated stream.
@@ -3406,6 +3419,13 @@ void SILFunction::dump(bool Verbose) const {
 // This is out of line so the debugger can find it.
 void SILFunction::dump() const {
   dump(false);
+}
+
+/// Pretty-print the SILFunction to errs.
+void SILFunction::dump(bool Verbose, bool DebugInfo) const {
+  SILPrintContext Ctx(llvm::errs(), Verbose, /*SortedSIL*/ false, DebugInfo,
+                      /*PrintFullConvention*/ false);
+  print(Ctx);
 }
 
 void SILFunction::dump(const char *FileName) const {
@@ -3729,6 +3749,13 @@ void SILGlobalVariable::printName(raw_ostream &OS) const {
 /// Pretty-print the SILModule to errs.
 void SILModule::dump(bool Verbose) const {
   SILPrintContext Ctx(llvm::errs(), Verbose);
+  print(Ctx);
+}
+
+/// Pretty-print the SILModule to errs with DebugInfo.
+void SILModule::dump(bool Verbose, bool DebugInfo) const {
+  SILPrintContext Ctx(llvm::errs(), Verbose, /*SortedSIL*/ false, DebugInfo,
+                      /*PrintFullConvention*/ false);
   print(Ctx);
 }
 


### PR DESCRIPTION
This patch adds dump overload methods to SILInstruction, SILBasicBlock, SILFunction, and SILModule that prints the debug information as well.

This will make it easier for people working on swift debug info related features or bugs, especially when dealing with SILGen