### PR TITLE
[CSSimplify] Open key path type before assignment to its record requirements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -667,6 +667,8 @@ ERROR(expr_keypath_generic_type,none,
       "key path cannot refer to generic type %0", (Identifier))
 ERROR(expr_keypath_noncopyable_type,none,
       "key path cannot refer to noncopyable type %0", (Type))
+ERROR(expr_keypath_nonescapable_type,none,
+      "key path cannot refer to nonescapable type %0", (Type))
 ERROR(expr_keypath_not_property,none,
       "%select{key path|dynamic key path member lookup}1 cannot refer to %kind0",
       (const ValueDecl *, bool))

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4186,6 +4186,21 @@ public:
   bool resolveTapBody(TypeVariableType *typeVar, Type contextualType,
                       ConstraintLocatorBuilder locator);
 
+  /// Bind key path expression to the given contextual type and generate
+  /// constraints for its requirements.
+  ///
+  /// \param typeVar The type variable representing the key path expression.
+  /// \param contextualType The contextual type this key path expression
+  /// would be bound to.
+  /// \param flags The flags associated with this assignment.
+  /// \param locator The locator associated with contextual type.
+  ///
+  /// \returns `true` if it was possible to generate constraints for
+  /// the requirements and assign fixed type to the key path expression,
+  /// `false` otherwise.
+  bool resolveKeyPath(TypeVariableType *typeVar, Type contextualType,
+                      TypeMatchOptions flags, ConstraintLocatorBuilder locator);
+
   /// Assign a fixed type to the given type variable.
   ///
   /// \param typeVar The type variable to bind.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -683,6 +683,15 @@ bool MissingConformanceFailure::diagnoseAsError() {
     }
   }
 
+  if (isExpr<KeyPathExpr>(anchor)) {
+    if (auto *P = dyn_cast<ProtocolDecl>(protocolType->getAnyNominal())) {
+      if (P->isSpecificProtocol(KnownProtocolKind::Copyable)) {
+        emitDiagnostic(diag::expr_keypath_noncopyable_type, nonConformingType);
+        return true;
+      }
+    }
+  }
+
   if (diagnoseAsAmbiguousOperatorRef())
     return true;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -689,6 +689,11 @@ bool MissingConformanceFailure::diagnoseAsError() {
         emitDiagnostic(diag::expr_keypath_noncopyable_type, nonConformingType);
         return true;
       }
+
+      if (P->isSpecificProtocol(KnownProtocolKind::Escapable)) {
+        emitDiagnostic(diag::expr_keypath_nonescapable_type, nonConformingType);
+        return true;
+      }
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4675,6 +4675,12 @@ ConstraintSystem::matchTypesBindTypeVar(
                : getTypeMatchFailure(locator);
   }
 
+  if (typeVar->getImpl().isKeyPathType()) {
+    return resolveKeyPath(typeVar, type, flags, locator)
+               ? getTypeMatchSuccess()
+               : getTypeMatchFailure(locator);
+  }
+
   assignFixedType(typeVar, type, /*updateState=*/true,
                   /*notifyInference=*/!flags.contains(TMF_BindingTypeVariable));
 
@@ -12255,6 +12261,15 @@ bool ConstraintSystem::resolveTapBody(TypeVariableType *typeVar,
   // With all of the contextual information recorded in the constraint system,
   // it's time to generate constraints for the body of this tap expression.
   return !generateConstraints(tapExpr);
+}
+
+bool ConstraintSystem::resolveKeyPath(TypeVariableType *typeVar,
+                                      Type contextualType,
+                                      TypeMatchOptions flags,
+                                      ConstraintLocatorBuilder locator) {
+  assignFixedType(typeVar, contextualType, /*updateState=*/true,
+                  /*notifyInference=*/!flags.contains(TMF_BindingTypeVariable));
+  return true;
 }
 
 ConstraintSystem::SolutionKind

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -318,3 +318,24 @@ extension Collection {
 func keypathToFunctionWithOptional() {
   _ = Array("").prefix(1...4, while: \.isNumber) // Ok
 }
+
+func test_new_key_path_type_requirements() {
+  struct V: ~Copyable {
+  }
+
+  struct S: ~Copyable {
+    var x: Int
+    var v: V
+  }
+
+  _ = \S.x // expected-error {{key path cannot refer to noncopyable type 'S'}}
+  _ = \S.v
+  // expected-error@-1 {{key path cannot refer to noncopyable type 'S'}}
+  // expected-error@-2 {{key path cannot refer to noncopyable type 'V'}}
+
+  func test<R>(_: KeyPath<R, Int>) {} // expected-note {{'where R: Copyable' is implicit here}}
+
+  test(\S.x)
+  // expected-error@-1 {{key path cannot refer to noncopyable type 'S'}}
+  // expected-error@-2 {{local function 'test' requires that 'S' conform to 'Copyable'}}
+}

--- a/test/Sema/keypaths_noncopyable.swift
+++ b/test/Sema/keypaths_noncopyable.swift
@@ -39,11 +39,18 @@ struct C {
 
 // rdar://109287447
 public func testKeypath<V: ~Copyable>(m: consuming M<V>) {
-  _ = m[keyPath: \.nc] // expected-error {{key path cannot refer to noncopyable type 'NC'}}
-  _ = m[keyPath: \.nc.data] // expected-error {{key path cannot refer to noncopyable type 'NC'}}
-  _ = m[keyPath: \.ncg] // expected-error {{key path cannot refer to noncopyable type 'V'}}
-  _ = m[keyPath: \.ncg.protocolProp] // expected-error {{key path cannot refer to noncopyable type 'V'}}
+  _ = m[keyPath: \.nc]
+  // expected-error@-1 {{key path cannot refer to noncopyable type 'M<V>'}}
+  // expected-error@-2 {{key path cannot refer to noncopyable type 'NC'}}
+  _ = m[keyPath: \.nc.data]
+  // expected-error@-1 {{key path cannot refer to noncopyable type 'M<V>'}}
+  _ = m[keyPath: \.ncg]
+  // expected-error@-1 {{key path cannot refer to noncopyable type 'M<V>'}}
+  // expected-error@-2 {{key path cannot refer to noncopyable type 'V'}}
+  _ = m[keyPath: \.ncg.protocolProp]
+  // expected-error@-1 {{key path cannot refer to noncopyable type 'M<V>'}}
   _ = m[keyPath: \.string]
+  // expected-error@-1 {{key path cannot refer to noncopyable type 'M<V>'}}
 
   let b = Box(NC())
   _ = b.with(\.data)

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -44,3 +44,18 @@ func invalidTarget(_ result: inout NE, _ source: consuming NE) { // expected-err
 func immortalConflict(_ immortal: Int) -> NE { // expected-error{{conflict between the parameter name and 'immortal' contextual keyword}}
   NE()
 }
+
+do {
+  struct Test: ~Escapable {
+    var v1: Int
+    var v2: NE
+  }
+
+  _ = \Test.v1 // expected-error {{key path cannot refer to nonescapable type 'Test'}}
+  _ = \Test.v2 // expected-error {{key path cannot refer to nonescapable type 'Test'}} expected-error {{key path cannot refer to nonescapable type 'NE'}}
+
+  func use(t: Test) {
+    t[keyPath: \.v1] // expected-error {{key path cannot refer to nonescapable type 'Test'}}
+    t[keyPath: \.v2] // expected-error {{key path cannot refer to nonescapable type 'Test'}} expected-error {{key path cannot refer to nonescapable type 'NE'}}
+  }
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -945,7 +945,9 @@ func testKeyPathHole() {
 
   func f(_ i: Int) {}
   f(\.x) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}} {{6-6=<#Root#>}}
+  // expected-error@-1 {{cannot convert value of type 'KeyPath<Root, Value>' to expected argument type 'Int'}}
   f(\.x.y) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}} {{6-6=<#Root#>}}
+  // expected-error@-1 {{cannot convert value of type 'KeyPath<Root, Value>' to expected argument type 'Int'}}
 
 func provideValueButNotRoot<T>(_ fn: (T) -> String) {} // expected-note 2 {{in call to function 'provideValueButNotRoot'}}
   provideValueButNotRoot(\.x) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}


### PR DESCRIPTION
`Root` and `Value` generic parameters now have conformance requirements
which we need to account for post-binding inference.

Resolves: rdar://143161190
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
