### PR TITLE
utils: split `Build-*` into `Build-` and `Test-`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2474,6 +2474,10 @@ function Build-Testing([Platform]$Platform, $Arch) {
     }
 }
 
+function Test-Testing {
+  throw "testing Testing is not supported"
+}
+
 function Write-PlatformInfoPlist([Platform] $Platform) {
   $Settings = @{
     DefaultProperties = @{
@@ -3296,9 +3300,7 @@ if (-not $IsCrossCompiling) {
   if ($Test -contains "xctest") {
     Test-XCTest
   }
-  if ($Test -contains "testing") {
-    Build-Testing Windows $HostArch -Test
-  }
+  if ($Test -contains "testing") { Test-Testing }
   if ($Test -contains "llbuild") { Test-LLBuild }
   if ($Test -contains "swiftpm") { Test-PackageManager }
   if ($Test -contains "swift-format") { Test-Format }

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -3293,7 +3293,7 @@ if (-not $IsCrossCompiling) {
     Build-Testing Windows $HostArch -Test
   }
   if ($Test -contains "llbuild") { Build-LLBuild $HostArch -Test }
-  if ($Test -contains "swiftpm") { Test-PackageManager $HostArch }
+  if ($Test -contains "swiftpm") { Test-PackageManager }
   if ($Test -contains "swift-format") { Test-Format }
   if ($Test -contains "sourcekit-lsp") { Test-SourceKitLSP }
 


### PR DESCRIPTION
This series of changes formally splits up the build step functions into a build function and a test function. This will allow us to properly measure build times and test times as well as helps reduce complexity. Most of the build steps are now effectively a CMake invocation only.