### PR TITLE
AST: Skip SILGen for decls that are unavailable in custom domains

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -123,11 +123,6 @@ private:
                : std::nullopt;
   }
 
-  const CustomAvailabilityDomain *getCustomDomain() const {
-    ASSERT(isCustom());
-    return storage.get<const CustomAvailabilityDomain *>();
-  }
-
 public:
   AvailabilityDomain() {}
 
@@ -206,6 +201,14 @@ public:
     return PlatformKind::none;
   }
 
+  /// If the domain represents a user-defined domain, returns the metadata for
+  /// the domain. Returns `nullptr` otherwise.
+  const CustomAvailabilityDomain *getCustomDomain() const {
+    if (isCustom())
+      return storage.get<const CustomAvailabilityDomain *>();
+    return nullptr;
+  }
+
   /// Returns true if availability for this domain can be specified in terms of
   /// version ranges.
   bool isVersioned() const;
@@ -228,11 +231,11 @@ public:
   /// set of active platform-specific domains.
   bool isActiveForTargetPlatform(const ASTContext &ctx) const;
 
-  /// Returns the minimum available range for the attribute's domain. For
+  /// Returns the domain's minimum available range for type checking. For
   /// example, for the domain of the platform that compilation is targeting,
-  /// this will be the deployment target. For the Swift language domain, this
-  /// will be the language mode for compilation. For domains which have don't
-  /// have a "deployment target", this returns `std::nullopt`.
+  /// this version is specified with the `-target` option. For the Swift
+  /// language domain, it is specified with the `-swift-version` option. Returns
+  /// `std::nullopt` for domains which have don't have a "deployment target".
   std::optional<AvailabilityRange>
   getDeploymentRange(const ASTContext &ctx) const;
 

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -251,10 +251,14 @@ public:
   /// universal domain (`*`) is the bottom element.
   bool contains(const AvailabilityDomain &other) const;
 
-  /// Returns the root availability domain that this domain must be compatible
-  /// with. For example, macCatalyst and visionOS must both be ABI compatible
-  /// with iOS. The compatible domain must contain this domain.
-  AvailabilityDomain getABICompatibilityDomain() const;
+  /// Returns true for domains that are not contained by any domain other than
+  /// the universal domain.
+  bool isRoot() const;
+
+  /// Returns the root availability domain that contains this domain (see
+  /// `isRoot()`). For example, macCatalyst and visionOS are both ultimately
+  /// descendants of the iOS domain.
+  AvailabilityDomain getRootDomain() const;
 
   bool operator==(const AvailabilityDomain &other) const {
     return storage.getOpaqueValue() == other.storage.getOpaqueValue();

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4153,6 +4153,10 @@ enum class DeclRuntimeAvailability : uint8_t {
   /// with strong references. To preserve ABI stability, the decl must still be
   /// emitted.
   AlwaysUnavailableABICompatible,
+
+  /// The decl is always unavailable and should never be reachable at runtime
+  /// nor be required at load time.
+  AlwaysUnavailable,
 };
 
 class DeclRuntimeAvailabilityRequest

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1398,8 +1398,7 @@ static void configureAvailabilityDomains(const ASTContext &ctx,
   llvm::SmallDenseMap<Identifier, const CustomAvailabilityDomain *> domainMap;
   auto createAndInsertDomain = [&](const std::string &name,
                                    CustomAvailabilityDomain::Kind kind) {
-    auto *domain = CustomAvailabilityDomain::get(
-        name, mainModule, CustomAvailabilityDomain::Kind::Enabled, ctx);
+    auto *domain = CustomAvailabilityDomain::get(name, mainModule, kind, ctx);
     bool inserted = domainMap.insert({domain->getName(), domain}).second;
     ASSERT(inserted); // Domains must be unique.
   };

--- a/test/SILGen/unavailable_decl_custom_domain.swift
+++ b/test/SILGen/unavailable_decl_custom_domain.swift
@@ -1,0 +1,83 @@
+// RUN: %target-swift-emit-silgen -module-name Test %s -verify \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-disabled-availability-domain DisabledDomain \
+// RUN:   -define-dynamic-availability-domain DynamicDomain \
+// RUN:   | %FileCheck %s --check-prefixes=CHECK
+
+// RUN: %target-swift-emit-silgen -module-name Test %s -verify \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-disabled-availability-domain DisabledDomain \
+// RUN:   -define-dynamic-availability-domain DynamicDomain \
+// RUN:   -unavailable-decl-optimization=stub \
+// RUN:   | %FileCheck %s --check-prefixes=CHECK
+
+// RUN: %target-swift-emit-silgen -module-name Test %s -verify \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-disabled-availability-domain DisabledDomain \
+// RUN:   -define-dynamic-availability-domain DynamicDomain \
+// RUN:   -unavailable-decl-optimization=complete \
+// RUN:   | %FileCheck %s --check-prefixes=CHECK
+
+// REQUIRES: swift_feature_CustomAvailability
+
+// CHECK: s4Test24availableInEnabledDomainyyF
+@available(EnabledDomain)
+public func availableInEnabledDomain() { }
+
+// CHECK-NOT: s4Test26unavailableInEnabledDomainyyF
+@available(EnabledDomain, unavailable)
+public func unavailableInEnabledDomain() { }
+
+// CHECK-NOT: s4Test25availableInDisabledDomainyyF
+@available(DisabledDomain)
+public func availableInDisabledDomain() { }
+
+// CHECK: s4Test27unavailableInDisabledDomainyyF
+@available(DisabledDomain, unavailable)
+public func unavailableInDisabledDomain() { }
+
+// CHECK: s4Test24availableInDynamicDomainyyF
+@available(DynamicDomain)
+public func availableInDynamicDomain() { }
+
+// CHECK: s4Test26unavailableInDynamicDomainyyF
+@available(DynamicDomain, unavailable)
+public func unavailableInDynamicDomain() { }
+
+// CHECK: s4Test25deprecatedInEnabledDomainyyF
+@available(EnabledDomain, deprecated)
+public func deprecatedInEnabledDomain() { }
+
+// FIXME: [availability] This decl should be skipped.
+// CHECK: s4Test26deprecatedInDisabledDomainyyF
+@available(DisabledDomain, deprecated)
+public func deprecatedInDisabledDomain() { }
+
+// CHECK: s4Test25deprecatedInDynamicDomainyyF
+@available(DynamicDomain, deprecated)
+public func deprecatedInDynamicDomain() { }
+
+// CHECK: s4Test22renamedInEnabledDomainyyF
+@available(EnabledDomain, renamed: "availableInEnabledDomain")
+public func renamedInEnabledDomain() { }
+
+// CHECK-NOT: s4Test23renamedInDisabledDomainyyF
+@available(DisabledDomain, renamed: "availableInDisabledDomain")
+public func renamedInDisabledDomain() { }
+
+// CHECK: s4Test22renamedInDynamicDomainyyF
+@available(DynamicDomain, renamed: "availableInDynamicDomain")
+public func renamedInDynamicDomain() { }
+
+// CHECK-NOT: s4Test35availableInEnabledAndDisabledDomainyyF
+@available(EnabledDomain)
+@available(DisabledDomain)
+public func availableInEnabledAndDisabledDomain() { }
+
+// CHECK-NOT: s4Test35availableInDisabledAndEnabledDomainyyF
+@available(DisabledDomain)
+@available(EnabledDomain)
+public func availableInDisabledAndEnabledDomain() { }

--- a/test/SILGen/unavailable_decl_optimization_stub_maccatalyst.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_maccatalyst.swift
@@ -1,0 +1,93 @@
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -target %target-cpu-apple-ios13.1-macabi | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-EXTENSION
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -target %target-cpu-apple-ios13.1-macabi -application-extension | %FileCheck %s --check-prefixes=CHECK,CHECK-EXTENSION
+
+// REQUIRES: OS=macosx || OS=maccatalyst
+
+public struct S {}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test22macCatalystUnavailableAA1SVyF
+// CHECK-NOT:     _diagnoseUnavailableCodeReached
+// CHECK:       } // end sil function '$s4Test22macCatalystUnavailableAA1SVyF'
+@available(macCatalyst, unavailable)
+public func macCatalystUnavailable() -> S {
+  return S()
+}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test14iOSUnavailableAA1SVyF
+// CHECK:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:       } // end sil function '$s4Test14iOSUnavailableAA1SVyF'
+@available(iOS, unavailable)
+public func iOSUnavailable() -> S {
+  return S()
+}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test16macOSUnavailableAA1SVyF
+// CHECK-NOT:     _diagnoseUnavailableCodeReached
+// CHECK:       } // end sil function '$s4Test16macOSUnavailableAA1SVyF'
+@available(macOS, unavailable)
+public func macOSUnavailable() -> S {
+  return S()
+}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test34iOSUnavailableMacCatalystAvailableAA1SVyF
+// CHECK-NOT:     _diagnoseUnavailableCodeReached
+// CHECK:       } // end sil function '$s4Test34iOSUnavailableMacCatalystAvailableAA1SVyF'
+@available(iOS, unavailable)
+@available(macCatalyst, introduced: 1.0)
+public func iOSUnavailableMacCatalystAvailable() -> S {
+  return S()
+}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test28iOSAndMacCatalystUnavailableAA1SVyF
+// CHECK:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:       } // end sil function '$s4Test28iOSAndMacCatalystUnavailableAA1SVyF'
+@available(iOS, unavailable)
+@available(macCatalyst, unavailable)
+public func iOSAndMacCatalystUnavailable() -> S {
+  return S()
+}
+
+// CHECK-LABEL:              sil{{.*}}@$s4Test20iOSAppExtensionsOnlyAA1SVyF
+// CHECK-NO-EXTENSION:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NO-EXTENSION-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK-EXTENSION-NOT:        _diagnoseUnavailableCodeReached
+// CHECK:                    } // end sil function '$s4Test20iOSAppExtensionsOnlyAA1SVyF'
+@available(iOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(iOSApplicationExtension, introduced: 1.0)
+public func iOSAppExtensionsOnly() -> S {
+  return S()
+}
+
+// CHECK-LABEL:              sil{{.*}}@$s4Test28macCatalystAppExtensionsOnlyAA1SVyF
+// CHECK-NO-EXTENSION:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NO-EXTENSION-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK-EXTENSION-NOT:        _diagnoseUnavailableCodeReached
+// CHECK:                    } // end sil function '$s4Test28macCatalystAppExtensionsOnlyAA1SVyF'
+@available(iOS, unavailable)
+@available(macCatalyst, unavailable)
+@available(macCatalystApplicationExtension, introduced: 1.0)
+public func macCatalystAppExtensionsOnly() -> S {
+  return S()
+}
+
+@available(macCatalyst, unavailable)
+public struct UnavailableOnMacCatalyst {
+  // CHECK-LABEL: sil{{.*}}@$s4Test24UnavailableOnMacCatalystV14noAvailabilityAA1SVyF
+  // CHECK-NOT:     _diagnoseUnavailableCodeReached
+  // CHECK:       } // end sil function '$s4Test24UnavailableOnMacCatalystV14noAvailabilityAA1SVyF'
+  public func noAvailability() -> S {
+    return S()
+  }
+
+  // CHECK-LABEL: sil{{.*}}@$s4Test24UnavailableOnMacCatalystV022iOSUnavailableInheritsdeB0AA1SVyF
+  // CHECK:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+  // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+  // CHECK:       } // end sil function '$s4Test24UnavailableOnMacCatalystV022iOSUnavailableInheritsdeB0AA1SVyF'
+  @available(iOS, unavailable)
+  public func iOSUnavailableInheritsMacCatalystUnavailable() -> S {
+    return S()
+  }
+}

--- a/test/SILGen/unavailable_decl_optimization_stub_macos_zippered.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos_zippered.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-EXTENSION
+// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -application-extension | %FileCheck %s --check-prefixes=CHECK,CHECK-EXTENSION
 
 // REQUIRES: OS=macosx
 
@@ -34,6 +35,27 @@ public func unavailableOnMacCatalystFunc() {}
 @available(macOS, unavailable)
 @available(iOS, unavailable)
 public func unavailableOnMacOSAndiOSFunc() {}
+
+// CHECK-LABEL:             sil{{.*}}@$s4Test33availableOnMacOSExtensionOnlyFuncyyF
+// CHECK-NO-EXTENSION:        [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NO-EXTENSION-NEXT:   [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK-EXTENSION-NOT:       _diagnoseUnavailableCodeReached
+// CHECK:                   } // end sil function '$s4Test33availableOnMacOSExtensionOnlyFuncyyF'
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(macOSApplicationExtension, introduced: 10.9)
+public func availableOnMacOSExtensionOnlyFunc() {}
+
+// CHECK-LABEL:             sil{{.*}}@$s4Test31availableOniOSExtensionOnlyFuncyyF
+// CHECK-NO-EXTENSION:        [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NO-EXTENSION-NEXT:   [[APPLY:%.*]] = apply [[FNREF]]()
+// FIXME: [availability] This should not diagnose when building with -application-extension
+// CHECK-EXTENSION:           _diagnoseUnavailableCodeReached
+// CHECK:                   } // end sil function '$s4Test31availableOniOSExtensionOnlyFuncyyF'
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(iOSApplicationExtension, introduced: 9.0)
+public func availableOniOSExtensionOnlyFunc() {}
 
 @available(iOS, unavailable)
 public struct UnavailableOniOS {

--- a/test/SILGen/unavailable_decl_optimization_stub_struct.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_struct.swift
@@ -11,6 +11,7 @@ public struct ImplicitInitStruct {
   // CHECK:       } // end sil function '$s4Test18ImplicitInitStructVACycfC'
 }
 
+// CHECK-LABEL: sil{{.*}}@$s4Test23testImplicitConstructoryyF
 @available(*, unavailable)
 public func testImplicitConstructor() {
   // Force s4Test18ImplicitInitStructVACycfC to be emitted.

--- a/test/SILGen/unavailable_decl_optimization_stub_visionos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_visionos.swift
@@ -1,12 +1,12 @@
-// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -target arm64-apple-xros1.0 | %FileCheck %s --check-prefixes=CHECK
-// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -target arm64-apple-xros1.0 -application-extension | %FileCheck %s --check-prefixes=CHECK
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -target %target-cpu-apple-xros1.0 | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-EXTENSION
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -target %target-cpu-apple-xros1.0 -application-extension | %FileCheck %s --check-prefixes=CHECK,CHECK-EXTENSION
 
 // REQUIRES: OS=xros
 
 public struct S {}
 
 // CHECK-LABEL: sil{{.*}}@$s4Test19visionOSUnavailableAA1SVyF
-// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK-NOT:     _diagnoseUnavailableCodeReached
 // CHECK:       } // end sil function '$s4Test19visionOSUnavailableAA1SVyF'
 @available(visionOS, unavailable)
 public func visionOSUnavailable() -> S {
@@ -23,7 +23,7 @@ public func iOSUnavailable() -> S {
 }
 
 // CHECK-LABEL: sil{{.*}}@$s4Test16macOSUnavailableAA1SVyF
-// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK-NOT:     _diagnoseUnavailableCodeReached
 // CHECK:       } // end sil function '$s4Test16macOSUnavailableAA1SVyF'
 @available(macOS, unavailable)
 public func macOSUnavailable() -> S {
@@ -31,7 +31,7 @@ public func macOSUnavailable() -> S {
 }
 
 // CHECK-LABEL: sil{{.*}}@$s4Test31iOSUnavailableVisionOSAvailableAA1SVyF
-// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK-NOT:     _diagnoseUnavailableCodeReached
 // CHECK:       } // end sil function '$s4Test31iOSUnavailableVisionOSAvailableAA1SVyF'
 @available(iOS, unavailable)
 @available(visionOS, introduced: 1.0)
@@ -50,7 +50,9 @@ public func iOSAndVisionOSUnavailable() -> S {
 }
 
 // CHECK-LABEL: sil{{.*}}@$s4Test20iOSAppExtensionsOnlyAA1SVyF
-// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK-NO-EXTENSION:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NO-EXTENSION-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK-EXTENSION-NOT:        _diagnoseUnavailableCodeReached
 // CHECK:       } // end sil function '$s4Test20iOSAppExtensionsOnlyAA1SVyF'
 @available(iOS, unavailable)
 @available(visionOS, unavailable)
@@ -60,7 +62,9 @@ public func iOSAppExtensionsOnly() -> S {
 }
 
 // CHECK-LABEL: sil{{.*}}@$s4Test25visionOSAppExtensionsOnlyAA1SVyF
-// CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+// CHECK-NO-EXTENSION:         [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NO-EXTENSION-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK-EXTENSION-NOT:        _diagnoseUnavailableCodeReached
 // CHECK:       } // end sil function '$s4Test25visionOSAppExtensionsOnlyAA1SVyF'
 @available(iOS, unavailable)
 @available(visionOS, unavailable)
@@ -72,7 +76,7 @@ public func visionOSAppExtensionsOnly() -> S {
 @available(visionOS, unavailable)
 public struct UnavailableOnVisionOS {
   // CHECK-LABEL: sil{{.*}}@$s4Test21UnavailableOnVisionOSV14noAvailabilityAA1SVyF
-  // CHECK-NOT:     ss31_diagnoseUnavailableCodeReacheds5NeverOyF
+  // CHECK-NOT:     _diagnoseUnavailableCodeReached
   // CHECK:       } // end sil function '$s4Test21UnavailableOnVisionOSV14noAvailabilityAA1SVyF'
   public func noAvailability() -> S {
     return S()

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -124,19 +124,31 @@ TEST_F(AvailabilityDomainLattice, Contains) {
   EXPECT_FALSE(visionOSAppExt.contains(macOSAppExt));
 }
 
-TEST_F(AvailabilityDomainLattice, ABICompatibilityDomain) {
-  EXPECT_EQ(Universal.getABICompatibilityDomain(), Universal);
-  EXPECT_EQ(Swift.getABICompatibilityDomain(), Swift);
-  EXPECT_EQ(Package.getABICompatibilityDomain(), Package);
-  EXPECT_EQ(Embedded.getABICompatibilityDomain(), Embedded);
-  EXPECT_EQ(macOS.getABICompatibilityDomain(), macOS);
-  EXPECT_EQ(macOSAppExt.getABICompatibilityDomain(), macOS);
-  EXPECT_EQ(iOS.getABICompatibilityDomain(), iOS);
-  EXPECT_EQ(iOSAppExt.getABICompatibilityDomain(), iOS);
-  EXPECT_EQ(macCatalyst.getABICompatibilityDomain(), iOS);
-  EXPECT_EQ(macCatalystAppExt.getABICompatibilityDomain(), iOS);
-  EXPECT_EQ(visionOS.getABICompatibilityDomain(), iOS);
-  EXPECT_EQ(visionOSAppExt.getABICompatibilityDomain(), iOS);
+TEST_F(AvailabilityDomainLattice, RootDomain) {
+  EXPECT_EQ(Universal.getRootDomain(), Universal);
+  EXPECT_TRUE(Universal.isRoot());
+  EXPECT_EQ(Swift.getRootDomain(), Swift);
+  EXPECT_TRUE(Swift.isRoot());
+  EXPECT_EQ(Package.getRootDomain(), Package);
+  EXPECT_TRUE(Package.isRoot());
+  EXPECT_EQ(Embedded.getRootDomain(), Embedded);
+  EXPECT_TRUE(Embedded.isRoot());
+  EXPECT_EQ(macOS.getRootDomain(), macOS);
+  EXPECT_TRUE(macOS.isRoot());
+  EXPECT_EQ(macOSAppExt.getRootDomain(), macOS);
+  EXPECT_FALSE(macOSAppExt.isRoot());
+  EXPECT_EQ(iOS.getRootDomain(), iOS);
+  EXPECT_TRUE(iOS.isRoot());
+  EXPECT_EQ(iOSAppExt.getRootDomain(), iOS);
+  EXPECT_FALSE(iOSAppExt.isRoot());
+  EXPECT_EQ(macCatalyst.getRootDomain(), iOS);
+  EXPECT_FALSE(macCatalyst.isRoot());
+  EXPECT_EQ(macCatalystAppExt.getRootDomain(), iOS);
+  EXPECT_FALSE(macCatalystAppExt.isRoot());
+  EXPECT_EQ(visionOS.getRootDomain(), iOS);
+  EXPECT_FALSE(visionOS.isRoot());
+  EXPECT_EQ(visionOSAppExt.getRootDomain(), iOS);
+  EXPECT_FALSE(visionOSAppExt.isRoot());
 }
 
 TEST(AvailabilityDomain, TargetPlatform) {


### PR DESCRIPTION
Regardless of the value specified for `-unavailable-decl-optimization`, decls that are unavailable in custom availability domains should be treated as unreachable at runtime and skipped during SILGen.

Part of rdar://138441307.