### PR TITLE
[test] Import locale modules explicitly in PrintFloat.swift.gyb.

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -13,7 +13,9 @@
 
 import StdlibUnittest
 import SwiftPrivateLibcExtras
-#if canImport(Darwin)
+#if canImport(locale_h)
+  import locale_h
+#elseif canImport(Darwin)
   import Darwin
 #elseif canImport(Glibc)
   import Glibc


### PR DESCRIPTION
Darwin module is being split up and will eventually stop importing locale APIs.

