### PR TITLE
[cxx-interop] Conform `std::string` to `ExpressibleByStringInterpolation`

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -82,21 +82,27 @@ extension std.u32string {
 
 // MARK: Initializing C++ string from a Swift String literal
 
-extension std.string: ExpressibleByStringLiteral {
+extension std.string: ExpressibleByStringLiteral,
+  ExpressibleByStringInterpolation {
+
   @_alwaysEmitIntoClient
   public init(stringLiteral value: String) {
     unsafe self.init(value)
   }
 }
 
-extension std.u16string: ExpressibleByStringLiteral {
+extension std.u16string: ExpressibleByStringLiteral,
+  ExpressibleByStringInterpolation {
+
   @_alwaysEmitIntoClient
   public init(stringLiteral value: String) {
     unsafe self.init(value)
   }
 }
 
-extension std.u32string: ExpressibleByStringLiteral {
+extension std.u32string: ExpressibleByStringLiteral,
+  ExpressibleByStringInterpolation {
+
   @_alwaysEmitIntoClient
   public init(stringLiteral value: String) {
     unsafe self.init(value)

--- a/test/Interop/Cxx/stdlib/use-std-string-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string-typechecker.swift
@@ -4,3 +4,6 @@ import CxxStdlib
 import StdString
 
 let _ = HasMethodThatReturnsString().getString()
+
+let x: std.string = "Hello"
+let y: std.string = "\(x), World!" 

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -65,6 +65,12 @@ StdStringTestSuite.test("std::string <=> Swift.String") {
     }
     let swift7 = String(cxx7)
     expectEqual(swift7, "���")
+
+    let cxxLiteral: std.string = "Hello"
+    let cxx8: std.string = "\(cxxLiteral), World!"
+    expectEqual(cxx8.size(), 13)
+    let swift8 = String(cxx8)
+    expectEqual(swift8, "Hello, World!")
 }
 
 StdStringTestSuite.test("std::string operators") {
@@ -287,6 +293,12 @@ StdStringTestSuite.test("std::u16string <=> Swift.String") {
     expectEqual(cxx6.size(), 7)
     let swift6 = String(cxx6)
     expectEqual(swift6, "xyz\0abc")
+
+    let cxxLiteral: std.u16string = "Hello"
+    let cxx8: std.u16string = "\(cxxLiteral), World!"
+    expectEqual(cxx8.size(), 13)
+    let swift8 = String(cxx8)
+    expectEqual(swift8, "Hello, World!")
 }
 
 StdStringTestSuite.test("std::u32string <=> Swift.String") {
@@ -317,6 +329,12 @@ StdStringTestSuite.test("std::u32string <=> Swift.String") {
     expectEqual(cxx6.size(), 7)
     let swift6 = String(cxx6)
     expectEqual(swift6, "xyz\0abc")
+
+    let cxxLiteral: std.u32string = "Hello"
+    let cxx8: std.u32string = "\(cxxLiteral), World!"
+    expectEqual(cxx8.size(), 13)
+    let swift8 = String(cxx8)
+    expectEqual(swift8, "Hello, World!")
 }
 
 StdStringTestSuite.test("std::string as Swift.CustomDebugStringConvertible") {


### PR DESCRIPTION
This adds conformances for C++ string types (`std::string`, `std::u16string`, `std::u32string`) to `Swift.ExpressibleByStringInterpolation`.

These conformances currently implicitly use `DefaultStringInterpolation`. In the future we can provide more performant interpolation mechanisms for C++ strings specifically that avoid the extra conversion between Swift String and C++ string types.

rdar://147249169

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
