### PR TITLE
Disable building Ninja tests

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -57,6 +57,7 @@ class NinjaBuilder(product.ProductBuilder):
             "-S", self.source_dir,
             "-B", self.build_dir,
             "-DCMAKE_BUILD_TYPE=Release",
+            "-DBUILD_TESTING=OFF",
             f"-DCMAKE_C_COMPILER={self.toolchain.cc}",
             f"-DCMAKE_CXX_COMPILER={self.toolchain.cxx}"])
         shell.call([self.toolchain.cmake, "--build", self.build_dir])

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -93,6 +93,7 @@ class NinjaTestCase(unittest.TestCase):
 -S {self.workspace.source_dir('ninja')} \
 -B {self.workspace.build_dir('build', 'ninja')} \
 -DCMAKE_BUILD_TYPE=Release \
+-DBUILD_TESTING=OFF \
 -DCMAKE_C_COMPILER=/path/to/cc \
 -DCMAKE_CXX_COMPILER=/path/to/cxx
 + {self.toolchain.cmake} --build {self.workspace.build_dir('build', 'ninja')}


### PR DESCRIPTION
Ninja builds its tests by default.
We don't run the Ninja test suite, we aren't doing development on Ninja, and we are using a release tag that has been verified to work. There isn't much point in building the tests if we're not going to use them. Disabling building the Ninja tests. If it is desirable to build them, one can set `BUILD_TESTING` to `YES` and re-run their build.