### PR TITLE
[cxx-interop] Disable debug info in synthesized C++ methods

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2106,6 +2106,7 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
   newMethod->setImplicit();
   newMethod->setImplicitlyInline();
   newMethod->setAccess(clang::AccessSpecifier::AS_public);
+  newMethod->addAttr(clang::NoDebugAttr::CreateImplicit(clangCtx));
   if (method->hasAttr<clang::CFReturnsRetainedAttr>()) {
     // Return an FRT field at +1 if the base method also follows this
     // convention.

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -50,6 +50,10 @@ struct DerivedFromCallsPureMethod : CallsPureMethod {
 
 struct DerivedFromDerivedFromCallsPureMethod : DerivedFromCallsPureMethod {};
 
+struct HasDestructor {
+  ~HasDestructor() {}
+};
+
 // MARK: Reference Types:
 
 #define IMMORTAL_FRT                                                           \
@@ -74,6 +78,11 @@ struct IMMORTAL_FRT Immortal : public ImmortalBase {
 
 struct IMMORTAL_FRT DerivedFromImmortal : public Immortal {
   static DerivedFromImmortal *_Nonnull create() { return new DerivedFromImmortal(); }
+};
+
+struct IMMORTAL_FRT Immortal2 {
+public:
+  virtual void virtualMethod(HasDestructor) = 0;
 };
 
 inline const ImmortalBase *_Nonnull castToImmortalBase(

--- a/test/Interop/Cxx/class/inheritance/virtual-methods.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-5.9)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-g -I %S/Inputs -cxx-interoperability-mode=default)
 
 // REQUIRES: executable_test
 
@@ -52,5 +53,15 @@ if #available(SwiftStdlib 5.8, *) {
     expectEqual(321, base2.getIntValue())
   }
 }
+
+#if !os(Windows) 
+// FIXME in Windows, non-trivial C++ class with trivial ABI is not yet available in Swift
+VirtualMethodsTestSuite.test("C++ virtual method with complex parameter") {
+  @available(macOS 13.3, *)
+  func f(simpleClass: HasDestructor, immortalClass: Immortal2) {
+    immortalClass.virtualMethod(simpleClass)
+  }
+}
+#endif
 
 runAllTests()


### PR DESCRIPTION
Generating debug info for synthesized C++ methods was resulting in a crash due to missing `!dbg` on a call to destructors inside the synthesized body of these methods. 
We disable debug info for these synthesized C++ methods because `!dbg` wouldn't point to real source locations anyways.

Fixes #79670

rdar://141167229

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
