### PR TITLE
SIL: Allow to selectively disabled cond_fails by cond_fail message

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -43,7 +43,10 @@
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/Statistic.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
+#include <fstream>
+#include <set>
 
 using namespace swift;
 
@@ -689,4 +692,30 @@ void SwiftPassInvocation::eraseInstruction(SILInstruction *inst) {
       inst->eraseFromParent();
     }
   }
+}
+
+static llvm::cl::opt<std::string> CondFailConfigFile(
+    "cond-fail-config-file", llvm::cl::init(""),
+    llvm::cl::desc("read the cond_fail message strings to elimimate from file"));
+
+static std::set<std::string> CondFailsToRemove;
+
+bool SILCombiner::shouldRemoveCondFail(CondFailInst &CFI) {
+  if (CondFailConfigFile.empty())
+    return false;
+
+  std::fstream fs(CondFailConfigFile);
+  if (!fs) {
+    llvm::errs() << "cannot cond_fail disablement config file\n";
+    exit(1);
+  }
+  if (CondFailsToRemove.empty()) {
+    std::string line;
+    while (std::getline(fs, line)) {
+      CondFailsToRemove.insert(line);
+    }
+    fs.close();
+  }
+  auto message = CFI.getMessage();
+  return CondFailsToRemove.find(message.str()) != CondFailsToRemove.end();
 }

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -136,6 +136,8 @@ public:
 
   bool runOnFunction(SILFunction &F);
 
+  bool shouldRemoveCondFail(CondFailInst &);
+
   void clear() {
     Iteration = 0;
     Worklist.resetChecked();

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -803,6 +803,9 @@ SILInstruction *SILCombiner::visitCondFailInst(CondFailInst *CFI) {
   if (RemoveCondFails)
     return eraseInstFromFunction(*CFI);
 
+  if (shouldRemoveCondFail(*CFI))
+    return eraseInstFromFunction(*CFI);
+
   auto *I = dyn_cast<IntegerLiteralInst>(CFI->getOperand());
   if (!I)
     return nullptr;


### PR DESCRIPTION
The standard library uses `_precondition` calls which have a message argument.

Allow disabling the generated cond_fail by these message arguments.

For example:
```
 _precondition(source >= (0 as T), "Negative value is not representable")
```

results in a `cond_fail "Negative value is not representable"`.

This commit allows for specifying a file that contains these messages on each line.

/path/to/disable_cond_fails:
```
Negative value is not representable
Array index is out of range
```

The optimizer will remove these cond_fails if the swift frontend is invoked with `-Xllvm -cond-fail-config-file=/path/to/disable_cond_fails`.
