### PR TITLE
Runtimes: properly link in `swiftrtT?.obj` on Windows

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -115,10 +115,7 @@ target_link_libraries(swift_Concurrency PRIVATE
   $<$<PLATFORM_ID:Windows>:Synchronization>
   $<$<PLATFORM_ID:Windows>:mincore>
   # Link to the runtime that we are just building.
-  swiftCore
-  $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftrt>)
-target_link_options(swift_Concurrency PRIVATE
-  -nostartfiles)
+  swiftCore)
 set_target_properties(swift_Concurrency PROPERTIES
   Swift_MODULE_NAME _Concurrency)
 

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -313,8 +313,16 @@ target_link_libraries(swiftCore
     $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftrt$<$<PLATFORM_ID:Windows>:T>>
   PUBLIC
     swiftShims)
-target_link_options(swiftCore PRIVATE
-  -nostartfiles)
+target_link_options(swiftCore PUBLIC
+  $<$<LINK_LANGUAGE:Swift>:-nostartfiles>)
+string(TOLOWER "${SwiftCore_OBJECT_FORMAT}" SwiftCore_OBJECT_FORMAT_lc)
+if("${SwiftCore_OBJECT_FORMAT_lc}" STREQUAL "elf")
+  target_link_libraries(swiftCore INTERFACE
+    swiftrt$<$<BOOL:NO>:>)
+elseif("${SwiftCore_OBJECT_FORMAT_lc}" STREQUAL "coff")
+  target_link_libraries(swiftCore INTERFACE
+    swiftrt$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:T>)
+endif()
 if(NOT POLICY CMP0157)
   target_compile_options(swiftCore PRIVATE
     $<TARGET_OBJECTS:swiftRuntime>

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -173,6 +173,7 @@ elseif("${SwiftCore_OBJECT_FORMAT}" STREQUAL "coffx")
     SWIFT_STATIC_STDLIB)
   target_link_libraries(swiftrtT PRIVATE swiftShims)
   install(FILES $<TARGET_OBJECTS:swiftrtT>
+    COMPONENT SwiftCore_runtime
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
     RENAME swiftrtT.obj)
 


### PR DESCRIPTION
`swiftrtT.obj` should be used for statically linking the standard library (or within the standard library itself). For the other modules, we need to differentiate between `swiftrt.obj` and `swiftrtT.obj`. This fixes that oversight. This was not caught by the CI builds as we do not currently build both the static and dynamic variants of the new runtimes.