### PR TITLE
[build-script]: Automatically choose a built ninja

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -745,10 +745,6 @@ def main_normal():
         sys.stdout.write("Cleaning install destdir!\n")
         shell.rmtree(args.install_destdir)
 
-    # Build ninja if required, which will update the toolchain.
-    if args.build_ninja:
-        invocation.build_ninja()
-
     # Execute the underlying build script implementation.
     invocation.execute()
 

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -852,7 +852,7 @@ def create_argument_parser():
            help='install playground support')
 
     option('--build-ninja', toggle_true,
-           help='build the Ninja tool')
+           help='build the Ninja tool [deprecated: Ninja is built when necessary]')
 
     option(['--build-lld'], toggle_true('build_lld'), default=True,
            help='build lld as part of llvm')

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -29,6 +29,8 @@ from swift_build_support.swift_build_support.host_specific_configuration \
     import HostSpecificConfiguration
 from swift_build_support.swift_build_support.productpipeline_list_builder \
     import ProductPipelineListBuilder
+from swift_build_support.swift_build_support.products.ninja \
+    import get_ninja_path
 from swift_build_support.swift_build_support.targets \
     import StdlibDeploymentTarget
 from swift_build_support.swift_build_support.utils import clear_log_time
@@ -52,24 +54,13 @@ class BuildScriptInvocation(object):
 
         clear_log_time()
 
+        self.toolchain.ninja = get_ninja_path(self.toolchain,
+                                              self.args,
+                                              self.workspace)
+
     @property
     def install_all(self):
         return self.args.install_all or self.args.infer_dependencies
-
-    def build_ninja(self):
-        if not os.path.exists(self.workspace.source_dir("ninja")):
-            fatal_error(
-                "can't find source directory for ninja "
-                "(tried %s)" % (self.workspace.source_dir("ninja")))
-
-        ninja_build = products.Ninja.new_builder(
-            args=self.args,
-            toolchain=self.toolchain,
-            workspace=self.workspace,
-            host=StdlibDeploymentTarget.get_target_for_name(
-                self.args.host_target))
-        ninja_build.build()
-        self.toolchain.ninja = ninja_build.ninja_bin_path
 
     def convert_to_impl_arguments(self):
         """convert_to_impl_arguments() -> (env, args)

--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -15,11 +15,13 @@ Ninja build
 # ----------------------------------------------------------------------------
 
 import os.path
+import re
 
 from build_swift.build_swift import cache_utils
 
 from . import product
 from .. import shell
+from ..utils import log_time_in_scope
 
 
 class Ninja(product.Product):
@@ -52,12 +54,48 @@ class NinjaBuilder(product.ProductBuilder):
     def build(self):
         if os.path.exists(self.ninja_bin_path):
             return
-        shell.call([
-            self.toolchain.cmake,
-            "-S", self.source_dir,
-            "-B", self.build_dir,
-            "-DCMAKE_BUILD_TYPE=Release",
-            "-DBUILD_TESTING=OFF",
-            f"-DCMAKE_C_COMPILER={self.toolchain.cc}",
-            f"-DCMAKE_CXX_COMPILER={self.toolchain.cxx}"])
-        shell.call([self.toolchain.cmake, "--build", self.build_dir])
+
+        print("--- Local Ninja Build ---")
+        with log_time_in_scope('local ninja'):
+            shell.call([
+                self.toolchain.cmake,
+                "-S", self.source_dir,
+                "-B", self.build_dir,
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_TESTING=OFF",
+                f"-DCMAKE_C_COMPILER={self.toolchain.cc}",
+                f"-DCMAKE_CXX_COMPILER={self.toolchain.cxx}"])
+            shell.call([self.toolchain.cmake, "--build", self.build_dir])
+
+
+def get_ninja_version(ninja_bin_path):
+    if not ninja_bin_path or not os.path.isfile(ninja_bin_path):
+        return
+    ninja_version_pattern = re.compile(r'^(\d+)\.(\d+)\.(\d+).*')
+    version = shell.capture([ninja_bin_path, "--version"], dry_run=False,
+                            echo=True, optional=True)
+    m = ninja_version_pattern.match(version)
+    if m is None:
+        return
+    (major, minor, patch) = map(int, m.groups())
+    return (major, minor, patch)
+
+
+def get_ninja_path(toolchain, args, workspace):
+    min_ninja_version = (1, 8, 2)
+
+    built_ninja_path = os.path.join(workspace.build_dir('build', 'ninja'), 'ninja')
+    built_ninja_version = get_ninja_version(built_ninja_path)
+    if built_ninja_version and min_ninja_version <= built_ninja_version:
+        return built_ninja_path
+
+    toolchain_ninja_version = get_ninja_version(toolchain.ninja)
+    if toolchain_ninja_version and min_ninja_version <= toolchain_ninja_version:
+        return toolchain.ninja
+
+    # Build ninja from source
+    ninja_build = Ninja.new_builder(args=args,
+                                    toolchain=toolchain,
+                                    workspace=workspace)
+    ninja_build.build()
+    return ninja_build.ninja_bin_path

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -45,7 +45,6 @@ class NinjaTestCase(unittest.TestCase):
 
         # Setup args
         self.args = argparse.Namespace(
-            build_ninja=True,
             darwin_deployment_version_osx="10.9")
 
         # Setup shell
@@ -89,6 +88,7 @@ class NinjaTestCase(unittest.TestCase):
         ninja_build.build()
 
         self.assertEqual(self.stdout.getvalue(), f"""\
+--- Local Ninja Build ---
 + {self.toolchain.cmake} \
 -S {self.workspace.source_dir('ninja')} \
 -B {self.workspace.build_dir('build', 'ninja')} \


### PR DESCRIPTION
Instead of using `--build-ninja` to decide to build ninja, build it automatically if a sufficiently new enough version is not available. Also record the build time taken to build the local Ninja so that we can see how much time we would save by stashing a pre-built Ninja in CI.

This is more like how build-script pre-builds CMake when necessary.