### PR TITLE
Strict safety more minor cleanups

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8204,6 +8204,8 @@ NOTE(note_use_of_unsafe_conformance_is_unsafe,none,
      (Type, const ValueDecl *))
 NOTE(note_unsafe_storage,none,
      "%kindbase1 involves unsafe type %2", (bool, const ValueDecl *, Type))
+NOTE(note_unsafe_temporarily_escaping,none,
+     "'withoutActuallyEscaping' function of type %0 is unsafe", (Type))
 
 GROUPED_WARNING(decl_unsafe_storage,StrictMemorySafety,none,
       "%kindbase0 has storage involving unsafe types",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8242,9 +8242,9 @@ GROUPED_WARNING(unsafe_without_unsafe,StrictMemorySafety,none,
       "expression uses unsafe constructs but is not marked with 'unsafe'", ())
 GROUPED_WARNING(for_unsafe_without_unsafe,StrictMemorySafety,none,
       "for-in loop uses unsafe constructs but is not marked with 'unsafe'", ())
-WARNING(no_unsafe_in_unsafe,none,
+GROUPED_WARNING(no_unsafe_in_unsafe,StrictMemorySafety,none,
         "no unsafe operations occur within 'unsafe' expression", ())
-WARNING(no_unsafe_in_unsafe_for,none,
+GROUPED_WARNING(no_unsafe_in_unsafe_for,StrictMemorySafety,none,
         "no unsafe operations occur within 'unsafe' for-in loop", ())
 NOTE(make_subclass_unsafe,none,
      "make class %0 @unsafe to allow unsafe overrides of safe superclass methods",

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4420,7 +4420,8 @@ private:
       return;
     }
 
-    Ctx.Diags.diagnose(E->getUnsafeLoc(), diag::no_unsafe_in_unsafe);
+    Ctx.Diags.diagnose(E->getUnsafeLoc(), diag::no_unsafe_in_unsafe)
+      .fixItRemove(E->getUnsafeLoc());
   }
   
   std::pair<SourceLoc, std::string>

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -644,7 +644,10 @@ public:
           break;
         }
       }
+    } else if (auto TE = dyn_cast<MakeTemporarilyEscapableExpr>(E)) {
+      recurse = asImpl().checkTemporarilyEscapable(TE);
     }
+
     // Error handling validation (via checkTopLevelEffects) happens after
     // type checking. If an unchecked expression is still around, the code was
     // invalid.
@@ -1087,6 +1090,15 @@ public:
     Classification result;
     result.AsyncKind = conditionalKind;
     result.AsyncReason = reason;
+    return result;
+  }
+
+  /// Return a potentially-unsafe classification by recording all of the
+  /// provided unsafe uses.
+  static Classification forUnsafe(ArrayRef<UnsafeUse> unsafeUses) {
+    Classification result;
+    for (const auto &unsafeUse : unsafeUses)
+      result.recordUnsafeUse(unsafeUse);
     return result;
   }
 
@@ -1856,6 +1868,38 @@ public:
     return result;
   }
 
+  Classification classifyTemporarilyEscapable(MakeTemporarilyEscapableExpr *E) {
+    auto opaqueValue = E->getOpaqueValue();
+    if (!opaqueValue)
+      return Classification();
+
+    auto type = opaqueValue->getType();
+    if (!type)
+      return Classification();
+
+    auto fnType = type->getAs<AnyFunctionType>();
+    if (!fnType)
+      return Classification();
+
+    // Runtime safety checks for temporarily-escapable functions aren't
+    // always available.
+    switch (fnType->getRepresentation()) {
+    case FunctionTypeRepresentation::Swift:
+      // Swift performs runtime checking to ensure that the function did not
+      // escape.
+      return Classification();
+
+    case FunctionTypeRepresentation::Block:
+      return Classification::forUnsafe({UnsafeUse::forTemporarilyEscaping(E)});
+
+    case FunctionTypeRepresentation::Thin:
+    case FunctionTypeRepresentation::CFunctionPointer:
+      // Thin and C functions cannot carry any state with them, so escaping
+      // the pointers does not introduce a memory-safety issue.
+      return Classification();
+    }
+  }
+
 private:
   /// Classify a throwing or async function according to our local
   /// knowledge of its implementation.
@@ -2073,6 +2117,10 @@ private:
       return ShouldRecurse;
     }
 
+    ShouldRecurse_t checkTemporarilyEscapable(MakeTemporarilyEscapableExpr *E) {
+      return ShouldRecurse;
+    }
+
     ConditionalEffectKind checkExhaustiveDoBody(DoCatchStmt *S) {
       // All errors thrown by the do body are caught, but any errors thrown
       // by the catch bodies are bounded by the throwing kind of the do body.
@@ -2214,6 +2262,10 @@ private:
       return ShouldRecurse;
     }
 
+    ShouldRecurse_t checkTemporarilyEscapable(MakeTemporarilyEscapableExpr *E) {
+      return ShouldRecurse;
+    }
+
     void visitExprPre(Expr *expr) { return; }
   };
 
@@ -2324,6 +2376,11 @@ private:
             Classification::forType(type, loc).onlyUnsafe());
       }
 
+      return ShouldRecurse;
+    }
+
+    ShouldRecurse_t checkTemporarilyEscapable(MakeTemporarilyEscapableExpr *E) {
+      classification.merge(Self.classifyTemporarilyEscapable(E));
       return ShouldRecurse;
     }
 
@@ -3770,6 +3827,13 @@ private:
     if (assumedSafeArguments.contains(E))
       classification = classification.withoutUnsafe();
 
+    checkEffectSite(E, /*requiresTry=*/false, classification);
+    return ShouldRecurse;
+  }
+
+  ShouldRecurse_t checkTemporarilyEscapable(MakeTemporarilyEscapableExpr *E) {
+    auto classification = getApplyClassifier().
+        classifyTemporarilyEscapable(E);
     checkEffectSite(E, /*requiresTry=*/false, classification);
     return ShouldRecurse;
   }

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -154,6 +154,14 @@ void swift::diagnoseUnsafeUse(const UnsafeUse &use) {
     return;
   }
 
+  case UnsafeUse::TemporarilyEscaping: {
+    Type type = use.getType();
+    ASTContext &ctx = type->getASTContext();
+    ctx.Diags.diagnose(
+        use.getLocation(), diag::note_unsafe_temporarily_escaping, type);
+    return;
+  }
+
   case UnsafeUse::PreconcurrencyImport: {
     auto importDecl = cast<ImportDecl>(use.getDecl());
     importDecl->diagnose(diag::preconcurrency_import_unsafe);

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -195,7 +195,7 @@ func unsafeFun() {
   acceptBoolsUnsafeLabel(unsafe: unsafe, unsafe)
 
   let color: Color
-  // expected-warning@+1{{no unsafe operations occur within 'unsafe' expression}}
+  // expected-warning@+1{{no unsafe operations occur within 'unsafe' expression}}{{11-18=}}
   color = unsafe .red
   _ = color
 

--- a/test/Unsafe/unsafe_withoutactuallyescaping.swift
+++ b/test/Unsafe/unsafe_withoutactuallyescaping.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -strict-memory-safety
+
+// REQUIRES: objc_interop
+
+func callMe(body: @escaping @convention(block) () -> Void) { }
+
+func callMeSwiftly(body: @escaping () -> Void) { }
+
+func testCall(body: @convention(block) () -> Void, swiftBody: () -> Void) {
+  // expected-warning@+2{{unsafe}}{{3-3=unsafe }}
+  // expected-note@+1{{'withoutActuallyEscaping' function of type '@convention(block) () -> Void' is unsafe}}
+  withoutActuallyEscaping(body) { nonescapingBody in
+    callMe(body: nonescapingBody)
+  }
+
+  withoutActuallyEscaping(swiftBody) { nonescapingBody in
+    callMeSwiftly(body: nonescapingBody)
+  }
+}


### PR DESCRIPTION
Two small improvements to SE-458 strict memory safety checking:
* `withoutActuallyEscaping` is unsafe for `@convention(block)` (rdar://139994149)
* Add a Fix-It to remove `unsafe` in the `no unsafe operations occur within 'unsafe' expression` warning and put it into the StrictMemorySafety diagnostic group