### PR TITLE
[utils] Replace gold with lld as the default linker on Linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -926,7 +926,7 @@ reconfigure
 # Use the clang that we install in the path for macros
 llvm-cmake-options=
   -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
-  -DCLANG_DEFAULT_LINKER=gold
+  -DCLANG_DEFAULT_LINKER=ld.lld
 
 [preset: buildbot_linux]
 mixin-preset=
@@ -1099,7 +1099,7 @@ skip-test-swiftdocc
 # Use the clang that we install in the path for macros
 llvm-cmake-options=
   -DCROSS_TOOLCHAIN_FLAGS_LLVM_NATIVE='-DCMAKE_C_COMPILER=clang;-DCMAKE_CXX_COMPILER=clang++'
-  -DCLANG_DEFAULT_LINKER=gold
+  -DCLANG_DEFAULT_LINKER=ld.lld
 
 [preset: buildbot_linux_1404_no_lldb]
 mixin-preset=buildbot_incremental_linux
@@ -1180,7 +1180,7 @@ reconfigure
 relocate-xdg-cache-home-under-build-subdir
 
 llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+  -DCLANG_DEFAULT_LINKER=ld.lld
 
 build-embedded-stdlib-cross-compiling
 
@@ -1809,7 +1809,7 @@ skip-test-osx
 
 [preset: pr_apple_llvm_project_linux]
 
-llvm-cmake-options=-DCLANG_DEFAULT_LINKER=gold
+llvm-cmake-options=-DCLANG_DEFAULT_LINKER=ld.lld
 
 foundation
 libdispatch
@@ -1875,7 +1875,7 @@ skip-test-libdispatch
 skip-test-xctest
 
 llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+  -DCLANG_DEFAULT_LINKER=ld.lld
 
 # SwiftPM package base
 [preset: mixin_swiftpm_package_macos_platform]
@@ -1912,7 +1912,7 @@ skip-test-llbuild
 skip-test-swiftpm
 
 llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+  -DCLANG_DEFAULT_LINKER=ld.lld
 
 #===------------------------------------------------------------------------===#
 # Test swiftPM on macOS builder
@@ -2184,7 +2184,7 @@ skip-test-libdispatch
 skip-test-foundation
 
 llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+  -DCLANG_DEFAULT_LINKER=ld.lld
 
 #===------------------------------------------------------------------------===#
 # Remote Mirror Library
@@ -3020,7 +3020,7 @@ install-xctest
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
 
 llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+  -DCLANG_DEFAULT_LINKER=ld.lld
 
 [preset: source_compat_suite_macos_DA]
 mixin-preset=source_compat_suite_macos_base
@@ -3108,7 +3108,7 @@ skip-build-benchmarks
 skip-test-foundation
 
 llvm-cmake-options=
-  -DCLANG_DEFAULT_LINKER=gold
+  -DCLANG_DEFAULT_LINKER=ld.lld
 
 #===------------------------------------------------------------------------===#
 # Toolchain Bootstrapping Stages


### PR DESCRIPTION
GNU Gold is deprecated[0] and will not be updated by upstream binutils. This begins with binutils 2.44, released in February 2025.

[0] https://lists.gnu.org/archive/html/info-gnu/2025-02/msg00001.html

Resolves #79163 

cc @etcwilde 