### PR TITLE
Fix a few more callers of ProtocolConformanceRef::forAbstract() to pass in a subject type

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Conformance.swift
+++ b/SwiftCompilerSources/Sources/AST/Conformance.swift
@@ -37,6 +37,9 @@ public struct Conformance: CustomStringConvertible, NoReflectionChildren {
     return Type(bridged: bridged.getType())
   }
 
+  public var proto: ProtocolDecl {
+    return bridged.getRequirement().getAs(ProtocolDecl.self)
+  }
   public var isSpecialized: Bool {
     assert(isConcrete)
     return bridged.isSpecializedConformance()

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -144,14 +144,17 @@ func specializeWitnessTable(forConformance conformance: Conformance,
     case .associatedType(let requirement, let witness):
       let substType = witness.subst(with: conformance.specializedSubstitutions)
       return .associatedType(requirement: requirement, witness: substType)
-    case .associatedConformance(let requirement, let proto, _):
-      let concreteAssociateConf = conformance.getAssociatedConformance(ofAssociatedType: requirement.rawType, to: proto)
+    case .associatedConformance(let requirement, let substType, let assocConf):
+      // FIXME: let concreteAssociateConf = assocConf.subst(with: conformance.specializedSubstitutions)
+      let concreteAssociateConf = conformance.getAssociatedConformance(ofAssociatedType: requirement.rawType, to: assocConf.proto)
       if concreteAssociateConf.isSpecialized {
         specializeWitnessTable(forConformance: concreteAssociateConf,
                                errorLocation: errorLocation,
                                context, notifyNewWitnessTable)
       }
-      return .associatedConformance(requirement: requirement, protocol: proto, witness: concreteAssociateConf)
+      return .associatedConformance(requirement: requirement,
+                                    substType: substType.subst(with: conformance.specializedSubstitutions),
+                                    witness: concreteAssociateConf)
     }
   }
   let newWT = context.createWitnessTable(entries: newEntries,conformance: conformance,

--- a/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
+++ b/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
@@ -31,7 +31,7 @@ public struct WitnessTable : CustomStringConvertible, NoReflectionChildren {
     case associatedType(requirement: AssociatedTypeDecl, witness: CanonicalType)
 
     /// A witness table entry describing the witness for an associated type's protocol requirement.
-    case associatedConformance(requirement: CanonicalType, protocol: ProtocolDecl, witness: Conformance)
+    case associatedConformance(requirement: CanonicalType, substType: CanonicalType, witness: Conformance)
 
     /// A witness table entry referencing the protocol conformance for a refined base protocol.
     case baseProtocol(requirement: ProtocolDecl, witness: Conformance)
@@ -48,7 +48,7 @@ public struct WitnessTable : CustomStringConvertible, NoReflectionChildren {
                                witness: CanonicalType(bridged: bridged.getAssociatedTypeWitness()))
       case .associatedConformance:
         self = .associatedConformance(requirement: CanonicalType(bridged: bridged.getAssociatedConformanceRequirement()),
-                                      protocol: bridged.getAssociatedConformanceDecl().getAs(ProtocolDecl.self),
+                                      substType: CanonicalType(bridged: bridged.getAssociatedConformanceSubstType()),
                                       witness: Conformance(bridged: bridged.getAssociatedConformanceWitness()))
       case .baseProtocol:
         self = .baseProtocol(requirement: bridged.getBaseProtocolRequirement().getAs(ProtocolDecl.self),
@@ -71,9 +71,9 @@ public struct WitnessTable : CustomStringConvertible, NoReflectionChildren {
                                                      OptionalBridgedFunction(obj: witness?.bridged.obj))
       case .associatedType(let requirement, let witness):
         return BridgedWitnessTableEntry.createAssociatedType(requirement.bridged, witness.bridged)
-      case .associatedConformance(let requirement, let protocolDecl, let witness):
+      case .associatedConformance(let requirement, let substType, let witness):
         return BridgedWitnessTableEntry.createAssociatedConformance(requirement.bridged,
-                                                                    protocolDecl.bridged,
+                                                                    substType.bridged,
                                                                     witness.bridged)
       case .baseProtocol(let requirement, let witness):
         return BridgedWitnessTableEntry.createBaseProtocol(requirement.bridged, witness.bridged)

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -3110,6 +3110,7 @@ struct BridgedConformance {
   BRIDGED_INLINE bool isSpecializedConformance() const;
   BRIDGED_INLINE bool isInheritedConformance() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType getType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getRequirement() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getGenericConformance() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getInheritedConformance() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getSpecializedSubstitutions() const;

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -601,6 +601,10 @@ BridgedASTType BridgedConformance::getType() const {
   return {unbridged().getConcrete()->getType().getPointer()};
 }
 
+BridgedDeclObj BridgedConformance::getRequirement() const {
+  return {unbridged().getRequirement()};
+}
+
 BridgedConformance BridgedConformance::getGenericConformance() const {
   auto *specPC = swift::cast<swift::SpecializedProtocolConformance>(unbridged().getConcrete());
   return {swift::ProtocolConformanceRef(specPC->getGenericConformance())};

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -19,6 +19,7 @@
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"
+#include "swift/Basic/Assertions.h"
 #include "swift/Basic/Debug.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/PointerUnion.h"
@@ -101,6 +102,7 @@ public:
     return !isInvalid() && Union.is<ProtocolConformance*>();
   }
   ProtocolConformance *getConcrete() const {
+    ASSERT(isConcrete());
     return Union.get<ProtocolConformance*>();
   }
 
@@ -108,6 +110,7 @@ public:
     return !isInvalid() && Union.is<PackConformance*>();
   }
   PackConformance *getPack() const {
+    ASSERT(isPack());
     return Union.get<PackConformance*>();
   }
 
@@ -116,6 +119,7 @@ public:
   }
 
   ProtocolDecl *getAbstract() const {
+    ASSERT(isAbstract());
     return Union.get<ProtocolDecl*>();
   }
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1007,7 +1007,7 @@ struct BridgedWitnessTableEntry {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getAssociatedTypeRequirement() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getAssociatedTypeWitness() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getAssociatedConformanceRequirement() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getAssociatedConformanceDecl() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getAssociatedConformanceSubstType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getAssociatedConformanceWitness() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getBaseProtocolRequirement() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getBaseProtocolWitness() const;
@@ -1022,7 +1022,7 @@ struct BridgedWitnessTableEntry {
                                                        BridgedCanType witness);
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   static BridgedWitnessTableEntry createAssociatedConformance(BridgedCanType requirement,
-                                                              BridgedDeclObj protocolDecl,
+                                                              BridgedCanType substType,
                                                               BridgedConformance witness);
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   static BridgedWitnessTableEntry createBaseProtocol(BridgedDeclObj requirement,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1832,8 +1832,8 @@ BridgedCanType BridgedWitnessTableEntry::getAssociatedConformanceRequirement() c
   return unbridged().getAssociatedConformanceWitness().Requirement;
 }
 
-BridgedDeclObj BridgedWitnessTableEntry::getAssociatedConformanceDecl() const {
-  return {unbridged().getAssociatedConformanceWitness().Protocol};
+BridgedCanType BridgedWitnessTableEntry::getAssociatedConformanceSubstType() const {
+  return {unbridged().getAssociatedConformanceWitness().SubstType};
 }
 
 BridgedConformance BridgedWitnessTableEntry::getAssociatedConformanceWitness() const {
@@ -1867,11 +1867,11 @@ BridgedWitnessTableEntry BridgedWitnessTableEntry::createAssociatedType(BridgedD
 }
 
 BridgedWitnessTableEntry BridgedWitnessTableEntry::createAssociatedConformance(BridgedCanType requirement,
-                                                                               BridgedDeclObj protocolDecl,
+                                                                               BridgedCanType substType,
                                                                                BridgedConformance witness) {
   return bridge(swift::SILWitnessTable::Entry(
     swift::SILWitnessTable::AssociatedConformanceWitness{requirement.unbridged(),
-                                                         protocolDecl.getAs<swift::ProtocolDecl>(),
+                                                         substType.unbridged(),
                                                          witness.unbridged()}));
 }
 

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -64,13 +64,11 @@ public:
   /// A witness table entry describing the witness for an associated type's
   /// protocol requirement.
   struct AssociatedConformanceWitness {
-    /// The associated type required.  A dependent type in the protocol's
-    /// context.
+    /// The subject type of the associated requirement.
     CanType Requirement;
-    /// The protocol requirement on the type.
-    ProtocolDecl *Protocol;
-    /// The ProtocolConformance satisfying the requirement. Null if the
-    /// conformance is dependent.
+    /// FIXME: Temporary.
+    CanType SubstType;
+    /// The ProtocolConformanceRef satisfying the requirement.
     ProtocolConformanceRef Witness;
   };
   
@@ -160,6 +158,7 @@ public:
   /// conditional. These aren't public, but any witness thunks need to feed them
   /// into the true witness functions.
   struct ConditionalConformance {
+    /// FIXME: Temporary.
     CanType Requirement;
     ProtocolConformanceRef Conformance;
   };

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -49,8 +49,6 @@ bool ProtocolConformanceRef::isInvalid() const {
 }
 
 ProtocolDecl *ProtocolConformanceRef::getRequirement() const {
-  assert(!isInvalid());
-
   if (isConcrete()) {
     return getConcrete()->getProtocol();
   } else if (isPack()) {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1182,14 +1182,17 @@ namespace {
 
       for (auto &entry : DefaultWitnesses->getEntries()) {
         if (!entry.isValid() ||
-            entry.getKind() != SILWitnessTable::AssociatedConformance ||
-            entry.getAssociatedConformanceWitness().Protocol != requirement ||
-            entry.getAssociatedConformanceWitness().Requirement != association)
+            entry.getKind() != SILWitnessTable::AssociatedConformance)
           continue;
 
-        auto witness = entry.getAssociatedConformanceWitness().Witness;
+        auto assocConf = entry.getAssociatedConformanceWitness();
+        if (assocConf.Requirement != association ||
+            assocConf.Witness.getRequirement() != requirement)
+          continue;
+
         AssociatedConformance conformance(Proto, association, requirement);
-        defineDefaultAssociatedConformanceAccessFunction(conformance, witness);
+        defineDefaultAssociatedConformanceAccessFunction(
+            conformance, assocConf.Witness);
         return IGM.getMangledAssociatedConformance(nullptr, conformance);
       }
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -4269,13 +4269,18 @@ void SILWitnessTable::Entry::print(llvm::raw_ostream &out, bool verbose,
   case WitnessKind::AssociatedConformance: {
     // associated_conformance (AssociatedTypeName: Protocol): <conformance>
     auto &assocProtoWitness = getAssociatedConformanceWitness();
+    if (assocProtoWitness.Witness.isInvalid())
+      return;
     out << "associated_conformance (";
     (void) printAssociatedTypePath(out, assocProtoWitness.Requirement);
-    out << ": " << assocProtoWitness.Protocol->getName() << "): ";
-    if (assocProtoWitness.Witness.isConcrete())
-      assocProtoWitness.Witness.getConcrete()->printName(out, options);
-    else
-      out << "dependent";
+    auto conformance = assocProtoWitness.Witness;
+    out << ": " << conformance.getRequirement()->getName() << "): ";
+    if (conformance.isConcrete())
+      conformance.getConcrete()->printName(out, options);
+    else {
+      out << "dependent ";
+      assocProtoWitness.SubstType->print(out, options);
+    }
     break;
   }
   case WitnessKind::BaseProtocol: {
@@ -4316,14 +4321,19 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
   for (auto conditionalConformance : getConditionalConformances()) {
     // conditional_conformance (TypeName: Protocol):
     // <conformance>
+    if (conditionalConformance.Conformance.isInvalid())
+      continue;
+
     OS << "  conditional_conformance (";
     conditionalConformance.Requirement.print(OS, Options);
     OS << ": " << conditionalConformance.Conformance.getRequirement()->getName()
        << "): ";
     if (conditionalConformance.Conformance.isConcrete())
       conditionalConformance.Conformance.getConcrete()->printName(OS, Options);
-    else
-      OS << "dependent";
+    else {
+      OS << "dependent ";
+      conditionalConformance.Requirement->print(OS, Options);
+    }
 
     OS << '\n';
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -8168,23 +8168,47 @@ static bool parseSILWitnessTableEntry(
         P.parseToken(tok::colon, diag::expected_sil_witness_colon))
       return true;
 
-    // FIXME: Passing an empty Type() here temporarily.
-    auto conformance = ProtocolConformanceRef::forAbstract(Type(), proto);
+    CanType substType;
+    ProtocolConformanceRef conformance;
     if (P.Tok.getText() != "dependent") {
       auto concrete =
         witnessState.parseProtocolConformance();
       // Ignore invalid and abstract witness entries.
       if (concrete.isInvalid() || !concrete.isConcrete())
         return false;
+      substType = concrete.getConcrete()->getType()->getCanonicalType();
       conformance = concrete;
     } else {
       P.consumeToken();
+
+      // Parse AST type.
+      ParserResult<TypeRepr> TyR = P.parseType();
+      if (TyR.isNull())
+        return true;
+
+      SILTypeResolutionContext silContext(/*isSILType=*/false,
+                                          witnessParams,
+                                          /*openedPacks=*/nullptr);
+      auto Ty =
+          swift::performTypeResolution(TyR.get(), P.Context,
+                                       witnessSig, &silContext,
+                                       &P.SF);
+      if (witnessSig) {
+        Ty = witnessSig.getGenericEnvironment()->mapTypeIntoContext(Ty);
+      }
+
+      if (Ty->hasError())
+        return true;
+
+      substType = Ty->getCanonicalType();
+      conformance = ProtocolConformanceRef::forAbstract(
+          Ty->getCanonicalType(), proto);
     }
 
     if (EntryKeyword.str() == "associated_conformance")
       witnessEntries.push_back(
           SILWitnessTable::AssociatedConformanceWitness{assocOrSubject,
-                                                        proto,
+                                                        substType,
                                                         conformance});
     else
       conditionalConformances.push_back(

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1884,8 +1884,7 @@ SubstitutionMap getApplySubstitutionsFromParsed(
                       proto->getDeclaredInterfaceType());
         failed = true;
 
-        // FIXME: Passing an empty Type() here temporarily.
-        return ProtocolConformanceRef::forAbstract(Type(), proto);
+        return ProtocolConformanceRef::forInvalid();
       });
 
   return failed ? SubstitutionMap() : subMap;

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -670,12 +670,13 @@ public:
     auto assocConformance =
       Conformance->getAssociatedConformance(req.getAssociation(),
                                             req.getAssociatedRequirement());
+    auto substType =
+      Conformance->getAssociatedType(req.getAssociation())->getCanonicalType();
 
     SGM.useConformance(assocConformance);
 
     Entries.push_back(SILWitnessTable::AssociatedConformanceWitness{
-        req.getAssociation(), req.getAssociatedRequirement(),
-        assocConformance});
+        req.getAssociation(), substType, assocConformance});
   }
 
   void addConditionalRequirements() {
@@ -1105,7 +1106,7 @@ public:
       return addMissingDefault();
 
     auto entry = SILWitnessTable::AssociatedConformanceWitness{
-        req.getAssociation(), req.getAssociatedRequirement(), witness};
+        req.getAssociation(), req.getAssociation(), witness};
     DefaultWitnesses.push_back(entry);
   }
 };

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8747,11 +8747,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
   // separately.
   switch (kind) {
   case ConstraintKind::Subtype: {
-    auto conformance = TypeChecker::containsProtocol(
+    auto pair = TypeChecker::containsProtocol(
         type, protocol, /*allowMissing=*/true);
-    if (conformance) {
-      return recordConformance(conformance);
-    }
+    if (pair.first)
+      return SolutionKind::Solved;
+    if (pair.second)
+      return recordConformance(pair.second);
   } break;
   case ConstraintKind::NonisolatedConformsTo:
   case ConstraintKind::ConformsTo:

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -834,12 +834,15 @@ Expr *addImplicitLoadExpr(
     std::function<void(Expr *, Type)> setType =
         [](Expr *E, Type type) { E->setType(type); });
 
-/// Determine whether the given type contains the given protocol.
+/// Determine whether the given type either conforms to, or itself an
+/// existential subtype of, the given protocol.
 ///
-/// \returns the conformance, if \c T conforms to the protocol \c Proto, or
-/// an empty optional.
-ProtocolConformanceRef containsProtocol(Type T, ProtocolDecl *Proto,
-                                        bool allowMissing=false);
+/// \returns if the first element of the pair is true, T is an existential
+/// subtype of Proto, and the second element is ignored; if the first element
+/// is false, the second element is the result of the conformance lookup.
+std::pair<bool, ProtocolConformanceRef>
+containsProtocol(Type T, ProtocolDecl *Proto,
+                 bool allowMissing=false);
 
 /// Check whether the type conforms to a given known protocol.
 bool conformsToKnownProtocol(Type type, KnownProtocolKind protocol,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -8734,6 +8734,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     for (const auto &req : proto->getRequirementSignature().getRequirements()) {
       if (req.getKind() != RequirementKind::Conformance)
         continue;
+      ASSERT(req.getFirstType()->isEqual(proto->getSelfInterfaceType()));
       ProtocolDecl *proto = req.getProtocolDecl();
       auto iter = conformancesForProtocols.find(proto);
       if (iter != conformancesForProtocols.end()) {
@@ -8745,10 +8746,8 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
         // conformance to an Objective-C protocol for anything important.
         // There are no associated types and we don't emit a Swift conformance
         // record.
-        //
-        // FIXME: Passing an empty Type() here temporarily.
         reqConformances.push_back(ProtocolConformanceRef::forAbstract(
-            Type(), proto));
+            conformance->getType(), proto));
       }
     }
   } else {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -4446,16 +4446,16 @@ void SILDeserializer::readWitnessTableEntries(
         proto, conformance.getConcrete()
       });
     } else if (kind == SIL_WITNESS_ASSOC_PROTOCOL) {
-      TypeID assocId;
-      DeclID protoId;
+      TypeID origTypeId;
+      DeclID substTypeId;
       ProtocolConformanceID conformanceId;
-      WitnessAssocProtocolLayout::readRecord(scratch, assocId, protoId,
+      WitnessAssocProtocolLayout::readRecord(scratch, origTypeId, substTypeId,
                                              conformanceId);
-      CanType type = MF->getType(assocId)->getCanonicalType();
-      ProtocolDecl *proto = cast<ProtocolDecl>(MF->getDecl(protoId));
+      CanType origType = MF->getType(origTypeId)->getCanonicalType();
+      CanType substType = MF->getType(substTypeId)->getCanonicalType();
       auto conformance = MF->getConformance(conformanceId);
       witnessEntries.push_back(SILWitnessTable::AssociatedConformanceWitness{
-        type, proto, conformance
+        origType, substType, conformance
       });
     } else if (kind == SIL_WITNESS_ASSOC_ENTRY) {
       DeclID assocId;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 925; // isolated conformances
+const uint16_t SWIFTMODULE_VERSION_MINOR = 926; // abstract conformances
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -244,8 +244,8 @@ namespace sil_block {
 
   using WitnessAssocProtocolLayout = BCRecordLayout<
     SIL_WITNESS_ASSOC_PROTOCOL,
-    TypeIDField, // ID of associated type
-    DeclIDField, // ID of ProtocolDecl
+    TypeIDField, // ID of requirement subject type
+    TypeIDField, // ID of substituted subject type
     ProtocolConformanceIDField
   >;
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -3359,13 +3359,13 @@ void SILSerializer::writeSILWitnessTableEntry(
     auto &assoc = entry.getAssociatedConformanceWitness();
 
     auto requirementID = S.addTypeRef(assoc.Requirement);
-    auto protocolID = S.addDeclRef(assoc.Protocol);
+    auto substTypeID = S.addTypeRef(assoc.SubstType);
     auto conformanceID = S.addConformanceRef(assoc.Witness);
 
     WitnessAssocProtocolLayout::emitRecord(
       Out, ScratchRecord,
       SILAbbrCodes[WitnessAssocProtocolLayout::Code],
-      requirementID, protocolID, conformanceID);
+      requirementID, substTypeID, conformanceID);
     return;
   }
 

--- a/test/SIL/Parser/witness_tables.sil
+++ b/test/SIL/Parser/witness_tables.sil
@@ -107,10 +107,10 @@ extension ConditionalStruct : P where T : P {
 }
 
 // CHECK-LABEL: sil_witness_table hidden <T where T : P> ConditionalStruct<T>: P module witness_tables {
-// CHECK-NEXT:    conditional_conformance (T: P): dependent
+// CHECK-NEXT:    conditional_conformance (T: P): dependent T
 // CHECK-NEXT:   }
 sil_witness_table hidden <T where T : P> ConditionalStruct<T>: P module t4 {
-  conditional_conformance (T: P): dependent
+  conditional_conformance (T: P): dependent T
 }
 
 sil_default_witness_table hidden P {

--- a/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
+++ b/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
@@ -399,7 +399,7 @@ sil_witness_table hidden <T where T == UInt8> S1<T>: HasFoo module tot {
 
 sil_witness_table hidden <T where T : P> S2<T>: HasFoo module tot {
   method #HasFoo.foo: <Self where Self : HasFoo> (Self) -> () -> () : @witnessS2
-  conditional_conformance (T: P): dependent
+  conditional_conformance (T: P): dependent T
 }
 
 sil_witness_table hidden IsP: P module tot {


### PR DESCRIPTION
I want to make abstract conformances store a subject type, eventually.

This PR is another small step in that direction, by making us pass down a subject type instead of Type() in most places.

I wanted to avoid this becoming too much of a yak shave, so a couple of bits are a little hacky. IRGen's LocalTypeDataKind duplicates ProtocolConformanceRef in an awkward way, and SILWitnessTable::AssociatedConformanceWitness needs a temporary hack. We can unwind these later once the core representation is fixed.

One more call to forAbstract() without a subject type remains. Once that's fixed, we can start storing the subject type that is passed in to forAbstract(). This will allow simplifying some APIs, which will make them more convenient to call from Swift -- something that @eeckstein ran into, which is why I decided to pick up this refactoring again.