### PR TITLE
Serialization: Protect `deserializeEnum` and more against failures

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5037,7 +5037,9 @@ public:
       theEnum->setImplicit();
     theEnum->setIsObjC(isObjC);
 
-    theEnum->setRawType(MF.getType(rawTypeID));
+    Type rawType;
+    SET_OR_RETURN_ERROR(rawType, MF.getTypeChecked(rawTypeID));
+    theEnum->setRawType(rawType);
 
     handleInherited(theEnum, inheritedIDs);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -873,7 +873,8 @@ ProtocolConformanceDeserializer::readSpecializedProtocolConformance(
   auto subMap = subMapOrError.get();
 
   ProtocolConformanceRef genericConformance;
-  UNWRAP(MF.getConformanceChecked(conformanceID), genericConformance);
+  SET_OR_RETURN_ERROR(genericConformance,
+                      MF.getConformanceChecked(conformanceID));
 
   PrettyStackTraceDecl traceTo("... to", genericConformance.getRequirement());
   ++NumNormalProtocolConformancesLoaded;
@@ -906,7 +907,8 @@ ProtocolConformanceDeserializer::readInheritedProtocolConformance(
                              conformingType);
 
   ProtocolConformanceRef inheritedConformance;
-  UNWRAP(MF.getConformanceChecked(conformanceID), inheritedConformance);
+  SET_OR_RETURN_ERROR(inheritedConformance,
+                      MF.getConformanceChecked(conformanceID));
   PrettyStackTraceDecl traceTo("... to",
                                inheritedConformance.getRequirement());
 
@@ -957,12 +959,12 @@ ProtocolConformanceDeserializer::readNormalProtocolConformanceXRef(
                                             moduleID);
 
   Decl *maybeNominal;
-  UNWRAP(MF.getDeclChecked(nominalID), maybeNominal);
+  SET_OR_RETURN_ERROR(maybeNominal, MF.getDeclChecked(nominalID));
   auto nominal = cast<NominalTypeDecl>(maybeNominal);
   PrettyStackTraceDecl trace("cross-referencing conformance for", nominal);
 
   Decl *maybeProto;
-  UNWRAP(MF.getDeclChecked(protoID), maybeProto);
+  SET_OR_RETURN_ERROR(maybeProto, MF.getDeclChecked(protoID));
   auto proto = cast<ProtocolDecl>(maybeProto);
   PrettyStackTraceDecl traceTo("... to", proto);
 
@@ -7915,7 +7917,8 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
   ProtocolConformanceRef witnessMethodConformance;
   if (*representation == swift::SILFunctionTypeRepresentation::WitnessMethod) {
     auto conformanceID = variableData[nextVariableDataIndex++];
-    UNWRAP(MF.getConformanceChecked(conformanceID), witnessMethodConformance);
+    SET_OR_RETURN_ERROR(witnessMethodConformance,
+                        MF.getConformanceChecked(conformanceID));
   }
 
   GenericSignature invocationSig =

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4084,7 +4084,9 @@ public:
 
     declOrOffset = param;
 
-    auto paramTy = MF.getType(interfaceTypeID);
+    Type paramTy;
+    SET_OR_RETURN_ERROR(paramTy, MF.getTypeChecked(interfaceTypeID));
+
     if (paramTy->hasError() && !MF.allowCompilerErrors()) {
       // FIXME: This should never happen, because we don't serialize
       // error types.
@@ -4106,7 +4108,9 @@ public:
     if (auto defaultArg = getActualDefaultArgKind(rawDefaultArg)) {
       param->setDefaultArgumentKind(*defaultArg);
 
-      if (auto exprType = MF.getType(defaultExprType))
+      Type exprType;
+      SET_OR_RETURN_ERROR(exprType, MF.getTypeChecked(defaultExprType));
+      if (exprType)
         param->setDefaultExprType(exprType);
 
       auto isoKind = *getActualActorIsolationKind(rawDefaultArgIsolation);
@@ -4952,7 +4956,11 @@ public:
     if (isImplicit)
       theClass->setImplicit();
     theClass->setIsObjC(isObjC);
-    theClass->setSuperclass(MF.getType(superclassID));
+
+    Type superclass;
+    SET_OR_RETURN_ERROR(superclass, MF.getTypeChecked(superclassID));
+    theClass->setSuperclass(superclass);
+
     ctx.evaluator.cacheOutput(InheritsSuperclassInitializersRequest{theClass},
                               std::move(inheritsSuperclassInitializers));
     ctx.evaluator.cacheOutput(HasMissingDesignatedInitializersRequest{theClass},

--- a/test/Serialization/Recovery/Inputs/implementation-only-missing/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/implementation-only-missing/module.modulemap
@@ -1,1 +1,0 @@
-module public_lib [system] {}

--- a/test/Serialization/Recovery/implementation-only-missing.swift
+++ b/test/Serialization/Recovery/implementation-only-missing.swift
@@ -61,7 +61,7 @@ public protocol HiddenProtocolWithOverride {
   func hiddenOverride()
 }
 
-public class HiddenClass {}
+open class HiddenClass {}
 
 public struct HiddenRawType: ExpressibleByStringLiteral, Equatable, CustomStringConvertible {
 
@@ -147,6 +147,14 @@ protocol InheritingFromCompositionDirect : CompositionMemberSimple & HiddenProto
 enum InternalEnumWithRawType: HiddenRawType {
     case a
 }
+
+class InternalSubclass: HiddenClass {}
+class GenericBase<T> {}
+class Sub: GenericBase<Sub.Nested> {
+  class Nested: HiddenClass {}
+}
+
+func InternalFuncWithParam(a: HiddenRawType)  {}
 
 //--- Client.swift
 

--- a/test/Serialization/Recovery/implementation-only-missing.swift
+++ b/test/Serialization/Recovery/implementation-only-missing.swift
@@ -3,24 +3,36 @@
 // rdar://problem/52837313
 
 // RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
 
 //// Build the private module, the public module and the client app normally.
 //// Force the public module to be system with an underlying Clang module.
-// RUN: %target-swift-frontend -emit-module -DPRIVATE_LIB %s -module-name private_lib -emit-module-path %t/private_lib.swiftmodule
-// RUN: %target-swift-frontend -emit-module -DPUBLIC_LIB %s -module-name public_lib -emit-module-path %t/public_lib.swiftmodule -I %t -I %S/Inputs/implementation-only-missing -import-underlying-module
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift \
+// RUN:   -emit-module-path %t/PrivateLib.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift \
+// RUN:   -emit-module-path %t/PublicLib.swiftmodule \
+// RUN:   -I %t -import-underlying-module
 
-//// The client app should build OK without the private module. Removing the
-//// private module is superfluous but makes sure that it's not somehow loaded.
-// RUN: rm %t/private_lib.swiftmodule
-// RUN: %target-swift-frontend -typecheck -DCLIENT_APP %s -I %t -index-system-modules -index-store-path %t
-// RUN: %target-swift-frontend -typecheck -DCLIENT_APP %s -I %t -D FAIL_TYPECHECK -verify
-// RUN: %target-swift-frontend -emit-sil -DCLIENT_APP %s -I %t -module-name client
+//// Remove the private module make sure it's not somehow loaded.
+// RUN: rm %t/PrivateLib.swiftmodule
+
+//// The client app should build and index OK without the private module.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -index-system-modules -index-store-path %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -D FAIL_TYPECHECK -verify
+// RUN: %target-swift-frontend -emit-sil %t/Client.swift -I %t \
+// RUN:   -module-name client
 
 //// Printing the public module should not crash when checking for overrides of
 //// methods from the private module.
-// RUN: %target-swift-ide-test -print-module -module-to-print=public_lib -source-filename=x -skip-overrides -I %t
+// RUN: %target-swift-ide-test -print-module -module-to-print=PublicLib \
+// RUN:   -source-filename=x -skip-overrides -I %t
 
-#if PRIVATE_LIB
+//--- module.modulemap
+module PublicLib [system] {}
+
+//--- PrivateLib.swift
 
 @propertyWrapper
 public struct IoiPropertyWrapper<V> {
@@ -51,9 +63,10 @@ public protocol HiddenProtocolWithOverride {
 
 public class HiddenClass {}
 
-#elseif PUBLIC_LIB
 
-@_implementationOnly import private_lib
+//--- PublicLib.swift
+
+@_implementationOnly import PrivateLib
 
 struct LibProtocolConstraint { }
 
@@ -112,9 +125,10 @@ struct StructInheritingFromComposition : CompositionMemberInheriting & Compositi
 class ClassInheritingFromComposition : CompositionMemberInheriting & CompositionMemberSimple {}
 protocol InheritingFromCompositionDirect : CompositionMemberSimple & HiddenProtocol2 {}
 
-#elseif CLIENT_APP
 
-import public_lib
+//--- Client.swift
+
+import PublicLib
 
 var s = PublicStruct()
 print(s.nonWrappedVar)
@@ -128,6 +142,4 @@ print(p)
     class ClassUnrelatedToSomeClass {}
     var something = ClassUnrelatedToSomeClass() as AnyObject
     something.triggerTypoCorrection = 123 // expected-error {{value of type 'AnyObject' has no member 'triggerTypoCorrection'}}
-#endif
-
 #endif

--- a/test/Serialization/Recovery/implementation-only-missing.swift
+++ b/test/Serialization/Recovery/implementation-only-missing.swift
@@ -63,6 +63,24 @@ public protocol HiddenProtocolWithOverride {
 
 public class HiddenClass {}
 
+public struct HiddenRawType: ExpressibleByStringLiteral, Equatable, CustomStringConvertible {
+
+    fileprivate var staticValue: String
+
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+
+    public init(_ value: String) {
+        self.staticValue = value
+    }
+
+    public static func == (lhs: HiddenRawType, rhs: HiddenRawType) -> Bool {
+        return lhs.staticValue == rhs.staticValue
+    }
+
+    public var description: String { self.staticValue }
+}
 
 //--- PublicLib.swift
 
@@ -125,6 +143,10 @@ struct StructInheritingFromComposition : CompositionMemberInheriting & Compositi
 class ClassInheritingFromComposition : CompositionMemberInheriting & CompositionMemberSimple {}
 protocol InheritingFromCompositionDirect : CompositionMemberSimple & HiddenProtocol2 {}
 
+// rdar://147091863
+enum InternalEnumWithRawType: HiddenRawType {
+    case a
+}
 
 //--- Client.swift
 

--- a/validation-test/Serialization/crash-superclass-dependency-removal.swift
+++ b/validation-test/Serialization/crash-superclass-dependency-removal.swift
@@ -2,9 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -o %t/Lib.swiftmodule -enable-objc-interop -I %S/Inputs/custom-modules %s
 // RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -enable-objc-interop -I %t -I %S/Inputs/custom-modules | %FileCheck %s
 
-// FIXME: We need a way to handle the disappearing superclass in a position we
-// can't track easily from the containing class. rdar://problem/50835214
-// RUN: not --crash %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -enable-objc-interop -I %t -I %S/Inputs/custom-modules -Xcc -DBAD
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -enable-objc-interop -I %t -I %S/Inputs/custom-modules -Xcc -DBAD
 
 import SuperclassObjC
 


### PR DESCRIPTION
Recover from a raw type hidden behind an `internal` or implementation-only import by dropping the whole enum when the raw type is not visible.  This scenario should happen only when looking at non-public decl for indexing or debugging, or if dependencies somehow changed and left behind a stale swiftmodule file.

Apply the same recovery logic to other notable uses of `getType` at deserializing a class or parameter.

Also clean up a few related pieces of code. Rename the macro `UNWRAP` to `SET_OR_RETURN_ERROR` for clarity and invert its parameters to have a more intuitive order of assignment target and then expression. And update the multipurpose test `implementation-only-missing.swift` to use split-file.

rdar://147091863