### PR TITLE
[Distributed] Correct handling ad-hoc requirements in non-final classes

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1000,8 +1000,7 @@ namespace {
 
       // Emit the dispatch thunk.
       auto shouldEmitDispatchThunk =
-          (Resilient || IGM.getOptions().WitnessMethodElimination) &&
-          (!func.isDistributed() || !func.isDistributedThunk());
+          (Resilient || IGM.getOptions().WitnessMethodElimination);
       if (shouldEmitDispatchThunk) {
         IGM.emitDispatchThunk(func);
       }
@@ -1082,14 +1081,10 @@ namespace {
             // Define the method descriptor.
             SILDeclRef func(entry.getFunction());
 
-            /// Distributed thunks don't need method descriptors
-            if (!func.isDistributedThunk()) {
-              auto *descriptor =
-                B.getAddrOfCurrentPosition(
-                  IGM.ProtocolRequirementStructTy);
-              IGM.defineMethodDescriptor(func, Proto, descriptor,
-                                         IGM.ProtocolRequirementStructTy);
-            }
+            auto *descriptor =
+                B.getAddrOfCurrentPosition(IGM.ProtocolRequirementStructTy);
+            IGM.defineMethodDescriptor(func, Proto, descriptor,
+                                       IGM.ProtocolRequirementStructTy);
           }
         }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2348,12 +2348,6 @@ namespace {
               LinkEntity::forBaseConformanceDescriptor(requirement));
           B.addRelativeAddress(baseConformanceDescriptor);
         } else if (entry.getKind() == SILWitnessTable::Method) {
-          // distributed thunks don't need resilience
-          if (entry.getMethodWitness().Requirement.isDistributedThunk()) {
-            witnesses = witnesses.drop_back();
-            continue;
-          }
-
           // Method descriptor.
           auto declRef = entry.getMethodWitness().Requirement;
           auto requirement =

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -157,14 +157,6 @@ public:
   }
 
   void addMethodDescriptor(SILDeclRef declRef) override {
-    if (declRef.isDistributedThunk()) {
-      auto afd = declRef.getAbstractFunctionDecl();
-      auto DC = afd->getDeclContext();
-      if (isa<ProtocolDecl>(DC)) {
-        return;
-      }
-    }
-
     addLinkEntity(LinkEntity::forMethodDescriptor(declRef));
   }
 

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -835,7 +835,6 @@ public:
                   V.Ctx.getOpts().WitnessMethodElimination} {}
 
         void addMethod(SILDeclRef declRef) {
-          // TODO: alternatively maybe prevent adding distributed thunk here rather than inside those?
           if (Resilient || WitnessMethodElimination) {
             Visitor.addDispatchThunk(declRef);
             Visitor.addMethodDescriptor(declRef);

--- a/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
+++ b/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
@@ -1,13 +1,14 @@
 // REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: concurrency
 // REQUIRES: distributed
+// UNSUPPORTED: use_os_stdlib
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
 // RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -enable-library-evolution -target %target-cpu-apple-macosx13.0 -parse-as-library -emit-library -emit-module-path %t/Library.swiftmodule -module-name Library %t/library.swift -o %t/%target-library-name(Library)
 // RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -target %target-cpu-apple-macosx13.0 -parse-as-library -lLibrary -module-name main -I %t -L %t %t/main.swift -o %t/a.out
-
 
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out

--- a/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
+++ b/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
@@ -1,0 +1,66 @@
+// REQUIRES: VENDOR=apple
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -enable-library-evolution -target %target-cpu-apple-macosx13.0 -parse-as-library -emit-library -emit-module-path %t/Library.swiftmodule -module-name Library %t/library.swift -o %t/%target-library-name(Library)
+// RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -target %target-cpu-apple-macosx13.0 -parse-as-library -lLibrary -module-name main -I %t -L %t %t/main.swift -o %t/a.out
+
+
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+//--- library.swift
+import Distributed
+
+//public protocol NormalProtocol {
+//  func NORMAL() async -> Int
+//}
+
+public protocol SimpleProtocol: DistributedActor
+    where ActorSystem == LocalTestingDistributedActorSystem {
+
+  // nonisolated override var id: ID { get } // comes from DistributedActor
+
+  // Has to have a distributed method to fail
+  distributed func test() -> Int
+}
+
+//--- main.swift
+import Distributed
+import Library
+
+//actor NormalActor: NormalProtocol {
+//  func NORMAL() async -> Int { 1 }
+//}
+
+public distributed actor SimpleActor: SimpleProtocol {
+  public distributed func test() -> Int { 1 }
+}
+
+// Passes
+public func makeFromPass<Act: DistributedActor>(_ act: Act) {
+  print(act.id)
+}
+
+// Fails
+public func makeFromFail<Act: SimpleProtocol>(_ act: Act) async {
+  print(act.id)
+  try! await print(act.test())
+}
+
+@main
+struct TestSwiftFrameworkTests {
+  static func main() async {
+    let system = LocalTestingDistributedActorSystem()
+
+    // let norm = NormalActor()
+
+    let simpleActor = SimpleActor(actorSystem: system)
+//    makeFromPass(simpleActor)
+
+    await makeFromFail(simpleActor)
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
+++ b/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
@@ -11,14 +11,10 @@
 // RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -target %target-cpu-apple-macosx13.0 -parse-as-library -lLibrary -module-name main -I %t -L %t %t/main.swift -o %t/a.out
 
 // RUN: %target-codesign %t/a.out
-// RUN: %target-run %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
 
 //--- library.swift
 import Distributed
-
-//public protocol NormalProtocol {
-//  func NORMAL() async -> Int
-//}
 
 public protocol SimpleProtocol: DistributedActor
     where ActorSystem == LocalTestingDistributedActorSystem {
@@ -33,23 +29,18 @@ public protocol SimpleProtocol: DistributedActor
 import Distributed
 import Library
 
-//actor NormalActor: NormalProtocol {
-//  func NORMAL() async -> Int { 1 }
-//}
-
 public distributed actor SimpleActor: SimpleProtocol {
-  public distributed func test() -> Int { 1 }
+  public distributed func test() -> Int {
+    print("SimpleActor.test")
+    return 1
+  }
 }
 
-// Passes
-public func makeFromPass<Act: DistributedActor>(_ act: Act) {
-  print(act.id)
-}
-
-// Fails
 public func makeFromFail<Act: SimpleProtocol>(_ act: Act) async {
   print(act.id)
-  try! await print(act.test())
+  try! await print("act.test() = \(act.test())")
+  // CHECK: SimpleActor.test
+  // CHECK: act.test() = 1
 }
 
 @main
@@ -57,11 +48,7 @@ struct TestSwiftFrameworkTests {
   static func main() async {
     let system = LocalTestingDistributedActorSystem()
 
-    // let norm = NormalActor()
-
     let simpleActor = SimpleActor(actorSystem: system)
-//    makeFromPass(simpleActor)
-
     await makeFromFail(simpleActor)
   }
 }


### PR DESCRIPTION
Reproduces https://github.com/swiftlang/swift/issues/79318

The problem is that the protocol requirements for those "ad-hoc" requirements are declared as: 

```
protocol DistributedTargetInvocationResultHandler {
  func onReturn<Success/*: SerializationRequirement*/>(value: Success) async throws

...
```

and then inside `EmitPolymorphicParameters::injectAdHocDistributedRequirements` we detect those few requirements that get this treatment, and we add the `Success: SerializationRequirement` constraints.

This _works_ in **debug** mode, but as https://github.com/swiftlang/swift/issues/79318 uncovered, it is not quite enough and will crash in **release** mode. Specifically, we add the witness information like this:

```
    IGF.setUnscopedLocalTypeData(
        archetypeTy,
        LocalTypeDataKind::forAbstractProtocolWitnessTable(proto),
        witnessTable);
```

which seems is not enough in release mode (?) or something gets optimized away, but could not figure out what exactly would even be expected to "be" there.

The crash manifests as an assertion about an invalid requirement which is because we're missed to add (or... lost somehow, due to some optimization?) the `: Transferable` the inject was adding. For reference, here's where we end up triggering the assertion:

```
Assertion failed: (!isInvalid()), function getRequirement, file ProtocolConformanceRef.cpp, line 52.
* thread #1, queue = 'com.apple.main-thread', stop reason = hit program assert
    frame #0: 0x0000000185223720 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x000000018525bf70 libsystem_pthread.dylib`pthread_kill + 288
    frame #2: 0x0000000185168908 libsystem_c.dylib`abort + 128
    frame #3: 0x0000000185167c1c libsystem_c.dylib`__assert_rtn + 284
  * frame #4: 0x0000000105835dec swift-frontend`swift::ProtocolConformanceRef::getRequirement() const (.cold.1) at ProtocolConformanceRef.cpp:52:3 [opt]
    frame #5: 0x00000001018e3cec swift-frontend`swift::ProtocolConformanceRef::getRequirement(this=<unavailable>) const at ProtocolConformanceRef.cpp:52:3 [opt]
    frame #6: 0x00000001006b2104 swift-frontend`swift::irgen::emitWitnessTableRef(IGF=0x000000016fdf5248, srcType=CanType @ x19, srcMetadataCache=0x000000016fdf3500, conformance=ProtocolConformanceRef @ 0x000000016fdf3478) at GenProto.cpp:3779:28 [opt]
    frame #7: 0x00000001006b2d94 swift-frontend`swift::irgen::emitGenericRequirementFromSubstitutions(swift::irgen::IRGenFunction&, swift::GenericRequirement, swift::MetadataState, swift::SubstitutionMap, bool) [inlined] swift::irgen::emitWitnessTableRef(IGF=0x000000016fdf5248, srcType=CanType @ x20, conformance=<unavailable>) at GenProto.cpp:3771:10 [opt]
    frame #8: 0x00000001006b2d80 swift-frontend`swift::irgen::emitGenericRequirementFromSubstitutions(IGF=0x000000016fdf5248, requirement=GenericRequirement @ 0x000000016fdf3770, metadataState=Complete, subs=SubstitutionMap @ 0x000000016fdf3728, onHeapPacks=false) at GenProto.cpp:4135:12 [opt]
    frame #9: 0x00000001006b88f4 swift-frontend`void llvm::function_ref<void (swift::GenericRequirement)>::callback_fn<(anonymous namespace)::EmitPolymorphicArguments::emit(swift::SubstitutionMap, swift::irgen::WitnessMetadata*, swift::irgen::Explosion&)::$_0>(long, swift::GenericRequirement) [inlined] (anonymous namespace)::EmitPolymorphicArguments::emit(swift::SubstitutionMap, swift::irgen::WitnessMetadata*, swift::irgen::Explosion&)::$_0::operator()(this=0x000000016fdf3920, requirement=<unavailable>) const at GenProto.cpp:3935:7 [opt]
    frame #10: 0x00000001006b88dc swift-frontend`void llvm::function_ref<void (swift::GenericRequirement)>::callback_fn<(anonymous namespace)::EmitPolymorphicArguments::emit(swift::SubstitutionMap, swift::irgen::WitnessMetadata*, swift::irgen::Explosion&)::$_0>(callable=6171867424, params=<unavailable>) at STLFunctionalExtras.h:45:12 [opt]
    frame #11: 0x00000001006b8da8 swift-frontend`void llvm::function_ref<void (swift::GenericRequirement)>::callback_fn<(anonymous namespace)::PolymorphicConvention::enumerateUnfulfilledRequirements(llvm::function_ref<void (swift::GenericRequirement)> const&)::$_0>(long, swift::GenericRequirement) [inlined] llvm::function_ref<void (swift::GenericRequirement)>::operator()(this=<unavailable>, params=<unavailable>) const at STLFunctionalExtras.h:68:12 [opt]
    frame #12: 0x00000001006b8d8c swift-frontend`void llvm::function_ref<void (swift::GenericRequirement)>::callback_fn<(anonymous namespace)::PolymorphicConvention::enumerateUnfulfilledRequirements(llvm::function_ref<void (swift::GenericRequirement)> const&)::$_0>(long, swift::GenericRequirement) [inlined] (anonymous namespace)::PolymorphicConvention::enumerateUnfulfilledRequirements(llvm::function_ref<void (swift::GenericRequirement)> const&)::$_0::operator()(this=0x000000016fdf3950, requirement=GenericRequirement @ 0x000000016fdf37b0) const at GenProto.cpp:327:7 [opt]
    frame #13: 0x00000001006b8d1c swift-frontend`void llvm::function_ref<void (swift::GenericRequirement)>::callback_fn<(anonymous namespace)::PolymorphicConvention::enumerateUnfulfilledRequirements(llvm::function_ref<void (swift::GenericRequirement)> const&)::$_0>(callable=6171867472, params=<unavailable>) at STLFunctionalExtras.h:45:12 [opt]
    frame #14: 0x00000001006aa464 swift-frontend`swift::irgen::enumerateGenericSignatureRequirements(swift::CanGenericSignature, llvm::function_ref<void (swift::GenericRequirement)> const&) [inlined] llvm::function_ref<void (swift::GenericRequirement)>::operator()(this=0x000000016fdf3960, params=<unavailable>) const at STLFunctionalExtras.h:68:12 [opt]
    frame #15: 0x00000001006aa450 swift-frontend`swift::irgen::enumerateGenericSignatureRequirements(signature=CanGenericSignature @ 0x000000016fdf3850, callback=0x000000016fdf3960) at GenProto.cpp:309:11 [opt]
    frame #16: 0x00000001006b24a0 swift-frontend`swift::irgen::emitPolymorphicArguments(swift::irgen::IRGenFunction&, swift::CanTypeWrapper<swift::SILFunctionType>, swift::SubstitutionMap, swift::irgen::WitnessMetadata*, swift::irgen::Explosion&) [inlined] (anonymous namespace)::PolymorphicConvention::enumerateRequirements(this=0x000000016fdf38c0, callback=0x000000016fdf3960) at GenProto.cpp:320:10 [opt]
    frame #17: 0x00000001006b2494 swift-frontend`swift::irgen::emitPolymorphicArguments(swift::irgen::IRGenFunction&, swift::CanTypeWrapper<swift::SILFunctionType>, swift::SubstitutionMap, swift::irgen::WitnessMetadata*, swift::irgen::Explosion&) [inlined] (anonymous namespace)::PolymorphicConvention::enumerateUnfulfilledRequirements(this=0x000000016fdf38c0, callback=0x000000016fdf3938) at GenProto.cpp:325:3 [opt]
    frame #18: 0x00000001006b2480 swift-frontend`swift::irgen::emitPolymorphicArguments(swift::irgen::IRGenFunction&, swift::CanTypeWrapper<swift::SILFunctionType>, swift::SubstitutionMap, swift::irgen::WitnessMetadata*, swift::irgen::Explosion&) [inlined] (anonymous namespace)::EmitPolymorphicArguments::emit(this=0x000000016fdf38c0, subs=SubstitutionMap @ 0x000000016fdf3948, witnessMetadata=<unavailable>, out=<unavailable>) at GenProto.cpp:3933:3 [opt]
    frame #19: 0x00000001006b23e0 swift-frontend`swift::irgen::emitPolymorphicArguments(IGF=<unavailable>, origFnType=<unavailable>, subs=SubstitutionMap @ x21, witnessMetadata=0x000000016fdf3ac8, out=0x000000016fdf3b48) at GenProto.cpp:3923:45 [opt]
    frame #20: 0x000000010076da34 swift-frontend`(anonymous namespace)::IRGenSILFunction::visitFullApplySite(this=0x000000016fdf5248, site=FullApplySite @ 0x000000016fdf3d78) at IRGenSIL.cpp:3929:5 [opt]
    frame #21: 0x0000000100750538 swift-frontend`(anonymous namespace)::IRGenSILFunction::visitSILBasicBlock(swift::SILBasicBlock*) [inlined] swift::SILInstructionVisitor<(anonymous namespace)::IRGenSILFunction, void>::visit(this=0x000000016fdf5248, inst=0x00000001278a0180) at SILVisitor.h:0:5 [opt]
    frame #22: 0x00000001007504d8 swift-frontend`(anonymous namespace)::IRGenSILFunction::visitSILBasicBlock(this=<unavailable>, BB=<unavailable>) at IRGenSIL.cpp:2860:5 [opt]
    frame #23: 0x000000010074ecc0 swift-frontend`(anonymous namespace)::IRGenSILFunction::emitSILFunction(this=<unavailable>) at IRGenSIL.cpp:2720:5 [opt]
    frame #24: 0x000000010074c518 swift-frontend`swift::irgen::IRGenModule::emitSILFunction(this=0x000000016fdf5e40, f=0x000000015904bce0) at IRGenSIL.cpp:2568:30 [opt]
    frame #25: 0x00000001005fb620 swift-frontend`swift::irgen::IRGenerator::emitLazyDefinitions(this=0x000000016fdf8320) at GenDecl.cpp:1446:12 [opt]
    frame #26: 0x0000000100703350 swift-frontend`swift::IRGenRequest::evaluate(this=<unavailable>, evaluator=<unavailable>, desc=IRGenDescriptor @ 0x000000016fdf8bc8) const at IRGen.cpp:1297:11 [opt]
    frame #27: 0x000000010074b764 swift-frontend`swift::GeneratedModule swift::SimpleRequest<swift::IRGenRequest, swift::GeneratedModule (swift::IRGenDescriptor), (swift::RequestFlags)17>::callDerived<0ul>(this=<unavailable>, evaluator=<unavailable>, (null)=<unavailable>) const at SimpleRequest.h:287:24 [opt]
    frame #28: 0x000000010070a610 swift-frontend`swift::IRGenRequest::OutputType swift::Evaluator::getResultUncached<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'()>(this=0x000000015700c880, request=0x000000016fdf8db0, defaultValueFn=<unavailable>) at Evaluator.h:347:19 [opt]
    frame #29: 0x00000001007041c8 swift-frontend`swift::performIRGeneration(swift::ModuleDecl*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm::GlobalVariable**) [inlined] swift::IRGenRequest::OutputType swift::Evaluator::operator()<swift::IRGenRequest, swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(swift::Evaluator&, swift::IRGenRequest)::'lambda'(), (void*)0>(this=<unavailable>, request=0x000000016fdf8db0, defaultValueFn=<unavailable>) at Evaluator.h:235:12 [opt]
    frame #30: 0x00000001007041bc swift-frontend`swift::performIRGeneration(swift::ModuleDecl*, swift::IRGenOptions const&, swift::TBDGenOptions const&, std::__1::unique_ptr<swift::SILModule, std::__1::default_delete<swift::SILModule>>, llvm::StringRef, swift::PrimarySpecificPaths const&, llvm::ArrayRef<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, llvm::GlobalVariable**) [inlined] swift::IRGenRequest::OutputType swift::evaluateOrFatal<swift::IRGenRequest>(eval=<unavailable>, req=IRGenRequest @ 0x000000016fdf8db0) at Evaluator.h:448:10 [opt]
    frame #31: 0x00000001007041bc swift-frontend`swift::performIRGeneration(M=0x0000000157847be8, Opts=<unavailable>, TBDOpts=0x0000000157821b38, SILMod=<unavailable>, ModuleName=<unavailable>, PSPs=<unavailable>, parallelOutputFilenames=(Data = Summary Unavailable, Length = 1), outModuleHash=0x000000016fdf98e0) at IRGen.cpp:1697:10 [opt]
    frame #32: 0x000000010027f7b0 swift-frontend`generateIR(IRGenOpts=0x0000000157821630, TBDOpts=0x0000000157821b38, SM=nullptr, PSPs=0x000000016fdf9fc0, OutputFilename=<unavailable>, MSF=<unavailable>, HashGlobal=0x000000016fdf98e0, parallelOutputFilenames=<unavailable>) at FrontendTool.cpp:1464:12 [opt]
    frame #33: 0x000000010027c48c swift-frontend`performCompileStepsPostSILGen(Instance=0x0000000157820200, SM=nullptr, MSF=swift::ModuleOrSourceFile @ 0x000000016fdf9920, PSPs=0x000000016fdf9fc0, ReturnValue=<unavailable>, observer=<unavailable>) at FrontendTool.cpp:1820:7 [opt]
    frame #34: 0x000000010027bc60 swift-frontend`swift::performCompileStepsPostSema(Instance=0x0000000157820200, ReturnValue=<unavailable>, observer=<unavailable>) at FrontendTool.cpp:761:12 [opt]
```

We also notice that this problem does not happen when the type is a `struct`, and it seems to be related with how the try_apply is made to the function because if we make (sorry example below has `remoteCall`, but it is the same issue as the `onReturn`) the call to such method using a function ref:

```
  %8 = function_ref @$s17DistributedSystemAAC10remoteCall2on6target10invocation8throwing9returningq0_x_0A006RemoteD6TargetVAA0jD7EncoderVzq_mq0_mtYaKAI0A5ActorRzs5ErrorR_AA12TransferableR0_AA18EndpointIdentifierV2IDRtzr1_lF : $@convention(method) @async <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : DistributedActor, τ_0_1 : Error, τ_0_2 : Transferable, τ_0_0.ID == EndpointIdentifier> (@guaranteed τ_0_0, @in_guaranteed RemoteCallTarget, @inout RemoteCallEncoder, @thick τ_0_1.Type, @thick τ_0_2.Type, @guaranteed DistributedSystem) -> (@out τ_0_2, @error any Error) // user: %9
  try_apply %8<τ_0_0, τ_0_1, τ_0_2>(%0, %1, %2, %3, %4, %5, %7) : $@convention(method) @async <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : DistributedActor, τ_0_1 : Error, τ_0_2 : Transferable, τ_0_0.ID == EndpointIdentifier> (@guaranteed τ_0_0, @in_guaranteed RemoteCallTarget, @inout RemoteCallEncoder, @thick τ_0_1.Type, @thick τ_0_2.Type, @guaranteed DistributedSystem) -> (@out τ_0_2, @error any Error), normal bb1, error bb2 // id: %9
```

We fail; because we're missing the Transferable type information. If the call is made as a `class_method` call like this (which happens in **debug** mode):

```
// protocol witness for DistributedActorSystem.remoteCall<A, B, C>(on:target:invocation:throwing:returning:) in conformance DistributedSystem
sil shared [transparent] [thunk] @$s4main17DistributedSystemC0B00b5ActorC0AadEP10remoteCall2on6target10invocation8throwing9returningqd_1_qd___AD06RemoteF6TargetV17InvocationEncoderQzzqd_0_mqd_1_mtYaKAD0bD0Rd__s5ErrorRd_0_2IDQyd__0dQ0Rtzr1_lFTW : $@convention(witness_method: DistributedActorSystem) @async <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : DistributedActor, τ_0_1 : Error, τ_0_0.ID == String> (@guaranteed τ_0_0, @in_guaranteed RemoteCallTarget, @inout RemoteCallEncoder, @thick τ_0_1.Type, @thick τ_0_2.Type, @in_guaranteed DistributedSystem) -> (@out τ_0_2, @error any Error) {
...
[global: read,write,copy,destroy,allocate,deinit_barrier]
...
bb0(%0 : $*τ_0_2, %1 : $τ_0_0, %2 : $*RemoteCallTarget, %3 : $*RemoteCallEncoder, %4 : $@thick τ_0_1.Type, %5 : $@thick τ_0_2.Type, %6 : $*DistributedSystem):
  %7 = load %6                                    // users: %8, %9
  %8 = class_method %7, #DistributedSystem.remoteCall : <Actor, Err, Res where Actor : DistributedActor, Err : Error, Res : Transferable, Actor.ID == String> (DistributedSystem) -> (Actor, RemoteCallTarget, inout RemoteCallEncoder, Err.Type, Res.Type) async throws -> Res, $@convention(method) @async <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : DistributedActor, τ_0_1 : Error, τ_0_2 : Transferable, τ_0_0.ID == String> (@guaranteed τ_0_0, @in_guaranteed RemoteCallTarget, @inout RemoteCallEncoder, @thick τ_0_1.Type, @thick τ_0_2.Type, @guaranteed DistributedSystem) -> (@out τ_0_2, @error any Error) // user: %9
  try_apply %8<τ_0_0, τ_0_1, τ_0_2>(%0, %1, %2, %3, %4, %5, %7) : $@convention(method) @async <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : DistributedActor, τ_0_1 : Error, τ_0_2 : Transferable, τ_0_0.ID == String> (@guaranteed τ_0_0, @in_guaranteed RemoteCallTarget, @inout RemoteCallEncoder, @thick τ_0_1.Type, @thick τ_0_2.Type, @guaranteed DistributedSystem) -> (@out τ_0_2, @error any Error), normal bb1, error bb2 // id: %9
```

This works because it seems the first thing the class method does is "get" that type information using a `conformsToProtocol`... 

Not really sure what to explore further here. Key finding is that this is specifically a release mode issue, and that we're then missing the `t_0_2: Transferable` bit that our `injectAdHocDistributedRequirements` would have added. What could be different here in a release mode?


rdar://146101172 