### PR TITLE
[SILOptimizer] Cache "is self recursive" check that analyzes `SILFunc…

### DIFF
--- a/include/swift/AST/SILOptimizerRequests.h
+++ b/include/swift/AST/SILOptimizerRequests.h
@@ -87,6 +87,26 @@ private:
                                       ASTLoweringDescriptor desc) const;
 };
 
+class IsSelfRecursiveRequest
+    : public SimpleRequest<IsSelfRecursiveRequest, bool(SILFunction *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  bool evaluate(Evaluator &evaluator, SILFunction *F) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
+void simple_display(llvm::raw_ostream &out, const SILFunction *);
+SourceLoc extractNearestSourceLoc(const SILFunction *);
+
 /// Report that a request of the given kind is being evaluated, so it
 /// can be recorded by the stats reporter.
 template <typename Request>

--- a/include/swift/AST/SILOptimizerTypeIDZone.def
+++ b/include/swift/AST/SILOptimizerTypeIDZone.def
@@ -20,3 +20,6 @@ SWIFT_REQUEST(SILOptimizer, ExecuteSILPipelineRequest,
 SWIFT_REQUEST(SILOptimizer, LoweredSILRequest,
               std::unique_ptr<SILModule>(ASTLoweringDescriptor),
               Uncached, NoLocationInfo)
+SWIFT_REQUEST(SILOptimizer, IsSelfRecursiveRequest,
+              bool(SILFunction *),
+              Cache, NoLocationInfo)

--- a/lib/SILOptimizer/PassManager/SILOptimizerRequests.cpp
+++ b/lib/SILOptimizer/PassManager/SILOptimizerRequests.cpp
@@ -52,9 +52,19 @@ void swift::simple_display(llvm::raw_ostream &out,
   simple_display(out, desc.SM);
 }
 
+void swift::simple_display(llvm::raw_ostream &out, const SILFunction *F) {
+  out << "SILFunction '" << F->getName() << "' in ";
+  simple_display(out, &F->getModule());
+}
+
 SourceLoc
 swift::extractNearestSourceLoc(const SILPipelineExecutionDescriptor &desc) {
   return extractNearestSourceLoc(desc.SM);
+}
+
+SourceLoc
+swift::extractNearestSourceLoc(const SILFunction *F) {
+  return F->hasLocation() ? F->getLocation().getSourceLoc() : SourceLoc();
 }
 
 //----------------------------------------------------------------------------//


### PR DESCRIPTION
…tion` body

The body is re-analyzed for every call site of the function, which is very expensive and if the body is not changed would produce the same result. This takes about ~10% from swift-syntax overall build time in release configuration.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
