### PR TITLE
[SE-0456] Span properties over utf8 views

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -421,9 +421,11 @@ extension _StringGuts {
 extension _StringGuts {
 
   private static var associationKey: UnsafeRawPointer {
-    // We never dereference this, we just use this address as a unique key
-    // TODO: perhaps use the address of a metatype instead
-    unsafe UnsafeRawPointer(Builtin.addressof(&_swiftEmptyArrayStorage))
+    // We never dereference this, we only use this address as a unique key
+    unsafe unsafeBitCast(
+      ObjectIdentifier(_StringGuts.self),
+      to: UnsafeRawPointer.self
+    )
   }
 
   internal func getAssociatedStorage() -> __StringStorage? {

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -423,7 +423,7 @@ extension _StringGuts {
   private static var associationKey: UnsafeRawPointer {
     // We never dereference this, we only use this address as a unique key
     unsafe unsafeBitCast(
-      ObjectIdentifier(_StringGuts.self),
+      ObjectIdentifier(__StringStorage.self),
       to: UnsafeRawPointer.self
     )
   }
@@ -437,7 +437,6 @@ extension _StringGuts {
       ) -> UnsafeRawPointer?).self
     )
     _precondition(_object.hasObjCBridgeableObject)
-    // print("has ObjC Bridgeable Object")
     if let assocPtr = unsafe getter(
       _object.objCBridgeableObject,
       Self.associationKey
@@ -484,7 +483,7 @@ extension _StringGuts {
       } else {
         var contents = String.UnicodeScalarView()
         // always reserve a size larger than a small string
-        contents.reserveCapacity(Swift.max(31, 1 + count + count >> 1))
+        contents.reserveCapacity(Swift.max(_SmallString.capacity + 1, 1 + count + count >> 1))
         for c in String.UnicodeScalarView(self) {
           contents.append(c)
         }

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -324,6 +324,21 @@ extension String.UTF8View {
   public var span: Span<UTF8.CodeUnit> {
     @lifetime(borrow self)
     borrowing get {
+#if _runtime(_ObjC)
+      // handle non-UTF8 Objective-C bridging cases here
+      if !_guts.isFastUTF8 && _guts._object.hasObjCBridgeableObject {
+        let storage: __StringStorage
+        if let associated = _guts.getAssociatedStorage() {
+          storage = associated
+        }
+        else {
+          storage = _guts.getOrAllocateAssociatedStorage()
+        }
+        let (start, count) = unsafe (storage.start, storage.count)
+        let span = unsafe Span(_unsafeStart: start, count: count)
+        return unsafe _overrideLifetime(span, borrowing: self)
+      }
+#endif
       let count = _guts.count
       if _guts.isSmall {
         let a = Builtin.addressOfBorrow(self)
@@ -331,14 +346,11 @@ extension String.UTF8View {
         let span = unsafe Span(_unsafeStart: address, count: count)
         return unsafe _overrideLifetime(span, borrowing: self)
       }
-      else if _guts.isFastUTF8 {
-        let buffer = unsafe _guts._object.fastUTF8
-        _internalInvariant(count == buffer.count)
-        let span = unsafe Span(_unsafeElements: buffer)
-        return unsafe _overrideLifetime(span, borrowing: self)
-      }
-      // handle other Objective-C bridging cases here
-      fatalError("Some bridged Strings are not supported at this time")
+      _precondition(_guts.isFastUTF8)
+      let buffer = unsafe _guts._object.fastUTF8
+      _internalInvariant(count == buffer.count)
+      let span = unsafe Span(_unsafeElements: buffer)
+      return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
 }

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -337,13 +337,7 @@ extension String.UTF8View {
 #if _runtime(_ObjC)
       // handle non-UTF8 Objective-C bridging cases here
       if !_guts.isFastUTF8 && _guts._object.hasObjCBridgeableObject {
-        let storage: __StringStorage
-        if let associated = _guts.getAssociatedStorage() {
-          storage = associated
-        }
-        else {
-          storage = _guts.getOrAllocateAssociatedStorage()
-        }
+        let storage = _guts.getOrAllocateAssociatedStorage()
         let (start, count) = unsafe (storage.start, storage.count)
         let span = unsafe Span(_unsafeStart: start, count: count)
         return unsafe _overrideLifetime(span, borrowing: self)

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -319,6 +319,17 @@ extension String.UTF8View {
 
 extension String.UTF8View {
 
+  /// A span over the UTF8 code units that make up this string.
+  ///
+  /// - Note: In the case of bridged UTF16 String instances (on Apple
+  /// platforms,) this property transcodes the code units the first time
+  /// it is called. The transcoded buffer is cached, and subsequent calls
+  /// to `span` can reuse the buffer.
+  ///
+  ///  Returns: a `Span` over the UTF8 code units of this String.
+  ///
+  ///  Complexity: O(1) for native UTF8 Strings,
+  ///  amortized O(1) for bridged UTF16 Strings.
   @available(SwiftStdlib 6.2, *)
   public var span: Span<UTF8.CodeUnit> {
     @lifetime(borrow self)

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -337,7 +337,7 @@ extension String.UTF8View {
 #if _runtime(_ObjC)
       // handle non-UTF8 Objective-C bridging cases here
       if !_guts.isFastUTF8 && _guts._object.hasObjCBridgeableObject {
-        let storage = _guts.getOrAllocateAssociatedStorage()
+        let storage = _guts._getOrAllocateAssociatedStorage()
         let (start, count) = unsafe (storage.start, storage.count)
         let span = unsafe Span(_unsafeStart: start, count: count)
         return unsafe _overrideLifetime(span, borrowing: self)

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -89,7 +89,6 @@ extension String {
   ///     print(String(s1.utf8.prefix(15))!)
   ///     // Prints "They call me 'B"
   @frozen
-  @_addressableForDependencies
   public struct UTF8View: Sendable {
     @usableFromInline
     internal var _guts: _StringGuts
@@ -344,6 +343,7 @@ extension String.UTF8View {
         let a = Builtin.addressOfBorrow(self)
         let address = unsafe UnsafePointer<UTF8.CodeUnit>(a)
         let span = unsafe Span(_unsafeStart: address, count: count)
+        fatalError("Span over the small string form is not supported yet.")
         return unsafe _overrideLifetime(span, borrowing: self)
       }
       _precondition(_guts.isFastUTF8)

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -630,7 +630,6 @@ extension Substring: LosslessStringConvertible {
 
 extension Substring {
   @frozen
-  @_addressableForDependencies
   public struct UTF8View: Sendable {
     @usableFromInline
     internal var _slice: Slice<String.UTF8View>
@@ -775,6 +774,7 @@ extension Substring.UTF8View {
         let offset = first &+ (2 &* MemoryLayout<String.Index>.stride)
         let start = unsafe UnsafePointer<UTF8.CodeUnit>(a).advanced(by: offset)
         let span = unsafe Span(_unsafeStart: start, count: end &- first)
+        fatalError("Span over the small string form is not supported yet.")
         return unsafe _overrideLifetime(span, borrowing: self)
       }
       _internalInvariant(_wholeGuts.isFastUTF8)

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -751,6 +751,27 @@ extension Substring.UTF8View: BidirectionalCollection {
 
 extension Substring.UTF8View {
 
+  /// A span over the UTF8 code units that make up this substring.
+  ///
+  /// - Note: In the case of bridged UTF16 String instances (on Apple
+  /// platforms,) this property needs to transcode the code units every time
+  /// it is called.
+  /// For example, if `string` has the bridged UTF16 representation,
+  ///     for word in string.split(separator: " ") {
+  ///         useSpan(word.span)
+  ///     }
+  ///  is accidentally quadratic because of this issue. A workaround is to
+  ///  explicitly convert the string into its native UTF8 representation:
+  ///      var nativeString = consume string
+  ///      nativeString.makeContiguousUTF8()
+  ///      for word in nativeString.split(separator: " ") {
+  ///          useSpan(word.span)
+  ///      }
+  ///  This second option has linear time complexity, as expected.
+  ///
+  ///  Returns: a `Span` over the UTF8 code units of this Substring.
+  ///
+  ///  Complexity: O(1) for native UTF8 Strings, O(n) for bridged UTF16 Strings.
   @available(SwiftStdlib 6.2, *)
   public var span: Span<UTF8.CodeUnit> {
     @lifetime(borrow self)

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -761,9 +761,7 @@ extension Substring.UTF8View {
         let base: String.UTF8View = self._base
         let first = base._foreignDistance(from: base.startIndex, to: startIndex)
         let count = base._foreignDistance(from: startIndex, to: endIndex)
-        let span = unsafe base.span._extracting(
-          unchecked: Range(_uncheckedBounds: (first, first &+ count))
-        )
+        let span = unsafe base.span._extracting(first..<(first &+ count))
         return unsafe _overrideLifetime(span, borrowing: self)
       }
 #endif
@@ -778,10 +776,8 @@ extension Substring.UTF8View {
         return unsafe _overrideLifetime(span, borrowing: self)
       }
       _internalInvariant(_wholeGuts.isFastUTF8)
-      let buffer = unsafe _wholeGuts._object.fastUTF8.extracting(
-        Range(_uncheckedBounds: (first, end))
-      )
-      let span = unsafe Span(_unsafeElements: buffer)
+      var span = unsafe Span(_unsafeElements: _wholeGuts._object.fastUTF8)
+      span = span._extracting(first..<end)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -837,6 +837,10 @@ Added: _$ss13KeyValuePairsV4spans4SpanVyx3key_q_5valuetGvpMV
 Added: _$ss15CollectionOfOneV4spans4SpanVyxGvpMV
 Added: _$ss15ContiguousArrayV4spans4SpanVyxGvpMV
 Added: _$ss4SpanVss15BitwiseCopyableRzlE5bytess03RawA0VvpMV
+Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvg
+Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
+Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
+Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
 
 // SE-0467 mutableSpan properties
 Added: _$sSa11mutableSpans07MutableB0VyxGvr

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -838,6 +838,10 @@ Added: _$ss13KeyValuePairsV4spans4SpanVyx3key_q_5valuetGvpMV
 Added: _$ss15CollectionOfOneV4spans4SpanVyxGvpMV
 Added: _$ss15ContiguousArrayV4spans4SpanVyxGvpMV
 Added: _$ss4SpanVss15BitwiseCopyableRzlE5bytess03RawA0VvpMV
+Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvg
+Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
+Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
+Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
 
 // SE-0467 mutableSpan properties
 Added: _$sSa11mutableSpans07MutableB0VyxGvr

--- a/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
+++ b/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
@@ -1,0 +1,94 @@
+//===--- BridgedStringSpanTests.swift -------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-stdlib-swift -enable-experimental-feature LifetimeDependence
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_LifetimeDependence
+
+import StdlibUnittest
+
+import Foundation
+
+var suite = TestSuite("EagerLazyBridging String Tests")
+defer { runAllTests() }
+
+let strings = [
+  "Hello, World!",
+  "A long ASCII string exceeding 16 code units.",
+  "🇯🇵",
+  "🏂☃❅❆❄︎⛄️❄️",
+]
+
+strings.forEach { expected in
+  suite.test("Span from Bridged String Stability: \(expected)")
+  .require(.stdlib_6_2).code {
+    guard #available(SwiftStdlib 6.2, *) else { return }
+
+    let string = NSString(utf8String: expected)
+    guard let string else { expectNotNil(string); return }
+
+    let bridged = String(string).utf8
+    var p: ObjectIdentifier? = nil
+    for (i, j) in zip(0..<3, bridged.indices) {
+      let span = bridged.span
+      let c = span.withUnsafeBufferPointer {
+        let o = unsafeBitCast($0.baseAddress, to: ObjectIdentifier.self)
+        if p == nil {
+          p = o
+        } else {
+          expectEqual(p, o)
+        }
+        return $0[i]
+      }
+      expectEqual(c, bridged[j])
+    }
+  }
+}
+
+strings.forEach { expected in
+  suite.test("Span from Bridged String: \(expected)")
+  .require(.stdlib_6_2).code {
+    guard #available(SwiftStdlib 6.2, *) else { return }
+
+    let string = NSString(utf8String: expected)
+    guard let string else { expectNotNil(string); return }
+
+    let bridged = String(string)
+    let utf8 = bridged.utf8
+    let span = utf8.span
+    expectEqual(span.count, expected.utf8.count)
+    for (i,j) in zip(span.indices, expected.utf8.indices) {
+      expectEqual(span[i], expected.utf8[j])
+    }
+  }
+}
+
+strings.forEach { expected in
+  suite.test("Span from Bridged String Substring: \(expected)")
+  .require(.stdlib_6_2).code {
+    guard #available(SwiftStdlib 6.2, *) else { return }
+
+    let string = NSString(utf8String: expected)
+    guard let string else { expectNotNil(string); return }
+
+    let bridged = String(string).dropFirst()
+    let utf8 = bridged.utf8
+    let span = utf8.span
+    let expected = expected.dropFirst()
+    expectEqual(span.count, expected.utf8.count)
+    for (i,j) in zip(span.indices, expected.utf8.indices) {
+      expectEqual(span[i], expected.utf8[j])
+    }
+  }
+}

--- a/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
+++ b/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
@@ -28,7 +28,9 @@ let strings = [
   "A long ASCII string exceeding 16 code units.",
   "🇯🇵",
   "🏂☃❅❆❄︎⛄️❄️",
-  "",
+// Enable the following once the small native string form is supported
+//  "z",
+//  "",
 ]
 
 strings.forEach { expected in

--- a/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
+++ b/test/stdlib/Span/BridgedStringUTF8ViewSpanTests.swift
@@ -28,6 +28,7 @@ let strings = [
   "A long ASCII string exceeding 16 code units.",
   "🇯🇵",
   "🏂☃❅❆❄︎⛄️❄️",
+  "",
 ]
 
 strings.forEach { expected in

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -13,6 +13,8 @@
 // RUN: %target-run-stdlib-swift(-enable-experimental-feature LifetimeDependence -enable-experimental-feature Span -enable-experimental-feature AddressableTypes)
 
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_AddressableTypes
 
 import StdlibUnittest
 
@@ -81,45 +83,5 @@ suite.test("Span from Large Native String's Substring")
 
   for i in span.indices {
     expectEqual(span[i], u[i])
-  }
-}
-
-import Foundation
-
-let strings: [NSString: String] = [
-  "Hello, World!" as NSString: "Hello, World!",
-  "A long ASCII string exceeding 16 code units." as NSString: "A long ASCII string exceeding 16 code units.",
-  "🇯🇵" as NSString: "🇯🇵",
-  NSString(utf8String: "🏂☃❅❆❄︎⛄️❄️")!: "🏂☃❅❆❄︎⛄️❄️",
-]
-
-strings.forEach { string, expected in
-  suite.test("Span from Bridged String: \(expected)")
-  .require(.stdlib_6_2).code {
-    guard #available(SwiftStdlib 6.2, *) else { return }
-
-    let bridged = String(string)
-    let utf8 = bridged.utf8
-    let span = utf8.span
-    expectEqual(span.count, expected.utf8.count)
-    for (i,j) in zip(span.indices, expected.utf8.indices) {
-      expectEqual(span[i], expected.utf8[j])
-    }
-  }
-}
-
-strings.forEach { string, expected in
-  suite.test("Span from Bridged String Substring: \(expected)")
-  .require(.stdlib_6_2).code {
-    guard #available(SwiftStdlib 6.2, *) else { return }
-
-    let bridged = String(string).dropFirst()
-    let utf8 = bridged.utf8
-    let span = utf8.span
-    let expected = expected.dropFirst()
-    expectEqual(span.count, expected.utf8.count)
-    for (i,j) in zip(span.indices, expected.utf8.indices) {
-      expectEqual(span[i], expected.utf8[j])
-    }
   }
 }

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %target-run-stdlib-swift(-enable-experimental-feature LifetimeDependence -enable-experimental-feature Span -enable-experimental-feature AddressableTypes)
+// RUN: %target-run-stdlib-swift(-enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes)
 
 // REQUIRES: executable_test
 // REQUIRES: swift_feature_LifetimeDependence
@@ -22,11 +22,13 @@ var suite = TestSuite("StringUTF8StorageProperty")
 defer { runAllTests() }
 
 suite.test("Span from Small String")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
 
   let s = "A small string.".utf8
   let u = Array(s)
+  expectCrashLater()
   let span = s.span
 
   let count = span.count
@@ -54,11 +56,13 @@ suite.test("Span from Large Native String")
 }
 
 suite.test("Span from Small String's Substring")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
 
   let s = "A small string.".dropFirst(8).utf8
   let u = Array("string.".utf8)
+  expectCrashLater()
   let span = s.span
 
   let count = span.count

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -1,0 +1,52 @@
+//===--- StringUTF8StorageProperty.swift ----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-stdlib-swift(-enable-experimental-feature LifetimeDependence -enable-experimental-feature Span -enable-experimental-feature AddressableTypes)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var suite = TestSuite("StringUTF8StorageProperty")
+defer { runAllTests() }
+
+suite.test("Span from Small String")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = "A small string.".utf8
+  let u = Array(s)
+  let span = s.span
+
+  let count = span.count
+  expectEqual(count, s.count)
+
+  for i in span.indices {
+    expectEqual(span[i], u[i])
+  }
+}
+
+suite.test("Span from Large Native String")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = "A long string that is altogether not smol.".utf8
+  let u = Array(s)
+  let span = s.span
+
+  let count = span.count
+  expectEqual(count, s.count)
+
+  for i in span.indices {
+    expectEqual(span[i], u[i])
+  }
+}

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -107,3 +107,19 @@ strings.forEach { string, expected in
     }
   }
 }
+
+strings.forEach { string, expected in
+  suite.test("Span from Bridged String Substring: \(expected)")
+  .require(.stdlib_6_2).code {
+    guard #available(SwiftStdlib 6.2, *) else { return }
+
+    let bridged = String(string).dropFirst()
+    let utf8 = bridged.utf8
+    let span = utf8.span
+    let expected = expected.dropFirst()
+    expectEqual(span.count, expected.utf8.count)
+    for (i,j) in zip(span.indices, expected.utf8.indices) {
+      expectEqual(span[i], expected.utf8[j])
+    }
+  }
+}

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -83,3 +83,27 @@ suite.test("Span from Large Native String's Substring")
     expectEqual(span[i], u[i])
   }
 }
+
+import Foundation
+
+let strings: [NSString: String] = [
+  "Hello, World!" as NSString: "Hello, World!",
+  "A long ASCII string exceeding 16 code units." as NSString: "A long ASCII string exceeding 16 code units.",
+  "🇯🇵" as NSString: "🇯🇵",
+  NSString(utf8String: "🏂☃❅❆❄︎⛄️❄️")!: "🏂☃❅❆❄︎⛄️❄️",
+]
+
+strings.forEach { string, expected in
+  suite.test("Span from Bridged String: \(expected)")
+  .require(.stdlib_6_2).code {
+    guard #available(SwiftStdlib 6.2, *) else { return }
+
+    let bridged = String(string)
+    let utf8 = bridged.utf8
+    let span = utf8.span
+    expectEqual(span.count, expected.utf8.count)
+    for (i,j) in zip(span.indices, expected.utf8.indices) {
+      expectEqual(span[i], expected.utf8[j])
+    }
+  }
+}

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -50,3 +50,36 @@ suite.test("Span from Large Native String")
     expectEqual(span[i], u[i])
   }
 }
+
+suite.test("Span from Small String's Substring")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = "A small string.".dropFirst(8).utf8
+  let u = Array("string.".utf8)
+  let span = s.span
+
+  let count = span.count
+  expectEqual(count, s.count)
+
+  for i in span.indices {
+    expectEqual(span[i], u[i])
+  }
+}
+
+suite.test("Span from Large Native String's Substring")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let t = "A long string that is altogether not smol."
+  let s = t.dropFirst(22).prefix(10).utf8
+  let u = Array("altogether".utf8)
+  let span = s.span
+
+  let count = span.count
+  expectEqual(count, s.count)
+
+  for i in span.indices {
+    expectEqual(span[i], u[i])
+  }
+}


### PR DESCRIPTION
Implements most of the `String`-related parts of SE-0456 not implemented in https://github.com/swiftlang/swift/pull/78561

**`Span`s vended from the small string representation are disabled at the moment**

Addresses the remainder of rdar://137710901