### PR TITLE
[NFC] Fix a use of an uninitialized captured value.

### DIFF
--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -541,11 +541,9 @@ public:
           if (!eltTL.isAddressOnly()) {
             auto load = eltTL.emitLoad(SGF.B, loc, eltAddr,
                                        LoadOwnershipQualifier::Take);
-            eltMV = SGF.emitManagedRValueWithCleanup(load, eltTL);
-          } else {
-            eltMV = SGF.emitManagedBufferWithCleanup(eltAddr, eltTL);
+            return SGF.emitManagedRValueWithCleanup(load, eltTL);
           }
-          return eltMV;
+          return SGF.emitManagedBufferWithCleanup(eltAddr, eltTL);
         }();
 
         // Finish in the normal way for scalar results.


### PR DESCRIPTION
On a very recent tip-of-tree build of Clang, this was producing the following error:

`variable 'eltMV' is uninitialized when used within its own initialization [-Werror,-Wuninitialized]`
