### PR TITLE
[Runtime] Include size/alignment in allocation failure fatal error message.

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -160,6 +160,10 @@ void swift_abortDynamicReplacementDisabling();
 SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_RUNTIME_ATTRIBUTE_NOINLINE
 void swift_abortDisabledUnicodeSupport();
 
+// Halt due to a failure to allocate memory.
+SWIFT_RUNTIME_ATTRIBUTE_NORETURN
+void swift_abortAllocationFailure(size_t size, size_t alignMask);
+
 /// This function dumps one line of a stack trace. It is assumed that \p framePC
 /// is the address of the stack frame at index \p index. If \p shortOutput is
 /// true, this functions prints only the name of the symbol and offset, ignores

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -481,21 +481,23 @@ SWIFT_RUNTIME_EXPORT SWIFT_NORETURN void swift_deletedMethodError() {
 // FIXME: can't pass the object's address from InlineRefCounts without hacks
 void swift::swift_abortRetainOverflow() {
   swift::fatalError(FatalErrorFlags::ReportBacktrace,
-                    "Fatal error: Object was retained too many times");
+                    "Fatal error: Object was retained too many times\n");
 }
 
 // Crash due to an unowned retain count overflow.
 // FIXME: can't pass the object's address from InlineRefCounts without hacks
 void swift::swift_abortUnownedRetainOverflow() {
   swift::fatalError(FatalErrorFlags::ReportBacktrace,
-                    "Fatal error: Object's unowned reference was retained too many times");
+                    "Fatal error: Object's unowned reference was retained too "
+                    "many times\n");
 }
 
 // Crash due to a weak retain count overflow.
 // FIXME: can't pass the object's address from InlineRefCounts without hacks
 void swift::swift_abortWeakRetainOverflow() {
   swift::fatalError(FatalErrorFlags::ReportBacktrace,
-                    "Fatal error: Object's weak reference was retained too many times");
+                    "Fatal error: Object's weak reference was retained too "
+                    "many times\n");
 }
 
 // Crash due to retain of a dead unowned reference.
@@ -504,11 +506,11 @@ void swift::swift_abortRetainUnowned(const void *object) {
   if (object) {
     swift::fatalError(FatalErrorFlags::ReportBacktrace,
                       "Fatal error: Attempted to read an unowned reference but "
-                      "object %p was already deallocated", object);
+                      "object %p was already deallocated\n", object);
   } else {
     swift::fatalError(FatalErrorFlags::ReportBacktrace,
                       "Fatal error: Attempted to read an unowned reference but "
-                      "the object was already deallocated");
+                      "the object was already deallocated\n");
   }
 }
 
@@ -516,20 +518,28 @@ void swift::swift_abortRetainUnowned(const void *object) {
 void swift::swift_abortDynamicReplacementEnabling() {
   swift::fatalError(FatalErrorFlags::ReportBacktrace,
                     "Fatal error: trying to enable a dynamic replacement "
-                    "that is already enabled");
+                    "that is already enabled\n");
 }
 
 /// Halt due to disabling an already disabled dynamic replacement().
 void swift::swift_abortDynamicReplacementDisabling() {
   swift::fatalError(FatalErrorFlags::ReportBacktrace,
                     "Fatal error: trying to disable a dynamic replacement "
-                    "that is already disabled");
+                    "that is already disabled\n");
+}
+
+/// Halt due to a failure to allocate memory.
+void swift::swift_abortAllocationFailure(size_t size, size_t alignMask) {
+  swift::fatalError(FatalErrorFlags::ReportBacktrace,
+                    "Fatal error: failed to allocate %zu bytes of memory with "
+                    "alignment %zu\n", size, alignMask + 1);
 }
 
 /// Halt due to trying to use unicode data on platforms that don't have it.
 void swift::swift_abortDisabledUnicodeSupport() {
   swift::fatalError(FatalErrorFlags::ReportBacktrace,
-                    "Unicode normalization data is disabled on this platform");
+                    "Unicode normalization data is disabled on this "
+                    "platform\n");
 
 }
 

--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -91,7 +91,7 @@ void *swift::swift_slowAlloc(size_t size, size_t alignMask) {
     size_t alignment = computeAlignment(alignMask);
     p = AlignedAlloc(size, alignment);
   }
-  if (!p) swift::crash("Could not allocate memory.");
+  if (!p) swift::swift_abortAllocationFailure(size, alignMask);
   return p;
 }
 
@@ -113,7 +113,7 @@ void *swift::swift_slowAllocTyped(size_t size, size_t alignMask,
       if (err != 0)
         p = nullptr;
     }
-    if (!p) swift::crash("Could not allocate memory.");
+    if (!p) swift::swift_abortAllocationFailure(size, alignMask);
     return p;
   }
 #endif
@@ -125,7 +125,7 @@ void *swift::swift_coroFrameAlloc(size_t size,
 #if SWIFT_STDLIB_HAS_MALLOC_TYPE
   if (__builtin_available(macOS 15, iOS 17, tvOS 17, watchOS 10, *)) {
     void *p = malloc_type_malloc(size, typeId);
-    if (!p) swift::crash("Could not allocate memory.");
+    if (!p) swift::swift_abortAllocationFailure(size, 0);
     return p;
   }
 #endif


### PR DESCRIPTION
It's hard to tell why a crash occurred with just "Could not allocate memory." Modify the message to include the size/alignment, which will help distinguish between an actual lack of memory and a request for an excessively large allocation.

While we're in there, add \n to a bunch of other fatal error helper functions that didn't have it.