### PR TITLE
[Windows] Use a multiroot data file to test (corelibs-)foundation on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2824,12 +2824,17 @@ function Build-Foundation {
 }
 
 function Test-Foundation {
+  $ScratchPath = "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests"
+
   # Foundation tests build via swiftpm rather than CMake
   Build-SPMProject `
     -Action Test `
     -Src $SourceCache\swift-foundation `
-    -Bin "$BinaryCache\$($BuildPlatform.Triple)\CoreFoundationTests" `
-    -Platform $BuildPlatform
+    -Bin "$ScratchPath" `
+    -Platform $BuildPlatform `
+    -Configuration $FoundationTestConfiguration `
+    --multiroot-data-file "$SourceCache\swift\utils\build_swift\resources\SwiftPM-Unified-Build.xcworkspace" `
+    --test-product swift-foundationPackageTests
 
   Invoke-IsolatingEnvVars {
     $env:DISPATCH_INCLUDE_PATH="$(Get-SwiftSDK $BuildPlatform.OS)/usr/include"
@@ -2841,10 +2846,12 @@ function Test-Foundation {
     Build-SPMProject `
       -Action Test `
       -Src $SourceCache\swift-corelibs-foundation `
-      -Bin "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests" `
+      -Bin "$ScratchPath" `
       -Platform $BuildPlatform `
       -Configuration $FoundationTestConfiguration `
-      -j 1
+      --multiroot-data-file "$SourceCache\swift\utils\build_swift\resources\SwiftPM-Unified-Build.xcworkspace" `
+      --test-product swift-corelibs-foundationPackageTests `
+      -j 1 # Running parallel causes a non-deterministic crash in CI only, see https://github.com/swiftlang/swift/issues/83606
   }
 }
 

--- a/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
+++ b/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace/contents.xcworkspacedata
@@ -6,10 +6,13 @@
    <FileRef location = "group:../../../../sourcekit-lsp"></FileRef>
    <FileRef location = "group:../../../../swift-argument-parser"></FileRef>
    <FileRef location = "group:../../../../swift-collections"></FileRef>
+   <FileRef location = "group:../../../../swift-corelibs-foundation"></FileRef>
    <FileRef location = "group:../../../../swift-crypto"></FileRef>
    <FileRef location = "group:../../../../swift-docc"></FileRef>
    <FileRef location = "group:../../../../swift-driver"></FileRef>
    <FileRef location = "group:../../../../swift-format"></FileRef>
+   <FileRef location = "group:../../../../swift-foundation"></FileRef>
+   <FileRef location = "group:../../../../swift-foundation-icu"></FileRef>
    <FileRef location = "group:../../../../swift-stress-tester/SourceKitStressTester"></FileRef>
    <FileRef location = "group:../../../../swift-syntax"></FileRef>
    <FileRef location = "group:../../../../swift-syntax/CodeGeneration"></FileRef>


### PR DESCRIPTION
We currently rebuild swift-syntax, swift-foundation-icu and swift-foundation twice: Once to test swift-foundation and once to test swift-corelibs-foundation. Using a unified build for both projects means that we only need to rebuild them once, saving ~5 minutes.
