### PR TITLE
Fix FoundationMacro build failure in ARM64 cross-build

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2396,6 +2396,11 @@ function Build-FoundationMacros() {
     [hashtable]$Arch
   )
 
+  $SwiftSyntaxDir = (Get-ProjectCMakeModules $Arch Compilers)
+  if (-not (Test-Path $SwiftSyntaxDir)) {
+    throw "The swift-syntax from the compiler build for $Platform $Arch.ShortName isn't available"
+  }
+
   Build-CMakeProject `
     -Src $SourceCache\swift-foundation\Sources\FoundationMacros `
     -Bin (Get-ProjectBinaryCache $Arch FoundationMacros) `
@@ -2405,7 +2410,7 @@ function Build-FoundationMacros() {
     -UseBuiltCompilers Swift `
     -SwiftSDK (Get-SwiftSDK $Platform) `
     -Defines @{
-      SwiftSyntax_DIR = (Get-ProjectCMakeModules $HostArch Compilers);
+      SwiftSyntax_DIR = $SwiftSyntaxDir;
     }
 }
 


### PR DESCRIPTION
To fix build failure https://ci-external.swift.org/job/swift-main-windows-toolchain-arm64/1074/consoleText
```
[2025-03-19 07:38:15] Building 'C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift-foundation\Sources\FoundationMacros' to 'T:\x86_64-unknown-windows-msvc\FoundationMacros' ...
cmake.exe -B T:\x86_64-unknown-windows-msvc\FoundationMacros -S C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift-foundation\Sources\FoundationMacros -G Ninja -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=T:/x64/toolchains/0.0.0+Asserts/usr -D CMAKE_Swift_COMPILER=T:/1/bin/swiftc.exe -D CMAKE_Swift_COMPILER_TARGET=x86_64-unknown-windows-msvc -D CMAKE_Swift_FLAGS=-sdk \"T:/Program Files/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk\" -gnone -Xlinker /INCREMENTAL:NO -Xlinker /OPT:REF -Xlinker /OPT:ICF -D CMAKE_Swift_FLAGS_RELEASE=-O -D CMAKE_Swift_FLAGS_RELWITHDEBINFO=-O -D SwiftSyntax_DIR=T:/5/cmake/modules
-- The Swift compiler identification is Apple 6.2
<unknown>:0: warning: using (deprecated) legacy driver, Swift installation does not contain swift-driver at: 'C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\build\1\bin\swift-driver-new.exe'
-- Check for working Swift compiler: T:/1/bin/swiftc.exe
-- Check for working Swift compiler: T:/1/bin/swiftc.exe - works
-- SwiftSyntax_DIR provided, using swift-syntax from T:/5/cmake/modules
-- Configuring done (1.1s)
-- Generating done (0.0s)
-- Build files have been written to: T:/x86_64-unknown-windows-msvc/FoundationMacros
[1/3][ 33%][0.627s]Building Swift object FoundationMacros.swiftmodule CMakeFiles\FoundationMacros.dir\FoundationMacros.swift.obj CMakeFiles\FoundationMacros.dir\PredicateMacro.swift.obj
FAILED: FoundationMacros.swiftmodule CMakeFiles/FoundationMacros.dir/FoundationMacros.swift.obj CMakeFiles/FoundationMacros.dir/PredicateMacro.swift.obj 
T:\1\bin\swiftc.exe -target x86_64-unknown-windows-msvc -j 36 -num-threads 36 -c -DFOUNDATION_MACROS_LIBRARY -DFoundationMacros_EXPORTS -parse-as-library -emit-module -emit-module-path FoundationMacros.swiftmodule -module-name FoundationMacros -module-link-name FoundationMacros -sdk "T:/Program Files/Swift/Platforms/Windows.platform/Developer/SDKs/Windows.sdk" -gnone -Xlinker /INCREMENTAL:NO -Xlinker /OPT:REF -Xlinker /OPT:ICF -O -incremental -parse-as-library -Xfrontend -enable-experimental-feature -Xfrontend AccessLevelOnImport -Xfrontend -enable-experimental-feature -Xfrontend StrictConcurrency -Xfrontend -enable-upcoming-feature -Xfrontend InferSendableFromCaptures -output-file-map CMakeFiles\FoundationMacros.dir\Release\output-file-map.json -I T:\5\.\lib\swift\host C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift-foundation\Sources\FoundationMacros\FoundationMacros.swift C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift-foundation\Sources\FoundationMacros\PredicateMacro.swift
<unknown>:0: warning: using (deprecated) legacy driver, Swift installation does not contain swift-driver at: 'C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\build\1\bin\swift-driver-new.exe'
<unknown>:0: warning: option '-incremental' is only supported in swift-driver
C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift-foundation\Sources\FoundationMacros\PredicateMacro.swift:13:8: error: could not find module 'SwiftSyntax' for target 'x86_64-unknown-windows-msvc'; found: aarch64-unknown-windows-msvc, at: T:\5\.\lib\swift\host\SwiftSyntax.swiftmodule
  11 | //===----------------------------------------------------------------------===//
  12 | 
  13 | import SwiftSyntax
     |        `- error: could not find module 'SwiftSyntax' for target 'x86_64-unknown-windows-msvc'; found: aarch64-unknown-windows-msvc, at: T:\5\.\lib\swift\host\SwiftSyntax.swiftmodule
  14 | import SwiftSyntaxMacros
  15 | internal import SwiftDiagnostics
C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain-arm64\swift-foundation\Sources\FoundationMacros\PredicateMacro.swift:13:8: error: could not find module 'SwiftSyntax' for target 'x86_64-unknown-windows-msvc'; found: aarch64-unknown-windows-msvc, at: T:\5\.\lib\swift\host\SwiftSyntax.swiftmodule
  11 | //===----------------------------------------------------------------------===//

  12 | 

  13 | import SwiftSyntax

     |        `- error: could not find module 'SwiftSyntax' for target 'x86_64-unknown-windows-msvc'; found: aarch64-unknown-windows-msvc, at: T:\5\.\lib\swift\host\SwiftSyntax.swiftmodule

  14 | import SwiftSyntaxMacros

  15 | internal import SwiftDiagnostics
```