### PR TITLE
[DiagnosticBridge] NFC: Refactor `addQueuedDiagnostic` to use Bridged* types instead of pointers

### DIFF
--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -32,7 +32,7 @@ void swift_ASTGen_addQueuedDiagnostic(
     BridgedSourceLoc sourceLoc,
     BridgedStringRef categoryName,
     BridgedStringRef documentationPath,
-    const void *_Nullable *_Nullable highlightRanges,
+    const BridgedCharSourceRange *_Nullable highlightRanges,
     ptrdiff_t numHighlightRanges);
 void swift_ASTGen_renderQueuedDiagnostics(
     void *_Nonnull queued, ssize_t contextSize, ssize_t colorize,

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -27,11 +27,10 @@ void swift_ASTGen_addQueuedSourceFile(
     intptr_t displayNameLength, ssize_t parentID, ssize_t positionInParent);
 void swift_ASTGen_addQueuedDiagnostic(
     void *_Nonnull queued, void *_Nonnull state,
-    const char *_Nonnull text, ptrdiff_t textLength,
+    BridgedStringRef text,
     BridgedDiagnosticSeverity severity, const void *_Nullable sourceLoc,
-    const char *_Nullable categoryName, ptrdiff_t categoryNameLength,
-    const char *_Nullable documentationPath,
-    ptrdiff_t documentationPathLength,
+    BridgedStringRef categoryName,
+    BridgedStringRef documentationPath,
     const void *_Nullable *_Nullable highlightRanges,
     ptrdiff_t numHighlightRanges);
 void swift_ASTGen_renderQueuedDiagnostics(

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -28,7 +28,8 @@ void swift_ASTGen_addQueuedSourceFile(
 void swift_ASTGen_addQueuedDiagnostic(
     void *_Nonnull queued, void *_Nonnull state,
     BridgedStringRef text,
-    BridgedDiagnosticSeverity severity, const void *_Nullable sourceLoc,
+    BridgedDiagnosticSeverity severity,
+    BridgedSourceLoc sourceLoc,
     BridgedStringRef categoryName,
     BridgedStringRef documentationPath,
     const void *_Nullable *_Nullable highlightRanges,

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -71,12 +71,10 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
 
   // FIXME: Translate Fix-Its.
   swift_ASTGen_addQueuedDiagnostic(queuedDiagnostics, perFrontendState,
-                                   text.data(), text.size(),
+                                   text.str(),
                                    severity, info.Loc.getOpaquePointerValue(),
-                                   info.Category.data(),
-                                   info.Category.size(),
-                                   documentationPath.data(),
-                                   documentationPath.size(),
+                                   info.Category,
+                                   documentationPath,
                                    highlightRanges.data(),
                                    highlightRanges.size() / 2);
 

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -56,13 +56,10 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
   }
 
   // Map the highlight ranges.
-  SmallVector<const void *, 2> highlightRanges;
+  SmallVector<BridgedCharSourceRange, 2> highlightRanges;
   for (const auto &range : info.Ranges) {
-    if (range.isInvalid())
-      continue;
-
-    highlightRanges.push_back(range.getStart().getOpaquePointerValue());
-    highlightRanges.push_back(range.getEnd().getOpaquePointerValue());
+    if (range.isValid())
+      highlightRanges.push_back(range);
   }
 
   StringRef documentationPath;
@@ -76,7 +73,7 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
                                    info.Category,
                                    documentationPath,
                                    highlightRanges.data(),
-                                   highlightRanges.size() / 2);
+                                   highlightRanges.size());
 
   // TODO: A better way to do this would be to pass the notes as an
   // argument to `swift_ASTGen_addQueuedDiagnostic` but that requires

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -72,7 +72,7 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
   // FIXME: Translate Fix-Its.
   swift_ASTGen_addQueuedDiagnostic(queuedDiagnostics, perFrontendState,
                                    text.str(),
-                                   severity, info.Loc.getOpaquePointerValue(),
+                                   severity, info.Loc,
                                    info.Category,
                                    documentationPath,
                                    highlightRanges.data(),

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -246,7 +246,7 @@ public func addQueuedDiagnostic(
   cLoc: BridgedSourceLoc,
   categoryName: BridgedStringRef,
   documentationPath: BridgedStringRef,
-  highlightRangesPtr: UnsafePointer<BridgedSourceLoc>?,
+  highlightRangesPtr: UnsafePointer<BridgedCharSourceRange>?,
   numHighlightRanges: Int
 ) {
   let queuedDiagnostics = queuedDiagnosticsPtr.assumingMemoryBound(
@@ -299,14 +299,16 @@ public func addQueuedDiagnostic(
 
   // Map the highlights.
   var highlights: [Syntax] = []
-  let highlightRanges = UnsafeBufferPointer<BridgedSourceLoc>(
+  let highlightRanges = UnsafeBufferPointer<BridgedCharSourceRange>(
     start: highlightRangesPtr,
-    count: numHighlightRanges * 2
+    count: numHighlightRanges
   )
   for index in 0..<numHighlightRanges {
+    let range = highlightRanges[index]
+
     // Make sure both the start and the end land within this source file.
-    guard let start = highlightRanges[index * 2].getOpaquePointerValue(),
-      let end = highlightRanges[index * 2 + 1].getOpaquePointerValue()
+    guard let start = range.start.getOpaquePointerValue(),
+      let end = range.start.advanced(by: range.byteLength).getOpaquePointerValue()
     else {
       continue
     }


### PR DESCRIPTION
Instead of pointer + size for strings, `void *` for source locks and multiple entries for highlights refactor the API to use `BridgedStringRef`, `BridgedSourceLoc` and `BridgedCharSourceRange`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
