### PR TITLE
[Sema] Add missing null check for `getAttachedResultBuilder`

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4638,7 +4638,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
 
     // Complain if this isn't the primary result-builder attribute.
     auto attached = decl->getAttachedResultBuilder();
-    if (attached != attr) {
+    if (attached && attached != attr) {
       diagnose(attr->getLocation(), diag::result_builder_multiple,
                isa<ParamDecl>(decl));
       diagnose(attached->getLocation(), diag::previous_result_builder_here);


### PR DESCRIPTION
I haven't been able to come up with a test case, but it seems like it's possible for the attribute to be invalidated during the call to `visitCustomAttr`, in which case `getAttachedResultBuilder` can return `nullptr`.

rdar://118642163
