### PR TITLE
[cxx-interop] Determine owning module correctly for C++ decls in nested modules

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -903,6 +903,10 @@ static ModuleDecl *getModuleContextForNameLookupForCxxDecl(const Decl *decl) {
   if (!clangModule)
     return nullptr;
 
+  // Swift groups all submodules of a Clang module together, and imports them as
+  // a single top-level module.
+  clangModule = clangModule->getTopLevelModule();
+
   return ctx.getClangModuleLoader()->getWrapperForModule(clangModule);
 }
 

--- a/test/Interop/Cxx/modules/Inputs/another-deep-submodule.h
+++ b/test/Interop/Cxx/modules/Inputs/another-deep-submodule.h
@@ -1,0 +1,2 @@
+namespace NS {
+} // namespace NS

--- a/test/Interop/Cxx/modules/Inputs/deep-submodule.h
+++ b/test/Interop/Cxx/modules/Inputs/deep-submodule.h
@@ -1,0 +1,5 @@
+namespace NS {
+
+struct MyStructInDeepSubModule {};
+
+} // namespace NS

--- a/test/Interop/Cxx/modules/Inputs/module.modulemap
+++ b/test/Interop/Cxx/modules/Inputs/module.modulemap
@@ -2,3 +2,18 @@ module Namespaces {
   header "namespace.h"
   requires cplusplus
 }
+
+module TopLevelModule {
+  module SubModule {
+    module DeepSubModule {
+      header "deep-submodule.h"
+      export *
+    }
+    module AnotherDeepSubModule {
+      header "another-deep-submodule.h"
+      export *
+    }
+    export *
+  }
+  export *
+}

--- a/test/Interop/Cxx/modules/deep-submodule.swift
+++ b/test/Interop/Cxx/modules/deep-submodule.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -enable-upcoming-feature MemberImportVisibility
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -D IMPORT_TOP_LEVEL
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default -D IMPORT_ANOTHER_SUBMODULE
+
+// REQUIRES: swift_feature_MemberImportVisibility
+
+#if IMPORT_TOP_LEVEL
+import TopLevelModule
+#elseif IMPORT_ANOTHER_SUBMODULE
+import TopLevelModule.SubModule.AnotherDeepSubModule
+#else
+import TopLevelModule.SubModule.DeepSubModule
+#endif
+
+let _: NS.MyStructInDeepSubModule! = nil
+
+extension NS.MyStructInDeepSubModule {
+  public static func takesInstance(_ i: NS.MyStructInDeepSubModule) {}
+}


### PR DESCRIPTION
This fixes a compiler bug that got exposed by https://github.com/llvm/llvm-project/commit/f11abac6524f8643817711d04be0367a0e639311.

If a C++ type is declared in a nested Clang submodule, Swift was emitting errors that look like:
```
Type alias 'string' is not available due to missing import of defining module 'fwd’
```

rdar://146899125

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
