### PR TITLE
🍒[cxx-interop] Fix libc++ tests

### DIFF
--- a/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
@@ -11,6 +11,9 @@
 // This test is specific to libc++ and therefore only runs on Darwin platforms.
 // REQUIRES: OS=macosx || OS=ios
 
+// Since this test runs check-libcxx-version, it requires execution.
+// REQUIRES: executable_test
+
 // CHECK-STD: import CxxStdlib.iosfwd
 // CHECK-STD: import CxxStdlib.string
 

--- a/test/Interop/Cxx/stdlib/libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-symbolic-module-interface.swift
@@ -11,6 +11,9 @@
 // REQUIRES: OS=macosx
 // REQUIRES: swift_feature_ImportSymbolicCXXDecls
 
+// Since this test runs check-libcxx-version, it requires execution.
+// REQUIRES: executable_test
+
 // CHECK: enum std {
 // CHECK: enum __1 {
 


### PR DESCRIPTION
These two tests require execution privileges in order to run `check-libcxx-version`, which is used to restrict the tests to a range of libc++ versions. They were failing on `non_executable` CI jobs because of missing `// REQUIRES: executable_test`.

rdar://145821727
(cherry picked from commit 8ef468c5f14bfbdac95f673ae818cdf99a1b6b83)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
