### PR TITLE
[WIP] Use Arguments to Match Parameterized Protocol

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6464,6 +6464,13 @@ public:
 
   void getRequirements(Type baseType, SmallVectorImpl<Requirement> &reqs) const;
 
+  /// Extracts the type arguments from both the parameterized protocol type
+  /// and the concrete base type. These arguments must match in order to
+  /// satisfy the protocol's requirements.
+  void getMatchingTypeArguments(Type baseType,
+                                SmallVectorImpl<Type> &subjectArgTypes,
+                                SmallVectorImpl<Type> &protoArgTypes) const;
+
   void Profile(llvm::FoldingSetNodeID &ID) {
     Profile(ID, Base, getArgs());
   }

--- a/test/Constraints/variadic_generic_types.swift
+++ b/test/Constraints/variadic_generic_types.swift
@@ -124,3 +124,23 @@ do {
   _ = Foo(nil) // expected-error {{'nil' requires a contextual type}}
   _ = Foo(nil, 1) // expected-error {{'nil' requires a contextual type}}
 }
+// https://github.com/swiftlang/swift/issues/79920
+protocol P<V> {
+  associatedtype V
+}
+do {
+  struct Q: P { enum V {} }
+  struct R<V>: P {}
+  struct S {}
+  struct A<each T> {
+    var x: any P<(Any, repeat each T)>
+    mutating func f() {
+      self.x = Q()
+      // expected-error@-1 {{cannot assign value of type 'Q' to type 'any P<(Any, repeat each T)>'}}
+      self.x = R<Void>()
+      // expected-error@-1 {{cannot assign value of type 'R<Void>' to type 'any P<(Any, repeat each T)>'}}
+      self.x = S()
+      // expected-error@-1 {{cannot assign value of type 'S' to type 'any P<(Any, repeat each T)>'}}
+    }
+  }
+}


### PR DESCRIPTION
Resolves: [swiftlang/swift#79920](https://github.com/swiftlang/swift/issues/79920)

When matching an existential type to a concrete type, we previously returned on the first failing requirement, leading to diagnostics that lacked full context. This change collects all mismatches instead of returning early, allowing for a more cohesive fix or failure diagnostic.

## Example

```swift
protocol P<V> {
  associatedtype V
}
do {
  struct Q: P { enum V {} }
  struct R<V>: P {}
  struct S {}
  struct A<each T> {
    var x: any P<(Any, repeat each T)>
    mutating func f() {
      // Before
      self.x = Q() // crash
      self.x = S() // crash
      self.x = R<(Any)>() // incorrect diagnostic
            // `- error: cannot assign value of type 'Any' to type '(Any, repeat each T)'

      // After
      self.x = Q() 
            // `- error: cannot assign value of type 'Q' to type 'any P<(Any, repeat each T)>'
      self.x = S()
            // `- error: cannot assign value of type 'S' to type 'any P<(Any, repeat each T)>'
      self.x = R<(Any)>() 
            // `- error: cannot assign value of type 'R<Any>' to type 'any P<(Any, repeat each T)>'
    }
  }
}
```
