### PR TITLE
[CMake] Use CXX linker for Core and Concurrency

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -29,7 +29,7 @@
 #   -- Will need shadow invocations to generate swiftmodules for Swift parts
 # Install *.abi.json, swiftdoc, and swiftsourceinfo
 
-cmake_minimum_required(VERSION 3.26...3.29)
+cmake_minimum_required(VERSION 3.29)
 
 set(CMAKE_C_VISIBILITY_PRESET "hidden")
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")

--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -117,7 +117,8 @@ target_link_libraries(swift_Concurrency PRIVATE
   # Link to the runtime that we are just building.
   swiftCore)
 set_target_properties(swift_Concurrency PROPERTIES
-  Swift_MODULE_NAME _Concurrency)
+  Swift_MODULE_NAME _Concurrency
+  LINKER_LANGUAGE CXX)
 
 install(TARGETS swift_Concurrency
   EXPORT SwiftCoreTargets

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -269,7 +269,9 @@ if(SwiftCore_ENABLE_VECTOR_TYPES)
     "${CMAKE_CURRENT_BINARY_DIR}/SIMDVectorTypes.swift")
 endif()
 
-set_target_properties(swiftCore PROPERTIES Swift_MODULE_NAME Swift)
+set_target_properties(swiftCore PROPERTIES
+  Swift_MODULE_NAME Swift
+  LINKER_LANGUAGE CXX)
 
 target_compile_definitions(swiftCore
   PRIVATE


### PR DESCRIPTION
swiftCore and swift_Concurrency libraries use C++ and Swift. The C++
does not use the Swift C++ interop. Swift driver only uses clang++ to
link when building in C++ interop mode and there currently isn't a flag
to change that. Since we're explicitly linking the runtime registration
when necessary and do not need compatibility libraries, it is safe to
use clang++ as the linker directly, instead of going through swiftc.

In versions of CMake older than 3.29, Swift is always used as a linker
and has no compile stage. By using clang++ as the linker, we require the
split build model (CMP0157), so we cannot allow versions of CMake older
than 3.29.