### PR TITLE
[tests] Run swift-(corelibs-)foundation tests in debug configuration on Windows

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -107,6 +107,9 @@ The memory allocator used in the toolchain binaries, if it's
 `mimalloc`, it uses mimalloc. Otherwise, it uses the default
 allocator.
 
+.PARAMETER FoundationTestConfiguration
+Whether to run swift-foundation and swift-corelibs-foundation tests in a debug or release configuration.
+
 .EXAMPLE
 PS> .\Build.ps1
 
@@ -142,6 +145,8 @@ param(
   [switch] $Clean,
   [switch] $DebugInfo,
   [switch] $EnableCaching,
+  [ValidateSet("debug", "release")]
+  [string] $FoundationTestConfiguration = "debug",
   [string] $Cache = "",
   [string] $Allocator = "",
   [switch] $Summary,
@@ -1234,6 +1239,7 @@ function Build-SPMProject {
     [string] $Src,
     [string] $Bin,
     [hashtable] $Arch,
+    [string] $Configuration = "release",
     [Parameter(ValueFromRemainingArguments)]
     [string[]] $AdditionalArguments
   )
@@ -1263,7 +1269,7 @@ function Build-SPMProject {
     $Arguments = @(
         "--scratch-path", $Bin,
         "--package-path", $Src,
-        "-c", "release",
+        "-c", $Configuration,
         "-Xbuild-tools-swiftc", "-I$SDKInstallRoot\usr\lib\swift",
         "-Xbuild-tools-swiftc", "-L$SDKInstallRoot\usr\lib\swift\windows",
         "-Xcc", "-I$SDKInstallRoot\usr\lib\swift",
@@ -1851,7 +1857,8 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         -Action Test `
         -Src $SourceCache\swift-foundation `
         -Bin $OutDir `
-        -Arch $HostArch
+        -Arch $HostArch `
+        -Configuration $FoundationTestConfiguration
     }
 
     $OutDir = Join-Path -Path $HostArch.BinaryCache -ChildPath foundation-tests
@@ -1869,7 +1876,8 @@ function Build-Foundation([Platform]$Platform, $Arch, [switch]$Test = $false) {
         -Action Test `
         -Src $SourceCache\swift-corelibs-foundation `
         -Bin $OutDir `
-        -Arch $HostArch
+        -Arch $HostArch `
+        -Configuration $FoundationTestConfiguration
     }
   } else {
     $DispatchBinaryCache = Get-TargetProjectBinaryCache $Arch Dispatch


### PR DESCRIPTION
- **Explanation**: This should improve CI times because building in debug configuration instead of release configuration is significantly faster. Since we don’t install the build of swift-(corelibs-)foundation using SwiftPM into the toolchain, this doesn’t have any performance impact on users of the toolchain.
- **Scope**: Testing of swift-(corelibs-)foundation, no impact on any products installed into the toolchain
- **Issue**: n/a
- **Original PR**: https://github.com/swiftlang/swift/pull/80076
- **Risk**: Very low, since this doesn’t affect any binaries installed into the toolchain
- **Testing**: Verified that testing is about 35 minutes faster
- **Reviewer**: @jmschonfeld 
