### PR TITLE
[IDE] Add pretty stack trace entry for IDE inspection location

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -125,6 +125,9 @@ bool IDEInspectionSecondPassRequest::evaluate(
   auto state = parserState->takeIDEInspectionDelayedDeclState();
   auto &Ctx = SF->getASTContext();
 
+  auto inspectionLoc = Ctx.SourceMgr.getIDEInspectionTargetLoc();
+  PrettyStackTraceLocation stackTrace(Ctx, "IDE inspecting", inspectionLoc);
+
   auto BufferID = Ctx.SourceMgr.getIDEInspectionTargetBufferID();
   Parser TheParser(BufferID, *SF, nullptr, parserState);
 


### PR DESCRIPTION
Make it easier to reproduce e.g completion crashes by logging the location the inspection was done at.