### PR TITLE
Update ucrt.modulemap for Windows SDK 10.0.26100

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -92,6 +92,13 @@ module ucrt [system] {
     module stdio {
       header "stdio.h"
       export *
+
+      // NOTE(compnerd) this is a horrible workaround for the fact that
+      // Microsoft has fully inlined nearly all of the printf family of
+      // functions in the headers which results in the definitions being elided
+      // resulting in undefined symbols.  The legacy_stdio_definitions provides
+      // out-of-line definitions for these functions.
+      link "legacy_stdio_definitions"
     }
 
     module stdlib {

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -10,13 +10,55 @@
 //
 //===----------------------------------------------------------------------===//
 
-module _complex [system] {
+// The following modules have to be standalone top-level modules to deal with
+// version 10.0.26100 of the Windows SDK.
+module _malloc [system] [no_undeclared_includes] {
+  use corecrt
+  header "malloc.h"
+  export *
+}
+
+module _complex [system] [no_undeclared_includes] {
+  use corecrt
+  use std
   header "complex.h"
   export *
 }
 
+module _fenv [system] [no_undeclared_includes] {
+  use corecrt
+  use _float
+  header "fenv.h"
+  export *
+}
+
+module _float [system] [no_undeclared_includes] {
+  use corecrt
+  header "float.h"
+  export *
+}
+
+module _stddef [system] [no_undeclared_includes] {
+  header "stddef.h"
+  export *
+}
+
+module _stdlib [system] [no_undeclared_includes] {
+  use corecrt
+  header "stdlib.h"
+  export *
+}
+
 module ucrt [system] {
+  export _malloc
+
   module C {
+    export _complex
+    export _fenv
+    export _float
+    export _stddef
+    export _stdlib
+
     module ctype {
       header "ctype.h"
       export *
@@ -24,16 +66,6 @@ module ucrt [system] {
 
     module errno {
       header "errno.h"
-      export *
-    }
-
-    module fenv {
-      header "fenv.h"
-      export *
-    }
-
-    module float {
-      header "float.h"
       export *
     }
 
@@ -57,21 +89,9 @@ module ucrt [system] {
       export *
     }
 
-    module stddef {
-      header "stddef.h"
-      export *
-    }
-
     module stdio {
       header "stdio.h"
       export *
-
-      // NOTE(compnerd) this is a horrible workaround for the fact that
-      // Microsoft has fully inlined nearly all of the printf family of
-      // functions in the headers which results in the definitions being elided
-      // resulting in undefined symbols.  The legacy_stdio_definitions provides
-      // out-of-line definitions for these functions.
-      link "legacy_stdio_definitions"
     }
 
     module stdlib {
@@ -129,11 +149,6 @@ module ucrt [system] {
 
   module dos {
     header "dos.h"
-    export *
-  }
-
-  module malloc {
-    header "malloc.h"
     export *
   }
 

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -25,19 +25,6 @@ module _complex [system] [no_undeclared_includes] {
   export *
 }
 
-module _fenv [system] [no_undeclared_includes] {
-  use corecrt
-  use _float
-  header "fenv.h"
-  export *
-}
-
-module _float [system] [no_undeclared_includes] {
-  use corecrt
-  header "float.h"
-  export *
-}
-
 module _stddef [system] [no_undeclared_includes] {
   header "stddef.h"
   export *
@@ -54,8 +41,6 @@ module ucrt [system] {
 
   module C {
     export _complex
-    export _fenv
-    export _float
     export _stddef
     export _stdlib
 
@@ -66,6 +51,16 @@ module ucrt [system] {
 
     module errno {
       header "errno.h"
+      export *
+    }
+
+    module fenv {
+      header "fenv.h"
+      export *
+    }
+
+    module float {
+      header "float.h"
       export *
     }
 


### PR DESCRIPTION
  - **Explanation**:
    Windows SDK 10.0.26100 added an include to compiler intrinsics headers in `wchar.h`. In turn, these headers include `malloc.h`, `stdlib.h` and `stddef.h` from `ucrt`, this leads to a cyclic dependency between the `ucrt` and compiler intrinsics modules. Furthermore, Clang 19 (from Swift 6.1) intrinsics headers sometimes clash with the ucrt headers dependencies.
    These changes separate the problematic headers into different standalone modules.
  - **Scope**:
    The changes are limited to `ucrt.modulemap`, and should be backward-compatible with older Windows SDK versions.
  - **Issues**:
    - compnerd/swift-build#909
    - #79745
  - **Original PRs**:
    #79751
    #80151
    #80200
  - **Risk**:
    Very low. 
  - **Testing**:
    Local testing with simple projects including the `ucrt` module with the new module map.
  - **Reviewers**:
    @compnerd 
