### PR TITLE
[test] sendability of POSIXErrorCode

### DIFF
--- a/validation-test/stdlib/POSIXErrorCode.swift
+++ b/validation-test/stdlib/POSIXErrorCode.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift -strict-concurrency=complete
 // REQUIRES: executable_test
 // REQUIRES: VENDOR=apple || OS=linux-androideabi || OS=linux-android || OS=linux-gnu || OS=openbsd || OS=freebsd
 // UNSUPPORTED: freestanding
@@ -17,6 +17,10 @@ import StdlibUnittest
 #endif
 
 var POSIXErrorCodeTestSuite = TestSuite("POSIXErrorCode")
+
+// Ensure that POSIXErrorCode is actually Sendable
+func send(_ value: some Sendable) {}
+send(POSIXErrorCode.EPERM)
 
 #if canImport(Darwin)
 


### PR DESCRIPTION
Companion PR to https://github.com/swiftlang/swift/pull/75000
This should have been a part of that change.
