### PR TITLE
Restore legacy_stdio_definitions in ucrt.modulemap

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -92,6 +92,13 @@ module ucrt [system] {
     module stdio {
       header "stdio.h"
       export *
+
+      // NOTE(compnerd) this is a horrible workaround for the fact that
+      // Microsoft has fully inlined nearly all of the printf family of
+      // functions in the headers which results in the definitions being elided
+      // resulting in undefined symbols.  The legacy_stdio_definitions provides
+      // out-of-line definitions for these functions.
+      link "legacy_stdio_definitions"
     }
 
     module stdlib {


### PR DESCRIPTION
This was removed in #79751 but is required in some cases.
