### PR TITLE
[Dependency Scanning] Batching Clang Import Scans by Name

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1255,7 +1255,7 @@ public:
                         ModuleDependencyInfo dependencies);
 
   /// Record dependencies for the given module collection.
-  void recordDependencies(ModuleDependencyVector moduleDependencies);
+  void recordDependencies(const ModuleDependencyVector &moduleDependencies);
 
   /// Update stored dependencies for the given module.
   void updateDependency(ModuleDependencyID moduleID,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -495,6 +495,18 @@ public:
                         llvm::PrefixMapper *mapper,
                         bool isTestableImport = false) override;
 
+  // The moduleOutputPath specifies a directory where the precompiled modules
+  // reside in. It should not vary accross the list of modules.
+  llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
+  getModuleDependencies(
+      ArrayRef<StringRef> moduleNames, StringRef moduleOutputPath,
+      const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
+          &alreadySeenClangModules,
+      clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
+      InterfaceSubContextDelegate &delegate, llvm::PrefixMapper *mapper,
+      llvm::StringSet<> &successModules, llvm::StringSet<> &notFoundModules,
+      llvm::StringSet<> &errorModules, bool isTestableImport = false);
+
   void recordBridgingHeaderOptions(
       ModuleDependencyInfo &MDI,
       const clang::tooling::dependencies::TranslationUnitDeps &deps);

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -504,8 +504,9 @@ public:
           &alreadySeenClangModules,
       clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
       InterfaceSubContextDelegate &delegate, llvm::PrefixMapper *mapper,
-      llvm::StringSet<> &successModules, llvm::StringSet<> &notFoundModules,
-      llvm::StringSet<> &errorModules, bool isTestableImport = false);
+      std::vector<StringRef> &successModules,
+      std::vector<StringRef> &notFoundModules,
+      std::vector<StringRef> &errorModules, bool isTestableImport = false);
 
   void recordBridgingHeaderOptions(
       ModuleDependencyInfo &MDI,

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -43,6 +43,15 @@ private:
                                          const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenModules,
                                          llvm::PrefixMapper *prefixMapper);
 
+  /// Retrieve the module dependencies for a list of Clang modules given a list
+  /// of names.
+  ModuleDependencyVector scanFilesystemForClangModuleDependency(
+      ArrayRef<StringRef> moduleNames, StringRef moduleOutputPath,
+      const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
+          &alreadySeenModules,
+      llvm::PrefixMapper *prefixMapper, llvm::StringSet<> &successModules,
+      llvm::StringSet<> &notFoundModules, llvm::StringSet<> &errorModules);
+
   /// Retrieve the module dependencies for the Swift module with the given name.
   ModuleDependencyVector
   scanFilesystemForSwiftModuleDependency(Identifier moduleName, StringRef moduleOutputPath,

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -91,13 +91,6 @@ public:
   performDependencyScan(ModuleDependencyID rootModuleID,
                         ModuleDependenciesCache &cache);
 
-  /// Query the module dependency info for the Clang module with the given name.
-  /// Explicit by-name lookups are useful for batch mode scanning.
-  std::optional<const ModuleDependencyInfo *>
-  getNamedClangModuleDependencyInfo(StringRef moduleName,
-                                    ModuleDependenciesCache &cache,
-                                    ModuleDependencyIDSetVector &discoveredClangModules);
-
   /// Query the module dependency info for the Swift module with the given name.
   /// Explicit by-name lookups are useful for batch mode scanning.
   std::optional<const ModuleDependencyInfo *>

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -49,8 +49,9 @@ private:
       ArrayRef<StringRef> moduleNames, StringRef moduleOutputPath,
       const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
           &alreadySeenModules,
-      llvm::PrefixMapper *prefixMapper, llvm::StringSet<> &successModules,
-      llvm::StringSet<> &notFoundModules, llvm::StringSet<> &errorModules);
+      llvm::PrefixMapper *prefixMapper, std::vector<StringRef> &successModules,
+      std::vector<StringRef> &notFoundModules,
+      std::vector<StringRef> &errorModules);
 
   /// Retrieve the module dependencies for the Swift module with the given name.
   ModuleDependencyVector

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -875,7 +875,7 @@ void ModuleDependenciesCache::recordDependency(
 }
 
 void ModuleDependenciesCache::recordDependencies(
-    ModuleDependencyVector dependencies) {
+    const ModuleDependencyVector &dependencies) {
   for (const auto &dep : dependencies) {
     if (!hasDependency(dep.first))
       recordDependency(dep.first.ModuleName, dep.second);

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -457,8 +457,9 @@ ModuleDependencyVector ClangImporter::getModuleDependencies(
         &alreadySeenClangModules,
     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
     InterfaceSubContextDelegate &delegate, llvm::PrefixMapper *mapper,
-    llvm::StringSet<> &successModules, llvm::StringSet<> &notFoundModules,
-    llvm::StringSet<> &errorModules, bool isTestableImport) {
+    std::vector<StringRef> &successModules,
+    std::vector<StringRef> &notFoundModules,
+    std::vector<StringRef> &errorModules, bool isTestableImport) {
   auto &ctx = Impl.SwiftContext;
   // Determine the command-line arguments for dependency scanning.
   std::vector<std::string> commandLineArgs =
@@ -495,18 +496,19 @@ ModuleDependencyVector ClangImporter::getModuleDependencies(
           std::string::npos) {
         if (errorStr.find("'" + N.str() + "'") != std::string::npos) {
           showError = true;
-          errorModules.insert(N);
+          errorModules.push_back(N);
         } else
-          successModules.insert(N);
+          successModules.push_back(N);
       } else
-        notFoundModules.insert(N);
+        notFoundModules.push_back(N);
     }
 
     if (showError)
       ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
                          errorStr);
   } else
-    successModules.insert(moduleNames.begin(), moduleNames.end());
+    successModules.insert(successModules.end(), moduleNames.begin(),
+                          moduleNames.end());
 
   if (!clangModuleDependencies.size())
     return {};


### PR DESCRIPTION
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

_This PR is a work in progress at the moment and intends to show a functional prototype._ 

This PR teaches the dependency scanner to batch the module names and scan a list of names using one thread, instead
of dispatching each individual module by name to the `clang` importer. This way, the `clang` importer can process the
list in one shot, avoiding creating duplicating resource for each individual modules. 

This PR works in tandem with https://github.com/llvm/llvm-project/pull/129915. 

rdar://136303612

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
