### PR TITLE
[ASTGen] Update for 'Parser.ExperimentalFeatures.abiAttribute' removal

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -76,9 +76,8 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.TrailingComma, to: .trailingComma)
     mapFeature(.CoroutineAccessors, to: .coroutineAccessors)
     mapFeature(.ValueGenerics, to: .valueGenerics)
-    mapFeature(.ABIAttribute, to: .abiAttribute)
-    mapFeature(.OldOwnershipOperatorSpellings, to: .oldOwnershipOperatorSpellings)
     mapFeature(.KeyPathWithMethodMembers, to: .keypathWithMethodMembers)
+    mapFeature(.OldOwnershipOperatorSpellings, to: .oldOwnershipOperatorSpellings)
   }
 }
 


### PR DESCRIPTION
Update for https://github.com/swiftlang/swift-syntax/pull/3025