### PR TITLE
Fix `.swiftdeps` file deterministic issues

### DIFF
--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -98,6 +98,11 @@ int Identifier::compare(Identifier other) const {
 }
 
 int DeclName::compare(DeclName other) const {
+  // Fast equality comparsion.
+  if (getOpaqueValue() == other.getOpaqueValue())
+    return 0;
+
+
   // Compare base names.
   if (int result = getBaseName().compare(other.getBaseName()))
     return result;
@@ -111,10 +116,13 @@ int DeclName::compare(DeclName other) const {
       return result;
   }
 
-  if (argNames.size() == otherArgNames.size())
-    return 0;
+  if (argNames.size() != otherArgNames.size())
+    return argNames.size() < otherArgNames.size() ? -1 : 1;
 
-  return argNames.size() < otherArgNames.size() ? -1 : 1;
+  // Order based on if it is compound name or not.
+  assert(isSimpleName() != other.isSimpleName() &&
+         "equality should be covered by opaque value comparsion");
+  return isSimpleName() ? -1 : 1;
 }
 
 static bool equals(ArrayRef<Identifier> idents, ArrayRef<StringRef> strings) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -694,13 +694,17 @@ void SourceLookupCache::lookupClassMembers(ImportPath::Access accessPath,
                                            VisibleDeclConsumer &consumer) {
   assert(accessPath.size() <= 1 && "can only refer to top-level decls");
 
-  if (!accessPath.empty()) {
-    for (auto &member : ClassMembers) {
-      // Non-simple names are also stored under their simple name, so make
-      // sure to only report them once.
-      if (!member.first.isSimpleName())
-        continue;
+  std::vector<std::pair<DeclName, TinyPtrVector<ValueDecl *>>> OrderedMembers;
+  for (auto &member : ClassMembers) {
+    if (!member.first.isSimpleName())
+      continue;
+    OrderedMembers.emplace_back(member.first, member.second);
+  }
+  llvm::sort(OrderedMembers,
+             [](auto &LHS, auto &RHS) { return LHS.first < RHS.first; });
 
+  if (!accessPath.empty()) {
+    for (auto &member : OrderedMembers) {
       for (ValueDecl *vd : member.second) {
         auto *nominal = vd->getDeclContext()->getSelfNominalTypeDecl();
         if (nominal && nominal->getName() == accessPath.front().Item)
@@ -712,12 +716,7 @@ void SourceLookupCache::lookupClassMembers(ImportPath::Access accessPath,
     return;
   }
 
-  for (auto &member : ClassMembers) {
-    // Non-simple names are also stored under their simple name, so make sure to
-    // only report them once.
-    if (!member.first.isSimpleName())
-      continue;
-
+  for (auto &member : OrderedMembers) {
     for (ValueDecl *vd : member.second)
       if (ABIRoleInfo(vd).matchesOptions(OptionSet<ModuleLookupFlags>())) // FIXME: figure this out
         consumer.foundDecl(vd, DeclVisibilityKind::DynamicLookup,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/ASTDumper.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/AvailabilityScope.h"
+#include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/FileSystem.h"
@@ -2100,6 +2101,11 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     // Setup a verfication instance to run.
     std::unique_ptr<CompilerInstance> VerifyInstance =
         std::make_unique<CompilerInstance>();
+    // Add a null diagnostic consumer to the diagnostic engine so the
+    // compilation will exercise all the diagnose code path but not emitting
+    // anything.
+    NullDiagnosticConsumer DC;
+    VerifyInstance->getDiags().addConsumer(DC);
     std::string InstanceSetupError;
     // This should not fail because it passed already.
     (void)VerifyInstance->setup(Invocation, InstanceSetupError, Args);

--- a/test/Frontend/output_determinism_check.swift
+++ b/test/Frontend/output_determinism_check.swift
@@ -38,3 +38,28 @@
 
 public var x = 1
 public func test() {}
+
+class A {
+  var a = 0
+  var b = 0
+  var c = 0
+  var d = 0
+}
+class B {
+  var a = 0
+  var b = 0
+  var c = 0
+  var d = 0
+}
+class C {
+  var a = 0
+  var b = 0
+  var c = 0
+  var d = 0
+}
+class D {
+  var a = 0
+  var b = 0
+  var c = 0
+  var d = 0
+}

--- a/test/Frontend/output_determinism_check.swift
+++ b/test/Frontend/output_determinism_check.swift
@@ -37,7 +37,9 @@
 // PCM_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.pcm'
 
 public var x = 1
-public func test() {}
+public func test() {
+  precondition(x == 1, "dummy check")
+}
 
 class A {
   var a = 0


### PR DESCRIPTION
Fix two more deterministic issue for swiftdeps output:
* The iteration order in SourceFile is not deterministic
* The different diagnostic consumer configuration in verify instance can cause different amount of work done, thus different dependency gets generated.