### PR TITLE
AST: Fix `AvailabilityContext` platform range for certain targets

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -152,16 +152,6 @@ public:
     return AvailabilityDomain(domain);
   }
 
-  /// Returns the most specific platform domain for the target of the
-  /// compilation context.
-  static std::optional<AvailabilityDomain>
-  forTargetPlatform(const ASTContext &ctx);
-
-  /// Returns the most specific platform domain for the target variant of the
-  /// compilation context.
-  static std::optional<AvailabilityDomain>
-  forTargetVariantPlatform(const ASTContext &ctx);
-
   /// Returns the built-in availability domain identified by the given string.
   static std::optional<AvailabilityDomain>
   builtinDomainForString(StringRef string, const DeclContext *declContext);
@@ -226,10 +216,6 @@ public:
   /// Returns true if this domain is considered active in the current
   /// compilation context.
   bool isActive(const ASTContext &ctx) const;
-
-  /// Returns true if this domain is a platform domain that is contained by the
-  /// set of active platform-specific domains.
-  bool isActiveForTargetPlatform(const ASTContext &ctx) const;
 
   /// Returns the domain's minimum available range for type checking. For
   /// example, for the domain of the platform that compilation is targeting,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -7097,8 +7097,9 @@ ValueOwnership swift::asValueOwnership(ParameterOwnership o) {
 }
 
 AvailabilityDomain ASTContext::getTargetAvailabilityDomain() const {
-  if (auto domain = AvailabilityDomain::forTargetPlatform(*this))
-    return *domain;
+  auto platform = swift::targetPlatform(LangOpts);
+  if (platform != PlatformKind::none)
+    return AvailabilityDomain::forPlatform(platform);
 
   // Fall back to the universal domain for triples without a platform.
   return AvailabilityDomain::forUniversal();

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -552,11 +552,15 @@ getRootTargetDomains(const ASTContext &ctx) {
   if (ctx.LangOpts.hasFeature(Feature::Embedded))
     return domains;
 
-  if (auto targetDomain = AvailabilityDomain::forTargetPlatform(ctx))
-    domains.insert(targetDomain->getRootDomain());
+  auto targetPlatform = swift::targetPlatform(ctx.LangOpts);
+  if (targetPlatform != PlatformKind::none)
+    domains.insert(
+        AvailabilityDomain::forPlatform(targetPlatform).getRootDomain());
 
-  if (auto variantDomain = AvailabilityDomain::forTargetVariantPlatform(ctx))
-    domains.insert(variantDomain->getRootDomain());
+  auto targetVariantPlatform = swift::targetVariantPlatform(ctx.LangOpts);
+  if (targetVariantPlatform != PlatformKind::none)
+    domains.insert(
+        AvailabilityDomain::forPlatform(targetVariantPlatform).getRootDomain());
 
   return domains;
 }

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -223,9 +223,8 @@ AvailabilityContext::getAvailabilityRange(AvailabilityDomain domain,
                                           const ASTContext &ctx) const {
   DEBUG_ASSERT(domain.supportsContextRefinement());
 
-  if (domain.isActiveForTargetPlatform(ctx)) {
+  if (domain.isActive(ctx) && domain.isPlatform())
     return storage->platformRange;
-  }
 
   for (auto domainInfo : storage->getDomainInfos()) {
     if (domain == domainInfo.getDomain() && !domainInfo.isUnavailable())
@@ -289,7 +288,7 @@ void AvailabilityContext::constrainWithAvailabilityRange(
     const AvailabilityRange &range, AvailabilityDomain domain,
     const ASTContext &ctx) {
 
-  if (domain.isActiveForTargetPlatform(ctx)) {
+  if (domain.isActive(ctx) && domain.isPlatform()) {
     constrainWithPlatformRange(range, ctx);
     return;
   }
@@ -345,7 +344,7 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
       break;
     case AvailabilityConstraint::Reason::PotentiallyUnavailable:
       if (auto introducedRange = attr.getIntroducedRange(ctx)) {
-        if (domain.isActiveForTargetPlatform(ctx)) {
+        if (domain.isActive(ctx) && domain.isPlatform()) {
           isConstrained |= constrainRange(platformRange, *introducedRange);
         } else {
           declDomainInfos.push_back({domain, *introducedRange});

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -22,24 +22,6 @@
 using namespace swift;
 
 std::optional<AvailabilityDomain>
-AvailabilityDomain::forTargetPlatform(const ASTContext &ctx) {
-  auto platform = swift::targetPlatform(ctx.LangOpts);
-  if (platform == PlatformKind::none)
-    return std::nullopt;
-
-  return forPlatform(platform);
-}
-
-std::optional<AvailabilityDomain>
-AvailabilityDomain::forTargetVariantPlatform(const ASTContext &ctx) {
-  auto platform = swift::targetVariantPlatform(ctx.LangOpts);
-  if (platform == PlatformKind::none)
-    return std::nullopt;
-
-  return forPlatform(platform);
-}
-
-std::optional<AvailabilityDomain>
 AvailabilityDomain::builtinDomainForString(StringRef string,
                                            const DeclContext *declContext) {
   // This parameter is used in downstream forks, do not remove.
@@ -116,15 +98,6 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
     // the future someone might want to define a domain but leave it inactive.
     return true;
   }
-}
-
-bool AvailabilityDomain::isActiveForTargetPlatform(
-    const ASTContext &ctx) const {
-  if (isPlatform()) {
-    if (auto targetDomain = AvailabilityDomain::forTargetPlatform(ctx))
-      return targetDomain->getRootDomain().contains(*this);
-  }
-  return false;
 }
 
 static std::optional<llvm::VersionTuple>

--- a/test/Parse/diagnose_availability_windows.swift
+++ b/test/Parse/diagnose_availability_windows.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -target x86_64-unknown-windows-msvc -parse-stdlib
+// RUN: %target-typecheck-verify-swift -target x86_64-unknown-windows-msvc -parse-stdlib -verify-additional-prefix no-target-
+// RUN: %target-typecheck-verify-swift -target x86_64-unknown-windows8.0-msvc -parse-stdlib
 
 // expected-note@+2{{'unavailable()' has been explicitly marked unavailable here}}
 @available(Windows, unavailable, message: "unsupported")
@@ -14,14 +15,30 @@ func introduced_deprecated() {}
 introduced_deprecated()
 // expected-note@-1 {{add 'if #available' version check}}
 
+@available(Windows 8, *)
+func windows8() {}
+
 @available(Windows 10, *)
 func windows10() {}
+
+windows8() // expected-no-target-error {{'windows8()' is only available in Windows 8 or newer}}
+// expected-no-target-note@-1 {{add 'if #available' version check}}
 
 // expected-error@+1 {{'windows10()' is only available in Windows 10 or newer}}
 windows10()
 // expected-note@-1 {{add 'if #available' version check}}
 
 func conditional_compilation() {
+  // expected-note@-1 {{add @available attribute to enclosing global function}}
   if #available(Windows 10, *) {
+    windows10() // OK
+  } else {
+    windows10() // expected-error {{'windows10()' is only available in Windows 10 or newer}}
+    // expected-note@-1 {{add 'if #available' version check}}
   }
+}
+
+@available(Windows 10, *)
+func windows10_caller() {
+  windows10() // OK
 }

--- a/unittests/AST/AvailabilityDomainTests.cpp
+++ b/unittests/AST/AvailabilityDomainTests.cpp
@@ -150,32 +150,3 @@ TEST_F(AvailabilityDomainLattice, RootDomain) {
   EXPECT_EQ(visionOSAppExt.getRootDomain(), iOS);
   EXPECT_FALSE(visionOSAppExt.isRoot());
 }
-
-TEST(AvailabilityDomain, TargetPlatform) {
-  using namespace llvm;
-
-  struct TargetToPlatformKind {
-    Triple target;
-    PlatformKind platformKind;
-  };
-  TargetToPlatformKind tests[] = {
-      {Triple("x86_64", "apple", "macosx10.15"), PlatformKind::macOS},
-      {Triple("arm64", "apple", "ios13"), PlatformKind::iOS},
-      {Triple("arm64_32", "apple", "watchos8"), PlatformKind::watchOS},
-      {Triple("x86_64", "apple", "ios14", "macabi"), PlatformKind::macCatalyst},
-      {Triple("x86_64", "unknown", "windows", "msvc"), PlatformKind::none},
-      {Triple("x86_64", "unknown", "linux", "gnu"), PlatformKind::none},
-  };
-
-  for (TargetToPlatformKind test : tests) {
-    TestContext context{test.target};
-    auto domain = AvailabilityDomain::forTargetPlatform(context.Ctx);
-    if (test.platformKind != PlatformKind::none) {
-      EXPECT_TRUE(domain);
-      if (domain)
-        EXPECT_TRUE(domain->getPlatformKind() == test.platformKind);
-    } else {
-      EXPECT_FALSE(domain);
-    }
-  }
-}


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/79807 caused a regression in which `AvailabilityContext` stopped tracking the available version range for the active platform domain for certain platforms. Fix this by reverting to checking `AvailabilityDomain::isActive()` to determine when a given platform `AvailabilityDomain` represents the target platform. The compiler's existing mapping from target triple to platform domain is incomplete and it's not clear to me whether fixing that could cause other regressions.

Resolves rdar://147413616.
