### PR TITLE
Fix non-asserting build.

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1777,7 +1777,11 @@ public:
 #ifndef NDEBUG
       assert(entry.getKind() == SILWitnessTable::AssociatedConformance
              && "sil witness table does not match protocol");
+#endif
+
       auto associatedWitness = entry.getAssociatedConformanceWitness();
+
+#ifndef NDEBUG
       assert(associatedWitness.Requirement == requirement.getAssociation()
              && "sil witness table does not match protocol");
       auto piIndex = PI.getAssociatedConformanceIndex(requirement);


### PR DESCRIPTION
The variable `associatedWitness` defined inside of an `NDEBUG` block is now used outside of the block. This change declares it outside the block.