### PR TITLE
Rework diagnostics for conformance isolation failures 

### DIFF
--- a/include/swift/AST/ASTContextGlobalCache.h
+++ b/include/swift/AST/ASTContextGlobalCache.h
@@ -18,17 +18,72 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ActorIsolation.h"
+#include <variant>
 
 namespace swift {
 
+class NormalProtocolConformance;
+class ValueDecl;
+
+/// Describes an isolation error where the witness has actor isolation that
+/// conflicts with the requirement's expectation.
+struct WitnessIsolationError {
+  /// The requirement declaration.
+  ValueDecl *requirement;
+
+  /// The witness.
+  ValueDecl *witness;
+
+  /// The pre-Swift-6 diagnostic behavior.
+  DiagnosticBehavior behavior;
+
+  /// Whether the witness is missing "distributed".
+  bool isMissingDistributed;
+
+  /// The isolation of the requirement, mapped into the conformance.
+  ActorIsolation requirementIsolation;
+
+  /// The isolation domain that the witness would need to go into for it
+  /// to be suitable for the requirement.
+  ActorIsolation referenceIsolation;
+
+  /// Diagnose this witness isolation error.
+  void diagnose(const NormalProtocolConformance *conformance,
+                bool &suggestedPreconcurrencyOrIsolated) const;
+};
+
+/// Describes an isolation error involving an associated conformance.
+struct AssociatedConformanceIsolationError {
+  ProtocolConformance *isolatedConformance;
+
+  /// Diagnose this associated conformance isolation error.
+  void diagnose(const NormalProtocolConformance *conformance) const;
+};
+
+/// Describes an isolation error that occurred during conformance checking.
+using ConformanceIsolationError = std::variant<
+    WitnessIsolationError, AssociatedConformanceIsolationError>;
+
 /// A collection of side tables associated with the ASTContext itself, meant
-// as
+/// as a way to keep sparse information out of the AST nodes themselves and
+/// not require one to touch ASTContext.h to add such information.
 struct ASTContext::GlobalCache {
   /// Mapping from normal protocol conformances to the explicitly-specified
   /// global actor isolations, e.g., when the conformance was spelled
   /// `@MainActor P` or similar.
   llvm::DenseMap<const NormalProtocolConformance *, TypeExpr *>
       conformanceExplicitGlobalActorIsolation;
+
+  /// Mapping from normal protocol conformances to the set of actor isolation
+  /// problems that occur within the conformances.
+  ///
+  /// This map will be empty for well-formed code, and is used to accumulate
+  /// information so that the diagnostics can be coalesced.
+  llvm::DenseMap<
+    const NormalProtocolConformance *,
+    std::vector<ConformanceIsolationError>
+  > conformanceIsolationErrors;
 };
 
 } // end namespace 

--- a/include/swift/AST/ASTContextGlobalCache.h
+++ b/include/swift/AST/ASTContextGlobalCache.h
@@ -49,8 +49,7 @@ struct WitnessIsolationError {
   ActorIsolation referenceIsolation;
 
   /// Diagnose this witness isolation error.
-  void diagnose(const NormalProtocolConformance *conformance,
-                bool &suggestedPreconcurrencyOrIsolated) const;
+  void diagnose(const NormalProtocolConformance *conformance) const;
 };
 
 /// Describes an isolation error involving an associated conformance.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2734,8 +2734,6 @@ WARNING(add_predates_concurrency_import,none,
 GROUPED_WARNING(remove_predates_concurrency_import,PreconcurrencyImport,
                 DefaultIgnore,
                 "'@preconcurrency' attribute on module %0 has no effect", (Identifier))
-NOTE(add_preconcurrency_to_conformance,none,
-     "add '@preconcurrency' to the %0 conformance to defer isolation checking to run time", (DeclName))
 WARNING(remove_public_import,none,
         "public import of %0 was not used in public declarations or inlinable code",
         (Identifier))
@@ -5435,11 +5433,7 @@ ERROR(async_in_nonasync_function,none,
       (unsigned, bool))
 NOTE(note_add_async_to_function,none,
      "add 'async' to function %0 to make it asynchronous", (const ValueDecl *))
-NOTE(note_add_nonisolated_to_decl,none,
-     "add 'nonisolated' to %0 to make this %kindonly0 not isolated to the actor",
-     (const ValueDecl *))
-NOTE(note_add_distributed_to_decl,none,
-     "add 'distributed' to %0 to make this %kindonly0 satisfy the protocol requirement",
+NOTE(note_non_distributed,none, "non-distributed %kind0",
      (const ValueDecl *))
 ERROR(invalid_isolated_calls_in_body,none,
      "calls to '@%0'-isolated' code in %kind1",
@@ -5671,6 +5665,11 @@ ERROR(distributed_actor_func_unsupported_specifier, none,
 ERROR(distributed_actor_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))
+ERROR(conformance_missing_distributed,none,
+      "conformance of %0 to distributed %kind1 uses non-distributed operations",
+      (Type, const ValueDecl *))
+NOTE(note_add_distributed_multi,none,
+     "mark all declarations used in the conformance 'distributed'", ())
 NOTE(actor_mutable_state,none,
      "mutation of this %0 is only permitted within the actor",
      (DescriptiveDeclKind))
@@ -5689,16 +5688,28 @@ NOTE(shared_state_make_immutable,none,
      (const ValueDecl *))
 NOTE(shared_state_nonisolated_unsafe,none,
      "disable concurrency-safety checks if accesses are protected by an external synchronization mechanism", (const ValueDecl *))
-ERROR(actor_isolated_witness,none,
-     "%select{|distributed }0%1 %kind2 cannot be used to satisfy %3 "
-     "requirement from protocol %base4",
-     (bool, ActorIsolation, const ValueDecl *, ActorIsolation,
+NOTE(note_actor_isolated_witness,none,
+     "%0 %kind1 cannot be used to satisfy %2 "
+     "requirement from protocol %base3",
+     (ActorIsolation, const ValueDecl *, ActorIsolation,
       const ValueDecl *))
 ERROR(actor_cannot_conform_to_global_actor_protocol,none,
       "actor %0 cannot conform to global actor isolated protocol %1",
       (Type, Type))
 NOTE(protocol_isolated_to_global_actor_here,none,
      "%0 is isolated to global actor %1 here", (Type, Type))
+ERROR(conformance_mismatched_isolation,none,
+      "conformance of %0 to %kind1 involves isolation mismatches "
+      "and can cause data races",
+      (Type, const ValueDecl *))
+ERROR(conformance_mismatched_isolation_common,none,
+      "conformance of %0 to %kind1 crosses into %2 code and can cause "
+      "data races", (Type, const ValueDecl *, ActorIsolation))
+NOTE(note_make_conformance_preconcurrency,none,
+     "turn data races into runtime errors with '@preconcurrency'",
+     ())
+NOTE(note_make_witnesses_nonisolated,none,
+     "mark all declarations used in the conformance 'nonisolated'", ())
 
 ERROR(isolated_parameter_not_actor,none,
       "'isolated' parameter type %0 does not conform to 'Actor' "
@@ -8318,15 +8329,15 @@ ERROR(attr_abi_incompatible_with_silgen_name,none,
 ERROR(isolated_conformance_experimental_feature,none,
       "isolated conformances require experimental feature "
       " 'IsolatedConformances'", ())
+NOTE(note_isolate_conformance_to_global_actor,none,
+     "isolate this conformance to the %select{global actor %0|main actor}1 "
+     "with '@%2'", (Type, bool, StringRef))
+NOTE(note_depends_on_isolated_conformance,none,
+     "conformance depends on %0 conformance of %1 to %kind2",
+     (ActorIsolation, Type, const ValueDecl *))
 ERROR(nonisolated_conformance_depends_on_isolated_conformance,none,
       "conformance of %0 to %1 depends on %2 conformance of %3 to %4; mark it as '%5'",
       (Type, DeclName, ActorIsolation, Type, DeclName, StringRef))
-ERROR(isolated_conformance_mismatch_with_associated_isolation,none,
-      "%0 conformance of %1 to %2 cannot depend on %3 conformance of %4 to %5",
-      (ActorIsolation, Type, DeclName, ActorIsolation, Type, DeclName))
-NOTE(add_isolated_to_conformance,none,
-     "add '%0' to the %1 conformance to restrict it to %2 code",
-    (StringRef, DeclName, ActorIsolation))
 ERROR(isolated_conformance_with_sendable,none,
       "%4 conformance of %0 to %1 cannot be used to satisfy conformance "
       "requirement for a %select{`Sendable`|`SendableMetatype`}2 type "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -42,8 +42,6 @@ NOTE(opaque_return_type_declared_here,none,
      "opaque return type declared here", ())
 NOTE(default_value_declared_here,none,
      "default value declared here", ())
-NOTE(protocol_requirement_declared_here,none,
-     "requirement %0 declared here", (const ValueDecl *))
 
 //------------------------------------------------------------------------------
 // MARK: Constraint solver diagnostics
@@ -5440,10 +5438,6 @@ NOTE(note_add_async_to_function,none,
 NOTE(note_add_nonisolated_to_decl,none,
      "add 'nonisolated' to %0 to make this %kindonly0 not isolated to the actor",
      (const ValueDecl *))
-NOTE(note_add_async_and_throws_to_decl,none,
-     "mark the protocol requirement %0 '%select{|async|throws|async throws}1' "
-     "to allow actor-isolated conformances",
-     (const ValueDecl *, unsigned))
 NOTE(note_add_distributed_to_decl,none,
      "add 'distributed' to %0 to make this %kindonly0 satisfy the protocol requirement",
      (const ValueDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5689,10 +5689,8 @@ NOTE(shared_state_make_immutable,none,
 NOTE(shared_state_nonisolated_unsafe,none,
      "disable concurrency-safety checks if accesses are protected by an external synchronization mechanism", (const ValueDecl *))
 NOTE(note_actor_isolated_witness,none,
-     "%0 %kind1 cannot be used to satisfy %2 "
-     "requirement from protocol %base3",
-     (ActorIsolation, const ValueDecl *, ActorIsolation,
-      const ValueDecl *))
+     "%0 %kind1 cannot satisfy %2 requirement",
+     (ActorIsolation, const ValueDecl *, ActorIsolation))
 ERROR(actor_cannot_conform_to_global_actor_protocol,none,
       "actor %0 cannot conform to global actor isolated protocol %1",
       (Type, Type))
@@ -8339,11 +8337,11 @@ ERROR(nonisolated_conformance_depends_on_isolated_conformance,none,
       "conformance of %0 to %1 depends on %2 conformance of %3 to %4; mark it as '%5'",
       (Type, DeclName, ActorIsolation, Type, DeclName, StringRef))
 ERROR(isolated_conformance_with_sendable,none,
-      "%4 conformance of %0 to %1 cannot be used to satisfy conformance "
+      "%4 conformance of %0 to %1 cannot satisfy conformance "
       "requirement for a %select{`Sendable`|`SendableMetatype`}2 type "
       "parameter %3", (Type, DeclName, bool, Type, ActorIsolation))
 ERROR(isolated_conformance_with_sendable_simple,none,
-      "%2 conformance of %0 to %1 cannot be used to satisfy "
+      "%2 conformance of %0 to %1 cannot satisfy "
       "conformance requirement for a `Sendable` type parameter ",
       (Type, DeclName, ActorIsolation))
 ERROR(isolated_conformance_wrong_domain,none,

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -107,4 +107,9 @@ EDUCATIONAL_NOTES(actor_isolated_call_decl,
 EDUCATIONAL_NOTES(error_in_swift_lang_mode,
                   "error-in-future-swift-version.md")
 
+EDUCATIONAL_NOTES(conformance_mismatched_isolation,
+                  "conformance-isolation.md")
+EDUCATIONAL_NOTES(conformance_mismatched_isolation_common,
+                  "conformance-isolation.md")
+
 #undef EDUCATIONAL_NOTES

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4795,8 +4795,7 @@ void WitnessIsolationError::diagnose(
   // Complain that this witness cannot conform to the requirement due to
   // actor isolation.
   witness->diagnose(diag::note_actor_isolated_witness,
-                    referenceIsolation, witness, requirementIsolation,
-                    conformance->getProtocol());
+                    referenceIsolation, witness, requirementIsolation);
 }
 
 void AssociatedConformanceIsolationError::diagnose(

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4790,110 +4790,43 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
 }
 
 void WitnessIsolationError::diagnose(
-    const NormalProtocolConformance *conformance,
-    bool &suggestedPreconcurrencyOrIsolated
+    const NormalProtocolConformance *conformance
 ) const {
-  bool isDistributed = referenceIsolation.isDistributedActor() &&
-      !witness->getAttrs().hasAttribute<NonisolatedAttr>();
-
   // Complain that this witness cannot conform to the requirement due to
   // actor isolation.
-  witness
-      ->diagnose(diag::actor_isolated_witness,
-                 isDistributed && !isDistributedDecl(witness),
-                 referenceIsolation, witness, requirementIsolation,
-                 conformance->getProtocol())
-      .limitBehaviorUntilSwiftVersion(behavior, 6);
-
-  // If we need 'distributed' on the witness, add it.
-  if (isMissingDistributed) {
-    witness->diagnose(
-        diag::note_add_distributed_to_decl, witness)
-      .fixItInsert(witness->getAttributeInsertionLoc(true), "distributed ");
-  }
-
-  // If either of these are distributed, there's nothing more to say.
-  if (isDistributedDecl(requirement) || isDistributedDecl(witness))
-    return;
-
-  // If 'nonisolated' or 'preconcurrency' might help us, provide those as
-  // options.
-  // One way to address the issue is to make the witness function nonisolated.
-  if ((isa<AbstractFunctionDecl>(witness) || isa<SubscriptDecl>(witness)) &&
-      !hasExplicitGlobalActorAttr(witness)) {
-    witness->diagnose(diag::note_add_nonisolated_to_decl, witness)
-          .fixItInsert(witness->getAttributeInsertionLoc(true), "nonisolated ");
-  }
-
-  // Another way to address the issue is to mark the conformance as
-  // isolated to the global actor or "@preconcurrency".
-  if (conformance->getSourceKind() == ConformanceEntryKind::Explicit &&
-      !conformance->isIsolated() &&
-      !conformance->isPreconcurrency() &&
-      !suggestedPreconcurrencyOrIsolated &&
-      !requirementIsolation.isActorIsolated()) {
-    auto proto = conformance->getProtocol();
-    ASTContext &ctx = proto->getASTContext();
-    if (ctx.LangOpts.hasFeature(Feature::IsolatedConformances) &&
-        referenceIsolation.isGlobalActor()) {
-      std::string globalActorStr = "@" +
-          referenceIsolation.getGlobalActor().getString();
-      ctx.Diags.diagnose(conformance->getProtocolNameLoc(),
-                         diag::add_isolated_to_conformance,
-                         globalActorStr,
-                         proto->getName(), referenceIsolation)
-          .fixItInsert(conformance->getProtocolNameLoc(),
-                       globalActorStr + " ");
-    }
-
-    ctx.Diags.diagnose(conformance->getProtocolNameLoc(),
-                       diag::add_preconcurrency_to_conformance,
-                       proto->getName())
-        .fixItInsert(conformance->getProtocolNameLoc(), "@preconcurrency ");
-
-    suggestedPreconcurrencyOrIsolated = true;
-  }
+  witness->diagnose(diag::note_actor_isolated_witness,
+                    referenceIsolation, witness, requirementIsolation,
+                    conformance->getProtocol());
 }
 
 void AssociatedConformanceIsolationError::diagnose(
     const NormalProtocolConformance *conformance
 ) const {
-  auto outerIsolation = conformance->getIsolation();
   auto innerIsolation = isolatedConformance->getIsolation();
 
   ASTContext &ctx = conformance->getDeclContext()->getASTContext();
 
-  // If the conformance we're checking isn't isolated at all, it
-  // needs to be isolated to the given global actor.
-  if (!outerIsolation.isGlobalActor()) {
-    std::string globalActorStr = "@" +
-    innerIsolation.getGlobalActor().getString();
-    ctx.Diags.diagnose(
-        conformance->getLoc(),
-        diag::nonisolated_conformance_depends_on_isolated_conformance,
-        conformance->getType(),
-        conformance->getProtocol()->getName(),
-        innerIsolation,
-        isolatedConformance->getType(),
-        isolatedConformance->getProtocol()->getName(),
-        globalActorStr
-   ).fixItInsert(conformance->getProtocolNameLoc(),
-                 globalActorStr + " ");
-
-    return;
-  }
-
-  assert(outerIsolation != innerIsolation);
   ctx.Diags.diagnose(
       conformance->getLoc(),
-      diag::isolated_conformance_mismatch_with_associated_isolation,
-      outerIsolation,
-      conformance->getType(),
-      conformance->getProtocol()->getName(),
+      diag::note_depends_on_isolated_conformance,
       innerIsolation,
       isolatedConformance->getType(),
-      isolatedConformance->getProtocol()->getName()
+      isolatedConformance->getProtocol()
   );
+}
+
+/// Check whether isolations match closely enough for us to treat them as
+/// equivalent for diagnostic purposes.
+static bool isolationsMatch(
+    const ActorIsolation &lhs, const ActorIsolation &rhs) {
+  if (lhs.isGlobalActor() && rhs.isGlobalActor())
+    return lhs.getGlobalActor()->isEqual(rhs.getGlobalActor());
+
+  if (lhs.isActorInstanceForSelfParameter() &&
+      rhs.isActorInstanceForSelfParameter())
+    return true;
+
+  return false;
 }
 
 static void diagnoseConformanceIsolationErrors(
@@ -4910,15 +4843,199 @@ static void diagnoseConformanceIsolationErrors(
   auto isolationErrors = std::move(known->second);
   globalCache.conformanceIsolationErrors.erase(known);
 
-  bool suggestedPreconcurrencyOrIsolated = false;
+  // Classify the errors to determine potential courses of action.
+
+  // Those witnesses that could be marked "nonisolated".
+  llvm::TinyPtrVector<ValueDecl *> potentialNonisolated;
+
+  // Those witnesses that could be marked "distributed".
+  llvm::TinyPtrVector<ValueDecl *> missingDistributed;
+
+  // Whether there were any issues not addressible by adding 'distributed'.
+  bool anyNonDistributedIssues = false;
+
+  // The isolation that the various witnesses and conformances are within.
+  std::optional<ActorIsolation> potentialIsolation;
+  bool hasConflictingIsolation = false;
+  auto noteIsolation = [&](ActorIsolation isolation) {
+    if (!potentialIsolation) {
+      potentialIsolation = isolation;
+    } else if (!isolationsMatch(*potentialIsolation, isolation)) {
+      hasConflictingIsolation = true;
+    }
+  };
+
+  // Whether there were any isolated conformances in the mix.
+  bool hasIsolatedConformances = false;
+
+  DiagnosticBehavior behavior = DiagnosticBehavior::Error;
   for (const auto &error : isolationErrors) {
     if (std::holds_alternative<WitnessIsolationError>(error)) {
       const auto &witnessError = std::get<WitnessIsolationError>(error);
-      witnessError.diagnose(conformance, suggestedPreconcurrencyOrIsolated);
+
+      // Take the least-restrictive behavior.
+      behavior = behavior.merge(witnessError.behavior);
+
+      // Keep track of witnesses that need 'distributed'.
+      if (witnessError.isMissingDistributed) {
+        missingDistributed.push_back(witnessError.witness);
+      } else {
+        anyNonDistributedIssues = true;
+      }
+
+      // Distributed functions can't have any of the other fixes.
+      if (isDistributedDecl(witnessError.requirement) ||
+          isDistributedDecl(witnessError.witness)) {
+        continue;
+      }
+
+      // If this is an entity where `nonisolated` would make sense, suggest it.
+      if ((isa<AbstractFunctionDecl>(witnessError.witness) ||
+           isa<SubscriptDecl>(witnessError.witness)) &&
+          !hasExplicitGlobalActorAttr(witnessError.witness) &&
+          witnessError.witness->getLoc().isValid()) {
+        potentialNonisolated.push_back(witnessError.witness);
+      }
+
+      // If the conformance was already marked as isolated or @preconcurrency,
+      // or the requirement has isolation, we shouldn't suggest any of them.
+      if (conformance->isIsolated() ||
+          conformance->isPreconcurrency() ||
+          witnessError.requirementIsolation.isActorIsolated())
+        continue;
+
+      // If witness is global-actor-isolated, check whether that isolation
+      // is consistent with other witnesses we've come across.
+      auto referenceIsolation = witnessError.referenceIsolation;
+      if (referenceIsolation.isActorIsolated()) {
+        noteIsolation(referenceIsolation);
+      }
+
+      continue;
+    }
+
+    const auto &assocConformanceError =
+        std::get<AssociatedConformanceIsolationError>(error);
+
+    auto assocConformanceIsolation =
+        assocConformanceError.isolatedConformance->getIsolation();
+    if (assocConformanceIsolation.isGlobalActor()) {
+      noteIsolation(assocConformanceIsolation);
+      hasIsolatedConformances = true;
+    }
+
+    anyNonDistributedIssues = true;
+  }
+
+  // If there were any conflicts with potential isolation, forget about it.
+  if (hasConflictingIsolation)
+    potentialIsolation = std::nullopt;
+
+  if (anyNonDistributedIssues) {
+    // Diagnose issues not related to 'distributed'.
+
+    if (potentialIsolation)  {
+      ctx.Diags.diagnose(
+          conformance->getProtocolNameLoc(),
+          diag::conformance_mismatched_isolation_common,
+          conformance->getType(),
+          conformance->getProtocol(),
+          *potentialIsolation
+      ).limitBehaviorUntilSwiftVersion(behavior, 6);
     } else {
-      const auto &assocConformanceError =
-          std::get<AssociatedConformanceIsolationError>(error);
-      assocConformanceError.diagnose(conformance);
+      ctx.Diags.diagnose(
+          conformance->getProtocolNameLoc(),
+          diag::conformance_mismatched_isolation,
+          conformance->getType(),
+          conformance->getProtocol()
+      ).limitBehaviorUntilSwiftVersion(behavior, 6);
+    }
+
+    // Suggest isolating the conformance, if possible.
+    if (ctx.LangOpts.hasFeature(Feature::IsolatedConformances) &&
+        potentialIsolation && potentialIsolation->isGlobalActor() &&
+        !conformance->isIsolated()) {
+      bool isMainActor = false;
+      Type globalActorIsolation = potentialIsolation->getGlobalActor();
+      if (auto nominal = globalActorIsolation->getAnyNominal())
+        isMainActor = nominal->isMainActor();
+
+      ctx.Diags.diagnose(
+          conformance->getProtocolNameLoc(),
+          diag::note_isolate_conformance_to_global_actor,
+          globalActorIsolation,
+          isMainActor,
+          globalActorIsolation.getString())
+        .fixItInsert(conformance->getProtocolNameLoc(),
+                     "@" + globalActorIsolation.getString() + " ");
+    }
+
+    // If marking witnesses as 'nonisolated' could work, suggest that.
+    if (!potentialNonisolated.empty() && !hasIsolatedConformances) {
+      auto diag = ctx.Diags.diagnose(
+          conformance->getLoc(),
+          diag::note_make_witnesses_nonisolated);
+      for (auto witness: potentialNonisolated) {
+        diag.fixItInsert(
+            witness->getAttributeInsertionLoc(/*forModifier=*/true),
+            "nonisolated ");
+      }
+    }
+
+    // If the conformance could be @preconcurrency, suggest it.
+    if (!conformance->isIsolated() && !conformance->isPreconcurrency() &&
+        !hasIsolatedConformances) {
+      ctx.Diags.diagnose(
+          conformance->getProtocolNameLoc(),
+          diag::note_make_conformance_preconcurrency)
+        .fixItInsert(conformance->getProtocolNameLoc(), "@preconcurrency ");
+    }
+
+    // Make a note of all of the isolation problems we encountered in this
+    // conformance. Even if we couldn't describe a course of action, this
+    // at least details all of the problems encountered.
+
+    // First pass: all of the associated conformance isolation errors, which
+    // can only meaningfully be anchored on the conformance themselves.
+    for (const auto &error : isolationErrors) {
+      if (std::holds_alternative<AssociatedConformanceIsolationError>(error)) {
+        auto assocError = std::get<AssociatedConformanceIsolationError>(error);
+        assocError.diagnose(conformance);
+      }
+    }
+
+    // Second pass: all of the witnesses with isolation errors.
+    for (const auto &error : isolationErrors) {
+      if (std::holds_alternative<WitnessIsolationError>(error)) {
+        const auto &witnessError = std::get<WitnessIsolationError>(error);
+
+        if (!witnessError.isMissingDistributed)
+          witnessError.diagnose(conformance);
+      }
+    }
+  }
+
+  // Diagnose missing 'distributed' on witnesses.
+  if (!missingDistributed.empty()) {
+    // The primary diagnostic adds "distributed" to each of the witnesses
+    // that needed it.
+    {
+      ctx.Diags.diagnose(
+          conformance->getLoc(), diag::conformance_missing_distributed,
+          conformance->getType(), conformance->getProtocol());
+
+      auto noteDiag = ctx.Diags.diagnose(
+          conformance->getLoc(), diag::note_add_distributed_multi);
+      for (auto witness : missingDistributed) {
+        noteDiag.fixItInsert(
+            witness->getAttributeInsertionLoc(/*forModifier=*/true),
+            "distributed ");
+      }
+    }
+
+    // Note which functions need to be distirbuted.
+    for (auto witness : missingDistributed) {
+      witness->diagnose(diag::note_non_distributed, witness);
     }
   }
 }

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -112,9 +112,6 @@ enum class ResolveWitnessResult {
 /// This helper class handles most of the details of checking whether a
 /// given type (\c Adoptee) conforms to a protocol (\c Proto).
 class ConformanceChecker : public WitnessChecker {
-  /// Whether we already suggested adding `@preconcurrency` or 'isolated'.
-  bool suggestedPreconcurrencyOrIsolated = false;
-
 public:
   NormalProtocolConformance *Conformance;
   SourceLoc Loc;

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1508,11 +1508,14 @@ protocol SGA_Proto {
 }
 
 // try to override a MA method with inferred isolation from a protocol requirement
+// expected-warning@+1{{conformance of 'SGA_MA' to protocol 'SGA_Proto' involves isolation mismatches and can cause data races}}
 class SGA_MA: MA, SGA_Proto {
+  // expected-note@-1{{mark all declarations used in the conformance 'nonisolated'}}
+  // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
+  
   // expected-error@+2 {{call to global actor 'SomeGlobalActor'-isolated global function 'onions_sga()' in a synchronous main actor-isolated context}}
-  // expected-warning@+1 {{main actor-isolated instance method 'method()' cannot be used to satisfy global actor 'SomeGlobalActor'-isolated requirement from protocol 'SGA_Proto'}}
+  // expected-note@+1 {{main actor-isolated instance method 'method()' cannot be used to satisfy global actor 'SomeGlobalActor'-isolated requirement from protocol 'SGA_Proto'}}
   override func method() { onions_sga() }
-  // expected-note@-1{{add 'nonisolated' to 'method()' to make this instance method not isolated to the actor}}{{3-3=nonisolated }}
 }
 
 class None_MA: MA {
@@ -1617,10 +1620,11 @@ protocol NonisolatedProtocol {
   var ns: NonSendable { get }
 }
 
+// expected-warning@+1{{conformance of 'ActorWithNonSendableLet' to protocol 'NonisolatedProtocol' crosses into actor-isolated code and can cause data races}}
 actor ActorWithNonSendableLet: NonisolatedProtocol {
-  // expected-note@-1{{add '@preconcurrency' to the 'NonisolatedProtocol' conformance to defer isolation checking to run time}}{{32-32=@preconcurrency }}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{32-32=@preconcurrency }}
 
-  // expected-warning@+1 {{actor-isolated property 'ns' cannot be used to satisfy nonisolated requirement from protocol 'NonisolatedProtocol'; this is an error in the Swift 6 language mode}}
+  // expected-note@+1 {{actor-isolated property 'ns' cannot be used to satisfy nonisolated requirement from protocol 'NonisolatedProtocol'}}
   let ns = NonSendable()
 }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1504,7 +1504,7 @@ class MA {
 @SomeGlobalActor class SGA: MA {} // expected-error {{global actor 'SomeGlobalActor'-isolated class 'SGA' has different actor isolation from main actor-isolated superclass 'MA'}}
 
 protocol SGA_Proto {
-  @SomeGlobalActor func method() // expected-note {{mark the protocol requirement 'method()' 'async' to allow actor-isolated conformances}}
+  @SomeGlobalActor func method()
 }
 
 // try to override a MA method with inferred isolation from a protocol requirement
@@ -1614,7 +1614,7 @@ class OverridesNonsiolatedInit: SuperWithNonisolatedInit {
 class NonSendable {}
 
 protocol NonisolatedProtocol {
-  var ns: NonSendable { get } // expected-note {{requirement 'ns' declared here}}
+  var ns: NonSendable { get }
 }
 
 actor ActorWithNonSendableLet: NonisolatedProtocol {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1514,7 +1514,7 @@ class SGA_MA: MA, SGA_Proto {
   // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
   
   // expected-error@+2 {{call to global actor 'SomeGlobalActor'-isolated global function 'onions_sga()' in a synchronous main actor-isolated context}}
-  // expected-note@+1 {{main actor-isolated instance method 'method()' cannot be used to satisfy global actor 'SomeGlobalActor'-isolated requirement from protocol 'SGA_Proto'}}
+  // expected-note@+1 {{main actor-isolated instance method 'method()' cannot satisfy global actor 'SomeGlobalActor'-isolated requirement}}
   override func method() { onions_sga() }
 }
 
@@ -1624,7 +1624,7 @@ protocol NonisolatedProtocol {
 actor ActorWithNonSendableLet: NonisolatedProtocol {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{32-32=@preconcurrency }}
 
-  // expected-note@+1 {{actor-isolated property 'ns' cannot be used to satisfy nonisolated requirement from protocol 'NonisolatedProtocol'}}
+  // expected-note@+1 {{actor-isolated property 'ns' cannot satisfy nonisolated requirement}}
   let ns = NonSendable()
 }
 

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -38,14 +38,20 @@ struct S3_P1: P1 {
   nonisolated func onMainActor() { }
 }
 
+// expected-warning@+1{{conformance of 'S4_P1_not_quietly' to protocol 'P1' involves isolation mismatches and can cause data races}}
 struct S4_P1_not_quietly: P1 {
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
+
   @SomeGlobalActor func onMainActor() { }
-  // expected-warning @-1 {{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated requirement from protocol 'P1'}}
+  // expected-note @-1 {{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated requirement from protocol 'P1'}}
 }
 
+// expected-warning@+2{{conformance of 'S4_P1' to protocol 'P1' involves isolation mismatches and can cause data races}}
 @SomeGlobalActor
 struct S4_P1: P1 {
-  @SomeGlobalActor func onMainActor() { } // expected-warning{{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated requirement from protocol 'P1'}}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
+
+  @SomeGlobalActor func onMainActor() { } // expected-note{{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated requirement from protocol 'P1'}}
 }
 
 // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -23,7 +23,7 @@ actor SomeGlobalActor {
 // ----------------------------------------------------------------------
 protocol P1 {
   // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
-  @MainActor(unsafe) func onMainActor() // expected-note 2{{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
+  @MainActor(unsafe) func onMainActor()
 }
 
 struct S1_P1: P1 {

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -43,7 +43,7 @@ struct S4_P1_not_quietly: P1 {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
 
   @SomeGlobalActor func onMainActor() { }
-  // expected-note @-1 {{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated requirement from protocol 'P1'}}
+  // expected-note @-1 {{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot satisfy main actor-isolated requirement}}
 }
 
 // expected-warning@+2{{conformance of 'S4_P1' to protocol 'P1' involves isolation mismatches and can cause data races}}
@@ -51,7 +51,7 @@ struct S4_P1_not_quietly: P1 {
 struct S4_P1: P1 {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
 
-  @SomeGlobalActor func onMainActor() { } // expected-note{{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated requirement from protocol 'P1'}}
+  @SomeGlobalActor func onMainActor() { } // expected-note{{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot satisfy main actor-isolated requirement}}
 }
 
 // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -123,11 +123,12 @@ protocol Interface {
   nonisolated var baz: Int { get }
 }
 
+// expected-warning@+2{{conformance of 'Object' to protocol 'Interface' crosses into main actor-isolated code and can cause data races}}
 @MainActor
 class Object: Interface {
-  // expected-note@-1{{add '@preconcurrency' to the 'Interface' conformance to defer isolation checking to run time}}{{15-15=@preconcurrency }}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{15-15=@preconcurrency }}
 
-  var baz: Int = 42 // expected-warning{{main actor-isolated property 'baz' cannot be used to satisfy nonisolated requirement from protocol 'Interface'}}
+  var baz: Int = 42 // expected-note{{main actor-isolated property 'baz' cannot be used to satisfy nonisolated requirement from protocol 'Interface'}}
 }
 
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -128,7 +128,7 @@ protocol Interface {
 class Object: Interface {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{15-15=@preconcurrency }}
 
-  var baz: Int = 42 // expected-note{{main actor-isolated property 'baz' cannot be used to satisfy nonisolated requirement from protocol 'Interface'}}
+  var baz: Int = 42 // expected-note{{main actor-isolated property 'baz' cannot satisfy nonisolated requirement}}
 }
 
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -120,7 +120,7 @@ func testNotAllInP1(nap1: NotAllInP1) { // expected-note{{add '@SomeGlobalActor'
 // Make sure we don't infer 'nonisolated' for stored properties.
 @MainActor
 protocol Interface {
-  nonisolated var baz: Int { get } // expected-note{{requirement 'baz' declared here}}
+  nonisolated var baz: Int { get }
 }
 
 @MainActor

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -169,15 +169,18 @@ struct S2: InferMainActorInherited {
   @MainActor func g() { } // okay for the same reasons, but more explicitly
 }
 
+// expected-error@+2{{conformance of 'S3' to protocol 'InferMainActorInherited' involves isolation mismatches and can cause data races}}
 @SomeGlobalActor
 struct S3: InferenceConflict {
+  // expected-note@-1{{mark all declarations used in the conformance 'nonisolated'}}
+  // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
   nonisolated func g() { }
 }
 
 extension S3 {
+
   func f() { }
-  // expected-error@-1{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot be used to satisfy main actor-isolated requirement from protocol 'InferMainActorInherited'}}
-  //expected-note@-2{{add 'nonisolated' to 'f()' to make this instance method not isolated to the actor}}
+  // expected-note@-1{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot be used to satisfy main actor-isolated requirement from protocol 'InferMainActorInherited'}}
 }
 
 @MainActor
@@ -200,15 +203,15 @@ protocol InferenceConflictWithSuperclass: MainActorSuperclass, InferSomeGlobalAc
   func g()
 }
 
-
+// expected-error@+1{{conformance of 'C2' to protocol 'InferenceConflictWithSuperclass' crosses into main actor-isolated code and can cause data races}}
 class C2: MainActorSuperclass, InferenceConflictWithSuperclass {
-//expected-note@-1 {{add '@preconcurrency' to the 'InferenceConflictWithSuperclass' conformance to defer isolation checking to run time}}
+  //expected-note@-1 {{turn data races into runtime errors with '@preconcurrency'}}
+  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   func f() {}
 
   func g() {}
-  // expected-error@-1 {{main actor-isolated instance method 'g()' cannot be used to satisfy nonisolated requirement from protocol 'InferenceConflictWithSuperclass'}}
-  // expected-note@-2 {{add 'nonisolated' to 'g()' to make this instance method not isolated to the actor}}
+  // expected-note@-1 {{main actor-isolated instance method 'g()' cannot be used to satisfy nonisolated requirement from protocol 'InferenceConflictWithSuperclass'}}
 }
 
 

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -180,7 +180,7 @@ struct S3: InferenceConflict {
 extension S3 {
 
   func f() { }
-  // expected-note@-1{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot be used to satisfy main actor-isolated requirement from protocol 'InferMainActorInherited'}}
+  // expected-note@-1{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot satisfy main actor-isolated requirement}}
 }
 
 @MainActor
@@ -211,7 +211,7 @@ class C2: MainActorSuperclass, InferenceConflictWithSuperclass {
   func f() {}
 
   func g() {}
-  // expected-note@-1 {{main actor-isolated instance method 'g()' cannot be used to satisfy nonisolated requirement from protocol 'InferenceConflictWithSuperclass'}}
+  // expected-note@-1 {{main actor-isolated instance method 'g()' cannot satisfy nonisolated requirement}}
 }
 
 

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -155,7 +155,7 @@ struct S: InferMainActor {
 }
 
 protocol InferMainActorInherited: InferMainActor {
-  func f() // expected-note{{mark the protocol requirement 'f()' 'async' to allow actor-isolated conformances}}
+  func f()
   func g()
 }
 
@@ -198,7 +198,6 @@ class C1: MainActorSuperclass, InferMainFromSuperclass {
 
 protocol InferenceConflictWithSuperclass: MainActorSuperclass, InferSomeGlobalActor {
   func g()
-  // expected-note@-1 {{mark the protocol requirement 'g()' 'async' to allow actor-isolated conformances}}
 }
 
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -4,7 +4,7 @@
 // REQUIRES: concurrency
 
 protocol P {
-  func f() // expected-note{{mark the protocol requirement 'f()' 'async' to allow actor-isolated conformances}}
+  func f()
 }
 
 // ----------------------------------------------------------------------------

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -17,7 +17,7 @@ protocol P {
 @MainActor
 class CWithNonIsolated: P {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
-  func f() { } // expected-note{{main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+  func f() { } // expected-note{{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
 }
 
 actor SomeActor { }
@@ -108,8 +108,8 @@ struct PSendableMetaWrapper<T: P & SendableMetatype>: P {
 @MainActor
 func testIsolationConformancesInTypes() {
   typealias A1 = PWrapper<C>
-  typealias A2 = PSendableWrapper<C> // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter 'T'}}
-  typealias A3 = PSendableMetaWrapper<C> // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `SendableMetatype` type parameter 'T'}}
+  typealias A2 = PSendableWrapper<C> // expected-error{{isolated conformance of 'C' to 'P' cannot satisfy conformance requirement for a `Sendable` type parameter 'T'}}
+  typealias A3 = PSendableMetaWrapper<C> // expected-error{{isolated conformance of 'C' to 'P' cannot satisfy conformance requirement for a `SendableMetatype` type parameter 'T'}}
 }
 
 func acceptP<T: P>(_: T) { }
@@ -124,20 +124,20 @@ func acceptSendableMetaP<T: SendableMetatype & P>(_: T) { }
 func testIsolationConformancesInCall(c: C) {
   acceptP(c) // okay
 
-  acceptSendableP(c) // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
-  acceptSendableMetaP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
+  acceptSendableP(c) // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot satisfy conformance requirement for a `Sendable` type parameter}}
+  acceptSendableMetaP(c) // expected-error{{isolated conformance of 'C' to 'P' cannot satisfy conformance requirement for a `Sendable` type parameter}}
 }
 
 @MainActor
 func testIsolatedConformancesOfActor(a: SomeActor) {
   acceptP(a)
-  acceptSendableMetaP(a) // expected-error{{main actor-isolated conformance of 'SomeActor' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
+  acceptSendableMetaP(a) // expected-error{{main actor-isolated conformance of 'SomeActor' to 'P' cannot satisfy conformance requirement for a `Sendable` type parameter}}
 }
 
 @SomeGlobalActor
 func testIsolatedConformancesOfOtherGlobalActor(c: CMismatchedIsolation) {
   acceptP(c)
-  acceptSendableMetaP(c)  // expected-error{{global actor 'SomeGlobalActor'-isolated conformance of 'CMismatchedIsolation' to 'P' cannot be used to satisfy conformance requirement for a `Sendable` type parameter}}
+  acceptSendableMetaP(c)  // expected-error{{global actor 'SomeGlobalActor'-isolated conformance of 'CMismatchedIsolation' to 'P' cannot satisfy conformance requirement for a `Sendable` type parameter}}
 }
 
 func testIsolationConformancesFromOutside(c: C) {

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -6,7 +6,7 @@
 
 nonisolated
 protocol P {
-  func f() // expected-note{{mark the protocol requirement 'f()' 'async' to allow actor-isolated conformances}}
+  func f()
 }
 
 @MainActor

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -41,7 +41,7 @@ extension CImplicitMainActor: Q {
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 // expected-note@+1{{isolate this conformance to the main actor with '@MainActor'}}{{33-33=@MainActor }}
 nonisolated class CNonIsolated: P {
-  @MainActor func f() { } // expected-note{{main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+  @MainActor func f() { } // expected-note{{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
 }
 
 func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -37,10 +37,11 @@ extension CImplicitMainActor: Q {
   func g() { }
 }
 
-// expected-note@+2{{add '@preconcurrency' to the 'P' conformance to defer isolation checking to run time}}
-// expected-note@+1{{add '@MainActor' to the 'P' conformance to restrict it to main actor-isolated code}}
+// expected-error@+3{{conformance of 'CNonIsolated' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
+// expected-note@+1{{isolate this conformance to the main actor with '@MainActor'}}{{33-33=@MainActor }}
 nonisolated class CNonIsolated: P {
-  @MainActor func f() { } // expected-error{{main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+  @MainActor func f() { } // expected-note{{main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
 }
 
 func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -108,7 +108,7 @@ final class K : @preconcurrency Initializable {
 final class MainActorK: Initializable {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{25-25=@preconcurrency }}
   // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
-  init() { } // expected-note{{main actor-isolated initializer 'init()' cannot be used to satisfy nonisolated requirement from protocol 'Initializable'}}
+  init() { } // expected-note{{main actor-isolated initializer 'init()' cannot satisfy nonisolated requirement}}
 }
 
 protocol WithAssoc {
@@ -143,13 +143,13 @@ do {
     var a: Int = 42
 
     @MainActor var b: Int {
-      // expected-note@-1 {{main actor-isolated property 'b' cannot be used to satisfy global actor 'GlobalActor'-isolated requirement from protocol 'WithIndividuallyIsolatedRequirements'}}
+      // expected-note@-1 {{main actor-isolated property 'b' cannot satisfy global actor 'GlobalActor'-isolated requirement}}
       get { 0 }
       set {}
     }
 
     @MainActor func test() {
-      // expected-note@-1 {{main actor-isolated instance method 'test()' cannot be used to satisfy global actor 'GlobalActor'-isolated requirement from protocol 'WithIndividuallyIsolatedRequirements'}}
+      // expected-note@-1 {{main actor-isolated instance method 'test()' cannot satisfy global actor 'GlobalActor'-isolated requirement}}
     }
   }
 }
@@ -166,10 +166,10 @@ do {
     // expected-warning@-1 {{@preconcurrency attribute on conformance to 'WithNonIsolated' has no effect}}{{38-54=}}
 
     @GlobalActor var prop: Int = 42
-    // expected-note@-1 {{global actor 'GlobalActor'-isolated property 'prop' cannot be used to satisfy main actor-isolated requirement from protocol 'WithNonIsolated'}}
+    // expected-note@-1 {{global actor 'GlobalActor'-isolated property 'prop' cannot satisfy main actor-isolated requirement}}
 
     @MainActor func test() {}
-    // expected-note@-1 {{main actor-isolated instance method 'test()' cannot be used to satisfy nonisolated requirement from protocol 'WithNonIsolated'}}
+    // expected-note@-1 {{main actor-isolated instance method 'test()' cannot satisfy nonisolated requirement}}
   }
 }
 
@@ -237,7 +237,7 @@ do {
     // expected-note@-2:45 {{turn data races into runtime errors with '@preconcurrency'}}
     // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
     func foo() {}
-    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
+    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
   }
   // expected-warning@+1{{conformance of 'S5' to protocol 'P2' crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode}}
   @MainActor struct S5: P2, @preconcurrency P3 {
@@ -245,7 +245,7 @@ do {
     // expected-note@-2:25 {{turn data races into runtime errors with '@preconcurrency'}}
     // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
     func foo() {}
-    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
+    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
   }
   // expected-warning@+1 {{@preconcurrency attribute on conformance to 'P3' has no effect}}
   @MainActor struct S6: @preconcurrency P2, @preconcurrency P3 {
@@ -305,7 +305,7 @@ do {
     // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
     // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
     func foo() {}
-    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
+    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
   }
 }
 

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -103,11 +103,12 @@ final class K : @preconcurrency Initializable {
   init() {} // Ok
 }
 
+// expected-warning@+2{{conformance of 'MainActorK' to protocol 'Initializable' crosses into main actor-isolated code and can cause data races}}
 @MainActor
 final class MainActorK: Initializable {
-  // expected-note@-1{{add '@preconcurrency' to the 'Initializable' conformance to defer isolation checking to run time}}{{25-25=@preconcurrency }}
-  init() { } // expected-warning{{main actor-isolated initializer 'init()' cannot be used to satisfy nonisolated requirement from protocol 'Initializable'}}
-  // expected-note@-1{{add 'nonisolated' to 'init()' to make this initializer not isolated to the actor}}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{25-25=@preconcurrency }}
+  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
+  init() { } // expected-note{{main actor-isolated initializer 'init()' cannot be used to satisfy nonisolated requirement from protocol 'Initializable'}}
 }
 
 protocol WithAssoc {
@@ -134,6 +135,7 @@ protocol WithIndividuallyIsolatedRequirements {
 }
 
 do {
+  // expected-warning@+2{{conformance of 'TestExplicitGlobalActorAttrs' to protocol 'WithIndividuallyIsolatedRequirements' involves isolation mismatches and can cause data races}}
   @MainActor
   struct TestExplicitGlobalActorAttrs : @preconcurrency WithIndividuallyIsolatedRequirements {
     // expected-warning@-1 {{@preconcurrency attribute on conformance to 'WithIndividuallyIsolatedRequirements' has no effect}}
@@ -141,13 +143,13 @@ do {
     var a: Int = 42
 
     @MainActor var b: Int {
-      // expected-warning@-1 {{main actor-isolated property 'b' cannot be used to satisfy global actor 'GlobalActor'-isolated requirement from protocol 'WithIndividuallyIsolatedRequirements'}}
+      // expected-note@-1 {{main actor-isolated property 'b' cannot be used to satisfy global actor 'GlobalActor'-isolated requirement from protocol 'WithIndividuallyIsolatedRequirements'}}
       get { 0 }
       set {}
     }
 
     @MainActor func test() {
-      // expected-warning@-1 {{main actor-isolated instance method 'test()' cannot be used to satisfy global actor 'GlobalActor'-isolated requirement from protocol 'WithIndividuallyIsolatedRequirements'}}
+      // expected-note@-1 {{main actor-isolated instance method 'test()' cannot be used to satisfy global actor 'GlobalActor'-isolated requirement from protocol 'WithIndividuallyIsolatedRequirements'}}
     }
   }
 }
@@ -159,14 +161,15 @@ protocol WithNonIsolated {
 }
 
 do {
+  // expected-warning@+1{{conformance of 'TestExplicitOtherIsolation' to protocol 'WithNonIsolated' involves isolation mismatches and can cause data races}}
   class TestExplicitOtherIsolation : @preconcurrency WithNonIsolated {
     // expected-warning@-1 {{@preconcurrency attribute on conformance to 'WithNonIsolated' has no effect}}{{38-54=}}
 
     @GlobalActor var prop: Int = 42
-    // expected-warning@-1 {{global actor 'GlobalActor'-isolated property 'prop' cannot be used to satisfy main actor-isolated requirement from protocol 'WithNonIsolated'}}
+    // expected-note@-1 {{global actor 'GlobalActor'-isolated property 'prop' cannot be used to satisfy main actor-isolated requirement from protocol 'WithNonIsolated'}}
 
     @MainActor func test() {}
-    // expected-warning@-1 {{main actor-isolated instance method 'test()' cannot be used to satisfy nonisolated requirement from protocol 'WithNonIsolated'}}
+    // expected-note@-1 {{main actor-isolated instance method 'test()' cannot be used to satisfy nonisolated requirement from protocol 'WithNonIsolated'}}
   }
 }
 
@@ -228,19 +231,21 @@ do {
   // Explicit conformances to inherited protocols do not contribute to whether
   // preconcurrency has effect on the conformance to the refined protocol, so
   // preconcurrency has no effect here.
+  // expected-warning@+1{{conformance of 'S4' to protocol 'P2' crosses into main actor-isolated code and can cause data races}}
   @MainActor struct S4: @preconcurrency P3, P2 {
     // expected-warning@-1:21 {{@preconcurrency attribute on conformance to 'P3' has no effect}}
-    // expected-note@-2:45 {{add '@preconcurrency' to the 'P2' conformance to defer isolation checking to run time}}
+    // expected-note@-2:45 {{turn data races into runtime errors with '@preconcurrency'}}
+    // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
     func foo() {}
-    // expected-warning@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
-    // expected-note@-2 {{add 'nonisolated' to 'foo()' to make this instance method not isolated to the actor}}
+    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
   }
+  // expected-warning@+1{{conformance of 'S5' to protocol 'P2' crosses into main actor-isolated code and can cause data races; this is an error in the Swift 6 language mode}}
   @MainActor struct S5: P2, @preconcurrency P3 {
     // expected-warning@-1:21 {{@preconcurrency attribute on conformance to 'P3' has no effect}}
-    // expected-note@-2:25 {{add '@preconcurrency' to the 'P2' conformance to defer isolation checking to run time}}
+    // expected-note@-2:25 {{turn data races into runtime errors with '@preconcurrency'}}
+    // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
     func foo() {}
-    // expected-warning@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
-    // expected-note@-2 {{add 'nonisolated' to 'foo()' to make this instance method not isolated to the actor}}
+    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
   }
   // expected-warning@+1 {{@preconcurrency attribute on conformance to 'P3' has no effect}}
   @MainActor struct S6: @preconcurrency P2, @preconcurrency P3 {
@@ -293,11 +298,14 @@ do {
   @MainActor struct S3: @preconcurrency P5, P6 {
     func foo() {}
   }
+
+  // expected-warning@+1{{conformance of 'S4' to protocol 'P2' crosses into main actor-isolated code and can cause data races}}
   @MainActor struct S4: P6, @preconcurrency P5 {
-  // expected-warning@-1:21 {{@preconcurrency attribute on conformance to 'P5' has no effect}}
+    // expected-warning@-1:21 {{@preconcurrency attribute on conformance to 'P5' has no effect}}
+    // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
+    // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
     func foo() {}
-    // expected-warning@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
-    // expected-note@-2 {{add 'nonisolated' to 'foo()' to make this instance method not isolated to the actor}}
+    // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P2'}}
   }
 }
 

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -96,7 +96,6 @@ extension MyActor : @preconcurrency TestSendability {
 
 protocol Initializable {
   init()
-  // expected-note@-1{{mark the protocol requirement 'init()' 'async' to allow actor-isolated conformances}}
 }
 
 final class K : @preconcurrency Initializable {
@@ -130,10 +129,8 @@ struct GlobalActor {
 protocol WithIndividuallyIsolatedRequirements {
   @MainActor var a: Int { get set }
   @GlobalActor var b: Int { get set }
-  // expected-note@-1 {{requirement 'b' declared here}}
 
   @GlobalActor func test()
-  // expected-note@-1 {{mark the protocol requirement 'test()' 'async' to allow actor-isolated conformances}}
 }
 
 do {
@@ -158,9 +155,7 @@ do {
 @MainActor
 protocol WithNonIsolated {
   var prop: Int { get set }
-  // expected-note@-1 {{requirement 'prop' declared here}}
   nonisolated func test()
-  // expected-note@-1 {{mark the protocol requirement 'test()' 'async' to allow actor-isolated conformances}}
 }
 
 do {
@@ -212,7 +207,7 @@ do {
 do {
   protocol P1 {}
   protocol P2 {
-    func foo() // expected-note 2 {{mark the protocol requirement 'foo()' 'async' to allow actor-isolated conformances}}
+    func foo()
   }
   protocol P3: P1, P2 {}
 
@@ -278,7 +273,7 @@ do {
 do {
   protocol P1 {}
   protocol P2 {
-    func foo() // expected-note {{mark the protocol requirement 'foo()' 'async' to allow actor-isolated conformances}}
+    func foo()
   }
   protocol P3: P1, P2 {}
   protocol P5: P3 {}

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -229,14 +229,14 @@ protocol NotIsolated {
   func requirement()
 }
 
+// expected-complete-tns-warning@+1{{conformance of 'MainActorPreconcurrency' to protocol 'NotIsolated' crosses into main actor-isolated code and can cause data races}}
 extension MainActorPreconcurrency: NotIsolated {
   // expected-complete-note@-1{{add '@preconcurrency' to the 'NotIsolated' conformance to suppress isolation-related diagnostics}}{{36-36=@preconcurrency }}
-  // expected-complete-tns-note@-2{{add '@preconcurrency' to the 'NotIsolated' conformance to defer isolation checking to run time}}{{36-36=@preconcurrency }}
-
+  // expected-complete-tns-note@-2{{turn data races into runtime errors with '@preconcurrency'}}{{36-36=@preconcurrency }}
+  // expected-complete-tns-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
   func requirement() {}
-  // expected-complete-tns-warning@-1 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated requirement from protocol 'NotIsolated'}}
-  // expected-complete-tns-note@-2 {{add 'nonisolated' to 'requirement()' to make this instance method not isolated to the actor}}
-  // expected-complete-tns-note@-3 {{calls to instance method 'requirement()' from outside of its actor context are implicitly asynchronous}}
+  // expected-complete-tns-note@-1 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated requirement from protocol 'NotIsolated'}}
+  // expected-complete-tns-note@-2 {{calls to instance method 'requirement()' from outside of its actor context are implicitly asynchronous}}
 
 
   class Nested {

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -235,7 +235,7 @@ extension MainActorPreconcurrency: NotIsolated {
   // expected-complete-tns-note@-2{{turn data races into runtime errors with '@preconcurrency'}}{{36-36=@preconcurrency }}
   // expected-complete-tns-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
   func requirement() {}
-  // expected-complete-tns-note@-1 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated requirement from protocol 'NotIsolated'}}
+  // expected-complete-tns-note@-1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
   // expected-complete-tns-note@-2 {{calls to instance method 'requirement()' from outside of its actor context are implicitly asynchronous}}
 
 

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -227,7 +227,6 @@ nonisolated func blah() {
 
 protocol NotIsolated {
   func requirement()
-  // expected-complete-tns-note@-1 {{mark the protocol requirement 'requirement()' 'async' to allow actor-isolated conformances}}
 }
 
 extension MainActorPreconcurrency: NotIsolated {

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -108,22 +108,22 @@ distributed actor Nope1_StrictlyLocal: StrictlyLocal {
   // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   func local() {}
-  // expected-note@-1{{actor-isolated instance method 'local()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated instance method 'local()' cannot satisfy nonisolated requirement}}
   func localThrows() throws {}
-  // expected-note@-1{{actor-isolated instance method 'localThrows()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated instance method 'localThrows()' cannot satisfy nonisolated requirement}}
   func localAsync() async {}
-  // expected-note@-1{{actor-isolated instance method 'localAsync()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated instance method 'localAsync()' cannot satisfy nonisolated requirement}}
 }
 
 // expected-error@+1{{conformance of 'Nope2_StrictlyLocal' to protocol 'StrictlyLocal' involves isolation mismatches and can cause data races}}
 distributed actor Nope2_StrictlyLocal: StrictlyLocal {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
   distributed func local() {}
-  // expected-note@-1{{actor-isolated distributed instance method 'local()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated distributed instance method 'local()' cannot satisfy nonisolated requirement}}
   distributed func localThrows() throws {}
-  // expected-note@-1{{actor-isolated distributed instance method 'localThrows()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated distributed instance method 'localThrows()' cannot satisfy nonisolated requirement}}
   distributed func localAsync() async {}
-  // expected-note@-1{{actor-isolated distributed instance method 'localAsync()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated distributed instance method 'localAsync()' cannot satisfy nonisolated requirement}}
 }
 distributed actor OK_StrictlyLocal: StrictlyLocal {
   nonisolated func local() {}
@@ -207,7 +207,7 @@ distributed actor DA_TerminationWatchingA: TerminationWatchingA {
   // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   func terminated(a: String) { }
-  // expected-note@-1{{actor-isolated instance method 'terminated(a:)' cannot be used to satisfy nonisolated requirement from protocol 'TerminationWatchingA'}}
+  // expected-note@-1{{actor-isolated instance method 'terminated(a:)' cannot satisfy nonisolated requirement}}
 }
 
 distributed actor DA_TerminationWatchingDA: TerminationWatchingDA {

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -102,26 +102,28 @@ protocol StrictlyLocal {
   func localAsync() async
 }
 
+// expected-error@+1{{conformance of 'Nope1_StrictlyLocal' to protocol 'StrictlyLocal' crosses into actor-isolated code and can cause data races}}
 distributed actor Nope1_StrictlyLocal: StrictlyLocal {
-  // expected-note@-1{{add '@preconcurrency' to the 'StrictlyLocal' conformance to defer isolation checking to run time}}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{40-40=@preconcurrency }}
+  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   func local() {}
-  // expected-error@-1{{distributed actor-isolated instance method 'local()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
-  // expected-note@-2{{add 'nonisolated' to 'local()' to make this instance method not isolated to the actor}}
+  // expected-note@-1{{actor-isolated instance method 'local()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
   func localThrows() throws {}
-  // expected-error@-1{{distributed actor-isolated instance method 'localThrows()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
-  // expected-note@-2{{add 'nonisolated' to 'localThrows()' to make this instance method not isolated to the actor}}
+  // expected-note@-1{{actor-isolated instance method 'localThrows()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
   func localAsync() async {}
-  // expected-error@-1{{distributed actor-isolated instance method 'localAsync()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
-  // expected-note@-2{{add 'nonisolated' to 'localAsync()' to make this instance method not isolated to the actor}}
+  // expected-note@-1{{actor-isolated instance method 'localAsync()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
 }
+
+// expected-error@+1{{conformance of 'Nope2_StrictlyLocal' to protocol 'StrictlyLocal' involves isolation mismatches and can cause data races}}
 distributed actor Nope2_StrictlyLocal: StrictlyLocal {
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
   distributed func local() {}
-  // expected-error@-1{{actor-isolated distributed instance method 'local()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated distributed instance method 'local()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
   distributed func localThrows() throws {}
-  // expected-error@-1{{actor-isolated distributed instance method 'localThrows()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated distributed instance method 'localThrows()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
   distributed func localAsync() async {}
-  // expected-error@-1{{actor-isolated distributed instance method 'localAsync()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
+  // expected-note@-1{{actor-isolated distributed instance method 'localAsync()' cannot be used to satisfy nonisolated requirement from protocol 'StrictlyLocal'}}
 }
 distributed actor OK_StrictlyLocal: StrictlyLocal {
   nonisolated func local() {}
@@ -154,13 +156,12 @@ actor LocalOK_ImplicitlyThrowsAsync_AsyncThrowsAll: AsyncThrowsAll {
   func maybe(param: String, int: Int) -> Int { 1111 }
 }
 
+// expected-error@+1{{conformance of 'Nope1_AsyncThrowsAll' to distributed protocol 'AsyncThrowsAll' uses non-distributed operations}}
 distributed actor Nope1_AsyncThrowsAll: AsyncThrowsAll {
-  // expected-note@-1{{add '@preconcurrency' to the 'AsyncThrowsAll' conformance to defer isolation checking to run time}}
+  // expected-note@-1{{mark all declarations used in the conformance 'distributed'}}
 
   func maybe(param: String, int: Int) async throws -> Int { 111 }
-  // expected-error@-1{{distributed actor-isolated instance method 'maybe(param:int:)' cannot be used to satisfy nonisolated requirement from protocol 'AsyncThrowsAll'}}
-  // expected-note@-2{{add 'nonisolated' to 'maybe(param:int:)' to make this instance method not isolated to the actor}}
-  // expected-note@-3{{add 'distributed' to 'maybe(param:int:)' to make this instance method satisfy the protocol requirement}}
+  // expected-note@-1{{non-distributed instance method 'maybe(param:int:)'}}
 }
 
 distributed actor OK_AsyncThrowsAll: AsyncThrowsAll {
@@ -200,12 +201,13 @@ func test_watching_A(a: A_TerminationWatchingA) async throws {
   await a.terminated(a: "normal")
 }
 
+// expected-error@+1{{conformance of 'DA_TerminationWatchingA' to protocol 'TerminationWatchingA' crosses into actor-isolated code and can cause data races}}
 distributed actor DA_TerminationWatchingA: TerminationWatchingA {
-  // expected-note@-1{{add '@preconcurrency' to the 'TerminationWatchingA' conformance to defer isolation checking to run time}}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
+  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   func terminated(a: String) { }
-  // expected-error@-1{{distributed actor-isolated instance method 'terminated(a:)' cannot be used to satisfy nonisolated requirement from protocol 'TerminationWatchingA'}}
-  // expected-note@-2{{add 'nonisolated' to 'terminated(a:)' to make this instance method not isolated to the actor}}
+  // expected-note@-1{{actor-isolated instance method 'terminated(a:)' cannot be used to satisfy nonisolated requirement from protocol 'TerminationWatchingA'}}
 }
 
 distributed actor DA_TerminationWatchingDA: TerminationWatchingDA {

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -96,13 +96,10 @@ func outside_good_ext<DP: DistProtocol>(dp: DP) async throws {
 /// A distributed actor could only conform to this by making everything 'nonisolated':
 protocol StrictlyLocal {
   func local()
-  // expected-note@-1 2{{mark the protocol requirement 'local()' 'async throws' to allow actor-isolated conformances}}{{15-15= async throws}}
 
   func localThrows() throws
-  // expected-note@-1 2{{mark the protocol requirement 'localThrows()' 'async' to allow actor-isolated conformances}}{{22-22=async }}
 
   func localAsync() async
-  // expected-note@-1 2{{mark the protocol requirement 'localAsync()' 'throws' to allow actor-isolated conformances}}
 }
 
 distributed actor Nope1_StrictlyLocal: StrictlyLocal {
@@ -141,7 +138,6 @@ actor MyServer : Server {
 
 protocol AsyncThrowsAll {
   func maybe(param: String, int: Int) async throws -> Int
-  // expected-note@-1{{'maybe(param:int:)' declared here}}
 }
 
 actor LocalOK_AsyncThrowsAll: AsyncThrowsAll {
@@ -191,7 +187,6 @@ func testAsyncThrowsAll(p: AsyncThrowsAll,
 
 protocol TerminationWatchingA {
   func terminated(a: String) async
-  // expected-note@-1{{mark the protocol requirement 'terminated(a:)' 'throws' to allow actor-isolated conformances}}
 }
 
 protocol TerminationWatchingDA: DistributedActor {

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -15,20 +15,20 @@ extension MyActor: AsyncProtocol {
 }
 
 protocol SyncProtocol {
-  var propertyA: Int { get } // expected-note{{requirement 'propertyA' declared here}}
-  var propertyB: Int { get set } // expected-note{{requirement 'propertyB' declared here}}
+  var propertyA: Int { get }
+  var propertyB: Int { get set }
 
-  func syncMethodA() // expected-note{{mark the protocol requirement 'syncMethodA()' 'async' to allow actor-isolated conformances}}{{21-21= async}}
+  func syncMethodA()
 
   func syncMethodC() -> Int
 
-  func syncMethodE() -> Void // expected-note{{mark the protocol requirement 'syncMethodE()' 'async' to allow actor-isolated conformances}}{{21-21= async}}
+  func syncMethodE() -> Void
 
-  func syncMethodF(param: String) -> Int // expected-note{{mark the protocol requirement 'syncMethodF(param:)' 'async' to allow actor-isolated conformances}}{{34-34= async}}
+  func syncMethodF(param: String) -> Int
 
-  func syncMethodG() throws -> Void // expected-note{{mark the protocol requirement 'syncMethodG()' 'async' to allow actor-isolated conformances}}{{22-22=async }}
+  func syncMethodG() throws -> Void
 
-  subscript (index: Int) -> String { get } // expected-note{{requirement 'subscript(_:)' declared here}}
+  subscript (index: Int) -> String { get }
 
   static func staticMethod()
   static var staticProperty: Int { get }

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -40,28 +40,28 @@ actor OtherActor: SyncProtocol {
   // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   var propertyB: Int = 17
-  // expected-note@-1{{actor-isolated property 'propertyB' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated property 'propertyB' cannot satisfy nonisolated requirement}}
 
   var propertyA: Int { 17 }
-  // expected-note@-1{{actor-isolated property 'propertyA' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated property 'propertyA' cannot satisfy nonisolated requirement}}
 
   func syncMethodA() { }
-  // expected-note@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated instance method 'syncMethodA()' cannot satisfy nonisolated requirement}}
 
   // nonisolated methods are okay.
   nonisolated func syncMethodC() -> Int { 5 }
 
   func syncMethodE() -> Void { }
-  // expected-note@-1{{actor-isolated instance method 'syncMethodE()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated instance method 'syncMethodE()' cannot satisfy nonisolated requirement}}
 
   func syncMethodF(param: String) -> Int { 5 }
-  // expected-note@-1{{actor-isolated instance method 'syncMethodF(param:)' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated instance method 'syncMethodF(param:)' cannot satisfy nonisolated requirement}}
 
   func syncMethodG() { }
-  // expected-note@-1{{actor-isolated instance method 'syncMethodG()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated instance method 'syncMethodG()' cannot satisfy nonisolated requirement}}
 
   subscript (index: Int) -> String { "\(index)" }
-  // expected-note@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated subscript 'subscript(_:)' cannot satisfy nonisolated requirement}}
 
   // Static methods and properties are okay.
   static func staticMethod() { }

--- a/test/decl/class/actor/conformance.swift
+++ b/test/decl/class/actor/conformance.swift
@@ -34,39 +34,34 @@ protocol SyncProtocol {
   static var staticProperty: Int { get }
 }
 
-
+// expected-error@+1{{conformance of 'OtherActor' to protocol 'SyncProtocol' crosses into actor-isolated code and can cause data races}}
 actor OtherActor: SyncProtocol {
-  // expected-note@-1{{add '@preconcurrency' to the 'SyncProtocol' conformance to defer isolation checking to run time}}{{19-19=@preconcurrency }}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{19-19=@preconcurrency }}
+  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
 
   var propertyB: Int = 17
-  // expected-error@-1{{actor-isolated property 'propertyB' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated property 'propertyB' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
 
   var propertyA: Int { 17 }
-  // expected-error@-1{{actor-isolated property 'propertyA' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
+  // expected-note@-1{{actor-isolated property 'propertyA' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
 
   func syncMethodA() { }
-  // expected-error@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
-  // expected-note@-2{{add 'nonisolated' to 'syncMethodA()' to make this instance method not isolated to the actor}}{{3-3=nonisolated }}
+  // expected-note@-1{{actor-isolated instance method 'syncMethodA()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
 
   // nonisolated methods are okay.
-  // FIXME: Consider suggesting nonisolated if this didn't match.
   nonisolated func syncMethodC() -> Int { 5 }
 
   func syncMethodE() -> Void { }
-  // expected-error@-1{{actor-isolated instance method 'syncMethodE()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
-  // expected-note@-2{{add 'nonisolated' to 'syncMethodE()' to make this instance method not isolated to the actor}}{{3-3=nonisolated }}
+  // expected-note@-1{{actor-isolated instance method 'syncMethodE()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
 
   func syncMethodF(param: String) -> Int { 5 }
-  // expected-error@-1{{actor-isolated instance method 'syncMethodF(param:)' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
-  // expected-note@-2{{add 'nonisolated' to 'syncMethodF(param:)' to make this instance method not isolated to the actor}}{{3-3=nonisolated }}
+  // expected-note@-1{{actor-isolated instance method 'syncMethodF(param:)' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
 
   func syncMethodG() { }
-  // expected-error@-1{{actor-isolated instance method 'syncMethodG()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
-  // expected-note@-2{{add 'nonisolated' to 'syncMethodG()' to make this instance method not isolated to the actor}}{{3-3=nonisolated }}
+  // expected-note@-1{{actor-isolated instance method 'syncMethodG()' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
 
   subscript (index: Int) -> String { "\(index)" }
-  // expected-error@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
-  // expected-note@-2{{add 'nonisolated' to 'subscript(_:)' to make this subscript not isolated to the actor}}{{3-3=nonisolated }}
+  // expected-note@-1{{actor-isolated subscript 'subscript(_:)' cannot be used to satisfy nonisolated requirement from protocol 'SyncProtocol'}}
 
   // Static methods and properties are okay.
   static func staticMethod() { }

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -37,9 +37,9 @@ class C1 : P1, P2 {
 
   func method1() { }
 
-  @GenericGlobalActor<String> func method2() { } // expected-note{{global actor 'GenericGlobalActor<String>'-isolated instance method 'method2()' cannot be used to satisfy global actor 'GenericGlobalActor<Int>'-isolated requirement from protocol 'P1'}}
+  @GenericGlobalActor<String> func method2() { } // expected-note{{global actor 'GenericGlobalActor<String>'-isolated instance method 'method2()' cannot satisfy global actor 'GenericGlobalActor<Int>'-isolated requirement}}
   @GenericGlobalActor<String >func method3() { }
-  @GlobalActor func method4() { } // expected-note{{global actor 'GlobalActor'-isolated instance method 'method4()' cannot be used to satisfy nonisolated requirement from protocol 'P1'}}
+  @GlobalActor func method4() { } // expected-note{{global actor 'GlobalActor'-isolated instance method 'method4()' cannot satisfy nonisolated requirement}}
 
   // Okay: we can ignore the mismatch in global actor types for 'async' methods.
   func asyncMethod1() async { }
@@ -57,7 +57,7 @@ protocol NonIsolatedRequirement {
 extension OnMain: NonIsolatedRequirement {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
   // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
-  // expected-note@+1 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated requirement from protocol 'NonIsolatedRequirement'}}
+  // expected-note@+1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
   func requirement() {}
 }
 

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -29,16 +29,17 @@ protocol P2 {
   func asyncMethod3() async
 }
 
+// expected-warning@+1{{conformance of 'C1' to protocol 'P1' crosses into global actor 'GlobalActor'-isolated code and can cause data races}}
 class C1 : P1, P2 {
-  // expected-note@-1{{add '@preconcurrency' to the 'P1' conformance to defer isolation checking to run time}}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
 
   typealias Assoc = String
 
   func method1() { }
 
-  @GenericGlobalActor<String> func method2() { } // expected-warning{{global actor 'GenericGlobalActor<String>'-isolated instance method 'method2()' cannot be used to satisfy global actor 'GenericGlobalActor<Int>'-isolated requirement from protocol 'P1'}}
+  @GenericGlobalActor<String> func method2() { } // expected-note{{global actor 'GenericGlobalActor<String>'-isolated instance method 'method2()' cannot be used to satisfy global actor 'GenericGlobalActor<Int>'-isolated requirement from protocol 'P1'}}
   @GenericGlobalActor<String >func method3() { }
-  @GlobalActor func method4() { } // expected-warning{{global actor 'GlobalActor'-isolated instance method 'method4()' cannot be used to satisfy nonisolated requirement from protocol 'P1'}}
+  @GlobalActor func method4() { } // expected-note{{global actor 'GlobalActor'-isolated instance method 'method4()' cannot be used to satisfy nonisolated requirement from protocol 'P1'}}
 
   // Okay: we can ignore the mismatch in global actor types for 'async' methods.
   func asyncMethod1() async { }
@@ -52,11 +53,11 @@ protocol NonIsolatedRequirement {
 
 @MainActor class OnMain {}
 
+// expected-warning@+1{{conformance of 'OnMain' to protocol 'NonIsolatedRequirement' crosses into main actor-isolated code}}
 extension OnMain: NonIsolatedRequirement {
-  // expected-note@-1{{add '@preconcurrency' to the 'NonIsolatedRequirement' conformance to defer isolation checking to run time}}
-
-  // expected-warning@+2 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated requirement from protocol 'NonIsolatedRequirement'}}
-  // expected-note@+1 {{add 'nonisolated' to 'requirement()' to make this instance method not isolated to the actor}}
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
+  // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
+  // expected-note@+1 {{main actor-isolated instance method 'requirement()' cannot be used to satisfy nonisolated requirement from protocol 'NonIsolatedRequirement'}}
   func requirement() {}
 }
 

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -18,9 +18,9 @@ protocol P1 {
   associatedtype Assoc
 
   @GlobalActor func method1()
-  @GenericGlobalActor<Int> func method2()  // expected-note{{}}
+  @GenericGlobalActor<Int> func method2()
   @GenericGlobalActor<Assoc> func method3()
-  func method4() // expected-note{{mark the protocol requirement 'method4()' 'async' to allow actor-isolated conformances}}
+  func method4()
 }
 
 protocol P2 {
@@ -47,7 +47,6 @@ class C1 : P1, P2 {
 }
 
 protocol NonIsolatedRequirement {
-  // expected-note@+1 {{mark the protocol requirement 'requirement()' 'async' to allow actor-isolated conformances}}
   func requirement()
 }
 

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -86,6 +86,6 @@ distributed actor A: P {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
   typealias ActorSystem = LocalTestingDistributedActorSystem
   distributed func foo() { }
-  // expected-note@-1{{actor-isolated distributed instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+  // expected-note@-1{{actor-isolated distributed instance method 'foo()' cannot satisfy nonisolated requirement}}
 }
 // ---

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -57,10 +57,12 @@ protocol P1: DistributedActor {
   distributed func dist() -> String
 }
 
+// expected-error@+1{{conformance of 'D5' to distributed protocol 'P1' uses non-distributed operations}}
 distributed actor D5: P1 {
+  // expected-note@-1{{mark all declarations used in the conformance 'distributed'}}
+  
   func dist() -> String { "" }
-  // expected-error@-1{{distributed actor-isolated instance method 'dist()' cannot be used to satisfy actor-isolated requirement from protocol 'P1'}}
-  // expected-note@-2{{add 'distributed' to 'dist()' to make this instance method satisfy the protocol requirement}}{{3-3=distributed }}
+  // expected-note@-1{{non-distributed instance method 'dist()'}}
 }
 
 // ==== Tests ------------------------------------------------------------------
@@ -79,9 +81,11 @@ protocol P {
   func foo() -> Void
 }
 
+// expected-error@+1{{conformance of 'A' to protocol 'P' involves isolation mismatches and can cause data races}}
 distributed actor A: P {
+  // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
   typealias ActorSystem = LocalTestingDistributedActorSystem
   distributed func foo() { }
-  // expected-error@-1{{actor-isolated distributed instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
+  // expected-note@-1{{actor-isolated distributed instance method 'foo()' cannot be used to satisfy nonisolated requirement from protocol 'P'}}
 }
 // ---

--- a/test/decl/protocol/special/DistributedActor.swift
+++ b/test/decl/protocol/special/DistributedActor.swift
@@ -55,7 +55,6 @@ distributed actor D4 {
 
 protocol P1: DistributedActor {
   distributed func dist() -> String
-  // expected-note@-1{{requirement 'dist()' declared here}}
 }
 
 distributed actor D5: P1 {
@@ -78,7 +77,6 @@ func testConformance() {
 // https://github.com/apple/swift/issues/69244
 protocol P {
   func foo() -> Void
-  // expected-note@-1{{mark the protocol requirement 'foo()' 'async throws' to allow actor-isolated conformances}}{{13-13= async throws}}
 }
 
 distributed actor A: P {

--- a/userdocs/diagnostics/conformance-isolation.md
+++ b/userdocs/diagnostics/conformance-isolation.md
@@ -1,0 +1,54 @@
+# Protocol conformances crossing into actor-isolated code
+
+When a type conforms to a protocol, any generic code can perform operations on that type through the protocol. If the operations that the type used to satisfy the protocol requirements are actor-isolated, this may result in a diagnostic indicating that the conformance crosses into actor-isolated code. For example:
+
+```swift
+protocol P {
+  func f()
+}
+
+@MainActor
+struct MyData: P {
+  func f() { }
+}
+```
+
+This code will produce an error similar to:
+
+```swift
+| @MainActor
+| struct MyData: P {
+|        |- error: conformance of 'MyData' to protocol 'P' crosses into main actor-isolated code and can cause data races
+|        |- note: isolate this conformance to the main actor with '@MainActor'
+|        |- note: mark all declarations used in the conformance 'nonisolated'
+|        `- note: turn data races into runtime errors with '@preconcurrency'
+|   func f() { }
+|        `- note: main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'
+| }
+```
+
+There are several options for resolving this error, as indicated by the notes:
+
+* If all of the operations used to satisfy the protocol's requirements are on the same global actor (such as the main actor), the conformance itself can be isolated to that global actor. This allows the conformance to be used inside code running on that actor, but it cannot be used concurrency. A conformance can be isolated to a global actor the same way as anything else in the language, e.g.,
+```swift
+@MainActor
+struct MyData: @MainActor P {
+  func f() { }
+}
+```
+
+* If the conformance needs to be usable anywhere, then each of the operations used to satisfy its requirements must be marked `nonisolated`. This means that they will not have access to any actor-specific operations or state, because these operations can be called concurrently from anywhere. The result would look like this:
+```swift
+@MainActor
+struct MyData: P {
+  nonisolated func f() { }
+}
+```
+
+* If the protocol requirements themselves are meant to always be used from the correct isolation domain (for example, the main actor) but the protocol itself did not describe that requirement, the conformance can be marked with `@preconcurrency`. This approach moves isolation checking into a run-time assertion, which will produce a fatal error if an operation is called without already being on the right actor. A `@preconcurrency` conformance can be written as follows:
+```swift
+@MainActor
+struct MyData: @preconcurrency P {
+  func f() { }
+}
+```

--- a/userdocs/diagnostics/conformance-isolation.md
+++ b/userdocs/diagnostics/conformance-isolation.md
@@ -23,7 +23,7 @@ This code will produce an error similar to:
 |        |- note: mark all declarations used in the conformance 'nonisolated'
 |        `- note: turn data races into runtime errors with '@preconcurrency'
 |   func f() { }
-|        `- note: main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'
+|        `- note: main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement
 | }
 ```
 


### PR DESCRIPTION
A protocol conformance can be ill-formed due to isolation mismatches
between witnesses and requirements, or with associated conformances.
Previously, such failures would be emitted as a number of separate
errors (downgraded to warnings in Swift 5), one for each witness and
potentially an extra for associated conformances. The rest was a
potential flood of diagnostics that was hard to sort through.

Collect all of the isolation-related problems for a given conformance
together and produce a single error (downgraded to a warning when
appropriate) that describes the overall issue. That error will have up
to three notes suggesting specific courses of action:
* Isolating the conformance (when the experimental feature is enabled)
* Marking the witnesses as 'nonisolated' where needed
* Marking the conformance as '@preconcurrency'

The diagnostic also has notes to point out the witnesses/associated
conformances that have isolation problems. There is a new educational
note that also describes these options.

The diagnostic looks like this:

```
13 | 
14 | @MainActor
15 | final class C: P {
   |             |  |- error: conformance of 'C' to protocol 'P' crosses into main actor-isolated code and can cause data races [#conformance-isolation]
   |             |  |- note: isolate this conformance to the main actor with '@MainActor'
   |             |  `- note: turn data races into runtime errors with '@preconcurrency'
   |             `- note: mark all declarations used in the conformance 'nonisolated'
16 |   var v = 3
   |       `- note: main actor-isolated property 'v' cannot be used to satisfy nonisolated requirement from protocol 'P'
17 |   
18 |   init() {}
19 | 
20 |   func f() { }
   |        `- note: main actor-isolated instance method 'f()' cannot be used to satisfy nonisolated requirement from protocol 'P'
21 |   func g() { }
   |        `- note: main actor-isolated instance method 'g()' cannot be used to satisfy nonisolated requirement from protocol 'P'
22 | }
```

We give the same treatment to missing 'distributed' on witnesses to a
distributed protocol.

