### PR TITLE
[test] Isolate swift_build_support.swift testing

### DIFF
--- a/validation-test/Python/swift_build_support.swift
+++ b/validation-test/Python/swift_build_support.swift
@@ -7,4 +7,5 @@
 // UNSUPPORTED: OS=tvos
 // UNSUPPORTED: OS=watchos
 
-// RUN: %{python} %utils/swift_build_support/run_tests.py
+// RUN: %empty-directory(%t)
+// RUN: env SWIFT_BUILD_ROOT=%t %{python} %utils/swift_build_support/run_tests.py


### PR DESCRIPTION
The test was using the default value for SWIFT_BUILD_ROOT, which tried to write into `.build_script_log`. Use an environment variable so the tests use their own directory and write files that do not append to the actual `.build_script_log`.

Follow up to #80102