### PR TITLE
[cxx-interop] Do not create mutating properties for classes

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -129,7 +129,8 @@ static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
       params, voidTy, importedDecl, clangNode);
   setterDecl->setIsObjC(false);
   setterDecl->setIsDynamic(false);
-  setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
+  if (!isa<ClassDecl>(importedDecl))
+    setterDecl->setSelfAccessKind(SelfAccessKind::Mutating);
   setterDecl->setAccess(importedFieldDecl->getFormalAccess());
 
   return setterDecl;

--- a/test/Interop/Cxx/class/inline-function-codegen/Inputs/method-calls-function.h
+++ b/test/Interop/Cxx/class/inline-function-codegen/Inputs/method-calls-function.h
@@ -9,4 +9,18 @@ struct Incrementor {
 
 inline int callMethod(int value) { return Incrementor().callIncrement(value); }
 
+class __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")))
+__attribute__((swift_attr("unsafe"))) Cell {
+public:
+  bool is_marked() const { return m_marked; }
+  void set_marked(bool b) { m_marked = b; }
+
+private:
+  bool m_marked : 1 {false};
+};
+
+inline Cell *_Nonnull createCell() { return new Cell{}; }
+
 #endif // TEST_INTEROP_CXX_CLASS_INLINE_FUNCTION_THROUGH_MEMBER_INPUTS_METHOD_CALLS_FUNCTION_H

--- a/test/Interop/Cxx/class/inline-function-codegen/method-calls-function-execution.swift
+++ b/test/Interop/Cxx/class/inline-function-codegen/method-calls-function-execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default -Xcc -std=c++20 -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test
 
@@ -9,6 +9,13 @@ var MembersTestSuite = TestSuite("MembersTestSuite")
 
 MembersTestSuite.test("method calls function") {
   expectEqual(42, callMethod(41))
+}
+
+func doSomethingWith(_ s: Cell) { s.set_marked(true) }
+
+MembersTestSuite.test("method sets bitfield") {
+  let s = createCell()
+  doSomethingWith(s)
 }
 
 runAllTests()


### PR DESCRIPTION
In Swift, only value types can have mutating instance member functions or computed properties. The importer logic was violating this invariant when generating setters for bit fields of shared references.

Fixes #80182
