### PR TITLE
[build-script] Remove ninja host

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -32,7 +32,7 @@ class Ninja(product.Product):
         return False
 
     @classmethod
-    def new_builder(cls, args, toolchain, workspace, host):
+    def new_builder(cls, args, toolchain, workspace):
         return NinjaBuilder(cls, args, toolchain, workspace)
 
 

--- a/utils/swift_build_support/tests/products/test_ninja.py
+++ b/utils/swift_build_support/tests/products/test_ninja.py
@@ -71,8 +71,7 @@ class NinjaTestCase(unittest.TestCase):
         ninja_build = Ninja.new_builder(
             args=self.args,
             toolchain=self.toolchain,
-            workspace=self.workspace,
-            host=self.host)
+            workspace=self.workspace)
 
         self.assertEqual(ninja_build.ninja_bin_path,
                          os.path.join(
@@ -83,8 +82,7 @@ class NinjaTestCase(unittest.TestCase):
         ninja_build = Ninja.new_builder(
             args=self.args,
             toolchain=self.toolchain,
-            workspace=self.workspace,
-            host=self.host)
+            workspace=self.workspace)
 
         ninja_build.build()
 


### PR DESCRIPTION
The ninja builder took a host argument that was unused by the function. The ninja build failed to pass this argument, resulting in an execution failure. Removing the argument.