### PR TITLE
Put float and stddef back inside the ucrt module

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -25,19 +25,6 @@ module _complex [system] [no_undeclared_includes] {
   export *
 }
 
-module _fenv [system] [no_undeclared_includes] {
-  use corecrt
-  use _float
-  header "fenv.h"
-  export *
-}
-
-module _float [system] [no_undeclared_includes] {
-  use corecrt
-  header "float.h"
-  export *
-}
-
 module _stddef [system] [no_undeclared_includes] {
   header "stddef.h"
   export *
@@ -54,8 +41,6 @@ module ucrt [system] {
 
   module C {
     export _complex
-    export _fenv
-    export _float
     export _stddef
     export _stdlib
 
@@ -66,6 +51,16 @@ module ucrt [system] {
 
     module errno {
       header "errno.h"
+      export *
+    }
+
+    module fenv {
+      header "fenv.h"
+      export *
+    }
+
+    module float {
+      header "float.h"
       export *
     }
 


### PR DESCRIPTION
These were split out in #79751. However, this split is not needed for these. Furthermore, modulemaps have bugs when it comes to re-exporting some modules, resulting in missing exports.
