### PR TITLE
Concurrency: handle android similar to Linux

### DIFF
--- a/stdlib/public/Concurrency/PlatformExecutorLinux.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorLinux.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !$Embedded && os(Linux)
+#if !$Embedded && (os(Linux) || os(Android))
 
 import Swift
 


### PR DESCRIPTION
Android should use the dispatch based, Linux platform executor. However, Android reports as `os(Android)` rather than `os(Linux)`. This adjusts the condition to ensure that we have a platform executor factory for Android.