### PR TITLE
[IRGenModule] Fix hash function for FixedLayoutKey

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -2078,7 +2078,7 @@ struct DenseMapInfo<swift::irgen::IRGenModule::FixedLayoutKey> {
 
   static unsigned getHashValue(const FixedLayoutKey &key) {
     return hash_combine(key.size, key.numExtraInhabitants, key.align,
-                        (bool)key.pod, (bool)key.bitwiseTakable);
+                        (bool)key.pod, key.bitwiseTakable);
   }
   static bool isEqual(const FixedLayoutKey &a, const FixedLayoutKey &b) {
     return a.size == b.size


### PR DESCRIPTION
`bitwiseTakable` is not a boolean value and has more than binary value. Don't hash it as bool as it can cause unnecessary hash collision.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
