### PR TITLE
Runtimes: adjust path for referencing SwiftCoreTargets.cmake

### DIFF
--- a/Runtimes/Core/cmake/interface/SwiftCoreConfig.cmake.in
+++ b/Runtimes/Core/cmake/interface/SwiftCoreConfig.cmake.in
@@ -1,5 +1,5 @@
 @PACKAGE_INIT@
-include("${CMAKE_CURRENT_LIST_DIR}/SwiftCoreTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/SwiftCore/SwiftCoreTargets.cmake")
 
 set(SwiftCore_ENABLE_LIBRARY_EVOLUTION @SwiftCore_ENABLE_LIBRARY_EVOLUTION@)
 


### PR DESCRIPTION
This is loaded by the CMake package configuration so that you can add cross-package dependencies. Adjust the path so that the lookup succeeds on all targets.