### PR TITLE
Runtimes: add `_Builtin_float` to the overlay

### DIFF
--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -47,6 +47,7 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
 
+add_subdirectory(clang)
 if(WIN32)
   add_subdirectory(Windows)
 endif()

--- a/Runtimes/Overlay/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/clang/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+gyb_expand(float.swift.gyb float.swift)
+
+add_library(swift_Builtin_float
+  float.swift
+  "${PROJECT_SOURCE_DIR}/linker-support/magic-symbols-for-install-name.c")
+set_target_properties(swift_Builtin_float PROPERTIES
+  Swift_MODULE_NAME _Builtin_float)
+target_compile_options(swift_Builtin_float PRIVATE
+  "$<$<PLATFORM_ID:Darwin>:SHELL:-Xfrontend -module-abi-name -Xfrontend Darwin>")
+
+install(TARGETS swift_Builtin_float
+  ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+emit_swift_interface(swift_Builtin_float)
+install_swift_interface(swift_Builtin_float)
+
+embed_manifest(swift_Builtin_float)

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -98,6 +98,12 @@ copy_files("" "Core" FILES "Info.plist.in")
 
 # Platform Overlays
 
+# Copy magic linker symbols
+copy_library_sources("linker-support" "" "Overlay")
+
+message(STATUS "Clang[${StdlibSources}/public/ClangOverlays] -> ${CMAKE_CURRENT_LIST_DIR}/Overlay/clang")
+copy_files(public/ClangOverlays Overlay/clang FILES float.swift.gyb)
+
 # Windows Overlay
 message(STATUS "WinSDK[${StdlibSources}/public/Windows] -> ${CMAKE_CURRENT_LIST_DIR}/Overlay/Windows/WinSDK")
 copy_files(public/Windows Overlay/Windows/WinSDK FILES WinSDK.swift)


### PR DESCRIPTION
This adds the missing `_Builtin_float` module to the overlay project. This module is applicable to all platforms.