### PR TITLE
Runtimes: reorganise flags for swiftCore

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -250,8 +250,6 @@ if(NOT LINUX AND NOT ANDROID)
   target_sources(swiftCore PRIVATE ObjectIdentifier+DebugDescription.swift)
 endif()
 
-set_target_properties(swiftCore PROPERTIES Swift_MODULE_NAME Swift)
-
 if(SwiftCore_ENABLE_COMMANDLINE_SUPPORT)
   target_sources(swiftCore PRIVATE CommandLine.swift)
   target_link_libraries(swiftCore PRIVATE swiftCommandLineSupport)
@@ -271,11 +269,18 @@ if(SwiftCore_ENABLE_VECTOR_TYPES)
     "${CMAKE_CURRENT_BINARY_DIR}/SIMDVectorTypes.swift")
 endif()
 
-if(APPLE AND BUILD_SHARED_LIBS)
-  target_link_options(swiftCore PRIVATE "SHELL:-Xlinker -headerpad_max_install_names")
-endif()
+set_target_properties(swiftCore PROPERTIES Swift_MODULE_NAME Swift)
+
+target_compile_definitions(swiftCore
+  PRIVATE
+    $<$<BOOL:${SwiftCore_ENABLE_REFLECTION}>:-DSWIFT_ENABLE_REFLECTION>
+    $<$<BOOL:${SwiftCore_ENABLE_COMPACT_ABSOLUTE_FUNCTION_POINTERS}>:-DSWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER>
+    $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_TARGET_LIBRARY_NAME=swiftCore>
+  INTERFACE
+    $<$<BOOL:${SwiftCore_ENABLE_VECTOR_TYPES}>:-DSWIFT_STDLIB_ENABLE_VECTOR_TYPES>)
 
 target_compile_options(swiftCore PRIVATE
+  "$<$<AND:$<COMPILE_LANGUAGE:Swift>,$<BOOL:${BUILD_SHARED_LIBS}>>:SHELL:-Xcc -DswiftCore_EXPORTS>"
   # STAGING: Temporarily avoids having to write #fileID in Swift.swiftinterface.
   # see also 327ea8bce2d1107a847d444651b19ca6a2901c9e
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -enable-experimental-concise-pound-file>"
@@ -293,16 +298,6 @@ if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xllvm -sil-partial-specialization>")
 endif()
 
-target_compile_definitions(swiftCore
-  PRIVATE
-    $<$<BOOL:${SwiftCore_ENABLE_REFLECTION}>:-DSWIFT_ENABLE_REFLECTION>
-    $<$<BOOL:${SwiftCore_ENABLE_COMPACT_ABSOLUTE_FUNCTION_POINTERS}>:-DSWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER>
-    $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_TARGET_LIBRARY_NAME=swiftCore>
-  INTERFACE
-    $<$<BOOL:${SwiftCore_ENABLE_VECTOR_TYPES}>:-DSWIFT_STDLIB_ENABLE_VECTOR_TYPES>)
-target_compile_options(swiftCore PRIVATE
-  "$<$<AND:$<BOOL:${BUILD_SHARED_LIBS}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xcc -DswiftCore_EXPORTS>")
-
 target_link_libraries(swiftCore
   PRIVATE
     swiftRuntime
@@ -313,8 +308,7 @@ target_link_libraries(swiftCore
     $<$<NOT:$<PLATFORM_ID:Darwin>>:swiftrt$<$<PLATFORM_ID:Windows>:T>>
   PUBLIC
     swiftShims)
-target_link_options(swiftCore PUBLIC
-  $<$<LINK_LANGUAGE:Swift>:-nostartfiles>)
+
 string(TOLOWER "${SwiftCore_OBJECT_FORMAT}" SwiftCore_OBJECT_FORMAT_lc)
 if("${SwiftCore_OBJECT_FORMAT_lc}" STREQUAL "elf")
   target_link_libraries(swiftCore INTERFACE
@@ -323,6 +317,10 @@ elseif("${SwiftCore_OBJECT_FORMAT_lc}" STREQUAL "coff")
   target_link_libraries(swiftCore INTERFACE
     swiftrt$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:T>)
 endif()
+
+target_link_options(swiftCore PUBLIC
+  $<$<LINK_LANGUAGE:Swift>:-nostartfiles>)
+
 if(NOT POLICY CMP0157)
   target_compile_options(swiftCore PRIVATE
     $<TARGET_OBJECTS:swiftRuntime>
@@ -335,6 +333,10 @@ endif()
 if(NOT ANDROID AND NOT APPLE AND NOT LINUX AND NOT WIN32 AND UNIX)
   find_library(EXECINFO_LIBRARY execinfo)
   target_link_libraries(swiftCore PRIVATE "${EXECINFO_LIBRARY}")
+endif()
+
+if(APPLE AND BUILD_SHARED_LIBS)
+  target_link_options(swiftCore PRIVATE "SHELL:-Xlinker -headerpad_max_install_names")
 endif()
 
 install(TARGETS swiftCore


### PR DESCRIPTION
This re-organises the file a small amount to put the source listing and additions together. Subsequently, apply compile definitions, options, and then link libraries and finally options