### PR TITLE
Implement experimental feature InferIsolatedConformances

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -496,7 +496,6 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CustomAvailability, true)
 /// Be strict about the Sendable conformance of metatypes.
 EXPERIMENTAL_FEATURE(StrictSendableMetatypes, true)
 
-
 /// Allow public enumerations to be extensible by default
 /// regardless of whether the module they are declared in
 /// is resilient or not.
@@ -504,6 +503,9 @@ EXPERIMENTAL_FEATURE(ExtensibleEnums, true)
 
 /// Allow isolated conformances.
 EXPERIMENTAL_FEATURE(IsolatedConformances, true)
+
+/// Infer conformance isolation on global-actor-conforming types.
+EXPERIMENTAL_FEATURE(InferIsolatedConformances, true)
 
 /// Allow SwiftSettings
 EXPERIMENTAL_FEATURE(SwiftSettings, false)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -331,6 +331,7 @@ UNINTERESTING_FEATURE(ReinitializeConsumeInMultiBlockDefer)
 UNINTERESTING_FEATURE(SE427NoInferenceOnExtension)
 UNINTERESTING_FEATURE(TrailingComma)
 UNINTERESTING_FEATURE(RawIdentifiers)
+UNINTERESTING_FEATURE(InferIsolatedConformances)
 
 static ABIAttr *getABIAttr(Decl *decl) {
   if (auto pbd = dyn_cast<PatternBindingDecl>(decl))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -920,6 +920,9 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_strict_memory_safety))
     Opts.enableFeature(Feature::StrictMemorySafety);
 
+  if (Opts.hasFeature(Feature::UnspecifiedMeansMainActorIsolated))
+    Opts.enableFeature(Feature::InferIsolatedConformances);
+
   return HadError;
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4113,7 +4113,8 @@ namespace {
       }
 
       if (auto *macro = dyn_cast<MacroExpansionExpr>(expr)) {
-        expr = macro->getRewritten();
+        if (auto rewritten = macro->getRewritten())
+          expr = rewritten;
       }
 
       if (auto *isolation = dyn_cast<CurrentContextIsolationExpr>(expr)) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7924,15 +7924,14 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
   if (getActorIsolation(rootNormal->getProtocol()).isActorIsolated())
     return ActorIsolation::forNonisolated(false);
 
-  // In a context where we are inferring @MainActor, if the conforming type
-  // is on the main actor, then the conformance is, too.
+  // If we are inferring isolated conformances and the conforming type is
+  // isolated to a global actor,
   auto nominal = dc->getSelfNominalTypeDecl();
-  if (ctx.LangOpts.hasFeature(Feature::UnspecifiedMeansMainActorIsolated) &&
+  if (ctx.LangOpts.hasFeature(Feature::InferIsolatedConformances) &&
       nominal) {
     auto nominalIsolation = getActorIsolation(nominal);
-    if (nominalIsolation.isMainActor()) {
+    if (nominalIsolation.isGlobalActor())
       return nominalIsolation;
-    }
   }
 
   return ActorIsolation::forNonisolated(false);


### PR DESCRIPTION
Introduce the experimental feature InferIsolatedConformances to align
with the upcoming feature proposed in [SE-0470](https://swiftlang.github.io/swift-evolution/#?proposal=SE-0470). This is a slight
generalization of the main-actor-specific inference that was already
in place for the default-main-actor mode from [SE-0466](https://swiftlang.github.io/swift-evolution/#?proposal=SE-0466). Note that, as
specified in [SE-0470](https://swiftlang.github.io/swift-evolution/#?proposal=SE-0470), InferIsolatedConformances is implied by the
default-main-actor mode.