### PR TITLE
Runtimes: add an export for ConcurrencyInternalShims

### DIFF
--- a/Runtimes/Core/Concurrency/InternalShims/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/InternalShims/CMakeLists.txt
@@ -1,3 +1,8 @@
 add_library(swiftConcurrencyInternalShims INTERFACE)
 target_include_directories(swiftConcurrencyInternalShims INTERFACE
-  ${CMAKE_CURRENT_SOURCE_DIR})
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+install(TARGETS swiftConcurrencyInternalShims
+  EXPORT SwiftCoreTargets
+  COMPONENT SwiftCore_runtime)
+


### PR DESCRIPTION
This is required to use the SwiftCore package externally via `find_package` when Concurrency is enabled. We are otherwise unable to process the CMakeLists due to the missing dependency from the export set.