### PR TITLE
Add #objectFormat compilation conditional (SE-0492)

### DIFF
--- a/include/swift/AST/PlatformConditionKinds.def
+++ b/include/swift/AST/PlatformConditionKinds.def
@@ -49,5 +49,8 @@ PLATFORM_CONDITION_(PtrAuth, "ptrauth")
 /// The active arch target's max atomic bit width.
 PLATFORM_CONDITION_(HasAtomicBitWidth, "hasAtomicBitWidth")
 
+/// The active target's file format (Mach-O, ELF, COFF, WASM)
+PLATFORM_CONDITION_(ObjectFileFormat, "objectFormat")
+
 #undef PLATFORM_CONDITION
 #undef PLATFORM_CONDITION_

--- a/include/swift/AST/PlatformConditionKinds.def
+++ b/include/swift/AST/PlatformConditionKinds.def
@@ -50,7 +50,7 @@ PLATFORM_CONDITION_(PtrAuth, "ptrauth")
 PLATFORM_CONDITION_(HasAtomicBitWidth, "hasAtomicBitWidth")
 
 /// The active target's file format (Mach-O, ELF, COFF, WASM)
-PLATFORM_CONDITION_(ObjectFileFormat, "objectFormat")
+PLATFORM_CONDITION(ObjectFileFormat, "objectFormat")
 
 #undef PLATFORM_CONDITION
 #undef PLATFORM_CONDITION_

--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -120,6 +120,10 @@ struct CompilerBuildConfiguration: BuildConfiguration {
     staticBuildConfiguration.targetPointerBitWidth
   }
 
+  func isActiveTargetObjectFormat(name: String) throws -> Bool {
+    try staticBuildConfiguration.isActiveTargetObjectFormat(name: name)
+  }
+
   var targetAtomicBitWidths: [Int] {
     staticBuildConfiguration.targetAtomicBitWidths
   }

--- a/lib/ASTGen/Sources/ASTGen/EmbeddedSupport.swift
+++ b/lib/ASTGen/Sources/ASTGen/EmbeddedSupport.swift
@@ -124,6 +124,10 @@ struct EmbeddedBuildConfiguration: BuildConfiguration {
     return configuration.targetPointerBitWidth
   }
 
+  func isActiveTargetObjectFormat(name: String) throws -> Bool {
+    return try configuration.isActiveTargetObjectFormat(name: name)
+  }
+
   var targetAtomicBitWidths: [Int] {
     return configuration.targetAtomicBitWidths
   }

--- a/lib/Basic/LangOptionsBridging.cpp
+++ b/lib/Basic/LangOptionsBridging.cpp
@@ -228,6 +228,7 @@ void BridgedLangOptions_enumerateBuildConfigurationEntries(
 
       case PlatformConditionKind::Endianness:
       case PlatformConditionKind::PointerBitWidth:
+      case PlatformConditionKind::ObjectFileFormat:
       case PlatformConditionKind::CanImport:
       case PlatformConditionKind::HasAtomicBitWidth:
         // Handled separately.

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -385,7 +385,7 @@ public:
       return E;
     }
 
-    // ( 'os' | 'arch' | '_endian' | '_pointerBitWidth' | '_runtime' | '_hasAtomicBitWidth' ) '(' identifier ')''
+    // ( 'os' | 'arch' | '_endian' | '_pointerBitWidth' | '_runtime' | '_hasAtomicBitWidth' | 'objectFormat' ) '(' identifier ')''
     auto Kind = getPlatformConditionKind(*KindName);
     if (!Kind.has_value()) {
       D.diagnose(E->getLoc(), diag::unsupported_platform_condition_expression);
@@ -429,6 +429,8 @@ public:
         DiagName = "pointer authentication scheme"; break;
       case PlatformConditionKind::HasAtomicBitWidth:
         DiagName = "has atomic bit width"; break;
+      case PlatformConditionKind::ObjectFileFormat:
+        DiagName = "object file format"; break;
       case PlatformConditionKind::Runtime:
         llvm_unreachable("handled above");
       }

--- a/test/Parse/ConditionalCompilation/object_file_format.swift
+++ b/test/Parse/ConditionalCompilation/object_file_format.swift
@@ -1,0 +1,11 @@
+// RUN: %swift -typecheck %s -verify -target arm64-apple-none-macho -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target arm64-apple-none-elf -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target wasm32-unknown-wasi -parse-stdlib
+// RUN: %swift -typecheck %s -verify -target x86_64-unknown-windows-msvc -parse-stdlib
+// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm64-apple-macos
+
+#if objectFormat(MachO) || objectFormat(ELF) || objectFormat(Wasm) || objectFormat(COFF)
+class C {}
+var x = C()
+#endif
+var y = x

--- a/test/Parse/ConditionalCompilation/object_file_format.swift
+++ b/test/Parse/ConditionalCompilation/object_file_format.swift
@@ -1,11 +1,48 @@
-// RUN: %swift -typecheck %s -verify -target arm64-apple-none-macho -parse-stdlib
-// RUN: %swift -typecheck %s -verify -target arm64-apple-none-elf -parse-stdlib
-// RUN: %swift -typecheck %s -verify -target wasm32-unknown-wasi -parse-stdlib
-// RUN: %swift -typecheck %s -verify -target x86_64-unknown-windows-msvc -parse-stdlib
-// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm64-apple-macos
+// RUN: %swift -typecheck %s -target arm64-apple-none-macho -parse-stdlib 2>&1 | %FileCheck -check-prefix CHECK-MACHO %s
+// RUN: %swift -typecheck %s -target arm64-apple-none-elf -parse-stdlib 2>&1 | %FileCheck -check-prefix CHECK-ELF %s
+// RUN: %swift -typecheck %s -target wasm32-unknown-wasi -parse-stdlib 2>&1 | %FileCheck -check-prefix CHECK-WASM %s
+// RUN: %swift -typecheck %s -target x86_64-unknown-windows-msvc -parse-stdlib 2>&1 | %FileCheck -check-prefix CHECK-COFF %s
 
-#if objectFormat(MachO) || objectFormat(ELF) || objectFormat(Wasm) || objectFormat(COFF)
-class C {}
-var x = C()
+#if objectFormat(MachO)
+#warning("I'm MachO")
+#else
+#warning("I'm not MachO")
 #endif
-var y = x
+
+#if objectFormat(ELF)
+#warning("I'm ELF")
+#else
+#warning("I'm not ELF")
+#endif
+
+#if objectFormat(Wasm)
+#warning("I'm Wasm")
+#else
+#warning("I'm not Wasm")
+#endif
+
+#if objectFormat(COFF)
+#warning("I'm COFF")
+#else
+#warning("I'm not COFF")
+#endif
+
+// CHECK-MACHO: I'm MachO
+// CHECK-MACHO: I'm not ELF
+// CHECK-MACHO: I'm not Wasm
+// CHECK-MACHO: I'm not COFF
+
+// CHECK-ELF: I'm not MachO
+// CHECK-ELF: I'm ELF
+// CHECK-ELF: I'm not Wasm
+// CHECK-ELF: I'm not COFF
+
+// CHECK-WASM: I'm not MachO
+// CHECK-WASM: I'm not ELF
+// CHECK-WASM: I'm Wasm
+// CHECK-WASM: I'm not COFF
+
+// CHECK-COFF: I'm not MachO
+// CHECK-COFF: I'm not ELF
+// CHECK-COFF: I'm not Wasm
+// CHECK-COFF: I'm COFF


### PR DESCRIPTION
This implements the relevant part of the "Section Placement" proposal (draft: https://github.com/kubamracek/swift-evolution/blob/section-placement-control/proposals/0nnn-section-control.md, forum thread: https://forums.swift.org/t/pitch-3-section-placement-control/77435). Namely the ability to conditionalize on the object file format that the compiler is targeting (MachO, ELF, COFF of Wasm).

Adding with an underscored name (`#_objectFileFormat`) until the proposal is codified.

rdar://147505228
