### PR TITLE
[Backtracing] Rename `unsafeFirst` to `consumingFirst`.

### DIFF
--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -211,7 +211,7 @@ extension Sequence {
   /// This is not, in general, a safe thing to do, because the sequence might
   /// not be restartable.  For the cases where we're using it here, it's OK
   /// though.
-  public var unsafeFirst: Element? {
+  var consumingFirst: Element? {
     var iterator = makeIterator()
     return iterator.next()
   }

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -1008,14 +1008,14 @@ Generate a backtrace for the parent process.
           let formatter = backtraceFormatter()
           switch thread.backtrace {
             case let .raw(backtrace):
-              if let frame = backtrace.frames.unsafeFirst {
+              if let frame = backtrace.frames.consumingFirst {
                 let formatted = formatter.format(frame: frame)
                 writeln("\(formatted)")
               }
             case let .symbolicated(backtrace):
               if let frame = backtrace.frames.drop(while: {
                 $0.isSwiftRuntimeFailure
-              }).unsafeFirst {
+              }).consumingFirst {
                 let formatted = formatter.format(frame: frame)
                 writeln("\(formatted)")
               }
@@ -1087,7 +1087,7 @@ Generate a backtrace for the parent process.
 
             switch thread.backtrace {
               case let .raw(backtrace):
-                if let frame = backtrace.frames.unsafeFirst {
+                if let frame = backtrace.frames.consumingFirst {
                   rows += formatter.formatRows(
                     frame: frame
                   ).map{ row in
@@ -1103,7 +1103,7 @@ Generate a backtrace for the parent process.
               case let .symbolicated(backtrace):
                 if let frame = backtrace.frames.drop(while: {
                   $0.isSwiftRuntimeFailure
-                }).unsafeFirst {
+                }).consumingFirst {
                   rows += formatter.formatRows(
                     frame: frame
                   ).map{ row in


### PR DESCRIPTION
This seems like a better name.
