### PR TITLE
Serialization: Skip invalid `@available` attributes during lazy serialization

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3093,7 +3093,11 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
     case DeclAttrKind::Available: {
       auto theAttr = D->getSemanticAvailableAttr(cast<AvailableAttr>(DA));
-      assert(theAttr);
+
+      // In lazy typechecking mode, it's possible that we just discovered that
+      // the attribute is invalid.
+      if (!theAttr)
+        return;
 
       ENCODE_VER_TUPLE(Introduced, theAttr->getIntroduced())
       ENCODE_VER_TUPLE(Deprecated, theAttr->getDeprecated())

--- a/test/Serialization/lazy-typecheck-rdar147539902.swift
+++ b/test/Serialization/lazy-typecheck-rdar147539902.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -swift-version 5 %s -module-name lazy_typecheck -enable-library-evolution -parse-as-library -emit-module -emit-module-path /dev/null -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-exportable-decls
+
+public protocol P {
+  func req()
+}
+
+@available(macOS, renamed: "P")
+@available(iOS, renamed: "P")
+@available(tvOS, renamed: "P")
+@available(watchOS, renamed: "P")
+@available(visionOS, renamed: "P")
+public typealias Q = P


### PR DESCRIPTION
When performing lazy module serialization, we may be making the first attempt to turn an `AvailableAttr` into a `SemanticAvailableAttr`. If it turns out the attribute is invalid at that point, we need to skip it instead of assuming that the attribute will always be valid there.

Resolves rdar://147539902.
