### PR TITLE
[StdlibUnittest] add a TestRunPredicate for WASI

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2444,6 +2444,8 @@ public enum TestRunPredicate : CustomStringConvertible {
 
   case haikuAny(reason: String)
 
+  case wasiAny(reason: String)
+
   case objCRuntime(/*reason:*/ String)
   case nativeRuntime(/*reason:*/ String)
 
@@ -2564,6 +2566,9 @@ public enum TestRunPredicate : CustomStringConvertible {
 
     case .haikuAny(reason: let reason):
       return "haikuAny(*, reason: \(reason))"
+
+    case .wasiAny(reason: let reason):
+      return "wasiAny(*, reason: \(reason))"
 
     case .objCRuntime(let reason):
       return "Objective-C runtime, reason: \(reason))"
@@ -2942,6 +2947,14 @@ public enum TestRunPredicate : CustomStringConvertible {
     case .haikuAny:
       switch _getRunningOSVersion() {
       case .haiku:
+        return true
+      default:
+        return false
+      }
+
+    case .wasiAny:
+      switch _getRunningOSVersion() {
+      case .wasi:
         return true
       default:
         return false

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -131,9 +131,8 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
   expectEqual(array2, array1)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow") {
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 30,
     alignment: MemoryLayout<UInt64>.alignment
@@ -152,7 +151,8 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow") {
   expectEqualSequence([5, 4, 3],bound)
 }
 
-UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 30,
     alignment: MemoryLayout<UInt64>.alignment
@@ -170,7 +170,6 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
   expected.withUnsafeBytes { expectEqualSequence($0,buffer[0..<idx]) }
   expectEqualSequence([5, 4, 3],bound)
 }
-#endif
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
@@ -187,15 +186,13 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
   expectEqualSequence([5, 4, 3],bound)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr") {
+UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).invalidNilPtr")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
   let source: [Int64] = [5, 4, 3, 2, 1]
   expectCrashLater()
   _ = buffer.initializeMemory(as: Int64.self, from: source)
 }
-#endif
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).validNilPtr") {
   let buffer = UnsafeMutableRawBufferPointer(start: nil, count: 0)
@@ -305,9 +302,8 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
   expectEqualSequence(firstHalf, secondHalf)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -323,7 +319,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
   _ = bytes[-1]
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -339,7 +336,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow") {
   _ = bytes[1]
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -355,7 +353,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
   bytes[-1] = 0
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 2,
     alignment: MemoryLayout<UInt>.alignment
@@ -371,7 +370,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
   bytes[1] = 0
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -387,7 +387,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow") {
   _ = bytes[-1..<1]
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -403,7 +404,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
   _ = bytes[1..<3]
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -419,7 +421,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
   bytes[-1..<1] = bytes[0..<2]
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -436,7 +439,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
   bytes[1..<3] = bytes[0..<2]
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -450,7 +454,8 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
   buffer[0..<3] = buffer[0..<2]
 }
 
-UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
+UnsafeRawBufferPointerTestSuite.test("subscript.range.wide")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -463,7 +468,6 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
   // Performs a valid byte-wise copy but triggers a debug bounds check.
   buffer[0..<2] = buffer[0..<3]
 }
-#endif
 
 UnsafeRawBufferPointerTestSuite.test("_copyContents") {
   let a = Array<UInt8>(0..<20)
@@ -477,9 +481,8 @@ UnsafeRawBufferPointerTestSuite.test("_copyContents") {
   expectEqual(written, a.count)
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
+UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -495,7 +498,6 @@ UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
   UnsafeMutableRawBufferPointer(rebasing: bytes).copyMemory(
       from: UnsafeRawBufferPointer(buffer))
 }
-#endif
 
 // Use copyBytes without contiguous storage
 UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguousStorage") {
@@ -510,9 +512,8 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguousStorage") {
   }
 }
 
-#if !os(WASI)
-// Trap tests aren't available on WASI.
-UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
+UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI.")).code {
   let buffer = UnsafeMutableRawBufferPointer.allocate(
     byteCount: 3,
     alignment: MemoryLayout<UInt>.alignment
@@ -530,6 +531,7 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.before")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition."))
@@ -542,6 +544,7 @@ UnsafeRawBufferPointerTestSuite.test("load.before")
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.after")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -566,6 +569,7 @@ UnsafeRawBufferPointerTestSuite.test("load.aligned") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("load.invalid")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom({ !_isDebugAssertConfiguration() }, // require debugAssert
               reason: "This tests a debug precondition.."))
 .code {
@@ -594,6 +598,7 @@ UnsafeRawBufferPointerTestSuite.test("load.unaligned")
 }
 
 UnsafeRawBufferPointerTestSuite.test("store.before")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -605,6 +610,7 @@ UnsafeRawBufferPointerTestSuite.test("store.before")
   }
 }
 UnsafeRawBufferPointerTestSuite.test("store.after")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -641,6 +647,7 @@ UnsafeRawBufferPointerTestSuite.test("store.unaligned")
 }
 
 UnsafeRawBufferPointerTestSuite.test("store.invalid")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom({ !_isDebugAssertConfiguration() }, // require debugAssert
               reason: "This tests a debug precondition.."))
 .require(.stdlib_5_7)
@@ -666,6 +673,7 @@ UnsafeRawBufferPointerTestSuite.test("store.valid") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -682,6 +690,7 @@ UnsafeRawBufferPointerTestSuite.test("copy.bytes.overflow")
 }
 
 UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
+.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
     { !_isDebugAssertConfiguration() },
     reason: "This tests a debug precondition.."))
@@ -695,7 +704,6 @@ UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
     }
   }
 }
-#endif
 
 UnsafeRawBufferPointerTestSuite.test("copy.overlap") {
   let bytes = UnsafeMutableRawBufferPointer.allocate(


### PR DESCRIPTION
Many tests are conditionally excluded from compilation on WASI, and this is error-prone. Tests should instead be explicitly skipped in each case. By doing this on only one file, several wrongly-excluded test cases are restored to the WASI test suite.