### PR TITLE
[ASTGen] Improve diagnostic infrastructure

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/Sources/ASTGen/CMakeLists.txt
@@ -7,6 +7,7 @@ add_pure_swift_host_library(swiftASTGen STATIC CXX_INTEROP
   CompilerBuildConfiguration.swift
   DeclAttrs.swift
   Decls.swift
+  DiagnosticMessages.swift
   Diagnostics.swift
   DiagnosticsBridge.swift
   Exprs.swift

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -389,10 +389,12 @@ extension ASTGenVisitor {
   ///   @abi(func fn())
   ///   ```
   func generateABIAttr(attribute node: AttributeSyntax) -> BridgedABIAttr? {
-    guard
-      let arg = node.arguments?.as(ABIAttributeArgumentsSyntax.self)
-    else {
-      // TODO: diagnose
+    guard let arg = node.arguments else {
+      self.diagnose(.expectedArgumentsInAttribute(node))
+      return nil
+    }
+    guard let arg = arg.as(ABIAttributeArgumentsSyntax.self) else {
+      self.diagnose(.unexpectedArgumentsTypeInAttribute(node, arguments: arg, expected: ABIAttributeArgumentsSyntax.self))
       return nil
     }
 
@@ -435,6 +437,7 @@ extension ASTGenVisitor {
   ///   @_alignment(8)
   ///   ```
   func generateAlignmentAttr(attribute node: AttributeSyntax) -> BridgedAlignmentAttr? {
+    // FIXME: Should be LabeledExprListSyntax arguments.
     guard
       let arg = node.arguments?.as(TokenSyntax.self)
     else {
@@ -512,6 +515,7 @@ extension ASTGenVisitor {
     }
 
     return self.generateAvailableAttr(
+      attribute: node,
       atLoc: self.generateSourceLoc(node.atSign),
       range: self.generateAttrSourceRange(node),
       attrName: attrName,
@@ -924,7 +928,7 @@ extension ASTGenVisitor {
     // FIXME: SwiftParser should parse the argument as LabeledExprListArguments
     return self.generateWithLabeledExprListArguments(attribute: node) { args in
       // Exposure kind.
-      let kind: BridgedExposureKind? = self.generateConsumingPlainIdentifierAttrOption(args: &args) {
+      let kind: BridgedExposureKind? = self.generateConsumingPlainIdentifierAttrOption(attribute: node, args: &args) {
         switch $0.rawText {
         case "Cxx":
           return .cxx
@@ -939,7 +943,8 @@ extension ASTGenVisitor {
       }
 
       // Name.
-      let name = self.generateConsumingSimpleStringLiteralAttrOption(args: &args) ?? ""
+      let name = self.generateConsumingSimpleStringLiteralAttrOption(attribute: node, args: &args) ?? ""
+      // TODO: Diagnose if nil.
 
       return .createParsed(
         self.ctx,
@@ -959,7 +964,7 @@ extension ASTGenVisitor {
   ///   ```
   func generateExternAttr(attribute node: AttributeSyntax) -> BridgedExternAttr? {
     return self.generateWithLabeledExprListArguments(attribute: node) { args in
-      let kind: BridgedExternKind? = self.generateConsumingPlainIdentifierAttrOption(args: &args) {
+      let kind: BridgedExternKind? = self.generateConsumingPlainIdentifierAttrOption(attribute: node, args: &args, example: "c") {
         switch $0.rawText {
         case "c":
           return .C
@@ -979,12 +984,12 @@ extension ASTGenVisitor {
       switch kind {
       case .C:
         moduleName = nil
-        symbolName = args.isEmpty ? nil : self.generateConsumingSimpleStringLiteralAttrOption(args: &args)
+        symbolName = args.isEmpty ? nil : self.generateConsumingSimpleStringLiteralAttrOption(attribute: node, args: &args)
       case .wasm:
-        guard let _moduleName = self.generateConsumingSimpleStringLiteralAttrOption(args: &args, label: "module") else {
+        guard let _moduleName = self.generateConsumingSimpleStringLiteralAttrOption(attribute: node, args: &args, label: "module") else {
           return nil
         }
-        guard let _symbolName = self.generateConsumingSimpleStringLiteralAttrOption(args: &args, label: "name") else {
+        guard let _symbolName = self.generateConsumingSimpleStringLiteralAttrOption(attribute: node, args: &args, label: "name") else {
           return nil
         }
 
@@ -1011,7 +1016,8 @@ extension ASTGenVisitor {
   ///   ```
   func generateSectionAttr(attribute node: AttributeSyntax) -> BridgedSectionAttr? {
     return self.generateWithLabeledExprListArguments(attribute: node) { args in
-      guard let name = self.generateConsumingSimpleStringLiteralAttrOption(args: &args) else {
+      guard let name = self.generateConsumingSimpleStringLiteralAttrOption(attribute: node, args: &args) else {
+        // TODO: Diagnose if nil.
         return nil
       }
 
@@ -1300,7 +1306,7 @@ extension ASTGenVisitor {
 
     return self.generateWithLabeledExprListArguments(attribute: node) { args in
       // Macro role.
-      let role = self.generateConsumingPlainIdentifierAttrOption(args: &args) {
+      let role = self.generateConsumingPlainIdentifierAttrOption(attribute: node, args: &args) {
         BridgedMacroRole(from: $0.rawText.bridged)
       }
       guard let role = role else {
@@ -1706,7 +1712,7 @@ extension ASTGenVisitor {
       }
 
       func generateScalarLike() -> BridgedRawLayoutAttr? {
-        let tyR = self.generateConsumingAttrOption(args: &args, label: "like") {
+        let tyR = self.generateConsumingAttrOption(attribute: node, args: &args, label: "like") {
           self.generateTypeRepr(expr: $0)
         }
         guard let tyR else {
@@ -1727,7 +1733,7 @@ extension ASTGenVisitor {
       }
 
       func generateArrayLike() -> BridgedRawLayoutAttr? {
-        let tyR = self.generateConsumingAttrOption(args: &args, label: "likeArrayOf") {
+        let tyR = self.generateConsumingAttrOption(attribute: node, args: &args, label: "likeArrayOf") {
           self.generateTypeRepr(expr: $0)
         }
         guard let tyR else {
@@ -1735,7 +1741,7 @@ extension ASTGenVisitor {
         }
 
         // 'count:' can be integer literal or a generic parameter.
-        let count = self.generateConsumingAttrOption(args: &args, label: "count") {
+        let count = self.generateConsumingAttrOption(attribute: node, args: &args, label: "count") {
           self.generateValueOrType(expr: $0)
         }
         guard let count else {
@@ -1757,7 +1763,7 @@ extension ASTGenVisitor {
       }
 
       func generateConsumingIntegerLiteralOption(label: SyntaxText) -> Int? {
-        self.generateConsumingAttrOption(args: &args, label: label) {
+        self.generateConsumingAttrOption(attribute: node, args: &args, label: label) {
           guard let integerExpr = $0.as(IntegerLiteralExprSyntax.self) else {
             // TODO: Diagnose
             fatalError("expected integer literal for '\(String(syntaxText: label)):' in @_rawLayout")
@@ -1770,7 +1776,7 @@ extension ASTGenVisitor {
       }
 
       func generateConsumingMovesAsLike() -> Bool? {
-        self.generateConsumingPlainIdentifierAttrOption(args: &args) {
+        self.generateConsumingPlainIdentifierAttrOption(attribute: node, args: &args) {
           switch $0.rawText {
           case "movesAsLike":
             return true
@@ -1908,6 +1914,7 @@ extension ASTGenVisitor {
         targetFunction = self.generateDeclNameRef(declReferenceExpr: arg.declName).name
       case .specializeAvailabilityArgument(let arg):
         availableAttrs = self.generateAvailableAttr(
+          attribute: node,
           atLoc: self.generateSourceLoc(arg.availabilityLabel),
           range: self.generateSourceRange(
             start: arg.availabilityArguments.firstToken(viewMode: .all)!,
@@ -2163,11 +2170,16 @@ extension ASTGenVisitor {
     if node.arguments != nil {
       // FIXME: Should be normal LabeledExprListSyntax arguments.
 
-      guard let args = node.arguments?.as(UnavailableFromAsyncAttributeArgumentsSyntax.self) else {
-        // TODO: Diagnose.
+      guard let args = node.arguments else {
+        self.diagnose(.expectedArgumentsInAttribute(node))
+        return nil
+      }
+      guard let args = args.as(UnavailableFromAsyncAttributeArgumentsSyntax.self) else {
+        self.diagnose(.unexpectedArgumentsTypeInAttribute(node, arguments: args, expected: UnavailableFromAsyncAttributeArgumentsSyntax.self))
         return nil
       }
       message = self.generateStringLiteralTextIfNotInterpolated(expr: args.message)
+      // TODO: Diagnose if nil.
     }
     return .createParsed(
       self.ctx,
@@ -2208,7 +2220,7 @@ extension ASTGenVisitor {
     let initContext: BridgedCustomAttributeInitializer?
     if let args = node.arguments {
       guard let args = args.as(LabeledExprListSyntax.self) else {
-        // TODO: Diagnose?
+        self.diagnose(.unexpectedArgumentsTypeInAttribute(node, arguments: args, expected: LabeledExprListSyntax.self))
         return nil
       }
 
@@ -2255,9 +2267,8 @@ extension ASTGenVisitor {
     {
       return extractRawText(segments).bridged
     }
-    // TODO: Diagnose.
-    fatalError("expected string literal without interpolation")
-    // return nil
+    // Caller should diagnose.
+    return nil
   }
 
   /// Convenient method for processing an attribute with `LabeledExprListSyntax`.
@@ -2279,22 +2290,39 @@ extension ASTGenVisitor {
       return nil
     }
     if let extra = args.popFirst() {
-      self.diagnose(.extraneousArgumentsInAttribute(node, extra))
+      self.diagnose(.unexpectedArgumentInAttribute(node, extra))
     }
     return result
   }
 
   func generateConsumingAttrOption<R>(
+    attribute: AttributeSyntax,
     args: inout Slice<LabeledExprListSyntax>,
     label: SyntaxText?,
+    example: String? = nil,
     _ valueGeneratorFunction: (ExprSyntax) -> R?
   ) -> R? {
     guard let arg = args.first else {
+      if let example {
+        self.diagnose(.expectedOptionForAttribute(attribute, suchAs: example))
+      } else if let label {
+        self.diagnose(.expectedArgumentLabelInAttribute(
+          attribute,
+          label: String(syntaxText: label),
+          at: Syntax(attribute.rightParen) ?? Syntax(attribute)
+        ))
+      } else {
+        self.diagnose(.expectedArgumentsInAttribute(attribute))
+      }
       // TODO: Diagnose.
       return nil
     }
     guard arg.label?.rawText == label else {
-      // TODO: Diagnose.
+      if arg.label != nil {
+        self.diagnose(.unexpectedArgumentLabelInAttribute(attribute, at: arg))
+      } else {
+        self.diagnose(.expectedArgumentLabelInAttribute(attribute, label: String(syntaxText: label!), at: arg))
+      }
       return nil
     }
     // Label matched. Consume the argument even if the value is not valid.
@@ -2304,15 +2332,17 @@ extension ASTGenVisitor {
   }
 
   func generateConsumingPlainIdentifierAttrOption<R>(
+    attribute: AttributeSyntax,
     args: inout Slice<LabeledExprListSyntax>,
+    example: String? = nil,
     _ valueGeneratorFunction: (TokenSyntax) -> R?
   ) -> R? {
-    return generateConsumingAttrOption(args: &args, label: nil) {
+    return generateConsumingAttrOption(attribute: attribute, args: &args, label: nil, example: example) {
       guard
         let declRefExpr = $0.as(DeclReferenceExprSyntax.self),
         declRefExpr.argumentNames == nil
       else {
-        // TODO: Diagnose.
+        self.diagnose(.expectedIdentifierOptionForAttribute(attribute, at: $0))
         return nil
       }
       return valueGeneratorFunction(declRefExpr.baseName)
@@ -2320,10 +2350,12 @@ extension ASTGenVisitor {
   }
 
   func generateConsumingSimpleStringLiteralAttrOption(
+    attribute: AttributeSyntax,
     args: inout Slice<LabeledExprListSyntax>,
     label: SyntaxText? = nil
   ) -> BridgedStringRef? {
-    return self.generateConsumingAttrOption(args: &args, label: label) {
+    return self.generateConsumingAttrOption(attribute: attribute, args: &args, label: label) {
+      // TODO: Diagnose if 'nil'
       self.generateStringLiteralTextIfNotInterpolated(expr: $0)
     }
   }
@@ -2355,6 +2387,7 @@ extension ASTGenVisitor {
 
     return self.generateWithLabeledExprListArguments(attribute: node) { args in
       self.generateConsumingPlainIdentifierAttrOption(
+        attribute: node,
         args: &args,
         valueGeneratorFunction
       )

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticMessages.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticMessages.swift
@@ -1,0 +1,269 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftDiagnostics
+
+//===----------------------------------------------------------------------===//
+// MARK: Decl diagnostics
+//===----------------------------------------------------------------------===//
+
+extension ASTGenDiagnostic {
+  static func nonTrivialPatternForAccessor(_ pattern: some SyntaxProtocol) -> Self {
+    Self(
+      node: pattern,
+      message: "getter/setter can only be defined for a single variable"
+    )
+  }
+
+  static func unknownAccessorSpecifier(_ specifier: TokenSyntax) -> Self {
+    Self(
+      node: specifier,
+      message: "unknown accessor specifier '\(specifier.text)'"
+    )
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Decl attribute diagnostics
+//===----------------------------------------------------------------------===//
+
+extension ASTGenDiagnostic {
+  static func expectedArgumentsInAttribute(_ attribute: AttributeSyntax) -> Self {
+    Self(
+      node: attribute,
+      position: attribute.rightParen?.positionAfterSkippingLeadingTrivia ??  attribute.endPositionBeforeTrailingTrivia,
+      message: "expected arguments in '@\(attribute.attributeName.trimmedDescription)' attribute"
+    )
+  }
+
+  static func unexpectedArgumentInAttribute(_ attribute: AttributeSyntax, _ extra: some SyntaxProtocol) -> Self {
+    Self(
+      node: extra,
+      message: "unexpected arguments in '@\(attribute.attributeName.trimmedDescription)' attribute"
+    )
+  }
+
+  static func expectedOptionForAttribute(_ attribute: AttributeSyntax, suchAs example: String) -> Self {
+    Self(
+      node: attribute,
+      position: attribute.rightParen?.positionAfterSkippingLeadingTrivia ??  attribute.endPositionBeforeTrailingTrivia,
+      message: "expected option in '@\(attribute.attributeName)' attribute such as '\(example)'"
+    )
+  }
+
+  static func expectedIdentifierOptionForAttribute(_ attribute: AttributeSyntax, at arg: some SyntaxProtocol) -> Self {
+    Self(
+      node: arg,
+      message: "expected an identifier in '@\(attribute.attributeName)' attribute"
+    )
+  }
+
+  static func expectedArgumentLabelInAttribute(_ attribute: AttributeSyntax, label: String, at arg: some SyntaxProtocol) -> Self {
+    Self(
+      node: arg,
+      message: "expected '\(label)' argument in '@\(attribute.attributeName)' attribute"
+    )
+  }
+
+  static func expectedArgumentValueInAttribute(_ attribute: AttributeSyntax, label: String, value: String, at arg: some SyntaxProtocol) -> Self {
+    Self(
+      node: arg,
+      message: "expected \(value) for '\(label)' argument in '@\(attribute.attributeName)' attribute"
+    )
+  }
+
+
+  static func unexpectedArgumentLabelInAttribute(_ attribute: AttributeSyntax, at arg: LabeledExprSyntax) -> Self {
+    Self(
+      node: arg,
+      message: "unexpected argument label '\(arg.label!):' in '@\(attribute.attributeName)' attribute"
+    )
+  }
+
+  static func unexpectedArgumentsTypeInAttribute(_ attribute: AttributeSyntax, arguments: AttributeSyntax.Arguments, expected: any SyntaxProtocol.Type) -> Self {
+    Self(
+      node: attribute.arguments!,
+      message: "(compiler bug) unexpected argument type for @\(attribute.attributeName): \(arguments.kind.syntaxNodeType), expected: \(expected)"
+    )
+  }
+
+  static func duplicatedLabeledArgumentInAttribute(_ attribute: AttributeSyntax, argument: some SyntaxProtocol, name: String) -> Self {
+    Self(
+      node: argument,
+      message: "duplicated argument '\(name)' in '@\(attribute.attributeName)' attribute"
+    )
+  }
+
+  static func stringInterpolationNotAllowedInAttribute(_ attribute: AttributeSyntax, at node: some ExprSyntaxProtocol) -> Self {
+    Self(
+      node: Syntax(node),
+      message: "string interpolation is not accepted in '@\(attribute.attributeName)' attribute"
+    )
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Availability diagnostics
+//===----------------------------------------------------------------------===//
+
+extension ASTGenDiagnostic {
+  static func expectedVersionNumberInAvailableAttr(_ node: AvailabilityLabeledArgumentSyntax) -> Self {
+    Self(
+      node: node.value,
+      message: "expected version number for '\(node.label.text):' argument"
+    )
+  }
+
+  static func expectedVersionNumberAfterPlatform(_ node: TokenSyntax) -> Self {
+    Self(
+      node: node,
+      position: node.endPositionBeforeTrailingTrivia,
+      message: "expected version number after '\(node.text)'"
+    )
+  }
+
+  static func unexpectedArgumentInAvailabilitySpecList(_ node: TokenSyntax) -> Self {
+    Self(
+      node: node,
+      message: "expected platform name"
+    )
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Type diagnostics
+//===----------------------------------------------------------------------===//
+
+extension ASTGenDiagnostic {
+  static func classKeywordInheritanceDeprecated(_ node: ClassRestrictionTypeSyntax) -> Self {
+    Self(
+      node: node,
+      message: "using 'class' keyword to define a class-constrained protocol is deprecated",
+      severity: .warning
+    )
+    .withFixIt(
+      message: "use 'AnyObject' instead",
+      changes: .replaceTokenText(node.classKeyword, with: .identifier("AnyObject"))
+    )
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Misc diagnostics
+//===----------------------------------------------------------------------===//
+
+extension ASTGenDiagnostic {
+  static func illegalTopLevelStmt(_ stmt: some SyntaxProtocol) -> Self {
+    Self(
+      node: stmt,
+      message: "statements are not allowed at the top level"
+    )
+  }
+
+  static func illegalTopLevelExpr(_ expr: some SyntaxProtocol) -> Self {
+    Self(
+      node: expr,
+      message: "expressions are not allowed at the top level"
+    )
+  }
+
+  static func poundDiagnostic(_ node: StringLiteralExprSyntax, message: String, isError: Bool) -> Self {
+    Self(
+      node: node,
+      message: node.representedLiteralValue!,
+      severity: isError ? .error : .warning
+    )
+  }
+}
+
+extension ASTGenDiagnostic {
+  /// An error emitted when a token is of an unexpected kind.
+  static func unexpectedTokenKind(token: TokenSyntax) -> Self {
+    guard let parent = token.parent else {
+      preconditionFailure("Expected a child (not a root) token")
+    }
+
+    return Self(
+      node: token,
+      message: """
+      unexpected token kind for token:
+        \(token.debugDescription)
+      in parent:
+        \(parent.debugDescription(indentString: "  "))
+      """
+    )
+  }
+
+  /// An error emitted when an optional child token is unexpectedly nil.
+  static func missingChildToken(parent: some SyntaxProtocol, kindOfTokenMissing: TokenKind) -> Self {
+    Self(
+      node: parent,
+      message: """
+      missing child token of kind '\(kindOfTokenMissing)' in:
+        \(parent.debugDescription(indentString: "  "))
+      """
+    )
+  }
+
+  /// An error emitted when a syntax collection entry is encountered that is
+  /// considered a duplicate of a previous entry per the language grammar.
+  static func duplicateSyntax(duplicate: some SyntaxProtocol, original: some SyntaxProtocol) -> Self {
+    precondition(duplicate.kind == original.kind, "Expected duplicate and original to be of same kind")
+
+    guard let duplicateParent = duplicate.parent, let originalParent = original.parent,
+      duplicateParent == originalParent, duplicateParent.kind.isSyntaxCollection
+    else {
+      preconditionFailure("Expected a shared syntax collection parent")
+    }
+
+    return Self(
+      node: duplicate,
+      message: """
+      unexpected duplicate syntax in list:
+        \(duplicate.debugDescription(indentString: "  "))
+      previous syntax:
+        \(original.debugDescription(indentString: "  "))
+      """
+    )
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: Convenient message construction methods
+//===----------------------------------------------------------------------===//
+
+extension ASTGenDiagnostic {
+  fileprivate init(node: some SyntaxProtocol, position: AbsolutePosition? = nil, message: String, severity: DiagnosticSeverity = .error, function: String = #function) {
+    // Derive messageID from the function name.
+    let messageID = String(function.prefix(while: { $0 != "(" }))
+    self.init(id: messageID, node: Syntax(node), position: position, message: message, severity: severity)
+  }
+
+  fileprivate func withNote(node: some SyntaxProtocol, message: String) -> Self {
+    let messageID = "\(self.diagnosticID)_node\(self.fixIts.count)"
+    var copy = self
+    copy.notes.append(
+      Note(node: Syntax(node), message: message, messageID: messageID)
+    )
+    return copy
+  }
+
+  fileprivate func withFixIt(message: String, changes: FixIt.Change...) -> Self {
+    let messageID = "\(self.diagnosticID)_fixit\(self.fixIts.count)"
+    var copy = self
+    copy.fixIts.append(
+      FixIt(message: message, messageID: messageID, changes: changes)
+    )
+    return copy
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Copyright (c) 2023-2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -13,15 +13,20 @@
 import SwiftDiagnostics
 import SwiftSyntax
 
+//===----------------------------------------------------------------------===//
+// MARK: Diagnostic infrastructures
+//===----------------------------------------------------------------------===//
+
 extension ASTGenVisitor {
   /// Emits the given ASTGen diagnostic via the C++ diagnostic engine.
-  func diagnose(_ message: ASTGenDiagnostic, highlights: [Syntax]? = nil, notes: [Note] = [], fixIts: [FixIt] = []) {
+  func diagnose(_ diag: ASTGenDiagnostic) {
     self.diagnose(Diagnostic(
-      node: message.node,
-      message: message,
-      highlights: highlights,
-      notes: notes,
-      fixIts: fixIts
+      node: diag.node,
+      position: diag.position,
+      message: diag,
+      highlights: diag.highlights,
+      notes: diag.notes.map { Note(node: $0.node, message: $0) },
+      fixIts: diag.fixIts.map { FixIt(message: $0, changes: $0.changes) }
     ))
   }
 
@@ -42,136 +47,61 @@ extension ASTGenVisitor {
 }
 
 struct ASTGenDiagnostic: DiagnosticMessage {
+  struct Note: NoteMessage {
+    var node: Syntax
+    var message: String
+    var noteID: MessageID
+
+    init(node: Syntax, message: String, messageID: String) {
+      self.node = node
+      self.message = message
+      self.noteID = MessageID(domain: "ASTGen", id: messageID)
+    }
+  }
+
+  struct FixIt: FixItMessage {
+    typealias Change = SwiftDiagnostics.FixIt.Change
+
+    var message: String
+    var fixItID: MessageID
+    var changes: [Change]
+
+    init(message: String, messageID: String, changes: [Change]) {
+      self.fixItID = MessageID(domain: "ASTGen", id: messageID)
+      self.message = message
+      self.changes = changes
+    }
+  }
+
   var node: Syntax
+  var position: AbsolutePosition?
   var message: String
   var severity: DiagnosticSeverity
   var messageID: String
+  var highlights: [Syntax] = []
+  var notes: [Note] = []
+  var fixIts: [FixIt] = []
 
   var diagnosticID: MessageID {
     MessageID(domain: "ASTGen", id: messageID)
   }
 
-  init(node: some SyntaxProtocol, message: String, severity: DiagnosticSeverity = .error, messageID: String) {
-    self.node = Syntax(node)
+  init(id: String, node: Syntax, position: AbsolutePosition? = nil, message: String, severity: DiagnosticSeverity) {
+    self.node = node
+    self.position = position
     self.message = message
     self.severity = severity
-    self.messageID = messageID
-  }
-
-  fileprivate init(node: some SyntaxProtocol, message: String, severity: DiagnosticSeverity = .error, function: String = #function) {
-    // Extract messageID from the function name.
-    let messageID = String(function.prefix(while: { $0 != "(" }))
-    self.init(node: node, message: message, severity: severity, messageID: messageID)
+    self.messageID = id
   }
 }
 
-extension ASTGenDiagnostic {
-  /// An error emitted when a token is of an unexpected kind.
-  static func unexpectedTokenKind(token: TokenSyntax) -> Self {
-    guard let parent = token.parent else {
-      preconditionFailure("Expected a child (not a root) token")
-    }
-
-    return Self(
-      node: token,
-      message: """
-      unexpected token kind for token:
-        \(token.debugDescription)
-      in parent:
-        \(parent.debugDescription(indentString: "  "))
-      """
-    )
+// Convenient methods.
+extension FixIt.Change {
+  static func replace(_ oldNode: some SyntaxProtocol, with newNode: some SyntaxProtocol) -> Self {
+    .replace(oldNode: Syntax(oldNode), newNode: Syntax(newNode))
   }
 
-  /// An error emitted when an optional child token is unexpectedly nil.
-  static func missingChildToken(parent: some SyntaxProtocol, kindOfTokenMissing: TokenKind) -> Self {
-    Self(
-      node: parent,
-      message: """
-      missing child token of kind '\(kindOfTokenMissing)' in:
-        \(parent.debugDescription(indentString: "  "))
-      """
-    )
-  }
-
-  /// An error emitted when a syntax collection entry is encountered that is
-  /// considered a duplicate of a previous entry per the language grammar.
-  static func duplicateSyntax(duplicate: some SyntaxProtocol, original: some SyntaxProtocol) -> Self {
-    precondition(duplicate.kind == original.kind, "Expected duplicate and original to be of same kind")
-
-    guard let duplicateParent = duplicate.parent, let originalParent = original.parent,
-      duplicateParent == originalParent, duplicateParent.kind.isSyntaxCollection
-    else {
-      preconditionFailure("Expected a shared syntax collection parent")
-    }
-
-    return Self(
-      node: duplicate,
-      message: """
-      unexpected duplicate syntax in list:
-        \(duplicate.debugDescription(indentString: "  "))
-      previous syntax:
-        \(original.debugDescription(indentString: "  "))
-      """
-    )
-  }
-
-  static func nonTrivialPatternForAccessor(_ pattern: some SyntaxProtocol) -> Self {
-    Self(
-      node: pattern,
-      message: "getter/setter can only be defined for a single variable"
-    )
-  }
-
-  static func unknownAccessorSpecifier(_ specifier: TokenSyntax) -> Self {
-    Self(
-      node: specifier,
-      message: "unknown accessor specifier '\(specifier.text)'"
-    )
-  }
-}
-
-/// Decl diagnostics
-extension ASTGenDiagnostic {
-  static func illegalTopLevelStmt(_ stmt: some SyntaxProtocol) -> Self {
-    Self(
-      node: stmt,
-      message: "statements are not allowed at the top level"
-    )
-  }
-
-  static func illegalTopLevelExpr(_ expr: some SyntaxProtocol) -> Self {
-    Self(
-      node: expr,
-      message: "expressions are not allowed at the top level"
-    )
-  }
-}
-
-/// DeclAttributes diagnostics
-extension ASTGenDiagnostic {
-  static func expectedArgumentsInAttribute(_ attribute: AttributeSyntax) -> Self {
-    // FIXME: The diagnostic position should be at the and of the attribute name.
-    Self(
-      node: attribute,
-      message: "expected arguments for '\(attribute.attributeName.trimmedDescription)' attribute"
-    )
-  }
-
-  static func extraneousArgumentsInAttribute(_ attribute: AttributeSyntax, _ extra: some SyntaxProtocol) -> Self {
-    Self(
-      node: extra,
-      message: "unexpected arguments in '\(attribute.attributeName.trimmedDescription)' attribute"
-    )
-  }
-}
-
-extension ASTGenDiagnostic {
-  static func poundDiagnostic(_ node: StringLiteralExprSyntax, message: String, isError: Bool) -> Self {
-    Self(
-      node: node,
-      message: node.representedLiteralValue!,
-      severity: isError ? .error : .warning
-    )
+  static func replaceTokenText(_ token: TokenSyntax, with tokenKind: TokenKind) -> Self {
+    .replace(oldNode: Syntax(token), newNode: Syntax(token.detached.with(\.tokenKind, tokenKind)))
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
@@ -155,6 +155,7 @@ extension ASTGenVisitor {
     let cTypeNameLoc: BridgedSourceLoc?
     if let ctypeString = args.cTypeString {
       cTypeName = self.generateStringLiteralTextIfNotInterpolated(expr: ctypeString)
+      // TODO: Diagnose if nil.
       cTypeNameLoc = cTypeName != nil ? self.generateSourceLoc(ctypeString) : nil
     } else {
       cTypeName = nil

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -300,16 +300,15 @@ extension ASTGenVisitor {
   }
 
   func generate(classRestrictionType node: ClassRestrictionTypeSyntax) -> BridgedUnqualifiedIdentTypeRepr {
-    // TODO: diagnostics.
-    // warning: using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
+    // Diagnose to replace 'class' with 'AnyObject'
+    self.diagnose(.classKeywordInheritanceDeprecated(node))
+
     return .createParsed(
       self.ctx,
       loc: self.generateSourceLoc(node.classKeyword),
       name: self.ctx.getIdentifier("AnyObject")
     )
   }
-
-  // NOTE: When implementing new `generate(type:)`, please update  `isTypeMigrated(_:)`.
 }
 
 // MARK: - SpecifierTypeRepr/AttributedTypeRepr

--- a/test/ASTGen/diagnostics.swift
+++ b/test/ASTGen/diagnostics.swift
@@ -23,12 +23,6 @@ _ = [(Int) -> async throws Int]()
 // expected-error@-1{{'async throws' must precede '->'}}
 // expected-note@-2{{move 'async throws' in front of '->'}}{{15-21=}} {{21-28=}} {{12-12=async }} {{12-12=throws }}
 
-@freestanding // expected-error {{expected arguments for 'freestanding' attribute}}
-func dummy() {}
-
-@_silgen_name("whatever", extra)  // expected-error@:27 {{unexpected arguments in '_silgen_name' attribute}}
-func _whatever()
-
 struct S {
     subscript(x: Int) { _ = 1 } // expected-error@:23 {{expected '->' and return type in subscript}}
                                 // expected-note@-1:23 {{insert '->' and return type}}

--- a/test/ASTGen/diagnostics_attrs.swift
+++ b/test/ASTGen/diagnostics_attrs.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -enable-experimental-feature ParserASTGen
+
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_ParserASTGen
+
+@freestanding // expected-error {{expected arguments in '@freestanding' attribute}}
+func dummy() {}
+
+@_extern(lang: c) // expected-error@:10 {{unexpected argument label 'lang:' in '@_extern' attribute}}
+func c_func() {}
+
+@_extern() // expected-error@:10 {{expected option in '@_extern' attribute such as 'c'}}
+func unknown_func() {}
+
+@_extern("C") // expected-error@:10 {{expected an identifier in '@_extern' attribute}}
+func unknown_func_str() {}
+
+@implementation()  // expected-error@:17 {{expected arguments in '@implementation' attribute}}
+func implementaiton_func() {}
+
+@_silgen_name("whatever", extra)  // expected-error@:27 {{unexpected arguments in '@_silgen_name' attribute}}
+func _whatever()
+
+@available(*, unavailable, message: "foo", message: "bar") // expected-error@:44 {{duplicated argument 'message' in '@available' attribute}}
+func unavailable_func() {}
+
+@available(swift) // expected-error@:17 {{expected version number after 'swift'}}
+func unavailable_swift() {}
+
+@available(swift 99, message: "foo") // expected-error@:22 {{expected platform name}}
+func unavailable_swift99() {}

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -63,8 +63,9 @@ struct FileDescriptor: ~Copyable {
   var fd = 1
 }
 
-// FIXME: warning for 'class'
 protocol ClassOnly: class {}
+// expected-warning@-1 {{using 'class' keyword to define a class-constrained protocol is deprecated}}
+// expected-note@-2 {{use 'AnyObject' instead}} {{21-26=AnyObject}}
 
 actor SomeActor { }
 @globalActor


### PR DESCRIPTION
* `ASTGenDiagnostic` now contains fix-its and notes.
* Infrastructure to attach notes and fix-its: `ASTGenDiagnostic.withFixIt()`/`ASTGenDiagnostic.withNote()`
* Implement and improve some diagnostics
