### PR TITLE
[Concurrency] SE-0466: Replace `UnspecifiedMeansMainActorIsolated` flag with `-default-isolation`

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -465,9 +465,6 @@ EXPERIMENTAL_FEATURE(ImportNonPublicCxxMembers, true)
 // Isolated deinit
 SUPPRESSIBLE_LANGUAGE_FEATURE(IsolatedDeinit, 371, "isolated deinit")
 
-// When a parameter has unspecified isolation, infer it as main actor isolated.
-EXPERIMENTAL_FEATURE(UnspecifiedMeansMainActorIsolated, false)
-
 /// modify/read single-yield coroutines
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CoroutineAccessors, true)
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -96,6 +96,11 @@ namespace swift {
     TaskToThread,
   };
 
+  enum class DefaultIsolation : uint8_t {
+    MainActor,
+    Nonisolated
+  };
+
   /// Describes the code size optimization behavior for code associated with
   /// declarations that are marked unavailable.
   enum class UnavailableDeclOptimization : uint8_t {
@@ -631,6 +636,9 @@ namespace swift {
 
     /// Disables `DynamicActorIsolation` feature.
     bool DisableDynamicActorIsolation = false;
+
+    /// Defines the default actor isolation.
+    DefaultIsolation DefaultIsolationBehavior = DefaultIsolation::Nonisolated;
 
     /// Whether or not to allow experimental features that are only available
     /// in "production".

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -985,6 +985,15 @@ def strict_concurrency : Joined<["-"], "strict-concurrency=">,
            "concurrency model, or 'complete' ('Sendable' and other checking is "
            "enabled for all code in the module)">;
 
+def default_isolation : Separate<["-"], "default-isolation">,
+  Flags<[FrontendOption]>,
+  HelpText<"Specify the default actor isolation: MainActor or nonisolated. "
+  "Defaults to nonisolated.">,
+  MetaVarName<"MainActor|nonisolated">;
+def default_isolation_EQ :  Joined<["-"], "default-isolation=">,
+  Flags<[FrontendOption]>,
+  Alias<default_isolation>;
+
 def enable_experimental_feature :
   Separate<["-"], "enable-experimental-feature">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -205,7 +205,6 @@ UNINTERESTING_FEATURE(StaticExclusiveOnly)
 UNINTERESTING_FEATURE(ExtractConstantsFromMembers)
 UNINTERESTING_FEATURE(GroupActorErrors)
 UNINTERESTING_FEATURE(SameElementRequirements)
-UNINTERESTING_FEATURE(UnspecifiedMeansMainActorIsolated)
 
 static bool usesFeatureSendingArgsAndResults(Decl *decl) {
   auto isFunctionTypeWithSending = [](Type type) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5798,7 +5798,7 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
 
     // If we are required to use main actor... just use that.
     if (!ignoreUnspecifiedMeansMainActorIsolated &&
-        ctx.LangOpts.hasFeature(Feature::UnspecifiedMeansMainActorIsolated))
+        ctx.LangOpts.DefaultIsolationBehavior == DefaultIsolation::MainActor)
       if (auto result =
               globalActorHelper(ctx.getMainActorType()->mapTypeOutOfContext()))
         return *result;

--- a/test/Concurrency/Runtime/unspecified_is_main_actor.swift
+++ b/test/Concurrency/Runtime/unspecified_is_main_actor.swift
@@ -1,11 +1,10 @@
-// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -swift-version 6 -g -import-objc-header %S/Inputs/RunOnMainActor.h %import-libdispatch -enable-experimental-feature UnspecifiedMeansMainActorIsolated )
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -swift-version 6 -g -import-objc-header %S/Inputs/RunOnMainActor.h %import-libdispatch -Xfrontend -default-isolation=MainActor )
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // REQUIRES: libdispatch
 // REQUIRES: asserts
-// REQUIRES: swift_feature_UnspecifiedMeansMainActorIsolated
 
 // UNSUPPORTED: freestanding
 

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -1,10 +1,8 @@
-// RUN: %target-swift-frontend -swift-version 6 -emit-silgen -enable-experimental-feature UnspecifiedMeansMainActorIsolated %s | %FileCheck %s
-// RUN: %target-swift-frontend -swift-version 6 -emit-sil -enable-experimental-feature UnspecifiedMeansMainActorIsolated %s -verify
-
-// REQUIRES: swift_feature_UnspecifiedMeansMainActorIsolated
+// RUN: %target-swift-frontend -swift-version 6 -emit-silgen -default-isolation MainActor %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify
 
 // READ THIS! This test is meant to FileCheck the specific isolation when
-// UnspecifiedMeansMainActorIsolated is enabled. Please do not put other types
+// `-default-isolation` is set to `MainActor`. Please do not put other types
 // of tests in here.
 
 class Klass {

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -1,9 +1,7 @@
-// RUN: %target-swift-frontend -swift-version 6 -emit-sil -enable-experimental-feature UnspecifiedMeansMainActorIsolated %s -verify
-
-// REQUIRES: swift_feature_UnspecifiedMeansMainActorIsolated
+// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify
 
 // READ THIS! This test is meant to check the specific isolation when
-// UnspecifiedMeansMainActorIsolated is enabled in combination with validating
+// `-default-isolation` is set to `MainActor` in combination with validating
 // behavior around explicitly non-Sendable types that trigger type checker
 // specific errors. Please do not put other types of tests in here.
 

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -1,7 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances -enable-experimental-feature UnspecifiedMeansMainActorIsolated %s
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances -default-isolation MainActor %s
 
 // REQUIRES: swift_feature_IsolatedConformances
-// REQUIRES: swift_feature_UnspecifiedMeansMainActorIsolated
 // REQUIRES: concurrency
 
 nonisolated

--- a/test/Concurrency/swiftsettings_defaultIsolation.swift
+++ b/test/Concurrency/swiftsettings_defaultIsolation.swift
@@ -1,11 +1,10 @@
 // RUN: %target-swift-frontend -enable-experimental-feature SwiftSettings -c -verify -swift-version 6 -verify-additional-prefix nonisolated- -disable-availability-checking %s
 // RUN: %target-swift-frontend -enable-experimental-feature SwiftSettings -c -verify -swift-version 6 -verify-additional-prefix main-actor- -disable-availability-checking -DSWIFT_SETTINGS_MAIN_ACTOR %s
-// RUN: %target-swift-frontend -enable-experimental-feature UnspecifiedMeansMainActorIsolated -enable-experimental-feature SwiftSettings -c -verify -swift-version 6 -disable-availability-checking -verify-additional-prefix main-actor- %s
-// RUN: %target-swift-frontend -enable-experimental-feature UnspecifiedMeansMainActorIsolated -enable-experimental-feature SwiftSettings -c -verify -swift-version 6 -disable-availability-checking -verify-additional-prefix nonisolated- -DSWIFT_SETTINGS_NONISOLATED %s
+// RUN: %target-swift-frontend -default-isolation MainActor -enable-experimental-feature SwiftSettings -c -verify -swift-version 6 -disable-availability-checking -verify-additional-prefix main-actor- %s
+// RUN: %target-swift-frontend -default-isolation MainActor -enable-experimental-feature SwiftSettings -c -verify -swift-version 6 -disable-availability-checking -verify-additional-prefix nonisolated- -DSWIFT_SETTINGS_NONISOLATED %s
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_UnspecifiedMeansMainActorIsolated
 // REQUIRES: swift_feature_SwiftSettings
 
 #if SWIFT_SETTINGS_MAIN_ACTOR


### PR DESCRIPTION
Adjust implementation based on the latest edition of SE-0466 proposal.

New flag accepts `MainActor` and `nonisolated` values.

Resolves: rdar://145768557

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
