### PR TITLE
[Concurrency] Allow capturing pack expansions in `@Sendable` closures if the pattern type conforms to `Sendable`.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2982,6 +2982,12 @@ namespace {
             ->mapTypeIntoContext(decl->getInterfaceType())
             ->getReferenceStorageReferent();
 
+        // Pack expansions are okay to capture as long as the pattern
+        // type is Sendable.
+        if (auto *expansion = type->getAs<PackExpansionType>()) {
+          type = expansion->getPatternType();
+        }
+
         if (type->hasError())
           continue;
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -507,3 +507,23 @@ func checkOpaqueType() -> some Sendable {
 class MainActorSub: MainActorSuper<MainActorSub.Nested> {
   struct Nested {}  // no cycle
 }
+
+@available(SwiftStdlib 5.9, *)
+struct SendablePack<each Element: Sendable>: Sendable {
+  let elements: (repeat each Element)
+}
+
+@available(SwiftStdlib 5.1, *)
+@MainActor
+func sendablePacks<each Element: Sendable>(
+    _ element: repeat each Element
+) async {
+  { @Sendable in
+    repeat _ = each element
+  }()
+
+  await sendPack(repeat each element)
+}
+
+@available(SwiftStdlib 5.1, *)
+func sendPack<each Element>(_: repeat each Element) async {}


### PR DESCRIPTION
Resolves: https://github.com/swiftlang/swift/issues/74484