### PR TITLE
 LifetimeDependence: enable addressable dependencies

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -138,7 +138,8 @@ extension LifetimeDependentApply {
       // for consistency, we use yieldAddress if any yielded value is an address.
       let targetKind = beginApply.yieldedValues.contains(where: { $0.type.isAddress })
         ? TargetKind.yieldAddress : TargetKind.yield
-      info.sources.push(LifetimeSource(targetKind: targetKind, convention: .scope(addressable: false),
+      info.sources.push(LifetimeSource(targetKind: targetKind,
+                                       convention: .scope(addressable: false, addressableForDeps: false),
                                        value: beginApply.token))
     }
     for operand in applySite.parameterOperands {
@@ -218,7 +219,7 @@ private extension LifetimeDependentApply.LifetimeSourceInfo {
       bases.append(source.value)
     case .result, .inParameter, .inoutParameter:
       // addressable dependencies directly depend on the incoming address.
-      if context.options.enableAddressDependencies() && source.convention.isAddressable {
+      if context.options.enableAddressDependencies() && source.convention.isAddressable(for: source.value) {
         bases.append(source.value)
         return
       }

--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -313,6 +313,7 @@ extension FunctionConvention {
       }
       if scope {
         let addressable = bridged.checkAddressable(bridgedIndex(parameterIndex: index))
+          || bridged.checkConditionallyAddressable(bridgedIndex(parameterIndex: index))
         return .scope(addressable: addressable)
       }
       return nil

--- a/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
+++ b/SwiftCompilerSources/Sources/SIL/FunctionConvention.swift
@@ -237,7 +237,7 @@ extension FunctionConvention {
 
 public enum LifetimeDependenceConvention : CustomStringConvertible {
   case inherit
-  case scope(addressable: Bool)
+  case scope(addressable: Bool, addressableForDeps: Bool)
 
   public var isScoped: Bool {
     switch self {
@@ -248,12 +248,12 @@ public enum LifetimeDependenceConvention : CustomStringConvertible {
     }
   }
 
-  public var isAddressable: Bool {
+  public func isAddressable(for value: Value) -> Bool {
     switch self {
     case .inherit:
       return false
-    case let .scope(addressable):
-      return addressable
+    case let .scope(addressable, addressableForDeps):
+      return addressable || (addressableForDeps && value.type.isAddressableForDeps(in: value.parentFunction))
     }
   }
 
@@ -313,8 +313,8 @@ extension FunctionConvention {
       }
       if scope {
         let addressable = bridged.checkAddressable(bridgedIndex(parameterIndex: index))
-          || bridged.checkConditionallyAddressable(bridgedIndex(parameterIndex: index))
-        return .scope(addressable: addressable)
+        let addressableForDeps = bridged.checkConditionallyAddressable(bridgedIndex(parameterIndex: index))
+        return .scope(addressable: addressable, addressableForDeps: addressableForDeps)
       }
       return nil
     }

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -92,6 +92,11 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
 
   public var isMarkedAsImmortal: Bool { bridged.isMarkedAsImmortal() }
 
+  /// True if a value of this type can have its address taken by a lifetime-dependent value.
+  public func isAddressableForDeps(in function: Function) -> Bool {
+    bridged.isAddressableForDeps(function.bridged)
+  }
+
   //===--------------------------------------------------------------------===//
   //                Properties of lowered `SILFunctionType`s
   //===--------------------------------------------------------------------===//

--- a/include/swift/AST/IndexSubset.h
+++ b/include/swift/AST/IndexSubset.h
@@ -197,6 +197,7 @@ public:
 
   bool isSubsetOf(IndexSubset *other) const;
   bool isSupersetOf(IndexSubset *other) const;
+  bool isDisjointWith(IndexSubset *other) const;
 
   IndexSubset *adding(unsigned index, ASTContext &ctx) const;
   IndexSubset *extendingCapacity(ASTContext &ctx,

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -250,11 +250,10 @@ public:
     assert(!inheritLifetimeParamIndices ||
            !inheritLifetimeParamIndices->isEmpty());
     assert(!scopeLifetimeParamIndices || !scopeLifetimeParamIndices->isEmpty());
-    assert((!conditionallyAddressableParamIndices
-            || (addressableParamIndices
-                && conditionallyAddressableParamIndices
-                    ->isSubsetOf(addressableParamIndices)))
-     && "conditionally-addressable params not a subset of addressable params?");
+    assert((!addressableParamIndices
+            || !conditionallyAddressableParamIndices
+            || conditionallyAddressableParamIndices->isDisjointWith(
+              addressableParamIndices)));
   }
 
   operator bool() const { return !empty(); }

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -333,7 +333,7 @@ public:
 
   /// Enable enforcement of lifetime dependencies on addressable arguments.
   /// Temporarily used to bootstrap the AddressableParameters feature.
-  bool EnableAddressDependencies = false;
+  bool EnableAddressDependencies = true;
 
   SILOptions() {}
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1505,6 +1505,9 @@ def platform_availability_inheritance_map_path
 def enable_address_dependencies : Flag<["-"], "enable-address-dependencies">,
   HelpText<"Enable enforcement of lifetime dependencies on addressable values.">;
 
+def disable_address_dependencies : Flag<["-"], "disable-address-dependencies">,
+  HelpText<"Disable enforcement of lifetime dependencies on addressable values.">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]
 
 def disable_experimental_parser_round_trip : Flag<["-"],

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -159,6 +159,7 @@ struct BridgedLifetimeDependenceInfo {
   swift::IndexSubset *_Nullable inheritLifetimeParamIndices;
   swift::IndexSubset *_Nullable scopeLifetimeParamIndices;
   swift::IndexSubset *_Nullable addressableParamIndices;
+  swift::IndexSubset *_Nullable conditionallyAddressableParamIndices;
   SwiftUInt targetIndex;
   bool immortal;
 
@@ -168,6 +169,7 @@ struct BridgedLifetimeDependenceInfo {
   BRIDGED_INLINE bool checkInherit(SwiftInt index) const;
   BRIDGED_INLINE bool checkScope(SwiftInt index) const;
   BRIDGED_INLINE bool checkAddressable(SwiftInt index) const;
+  BRIDGED_INLINE bool checkConditionallyAddressable(SwiftInt index) const;
   BRIDGED_INLINE SwiftInt getTargetIndex() const;
 
   BRIDGED_INLINE BridgedOwnedString getDebugDescription() const;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -261,6 +261,7 @@ struct BridgedType {
   BRIDGED_INLINE bool isExactSuperclassOf(BridgedType t) const;
   BRIDGED_INLINE bool isCalleeConsumedFunction() const;
   BRIDGED_INLINE bool isMarkedAsImmortal() const;
+  BRIDGED_INLINE bool isAddressableForDeps(BridgedFunction f) const;
   BRIDGED_INLINE SwiftInt getCaseIdxOfEnumType(BridgedStringRef name) const;
   BRIDGED_INLINE SwiftInt getNumNominalFields() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getFieldType(SwiftInt idx, BridgedFunction f) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -147,6 +147,8 @@ BridgedLifetimeDependenceInfo::BridgedLifetimeDependenceInfo(swift::LifetimeDepe
     : inheritLifetimeParamIndices(info.getInheritIndices()),
       scopeLifetimeParamIndices(info.getScopeIndices()),
       addressableParamIndices(info.getAddressableIndices()),
+      conditionallyAddressableParamIndices(
+        info.getConditionallyAddressableIndices()),
       targetIndex(info.getTargetIndex()), immortal(info.isImmortal()) {}
 
 SwiftInt BridgedLifetimeDependenceInfoArray::count() const {
@@ -175,6 +177,12 @@ bool BridgedLifetimeDependenceInfo::checkScope(SwiftInt index) const {
 
 bool BridgedLifetimeDependenceInfo::checkAddressable(SwiftInt index) const {
   return addressableParamIndices && addressableParamIndices->contains(index);
+}
+
+bool BridgedLifetimeDependenceInfo::
+checkConditionallyAddressable(SwiftInt index) const {
+  return conditionallyAddressableParamIndices
+    && conditionallyAddressableParamIndices->contains(index);
 }
 
 SwiftInt BridgedLifetimeDependenceInfo::getTargetIndex() const {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -393,7 +393,7 @@ bool BridgedType::isMarkedAsImmortal() const {
 }
 
 bool BridgedType::isAddressableForDeps(BridgedFunction f) const {
-  return unbridged().isAddressableForDeps();
+  return unbridged().isAddressableForDeps(*f.getFunction());
 }
 
 SwiftInt BridgedType::getCaseIdxOfEnumType(BridgedStringRef name) const {

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -392,6 +392,10 @@ bool BridgedType::isMarkedAsImmortal() const {
   return unbridged().isMarkedAsImmortal();
 }
 
+bool BridgedType::isAddressableForDeps(BridgedFunction f) const {
+  return unbridged().isAddressableForDeps();
+}
+
 SwiftInt BridgedType::getCaseIdxOfEnumType(BridgedStringRef name) const {
   return unbridged().getCaseIdxOfEnumType(name.unbridged());
 }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -927,6 +927,10 @@ public:
 
   bool isMarkedAsImmortal() const;
 
+  /// True if a value of this type can have its address taken by a
+  /// lifetime-dependent value.
+  bool isAddressableForDeps(const SILFunction &function) const;
+
   /// Returns true if this type is an actor type. Returns false if this is any
   /// other type. This includes distributed actors. To check for distributed
   /// actors and actors, use isAnyActor().

--- a/lib/AST/IndexSubset.cpp
+++ b/lib/AST/IndexSubset.cpp
@@ -52,6 +52,14 @@ bool IndexSubset::isSupersetOf(IndexSubset *other) const {
   return true;
 }
 
+bool IndexSubset::isDisjointWith(IndexSubset *other) const {
+  assert(capacity == other->capacity);
+  for (auto index : range(numBitWords))
+    if (getBitWord(index) & other->getBitWord(index))
+      return false;
+  return true;
+}
+
 IndexSubset *IndexSubset::adding(unsigned index, ASTContext &ctx) const {
   assert(index < getCapacity());
   if (contains(index))

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -63,11 +63,9 @@ std::string LifetimeDependenceInfo::getString() const {
         }
         result += kind;
         if (addressable && addressable->contains(i)) {
-          if (condAddressable && condAddressable->contains(i)) {
-            result += "address_for_deps ";
-          } else {
-            result += "address ";
-          }
+          result += "address ";
+        } else if (condAddressable && condAddressable->contains(i)) {
+          result += "address_for_deps ";
         }
         result += std::to_string(i);
         isFirstSetBit = false;
@@ -1136,7 +1134,6 @@ static std::optional<LifetimeDependenceInfo> checkSILTypeModifiers(
         break;
       case LifetimeDescriptor::IsConditionallyAddressable:
         conditionallyAddressableLifetimeParamIndices.set(index);
-        addressableLifetimeParamIndices.set(index);
         break;
       case LifetimeDescriptor::IsAddressable:
         addressableLifetimeParamIndices.set(index);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3110,7 +3110,10 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
         LTOKind.value() == IRGenLLVMLTOKind::None;
 
   
-  Opts.EnableAddressDependencies = Args.hasArg(OPT_enable_address_dependencies);
+  Opts.EnableAddressDependencies =
+    Args.hasFlag(OPT_enable_address_dependencies,
+                 OPT_disable_address_dependencies,
+                 Opts.EnableAddressDependencies);
 
   return false;
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1823,14 +1823,12 @@ private:
       // is addressable-for-dependencies, then lower it with maximal abstraction
       // as well.
       auto &initialSubstTL = TC.getTypeLowering(origType, substType, expansion);
-      if (initialSubstTL.getRecursiveProperties().isAddressableForDependencies()) {
+      if (initialSubstTL.getRecursiveProperties()
+          .isAddressableForDependencies()) {
         origType = AbstractionPattern::getOpaque();
 
-        // Remember that this lowered parameter is conditionally addressable in
-        // the addressable parameters vector.
-        AddressableLoweredParameters.resize(ParameterMap.size() + 1, false);
-        AddressableLoweredParameters[ParameterMap.size()] = true;
-
+        // Remember that this lowered parameter is conditionally
+        // addressable. Specialization may clear this flag.
         ConditionallyAddressableLoweredParameters
           .resize(ParameterMap.size() + 1, false);
         ConditionallyAddressableLoweredParameters[ParameterMap.size()] = true;

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1148,6 +1148,13 @@ bool SILType::isMarkedAsImmortal() const {
   return false;
 }
 
+bool SILType::isAddressableForDeps(const SILFunction &function) const {
+  auto contextType =
+    hasTypeParameter() ? function.mapTypeIntoContext(*this) : *this;
+  auto &tl = function.getTypeLowering(contextType);
+  return tl.getRecursiveProperties().isAddressableForDependencies();
+}
+
 intptr_t SILType::getFieldIdxOfNominalType(StringRef fieldName) const {
   auto *nominal = getNominalOrBoundGenericNominal();
   if (!nominal)

--- a/test/SILOptimizer/lifetime_dependence/dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence/dependence_insertion.swift
@@ -1,0 +1,220 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -Xllvm -sil-print-after=lifetime-dependence-insertion \
+// RUN:   -enable-builtin-module \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -define-availability "Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999" \
+// RUN:   -enable-address-dependencies \
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature AddressableParameters \
+// RUN:   -enable-experimental-feature AddressableTypes \
+// RUN:   -o /dev/null 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_AddressableParameters
+// REQUIRES: swift_feature_AddressableTypes
+
+import Builtin
+
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(borrow source)
+internal func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, borrowing source: borrowing U
+) -> T {
+  dependent
+}
+
+struct BV : ~Escapable {
+  let p: UnsafeRawPointer
+  let i: Int
+
+  @lifetime(borrow p)
+  init(_ p: UnsafeRawPointer, _ i: Int) {
+    self.p = p
+    self.i = i
+  }
+}
+
+struct NC : ~Copyable {
+  let p: UnsafeRawPointer
+  let i: Int
+
+  // Requires a borrow.
+  @lifetime(borrow self)
+  borrowing func getBV() -> BV {
+    BV(p, i)
+  }
+}
+
+public class C {
+  var i: Int = 42
+}
+
+@_silgen_name("use")
+func use(_ o : borrowing BV)
+
+// =============================================================================
+// Basic pointer dependencies
+// =============================================================================
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test13bv_borrow_var1p1iySV_SitF : $@convention(thin) (UnsafeRawPointer, Int) -> () {
+// CHECK: [[A:%.*]] = begin_access [read] [unknown] %{{.*}}
+// CHECK: [[U:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[A]] 
+// CHECK: [[L:%.*]] = load [copy] [[U]]
+// CHECK: [[R:%.*]] = apply %{{.*}}([[L]]) : $@convention(method) (@guaranteed NC) -> @lifetime(borrow 0) @owned BV
+// CHECK: [[M:%.*]] = mark_dependence [unresolved] [[R]] on [[A]]
+// CHECK: end_access [[A]]
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[M]]
+// CHECK: %{{.*}} = apply %{{.*}}([[MV]]) : $@convention(thin) (@guaranteed BV) -> ()
+// CHECK-LABEL: } // end sil function '$s4test13bv_borrow_var1p1iySV_SitF'
+func bv_borrow_var(p: UnsafeRawPointer, i: Int) {
+  var nc = NC(p: p, i: i)
+  let bv = nc.getBV()
+  use(bv)
+}
+
+// LifetimeDependence.Scope needs to see through typed-to-raw pointer conversion.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s4test18bv_pointer_convert1pAA2BVVSPySiG_tF : $@convention(thin) (UnsafePointer<Int>) -> @lifetime(borrow 0) @owned BV {
+// CHECK: bb0(%0 : $UnsafePointer<Int>):
+// CHECK: apply %{{.*}}<UnsafePointer<Int>, UnsafeRawPointer>([[RAW:%.*]], %{{.*}}) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : _Pointer, τ_0_1 : _Pointer> (@in_guaranteed τ_0_0) -> @out τ_0_1
+// CHECK: [[RAW:%.*]] = load [trivial] %6
+// CHECK: [[BV:%.*]] = apply %13([[RAW]], {{.*}}) : $@convention(method) (UnsafeRawPointer, Int, @thin BV.Type) -> @lifetime(borrow 0) @owned BV
+// CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[BV]] on %0
+// CHECK: return [[MD]]
+// CHECK-LABEL: } // end sil function '$s4test18bv_pointer_convert1pAA2BVVSPySiG_tF'
+@lifetime(borrow p)
+func bv_pointer_convert(p: UnsafePointer<Int>) -> BV {
+  BV(p, 0)
+}
+
+// =============================================================================
+// @_addressableForDependencies
+// =============================================================================
+
+@available(Span 0.1, *)
+public typealias IntSpan = Span<Int>
+
+@available(Span 0.1, *)
+protocol IntSpanable {
+  @lifetime(borrow self)
+  func getIntSpan() -> IntSpan
+}
+
+@available(Span 0.1, *)
+public struct Holder: IntSpanable {
+  let c: C
+  var p: UnsafePointer<Int>
+
+  init(_ c: C) {
+    self.c = c
+    self.p = UnsafePointer<Int>(bitPattern: 0)!
+    withUnsafePointer(to: c.i) {
+      self.p = $0
+    }
+  }
+
+  @lifetime(borrow self)
+  func getIntSpan() -> IntSpan {
+    let span = unsafe Span(_unsafeStart: p, count: 1)
+    return unsafe _overrideLifetime(span, borrowing: self)
+  }
+}
+
+@available(Span 0.1, *)
+@_addressableForDependencies
+public struct InlineHolder: IntSpanable {
+  var i: Int
+  var c: C
+
+  init(_ c: C) {
+    self.c = c
+    self.i = c.i
+  }
+
+  @lifetime(borrow self)
+  func getIntSpan() -> IntSpan {
+    let a = Builtin.addressOfBorrow(self)
+    let address = unsafe UnsafePointer<Int>(a)
+    let span = unsafe Span(_unsafeStart: address, count: 1)
+    return unsafe _overrideLifetime(span, borrowing: self)
+  }
+}
+
+// 'some Spanable' is AddressableForDependencies.
+@available(Span 0.1, *)
+@lifetime(borrow spanable)
+func getIntSpan(_ spanable: some IntSpanable) -> IntSpan {
+  spanable.getIntSpan()
+}
+
+// 'Holder' is not AddressableForDependencies.
+// 'span' depends on the value of the borrowed argument.
+//
+// CHECK-LABEL: sil {{.*}}@$s4test13getHolderSpanys0D0VySiGAA0C0VF : $@convention(thin) (@guaranteed Holder) -> @lifetime(borrow 0) @owned Span<Int> {
+// CHECK: bb0(%0 : @noImplicitCopy @guaranteed $Holder):
+// CHECK: [[C:%.*]] = apply %{{.*}}<Holder>(%{{.*}}) : $@convention(thin) <τ_0_0 where τ_0_0 : IntSpanable>
+// CHECK-SAME: (@in_guaranteed τ_0_0) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+// CHECK: mark_dependence [unresolved] [[C]] on %0
+// CHECK-LABEL: } // end sil function '$s4test13getHolderSpanys0D0VySiGAA0C0VF'
+@available(Span 0.1, *)
+public func getHolderSpan(_ holder: borrowing Holder) -> IntSpan {
+  let span = getIntSpan(holder)
+  return span
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4test0A10HolderSpanSiyF : $@convention(thin) () -> Int {
+// CHECK: [[C1:%.*]] = apply %{{.*}}(%{{.*}}) : $@convention(method) (@owned C, @thin Holder.Type) -> @owned Holder
+// CHECK: [[MV:%.*]] = move_value [lexical] [var_decl] [[C1]]
+// CHECK: [[C2:%.*]] = apply %{{.*}}([[MV]]) : $@convention(thin) (@guaranteed Holder) -> @lifetime(borrow 0) @owned Span<Int>
+// CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[C2]] on %10
+// CHECK-LABEL: } // end sil function '$s4test0A10HolderSpanSiyF'
+@available(Span 0.1, *)
+public func testHolderSpan() -> Int {
+  let c = C()
+  let holder = Holder(consume c)
+  let span = getHolderSpan(holder)
+  return span[0]
+}
+
+// 'InlineHolder' is AddressableForDependencies.
+// 'span' depends on the address of the borrowed argument.
+//
+// CHECK-LABEL: sil {{.*}}@$s4test19getInlineHolderSpanys0E0VySiGAA0cD0VF : $@convention(thin)
+// CHECK-SAME: (@in_guaranteed InlineHolder) -> @lifetime(borrow address_for_deps 0) @owned Span<Int> {
+// CHECK: [[VAR:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign]
+// CHECK: [[A:%.*]] = moveonlywrapper_to_copyable_addr [[VAR]]
+// CHECK: [[C:%.*]] = apply %{{.*}}<InlineHolder>([[A]]) : $@convention(thin) <τ_0_0 where τ_0_0 : IntSpanable>
+// CHECK-SAME: (@in_guaranteed τ_0_0) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+// CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[C]] on [[A]]
+// CHECK-LABEL: } // end sil function '$s4test19getInlineHolderSpanys0E0VySiGAA0cD0VF'
+@available(Span 0.1, *)
+public func getInlineHolderSpan(_ holder: borrowing InlineHolder) -> IntSpan {
+  let span = getIntSpan(holder)
+  return span
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4test0A16InlineHolderSpanSiyF : $@convention(thin) () -> Int {
+// CHECK: [[STK:%.*]] = alloc_stack $InlineHolder
+// CHECK: [[SB:%.*]] = store_borrow %{{.*}} to [[STK]]
+// CHECK: [[C:%.*]] = apply %{{.*}}([[SB]]) : $@convention(thin)
+// CHECK-SAME: (@in_guaranteed InlineHolder) -> @lifetime(borrow address_for_deps 0) @owned Span<Int>
+// CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[C]] on [[SB]]
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[MD]]
+// CHECK: destroy_value [[MV]]
+// CHECK: end_borrow [[SB]]
+// CHECK: dealloc_stack [[STK]]
+// CHECK-LABEL: } // end sil function '$s4test0A16InlineHolderSpanSiyF'
+@available(Span 0.1, *)
+public func testInlineHolderSpan() -> Int {
+  let c = C()
+  let holder = InlineHolder(consume c)
+  let span = getInlineHolderSpan(holder)
+  return span[0]
+}


### PR DESCRIPTION
Enable addressable dependencies

Handle conditionallyAddressableParamIndices. Preserve conditionallyAddressableParamIndices independent of any addressableParamIndices. The conditional dependencies are subject to change based on type substitution.