### PR TITLE
[Serialized diagnostics] Emit category documentation URL

### DIFF
--- a/test/diagnostics/diagnostic-group-serialization.swift
+++ b/test/diagnostics/diagnostic-group-serialization.swift
@@ -21,3 +21,5 @@ func test() {
   beCareful()
 // CHECK: [[@LINE-1]]:3: warning: expression uses unsafe constructs but is not marked with 'unsafe' [StrictMemorySafety] [-W{{.*}}strict-memory-safety.md] [StrictMemorySafety]
 }
+
+// CHECK: [StrictMemorySafety]: <{{.*}}strict-memory-safety.md>


### PR DESCRIPTION
Emit the category documentation URL into serialized diagnostics as part of the existing RECORD_CATEGORY, using the form

  <category name>@<category URL>

and keeping the existing "category name length" field referring to the length of the category name itself (up to the @). There is a corresponding update to libclang to process such category names correctly and add API, but it isn't strictly necessary: readers that use the category name length field correctly will see no behavior change, whereas readers that ignore it will merely see the extra `@<category URL>`.

This is a step toward staging out our (mis)use of the "flags" field as the place to stash educational note and diagnostic group documentation URLs.
