### PR TITLE
Runtimes: quote the path for module map files

### DIFF
--- a/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
+++ b/Runtimes/Core/SwiftShims/swift/shims/CMakeLists.txt
@@ -39,7 +39,7 @@ target_compile_definitions(swiftShims INTERFACE
   $<$<AND:$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>,$<COMPILE_LANGUAGE:C,CXX>>:SWIFT_STATIC_STDLIB>)
 target_compile_options(swiftShims INTERFACE
   "$<$<AND:$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xcc -DSWIFT_STATIC_STDLIB>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/module.modulemap>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/swift/shims/module.modulemap>>")
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=\"$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/module.modulemap>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_LIBDIR}/swift/shims/module.modulemap>\">")
 
 install(TARGETS swiftShims
   EXPORT SwiftCoreTargets


### PR DESCRIPTION
The install path may contain spaces which will be processed improperly when wired through the dependency. Add quotes to handle such paths.