### PR TITLE
[SILOptimizer] Turn "is self-recursive" check into analysis

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Analysis.def
+++ b/include/swift/SILOptimizer/Analysis/Analysis.def
@@ -46,5 +46,6 @@ SIL_ANALYSIS(RCIdentity)
 SIL_ANALYSIS(PassManagerVerifier)
 SIL_ANALYSIS(DeadEndBlocks)
 SIL_ANALYSIS(Region)
+SIL_ANALYSIS(IsSelfRecursive)
 
 #undef SIL_ANALYSIS

--- a/include/swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h
@@ -1,0 +1,75 @@
+//===--- IsSelfRecursiveAnalysis.h ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_ISSELFRECURSIVEANALYSIS_H
+#define SWIFT_SILOPTIMIZER_ISSELFRECURSIVEANALYSIS_H
+
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+
+namespace swift {
+class SILFunction;
+
+class IsSelfRecursive {
+  const SILFunction *f;
+  bool didComputeValue = false;
+  bool isSelfRecursive = false;
+
+  void compute();
+
+public:
+  IsSelfRecursive(const SILFunction *f) : f(f) {}
+
+  ~IsSelfRecursive();
+
+  bool isComputed() const { return didComputeValue; }
+
+  bool get() {
+    if (!didComputeValue) {
+      compute();
+      didComputeValue = true;
+    }
+    return isSelfRecursive;
+  }
+
+  SILFunction *getFunction() { return const_cast<SILFunction *>(f); }
+};
+
+class IsSelfRecursiveAnalysis final
+    : public FunctionAnalysisBase<IsSelfRecursive> {
+public:
+  IsSelfRecursiveAnalysis()
+      : FunctionAnalysisBase<IsSelfRecursive>(
+            SILAnalysisKind::IsSelfRecursive) {}
+
+  IsSelfRecursiveAnalysis(const IsSelfRecursiveAnalysis &) = delete;
+  IsSelfRecursiveAnalysis &operator=(const IsSelfRecursiveAnalysis &) = delete;
+
+  static SILAnalysisKind getAnalysisKind() {
+    return SILAnalysisKind::IsSelfRecursive;
+  }
+
+  static bool classof(const SILAnalysis *s) {
+    return s->getKind() == SILAnalysisKind::IsSelfRecursive;
+  }
+
+  std::unique_ptr<IsSelfRecursive> newFunctionAnalysis(SILFunction *f) override {
+    return std::make_unique<IsSelfRecursive>(f);
+  }
+
+  bool shouldInvalidate(SILAnalysis::InvalidationKind k) override {
+    return k & InvalidationKind::Calls;
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
+++ b/include/swift/SILOptimizer/Utils/PerformanceInlinerUtils.h
@@ -29,6 +29,7 @@ extern llvm::cl::opt<bool> EnableSILInliningOfGenerics;
 
 namespace swift {
 class BasicCalleeAnalysis;
+class IsSelfRecursiveAnalysis;
 
 // Controls the decision to inline functions with @_semantics, @effect and
 // global_init attributes.
@@ -40,7 +41,8 @@ enum class InlineSelection {
 
 /// Check if this ApplySite is eligible for inlining. If so, return the callee.
 SILFunction *getEligibleFunction(FullApplySite AI,
-                                 InlineSelection WhatToInline);
+                                 InlineSelection WhatToInline,
+                                 IsSelfRecursiveAnalysis *SRA);
 
 // Returns true if this is a pure call, i.e. the callee has no side-effects
 // and all arguments are constants.

--- a/lib/SILOptimizer/Analysis/CMakeLists.txt
+++ b/lib/SILOptimizer/Analysis/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(swiftSILOptimizer PRIVATE
   EpilogueARCAnalysis.cpp
   FunctionOrder.cpp
   IVAnalysis.cpp
+  IsSelfRecursiveAnalysis.cpp
   LoopAnalysis.cpp
   LoopRegionAnalysis.cpp
   NonLocalAccessBlockAnalysis.cpp

--- a/lib/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.cpp
@@ -1,0 +1,47 @@
+//===--- IsSelfRecursiveAnalysis.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h"
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+
+using namespace swift;
+
+// Force the compiler to generate the destructor in this C++ file.
+// Otherwise it can happen that it is generated in a SwiftCompilerSources module
+// and that results in unresolved-symbols linker errors.
+IsSelfRecursive::~IsSelfRecursive() = default;
+
+void IsSelfRecursive::compute() {
+  isSelfRecursive = false;
+
+  for (auto &BB : *getFunction()) {
+    for (auto &I : BB) {
+      if (auto Apply = FullApplySite::isa(&I)) {
+        if (Apply.getReferencedFunctionOrNull() == f) {
+          isSelfRecursive = true;
+          return;
+        }
+      }
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                              Main Entry Point
+//===----------------------------------------------------------------------===//
+
+SILAnalysis *swift::createIsSelfRecursiveAnalysis(SILModule *) {
+  return new IsSelfRecursiveAnalysis();
+}

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -17,6 +17,7 @@
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/OptimizationRemark.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
+#include "swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
@@ -107,6 +108,7 @@ class SILPerformanceInliner {
   DominanceAnalysis *DA;
   SILLoopAnalysis *LA;
   BasicCalleeAnalysis *BCA;
+  IsSelfRecursiveAnalysis *SRA;
 
   // For keys of SILFunction and SILLoop.
   llvm::DenseMap<SILFunction *, ShortestPathAnalysis *> SPAs;
@@ -238,14 +240,14 @@ class SILPerformanceInliner {
 
 public:
   SILPerformanceInliner(StringRef PassName, SILOptFunctionBuilder &FuncBuilder,
-                        InlineSelection WhatToInline,
-                        SILPassManager *pm, DominanceAnalysis *DA,
-                        PostDominanceAnalysis *PDA,
+                        InlineSelection WhatToInline, SILPassManager *pm,
+                        DominanceAnalysis *DA, PostDominanceAnalysis *PDA,
                         SILLoopAnalysis *LA, BasicCalleeAnalysis *BCA,
-                        OptimizationMode OptMode, OptRemark::Emitter &ORE)
+                        IsSelfRecursiveAnalysis *SRA, OptimizationMode OptMode,
+                        OptRemark::Emitter &ORE)
       : PassName(PassName), FuncBuilder(FuncBuilder),
-        WhatToInline(WhatToInline), pm(pm), DA(DA), LA(LA), BCA(BCA), CBI(DA, PDA), ORE(ORE),
-        OptMode(OptMode) {}
+        WhatToInline(WhatToInline), pm(pm), DA(DA), LA(LA), BCA(BCA), SRA(SRA),
+        CBI(DA, PDA), ORE(ORE), OptMode(OptMode) {}
 
   bool inlineCallsIntoFunction(SILFunction *F);
 };
@@ -1087,7 +1089,7 @@ void SILPerformanceInliner::collectAppliesToInline(
     // At this occasion we record additional weight increases.
     addWeightCorrection(FAS, WeightCorrections);
 
-    if (SILFunction *Callee = getEligibleFunction(FAS, WhatToInline)) {
+    if (SILFunction *Callee = getEligibleFunction(FAS, WhatToInline, SRA)) {
       // Compute the shortest-path analysis for the callee.
       SILLoopInfo *CalleeLI = LA->get(Callee);
       ShortestPathAnalysis *CalleeSPA = getSPA(Callee, CalleeLI);
@@ -1138,7 +1140,7 @@ void SILPerformanceInliner::collectAppliesToInline(
 
       FullApplySite AI = FullApplySite(&*I);
 
-      auto *Callee = getEligibleFunction(AI, WhatToInline);
+      auto *Callee = getEligibleFunction(AI, WhatToInline, SRA);
       if (Callee) {
         // Check if we have an always_inline or transparent function. If we do,
         // just add it to our final Applies list and continue.
@@ -1328,7 +1330,7 @@ void SILPerformanceInliner::visitColdBlocks(
       if (!AI)
         continue;
 
-      auto *Callee = getEligibleFunction(AI, WhatToInline);
+      auto *Callee = getEligibleFunction(AI, WhatToInline, SRA);
       if (Callee && decideInColdBlock(AI, Callee, numCallerBlocks)) {
         AppliesToInline.push_back(AI);
       }
@@ -1358,6 +1360,7 @@ public:
     PostDominanceAnalysis *PDA = PM->getAnalysis<PostDominanceAnalysis>();
     SILLoopAnalysis *LA = PM->getAnalysis<SILLoopAnalysis>();
     BasicCalleeAnalysis *BCA = PM->getAnalysis<BasicCalleeAnalysis>();
+    IsSelfRecursiveAnalysis *SRA = PM->getAnalysis<IsSelfRecursiveAnalysis>();
     OptRemark::Emitter ORE(DEBUG_TYPE, *getFunction());
 
     if (getOptions().InlineThreshold == 0) {
@@ -1369,7 +1372,8 @@ public:
     SILOptFunctionBuilder FuncBuilder(*this);
 
     SILPerformanceInliner Inliner(getID(), FuncBuilder, WhatToInline,
-                              getPassManager(), DA, PDA, LA, BCA, OptMode, ORE);
+                                  getPassManager(), DA, PDA, LA, BCA, SRA,
+                                  OptMode, ORE);
 
     assert(getFunction()->isDefinition() &&
            "Expected only functions with bodies!");

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -12,6 +12,7 @@
 
 #include "swift/SILOptimizer/Analysis/ArraySemantic.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
+#include "swift/SILOptimizer/Analysis/IsSelfRecursiveAnalysis.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/AST/Module.h"
 #include "swift/Basic/Assertions.h"
@@ -577,16 +578,6 @@ void ShortestPathAnalysis::Weight::updateBenefit(int &Benefit,
     Benefit = newBenefit;
 }
 
-// Return true if the callee has self-recursive calls.
-static bool calleeIsSelfRecursive(SILFunction *Callee) {
-  for (auto &BB : *Callee)
-    for (auto &I : BB)
-      if (auto Apply = FullApplySite::isa(&I))
-        if (Apply.getReferencedFunctionOrNull() == Callee)
-          return true;
-  return false;
-}
-
 SemanticFunctionLevel swift::getSemanticFunctionLevel(SILFunction *function) {
   // Currently, we only consider "array" semantic calls to be "optimizable
   // semantic functions" (non-transient) because we only have semantic passes
@@ -752,7 +743,8 @@ static bool isCallerAndCalleeLayoutConstraintsCompatible(FullApplySite AI) {
 
 // Returns the callee of an apply_inst if it is basically inlinable.
 SILFunction *swift::getEligibleFunction(FullApplySite AI,
-                                        InlineSelection WhatToInline) {
+                                        InlineSelection WhatToInline,
+                                        IsSelfRecursiveAnalysis *SRA) {
   SILFunction *Callee = AI.getReferencedFunctionOrNull();
 
   if (!Callee) {
@@ -864,10 +856,8 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
 
   // Inlining self-recursive functions into other functions can result
   // in excessive code duplication since we run the inliner multiple
-  // times in our pipeline
-  //
-  // FIXME: This should be cached!
-  if (calleeIsSelfRecursive(Callee)) {
+  // times in our pipeline.
+  if (SRA->get(Callee)->get()) {
     return nullptr;
   }
 


### PR DESCRIPTION
The body of a function has to be re-analyzed for every call site of the function, which is very expensive and if the body is not changed would produce the same result.

This takes about ~10% from swift-syntax overall build time in release configuration.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
