### PR TITLE
AliasAnalysis: fix effect of `end_apply` / `abort_apply` for read-only coroutines

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -275,10 +275,23 @@ struct AliasAnalysis {
       return getPartialApplyEffect(of: partialApply, on: memLoc)
 
     case let endApply as EndApplyInst:
-      return getApplyEffect(of: endApply.beginApply, on: memLoc)
+      let beginApply = endApply.beginApply
+      if case .yield(let addr) = memLoc.address.accessBase, addr.parentInstruction == beginApply {
+        // The lifetime of yielded values always end at the end_apply. This is required because a yielded
+        // address is non-aliasing inside the begin/end_apply scope, but might be aliasing after the end_apply.
+        // For example, if the callee yields an `ref_element_addr` (which is encapsulated in a begin/end_access).
+        // Therefore, even if the callee does not write anything, the effects must be "read" and "write".
+        return .worstEffects
+      }
+      return getApplyEffect(of: beginApply, on: memLoc)
 
     case let abortApply as AbortApplyInst:
-      return getApplyEffect(of: abortApply.beginApply, on: memLoc)
+      let beginApply = abortApply.beginApply
+      if case .yield(let addr) = memLoc.address.accessBase, addr.parentInstruction == beginApply {
+        // See the comment for `end_apply` above.
+        return .worstEffects
+      }
+      return getApplyEffect(of: beginApply, on: memLoc)
 
     case let builtin as BuiltinInst:
       return getBuiltinEffect(of: builtin, on: memLoc)

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -32,6 +32,7 @@ sil @unknown_func : $@convention(thin) (Int32, @in_guaranteed Int32) -> ()
 sil @single_indirect_arg : $@convention(thin) (@in_guaranteed Int32) -> Int32
 sil @single_indirect_arg_and_error : $@convention(thin) (@in Int32) -> (Int32, @error Error)
 sil @single_indirect_arg_coroutine : $@yield_once @convention(thin) (@in Int32) -> @yields Int32
+sil [readnone] @read_none_coroutine : $@yield_once @convention(thin) () -> @yields @inout Int32
 sil @indirect_arg_and_ptr : $@convention(thin) (@in_guaranteed Int32, Builtin.RawPointer) -> Int32
 sil @single_reference : $@convention(thin) (@guaranteed X) -> Int32
 sil @indirect_yield_coroutine : $@yield_once @convention(thin) (@inout Int32) -> @yields @inout Int32
@@ -405,6 +406,41 @@ bb0(%0 : $Int32):
   dealloc_stack %1 : $*Int32
   %9 = tuple ()
   return %9 : $()
+}
+
+// CHECK-LABEL:  @read_none_end_apply
+// CHECK:        PAIR #0.
+// CHECK-NEXT:       (%2, %3) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @inout Int32 // users: %8, %5
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=0,w=0
+// CHECK:        PAIR #1.
+// CHECK-NEXT:       %5 = end_apply %3 as $()
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=0,w=0
+// CHECK:        PAIR #2.
+// CHECK-NEXT:       %5 = end_apply %3 as $()
+// CHECK-NEXT:     (**%2**, %3) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @inout Int32
+// CHECK-NEXT:     r=1,w=1
+// CHECK:        PAIR #3.
+// CHECK-NEXT:       abort_apply %3
+// CHECK-NEXT:     %0 = argument of bb0 : $*Int32
+// CHECK-NEXT:     r=0,w=0
+// CHECK:        PAIR #4.
+// CHECK-NEXT:       abort_apply %3
+// CHECK-NEXT:     (**%2**, %3) = begin_apply %1() : $@yield_once @convention(thin) () -> @yields @inout Int32
+// CHECK-NEXT:     r=1,w=1
+sil [ossa] @read_none_end_apply : $@convention(thin) (@in Int32) -> () {
+bb0(%0 : $*Int32):
+  %3 = function_ref @read_none_coroutine : $@yield_once @convention(thin) () -> @yields @inout Int32
+  (%4, %5) = begin_apply %3() : $@yield_once @convention(thin) () -> @yields @inout Int32
+  cond_br undef, bb1, bb2
+bb1:
+  end_apply %5 as $()
+  %r = tuple ()
+  return %r
+bb2:
+  abort_apply %5
+  unreachable
 }
 
 // CHECK-LABEL: @refelementaddr_and_reference

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -41,11 +41,16 @@ public enum FakeOptional<T> {
 
 struct MOS: ~Copyable {}
 
+protocol P {
+  func foo()
+}
+
 sil [ossa] @getKlass : $@convention(thin) () -> @owned Klass
 sil [ossa] @getNonTrivialStruct : $@convention(thin) () -> @owned NonTrivialStruct
 sil [ossa] @getMOS : $@convention(thin) () -> @owned MOS
 
 sil @unknown : $@convention(thin) () -> ()
+sil [readonly] [ossa] @read_only_coroutine : $@yield_once @convention(thin) () -> @yields @in_guaranteed P
 
 sil [ossa] @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
 sil [ossa] @guaranteed_user_with_result : $@convention(thin) (@guaranteed Klass) -> @out Klass
@@ -632,10 +637,6 @@ bb0(%0 : $*Klass):
   dealloc_stack %1 : $*Klass
   %12 = tuple ()
   return %12 : $()
-}
-
-protocol P {
-  func foo()
 }
 
 sil [ossa] @getP : $@convention(thin) () -> @out Optional<P>
@@ -1876,3 +1877,19 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
   return %10 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_read_only_coroutine :
+// CHECK:         copy_addr
+// CHECK:         copy_addr
+// CHECK-LABEL: } // end sil function 'test_read_only_coroutine'
+sil [ossa] @test_read_only_coroutine : $@convention(thin) () -> @out P {
+bb0(%0 : $*P):
+  %5 = function_ref @read_only_coroutine : $@yield_once @convention(thin) () -> @yields @in_guaranteed P
+  (%6, %7) = begin_apply %5() : $@yield_once @convention(thin) () -> @yields @in_guaranteed P
+  %8 = alloc_stack $P
+  copy_addr %6 to [init] %8
+  %10 = end_apply %7 as $()
+  copy_addr [take] %8 to [init] %0
+  dealloc_stack %8
+  %15 = tuple ()
+  return %15
+}


### PR DESCRIPTION
The lifetime of yielded values always end at the end_apply. This is required because a yielded address is non-aliasing inside the begin/end_apply scope, but might be aliasing after the end_apply. For example, if the callee yields an `ref_element_addr` (which is encapsulated in a begin/end_access). Therefore, even if the callee does not write anything, the effects must be "read" and "write".

Fixes a SIL verifier error
rdar://147601749
