### PR TITLE
Fix a compilation error with LLVM 21

### DIFF
--- a/stdlib/public/runtime/GenericMetadataBuilder.cpp
+++ b/stdlib/public/runtime/GenericMetadataBuilder.cpp
@@ -56,7 +56,7 @@ public:
 
     /// Construct an arbitrarily typed buffer from a Buffer<const char>, using
     /// const char as an "untyped" buffer type.
-    Buffer(Buffer<const char> buffer)
+    Buffer(const Buffer<const char> &buffer)
         : ptr(reinterpret_cast<T *>(buffer.ptr)) {}
 
     /// The pointer to the buffer's underlying storage.


### PR DESCRIPTION
This fixes a `copy constructor must pass its first argument by reference` compilation error when compiled with a recent enough Clang (after https://github.com/llvm/llvm-project/commit/fe0d3e3764961b62f43f1b129f30aaec5f30bc16, targeted for LLVM 21 release).

```
swift/stdlib/public/runtime/GenericMetadataBuilder.cpp:59:31: error: copy constructor must pass its first argument by reference
   59 |     Buffer(Buffer<const char> buffer)
      |                               ^
      |                               const &
```