### PR TITLE
[Runtime] Ignore some global constructor warnings.

### DIFF
--- a/stdlib/public/Concurrency/Setup.cpp
+++ b/stdlib/public/Concurrency/Setup.cpp
@@ -41,6 +41,7 @@ bool _swift_task_isCurrentGlobalActor(
 // Register our type descriptors with standard manglings when the concurrency
 // runtime is loaded. This allows the runtime to quickly resolve those standard
 // manglings.
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
 __attribute__((constructor)) static void setupStandardConcurrencyDescriptors() {
   static const swift::ConcurrencyStandardTypeDescriptors descriptors = {
 #define STANDARD_TYPE(KIND, MANGLING, TYPENAME)
@@ -52,3 +53,4 @@ __attribute__((constructor)) static void setupStandardConcurrencyDescriptors() {
       &descriptors,
       &_swift_task_isCurrentGlobalActor);
 }
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3549,10 +3549,12 @@ static bool installLazyClassNameHook() {
   return false;
 }
 
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
 __attribute__((constructor)) SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE static bool
 supportsLazyObjcClassNames() {
   return SWIFT_LAZY_CONSTANT(installLazyClassNameHook());
 }
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 
 static void setUpGenericClassObjCName(ClassMetadata *theClass) {
   if (supportsLazyObjcClassNames()) {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -3282,12 +3282,14 @@ getObjCClassByMangledName(const char * _Nonnull typeName,
   return OldGetClassHook(typeName, outClass);
 }
 
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
 __attribute__((constructor))
 static void installGetClassHook() {
   if (SWIFT_RUNTIME_WEAK_CHECK(objc_setHook_getClass)) {
     SWIFT_RUNTIME_WEAK_USE(objc_setHook_getClass(getObjCClassByMangledName, &OldGetClassHook));
   }
 }
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 
 #endif
 

--- a/stdlib/toolchain/Compatibility50/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility50/Overrides.cpp
@@ -87,6 +87,7 @@ using mach_header_platform = mach_header_64;
 using mach_header_platform = mach_header;
 #endif
 
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
 __attribute__((constructor))
 static void installGetClassHook_untrusted() {
   extern char __dso_handle[];
@@ -118,3 +119,4 @@ static void installGetClassHook_untrusted() {
   }
 #pragma clang diagnostic pop
 }
+SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END


### PR DESCRIPTION
We have a few constructor functions that aren't wrapped in SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN/SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END and which have started to produce warnings in a new clang version. Explicitly allow these constructors by adding those.

rdar://147703947