### PR TITLE
[SILGen] Use the opaque element type for address in InlineArray literal

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4834,12 +4834,11 @@ static RValue emitInlineArrayLiteral(SILGenFunction &SGF, CollectionExpr *E,
   }
 
   auto elementType = iaTy->getGenericArgs()[1]->getCanonicalType();
-  auto loweredElementType = SGF.getLoweredType(elementType);
   auto &eltTL = SGF.getTypeLowering(AbstractionPattern::getOpaque(), elementType);
 
   SILValue alloc = SGF.emitTemporaryAllocation(E, loweredIAType);
   SILValue addr = SGF.B.createUncheckedAddrCast(E, alloc,
-                                            loweredElementType.getAddressType());
+                                            eltTL.getLoweredType().getAddressType());
 
   // Cleanups for any elements that have been initialized so far.
   SmallVector<CleanupHandle, 8> cleanups;

--- a/test/SILGen/inlinearray_literal.swift
+++ b/test/SILGen/inlinearray_literal.swift
@@ -106,3 +106,17 @@ func nontrivial() -> InlineArray<2, String> {
 func noncopyable() -> InlineArray<2, Atomic<Int>> {
   [Atomic(0), Atomic(1)]
 }
+
+// CHECK-LABEL: sil{{.*}} @$s19inlinearray_literal7closures11InlineArrayVy$0_S2icGyF : $@convention(thin) () -> @owned InlineArray<1, (Int) -> Int> {
+// CHECK:         [[IA_ALLOC:%.*]] = alloc_stack $InlineArray<1, (Int) -> Int>
+// CHECK-NEXT:    [[ADDR_CAST:%.*]] = unchecked_addr_cast [[IA_ALLOC]] to $*@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int, Int>
+// CHECK:         [[FN_REF:%.*]] = function_ref
+// CHECK-NEXT:    [[THIN_TO_THICK_FN:%.*]] = thin_to_thick_function [[FN_REF]] to $@callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int, Int>
+// CHECK-NEXT:    store [[THIN_TO_THICK_FN]] to [init] [[ADDR_CAST]]
+// CHECK-NEXT:    [[IA:%.*]] = load [take] [[IA_ALLOC]]
+// CHECK-NEXT:    dealloc_stack [[IA_ALLOC]]
+// CHECK-NEXT:    return [[IA]]
+// CHECK-LABEL: } // end sil function '$s19inlinearray_literal7closures11InlineArrayVy$0_S2icGyF'
+func closure() -> InlineArray<1, (Int) -> Int> {
+  [{$0 * 2}]
+}

--- a/test/stdlib/InlineArray.swift
+++ b/test/stdlib/InlineArray.swift
@@ -37,6 +37,7 @@ enum InlineArrayTests {
     testSuite.test("Noncopyable", testNoncopyable)
     testSuite.test("Uninhabited", testUninhabited)
     testSuite.test("Throws",      testThrows)
+    testSuite.test("Closures",    testClosures)
     runAllTests()
   }
 
@@ -195,6 +196,25 @@ enum InlineArrayTests {
         }
       }
     }
+  }
+
+  /// Test the handling of closure values in InlineArray literals
+  @available(SwiftStdlib 6.2, *)
+  static func testClosures() {
+    let ia: InlineArray<_, (Int) -> Int> = [{$0 * 2}]
+
+    for i in 0 ..< 10 {
+      expectEqual(i * 2, ia[0](i))
+    }
+
+    var x = 0
+    let ia2: InlineArray<_, () -> ()> = [{ x += 1 }]
+
+    for _ in 0 ..< 10 {
+      ia2[0]()
+    }
+
+    expectEqual(x, 10)
   }
 }
 


### PR DESCRIPTION
Resolves an issue where if you put a closure in the inline array literal, it will emit a non-opaque address to store to, but `ArgumentSource` always expects to store closure values as completely opaque in memory.