### PR TITLE
Concurrency: remove workaround for silencing UB

### DIFF
--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -18,6 +18,7 @@
 // DEP: _exit
 // DEP: _free
 // DEP: _malloc
+// DEP: _memcpy
 // DEP: _memmove
 // DEP: _memset
 // DEP: _memset_s

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -18,6 +18,7 @@
 // DEP: _exit
 // DEP: _free
 // DEP: _malloc
+// DEP: _memcpy
 // DEP: _memmove
 // DEP: _memset
 // DEP: _memset_s

--- a/test/embedded/dependencies-concurrency2.swift
+++ b/test/embedded/dependencies-concurrency2.swift
@@ -16,6 +16,7 @@
 // DEP: _exit
 // DEP: _free
 // DEP: _malloc
+// DEP: _memcpy
 // DEP: _memmove
 // DEP: _memset
 // DEP: _memset_s


### PR DESCRIPTION
The newer clang properly identifies UB on invalid pointer casts. This was previously being silenced by suppressing the warnings. Adjust the code to use `std::bit_cast` (or the shim implementation) to avoid the UB in this code.