### PR TITLE
[CS] Map caught error type into context

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3362,6 +3362,10 @@ public:
   /// Undo the above change.
   void removePotentialThrowSite(CatchNode catchNode);
 
+  /// Retrieve the explicit caught error type for the given catch node, without
+  /// attempting any inference.
+  Type getExplicitCaughtErrorType(CatchNode catchNode);
+
   /// Determine the caught error type for the given catch node.
   Type getCaughtErrorType(CatchNode node);
 

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -969,7 +969,7 @@ private:
     auto throwLoc = throwStmt->getThrowLoc();
     Type errorType;
     if (auto catchNode = ASTScope::lookupCatchNode(module, throwLoc))
-      errorType = catchNode.getExplicitCaughtType(cs.getASTContext());
+      errorType = cs.getExplicitCaughtErrorType(catchNode);
 
     if (!errorType) {
       if (!cs.getASTContext().getErrorDecl()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -511,7 +511,7 @@ void ConstraintSystem::recordPotentialThrowSite(
   recordPotentialThrowSite(catchNode, site);
 }
 
-Type ConstraintSystem::getCaughtErrorType(CatchNode catchNode) {
+Type ConstraintSystem::getExplicitCaughtErrorType(CatchNode catchNode) {
   ASTContext &ctx = getASTContext();
 
   // If there is an explicit caught type for this node, use it.
@@ -521,6 +521,16 @@ Type ConstraintSystem::getCaughtErrorType(CatchNode catchNode) {
 
     return explicitCaughtType;
   }
+
+  return Type();
+}
+
+Type ConstraintSystem::getCaughtErrorType(CatchNode catchNode) {
+  ASTContext &ctx = getASTContext();
+
+  // If we have an explicit caught error type for this node, use it.
+  if (auto explicitCaughtType = getExplicitCaughtErrorType(catchNode))
+    return explicitCaughtType;
 
   // Retrieve the thrown error type of a closure.
   // FIXME: This will need to change when we do inference of thrown error

--- a/test/SILGen/issue-77295.swift
+++ b/test/SILGen/issue-77295.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-silgen %s -verify
+
+// https://github.com/swiftlang/swift/issues/77295 - Make sure this compiles.
+extension Optional {
+  func foo<E: Error>(orThrow error: @autoclosure () -> E) throws(E) -> Wrapped {
+    switch self {
+    case .none:
+      throw error()
+    case .some(let wrapped):
+      wrapped
+    }
+  }
+}


### PR DESCRIPTION
Factor out `ConstraintSystem::getExplicitCaughtErrorType` from  `getCaughtErrorType`. Then use this for the contextual type for a `throw` syntactic element.

rdar://139000351
Resolves #77295