### PR TITLE
Runtimes: establish dependency on the registrar

### DIFF
--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -316,10 +316,15 @@ target_link_libraries(swiftCore
 string(TOLOWER "${SwiftCore_OBJECT_FORMAT}" SwiftCore_OBJECT_FORMAT_lc)
 if("${SwiftCore_OBJECT_FORMAT_lc}" STREQUAL "elf")
   target_link_libraries(swiftCore INTERFACE
-    swiftrt$<$<BOOL:NO>:>)
+    swiftrt)
 elseif("${SwiftCore_OBJECT_FORMAT_lc}" STREQUAL "coff")
-  target_link_libraries(swiftCore INTERFACE
-    swiftrt$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:T>)
+  if(BUILD_SHARED_LIBS)
+    target_link_libraries(swiftCore INTERFACE
+      swiftrt)
+  else()
+    target_link_libraries(swiftCore INTERFACE
+      swiftrtT)
+  endif()
 endif()
 
 target_link_options(swiftCore PUBLIC

--- a/Runtimes/Core/runtime/CMakeLists.txt
+++ b/Runtimes/Core/runtime/CMakeLists.txt
@@ -167,6 +167,10 @@ if("${SwiftCore_OBJECT_FORMAT}" STREQUAL "elfx")
     COMPONENT SwiftCore_runtime
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
     RENAME swiftrt.o)
+
+  install(TARGETS swiftrt
+    EXPORT SwiftCoreTargets
+    COMPONENT SwiftCore_runtime)
 elseif("${SwiftCore_OBJECT_FORMAT}" STREQUAL "coffx")
   add_library(swiftrtT OBJECT SwiftRT-COFF.cpp)
   target_compile_definitions(swiftrtT PRIVATE
@@ -183,6 +187,10 @@ elseif("${SwiftCore_OBJECT_FORMAT}" STREQUAL "coffx")
     COMPONENT SwiftCore_runtime
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
     RENAME swiftrt.obj)
+
+  install(TARGETS swiftrtT swiftrt
+    EXPORT SwiftCoreTargets
+    COMPONENT SwiftCore_runtime)
 elseif(NOT "${SwiftCore_OBJECT_FORMAT}" STREQUAL "x")
   message(SEND_ERROR "Unknown object format '${SwiftCore_OBJECT_FORMAT}'")
 endif()


### PR DESCRIPTION
This removes the workaround for the exporting of the registrar and enables proper dependency tracking across projects (primarily geared towards the Overlay).