### PR TITLE
[build-sciprt] Re-enable time tracking local ninja build

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -21,6 +21,7 @@ from build_swift.build_swift import cache_utils
 
 from . import product
 from .. import shell
+from ..utils import log_time_in_scope
 
 
 class Ninja(product.Product):
@@ -53,15 +54,18 @@ class NinjaBuilder(product.ProductBuilder):
     def build(self):
         if os.path.exists(self.ninja_bin_path):
             return
-        shell.call([
-            self.toolchain.cmake,
-            "-S", self.source_dir,
-            "-B", self.build_dir,
-            "-DCMAKE_BUILD_TYPE=Release",
-            "-DBUILD_TESTING=OFF",
-            f"-DCMAKE_C_COMPILER={self.toolchain.cc}",
-            f"-DCMAKE_CXX_COMPILER={self.toolchain.cxx}"])
-        shell.call([self.toolchain.cmake, "--build", self.build_dir])
+
+        print("--- Local Ninja Build ---")
+        with log_time_in_scope('local ninja'):
+            shell.call([
+                self.toolchain.cmake,
+                "-S", self.source_dir,
+                "-B", self.build_dir,
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DBUILD_TESTING=OFF",
+                f"-DCMAKE_C_COMPILER={self.toolchain.cc}",
+                f"-DCMAKE_CXX_COMPILER={self.toolchain.cxx}"])
+            shell.call([self.toolchain.cmake, "--build", self.build_dir])
 
 
 def get_ninja_version(ninja_bin_path):

--- a/utils/swift_build_support/swift_build_support/utils.py
+++ b/utils/swift_build_support/swift_build_support/utils.py
@@ -48,8 +48,11 @@ def clear_log_time():
 
 
 def log_time(event, command, duration=0):
-    f = open(log_time_path(), "a")
+    log_time_dir = os.path.dirname(log_time_path())
+    if not os.path.isdir(log_time_dir):
+        os.mkdir(log_time_dir)
 
+    f = open(log_time_path(), "a")
     log_event = {
         "event": event,
         "command": command,


### PR DESCRIPTION
Found the break in the script. The ninja product is often the first product so we didn't have a build directory to write the time tracking file into. Update `log_time` to create the directory where the build time log should go if it doesn't exist already.