### PR TITLE
[SE-0456, -0467] enable span properties for inline-storage types

### DIFF
--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -166,7 +166,9 @@ extension CollectionOfOne {
     @lifetime(borrow self)
     @_alwaysEmitIntoClient
     get {
-      fatalError("Span over CollectionOfOne is not supported yet.")
+      let pointer = unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(self))
+      let span = unsafe Span(_unsafeStart: pointer, count: 1)
+      return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
 }

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -171,6 +171,19 @@ extension CollectionOfOne {
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
+
+  @available(SwiftStdlib 6.2, *)
+  public var mutableSpan: MutableSpan<Element> {
+    @lifetime(borrow self)
+    @_alwaysEmitIntoClient
+    mutating get {
+      let pointer = unsafe UnsafeMutablePointer<Element>(
+        Builtin.addressOfBorrow(self)
+      )
+      let span = unsafe MutableSpan(_unsafeStart: pointer, count: 1)
+      return unsafe _overrideLifetime(span, mutating: &self)
+    }
+  }
 }
 
 @_unavailableInEmbedded

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -174,7 +174,7 @@ extension CollectionOfOne {
 
   @available(SwiftStdlib 6.2, *)
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(borrow self)
+    @lifetime(&self)
     @_alwaysEmitIntoClient
     mutating get {
       let pointer = unsafe UnsafeMutablePointer<Element>(

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -468,7 +468,9 @@ extension InlineArray where Element: ~Copyable {
     @lifetime(borrow self)
     @_alwaysEmitIntoClient
     borrowing get {
-      fatalError("Span over InlineArray is not supported yet.")
+      let pointer = _address
+      let span = unsafe Span(_unsafeStart: pointer, count: count)
+      return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
 }

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -476,7 +476,7 @@ extension InlineArray where Element: ~Copyable {
 
   @available(SwiftStdlib 6.2, *)
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(borrow self)
+    @lifetime(&self)
     @_alwaysEmitIntoClient
     mutating get {
       let pointer = unsafe _mutableAddress

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -468,9 +468,20 @@ extension InlineArray where Element: ~Copyable {
     @lifetime(borrow self)
     @_alwaysEmitIntoClient
     borrowing get {
-      let pointer = _address
+      let pointer = unsafe _address
       let span = unsafe Span(_unsafeStart: pointer, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
+    }
+  }
+
+  @available(SwiftStdlib 6.2, *)
+  public var mutableSpan: MutableSpan<Element> {
+    @lifetime(borrow self)
+    @_alwaysEmitIntoClient
+    mutating get {
+      let pointer = unsafe _mutableAddress
+      let span = unsafe MutableSpan(_unsafeStart: pointer, count: count)
+      return unsafe _overrideLifetime(span, mutating: &self)
     }
   }
 }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -846,6 +846,8 @@ Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
 Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
+Added: _$ss11InlineArrayVsRi__rlE11mutableSpans07MutableD0Vyq_Gvr
+Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -847,6 +847,8 @@ Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
 Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
+Added: _$ss11InlineArrayVsRi__rlE11mutableSpans07MutableD0Vyq_Gvr
+Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC

--- a/test/stdlib/Span/InlineSpanProperties.swift
+++ b/test/stdlib/Span/InlineSpanProperties.swift
@@ -23,7 +23,6 @@ var suite = TestSuite("Span properties backed by inline storage")
 defer { runAllTests() }
 
 suite.test("CollectionOfOne.span property")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -35,7 +34,6 @@ suite.test("CollectionOfOne.span property")
   let u = Array(s.utf8)
   let c = CollectionOfOne(consume s)
   s = ""
-  expectCrashLater()
   let span = c.span
   expectEqual(span.count, 1)
   let v = Array(span[0].utf8)
@@ -43,7 +41,6 @@ suite.test("CollectionOfOne.span property")
 }
 
 suite.test("CollectionOfOne.span property (simple)")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -52,7 +49,6 @@ suite.test("CollectionOfOne.span property (simple)")
   guard #available(SwiftStdlib 6.2, *) else { return }
   
   let c = CollectionOfOne(Int.random(in: 0..<100000))
-  expectCrashLater()
   let span = c.span
   expectEqual(span.count, c.indices.count)
   expectEqual(span[0], c[0])
@@ -63,7 +59,6 @@ struct Padded: BitwiseCopyable {
 }
 
 suite.test("CollectionOfOne.span stride test")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -72,14 +67,12 @@ suite.test("CollectionOfOne.span stride test")
   guard #available(SwiftStdlib 6.2, *) else { return }
 
   let c = CollectionOfOne(Padded(storage: (-1, 1)))
-  expectCrashLater()
   let span = c.span
   let bytes = span.bytes
   expectEqual(bytes.byteCount, MemoryLayout.size(ofValue: c))
 }
 
 suite.test("InlineArray.span property")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -89,7 +82,6 @@ suite.test("InlineArray.span property")
 
   var s = InlineArray<5, Int>(repeating: 0)
   s[3] = .random(in: 0..<1000)
-  expectCrashLater()
   let span = s.span
   expectEqual(span.count, s.count)
   for i in s.indices {
@@ -98,7 +90,6 @@ suite.test("InlineArray.span property")
 }
 
 suite.test("InlineArray.span property (String)")
-.skip(.wasiAny(reason: "Trap tests aren't supported on WASI."))
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -108,7 +99,6 @@ suite.test("InlineArray.span property (String)")
 
   var s = InlineArray<5, String>(repeating: "0")
   s[3] = String(Int.random(in: 0..<1000))
-  expectCrashLater()
   let span = s.span
   expectEqual(span.count, s.count)
   for i in s.indices {

--- a/test/stdlib/Span/InlineSpanProperties.swift
+++ b/test/stdlib/Span/InlineSpanProperties.swift
@@ -118,3 +118,31 @@ suite.test("InlineArray.span property (String)")
     expectEqual(span[i], s[i])
   }    
 }
+
+suite.test("InlineArray.mutableSpan property")
+.require(.stdlib_6_2).code
+{
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var v = InlineArray<5, Int>(repeating: 0)
+  let c = v.count
+  var span = v.mutableSpan
+  expectEqual(span.count, c)
+  span[3] = Int.random(in: .min..<0)
+  let r = span[3]
+  expectEqual(v[3], r)
+}
+
+suite.test("InlineArray.mutableSpan property (String)")
+.require(.stdlib_6_2).code
+{
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var v = InlineArray<5, String>(repeating: "0")
+  let c = v.count
+  var span = v.mutableSpan
+  expectEqual(span.count, c)
+  span[3] = String(repeating: "0", count: Int.random(in: 100..<500))
+  let s = span[3]
+  expectTrue(s._isIdentical(to: v[3]))
+}

--- a/test/stdlib/Span/InlineSpanProperties.swift
+++ b/test/stdlib/Span/InlineSpanProperties.swift
@@ -72,6 +72,19 @@ suite.test("CollectionOfOne.span stride test")
   expectEqual(bytes.byteCount, MemoryLayout.size(ofValue: c))
 }
 
+suite.test("CollectionOfOne.mutableSpan property (simple)")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  var c = CollectionOfOne(Int.random(in: 0..<100000))
+  expectEqual(c.count, 1)
+  var span = c.mutableSpan
+  expectEqual(span.count, 1)
+  span[0] = Int.random(in: .min..<0)
+  let r = span[0]
+  expectEqual(c[0], r)
+}
+
 suite.test("InlineArray.span property")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },


### PR DESCRIPTION
Continues SE-0456 from https://github.com/swiftlang/swift/pull/78561, continues SE-0467 from https://github.com/swiftlang/swift/pull/79650.

Adds `span` and `mutableSpan` properties for `CollectionOfOne` and `InlineArray`.

`UTF8View.span` will be enabled for the small string representation in https://github.com/swiftlang/swift/pull/80684