### PR TITLE
cmake: Remove LLVM_ENABLE_ASSERTIONS from Windows cmake cache.

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -13,10 +13,6 @@ set(LLVM_ENABLE_RUNTIMES
       compiler-rt
     CACHE STRING "")
 
-# NOTE(compnerd) always enable assertions, the toolchain will not provide enough
-# context to resolve issues otherwise and may silently generate invalid output.
-set(LLVM_ENABLE_ASSERTIONS YES CACHE BOOL "")
-
 set(ENABLE_X86_RELAX_RELOCATIONS YES CACHE BOOL "")
 
 # NOTE(compnerd) we can hardcode the default target triple since the cache files

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -13,10 +13,6 @@ set(LLVM_ENABLE_RUNTIMES
       compiler-rt
     CACHE STRING "")
 
-# NOTE(compnerd) always enable assertions, the toolchain will not provide enough
-# context to resolve issues otherwise and may silently generate invalid output.
-set(LLVM_ENABLE_ASSERTIONS YES CACHE BOOL "")
-
 set(ENABLE_X86_RELAX_RELOCATIONS YES CACHE BOOL "")
 
 # NOTE(compnerd) we can hardcode the default target triple since the cache files


### PR DESCRIPTION
Remove `LLVM_ENABLE_ASSERTIONS` from the cmake Cache files for Windows. We now control this via the `-Variant` flag for `build.ps1`, and the GHA will build both variants.