### PR TITLE
DiagnosticEngine: Print the ID of the wrapped, not wrapper, diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -1530,16 +1530,17 @@ namespace swift {
   public:
     DiagnosticKind declaredDiagnosticKindFor(const DiagID id);
 
-    /// Get a localized format string for a given `DiagID`. If no localization
-    /// available returns the default string for that `DiagID`.
-    llvm::StringRef diagnosticStringFor(DiagID id);
+    /// Get a localized format string for the given `DiagID`. If no localization
+    /// is available, returns the default string.
+    llvm::StringRef getFormatStringForDiagnostic(DiagID id);
 
-    /// Get a localized format string with an optional diagnostic name appended
-    /// to it. The diagnostic name type is defined by
-    /// `PrintDiagnosticNamesMode`.
-    llvm::StringRef diagnosticStringWithNameFor(
-        DiagID id, DiagGroupID groupID,
-        PrintDiagnosticNamesMode printDiagnosticNamesMode);
+    /// Get a localized format string for the given diagnostic. If no
+    /// localization is available, returns the default string.
+    ///
+    /// \param includeDiagnosticName Whether to at all consider embedding the
+    /// name of the diagnostic identifier or group, per the setting.
+    llvm::StringRef getFormatStringForDiagnostic(const Diagnostic &diagnostic,
+                                                 bool includeDiagnosticName);
 
     static llvm::StringRef diagnosticIDStringFor(const DiagID id);
 

--- a/lib/IDE/CodeCompletionDiagnostics.cpp
+++ b/lib/IDE/CodeCompletionDiagnostics.cpp
@@ -74,7 +74,7 @@ bool CodeCompletionDiagnostics::getDiagnostics(
     typename swift::detail::PassArgument<ArgTypes>::type... VArgs) {
   DiagID id = ID.ID;
   std::vector<DiagnosticArgument> DiagArgs{std::move(VArgs)...};
-  auto format = Engine.diagnosticStringFor(id);
+  auto format = Engine.getFormatStringForDiagnostic(id);
   DiagnosticEngine::formatDiagnosticText(Out, format, DiagArgs);
   severity = getSeverity(Engine.declaredDiagnosticKindFor(id));
 

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -1086,7 +1086,7 @@ public:
         // Emit a specific unavailable message when we know why a decl can't be
         // exposed, or a generic message otherwise.
         auto diagString =
-            M.getASTContext().Diags.diagnosticStringFor(diag.getID());
+            M.getASTContext().Diags.getFormatStringForDiagnostic(diag.getID());
         DiagnosticEngine::formatDiagnosticText(os, diagString, diag.getArgs(),
                                                DiagnosticFormatOptions());
         os << "\");\n";

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -8,6 +8,7 @@ add_swift_unittest(SwiftASTTests
   DiagnosticBehaviorTests.cpp
   DiagnosticConsumerTests.cpp
   DiagnosticGroupsTests.cpp
+  DiagnosticInfoTests.cpp
   SourceLocTests.cpp
   TestContext.cpp
   TypeMatchTests.cpp

--- a/unittests/AST/DiagnosticBehaviorTests.cpp
+++ b/unittests/AST/DiagnosticBehaviorTests.cpp
@@ -29,13 +29,12 @@ public:
     this->callback(Info);
   }
 };
-} // end anonymous namespace
 
-static void diagnosticBehaviorTestCase(
-    llvm::function_ref<void(DiagnosticEngine &)> diagnose,
-    llvm::function_ref<void(DiagnosticEngine &, const DiagnosticInfo &)>
-        callback,
-    unsigned expectedNumCallbackCalls) {
+static void
+testCase(llvm::function_ref<void(DiagnosticEngine &)> diagnose,
+         llvm::function_ref<void(DiagnosticEngine &, const DiagnosticInfo &)>
+             callback,
+         unsigned expectedNumCallbackCalls) {
   SourceManager sourceMgr;
   DiagnosticEngine diags(sourceMgr);
 
@@ -55,7 +54,7 @@ static void diagnosticBehaviorTestCase(
 }
 
 TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
-  diagnosticBehaviorTestCase(
+  testCase(
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({5}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
@@ -69,7 +68,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       },
       /*expectedNumCallbackCalls=*/1);
 
-  diagnosticBehaviorTestCase(
+  testCase(
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({4}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
@@ -87,7 +86,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       },
       /*expectedNumCallbackCalls=*/1);
 
-  diagnosticBehaviorTestCase(
+  testCase(
       [](DiagnosticEngine &diags) {
         diags.setLanguageVersion(version::Version({4}));
         diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
@@ -106,3 +105,5 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       },
       /*expectedNumCallbackCalls=*/1);
 }
+
+} // end anonymous namespace

--- a/unittests/AST/DiagnosticBehaviorTests.cpp
+++ b/unittests/AST/DiagnosticBehaviorTests.cpp
@@ -64,7 +64,7 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Error);
         EXPECT_EQ(info.FormatString,
-                  diags.diagnosticStringFor(
+                  diags.getFormatStringForDiagnostic(
                       diag::error_immediate_mode_missing_stdlib.ID));
       },
       /*expectedNumCallbackCalls=*/1);
@@ -77,12 +77,12 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       },
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Warning);
-        EXPECT_EQ(info.FormatString,
-                  diags.diagnosticStringFor(diag::error_in_swift_lang_mode.ID));
+        EXPECT_EQ(info.FormatString, diags.getFormatStringForDiagnostic(
+                                         diag::error_in_swift_lang_mode.ID));
 
         auto wrappedDiagInfo = info.FormatArgs.front().getAsDiagnostic();
         EXPECT_EQ(wrappedDiagInfo->FormatString,
-                  diags.diagnosticStringFor(
+                  diags.getFormatStringForDiagnostic(
                       diag::error_immediate_mode_missing_stdlib.ID));
       },
       /*expectedNumCallbackCalls=*/1);
@@ -96,12 +96,12 @@ TEST(DiagnosticBehavior, WarnUntilSwiftLangMode) {
       [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
         EXPECT_EQ(info.Kind, DiagnosticKind::Warning);
         EXPECT_EQ(info.FormatString,
-                  diags.diagnosticStringFor(
+                  diags.getFormatStringForDiagnostic(
                       diag::error_in_a_future_swift_lang_mode.ID));
 
         auto wrappedDiagInfo = info.FormatArgs.front().getAsDiagnostic();
         EXPECT_EQ(wrappedDiagInfo->FormatString,
-                  diags.diagnosticStringFor(
+                  diags.getFormatStringForDiagnostic(
                       diag::error_immediate_mode_missing_stdlib.ID));
       },
       /*expectedNumCallbackCalls=*/1);

--- a/unittests/AST/DiagnosticGroupsTests.cpp
+++ b/unittests/AST/DiagnosticGroupsTests.cpp
@@ -63,54 +63,6 @@ static void diagnosticGroupsTestCase(
   EXPECT_EQ(count, expectedNumCallbackCalls);
 }
 
-TEST(DiagnosticGroups, PrintDiagnosticGroups) {
-  // Test that we append the correct group in the format string.
-  diagnosticGroupsTestCase(
-      [](DiagnosticEngine &diags) {
-        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Group);
-
-        TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
-                                  DiagGroupID::DeprecatedDeclaration);
-        diags.diagnose(SourceLoc(), diagnostic);
-      },
-      [](const DiagnosticInfo &info) {
-        EXPECT_TRUE(info.FormatString.ends_with(" [DeprecatedDeclaration]"));
-      },
-      /*expectedNumCallbackCalls=*/1);
-
-  diagnosticGroupsTestCase(
-      [](DiagnosticEngine &diags) {
-        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Group);
-
-        TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
-                                  DiagGroupID::no_group);
-        diags.diagnose(SourceLoc(), diagnostic);
-      },
-      [](const DiagnosticInfo &info) {
-        EXPECT_FALSE(info.FormatString.ends_with("]"));
-      },
-      /*expectedNumCallbackCalls=*/1);
-}
-
-TEST(DiagnosticGroups, DiagnosticsWrappersInheritGroups) {
-  // Test that we don't loose the group of a diagnostic when it gets wrapped in
-  // another one.
-  diagnosticGroupsTestCase(
-      [](DiagnosticEngine &diags) {
-        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Group);
-
-        TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
-                                  DiagGroupID::DeprecatedDeclaration);
-        diags.diagnose(SourceLoc(), diagnostic)
-            .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 99);
-      },
-      [](const DiagnosticInfo &info) {
-        EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
-        EXPECT_TRUE(info.FormatString.ends_with(" [DeprecatedDeclaration]"));
-      },
-      /*expectedNumCallbackCalls=*/1);
-}
-
 TEST(DiagnosticGroups, TargetAll) {
   // Test that uncategorized diagnostics are escalated when escalating all
   // warnings.

--- a/unittests/AST/DiagnosticGroupsTests.cpp
+++ b/unittests/AST/DiagnosticGroupsTests.cpp
@@ -39,12 +39,10 @@ public:
 struct TestDiagnostic : public Diagnostic {
   TestDiagnostic(DiagID ID, DiagGroupID GroupID) : Diagnostic(ID, GroupID) {}
 };
-} // end anonymous namespace
 
-static void diagnosticGroupsTestCase(
-    llvm::function_ref<void(DiagnosticEngine &)> diagnose,
-    llvm::function_ref<void(const DiagnosticInfo &)> callback,
-    unsigned expectedNumCallbackCalls) {
+static void testCase(llvm::function_ref<void(DiagnosticEngine &)> diagnose,
+                     llvm::function_ref<void(const DiagnosticInfo &)> callback,
+                     unsigned expectedNumCallbackCalls) {
   SourceManager sourceMgr;
   DiagnosticEngine diags(sourceMgr);
 
@@ -66,7 +64,7 @@ static void diagnosticGroupsTestCase(
 TEST(DiagnosticGroups, TargetAll) {
   // Test that uncategorized diagnostics are escalated when escalating all
   // warnings.
-  diagnosticGroupsTestCase(
+  testCase(
       [](DiagnosticEngine &diags) {
         const std::vector rules = {
             WarningAsErrorRule(WarningAsErrorRule::Action::Enable)};
@@ -91,16 +89,16 @@ TEST(DiagnosticGroups, OverrideBehaviorLimitations) {
                               DiagGroupID::DeprecatedDeclaration);
 
     // Make sure ID actually is an error by default.
-    diagnosticGroupsTestCase(
+    testCase(
         [&diagnostic](DiagnosticEngine &diags) {
           diags.diagnose(SourceLoc(), diagnostic);
         },
         [](const DiagnosticInfo &info) {
-          EXPECT_TRUE(info.Kind == DiagnosticKind::Error);
+          EXPECT_EQ(info.Kind, DiagnosticKind::Error);
         },
         /*expectedNumCallbackCalls=*/1);
 
-    diagnosticGroupsTestCase(
+    testCase(
         [&diagnostic](DiagnosticEngine &diags) {
           const std::vector rules = {WarningAsErrorRule(
               WarningAsErrorRule::Action::Enable, "DeprecatedDeclaration")};
@@ -124,7 +122,7 @@ TEST(DiagnosticGroups, OverrideBehaviorLimitations) {
         DiagGroupID::DeprecatedDeclaration);
 
     // Make sure ID actually is a warning by default.
-    diagnosticGroupsTestCase(
+    testCase(
         [&diagnostic](DiagnosticEngine &diags) {
           diags.diagnose(SourceLoc(), diagnostic);
         },
@@ -133,7 +131,7 @@ TEST(DiagnosticGroups, OverrideBehaviorLimitations) {
         },
         /*expectedNumCallbackCalls=*/1);
 
-    diagnosticGroupsTestCase(
+    testCase(
         [&diagnostic](DiagnosticEngine &diags) {
           const std::vector rules = {WarningAsErrorRule(
               WarningAsErrorRule::Action::Enable, "DeprecatedDeclaration")};
@@ -148,3 +146,5 @@ TEST(DiagnosticGroups, OverrideBehaviorLimitations) {
         /*expectedNumCallbackCalls=*/1);
   }
 }
+
+} // end anonymous namespace

--- a/unittests/AST/DiagnosticInfoTests.cpp
+++ b/unittests/AST/DiagnosticInfoTests.cpp
@@ -1,0 +1,168 @@
+//===--- DiagnosticInfoTests.cpp --------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/DiagnosticGroups.h"
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/SourceManager.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+namespace {
+class TestDiagnosticConsumer : public DiagnosticConsumer {
+  llvm::function_ref<void(const DiagnosticInfo &)> callback;
+
+public:
+  TestDiagnosticConsumer(decltype(callback) callback) : callback(callback) {}
+
+  void handleDiagnostic(SourceManager &SM,
+                        const DiagnosticInfo &Info) override {
+    this->callback(Info);
+  }
+};
+
+struct TestDiagnostic : public Diagnostic {
+  TestDiagnostic(DiagID ID, DiagGroupID GroupID) : Diagnostic(ID, GroupID) {}
+};
+
+static void
+testCase(llvm::function_ref<void(DiagnosticEngine &)> diagnose,
+         llvm::function_ref<void(DiagnosticEngine &, const DiagnosticInfo &)>
+             callback,
+         unsigned expectedNumCallbackCalls) {
+  SourceManager sourceMgr;
+  DiagnosticEngine diags(sourceMgr);
+
+  unsigned count = 0;
+
+  const auto countingCallback = [&](const DiagnosticInfo &info) {
+    ++count;
+    callback(diags, info);
+  };
+
+  TestDiagnosticConsumer consumer(countingCallback);
+  diags.addConsumer(consumer);
+  diagnose(diags);
+  diags.removeConsumer(consumer);
+
+  EXPECT_EQ(count, expectedNumCallbackCalls);
+}
+
+// MARK: PrintDiagnosticNamesMode
+
+TEST(DiagnosticInfo, PrintDiagnosticNamesMode_None) {
+  // Test that we don't embed anything in the format string if told so.
+  testCase(
+      [](DiagnosticEngine &diags) {
+        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::None);
+
+        TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
+                                  DiagGroupID::DeprecatedDeclaration);
+        diags.diagnose(SourceLoc(), diagnostic);
+      },
+      [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
+        EXPECT_EQ(info.FormatString,
+                  diags.getFormatStringForDiagnostic(
+                      diag::error_immediate_mode_missing_stdlib.ID));
+      },
+      /*expectedNumCallbackCalls=*/1);
+}
+
+TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Identifier) {
+  // Test that we embed correct identifier in the format string.
+  testCase(
+      [](DiagnosticEngine &diags) {
+        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Identifier);
+
+        diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib);
+      },
+      [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
+        EXPECT_TRUE(info.FormatString.ends_with(
+            " [error_immediate_mode_missing_stdlib]"));
+      },
+      /*expectedNumCallbackCalls=*/1);
+}
+
+TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Identifier_WrappedDiag) {
+  // For a wrapper diagnostic, test that we embed the identifier of the wrapped
+  // diagnostic.
+  testCase(
+      [](DiagnosticEngine &diags) {
+        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Identifier);
+
+        diags.diagnose(SourceLoc(), diag::error_immediate_mode_missing_stdlib)
+            .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 99);
+      },
+      [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
+        EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
+        EXPECT_TRUE(info.FormatString.ends_with(
+            " [error_immediate_mode_missing_stdlib]"));
+      },
+      /*expectedNumCallbackCalls=*/1);
+}
+
+TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Group_NoGroup) {
+  // Test that we don't embed anything in the format string if the diagnostic
+  // has no group.
+  testCase(
+      [](DiagnosticEngine &diags) {
+        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Group);
+
+        TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
+                                  DiagGroupID::no_group);
+        diags.diagnose(SourceLoc(), diagnostic);
+      },
+      [](DiagnosticEngine &diags, const DiagnosticInfo &info) {
+        EXPECT_EQ(info.FormatString,
+                  diags.getFormatStringForDiagnostic(
+                      diag::error_immediate_mode_missing_stdlib.ID));
+      },
+      /*expectedNumCallbackCalls=*/1);
+}
+
+TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Group) {
+  // Test that we embed the correct group in the format string.
+  testCase(
+      [](DiagnosticEngine &diags) {
+        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Group);
+
+        TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
+                                  DiagGroupID::DeprecatedDeclaration);
+        diags.diagnose(SourceLoc(), diagnostic);
+      },
+      [](DiagnosticEngine &, const DiagnosticInfo &info) {
+        EXPECT_TRUE(info.FormatString.ends_with(" [DeprecatedDeclaration]"));
+      },
+      /*expectedNumCallbackCalls=*/1);
+}
+
+TEST(DiagnosticInfo, PrintDiagnosticNamesMode_Group_WrappedDiag) {
+  // For a wrapper diagnostic, test that we embed the group name of the wrapped
+  // diagnostic.
+  testCase(
+      [](DiagnosticEngine &diags) {
+        diags.setPrintDiagnosticNamesMode(PrintDiagnosticNamesMode::Group);
+
+        TestDiagnostic diagnostic(diag::error_immediate_mode_missing_stdlib.ID,
+                                  DiagGroupID::DeprecatedDeclaration);
+        diags.diagnose(SourceLoc(), diagnostic)
+            .limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 99);
+      },
+      [](DiagnosticEngine &, const DiagnosticInfo &info) {
+        EXPECT_EQ(info.ID, diag::error_in_a_future_swift_lang_mode.ID);
+        EXPECT_TRUE(info.FormatString.ends_with(" [DeprecatedDeclaration]"));
+      },
+      /*expectedNumCallbackCalls=*/1);
+}
+
+} // end anonymous namespace


### PR DESCRIPTION
`-debug-diagnostic-names` always favors the effective ID of an emitted diagnostic. This is not ideal for wrapper diagnostics because they are an implementation detail of the diagnostic engine:

```swift
protocol P {
    func test(_: () -> Void)
}

struct S: P {
    func test(_: @Sendable () -> Void) {}
}
```
```
warning: sendability of function types in instance method 'test' does not match requirement in protocol 'P'; this is an error in the Swift 6 language mode [error_in_swift_lang_mode]
```

What is most relevant to both a compiler engineer and developer is the identity of the underlying diagnostic the engine was instructed to emit by a client.
