### PR TITLE
SIL: add mark_dependence_addr

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -253,7 +253,7 @@ struct AliasAnalysis {
     case let storeBorrow as StoreBorrowInst:
       return memLoc.mayAlias(with: storeBorrow.destination, self) ? .init(write: true) : .noEffects
 
-    case let mdi as MarkDependenceInst:
+    case let mdi as MarkDependenceInstruction:
       if mdi.base.type.isAddress && memLoc.mayAlias(with: mdi.base, self) {
         return .init(read: true)
       }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -123,7 +123,7 @@ private func analyze(dependence: LifetimeDependence, _ context: FunctionPassCont
   // Check each lifetime-dependent use via a def-use visitor
   var walker = DiagnoseDependenceWalker(diagnostics, context)
   defer { walker.deinitialize() }
-  let result = walker.walkDown(root: dependence.dependentValue)
+  let result = walker.walkDown(dependence: dependence)
   // The walk may abort without a diagnostic error.
   assert(!error || result == .abortWalk)
   return result == .continueWalk
@@ -354,7 +354,7 @@ private struct LifetimeVariable {
 }
 
 /// Walk up an address into which a dependent value has been stored. If any address in the use-def chain is a
-/// mark_dependence, follow the depenedence base rather than the forwarded value. If any of the dependence bases in
+/// mark_dependence, follow the dependence base rather than the forwarded value. If any of the dependence bases in
 /// within the current scope is with (either local checkInoutResult), then storing a value into that address is
 /// nonescaping.
 ///

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjectOutliner.swift
@@ -305,7 +305,8 @@ private func isValidUseOfObject(_ use: Operand) -> Bool {
        is DeallocStackRefInst,
        is StrongRetainInst,
        is StrongReleaseInst,
-       is FixLifetimeInst:
+       is FixLifetimeInst,
+       is MarkDependenceAddrInst:
     return true
 
   case let mdi as MarkDependenceInst:

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/MemBehaviorDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/MemBehaviorDumper.swift
@@ -75,6 +75,7 @@ private extension Instruction {
          is BuiltinInst,
          is StoreBorrowInst,
          is MarkDependenceInst,
+         is MarkDependenceAddrInst,
          is DebugValueInst:
       return true
     default:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -56,12 +56,12 @@ protocol AddressUseVisitor {
     -> WalkResult
 
   /// A loaded address use propagates the value at the address.
-  mutating func loadedAddressUse(of operand: Operand, into value: Value)
+  mutating func loadedAddressUse(of operand: Operand, intoValue value: Value)
     -> WalkResult
 
   /// A loaded address use propagates the value at the address to the
   /// destination address operand.
-  mutating func loadedAddressUse(of operand: Operand, into address: Operand)
+  mutating func loadedAddressUse(of operand: Operand, intoAddress address: Operand)
     -> WalkResult
 
   /// Yielding an address may modify the value at the yield, but not past the yield. The yielded value may escape, but
@@ -137,14 +137,14 @@ extension AddressUseVisitor {
     case is LoadInst, is LoadUnownedInst,  is LoadWeakInst, is ValueMetatypeInst, is ExistentialMetatypeInst,
          is PackElementGetInst:
       let svi = operand.instruction as! SingleValueInstruction
-      return loadedAddressUse(of: operand, into: svi)
+      return loadedAddressUse(of: operand, intoValue: svi)
 
     case is YieldInst:
       return yieldedAddressUse(of: operand)
 
     case let sdai as SourceDestAddrInstruction
            where sdai.sourceOperand == operand:
-      return loadedAddressUse(of: operand, into: sdai.destinationOperand)
+      return loadedAddressUse(of: operand, intoAddress: sdai.destinationOperand)
 
     case let sdai as SourceDestAddrInstruction
            where sdai.destinationOperand == operand:
@@ -401,12 +401,12 @@ extension AddressInitializationWalker {
     return convention.isIndirectIn ? .continueWalk : .abortWalk
   }
 
-  mutating func loadedAddressUse(of operand: Operand, into value: Value)
+  mutating func loadedAddressUse(of operand: Operand, intoValue value: Value)
     -> WalkResult {
     return .continueWalk
   }
 
-  mutating func loadedAddressUse(of operand: Operand, into address: Operand)
+  mutating func loadedAddressUse(of operand: Operand, intoAddress address: Operand)
     -> WalkResult {
     return .continueWalk
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -68,10 +68,14 @@ protocol AddressUseVisitor {
   /// only if its type is escapable.
   mutating func yieldedAddressUse(of operand: Operand) -> WalkResult
 
-  /// A non-address owned `value` whose ownership depends on the in-memory
-  /// value at `address`, such as `mark_dependence %value on %address`.
-  mutating func dependentAddressUse(of operand: Operand, into value: Value)
-    -> WalkResult
+  /// A forwarded `value` whose ownership depends on the in-memory value at the address `operand`.
+  /// `%value` may be an address type, but only uses of this address value are dependent.
+  /// e.g. `%value = mark_dependence %_ on %operand`
+  mutating func dependentAddressUse(of operand: Operand, dependentValue value: Value) -> WalkResult
+
+  /// A dependent `address` whose lifetime depends on the in-memory value at `address`.
+  /// e.g. `mark_dependence_addr %address on %operand`
+  mutating func dependentAddressUse(of operand: Operand, dependentAddress address: Value) -> WalkResult
 
   /// A pointer escape may propagate the address beyond the current instruction.
   mutating func escapingAddressUse(of operand: Operand) -> WalkResult
@@ -91,34 +95,11 @@ extension AddressUseVisitor {
     case is EndAccessInst, is EndApplyInst, is AbortApplyInst, is EndBorrowInst:
       return scopeEndingAddressUse(of: operand)
 
-    case let markDep as MarkDependenceInst:
-      if markDep.valueOperand == operand {
-        return projectedAddressUse(of: operand, into: markDep)
-      }
-      assert(markDep.baseOperand == operand)
-      // If another address depends on the current address,
-      // handle it like a projection.
-      if markDep.type.isAddress {
-        return projectedAddressUse(of: operand, into: markDep)
-      }
-      switch markDep.dependenceKind {
-      case .Unresolved:
-        if LifetimeDependence(markDep, context) == nil {
-          break
-        }
-        fallthrough
-      case .NonEscaping:
-        // Note: This is unreachable from InteriorUseVisitor because the base address of a `mark_dependence
-        // [nonescaping]` must be a `begin_access`, and interior liveness does not check uses of the accessed address.
-        return dependentAddressUse(of: operand, into: markDep)
-      case .Escaping:
-        break
-      }
-      // A potentially escaping value depends on this address.
-      return escapingAddressUse(of: operand)
+    case is MarkDependenceInstruction:
+      return classifyMarkDependence(operand: operand)
 
     case let pai as PartialApplyInst where !pai.mayEscape:
-      return dependentAddressUse(of: operand, into: pai)
+      return dependentAddressUse(of: operand, dependentValue: pai)
 
     case let pai as PartialApplyInst where pai.mayEscape:
       return escapingAddressUse(of: operand)
@@ -196,6 +177,57 @@ extension AddressUseVisitor {
       }
       // Unknown instruction.
       return unknownAddressUse(of: operand)
+    }
+  }
+
+  private mutating func classifyMarkDependence(operand: Operand) -> WalkResult {
+    switch operand.instruction {
+    case let markDep as MarkDependenceInst:
+      if markDep.valueOperand == operand {
+        return projectedAddressUse(of: operand, into: markDep)
+      }
+      assert(markDep.baseOperand == operand)
+      // If another address depends on the current address,
+      // handle it like a projection.
+      if markDep.type.isAddress {
+        return projectedAddressUse(of: operand, into: markDep)
+      }
+      switch markDep.dependenceKind {
+      case .Unresolved:
+        if LifetimeDependence(markDep, context) == nil {
+          break
+        }
+        fallthrough
+      case .NonEscaping:
+        // Note: This is unreachable from InteriorUseVisitor because the base address of a `mark_dependence
+        // [nonescaping]` must be a `begin_access`, and interior liveness does not check uses of the accessed address.
+        return dependentAddressUse(of: operand, dependentValue: markDep)
+      case .Escaping:
+        break
+      }
+      // A potentially escaping value depends on this address.
+      return escapingAddressUse(of: operand)
+      
+    case let markDep as MarkDependenceAddrInst:
+      if markDep.addressOperand == operand {
+        return leafAddressUse(of: operand)
+      }
+      switch markDep.dependenceKind {
+      case .Unresolved:
+        if LifetimeDependence(markDep, context) == nil {
+          break
+        }
+        fallthrough
+      case .NonEscaping:
+        return dependentAddressUse(of: operand, dependentAddress: markDep.address)
+      case .Escaping:
+        break
+      }
+      // A potentially escaping value depends on this address.
+      return escapingAddressUse(of: operand)
+
+    default:
+      fatalError("Unexpected MarkDependenceInstruction")
     }
   }
 }
@@ -385,8 +417,11 @@ extension AddressInitializationWalker {
     return .continueWalk
   }
 
-  mutating func dependentAddressUse(of operand: Operand, into value: Value)
-    -> WalkResult {
+  mutating func dependentAddressUse(of operand: Operand, dependentValue value: Value) -> WalkResult {
+    return .continueWalk
+  }
+
+  mutating func dependentAddressUse(of operand: Operand, dependentAddress address: Value) -> WalkResult {
     return .continueWalk
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -36,6 +36,29 @@ private func log(_ message: @autoclosure () -> String) {
 // Local variables are accessed in one of these ways.
 //
 // Note: @in is only immutable up to when it is destroyed, so still requires a local live range.
+//
+// A .dependenceSource access creates a new dependent value that keeps this local alive.
+//
+//     %local = alloc_stack // this local
+//     %md = mark_dependence %val on %local
+//     mark_dependence_addr %adr on %local
+//
+// The effect of .dependenceSource on reachability is like a load of this local. The dependent value depends on any
+// value in this local that reaches this point.
+//
+// A .dependenceDest access is the point where another value becomes dependent on this local:
+//
+//     %local = alloc_stack // this local
+//     %md = mark_dependence %local on %val
+//     mark_dependence_addr %local on %val
+//
+// The effect of .dependenceDest on reachability is like a store of this local. All uses of this local reachable from
+// this point are uses of the dependence base.
+//
+// Note that the same mark_dependence_addr often involves two locals:
+//
+//     mark_dependence_addr %localDest on %localSource
+//
 struct LocalVariableAccess: CustomStringConvertible {
   enum Kind {
     case incomingArgument // @in, @inout, @inout_aliasable
@@ -43,7 +66,8 @@ struct LocalVariableAccess: CustomStringConvertible {
     case inoutYield       // indirect yield from this accessor
     case beginAccess // Reading or reassigning a 'var'
     case load        // Reading a 'let'. Returning 'var' from an initializer.
-    case dependence  // A mark_dependence after an apply with an indirect result. No effect.
+    case dependenceSource // A value/address depends on this local here (like a load)
+    case dependenceDest  // This local depends on another value/address here (like a store)
     case store       // 'var' initialization and destruction
     case apply       // indirect arguments
     case escape      // alloc_box captures
@@ -77,7 +101,7 @@ struct LocalVariableAccess: CustomStringConvertible {
       case .`init`, .modify:
         return true
       }
-    case .load, .dependence:
+    case .load, .dependenceSource, .dependenceDest:
       return false
     case .incomingArgument, .outgoingArgument, .store, .inoutYield:
       return true
@@ -116,8 +140,10 @@ struct LocalVariableAccess: CustomStringConvertible {
       str += "beginAccess"
     case .load:
       str += "load"
-    case .dependence:
-      str += "dependence"
+    case .dependenceSource:
+      str += "dependenceSource"
+    case .dependenceDest:
+      str += "dependenceDest"
     case .store:
       str += "store"
     case .apply:
@@ -152,7 +178,7 @@ class LocalVariableAccessInfo: CustomStringConvertible {
       case .`init`, .modify:
         break // lazily compute full assignment
       }
-    case .load, .dependence:
+      case .load, .dependenceSource, .dependenceDest:
       self._isFullyAssigned = false
     case .store:
       if let store = localAccess.instruction as? StoringInstruction {
@@ -365,7 +391,7 @@ extension LocalVariableAccessWalker : ForwardingDefUseWalker {
       break
     case let markDep as MarkDependenceInst:
       assert(markDep.baseOperand == operand)
-      visit(LocalVariableAccess(.dependence, operand))
+      visit(LocalVariableAccess(.dependenceSource, operand))
     default:
       visit(LocalVariableAccess(.escape, operand))
     }
@@ -381,10 +407,6 @@ extension LocalVariableAccessWalker : ForwardingDefUseWalker {
 extension LocalVariableAccessWalker: AddressUseVisitor {
   private mutating func walkDownAddressUses(address: Value) -> WalkResult {
     for operand in address.uses.ignoreTypeDependence {
-      if let md = operand.instruction as? MarkDependenceInst, operand == md.valueOperand {
-        // Record the forwarding mark_dependence as a fake access before continuing to walk down.
-        visit(LocalVariableAccess(.dependence, operand))
-      }
       if classifyAddress(operand: operand) == .abortWalk {
         return .abortWalk
       }
@@ -399,6 +421,13 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
   // temporaries do not have access scopes, so we need to walk down any projection that may be used to initialize the
   // temporary.
   mutating func projectedAddressUse(of operand: Operand, into value: Value) -> WalkResult {
+    // Intercept mark_dependence destination to record an access point which can be used like a store when finding all
+    // uses that affect the base after the point that the dependence was marked.
+    if let md = value as? MarkDependenceInst {
+      assert(operand == md.valueOperand)
+      visit(LocalVariableAccess(.dependenceDest, operand))
+      // walk down the forwarded address as usual...
+    }
     return walkDownAddressUses(address: value)
   }
 
@@ -432,6 +461,9 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
          is PackElementSetInst:
       // Handle instructions that initialize both temporaries and local variables.
       visit(LocalVariableAccess(.store, operand))
+    case let md as MarkDependenceAddrInst:
+      assert(operand == md.addressOperand)
+      visit(LocalVariableAccess(.dependenceDest, operand))
     case is DeallocStackInst:
       break
     default:
@@ -473,12 +505,12 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
     return .continueWalk
   }
 
-  mutating func loadedAddressUse(of operand: Operand, into value: Value) -> WalkResult {
+  mutating func loadedAddressUse(of operand: Operand, intoValue value: Value) -> WalkResult {
     visit(LocalVariableAccess(.load, operand))
     return .continueWalk
   }
 
-  mutating func loadedAddressUse(of operand: Operand, into address: Operand) -> WalkResult {
+  mutating func loadedAddressUse(of operand: Operand, intoAddress address: Operand) -> WalkResult {
     visit(LocalVariableAccess(.load, operand))
     return .continueWalk
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -452,7 +452,7 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
     return .continueWalk
   }
 
-  mutating func dependentAddressUse(of operand: Operand, into value: Value) -> WalkResult {
+  mutating func dependentAddressUse(of operand: Operand, dependentValue value: Value) -> WalkResult {
     // Find all uses of partial_apply [on_stack].
     if let pai = value as? PartialApplyInst, !pai.mayEscape {
       var walker = NonEscapingClosureDefUseWalker(context)
@@ -464,6 +464,11 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
         visit(LocalVariableAccess(.apply, operand))
       }
     }
+    // No other dependent uses can access to memory at this address.
+    return .continueWalk
+  }
+
+  mutating func dependentAddressUse(of operand: Operand, dependentAddress address: Value) -> WalkResult {
     // No other dependent uses can access to memory at this address.
     return .continueWalk
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -208,7 +208,8 @@ struct InteriorLivenessResult: CustomDebugStringConvertible {
 /// - forwardingUse(of:isInnerlifetime:)
 /// - interiorPointerUse(of:into:)
 /// - pointerEscapingUse(of:)
-/// - dependentUse(of:into:)
+/// - dependentUse(of:dependentValue:)
+/// - dependentUse(of:dependentAddress:)
 /// - borrowingUse(of:by:)
 ///
 /// This only visits the first level of uses. The implementation may transitively visit forwarded, borrowed, dependent,
@@ -269,7 +270,13 @@ protocol OwnershipUseVisitor {
   /// there are no explicit scope-ending operations. Instead
   /// BorrowingInstruction.scopeEndingOperands will return the final
   /// consumes in the dependent value's forwarding chain.
-  mutating func dependentUse(of operand: Operand, into value: Value) -> WalkResult
+  mutating func dependentUse(of operand: Operand, dependentValue value: Value) -> WalkResult
+
+  /// A use that creates an implicit borrow scope over all reachable uses of a value stored in
+  /// `dependentAddress`. This could conservatively be handled has `pointerEscapingUse`, but note that accessing the
+  /// `dependentAddress` only keeps the original owner alive, it cannot modify the original (modifying a dependent
+  /// address is still just a "read" of the dependence source.
+  mutating func dependentUse(of operand: Operand, dependentAddress address: Value) -> WalkResult
 
   /// A use that is scoped to an inner borrow scope.
   mutating func borrowingUse(of operand: Operand, by borrowInst: BorrowingInstruction) -> WalkResult
@@ -384,6 +391,9 @@ extension OwnershipUseVisitor {
       return forwardingUse(of: operand, isInnerLifetime: false)
 
     case .pointerEscape:
+      if let mdai = operand.instruction as? MarkDependenceAddrInst, operand == mdai.baseOperand {
+        return dependentUse(of: operand, dependentAddress: mdai.address)
+      }
       return pointerEscapingUse(of: operand)
 
     case .instantaneousUse, .forwardingUnowned, .unownedInstantaneousUse, .bitwiseEscape:
@@ -413,6 +423,9 @@ extension OwnershipUseVisitor {
       if operand.instruction is ProjectBoxInst {
         return visitInteriorPointerUse(of: operand)
       }
+      if let mdai = operand.instruction as? MarkDependenceAddrInst, operand == mdai.baseOperand {
+        return dependentUse(of: operand, dependentAddress: mdai.address)
+      }
       return pointerEscapingUse(of: operand)
 
     case .instantaneousUse, .forwardingUnowned, .unownedInstantaneousUse, .bitwiseEscape, .endBorrow, .reborrow:
@@ -436,12 +449,14 @@ extension OwnershipUseVisitor {
     switch operand.instruction {
     case let pai as PartialApplyInst:
       assert(!pai.mayEscape)
-      return dependentUse(of: operand, into: pai)
+      return dependentUse(of: operand, dependentValue: pai)
     case let mdi as MarkDependenceInst:
+      // .borrow operand ownership only applies to the base operand of a non-escaping markdep that forwards a
+      // non-address value.
       assert(operand == mdi.baseOperand && mdi.isNonEscaping)
-      return dependentUse(of: operand, into: mdi)
+      return dependentUse(of: operand, dependentValue: mdi)
     case let bfi as BorrowedFromInst where !bfi.borrowedPhi.isReborrow:
-      return dependentUse(of: operand, into: bfi)
+      return dependentUse(of: operand, dependentValue: bfi)
     default:
       return borrowingUse(of: operand,
                           by: BorrowingInstruction(operand.instruction)!)
@@ -586,7 +601,7 @@ extension InteriorUseWalker: OwnershipUseVisitor {
   }
 
   // Handle partial_apply [on_stack] and mark_dependence [nonescaping].
-  mutating func dependentUse(of operand: Operand, into value: Value) -> WalkResult {
+  mutating func dependentUse(of operand: Operand, dependentValue value: Value) -> WalkResult {
     // OSSA lifetime ignores trivial types.
     if value.type.isTrivial(in: function) {
       return .continueWalk
@@ -600,6 +615,12 @@ extension InteriorUseWalker: OwnershipUseVisitor {
       return .abortWalk
     }
     return walkDownUses(of: value)
+  }
+
+  mutating func dependentUse(of operand: Operand, dependentAddress address: Value) -> WalkResult {
+    // An mutable local variable depends a value that depends on the original interior pointer. This would require data
+    // flow to find local uses. InteriorUseWalker only walks the SSA uses.
+    pointerEscapingUse(of: operand)
   }
 
   mutating func pointerEscapingUse(of operand: Operand) -> WalkResult {
@@ -699,12 +720,12 @@ extension InteriorUseWalker: AddressUseVisitor {
     return .continueWalk
   }
 
-  mutating func loadedAddressUse(of operand: Operand, into value: Value)
+  mutating func loadedAddressUse(of operand: Operand, intoValue value: Value)
     -> WalkResult {
     return .continueWalk
   }    
 
-  mutating func loadedAddressUse(of operand: Operand, into address: Operand)
+  mutating func loadedAddressUse(of operand: Operand, intoAddress address: Operand)
     -> WalkResult {
     return .continueWalk
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -713,7 +713,7 @@ extension InteriorUseWalker: AddressUseVisitor {
     return .continueWalk
   }
 
-  mutating func dependentAddressUse(of operand: Operand, into value: Value)
+  mutating func dependentAddressUse(of operand: Operand, dependentValue value: Value)
     -> WalkResult {
     // For Escapable values, simply continue the walk.
     if value.mayEscape {
@@ -726,6 +726,11 @@ extension InteriorUseWalker: AddressUseVisitor {
     // for that special case and continue to bailout here.
     return escapingAddressUse(of: operand)
   }
+
+  mutating func dependentAddressUse(of operand: Operand, dependentAddress address: Value) -> WalkResult {
+    // TODO: consider data flow that finds reachable uses of `dependentAddress`.
+    return escapingAddressUse(of: operand)
+  }    
 
   mutating func escapingAddressUse(of operand: Operand) -> WalkResult {
     pointerStatus.setEscaping(operand: operand)

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -568,10 +568,16 @@ public struct Builder {
     return notifyNew(endMutation.getAs(EndCOWMutationInst.self))
   }
 
-  public func createMarkDependence(value: Value, base: Value, kind: MarkDependenceInst.DependenceKind) -> MarkDependenceInst {
+  public func createMarkDependence(value: Value, base: Value, kind: MarkDependenceKind) -> MarkDependenceInst {
     let markDependence = bridged.createMarkDependence(value.bridged, base.bridged,
                                                       BridgedInstruction.MarkDependenceKind(rawValue: kind.rawValue)!)
     return notifyNew(markDependence.getAs(MarkDependenceInst.self))
+  }
+
+  public func createMarkDependenceAddr(value: Value, base: Value, kind: MarkDependenceKind) -> MarkDependenceAddrInst {
+    let markDependence = bridged.createMarkDependenceAddr(
+      value.bridged, base.bridged, BridgedInstruction.MarkDependenceKind(rawValue: kind.rawValue)!)
+    return notifyNew(markDependence.getAs(MarkDependenceAddrInst.self))
   }
     
   @discardableResult

--- a/SwiftCompilerSources/Sources/SIL/Registration.swift
+++ b/SwiftCompilerSources/Sources/SIL/Registration.swift
@@ -195,6 +195,7 @@ public func registerSILClasses() {
   register(ObjCMetatypeToObjectInst.self)
   register(ValueToBridgeObjectInst.self)
   register(MarkDependenceInst.self)
+  register(MarkDependenceAddrInst.self)
   register(RefToBridgeObjectInst.self)
   register(BridgeObjectToRefInst.self)
   register(BridgeObjectToWordInst.self)

--- a/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
@@ -541,6 +541,12 @@ extension AddressDefUseWalker {
       } else {
         return unmatchedPath(address: operand, path: path)
       }
+    case is MarkDependenceAddrInst:
+      if operand.index == 0 {
+        return leafUse(address: operand, path: path)
+      } else {
+        return unmatchedPath(address: operand, path: path)
+      }
     default:
       return leafUse(address: operand, path: path)
     }

--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -293,7 +293,7 @@ public:
     case SILInstructionKind::DifferentiableFunctionInst:
       return nullptr;
     case SILInstructionKind::MarkDependenceInst:
-      return &forwardingInst->getOperandRef(MarkDependenceInst::Value);
+      return &forwardingInst->getOperandRef(MarkDependenceInst::Dependent);
     case SILInstructionKind::RefToBridgeObjectInst:
       return
         &forwardingInst->getOperandRef(RefToBridgeObjectInst::ConvertedOperand);

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -777,6 +777,9 @@ struct BridgedInstruction {
   BRIDGED_INLINE MarkDependenceKind MarkDependenceInst_dependenceKind() const;
   BRIDGED_INLINE void MarkDependenceInst_resolveToNonEscaping() const;
   BRIDGED_INLINE void MarkDependenceInst_settleToEscaping() const;
+  BRIDGED_INLINE MarkDependenceKind MarkDependenceAddrInst_dependenceKind() const;
+  BRIDGED_INLINE void MarkDependenceAddrInst_resolveToNonEscaping() const;
+  BRIDGED_INLINE void MarkDependenceAddrInst_settleToEscaping() const;
   BRIDGED_INLINE SwiftInt BeginAccessInst_getAccessKind() const;
   BRIDGED_INLINE bool BeginAccessInst_isStatic() const;
   BRIDGED_INLINE bool BeginAccessInst_isUnsafe() const;
@@ -1221,6 +1224,9 @@ struct BridgedBuilder{
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createEndCOWMutation(BridgedValue instance,
                                                                              bool keepUnique) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMarkDependence(
+    BridgedValue value, BridgedValue base, BridgedInstruction::MarkDependenceKind dependenceKind) const;
+
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMarkDependenceAddr(
     BridgedValue value, BridgedValue base, BridgedInstruction::MarkDependenceKind dependenceKind) const;
     
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createEndAccess(BridgedValue value) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1356,6 +1356,18 @@ void BridgedInstruction::MarkDependenceInst_settleToEscaping() const {
   getAs<swift::MarkDependenceInst>()->settleToEscaping();
 }
 
+BridgedInstruction::MarkDependenceKind BridgedInstruction::MarkDependenceAddrInst_dependenceKind() const {
+  return (MarkDependenceKind)getAs<swift::MarkDependenceAddrInst>()->dependenceKind();
+}
+
+void BridgedInstruction::MarkDependenceAddrInst_resolveToNonEscaping() const {
+  getAs<swift::MarkDependenceAddrInst>()->resolveToNonEscaping();
+}
+
+void BridgedInstruction::MarkDependenceAddrInst_settleToEscaping() const {
+  getAs<swift::MarkDependenceAddrInst>()->settleToEscaping();
+}
+
 SwiftInt BridgedInstruction::BeginAccessInst_getAccessKind() const {
   return (SwiftInt)getAs<swift::BeginAccessInst>()->getAccessKind();
 }
@@ -2376,6 +2388,12 @@ BridgedInstruction BridgedBuilder::createEndCOWMutation(BridgedValue instance, b
 
 BridgedInstruction BridgedBuilder::createMarkDependence(BridgedValue value, BridgedValue base, BridgedInstruction::MarkDependenceKind kind) const {
   return {unbridged().createMarkDependence(regularLoc(), value.getSILValue(), base.getSILValue(), swift::MarkDependenceKind(kind))};
+}
+
+BridgedInstruction BridgedBuilder::createMarkDependenceAddr(BridgedValue value, BridgedValue base, BridgedInstruction::MarkDependenceKind kind) const {
+  return {unbridged().createMarkDependenceAddr(
+      regularLoc(), value.getSILValue(), base.getSILValue(),
+      swift::MarkDependenceKind(kind))};
 }
 
 BridgedInstruction BridgedBuilder::createEndAccess(BridgedValue value) const {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2338,6 +2338,14 @@ public:
                     forwardingOwnershipKind, dependenceKind));
   }
 
+  MarkDependenceAddrInst *
+  createMarkDependenceAddr(SILLocation Loc, SILValue address, SILValue base,
+                           MarkDependenceKind dependenceKind) {
+    return insert(new (getModule()) MarkDependenceAddrInst(
+                    getSILDebugLocation(Loc), address, base,
+                    dependenceKind));
+  }
+
   IsUniqueInst *createIsUnique(SILLocation Loc, SILValue operand) {
     auto Int1Ty = SILType::getBuiltinIntegerType(1, getASTContext());
     return insert(new (getModule()) IsUniqueInst(getSILDebugLocation(Loc),

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -3142,6 +3142,17 @@ void SILCloner<ImplClass>::visitMarkDependenceInst(MarkDependenceInst *Inst) {
                 Inst->dependenceKind()));
 }
 
+template <typename ImplClass>
+void SILCloner<ImplClass>::
+visitMarkDependenceAddrInst(MarkDependenceAddrInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  recordClonedInstruction(
+      Inst, getBuilder().createMarkDependenceAddr(
+                getOpLocation(Inst->getLoc()), getOpValue(Inst->getAddress()),
+                getOpValue(Inst->getBase()),
+                Inst->dependenceKind()));
+}
+
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitStrongReleaseInst(StrongReleaseInst *Inst) {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8750,66 +8750,28 @@ enum class MarkDependenceKind {
 };
 static_assert(2 == SILNode::NumMarkDependenceKindBits, "Size mismatch");
 
-/// Indicates that the validity of the first operand ("the value") depends on
-/// the value of the second operand ("the base").  Operations that would destroy
-/// the base must not be moved before any instructions which depend on the
-/// result of this instruction, exactly as if the address had been obviously
-/// derived from that operand (e.g. using ``ref_element_addr``). The result is
-/// always equal to the first operand and thus forwards ownership through the
-/// first operand. This is a "regular" use of the second operand (i.e. the
-/// second operand must be live at the use point).
-///
-/// Example:
-///
-///   %base = ...
-///   %value = ... @trivial value ...
-///   %value_dependent_on_base = mark_dependence %value on %base
-///   ...
-///   use(%value_dependent_on_base)     (1)
-///   ...
-///   destroy_value %base               (2)
-///
-/// (2) can never move before (1). In English this is a way for the compiler
-/// writer to say to the optimizer: 'This subset of uses of "value" (the uses of
-/// result) have a dependence on "base" being alive. Do not allow for things
-/// that /may/ destroy base to be moved earlier than any of these uses of
-/// "value"'.
-///
-/// The dependent 'value' may be marked 'nonescaping', which guarantees that the
-/// lifetime dependence is statically enforceable. In this case, the compiler
-/// must be able to follow all values forwarded from the dependent 'value', and
-/// recognize all final (non-forwarded, non-escaping) use points. This implies
-/// that `findPointerEscape` is false. A diagnostic pass checks that the
-/// incoming SIL to verify that these use points are all initially within the
-/// 'base' lifetime. Regular 'mark_dependence' semantics ensure that
-/// optimizations cannot violate the lifetime dependence after diagnostics.
-class MarkDependenceInst
-    : public InstructionBase<SILInstructionKind::MarkDependenceInst,
-                             OwnershipForwardingSingleValueInstruction> {
-  friend SILBuilder;
-
+template <SILInstructionKind Kind, typename BaseTy>
+class MarkDependenceInstBase : public InstructionBase<Kind, BaseTy> {
   FixedOperandList<2> Operands;
 
-  USE_SHARED_UINT8;
+  TEMPLATE_USE_SHARED_UINT8(BaseTy);
 
-  MarkDependenceInst(SILDebugLocation DebugLoc, SILValue value, SILValue base,
-                     ValueOwnershipKind forwardingOwnershipKind,
-                     MarkDependenceKind dependenceKind)
-      : InstructionBase(DebugLoc, value->getType(), forwardingOwnershipKind),
-        Operands{this, value, base} {
-    sharedUInt8().MarkDependenceInst.dependenceKind = uint8_t(dependenceKind);
+protected:
+  template <typename... Rest>
+  MarkDependenceInstBase(SILDebugLocation DebugLoc, SILValue value,
+                         SILValue base, MarkDependenceKind dependenceKind,
+                         Rest &&...rest)
+    : InstructionBase<Kind, BaseTy>(DebugLoc, std::forward<Rest>(rest)...),
+      Operands{this, value, base} {
+    sharedUInt8().MarkDependenceInstBase.dependenceKind =
+      uint8_t(dependenceKind);
   }
 
 public:
-  enum { Value, Base };
-
-  SILValue getValue() const { return Operands[Value].get(); }
+  enum { Dependent, Base };
 
   SILValue getBase() const { return Operands[Base].get(); }
 
-  void setValue(SILValue newVal) {
-    Operands[Value].set(newVal);
-  }
   void setBase(SILValue newVal) {
     Operands[Base].set(newVal);
   }
@@ -8818,9 +8780,14 @@ public:
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 
   MarkDependenceKind dependenceKind() const {
-    return MarkDependenceKind(sharedUInt8().MarkDependenceInst.dependenceKind);
+    return MarkDependenceKind(
+      sharedUInt8().MarkDependenceInstBase.dependenceKind);
   }
 
+  /// True if the lifetime dependence is statically enforceable. If so, the
+  /// compiler can follow all values forwarded from the result, and recognize
+  /// all final (non-forwarded, non-escaping) use points. This implies that
+  /// `findPointerEscape` is false.
   bool isNonEscaping() const {
     return dependenceKind() == MarkDependenceKind::NonEscaping;
   }
@@ -8833,13 +8800,41 @@ public:
   }
 
   void resolveToNonEscaping() {
-    sharedUInt8().MarkDependenceInst.dependenceKind =
+    sharedUInt8().MarkDependenceInstBase.dependenceKind =
       uint8_t(MarkDependenceKind::NonEscaping);
   }
 
   void settleToEscaping() {
-    sharedUInt8().MarkDependenceInst.dependenceKind =
+    sharedUInt8().MarkDependenceInstBase.dependenceKind =
       uint8_t(MarkDependenceKind::Escaping);
+  }  
+};
+  
+/// The result forwards the value of the first operand ('value') and depends on
+/// the second operand ('base').
+///
+/// The 'value' and the forwarded result are both either an object type or an
+/// address type. The semantics are the same in each case.
+///
+/// 'base' may have either object or address type independent from the type of
+/// 'value'. If 'base' is an address, then the dependency is on the current
+/// value stored at the address.
+class MarkDependenceInst
+  : public MarkDependenceInstBase<SILInstructionKind::MarkDependenceInst,
+                                  OwnershipForwardingSingleValueInstruction> {
+  friend SILBuilder;
+
+  MarkDependenceInst(SILDebugLocation DebugLoc, SILValue value, SILValue base,
+                     ValueOwnershipKind forwardingOwnershipKind,
+                     MarkDependenceKind dependenceKind)
+    : MarkDependenceInstBase(DebugLoc, value, base, dependenceKind,
+                             value->getType(), forwardingOwnershipKind) {}
+
+public:
+  SILValue getValue() const { return getAllOperands()[Dependent].get(); }
+
+  void setValue(SILValue newVal) {
+    getAllOperands()[Dependent].set(newVal);
   }
 
   // True if the dependence is limited to the scope of an OSSA lifetime. Only
@@ -8858,6 +8853,97 @@ public:
   bool visitNonEscapingLifetimeEnds(
     llvm::function_ref<bool (Operand*)> visitScopeEnd,
     llvm::function_ref<bool (Operand*)> visitUnknownUse);
+};
+
+/// The in-memory value at the first operand ('address') depends on the value of
+/// the second operand ('base'). This is as if the location at 'address' aliases
+/// 'base' on all paths reachable from this instruction.
+///
+/// 'base' may have either object or address type. If 'base' is an address, then
+/// the dependency is on the current value stored at the address.
+class MarkDependenceAddrInst
+  : public MarkDependenceInstBase<SILInstructionKind::MarkDependenceAddrInst,
+                                  NonValueInstruction> {
+  friend SILBuilder;
+
+  MarkDependenceAddrInst(SILDebugLocation DebugLoc, SILValue value,
+                         SILValue base, MarkDependenceKind dependenceKind)
+    : MarkDependenceInstBase(DebugLoc, value, base, dependenceKind) {}
+
+public:
+  SILValue getAddress() const { return getAllOperands()[Dependent].get(); }
+
+  void setAddress(SILValue newVal) {
+    getAllOperands()[Dependent].set(newVal);
+  }
+};
+
+/// Shared API for MarkDependenceInst and MarkDependenceAddrInst.
+class MarkDependenceInstruction {
+  const SILInstruction *inst = nullptr;
+
+public:
+  explicit MarkDependenceInstruction(const SILInstruction *inst) {
+    switch (inst->getKind()) {
+    case SILInstructionKind::MarkDependenceInst:
+    case SILInstructionKind::MarkDependenceAddrInst:
+      this->inst = inst;
+      break;
+    default:
+      break;
+    }
+  }
+
+  explicit operator bool() const { return inst != nullptr; }
+    
+  SILValue getBase() const {
+    if (inst) {
+      switch (inst->getKind()) {
+      case SILInstructionKind::MarkDependenceInst:
+        return cast<MarkDependenceInst>(inst)->getBase();
+      case SILInstructionKind::MarkDependenceAddrInst:
+        return cast<MarkDependenceAddrInst>(inst)->getBase();
+      default:
+        break;
+      }
+    }
+    return SILValue();
+  }
+
+  SILValue getDependent() const {
+    if (inst) {
+      switch (inst->getKind()) {
+      case SILInstructionKind::MarkDependenceInst:
+        return cast<MarkDependenceInst>(inst)->getValue();
+      case SILInstructionKind::MarkDependenceAddrInst:
+        return cast<MarkDependenceAddrInst>(inst)->getAddress();
+      default:
+        break;
+      }
+    }
+    return SILValue();
+  }
+
+  SILType getType() const {
+    if (auto *mdi = dyn_cast<MarkDependenceInst>(inst))
+      return mdi->getType();
+
+    return SILType();
+  }
+
+  bool isNonEscaping() const {
+    if (inst) {
+      switch (inst->getKind()) {
+      case SILInstructionKind::MarkDependenceInst:
+        return cast<MarkDependenceInst>(inst)->isNonEscaping();
+      case SILInstructionKind::MarkDependenceAddrInst:
+        return cast<MarkDependenceAddrInst>(inst)->isNonEscaping();
+      default:
+        break;
+      }
+    }
+    return false;
+  }
 };
 
 /// Promote an Objective-C block that is on the stack to the heap, or simply

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -285,8 +285,8 @@ protected:
                  pointerEscape : 1,
                  fromVarDecl : 1);
 
-    SHARED_FIELD(MarkDependenceInst, uint8_t
-                 dependenceKind : NumMarkDependenceKindBits);
+    SHARED_TEMPLATE2_FIELD(SILInstructionKind, typename, MarkDependenceInstBase,
+                           uint8_t dependenceKind : NumMarkDependenceKindBits);
 
   // Do not use `_sharedUInt8_private` outside of SILNode.
   } _sharedUInt8_private;

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -441,6 +441,8 @@ ABSTRACT_VALUE_AND_INST(SingleValueInstruction, ValueBase, SILInstruction)
                     SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(ValueToBridgeObjectInst, value_to_bridge_object,
                     SingleValueInstruction, None, DoesNotRelease)
+  // MarkDependenceAddrInst has read effects for the base operand. See
+  // getMemoryBehavior()
   SINGLE_VALUE_INST(MarkDependenceInst, mark_dependence,
                     SingleValueInstruction, None, DoesNotRelease)
   SINGLE_VALUE_INST(CopyBlockInst, copy_block,
@@ -901,7 +903,12 @@ NON_VALUE_INST(IgnoredUseInst, ignored_use,
 NON_VALUE_INST(IncrementProfilerCounterInst, increment_profiler_counter,
                SILInstruction, MayReadWrite, DoesNotRelease)
 
-NODE_RANGE(NonValueInstruction, UnreachableInst, IncrementProfilerCounterInst)
+// MarkDependenceAddrInst has read effects for the base operand. See
+// getMemoryBehavior().
+NON_VALUE_INST(MarkDependenceAddrInst, mark_dependence_addr,
+               SILInstruction, None, DoesNotRelease)
+
+NODE_RANGE(NonValueInstruction, UnreachableInst, MarkDependenceAddrInst)
 
 ABSTRACT_INST(MultipleValueInstruction, SILInstruction)
 MULTIPLE_VALUE_INST(BeginApplyInst, begin_apply,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1427,6 +1427,7 @@ public:
     llvm_unreachable("unimplemented");
   }
   void visitMarkDependenceInst(MarkDependenceInst *i);
+  void visitMarkDependenceAddrInst(MarkDependenceAddrInst *i);
   void visitCopyBlockInst(CopyBlockInst *i);
   void visitCopyBlockWithoutEscapingInst(CopyBlockWithoutEscapingInst *i) {
     llvm_unreachable("not valid in canonical SIL");
@@ -6134,6 +6135,11 @@ void IRGenSILFunction::visitMarkDependenceInst(swift::MarkDependenceInst *i) {
     Explosion temp = getLoweredExplosion(value);
     setLoweredExplosion(i, temp);
   }
+}
+
+void IRGenSILFunction::
+visitMarkDependenceAddrInst(swift::MarkDependenceAddrInst *i) {
+  // Dependency-marking is purely for SIL. No result.
 }
 
 void IRGenSILFunction::visitCopyBlockInst(CopyBlockInst *i) {

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -870,6 +870,10 @@ namespace {
        return true;
     }
 
+    bool visitMarkDependenceAddrInst(const MarkDependenceAddrInst *RHS) {
+       return true;
+    }
+
     bool visitOpenExistentialRefInst(const OpenExistentialRefInst *RHS) {
       return true;
     }
@@ -1092,8 +1096,8 @@ MemoryBehavior SILInstruction::getMemoryBehavior() const {
     llvm_unreachable("Covered switch isn't covered?!");
   }
   
-  if (auto *mdi = dyn_cast<MarkDependenceInst>(this)) {
-    if (mdi->getBase()->getType().isAddress())
+  if (auto mdi = MarkDependenceInstruction(this)) {
+    if (mdi.getBase()->getType().isAddress())
       return MemoryBehavior::MayRead;
     return MemoryBehavior::None;
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2701,7 +2701,8 @@ public:
   void visitClassifyBridgeObjectInst(ClassifyBridgeObjectInst *CBOI) {
     *this << getIDAndType(CBOI->getOperand());
   }
-  void visitMarkDependenceInst(MarkDependenceInst *MDI) {
+  template <SILInstructionKind Opc, typename T>
+  void visitMarkDependenceInstBase(MarkDependenceInstBase<Opc, T> *MDI) {
     switch (MDI->dependenceKind()) {
     case MarkDependenceKind::Unresolved:
       *this << "[unresolved] ";
@@ -2712,9 +2713,16 @@ public:
       *this << "[nonescaping] ";
       break;
     }
-    *this << getIDAndType(MDI->getValue()) << " on "
-          << getIDAndType(MDI->getBase());
+    *this <<
+      getIDAndType(MDI->getOperand(MarkDependenceInstBase<Opc, T>::Dependent))
+          << " on " << getIDAndType(MDI->getBase());
+  }
+  void visitMarkDependenceInst(MarkDependenceInst *MDI) {
+    visitMarkDependenceInstBase(MDI);
     printForwardingOwnershipKind(MDI, MDI->getValue());
+  }
+  void visitMarkDependenceAddrInst(MarkDependenceAddrInst *MDI) {
+    visitMarkDependenceInstBase(MDI);
   }
   void visitCopyBlockInst(CopyBlockInst *RI) {
     *this << getIDAndType(RI->getOperand());

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -558,6 +558,7 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
   case SILInstructionKind::ClassifyBridgeObjectInst:
   case SILInstructionKind::ValueToBridgeObjectInst:
   case SILInstructionKind::MarkDependenceInst:
+  case SILInstructionKind::MarkDependenceAddrInst:
   case SILInstructionKind::MergeIsolationRegionInst:
   case SILInstructionKind::MoveValueInst:
   case SILInstructionKind::DropDeinitInst:

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2830,6 +2830,7 @@ void swift::visitAccessedAddress(SILInstruction *I,
   case SILInstructionKind::ExistentialMetatypeInst:
   case SILInstructionKind::FixLifetimeInst:
   case SILInstructionKind::MarkDependenceInst:
+  case SILInstructionKind::MarkDependenceAddrInst:
   case SILInstructionKind::GlobalAddrInst:
   case SILInstructionKind::HasSymbolInst:
   case SILInstructionKind::HopToExecutorInst:

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -339,7 +339,7 @@ bool MemoryLocations::analyzeLocationUsesRecursively(SILValue V, unsigned locIdx
         break;
       case SILInstructionKind::MarkDependenceInst: {
         auto *mdi = cast<MarkDependenceInst>(user);
-        if (use == &mdi->getAllOperands()[MarkDependenceInst::Value]) {
+        if (use == &mdi->getAllOperands()[MarkDependenceInst::Dependent]) {
           if (!analyzeLocationUsesRecursively(mdi, locIdx, collectedVals, subLocationMap))
             return false;
         }

--- a/lib/SIL/Verifier/LinearLifetimeChecker.cpp
+++ b/lib/SIL/Verifier/LinearLifetimeChecker.cpp
@@ -41,7 +41,7 @@ using namespace swift;
 /// Return true if \p operand can legally be consumed by another operand of the
 /// same instruction (in parallel).
 bool isParallelOperand(Operand *operand) {
-  return isa<MarkDependenceInst>(operand->getUser())
+  return isa<MarkDependenceInst>(operand->getUser()) //!!! why???
     || operand->getOperandOwnership() == OperandOwnership::Reborrow
     || operand->getOperandOwnership() == OperandOwnership::GuaranteedForwarding;
 }

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -889,16 +889,18 @@ void MemoryLifetimeVerifier::checkBlock(SILBasicBlock *block, Bits &bits) {
         locations.clearBits(bits, opVal);
         break;
       }
-      case SILInstructionKind::MarkDependenceInst: {
-        auto *mdi = cast<MarkDependenceInst>(&I);
-        if (mdi->getBase()->getType().isAddress() &&
+      case SILInstructionKind::MarkDependenceInst:
+      case SILInstructionKind::MarkDependenceAddrInst: {
+        auto mdi = MarkDependenceInstruction(&I);
+        if (mdi.getBase()->getType().isAddress() &&
             // In case the mark_dependence is used for a closure it might be that the base
             // is "self" in an initializer and "self" is not fully initialized, yet.
-            !mdi->getType().isFunction()) {
-          requireBitsSet(bits, mdi->getBase(), &I);
+            (!mdi.getType() || !mdi.getType().isFunction())) {
+          requireBitsSet(bits, mdi.getBase(), &I);
         }
         // TODO: check that the base operand is alive during the whole lifetime
-        // of the value operand.
+        // of the value operand. This requires treating all transitive uses of
+        // 'mdi' as uses of 'base' (including copies for non-Escapable types).
         break;
       }
       default:

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -711,6 +711,7 @@ struct ImmutableAddressUseVerifier {
         break;
       }
       case SILInstructionKind::MarkDependenceInst:
+      case SILInstructionKind::MarkDependenceAddrInst:
       case SILInstructionKind::LoadBorrowInst:
       case SILInstructionKind::ExistentialMetatypeInst:
       case SILInstructionKind::ValueMetatypeInst:
@@ -2193,7 +2194,7 @@ public:
               "mark_dependence [nonescaping] must be an owned value");
     }
   }
-  
+
   void checkPartialApplyInst(PartialApplyInst *PAI) {
     auto resultInfo = requireObjectType(SILFunctionType, PAI,
                                         "result of partial_apply");

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3003,6 +3003,7 @@ CONSTANT_TRANSLATION(UncheckedAddrCastInst, Assign)
 CONSTANT_TRANSLATION(UncheckedEnumDataInst, Assign)
 CONSTANT_TRANSLATION(UncheckedOwnershipConversionInst, Assign)
 CONSTANT_TRANSLATION(IndexRawPointerInst, Assign)
+CONSTANT_TRANSLATION(MarkDependenceAddrInst, Assign)
 
 CONSTANT_TRANSLATION(InitExistentialMetatypeInst, Assign)
 CONSTANT_TRANSLATION(OpenExistentialMetatypeInst, Assign)

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -471,7 +471,7 @@ bool COWArrayOpt::checkSafeArrayAddressUses(UserList &AddressUsers) {
       continue;
     }
 
-    if (isa<MarkDependenceInst>(UseInst)) {
+    if (MarkDependenceInstruction(UseInst)) {
       continue;
     }
 
@@ -569,8 +569,9 @@ bool COWArrayOpt::checkSafeArrayValueUses(UserList &ArrayValueUsers) {
       continue;
     }
 
-    if (isa<MarkDependenceInst>(UseInst))
+    if (MarkDependenceInstruction(UseInst)) {
       continue;
+    }
 
     if (isa<EndBorrowInst>(UseInst))
       continue;
@@ -638,8 +639,9 @@ bool COWArrayOpt::checkSafeArrayElementUse(SILInstruction *UseInst,
   //
   // The struct_extract, unchecked_ref_cast is handled below in the
   // "Transitive SafeArrayElementUse" code.
-  if (isa<MarkDependenceInst>(UseInst))
+  if (MarkDependenceInstruction(UseInst)) {
     return true;
+  }
 
   if (isa<EndBorrowInst>(UseInst))
     return true;

--- a/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ForEachLoopUnroll.cpp
@@ -303,10 +303,9 @@ void ArrayInfo::classifyUsesOfArray(SILValue arrayValue) {
     // above as the array would be passed indirectly.
     if (isFixLifetimeUseOfArray(user, arrayValue))
       continue;
-    if (auto *MDI = dyn_cast<MarkDependenceInst>(user)) {
-      if (MDI->getBase() == arrayValue) {
+    if (auto mdi = MarkDependenceInstruction(user)) {
+      if (mdi.getBase() == arrayValue)
         continue;
-      }
     }
     // Check if this is a forEach call on the array.
     if (TryApplyInst *forEachCall = isForEachUseOfArray(user, arrayValue)) {

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -1217,7 +1217,7 @@ static bool findEscapeOrMutationUses(Operand *op,
       if (isa<PartialApplyInst>(parent))
         return false;
       state.accumulatedEscapes.push_back(
-          &userMDI->getOperandRef(MarkDependenceInst::Value));
+          &userMDI->getOperandRef(MarkDependenceInst::Dependent));
       return true;
     }
   }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -1551,10 +1551,10 @@ static bool gatherBorrows(SILValue rootValue,
     // escape. Is it legal to canonicalize ForwardingUnowned?
     case OperandOwnership::ForwardingUnowned:
     case OperandOwnership::PointerEscape:
-      if (auto *md = dyn_cast<MarkDependenceInst>(use->getUser())) {
+      if (auto mdi = MarkDependenceInstruction(use->getUser())) {
         // mark_depenence uses only keep its base value alive; they do not use
         // the base value itself and are irrelevant for destructuring.
-        if (use == &md->getOperandRef(MarkDependenceInst::Base))
+        if (use->get() == mdi.getBase())
           continue;
       }
       return false;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -188,6 +188,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(DestructureStruct)
   NO_UPDATE_NEEDED(SelectEnum)
   NO_UPDATE_NEEDED(MarkDependence)
+  NO_UPDATE_NEEDED(MarkDependenceAddr)
   NO_UPDATE_NEEDED(DestroyAddr)
   NO_UPDATE_NEEDED(DeallocStack)
   NO_UPDATE_NEEDED(DeallocBox)

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -223,10 +223,9 @@ bool ElementUseCollector::collectContainerUses(SILValue boxValue) {
         return false;
       continue;
     }
-    if (auto *md = dyn_cast<MarkDependenceInst>(user)) {
-      // Another value depends on the current in-memory value. Consider that a
-      // load.
-      if (md->getBase() == ui->get()) {
+    if (auto mdi = MarkDependenceInstruction(user)) {
+      // Another value depends on the current in-memory value.
+      if (mdi.getBase() == ui->get()) {
         Uses.emplace_back(user, PMOUseKind::DependenceBase);
         continue;
       }
@@ -471,23 +470,31 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
     if (User->isDebugInstruction())
       continue;
 
-    if (auto *md = dyn_cast<MarkDependenceInst>(User)) {
-      if (md->getBase() == UI->get()) {
+    if (auto *mdi = dyn_cast<MarkDependenceInst>(User)) {
+      if (mdi->getBase() == UI->get()) {
         Uses.emplace_back(User, PMOUseKind::DependenceBase);
         continue;
       }
-      SILValue value = md->getValue();
-      assert(value == UI->get() && "missing mark_dependence use");
+      assert(mdi->getValue() == UI->get() && "missing mark_dependence use");
       // A mark_dependence creates a new dependent value in the same memory
       // location. Analogous to a load + init.
       Uses.emplace_back(User, PMOUseKind::Load);
       Uses.emplace_back(User, PMOUseKind::Initialization);
-      if (!collectUses(md))
+      // Follow a forwarding mark_dependence.
+      if (!collectUses(mdi))
         return false;
 
       continue;
     }
-
+    if (auto *mdi = dyn_cast<MarkDependenceAddrInst>(User)) {
+      if (mdi->getBase() == UI->get()) {
+        Uses.emplace_back(User, PMOUseKind::DependenceBase);
+        continue;
+      }
+      // Ignore the address use. It can be eliminated if the allocation is
+      // unused.
+      continue;
+    }
     // Otherwise, the use is something complicated, it escapes.
     Uses.emplace_back(User, PMOUseKind::Escape);
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -290,6 +290,7 @@ public:
   SILInstruction *visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI);
       
   SILInstruction *visitMarkDependenceInst(MarkDependenceInst *MDI);
+  SILInstruction *visitMarkDependenceAddrInst(MarkDependenceAddrInst *MDI);
   SILInstruction *visitConvertFunctionInst(ConvertFunctionInst *CFI);
   SILInstruction *
   visitConvertEscapeToNoEscapeInst(ConvertEscapeToNoEscapeInst *Cvt);

--- a/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayCountPropagation.cpp
@@ -128,8 +128,8 @@ bool ArrayAllocation::recursivelyCollectUses(ValueBase *Def) {
         isa<DebugValueInst>(User))
       continue;
 
-    if (auto *MDI = dyn_cast<MarkDependenceInst>(User)) {
-      if (Def == MDI->getBase()) {
+    if (auto mdi = MarkDependenceInstruction(User)) {
+      if (Def == mdi.getBase()) {
         continue;
       }
     }

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -166,6 +166,7 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::ClassifyBridgeObjectInst:
   case SILInstructionKind::ValueToBridgeObjectInst:
   case SILInstructionKind::MarkDependenceInst:
+  case SILInstructionKind::MarkDependenceAddrInst:
   case SILInstructionKind::MergeIsolationRegionInst:
   case SILInstructionKind::CopyBlockInst:
   case SILInstructionKind::CopyBlockWithoutEscapingInst:

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -878,6 +878,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::BeginBorrowInst:
   case SILInstructionKind::BorrowedFromInst:
   case SILInstructionKind::MarkDependenceInst:
+  case SILInstructionKind::MarkDependenceAddrInst:
   case SILInstructionKind::MergeIsolationRegionInst:
   case SILInstructionKind::PreviousDynamicFunctionRefInst:
   case SILInstructionKind::DynamicFunctionRefInst:

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2418,6 +2418,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         MarkDependenceKind(Attr));
     break;
   }
+  case SILInstructionKind::MarkDependenceAddrInst: {
+    auto Ty = MF->getType(TyID);
+    auto Ty2 = MF->getType(TyID2);
+    ResultInst = Builder.createMarkDependenceAddr(
+        Loc,
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
+                      getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)),
+        MarkDependenceKind(Attr));
+    break;
+  }
   case SILInstructionKind::BeginDeallocRefInst: {
     auto Ty = MF->getType(TyID);
     auto Ty2 = MF->getType(TyID2);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 930; // default override table
+const uint16_t SWIFTMODULE_VERSION_MINOR = 931; // mark_dependence_addr
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1854,6 +1854,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case SILInstructionKind::DeallocPartialRefInst:
   case SILInstructionKind::BeginDeallocRefInst:
   case SILInstructionKind::MarkDependenceInst:
+  case SILInstructionKind::MarkDependenceAddrInst:
   case SILInstructionKind::IndexAddrInst:
   case SILInstructionKind::IndexRawPointerInst: {
     SILValue operand, operand2;
@@ -1877,6 +1878,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     } else if (SI.getKind() == SILInstructionKind::MarkDependenceInst) {
       const MarkDependenceInst *MDI = cast<MarkDependenceInst>(&SI);
       operand = MDI->getValue();
+      operand2 = MDI->getBase();
+      Attr = unsigned(MDI->dependenceKind());
+    } else if (SI.getKind() == SILInstructionKind::MarkDependenceAddrInst) {
+      const MarkDependenceAddrInst *MDI = cast<MarkDependenceAddrInst>(&SI);
+      operand = MDI->getAddress();
       operand2 = MDI->getBase();
       Attr = unsigned(MDI->dependenceKind());
     } else {

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -313,6 +313,22 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_mark_dependence_addr : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+// CHECK: mark_dependence_addr %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+// CHECK: mark_dependence_addr [nonescaping] %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+// CHECK: mark_dependence_addr [unresolved] %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+// CHECK: } // end sil function 'test_mark_dependence_addr'
+sil [ossa] @test_mark_dependence_addr : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
+  mark_dependence_addr %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+  mark_dependence_addr [nonescaping] %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+  mark_dependence_addr [unresolved] %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+  destroy_addr %1 : $*Builtin.NativeObject
+  destroy_addr %0 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @testMarkUnresolvedNonCopyableValueInst : $@convention(thin) (@guaranteed Klass) -> () {
 // CHECK: mark_unresolved_non_copyable_value [consumable_and_assignable] %{{[0-9]+}} : $*MoveOnlyPair
 // CHECK: } // end sil function 'testMarkUnresolvedNonCopyableValueInst'

--- a/test/SIL/Serialization/basic2.sil
+++ b/test/SIL/Serialization/basic2.sil
@@ -228,6 +228,22 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_mark_dependence_addr : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+// CHECK: mark_dependence_addr %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+// CHECK: mark_dependence_addr [nonescaping] %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+// CHECK: mark_dependence_addr [unresolved] %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+// CHECK: } // end sil function 'test_mark_dependence_addr'
+sil [ossa] @test_mark_dependence_addr : $@convention(thin) (@in Builtin.NativeObject, @in Builtin.NativeObject) -> () {
+bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
+  mark_dependence_addr %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+  mark_dependence_addr [nonescaping] %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+  mark_dependence_addr [unresolved] %1 : $*Builtin.NativeObject on %0 : $*Builtin.NativeObject
+  destroy_addr %1 : $*Builtin.NativeObject
+  destroy_addr %0 : $*Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @test_moveonlywrapper_to_copyable_addr : $@convention(thin) (@in Builtin.NativeObject) -> () {
 // CHECK: moveonlywrapper_to_copyable_addr
 // CHECK: } // end sil function 'test_moveonlywrapper_to_copyable_addr'

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -834,14 +834,14 @@ bb0(%0 : @owned $T, %1 : @owned $Inner):
   return %8
 }
 
-sil [ossa] @mark_dependence_uninit_value : $@convention(thin) (@owned T, @owned Inner) -> @owned Inner {
+sil [ossa] @mark_dependence_addr : $@convention(method) (@owned T, @owned Inner) -> @owned Inner {
 bb0(%0 : @owned $T, %1 : @owned $Inner):
   %2 = alloc_stack $T
   store %0 to [init] %2
   %4 = alloc_stack $Inner
   store %1 to [init] %4
-  %6 = mark_dependence %4 on %2
-  %7 = begin_access [read] [dynamic] %6
+  mark_dependence_addr %4 on %2
+  %7 = begin_access [read] [dynamic] %4
   %8 = load [take] %7
   end_access %7
   dealloc_stack %4
@@ -864,5 +864,3 @@ bb0:
   %10 = tuple ()                                  
   return %10                                      
 } 
-
-

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -826,3 +826,19 @@ bb0:
 } 
 
 
+// CHECK: SIL memory lifetime failure in @mark_dependence_addr_uninit_base: memory is not initialized, but should be
+sil [ossa] @mark_dependence_addr_uninit_base : $@convention(thin) (@owned T, @owned Inner) -> @owned Inner {
+bb0(%0 : @owned $T, %1 : @owned $Inner):
+  %2 = alloc_stack $T
+  store %0 to [init] %2
+  %4 = alloc_stack $Inner
+  store %1 to [init] %4
+  destroy_addr %2
+  mark_dependence %4 on %2
+  %7 = begin_access [read] [dynamic] %4
+  %8 = load [take] %7
+  end_access %7
+  dealloc_stack %4
+  dealloc_stack %2
+  return %8
+}

--- a/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
+++ b/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
@@ -57,7 +57,7 @@ sil @useNE : $@convention(thin) (@guaranteed NE) -> ()
 // CHECK:   [[IN:%.*]] = alloc_stack $AnyObject
 // CHECK:   [[SB:%.*]] = store_borrow [[MV]] to [[IN]]
 // CHECK:   apply %{{.*}}([[OUT]], [[SB]]) : $@convention(thin) (@in_guaranteed AnyObject) -> @lifetime(borrow 0) @out NE
-// CHECK:   [[MD:%.*]] = mark_dependence [unresolved] [[OUT]] on %0
+// CHECK:   mark_dependence_addr [unresolved] [[OUT]] on %0
 // CHECK:   end_borrow [[SB]]
 // CHECK:   end_borrow [[TEMP]]
 // CHECK:   [[LD:%.*]] = load [take] [[OUT]]
@@ -95,7 +95,7 @@ bb0(%0 : @guaranteed $AnyObject):
 // CHECK:   [[MD:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[ALLOC]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] %0
 // CHECK:   apply %{{.*}}([[MD]], [[ACCESS]]) : $@convention(thin) (@inout AnyObject) -> @lifetime(borrow 0) @out NCE
-// CHECK:   mark_dependence [unresolved] [[ALLOC]] on [[ACCESS]]
+// CHECK:   mark_dependence_addr [unresolved] [[ALLOC]] on [[ACCESS]]
 // CHECK:   end_access [[ACCESS]]
 // CHECK-LABEL: } // end sil function 'testInoutSpanProp'
 sil [available 9999] [ossa] @testInoutSpanProp : $@convention(method) (@inout AnyObject) -> @lifetime(borrow 0) @owned NCE {

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1916,3 +1916,28 @@ bb0(%0 : $*C, %1 : $*C, %2 : @owned $C):
   %5 = mark_dependence %1 on %0
   return %4
 }
+
+// CHECK-LABEL: @test_mark_dependence_addr
+// CHECK:      PAIR #0.
+// CHECK-NEXT:   mark_dependence_addr %1 : $*C on %2 : $C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=0
+// CHECK:      PAIR #1.
+// CHECK-NEXT:   mark_dependence_addr %1 : $*C on %2 : $C
+// CHECK-NEXT:   %1 = argument of bb0 : $*C
+// CHECK-NEXT:   r=0,w=0
+// CHECK:      PAIR #2.
+// CHECK-NEXT:     mark_dependence_addr %1 : $*C on %0 : $*C
+// CHECK-NEXT:   %0 = argument of bb0 : $*C
+// CHECK-NEXT:  r=1,w=0
+// CHECK:      PAIR #3.
+// CHECK-NEXT:    mark_dependence_addr %1 : $*C on %0 : $*C
+// CHECK-NEXT:  %1 = argument of bb0 : $*C
+// CHECK-NEXT:  r=0,w=0
+sil [ossa] @test_mark_dependence_addr : $@convention(thin) (@in_guaranteed C, @in_guaranteed C, @guaranteed C) -> () {
+bb0(%0 : $*C, %1 : $*C, %2 : @guaranteed $C):
+  mark_dependence_addr %1 on %2
+  mark_dependence_addr %1 on %0
+  %99 = tuple ()
+  return %99 : $()
+}


### PR DESCRIPTION
SIL: add mark_dependence_addr

And support mark_dependence_addr in SIL passes.

Necessary whenever an addressable value depends on another value. We will need dataflow to determine the lifetime of the base.