### PR TITLE
[cxx-interop] Support foreing reference types in generic context

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -579,8 +579,9 @@ public:
           forwardDeclareCxxValueTypeIfNeeded(NTD);
         else if (isa<StructDecl>(TD) && NTD->hasClangNode())
           emitReferencedClangTypeMetadata(NTD);
-        else if (isa<ClassDecl>(TD) && TD->isObjC()) 
-          emitReferencedClangTypeMetadata(NTD);
+        else if (const auto *cd = dyn_cast<ClassDecl>(TD))
+          if (cd->isObjC() || cd->isForeignReferenceType())
+            emitReferencedClangTypeMetadata(NTD);
       } else if (auto TAD = dyn_cast<TypeAliasDecl>(TD)) {
         if (TAD->hasClangNode())
           emitReferencedClangTypeMetadata(TAD);

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -618,6 +618,15 @@ static bool isOptionalObjCExistential(Type ty) {
   return false;
 }
 
+static bool isOptionalForeignReferenceType(Type ty) {
+  if (auto obj = ty->getOptionalObjectType()) {
+    if (const auto *cd =
+            dyn_cast_or_null<ClassDecl>(obj->getNominalOrBoundGenericNominal()))
+      return cd->isForeignReferenceType();
+  }
+  return false;
+}
+
 // Returns false if the given direct type is not yet supported because
 // of its ABI.
 template <class T>
@@ -658,7 +667,8 @@ static bool printDirectReturnOrParamCType(
   if (isKnownCType(valueType, typeMapping) ||
       (Count == 1 && lastOffset.isZero() && !valueType->hasTypeParameter() &&
        (valueType->isAnyClassReferenceType() ||
-        isOptionalObjCExistential(valueType)))) {
+        isOptionalObjCExistential(valueType) ||
+        isOptionalForeignReferenceType(valueType)))) {
     prettifiedValuePrinter();
     return true;
   }
@@ -1506,10 +1516,9 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   if (!nonOptResultType)
     nonOptResultType = resultTy;
   if (auto *classDecl = nonOptResultType->getClassOrBoundGenericClass();
-      classDecl || nonOptResultType->isObjCExistentialType()) {
+      (classDecl && isa<clang::ObjCContainerDecl>(classDecl->getClangDecl())) ||
+      nonOptResultType->isObjCExistentialType()) {
     assert(!classDecl || classDecl->hasClangNode());
-    assert(!classDecl ||
-           isa<clang::ObjCContainerDecl>(classDecl->getClangDecl()));
     os << "return (__bridge_transfer ";
     declPrinter.withOutputStream(os).print(nonOptResultType);
     os << ")(__bridge void *)";
@@ -1766,6 +1775,9 @@ bool DeclAndTypeClangFunctionPrinter::hasKnownOptionalNullableCxxMapping(
               optionalObjectType->getNominalOrBoundGenericNominal())) {
         return typeInfo->canBeNullable;
       }
+      if (const auto *cd = dyn_cast<ClassDecl>(nominal))
+        if (cd->isForeignReferenceType())
+          return true;
       return isa_and_nonnull<clang::ObjCInterfaceDecl>(nominal->getClangDecl());
     }
   }

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -641,7 +641,9 @@ void ClangValueTypePrinter::printTypeGenericTraits(
               typeDecl, typeMetadataFuncName, typeMetadataFuncRequirements);
         });
   }
-  bool addPointer = typeDecl->isObjC();
+  auto classDecl = dyn_cast<ClassDecl>(typeDecl);
+  bool addPointer =
+      typeDecl->isObjC() || (classDecl && classDecl->isForeignReferenceType());
 
   os << "#pragma clang diagnostic push\n";
   os << "#pragma clang diagnostic ignored \"-Wc++17-extensions\"\n";

--- a/test/Interop/CxxToSwiftToCxx/allow-shared-frt-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/allow-shared-frt-back-to-cxx.swift
@@ -2,6 +2,9 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
+// RUN: cat %t/header.h >> %t/full-header.h
+// RUN: cat %t/UseCxxTy.h >> %t/full-header.h
+// RUN: %target-interop-build-clangxx -std=c++20 -c -xc++-header %t/full-header.h -o %t/o.o
 
 // RUN: %FileCheck %s < %t/UseCxxTy.h
 
@@ -28,6 +31,11 @@ import CxxTest
 
 public func consumeSharedFRT(_ x: consuming SharedFRT) {}
 public func takeSharedFRT(_ x: SharedFRT) {}
+
+public func takeSharedFRTGeneric(_ x: [SharedFRT]) {}
+public func returnSharedFRTGeneric() -> [SharedFRT] { [] }
+public func takeSharedFRTOptional(_ x: SharedFRT?) {}
+public func returnSharedFRTOptional() -> SharedFRT? { nil }
 
 // CHECK: SWIFT_EXTERN void $s8UseCxxTy16consumeSharedFRTyySo0eF0VnF(SharedFRT *_Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // consumeSharedFRT(_:)
 


### PR DESCRIPTION
Print the type traits in reverse interop to enable the use of foreign reference type in generics like Swift arrays. Also make sure optional foreign reference types can be passed around as raw pointers.

rdar://108139769
