### PR TITLE
IRGen: Fix assertion failure with typed throws

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4040,8 +4040,9 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
       Builder.emitBlock(typedErrorLoadBB);
 
       auto &errorTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(errorType));
-      auto silResultTy = CurSILFn->mapTypeIntoContext(
-          substConv.getSILResultType(IGM.getMaximalTypeExpansionContext()));
+      auto silResultTy =
+          substConv.getSILResultType(IGM.getMaximalTypeExpansionContext());
+      ASSERT(!silResultTy.hasTypeParameter());
       auto &resultTI = cast<LoadableTypeInfo>(IGM.getTypeInfo(silResultTy));
 
       auto &resultSchema = resultTI.nativeReturnValueSchema(IGM);

--- a/test/IRGen/typed_throws_generic.swift
+++ b/test/IRGen/typed_throws_generic.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-irgen
+
+// https://github.com/swiftlang/swift/issues/80020
+//
+// We used to assert if you had a loadable return type that contained
+// a generic parameter.
+
+public enum MyError: Error {
+  case error
+}
+
+public struct G<T> {}  // Note: G<T> is loadable
+
+public func f<T>(t: T) throws(MyError) -> G<T> {
+  return G<T>()
+}
+
+public func g<U>(u: U?) throws(MyError) -> G<U?> {
+  return try f(t: u)
+}


### PR DESCRIPTION
This fixes a regression from f6e7c16a8a24ed2c1b5a59b5aeacefd7f1c3591b. The mapTypeIntoContext() call in visitFullApplySite() was not necessary because the type in question is already fully substituted and should no longer contain type parameters.

However, it can contain archetypes, which is what caused mapTypeIntoContext() to assert. Indeed, this case where the return type is generic but still loadable wasn't covered by our test suite.

(I believe the other places where mapTypeIntoContext() was introduced in that commit are correct, because there we're dealing with the interface type of the current function, which can contain type parameters.)

- Fixes https://github.com/swiftlang/swift/issues/80020.
- Fixes rdar://147051717.