### PR TITLE
[build-script] Build CMake before Ninja

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -698,13 +698,13 @@ def main_normal():
     # Preprocess the arguments to apply defaults.
     apply_default_arguments(toolchain, args)
 
-    # Create the build script invocation.
-    invocation = build_script_invocation.BuildScriptInvocation(toolchain, args)
-
     cmake = CMake(args=args, toolchain=toolchain)
     toolchain.cmake = cmake.get_cmake_path(source_root=SWIFT_SOURCE_ROOT,
                                            build_root=SWIFT_BUILD_ROOT)
     args.cmake = toolchain.cmake
+
+    # Create the build script invocation.
+    invocation = build_script_invocation.BuildScriptInvocation(toolchain, args)
 
     # Validate the arguments.
     validate_arguments(toolchain, args)


### PR DESCRIPTION
Ninja requires CMake 3.15 or newer to build, while the CMake on Amazon Linux 2 is only 2.8. We bootstrap a newer CMake anyway, so build it before Ninja so that Ninja has a new enough CMake.

Note: Ninja is built as part of constructing the build-script invocation object.