### PR TITLE
[ASTGen] Remove ValueGeneric mapping

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -75,7 +75,6 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.NonescapableTypes, to: .nonescapableTypes)
     mapFeature(.TrailingComma, to: .trailingComma)
     mapFeature(.CoroutineAccessors, to: .coroutineAccessors)
-    mapFeature(.ValueGenerics, to: .valueGenerics)
     mapFeature(.ABIAttribute, to: .abiAttribute)
     mapFeature(.OldOwnershipOperatorSpellings, to: .oldOwnershipOperatorSpellings)
     mapFeature(.KeyPathWithMethodMembers, to: .keypathWithMethodMembers)


### PR DESCRIPTION
Now that the `ValueGenerics` feature is always enabled, we're removing this feature from swift-syntax here https://github.com/swiftlang/swift-syntax/pull/3022 which requires this change as well.