### PR TITLE
RemoteInspection: Update DefaultActorImpl layout

### DIFF
--- a/include/swift/RemoteInspection/RuntimeInternals.h
+++ b/include/swift/RemoteInspection/RuntimeInternals.h
@@ -159,14 +159,16 @@ struct FutureAsyncContextPrefix {
 };
 
 template <typename Runtime>
-struct ActiveActorStatusWithEscalation {
+struct alignas(2 * sizeof(typename Runtime::StoredPointer))
+    ActiveActorStatusWithEscalation {
   uint32_t Flags[1];
   uint32_t DrainLock[(sizeof(typename Runtime::StoredPointer) == 8) ? 1 : 2];
   typename Runtime::StoredPointer FirstJob;
 };
 
 template <typename Runtime>
-struct ActiveActorStatusWithoutEscalation {
+struct alignas(2 * sizeof(typename Runtime::StoredPointer))
+    ActiveActorStatusWithoutEscalation {
   uint32_t Flags[sizeof(typename Runtime::StoredPointer) == 8 ? 2 : 1];
   typename Runtime::StoredPointer FirstJob;
 };
@@ -174,9 +176,8 @@ struct ActiveActorStatusWithoutEscalation {
 template <typename Runtime, typename ActiveActorStatus>
 struct DefaultActorImpl {
   HeapObject<Runtime> HeapObject;
-  Job<Runtime> JobStorage;
-  ActiveActorStatus Status;
   bool IsDistributedRemote;
+  ActiveActorStatus Status;
 };
 
 template <typename Runtime>


### PR DESCRIPTION
The definition of `DefautlActorImpl` changed in https://github.com/swiftlang/swift/pull/70910 (re-committed in https://github.com/swiftlang/swift/pull/73998). This change reflects those changes on to RemoteInspection's platform independent definition.