### PR TITLE
[TypeChecker] Avoid dropping pre-check diagnostics in `typeCheckParam…

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -419,10 +419,12 @@ TypeChecker::typeCheckTarget(SyntacticElementTarget &target,
   PrettyStackTraceLocation stackTrace(Context, "type-checking-target",
                                       target.getLoc());
 
-  // First, pre-check the target, validating any types that occur in the
-  // expression and folding sequence expressions.
-  if (ConstraintSystem::preCheckTarget(target))
-    return errorResult();
+  if (!options.contains(TypeCheckExprFlags::AvoidInvalidatingAST)) {
+    // First, pre-check the target, validating any types that occur in the
+    // expression and folding sequence expressions.
+    if (ConstraintSystem::preCheckTarget(target))
+      return errorResult();
+  }
 
   // Check whether given target has a code completion token which requires
   // special handling. Returns true if handled, in which case we've already
@@ -509,6 +511,11 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
 
   auto paramInterfaceTy = paramType->mapTypeOutOfContext();
 
+  // Attempt to pre-check expression first, if that fails - skip type-checking.
+  // This would make sure that diagnostics about invalid AST are never dropped.
+  if (ConstraintSystem::preCheckTarget(defaultExprTarget))
+    return Type();
+
   {
     // Buffer all of the diagnostics produced by \c typeCheckExpression
     // since in some cases we need to try type-checking again with a
@@ -531,8 +538,8 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
     // First, let's try to type-check default expression using
     // archetypes, which guarantees that it would work for any
     // substitution of the generic parameter (if they are involved).
-    if (auto result = typeCheckExpression(
-            defaultExprTarget, options, &diagnostics)) {
+    if (auto result =
+            typeCheckTarget(defaultExprTarget, options, &diagnostics)) {
       defaultValue = result->getAsExpr();
       return defaultValue->getType();
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -135,8 +135,8 @@ enum class TypeCheckExprFlags {
   /// Don't expand macros.
   DisableMacroExpansions = 0x04,
 
-  /// If set, typeCheckExpression will avoid invalidating the AST if
-  /// type-checking fails. Do not add new uses of this.
+  /// If set, typeCheckExpression will avoid pre-checking and invalidating
+  /// the AST if type-checking fails. Do not add new uses of this.
   AvoidInvalidatingAST = 0x08,
 };
 

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -117,6 +117,7 @@ extension Task where Success == Never, Failure == Never {
     }
   }
 
+  #if !$Embedded
   /// Suspends the current task until the given deadline within a tolerance.
   ///
   /// If the task is canceled before the time ends, this function throws 
@@ -153,6 +154,7 @@ extension Task where Success == Never, Failure == Never {
   ) async throws {
     try await clock.sleep(for: duration, tolerance: tolerance)
   }
+  #endif
 }
 #else
 @available(SwiftStdlib 5.7, *)

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-73986.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-73986.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/apple/swift/issues/73986
+
+struct S {
+  init(_: () -> some Any = { Nonexistent() }) {}
+  // expected-error@-1 {{cannot find 'Nonexistent' in scope}}
+
+  init<C>(other: C = { _ = 42; return Nonexistent() }) {}
+  // expected-error@-1 {{cannot find 'Nonexistent' in scope}}
+}
+
+func test(x: some FixedWidthInteger = UNKNOWN_CONSTANT) {
+  // expected-error@-1 {{cannot find 'UNKNOWN_CONSTANT' in scope}}
+}


### PR DESCRIPTION
…eterDefault`

`typeCheck{Expression, Target}` has a pre-check phase which would replace some invalid AST nodes (i.e. name references that are not available in the given declaration context) with `ErrorExpr`s and emit a diagnostic. Such diagnostics were then dropped by `abort()` call to a diagnostic transaction. This results in invalid code being accepted by Sema and forwarded to SILGen.

Resolves: https://github.com/swiftlang/swift/issues/73986
Resolves: rdar://131732245

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
