### PR TITLE
Disable CompatibilitySpans outside of stdlib build

### DIFF
--- a/stdlib/toolchain/CompatibilitySpan/CMakeLists.txt
+++ b/stdlib/toolchain/CompatibilitySpan/CMakeLists.txt
@@ -1,15 +1,8 @@
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND DEFINED SWIFT_STDLIB_LIBRARY_BUILD_TYPES)
 
   set(library_name "swiftCompatibilitySpan")
 
-  if(SWIFT_STDLIB_LIBRARY_BUILD_TYPES)
-    set(COMPATIBILITY_SPAN_BUILD_TYPES "${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}")
-  else()
-    # This is not set when building build tools for the toolchain build.
-    set(COMPATIBILITY_SPAN_BUILD_TYPES "STATIC")
-  endif()
-
-  add_swift_target_library("${library_name}" ${COMPATIBILITY_SPAN_BUILD_TYPES} IS_STDLIB
+  add_swift_target_library("${library_name}" ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
     FakeStdlib.swift
     ../../public/core/Span/RawSpan.swift
     ../../public/core/Span/Span.swift

--- a/stdlib/toolchain/CompatibilitySpan/CMakeLists.txt
+++ b/stdlib/toolchain/CompatibilitySpan/CMakeLists.txt
@@ -2,7 +2,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 
   set(library_name "swiftCompatibilitySpan")
 
-  add_swift_target_library("${library_name}" ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+  if(SWIFT_STDLIB_LIBRARY_BUILD_TYPES)
+    set(COMPATIBILITY_SPAN_BUILD_TYPES "${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}")
+  else()
+    # This is not set when building build tools for the toolchain build.
+    set(COMPATIBILITY_SPAN_BUILD_TYPES "STATIC")
+  endif()
+
+  add_swift_target_library("${library_name}" ${COMPATIBILITY_SPAN_BUILD_TYPES} IS_STDLIB
     FakeStdlib.swift
     ../../public/core/Span/RawSpan.swift
     ../../public/core/Span/Span.swift


### PR DESCRIPTION
In some cases, like when building the Swift toolchain build tools, `SWIFT_STDLIB_LIBRARY_BUILD_TYPES` is not defined. This causes a configuration failure when the `CompatibilitySpan` library is being added.

This commit disables the `CompatibilitySpan` target when `SWIFT_STDLIB_LIBRARY_BUILD_TYPES` is not set.