### PR TITLE
[LLDB] Turn off resilience bypass for textual swiftinterface files

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1788,10 +1788,11 @@ MemoryBufferSerializedModuleLoader::loadModule(SourceLoc importLoc,
     Ctx.removeLoadedModule(moduleID.Item);
     return nullptr;
   }
-  // The MemoryBuffer loader is used by LLDB during debugging. Modules imported
-  // from .swift_ast sections are never produced from textual interfaces. By
-  // disabling resilience the debugger can directly access private members.
-  if (BypassResilience)
+  // The MemoryBuffer loader is used by LLDB during debugging. Modules
+  // imported from .swift_ast sections are not typically produced from
+  // textual interfaces. By disabling resilience, the debugger can
+  // directly access private members.
+  if (BypassResilience && !M->isBuiltFromInterface())
     M->setBypassResilience();
 
   return M;


### PR DESCRIPTION
As the old comment indicates, it was not expected that build systems would register binary swift modules produced from textual interfaces with -add_ast_path, but we have found examples of the in the wild and it leads to the most unexpected side effects. Fixing this is straightforward, we can just check if a binary module was compiled from a textual interface and then not bypass resilience.

rdar://145226754
