### PR TITLE
[IRGen] Map result to native representation in emitAsyncReturn

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -6653,10 +6653,12 @@ void irgen::emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &asyncLayout,
       if (combinedTy->isVoidTy()) {
         assert(result.empty() && "Unexpected result values");
       } else {
+        Explosion native = nativeSchema.mapIntoNative(
+            IGM, IGF, result, funcResultTypeInContext, /*isOutlined*/ false);
         if (auto *structTy = dyn_cast<llvm::StructType>(combinedTy)) {
           llvm::Value *nativeAgg = llvm::UndefValue::get(structTy);
-          for (unsigned i = 0, e = result.size(); i < e; ++i) {
-            llvm::Value *elt = result.claimNext();
+          for (unsigned i = 0, e = native.size(); i < e; ++i) {
+            llvm::Value *elt = native.claimNext();
             auto *nativeTy = structTy->getElementType(i);
             elt = convertForDirectError(IGF, elt, nativeTy,
                                         /*forExtraction*/ false);
@@ -6667,9 +6669,9 @@ void irgen::emitAsyncReturn(IRGenFunction &IGF, AsyncContextLayout &asyncLayout,
           while (!out.empty()) {
             nativeResultsStorage.push_back(out.claimNext());
           }
-        } else if (!result.empty()) {
+        } else if (!native.empty()) {
           auto *converted = convertForDirectError(
-              IGF, result.claimNext(), combinedTy, /*forExtraction*/ false);
+              IGF, native.claimNext(), combinedTy, /*forExtraction*/ false);
           nativeResultsStorage.push_back(converted);
         } else {
           nativeResultsStorage.push_back(llvm::UndefValue::get(combinedTy));

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -349,3 +349,13 @@ func callSmallErrorLargerResult() {
     }
   }
 }
+
+struct SomeStruct {
+    let x: Int
+    let y: UInt32
+    let z: UInt32
+}
+
+func someFunc() async throws(SmallError) -> SomeStruct {
+    SomeStruct(x: 42, y: 23, z: 25)
+}


### PR DESCRIPTION
rdar://147872231

When an async typed throwing function had a result type that combined multiple fields into a single register, we created invalid IR, that could lead to compiler crashes or in some cases even miscompiles. With this fix we are mapping the result to the native representation before mapping it to the combined result type.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
