### PR TITLE
[CoroutineAccessors] Directly reference allocators.

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -590,7 +590,7 @@ class LinkEntity {
     /// The pointer is a const char* of the name.
     KnownCoroFunctionPointer,
 
-    /// An coro function pointer for a distributed accessor (method or
+    /// A coro function pointer for a distributed accessor (method or
     /// property).
     /// The pointer is a SILFunction*.
     DistributedAccessorCoroFunctionPointer,

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_IRGEN_LINKING_H
 #define SWIFT_IRGEN_LINKING_H
 
+#include "swift/ABI/Coro.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ProtocolAssociations.h"
@@ -24,8 +25,8 @@
 #include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/ADT/DenseMapInfo.h"
-#include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/GlobalObject.h"
+#include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/Module.h"
 
 namespace llvm {
@@ -165,6 +166,9 @@ class LinkEntity {
     ExtendedExistentialIsUniqueMask = 0x100,
     ExtendedExistentialIsSharedShift = 9,
     ExtendedExistentialIsSharedMask = 0x200,
+
+    // Used by CoroAllocator.  2 bits.
+    CoroAllocatorKindShift = 8, CoroAllocatorKindMask = 0x300,
   };
 #define LINKENTITY_SET_FIELD(field, value) (value << field##Shift)
 #define LINKENTITY_GET_FIELD(value, field) ((value & field##Mask) >> field##Shift)
@@ -594,6 +598,9 @@ class LinkEntity {
     /// property).
     /// The pointer is a SILFunction*.
     DistributedAccessorCoroFunctionPointer,
+
+    /// An allocator to be passed to swift_coro_alloc and swift_coro_dealloc.
+    CoroAllocator,
   };
   friend struct llvm::DenseMapInfo<LinkEntity>;
 
@@ -1498,6 +1505,15 @@ public:
     return entity;
   }
 
+  static LinkEntity forCoroAllocator(CoroAllocatorKind kind) {
+    LinkEntity entity;
+    entity.Pointer = nullptr;
+    entity.SecondaryPointer = nullptr;
+    entity.Data = LINKENTITY_SET_FIELD(Kind, unsigned(Kind::CoroAllocator)) |
+                  LINKENTITY_SET_FIELD(CoroAllocatorKind, unsigned(kind));
+    return entity;
+  }
+
   static LinkEntity forCoroFunctionPointer(LinkEntity other) {
     LinkEntity entity;
     entity.Pointer = other.Pointer;
@@ -1707,6 +1723,11 @@ public:
            getKind() == Kind::MethodDescriptorDerivative);
     return reinterpret_cast<AutoDiffDerivativeFunctionIdentifier*>(
         SecondaryPointer);
+  }
+
+  CoroAllocatorKind getCoroAllocatorKind() const {
+    assert(getKind() == Kind::CoroAllocator);
+    return CoroAllocatorKind(LINKENTITY_GET_FIELD(Data, CoroAllocatorKind));
   }
 
   CanGenericSignature getExtendedExistentialTypeShapeGenSig() const {

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -128,25 +128,11 @@ void swift_task_dealloc(void *ptr);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void swift_task_dealloc_through(void *ptr);
 
-// TODO: CoroutineAccessors: Eliminate this entry point and replace its uses
-//                           with direct references the globals.
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift)
-CoroAllocator *swift_coro_getGlobalAllocator(CoroAllocatorFlags flags);
-
-// TODO: CoroutineAccessors: Mark the underlying struct const.
-SWIFT_EXPORT_FROM(swift_Concurrency)
-CoroAllocator *const _swift_coro_task_allocator;
-
 // TODO: CoroutineAccessors: Move these declarations back to swiftCore {{
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void *swift_coro_alloc(CoroAllocator *allocator, size_t size);
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void swift_coro_dealloc(CoroAllocator *allocator, void *ptr);
-
-// TODO: CoroutineAccessors: Mark the underlying struct const.
-SWIFT_EXPORT_FROM(swift_Concurrency)
-CoroAllocator *const _swift_coro_malloc_allocator;
 // }} TODO: CoroutineAccessors
 
 /// Cancel a task and all of its child tasks.

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -3028,16 +3028,6 @@ FUNCTION(CoroDealloc,
          EFFECT(RuntimeEffect::Deallocating, RuntimeEffect::Concurrency),
          UNKNOWN_MEMEFFECTS)
 
-// const CoroAllocator *swift_coro_getGlobalAllocator(CoroAllocatorFlags flags);
-FUNCTION(CoroGetGlobalAllocator, 
-         _Concurrency, swift_coro_getGlobalAllocator, SwiftCC, 
-         CoroutineAccessorsAvailability, 
-         RETURNS(CoroAllocatorPtrTy), 
-         ARGS(CoroAllocatorFlagsTy), 
-         ATTRS(NoUnwind, WillReturn), 
-         EFFECT(RuntimeEffect::Allocating),
-         UNKNOWN_MEMEFFECTS)
-
 #undef RETURNS
 #undef ARGS
 #undef ATTRS

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -44,6 +44,7 @@
 #include <optional>
 
 #include "CallEmission.h"
+#include "ConstantBuilder.h"
 #include "EntryPointArgumentEmission.h"
 #include "Explosion.h"
 #include "GenCall.h"
@@ -57,8 +58,8 @@
 #include "GenType.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
-#include "IRGenModule.h"
 #include "IRGenMangler.h"
+#include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
 #include "NativeConventionSchema.h"
 #include "Signature.h"
@@ -5197,18 +5198,47 @@ Address irgen::emitAllocYieldManyCoroutineBuffer(IRGenFunction &IGF) {
   return createOpaqueBufferAlloca(IGF, getYieldManyCoroutineBufferSize(IGF.IGM),
                                  getYieldManyCoroutineBufferAlignment(IGF.IGM));
 }
+
+static llvm::Constant *getAddrOfGlobalCoroAllocator(IRGenModule &IGM,
+                                                    CoroAllocatorKind kind,
+                                                    llvm::Constant *allocFn,
+                                                    llvm::Constant *deallocFn) {
+  auto entity = LinkEntity::forCoroAllocator(kind);
+  auto taskAllocator = IGM.getOrCreateLazyGlobalVariable(
+      entity,
+      [&](ConstantInitBuilder &builder) -> ConstantInitFuture {
+        auto allocator = builder.beginStruct(IGM.CoroAllocatorTy);
+        allocator.addInt32(CoroAllocatorFlags(kind).getOpaqueValue());
+        allocator.add(allocFn);
+        allocator.add(deallocFn);
+        return allocator.finishAndCreateFuture();
+      },
+      [&](llvm::GlobalVariable *var) { var->setConstant(true); });
+  return taskAllocator;
+}
+llvm::Constant *IRGenModule::getAddrOfGlobalCoroMallocAllocator() {
+  return getAddrOfGlobalCoroAllocator(*this, CoroAllocatorKind::Malloc,
+                                      getMallocFn(), getFreeFn());
+}
+llvm::Constant *IRGenModule::getAddrOfGlobalCoroAsyncTaskAllocator() {
+  return getAddrOfGlobalCoroAllocator(*this, CoroAllocatorKind::Async,
+                                      getTaskAllocFn(), getTaskDeallocFn());
+}
 llvm::Value *
 irgen::emitYieldOnce2CoroutineAllocator(IRGenFunction &IGF,
                                         std::optional<CoroAllocatorKind> kind) {
   if (!kind) {
     return IGF.getCoroutineAllocator();
   }
-  CoroAllocatorFlags flags(*kind);
-  auto *flagsValue = llvm::ConstantInt::get(IGF.IGM.CoroAllocatorFlagsTy,
-                                            flags.getOpaqueValue());
-
-  return IGF.Builder.CreateCall(
-      IGF.IGM.getCoroGetGlobalAllocatorFunctionPointer(), {flagsValue});
+  switch (*kind) {
+  case CoroAllocatorKind::Stack:
+    return llvm::ConstantPointerNull::get(IGF.IGM.CoroAllocatorPtrTy);
+  case CoroAllocatorKind::Async:
+    return IGF.IGM.getAddrOfGlobalCoroAsyncTaskAllocator();
+  case CoroAllocatorKind::Malloc:
+    return IGF.IGM.getAddrOfGlobalCoroMallocAllocator();
+  }
+  llvm_unreachable("unhandled case");
 }
 StackAddress irgen::emitAllocYieldOnce2CoroutineFrame(IRGenFunction &IGF,
                                                       llvm::Value *size) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -832,8 +832,8 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   CoroAllocatorTy = createStructType(*this, "swift.coro_allocator",
                                      {
                                          Int32Ty, // CoroAllocator.Flags
-                                         CoroAllocateFnTy,
-                                         CoroDeallocateFnTy,
+                                         CoroAllocateFnTy->getPointerTo(),
+                                         CoroDeallocateFnTy->getPointerTo(),
                                      });
   CoroAllocatorPtrTy = CoroAllocatorTy->getPointerTo();
 }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1671,6 +1671,9 @@ public:
                                             ConstantInit init);
   SILFunction *getSILFunctionForCoroFunctionPointer(llvm::Constant *cfp);
 
+  llvm::Constant *getAddrOfGlobalCoroMallocAllocator();
+  llvm::Constant *getAddrOfGlobalCoroAsyncTaskAllocator();
+
   llvm::Function *getAddrOfDispatchThunk(SILDeclRef declRef,
                                          ForDefinition_t forDefinition);
   void emitDispatchThunk(SILDeclRef declRef);

--- a/stdlib/public/Concurrency/TaskAlloc.cpp
+++ b/stdlib/public/Concurrency/TaskAlloc.cpp
@@ -69,38 +69,9 @@ void swift::_swift_task_dealloc_specific(AsyncTask *task, void *ptr) {
   allocator(task).dealloc(ptr);
 }
 
-static void *swift_task_alloc_thunk(size_t size) {
-  return swift_task_alloc(size);
-}
-
-static void swift_task_dealloc_thunk(void *ptr) { swift_task_dealloc(ptr); }
-
 void swift::swift_task_dealloc_through(void *ptr) {
   allocator(swift_task_getCurrent()).deallocThrough(ptr);
 }
-
-static CoroAllocator CoroTaskAllocatorImpl{
-    CoroAllocatorFlags(/*CoroAllocatorKind::Async*/ 1), swift_task_alloc_thunk,
-    swift_task_dealloc_thunk};
-
-CoroAllocator *const swift::_swift_coro_task_allocator = &CoroTaskAllocatorImpl;
-
-CoroAllocator *swift::swift_coro_getGlobalAllocator(CoroAllocatorFlags flags) {
-  switch (flags.getKind()) {
-  case CoroAllocatorKind::Stack:
-    return nullptr;
-  case CoroAllocatorKind::Async:
-    return _swift_coro_task_allocator;
-  case CoroAllocatorKind::Malloc:
-    return _swift_coro_malloc_allocator;
-  }
-}
-
-static CoroAllocator CoroMallocAllocatorImpl{
-    CoroAllocatorFlags(/*CoroAllocatorKind::Malloc*/ 2), malloc, free};
-
-CoroAllocator *const swift::_swift_coro_malloc_allocator =
-    &CoroMallocAllocatorImpl;
 
 void *swift::swift_coro_alloc(CoroAllocator *allocator, size_t size) {
   return allocator->allocate(size);

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -5,6 +5,25 @@
 
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// CHECK-LABEL: @"$s19coroutine_accessors1SV3irmSivxTwc" = {{.*}}global{{.*}} %swift.coro_func_pointer <{
+//           :    sub (
+// CHECK-SAME:      $s19coroutine_accessors1SV3irmSivx
+//           :      $s19coroutine_accessors1SV3irmSivxTwc
+//           :    ),
+// CHECK-SAME:    i32 0
+// CHECK-SAME:  }>
+
+// CHECK-LABEL: _swift_coro_malloc_allocator = linkonce_odr hidden constant %swift.coro_allocator {
+// CHECK-SAME:       i32 2,
+// CHECK-SAME:       malloc,
+// CHECK-SAME:       free
+// CHECK-SAME:  }
+// CHECK-LABEL: _swift_coro_async_allocator = linkonce_odr hidden constant %swift.coro_allocator {
+// CHECK-SAME:      i32 1,
+// CHECK-SAME:      swift_task_alloc,
+// CHECK-SAME:      swift_task_dealloc
+// CHECK-SAME:  }
+
 @frozen
 public struct S {
 public var o: any AnyObject
@@ -26,4 +45,182 @@ public var irm: Int {
     yield &_i
   }
 } // public var irm
+
+// CHECK-LABEL: define{{.*}} void @increment_irm(
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+//      :         [[SIZE_32:%[^,]+]] = load i32
+//           :        ptr getelementptr inbounds (
+//           :            %swift.coro_func_pointer
+// CHECK:                 $s19coroutine_accessors1SV3irmSivxTwc
+//           :            i32 0
+//           :            i32 1
+//           :        )
+// CHECK-64:      [[SIZE_64:%[^,]+]] = zext i32 {{%[^,]+}} to i64
+// CHECK-64:      [[FRAME:%[^,]+]] = alloca i8, [[INT]] [[SIZE_64]]
+// CHECK-32:      [[FRAME:%[^,]+]] = alloca i8, [[INT]] {{%[^,]+}}
+// CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s19coroutine_accessors1SV3irmSivx")
+// CHECK:         [[RETVAL:%[^,]+]] = call swiftcc { ptr, ptr } [[RAMP]](
+// CHECK-SAME:         [[FRAME]],
+// CHECK-SAME:         _swift_coro_malloc_allocator
+// CHECK-SAME:    )
+// CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
+// CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
+// CHECK:         call swiftcc void @"$s19coroutine_accessors9incrementyySizF"(
+// CHECK-SAME:        [[YIELD]]
+// CHECK-SAME:    )
+// CHECK:         call swiftcc void [[CONTINUATION]](
+// CHECK-SAME:        [[FRAME]],
+// CHECK-SAME:        _swift_coro_malloc_allocator
+// CHECK-SAME:    )
+// CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
+// CHECK:       }
+@_silgen_name("increment_irm")
+public mutating func increment_irm() {
+  increment(&irm)
+}
+
+// CHECK-LABEL: define{{.*}} void @increment_irm_async(
+//                  ptr swiftasync %0
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+//      :         [[SIZE_32:%[^,]+]] = load i32
+//           :        ptr getelementptr inbounds (
+//           :            %swift.coro_func_pointer
+// CHECK:                 $s19coroutine_accessors1SV3irmSivxTwc
+//           :            i32 0
+//           :            i32 1
+//           :        )
+// CHECK-64:      [[SIZE_64:%[^,]+]] = zext i32 {{%[^,]+}} to i64
+// CHECK-64:      [[SIZE_1:%[^,]+]] = add [[INT]] [[SIZE_64]], 15
+// CHECK-32:      [[SIZE_1:%[^,]+]] = add [[INT]] {{%[^,]+}}, 15
+// CHECK:         [[SIZE:%[^,]+]] = and [[INT]] [[SIZE_1]], -16
+// CHECK:         [[FRAME:%[^,]+]] = call swiftcc ptr @swift_task_alloc([[INT]] [[SIZE]])
+// CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s19coroutine_accessors1SV3irmSivx")
+// CHECK:         [[RETVAL:%[^,]+]] = call swiftcc { ptr, ptr } [[RAMP]](
+// CHECK-SAME:         [[FRAME]],
+// CHECK-SAME:         _swift_coro_async_allocator
+// CHECK-SAME:    )
+// CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
+// CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
+
+//                increment_async([[YIELD]])
+
+// CHECK:         call swiftcc void [[CONTINUATION]](
+// CHECK-SAME:        [[FRAME]],
+// CHECK-SAME:        _swift_coro_async_allocator
+// CHECK-SAME:    )
+// CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         call swiftcc void @swift_task_dealloc_through(ptr [[FRAME]])
+// CHECK:       }
+@_silgen_name("increment_irm_async")
+public mutating func increment_irm_async() async {
+  await increment_async(&irm)
+}
+
+public var force_yield_once_convention : () {
+  _read {
+    let nothing: () = ()
+    yield nothing
+  }
+// CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_irm_yield_once(
+//                  ptr noalias dereferenceable(32) %0
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+//      :         [[SIZE_32:%[^,]+]] = load i32
+//           :        ptr getelementptr inbounds (
+//           :            %swift.coro_func_pointer
+//           :            $s19coroutine_accessors1SV3irmSivxTwc
+//           :            i32 0
+//           :            i32 1
+//           :        )
+// CHECK-64:      [[SIZE_64:%[^,]+]] = zext i32 {{%[^,]+}} to i64
+// CHECK-64:      [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i64(i64 [[SIZE_64]], i32 16)
+// CHECK-32:      [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i32(i32 {{%[^,]+}}, i32 16)
+// CHECK:         [[FRAME:%[^,]+]] = call ptr @llvm.coro.alloca.get(token [[ALLOCATION]])
+// CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s19coroutine_accessors1SV3irmSivx")
+// CHECK:         [[RETVAL:%[^,]+]] = call swiftcc { ptr, ptr } [[RAMP]](
+// CHECK-SAME:         [[FRAME]],
+// CHECK-SAME:         _swift_coro_malloc_allocator
+// CHECK-SAME:    )
+// CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
+// CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
+// CHECK:         call swiftcc void @"$s19coroutine_accessors9incrementyySizF"(
+// CHECK-SAME:        [[YIELD]]
+// CHECK-SAME:    )
+// CHECK:         call swiftcc void [[CONTINUATION]](
+// CHECK-SAME:        [[FRAME]],
+// CHECK-SAME:        _swift_coro_malloc_allocator
+// CHECK-SAME:    )
+// CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         call void @llvm.coro.alloca.free(token [[ALLOCATION]])
+// CHECK:       }
+  @_silgen_name("increment_irm_yield_once")
+  _modify {
+    increment(&irm)
+
+    var nothing: () = ()
+    yield &nothing
+  }
+}
+
+public var force_yield_once_2_convention : () {
+  read {
+    let nothing: () = ()
+    yield nothing
+  }
+// CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_irm_yield_once_2(
+//                  ptr noalias %0
+// CHECK-SAME:      ptr [[ALLOCATOR:%[^,]+]]
+//                  ptr nocapture swiftself dereferenceable(16) %2
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+//      :         [[SIZE_32:%[^,]+]] = load i32
+//           :        ptr getelementptr inbounds (
+//           :            %swift.coro_func_pointer
+// CHECK:                 $s19coroutine_accessors1SV3irmSivxTwc
+//           :            i32 0
+//           :            i32 1
+//           :        )
+// CHECK-64:      [[SIZE_64:%[^,]+]] = zext i32 {{%[^,]+}} to i64
+// CHECK-64:      [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i64(i64 [[SIZE_64]], i32 16)
+// CHECK-32:      [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i32(i32 {{%[^,]+}}, i32 16)
+// CHECK:         [[FRAME:%[^,]+]] = call ptr @llvm.coro.alloca.get(token [[ALLOCATION]])
+// CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s19coroutine_accessors1SV3irmSivx")
+// CHECK:         [[RETVAL:%[^,]+]] = call swiftcc { ptr, ptr } [[RAMP]](
+// CHECK-SAME:         [[FRAME]],
+// CHECK-SAME:         [[ALLOCATOR]]
+// CHECK-SAME:    )
+// CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
+// CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
+// CHECK:         call swiftcc void @"$s19coroutine_accessors9incrementyySizF"(
+// CHECK-SAME:        [[YIELD]]
+// CHECK-SAME:    )
+// CHECK:         call swiftcc void [[CONTINUATION]](
+// CHECK-SAME:        [[FRAME]],
+// CHECK-SAME:        [[ALLOCATOR]]
+// CHECK-SAME:    )
+// CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         call void @llvm.coro.alloca.free(token [[ALLOCATION]])
+// CHECK:       }
+  @_silgen_name("increment_irm_yield_once_2")
+  modify {
+    increment(&irm)
+
+    var nothing: () = ()
+    yield &nothing
+  }
+}
+}
+
+public func increment_async(_ int: inout Int) async {
+  int += 1
+}
+
+public func increment(_ int: inout Int) {
+  int += 1
 }

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-irgen                                            \
 // RUN:     %s                                                              \
+// RUN:     -Onone                                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                 \
 // RUN:     -enable-arm64-corocc                                            \
 // RUN:     -enable-x86_64-corocc                                           \
@@ -8,6 +9,25 @@
 // REQUIRES: CPU=arm64 || CPU=arm64e || CPU=x86_64
 // REQUIRES: swift_feature_CoroutineAccessors
 
+// CHECK-LABEL: @"$s27coroutine_accessors_popless1iSivxTwc" = {{.*}}global{{.*}} %swift.coro_func_pointer <{
+//           :    sub (
+// CHECK-SAME:      $s27coroutine_accessors_popless1iSivx
+//           :      $s27coroutine_accessors_popless1iSivxTwc
+//           :    ),
+// CHECK-SAME:    i32 0
+// CHECK-SAME:  }>
+
+// CHECK-LABEL: _swift_coro_async_allocator = linkonce_odr hidden constant %swift.coro_allocator {
+// CHECK-SAME:      i32 1,
+// CHECK-SAME:      swift_task_alloc,
+// CHECK-SAME:      swift_task_dealloc
+// CHECK-SAME:  }
+// CHECK-LABEL: _swift_coro_malloc_allocator = linkonce_odr hidden constant %swift.coro_allocator {
+// CHECK-SAME:       i32 2,
+// CHECK-SAME:       malloc,
+// CHECK-SAME:       free
+// CHECK-SAME:  }
+
 // CHECK-LABEL: @__swift_coro_alloc_(
 // CHECK-SAME:      ptr [[ALLOCATOR:%[^,]+]]
 // CHECK-SAME:      i64 [[SIZE:%[^)]+]]
@@ -15,11 +35,11 @@
 // CHECK-SAME:  {
 // CHECK:       entry:
 // CHECK:         [[USE_POPLESS:%[^,]+]] = icmp eq ptr [[ALLOCATOR]], null
-// CHECK:         br i1 [[USE_POPLESS]], 
+// CHECK:         br i1 [[USE_POPLESS]],
 // CHECK-SAME:        label %coro.return.popless
 // CHECK-SAME:        label %coro.return.normal
 // CHECK:       coro.return.popless:
-// CHECK:         [[STACK_ALLOCATION:%[^,]+]] = alloca i8, i64 [[SIZE]], align 16
+// CHECK:         [[STACK_ALLOCATION:%[^,]+]] = alloca i8, i64 [[SIZE]]
 // CHECK:         musttail call void @llvm.ret.popless()
 // CHECK:         ret ptr [[STACK_ALLOCATION]]
 // CHECK:       coro.return.normal:
@@ -36,5 +56,180 @@ public var i: Int {
   read {
     yield _i
   }
+  modify {
+    yield &_i
+  }
 }
 
+// CHECK-LABEL: define{{.*}} void @increment_i(
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+//      :         [[SIZE_32:%[^,]+]] = load i32
+//           :        ptr getelementptr inbounds (
+//           :            %swift.coro_func_pointer
+// CHECK:                 $s27coroutine_accessors_popless1iSivxTwc
+//           :            i32 0
+//           :            i32 1
+//           :        )
+// CHECK-64:      [[SIZE_64:%[^,]+]] = zext i32 {{%[^,]+}} to i64
+// CHECK-64:      [[FRAME:%[^,]+]] = alloca i8, [[INT]] [[SIZE_64]]
+// CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s27coroutine_accessors_popless1iSivx")
+// CHECK:         [[RETVAL:%[^,]+]] = call swiftcorocc { ptr, ptr } [[RAMP]](
+// CHECK-SAME:         [[FRAME]],
+// CHECK-SAME:         null
+// CHECK-SAME:    )
+// CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
+// CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
+// CHECK:         call swiftcc void @"$s27coroutine_accessors_popless9incrementyySizF"(
+// CHECK-SAME:        [[YIELD]]
+// CHECK-SAME:    )
+// CHECK:         call swiftcorocc void [[CONTINUATION]](
+// CHECK-SAME:        [[FRAME]],
+// CHECK-SAME:        null
+// CHECK-SAME:    )
+// CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
+// CHECK:       }
+@_silgen_name("increment_i")
+public func increment_i() {
+  increment(&i)
+}
+
+public func increment(_ int: inout Int) {
+  int += 1
+}
+
+// CHECK-LABEL: define{{.*}} void @increment_i_async(
+//                  ptr swiftasync %0
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+//      :         [[SIZE_32:%[^,]+]] = load i32
+//           :        ptr getelementptr inbounds (
+//           :            %swift.coro_func_pointer
+// CHECK:                 $s27coroutine_accessors_popless1iSivxTwc
+//           :            i32 0
+//           :            i32 1
+//           :        )
+// CHECK:         [[SIZE_RAW:%[^,]+]] = zext i32 {{%[^,]+}} to i64
+// CHECK:         [[SIZE_1:%[^,]+]] = add i64 [[SIZE_RAW]], 15
+// CHECK:         [[SIZE:%[^,]+]] = and i64 [[SIZE_1]], -16
+// CHECK:         [[FRAME:%[^,]+]] = call swiftcc ptr @swift_task_alloc(i64 [[SIZE]])
+// CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s27coroutine_accessors_popless1iSivx")
+// CHECK:         [[RETVAL:%[^,]+]] = call swiftcorocc { ptr, ptr } [[RAMP]](
+// CHECK-SAME:         [[FRAME]],
+// CHECK-SAME:         _swift_coro_async_allocator
+// CHECK-SAME:    )
+// CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
+// CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
+
+//                increment_async([[YIELD]])
+
+// CHECK:         call swiftcorocc void [[CONTINUATION]](
+// CHECK-SAME:        [[FRAME]],
+// CHECK-SAME:        _swift_coro_async_allocator
+// CHECK-SAME:    )
+// CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         call swiftcc void @swift_task_dealloc_through(ptr [[FRAME]])
+// CHECK:       }
+@_silgen_name("increment_i_async")
+public func increment_i_async() async {
+  await increment_async(&i)
+}
+
+public func increment_async(_ int: inout Int) async {
+  int += 1
+}
+
+public var force_yield_once_convention : () {
+  _read {
+    let nothing: () = ()
+    yield nothing
+  }
+// CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_i_yield_once(
+//                  ptr noalias dereferenceable(32) %0
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+//      :         [[SIZE_32:%[^,]+]] = load i32
+//           :        ptr getelementptr inbounds (
+//           :            %swift.coro_func_pointer
+// CHECK:                 $s27coroutine_accessors_popless1iSivxTwc
+//           :            i32 0
+//           :            i32 1
+//           :        )
+// CHECK:         [[SIZE:%[^,]+]] = zext i32 {{%[^,]+}} to i64
+// CHECK:         [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i64(i64 [[SIZE]], i32 16)
+// CHECK:         [[FRAME:%[^,]+]] = call ptr @llvm.coro.alloca.get(token [[ALLOCATION]])
+// CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s27coroutine_accessors_popless1iSivx")
+// CHECK:         [[RETVAL:%[^,]+]] = call swiftcorocc { ptr, ptr } [[RAMP]](
+// CHECK-SAME:         [[FRAME]],
+// CHECK-SAME:         _swift_coro_malloc_allocator
+// CHECK-SAME:    )
+// CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
+// CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
+// CHECK:         call swiftcc void @"$s27coroutine_accessors_popless9incrementyySizF"(
+// CHECK-SAME:        [[YIELD]]
+// CHECK-SAME:    )
+// CHECK:         call swiftcorocc void [[CONTINUATION]](
+// CHECK-SAME:        [[FRAME]],
+// CHECK-SAME:        _swift_coro_malloc_allocator
+// CHECK-SAME:    )
+// CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         call void @llvm.coro.alloca.free(token [[ALLOCATION]])
+// CHECK:       }
+  @_silgen_name("increment_i_yield_once")
+  _modify {
+    increment(&i)
+
+    var nothing: () = ()
+    yield &nothing
+  }
+}
+
+public var force_yield_once_2_convention : () {
+  read {
+    let nothing: () = ()
+    yield nothing
+  }
+// CHECK-LABEL: define{{.*}} { ptr, ptr } @increment_i_yield_once_2(
+//                  ptr noalias %0
+// CHECK-SAME:      ptr [[ALLOCATOR:%[^)]+]]
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+//      :         [[SIZE_32:%[^,]+]] = load i32
+//           :        ptr getelementptr inbounds (
+//           :            %swift.coro_func_pointer
+// CHECK:                 $s27coroutine_accessors_popless1iSivxTwc
+//           :            i32 0
+//           :            i32 1
+//           :        )
+// CHECK:         [[SIZE:%[^,]+]] = zext i32 {{%[^,]+}} to i64
+// CHECK:         [[ALLOCATION:%[^,]+]] = call token @llvm.coro.alloca.alloc.i64(i64 [[SIZE]], i32 16)
+// CHECK:         [[FRAME:%[^,]+]] = call ptr @llvm.coro.alloca.get(token [[ALLOCATION]])
+// CHECK:         call void @llvm.lifetime.start.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         [[RAMP:%[^,]+]] = call ptr @llvm.coro.prepare.retcon(ptr @"$s27coroutine_accessors_popless1iSivx")
+// CHECK:         [[RETVAL:%[^,]+]] = call swiftcorocc { ptr, ptr } [[RAMP]](
+// CHECK-SAME:         [[FRAME]],
+// CHECK-SAME:         [[ALLOCATOR]]
+// CHECK-SAME:    )
+// CHECK:         [[CONTINUATION:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 0
+// CHECK:         [[YIELD:%[^,]+]] = extractvalue { ptr, ptr } [[RETVAL]], 1
+// CHECK:         call swiftcc void @"$s27coroutine_accessors_popless9incrementyySizF"(
+// CHECK-SAME:        [[YIELD]]
+// CHECK-SAME:    )
+// CHECK:         call swiftcorocc void [[CONTINUATION]](
+// CHECK-SAME:        [[FRAME]],
+// CHECK-SAME:        [[ALLOCATOR]]
+// CHECK-SAME:    )
+// CHECK:         call void @llvm.lifetime.end.p0(i64 -1, ptr [[FRAME]])
+// CHECK:         call void @llvm.coro.alloca.free(token [[ALLOCATION]])
+// CHECK:       }
+  @_silgen_name("increment_i_yield_once_2")
+  modify {
+    increment(&i)
+
+    var nothing: () = ()
+    yield &nothing
+  }
+}

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -410,11 +410,8 @@ Added: _$sScfsE25isIsolatingCurrentContextSbyF
 
 // add callee-allocated coro entrypoints
 // TODO: CoroutineAccessors: several of these symbols should be in swiftCore
-Added: __swift_coro_malloc_allocator
-Added: __swift_coro_task_allocator
 Added: _swift_coro_alloc
 Added: _swift_coro_dealloc
-Added: _swift_coro_getGlobalAllocator
 Added: _swift_task_dealloc_through
 
 // SwiftSettings

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -410,11 +410,8 @@ Added: _$sScfsE25isIsolatingCurrentContextSbyF
 
 // add callee-allocated coro entrypoints
 // TODO: CoroutineAccessors: several of these symbols should be in swiftCore
-Added: __swift_coro_malloc_allocator
-Added: __swift_coro_task_allocator
 Added: _swift_coro_alloc
 Added: _swift_coro_dealloc
-Added: _swift_coro_getGlobalAllocator
 Added: _swift_task_dealloc_through
 
 // SwiftSettings


### PR DESCRIPTION
Replace the call to a runtime function that looks up the allocator with a direct reference to a just-emitted sought-after global allocator.
