### PR TITLE
Properly recurse when removing "unsafe" from inlinable code

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
+++ b/lib/ASTGen/Sources/ASTGen/CompilerBuildConfiguration.swift
@@ -550,11 +550,13 @@ public func extractInlinableText(
 /// a syntax tree.
 fileprivate class RemoveUnsafeExprSyntaxRewriter: SyntaxRewriter {
   override func visit(_ node: UnsafeExprSyntax) -> ExprSyntax {
-    return node.expression.with(\.leadingTrivia, node.leadingTrivia)
+    let rewritten = super.visit(node).cast(UnsafeExprSyntax.self)
+    return rewritten.expression.with(\.leadingTrivia, node.leadingTrivia)
   }
 
   override func visit(_ node: ForStmtSyntax) -> StmtSyntax {
-    return StmtSyntax(node.with(\.unsafeKeyword, nil))
+    let rewritten = super.visit(node).cast(ForStmtSyntax.self)
+    return StmtSyntax(rewritten.with(\.unsafeKeyword, nil))
   }
 }
 

--- a/test/Unsafe/module-interface.swift
+++ b/test/Unsafe/module-interface.swift
@@ -23,7 +23,9 @@ public struct SequenceWithUnsafeIterator: Sequence {
   // CHECK-NOT: unsafe
   print( unsafe getIntUnsafely())
 
-  for unsafe _ in SequenceWithUnsafeIterator() { }
+  for unsafe _ in SequenceWithUnsafeIterator() {
+    _ = unsafe getIntUnsafely()
+  }
 }
 
 // CHECK: public protocol P


### PR DESCRIPTION
I forgot that I have to manually recurse in the syntactic rewriter. Do so. Fixes rdar://147877042
