### PR TITLE
Runtimes: allow building the Overlay against SwiftCore

### DIFF
--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -22,6 +22,8 @@ project(SwiftOverlay
   LANGUAGES C CXX Swift
   VERSION 6.1.0${BUILD_NUMBER})
 
+find_package(SwiftCore)
+
 # FIXME: We should not need to refer back into the compiler sources. This is
 # needed by gyb and AvailabilityMacros
 set(SwiftOverlay_SWIFTC_SOURCE_DIR

--- a/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
@@ -13,6 +13,8 @@ target_compile_definitions(swiftCRT PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
 target_compile_options(swiftCRT PRIVATE
   "SHELL:-Xcc -D_USE_MATH_DEFINES")
+target_link_libraries(swiftCRT PRIVATE
+  swiftCore)
 
 install(TARGETS swiftCRT
   ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"

--- a/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
@@ -5,6 +5,8 @@ set_target_properties(swiftWinSDK PROPERTIES
   Swift_MODULE_NAME WinSDK)
 target_compile_definitions(swiftCRT PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
+target_link_libraries(swiftWinSDK PRIVATE
+  swiftCore)
 
 install(TARGETS swiftWinSDK
   ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"

--- a/Runtimes/Overlay/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/clang/CMakeLists.txt
@@ -8,6 +8,8 @@ set_target_properties(swift_Builtin_float PROPERTIES
   Swift_MODULE_NAME _Builtin_float)
 target_compile_options(swift_Builtin_float PRIVATE
   "$<$<PLATFORM_ID:Darwin>:SHELL:-Xfrontend -module-abi-name -Xfrontend Darwin>")
+target_link_libraries(swift_Builtin_float PRIVATE
+  swiftCore)
 
 install(TARGETS swift_Builtin_float
   ARCHIVE DESTINATION "${SwiftOverlay_INSTALL_LIBDIR}"


### PR DESCRIPTION
Wire up the SwiftCore project to the Overlay project. This allows us to build against the just built SwiftCore.