### PR TITLE
[Concurrency] Properly set task create flags in TaskGroup.startTaskSy…

### DIFF
--- a/stdlib/public/Concurrency/Task+startSynchronously.swift.gyb
+++ b/stdlib/public/Concurrency/Task+startSynchronously.swift.gyb
@@ -170,8 +170,8 @@ extension ${GROUP_TYPE} {
       inheritContext: false,
       enqueueJob: false, // don't enqueue, we'll run it manually
       addPendingGroupTaskUnconditionally: true,
-      isDiscardingTask: false,
-      isSynchronousStart: false
+      isDiscardingTask: ${'true' if 'Discarding' in GROUP_TYPE else 'false'},
+      isSynchronousStart: true
     )
 
     // Create the task in this group.


### PR DESCRIPTION
…nchronously

rdar://147907609

When starting tasks synchronously on task groups, the task create flags for isSynchronousStart and isDiscardingTask were always set to `false`. With this change the former will always be `true` and the latter conditionally `true` for discarding task groups.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
