### PR TITLE
Clean up GenericFunctionType substitution

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4146,7 +4146,6 @@ public:
   /// function type and return the resulting non-generic type.
   FunctionType *substGenericArgs(SubstitutionMap subs,
                                  SubstOptions options = std::nullopt);
-  FunctionType *substGenericArgs(llvm::function_ref<Type(Type)> substFn) const;
 
   void Profile(llvm::FoldingSetNodeID &ID) {
     std::optional<ExtInfo> info = std::nullopt;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5754,7 +5754,7 @@ ProtocolConformanceRef ProtocolConformanceRef::forAbstract(
     properties |= conformingType->getRecursiveProperties();
   auto arena = getArena(properties);
 
-  // Profile the substitution map.
+  // Form the folding set key.
   llvm::FoldingSetNodeID id;
   AbstractConformance::Profile(id, conformingType, proto);
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -828,14 +828,12 @@ std::string ASTMangler::mangleAutoDiffGeneratedDeclaration(
 // Since we don't have a distinct mangling for sugared generic
 // parameter types, we must desugar them here.
 static Type getTypeForDWARFMangling(Type t) {
-  return t.subst(
-    [](SubstitutableType *t) -> Type {
-      if (t->isRootParameterPack()) {
-        return PackType::getSingletonPackExpansion(t->getCanonicalType());
-      }
-      return t->getCanonicalType();
-    },
-    MakeAbstractConformanceForGenericType());
+  return t.transformRec(
+    [](TypeBase *t) -> std::optional<Type> {
+      if (isa<GenericTypeParamType>(t))
+        return t->getCanonicalType();
+      return std::nullopt;
+    });
 }
 
 std::string ASTMangler::mangleTypeForDebugger(Type Ty, GenericSignature sig) {

--- a/lib/AST/AbstractConformance.h
+++ b/lib/AST/AbstractConformance.h
@@ -10,8 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines the AbstractConformance class, which stores an
-// abstract conformance that is stashed in a ProtocolConformanceRef.
+// This file defines the AbstractConformance class, which represents
+// the conformance of a type parameter or archetype to a protocol.
+// These are usually stashed inside a ProtocolConformanceRef.
 //
 //===----------------------------------------------------------------------===//
 #ifndef SWIFT_AST_ABSTRACT_CONFORMANCE_H
@@ -36,7 +37,7 @@ public:
     Profile(id, getType(), getProtocol());
   }
 
-  /// Profile the substitution map storage, for use with LLVM's FoldingSet.
+  /// Profile the storage for this conformance, for use with LLVM's FoldingSet.
   static void Profile(llvm::FoldingSetNodeID &id,
                       Type conformingType,
                       ProtocolDecl *requirement) {

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4265,16 +4265,16 @@ static void lowerKeyPathMemberIndexTypes(
   if (auto subscript = dyn_cast<SubscriptDecl>(decl)) {
     auto subscriptSubstTy = subscript->getInterfaceType();
     auto sig = subscript->getGenericSignature();
-    if (sig) {
-      subscriptSubstTy = subscriptSubstTy.subst(memberSubs);
+    if (auto *subscriptGenericTy = subscriptSubstTy->getAs<GenericFunctionType>()) {
+      subscriptSubstTy = subscriptGenericTy->substGenericArgs(memberSubs);
     }
     needsGenericContext |= subscriptSubstTy->hasArchetype();
     processIndicesOrParameters(subscript->getIndices(), &sig);
   } else if (auto method = dyn_cast<AbstractFunctionDecl>(decl)) {
     auto methodSubstTy = method->getInterfaceType();
     auto sig = method->getGenericSignature();
-    if (sig) {
-      methodSubstTy = methodSubstTy.subst(memberSubs);
+    if (auto *methodGenericTy = methodSubstTy->getAs<GenericFunctionType>()) {
+      methodSubstTy = methodGenericTy->substGenericArgs(memberSubs);
     }
     needsGenericContext |= methodSubstTy->hasArchetype();
     processIndicesOrParameters(method->getParameters(), &sig);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -946,8 +946,7 @@ static SILFunction *emitSelfConformanceWitness(SILGenModule &SGM,
                                           openedConf);
 
   // Substitute to get the formal substituted type of the thunk.
-  auto reqtSubstTy =
-    cast<AnyFunctionType>(reqtOrigTy.subst(reqtSubs)->getCanonicalType());
+  auto reqtSubstTy = reqtOrigTy.substGenericArgs(reqtSubs);
 
   // Substitute into the requirement type to get the type of the thunk.
   auto witnessSILFnType = requirementInfo.SILFnType->substGenericArgs(

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -666,7 +666,9 @@ synthesizeDesignatedInitOverride(AbstractFunctionDecl *fn, void *context) {
       .subst(subs);
   ConcreteDeclRef ctorRef(superclassCtor, subs);
 
-  auto type = superclassCtor->getInitializerInterfaceType().subst(subs);
+  auto type = superclassCtor->getInitializerInterfaceType();
+  if (auto *genericFnType = type->getAs<GenericFunctionType>())
+    type = genericFnType->substGenericArgs(subs);
   auto *ctorRefExpr =
       new (ctx) OtherConstructorDeclRefExpr(ctorRef, DeclNameLoc(),
                                             IsImplicit, type);

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -714,13 +714,9 @@ deriveBodyDistributedActor_unownedExecutor(AbstractFunctionDecl *getter, void *)
     auto substitutions = SubstitutionMap::get(
         buildRemoteExecutorDecl->getGenericSignature(),
         [&](SubstitutableType *dependentType) {
-          if (auto gp = dyn_cast<GenericTypeParamType>(dependentType)) {
-            if (gp->getDepth() == 0 && gp->getIndex() == 0) {
-              return getter->getImplicitSelfDecl()->getTypeInContext();
-            }
-          }
-
-          return Type();
+          auto gp = cast<GenericTypeParamType>(dependentType);
+          ASSERT(gp->getDepth() == 0 && gp->getIndex() == 0);
+          return getter->getImplicitSelfDecl()->getTypeInContext();
         },
         LookUpConformanceInModule()
     );
@@ -730,8 +726,8 @@ deriveBodyDistributedActor_unownedExecutor(AbstractFunctionDecl *getter, void *)
             DeclNameLoc(),/*implicit=*/true,
             AccessSemantics::Ordinary);
     buildRemoteExecutorExpr->setType(
-        buildRemoteExecutorDecl->getInterfaceType()
-         .subst(substitutions)
+        buildRemoteExecutorDecl->getInterfaceType()->castTo<GenericFunctionType>()
+         ->substGenericArgs(substitutions)
         );
 
     Expr *selfForBuildRemoteExecutor = DerivedConformance::createSelfDeclRef(getter);

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1731,8 +1731,12 @@ public:
         }
 
         // Use the most significant result from the arguments.
-        auto *fnSubstType = fnInterfaceType.subst(fnRef.getSubstitutions())
-            ->getAs<AnyFunctionType>();
+        FunctionType *fnSubstType = nullptr;
+        if (auto *fnGenericType = fnInterfaceType->getAs<GenericFunctionType>())
+          fnSubstType = fnGenericType->substGenericArgs(fnRef.getSubstitutions());
+        else
+          fnSubstType = fnInterfaceType->getAs<FunctionType>();
+
         if (!fnSubstType)  {
           result.merge(Classification::forInvalidCode());
           return;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3856,15 +3856,22 @@ filterProtocolRequirements(
 
     auto OverloadTy = Req->getOverloadSignatureType();
     if (OverloadTy) {
-      OverloadTy =
-          OverloadTy.subst(getProtocolSubstitutionMap(Req))->getCanonicalType();
+      auto Subs = getProtocolSubstitutionMap(Req);
+      // FIXME: This is wrong if the overload has its own generic parameters
+      if (auto GenericFnTy = dyn_cast<GenericFunctionType>(OverloadTy))
+        OverloadTy = GenericFnTy.substGenericArgs(Subs);
+      else
+        OverloadTy = OverloadTy.subst(Subs)->getCanonicalType();
     }
     if (llvm::any_of(DeclsByName[Req->getName()], [&](ValueDecl *OtherReq) {
           auto OtherOverloadTy = OtherReq->getOverloadSignatureType();
           if (OtherOverloadTy) {
-            OtherOverloadTy =
-                OtherOverloadTy.subst(getProtocolSubstitutionMap(OtherReq))
-                    ->getCanonicalType();
+            auto Subs = getProtocolSubstitutionMap(OtherReq);
+            // FIXME: This is wrong if the overload has its own generic parameters
+            if (auto GenericFnTy = dyn_cast<GenericFunctionType>(OtherOverloadTy))
+              OtherOverloadTy = GenericFnTy.substGenericArgs(Subs);
+            else
+              OtherOverloadTy = OtherOverloadTy.subst(Subs)->getCanonicalType();
           }
           return conflicting(Req->getASTContext(), Req->getOverloadSignature(),
                              OverloadTy, OtherReq->getOverloadSignature(),
@@ -7401,7 +7408,10 @@ bool swift::forEachConformance(
     if (forEachConformance(subs, body, visitedConformances))
       return true;
 
-    type = type.subst(subs);
+    if (auto *genericFnType = type->getAs<GenericFunctionType>())
+      type = genericFnType->substGenericArgs(subs);
+    else
+      type = type.subst(subs);
   }
 
   if (forEachConformance(type, body, visitedConformances))

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1910,7 +1910,9 @@ synthesizeObservedSetterBody(AccessorDecl *Set, TargetImpl target,
 
   auto callObserver = [&](AccessorDecl *observer, VarDecl *arg) {
     ConcreteDeclRef ref(observer, subs);
-    auto type = observer->getInterfaceType().subst(subs);
+    auto type = observer->getInterfaceType();
+    if (auto *genericFnType = type->getAs<GenericFunctionType>())
+      type = genericFnType->substGenericArgs(subs);
     Expr *Callee = new (Ctx) DeclRefExpr(ref, DeclNameLoc(), /*imp*/true);
     Callee->setType(type);
 
@@ -2101,7 +2103,9 @@ synthesizeModifyCoroutineBodyWithSimpleDidSet(AccessorDecl *accessor,
 
   auto callDidSet = [&]() {
     ConcreteDeclRef ref(DidSet, subs);
-    auto type = DidSet->getInterfaceType().subst(subs);
+    auto type = DidSet->getInterfaceType();
+    if (auto *genericFnType = type->getAs<GenericFunctionType>())
+      type = genericFnType->substGenericArgs(subs);
     Expr *Callee = new (ctx) DeclRefExpr(ref, DeclNameLoc(), /*imp*/ true);
     Callee->setType(type);
 

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -208,8 +208,12 @@ bool swift::enumerateUnsafeUses(ConcreteDeclRef declRef,
   auto subs = declRef.getSubstitutions();
   {
     auto type = decl->getInterfaceType();
-    if (subs)
-      type = type.subst(subs);
+    if (subs) {
+      if (auto *genericFnType = type->getAs<GenericFunctionType>())
+        type = genericFnType->substGenericArgs(subs);
+      else
+        type = type.subst(subs);
+    }
 
     bool shouldReturnTrue = false;
     diagnoseUnsafeType(ctx, loc, type, [&](Type unsafeType) {


### PR DESCRIPTION
`GenericFunctionType::substGenericArgs()` didn't support parameter packs. This can be fixed by replacing the implementation with a much simpler one: we form a new `FunctionType` by dropping the generic signature, and then we call `subst()`.

Now, if `subst()` was called directly on a `GenericFunctionType`, we would essentially do the same thing as above if the replacement types were not type parameters, and output a `FunctionType`. If the substitution replaced type parameters with type parameters though, we would attempt to build a new generic signature, and output a new `GenericFunctionType`. The way this was done wasn't really meaningful, except when the substitution map was the identity substitution map, in which case it did manage to rebuild the original signature.

Since this is an ongoing source of confusion, clean it up by changing `subst()` to simply assert if the input is a `GenericFunctionType`. Instead, callers must explicitly call `substGenericArgs()`.

A `GenericFunctionType` is really not like the other interface types at all; it is a closed term that can only contain type parameters of its own generic signature, while other interface types can contain free occurrences of arbitrary type parameters. Since Swift doesn't allow higher-rank polymorphism, `GenericFunctionType` is not the type of a first-class value, so most callers of `subst()` don't expect to see a `GenericFunctionType`. In the few cases that do, we should be explicit about what we're doing.