### PR TITLE
AST: Check subject type in ProtocolConformanceRef::forAbstract()

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5748,10 +5748,28 @@ ProtocolConformanceRef ProtocolConformanceRef::forAbstract(
     Type conformingType, ProtocolDecl *proto) {
   ASTContext &ctx = proto->getASTContext();
 
+  auto kind = conformingType->getDesugaredType()->getKind();
+  switch (kind) {
+  case TypeKind::GenericTypeParam:
+  case TypeKind::TypeVariable:
+  case TypeKind::DependentMember:
+  case TypeKind::Unresolved:
+  case TypeKind::Placeholder:
+  case TypeKind::PrimaryArchetype:
+  case TypeKind::PackArchetype:
+  case TypeKind::OpaqueTypeArchetype:
+  case TypeKind::ExistentialArchetype:
+  case TypeKind::ElementArchetype:
+    break;
+
+  default:
+    llvm::errs() << "Abstract conformance with bad subject type:\n";
+    conformingType->dump(llvm::errs());
+    abort();
+  }
+
   // Figure out which arena this should go in.
-  RecursiveTypeProperties properties;
-  if (conformingType)
-    properties |= conformingType->getRecursiveProperties();
+  auto properties = conformingType->getRecursiveProperties();
   auto arena = getArena(properties);
 
   // Profile the substitution map.

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -312,10 +312,8 @@ bool ProtocolConformanceRef::isCanonical() const {
   if (isPack())
     return getPack()->isCanonical();
 
-  if (isAbstract()) {
-    Type conformingType = getType();
-    return !conformingType || conformingType->isCanonical();
-  }
+  if (isAbstract())
+    return getType()->isCanonical();
 
   return getConcrete()->isCanonical();
 }
@@ -328,12 +326,8 @@ ProtocolConformanceRef::getCanonicalConformanceRef() const {
   if (isPack())
     return ProtocolConformanceRef(getPack()->getCanonicalConformance());
 
-  if (isAbstract()) {
-    Type conformingType = getType();
-    if (conformingType)
-      conformingType = conformingType->getCanonicalType();
-    return forAbstract(conformingType, getProtocol());
-  }
+  if (isAbstract())
+    return forAbstract(getType()->getCanonicalType(), getProtocol());
 
   return ProtocolConformanceRef(getConcrete()->getCanonicalConformance());
 }

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -154,18 +154,17 @@ operator()(CanType dependentType, Type conformingReplacementType,
         PackConformance::get(conformingPack, conformedProtocol, conformances));
   }
 
-  assert((conformingReplacementType->is<ErrorType>() ||
-          conformingReplacementType->is<SubstitutableType>() ||
-          conformingReplacementType->is<DependentMemberType>() ||
-          conformingReplacementType->hasTypeVariable()) &&
-         "replacement requires looking up a concrete conformance");
+  if (conformingReplacementType->is<ErrorType>())
+    return ProtocolConformanceRef::forInvalid();
+
   // A class-constrained archetype might conform to the protocol
   // concretely.
   if (auto *archetypeType = conformingReplacementType->getAs<ArchetypeType>()) {
-    if (auto superclassType = archetypeType->getSuperclass()) {
+    if (archetypeType->getSuperclass()) {
       return lookupConformance(archetypeType, conformedProtocol);
     }
   }
+
   return ProtocolConformanceRef::forAbstract(
     conformingReplacementType, conformedProtocol);
 }


### PR DESCRIPTION
All callers should now be passing in a non-null type with the correct kind.