### PR TITLE
[cxx-interop] Fix a regression making std::string unsafe

### DIFF
--- a/include/swift/ClangImporter/ClangImporterRequests.h
+++ b/include/swift/ClangImporter/ClangImporterRequests.h
@@ -537,6 +537,9 @@ enum class CxxEscapability { Escapable, NonEscapable, Unknown };
 struct EscapabilityLookupDescriptor final {
   const clang::Type *type;
   ClangImporter::Implementation *impl;
+  // Only explicitly ~Escapable annotated types are considered ~Escapable.
+  // This is for backward compatibility, so we continue to import aggregates
+  // containing pointers as Escapable types.
   bool annotationOnly = true;
 
   friend llvm::hash_code hash_value(const EscapabilityLookupDescriptor &desc) {

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -91,9 +91,11 @@ func useSafeParams(x: Owner, y: View, z: SafeEscapableAggregate, c: MyContainer)
 }
 
 func useCfType(x: CFArray) {
+  _ = x
 }
 
 func useString(x: std.string) {
+  _ = x
 }
 
 func useVecOfPtr(x: VecOfPtr) {
@@ -102,9 +104,11 @@ func useVecOfPtr(x: VecOfPtr) {
 }
 
 func useVecOfInt(x: VecOfInt) {
+  _ = x
 }
 
 func useSafeTuple(x: SafeTuple) {
+  _ = x
 }
 
 func useUnsafeTuple(x: UnsafeTuple) {


### PR DESCRIPTION
Currently, we only get warnings for using unsafe types in expressions but not in the function signature. The tests did not use the std::string object in the function body. As a result, we regressed and std::string was considered unsafe.

The reason is that the annotation only mode for calculating escapability of a type did not do what we intended. std::basic_string is conditionally escapable if the template argument is escapable. We considered 'char' to have unknown escapability in annotation only mode. The annotation only mode was introduced to avoid suddenly importing certain types as not escapable when they have pointer fields and break backward compatibility.

The solution is to make annotation only mode to still consider char and co as escapable types and only fall back to unknown when the inference otherwise would have deduced non-escapable (for unannotated types).
