### PR TITLE
[Concurrency] Eliminate StatusRecordLockRecord.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -62,9 +62,6 @@ enum {
   /// in a non-default distributed actor.
   NumWords_NonDefaultDistributedActor = 12,
 
-  /// The number of words in a task.
-  NumWords_AsyncTask = 24,
-
   /// The number of words in a task group.
   NumWords_TaskGroup = 32,
 

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -298,7 +298,18 @@ public:
 
   /// Private storage for the use of the runtime.
   struct alignas(2 * alignof(void*)) OpaquePrivateStorage {
-    void *Storage[14];
+#if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION && SWIFT_POINTER_IS_4_BYTES
+    static constexpr size_t ActiveTaskStatusSize = 4 * sizeof(void *);
+#else
+    static constexpr size_t ActiveTaskStatusSize = 4 * sizeof(void *);
+#endif
+
+    // Private storage is currently 6 pointers, 16 bytes of non-pointer data,
+    // the ActiveTaskStatus, and a RecursiveMutex.
+    static constexpr size_t PrivateStorageSize =
+        6 * sizeof(void *) + 16 + ActiveTaskStatusSize + sizeof(RecursiveMutex);
+
+    void *Storage[PrivateStorageSize];
 
     /// Initialize this storage during the creation of a task.
     void initialize(JobPriority basePri);
@@ -755,8 +766,6 @@ private:
 };
 
 // The compiler will eventually assume these.
-static_assert(sizeof(AsyncTask) == NumWords_AsyncTask * sizeof(void*),
-              "AsyncTask size is wrong");
 static_assert(alignof(AsyncTask) == 2 * alignof(void*),
               "AsyncTask alignment is wrong");
 #pragma clang diagnostic push

--- a/include/swift/Threading/Impl/C11.h
+++ b/include/swift/Threading/Impl/C11.h
@@ -147,6 +147,25 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
   (void)::mtx_unlock(&handle.mutex);
 }
 
+// .. Recursive mutex support .................................................
+
+using recursive_mutex_handle = ::mtx_t;
+
+inline void recursive_mutex_init(recursive_mutex_handle &handle,
+                                 bool checked = false) {
+  SWIFT_C11THREADS_CHECK(::mtx_init(&handle, ::mtx_recursive));
+}
+inline void recursive_mutex_destroy(recursive_mutex_handle &handle) {
+  ::mtx_destroy(&handle);
+}
+
+inline void recursive_mutex_lock(recursive_mutex_handle &handle) {
+  SWIFT_C11THREADS_CHECK(::mtx_lock(&handle));
+}
+inline void recursive_mutex_unlock(recursive_mutex_handle &handle) {
+  SWIFT_C11THREADS_CHECK(::mtx_unlock(&handle));
+}
+
 // .. ConditionVariable support ..............................................
 
 struct cond_handle {

--- a/include/swift/Threading/Impl/Darwin.h
+++ b/include/swift/Threading/Impl/Darwin.h
@@ -129,6 +129,42 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
   ::os_unfair_lock_unlock(&handle);
 }
 
+// .. Recursive mutex support .................................................
+
+// The os_unfair_recursive_lock interface is stable, but not in the SDK. Bring
+// our own definitions for what we need.
+
+#define OS_UNFAIR_RECURSIVE_LOCK_INIT                                          \
+  (os_unfair_recursive_lock{OS_UNFAIR_LOCK_INIT, 0})
+
+typedef struct os_unfair_recursive_lock_s {
+  os_unfair_lock ourl_lock;
+  uint32_t ourl_count;
+} os_unfair_recursive_lock, *os_unfair_recursive_lock_t;
+
+using recursive_mutex_handle = os_unfair_recursive_lock;
+
+extern "C" void
+os_unfair_recursive_lock_lock_with_options(os_unfair_recursive_lock_t lock,
+                                           uint32_t options);
+
+extern "C" void
+os_unfair_recursive_lock_unlock(os_unfair_recursive_lock_t lock);
+
+inline void recursive_mutex_init(recursive_mutex_handle &handle,
+                                 bool checked = false) {
+  handle = OS_UNFAIR_RECURSIVE_LOCK_INIT;
+}
+inline void recursive_mutex_destroy(recursive_mutex_handle &handle) {}
+
+inline void recursive_mutex_lock(recursive_mutex_handle &handle) {
+  os_unfair_recursive_lock_lock_with_options(&handle, 0);
+}
+
+inline void recursive_mutex_unlock(recursive_mutex_handle &handle) {
+  os_unfair_recursive_lock_unlock(&handle);
+}
+
 // .. ConditionVariable support ..............................................
 
 struct cond_handle {

--- a/include/swift/Threading/Impl/Linux.h
+++ b/include/swift/Threading/Impl/Linux.h
@@ -134,6 +134,29 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
   (void)::pthread_mutex_unlock(&handle);
 }
 
+// .. Recursive mutex support ................................................
+
+using recursive_mutex_handle = ::pthread_mutex_t;
+
+inline void recursive_mutex_init(mutex_handle &handle, bool checked = false) {
+  ::pthread_mutexattr_t attr;
+  SWIFT_LINUXTHREADS_CHECK(::pthread_mutexattr_init(&attr));
+  SWIFT_LINUXTHREADS_CHECK(
+      ::pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+  SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_init(&handle, &attr));
+  SWIFT_LINUXTHREADS_CHECK(::pthread_mutexattr_destroy(&attr));
+}
+inline void recursive_mutex_destroy(mutex_handle &handle) {
+  SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_destroy(&handle));
+}
+
+inline void recursive_mutex_lock(mutex_handle &handle) {
+  SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_lock(&handle));
+}
+inline void recursive_mutex_unlock(mutex_handle &handle) {
+  SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_unlock(&handle));
+}
+
 // .. ConditionVariable support ..............................................
 
 struct cond_handle {

--- a/include/swift/Threading/Impl/Linux.h
+++ b/include/swift/Threading/Impl/Linux.h
@@ -138,7 +138,7 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
 
 using recursive_mutex_handle = ::pthread_mutex_t;
 
-inline void recursive_mutex_init(mutex_handle &handle, bool checked = false) {
+inline void recursive_mutex_init(recursive_mutex_handle &handle, bool checked = false) {
   ::pthread_mutexattr_t attr;
   SWIFT_LINUXTHREADS_CHECK(::pthread_mutexattr_init(&attr));
   SWIFT_LINUXTHREADS_CHECK(
@@ -146,14 +146,14 @@ inline void recursive_mutex_init(mutex_handle &handle, bool checked = false) {
   SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_init(&handle, &attr));
   SWIFT_LINUXTHREADS_CHECK(::pthread_mutexattr_destroy(&attr));
 }
-inline void recursive_mutex_destroy(mutex_handle &handle) {
+inline void recursive_mutex_destroy(recursive_mutex_handle &handle) {
   SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_destroy(&handle));
 }
 
-inline void recursive_mutex_lock(mutex_handle &handle) {
+inline void recursive_mutex_lock(recursive_mutex_handle &handle) {
   SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_lock(&handle));
 }
-inline void recursive_mutex_unlock(mutex_handle &handle) {
+inline void recursive_mutex_unlock(recursive_mutex_handle &handle) {
   SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_unlock(&handle));
 }
 

--- a/include/swift/Threading/Impl/Nothreads.h
+++ b/include/swift/Threading/Impl/Nothreads.h
@@ -60,6 +60,16 @@ inline bool lazy_mutex_try_lock(lazy_mutex_handle &handle) { return true; }
 inline void lazy_mutex_unsafe_lock(lazy_mutex_handle &handle) {}
 inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {}
 
+// .. Recursive mutex support .................................................
+
+using recursive_mutex_handle = unsigned;
+
+inline void recursive_mutex_init(recursive_mutex_handle &handle,
+                                 bool checked = false) {}
+inline void recursive_mutex_destroy(recursive_mutex_handle &handle) {}
+inline void recursive_mutex_lock(recursive_mutex_handle &handle) {}
+inline void recursive_mutex_unlock(recursive_mutex_handle &handle) {}
+
 // .. ConditionVariable support ..............................................
 
 using cond_handle = unsigned;

--- a/include/swift/Threading/Impl/Pthreads.h
+++ b/include/swift/Threading/Impl/Pthreads.h
@@ -130,6 +130,29 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
   (void)::pthread_mutex_unlock(&handle);
 }
 
+// .. Recursive mutex support ................................................
+
+using recursive_mutex_handle = ::pthread_mutex_t;
+
+inline void recursive_mutex_init(mutex_handle &handle, bool checked = false) {
+  ::pthread_mutexattr_t attr;
+  SWIFT_PTHREADS_CHECK(::pthread_mutexattr_init(&attr));
+  SWIFT_PTHREADS_CHECK(
+      ::pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE));
+  SWIFT_PTHREADS_CHECK(::pthread_mutex_init(&handle, &attr));
+  SWIFT_PTHREADS_CHECK(::pthread_mutexattr_destroy(&attr));
+}
+inline void recursive_mutex_destroy(mutex_handle &handle) {
+  SWIFT_PTHREADS_CHECK(::pthread_mutex_destroy(&handle));
+}
+
+inline void recursive_mutex_lock(mutex_handle &handle) {
+  SWIFT_PTHREADS_CHECK(::pthread_mutex_lock(&handle));
+}
+inline void recursive_mutex_unlock(mutex_handle &handle) {
+  SWIFT_PTHREADS_CHECK(::pthread_mutex_unlock(&handle));
+}
+
 // .. ConditionVariable support ..............................................
 
 struct cond_handle {

--- a/include/swift/Threading/Impl/Pthreads.h
+++ b/include/swift/Threading/Impl/Pthreads.h
@@ -134,7 +134,7 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
 
 using recursive_mutex_handle = ::pthread_mutex_t;
 
-inline void recursive_mutex_init(mutex_handle &handle, bool checked = false) {
+inline void recursive_mutex_init(recursive_mutex_handle &handle, bool checked = false) {
   ::pthread_mutexattr_t attr;
   SWIFT_PTHREADS_CHECK(::pthread_mutexattr_init(&attr));
   SWIFT_PTHREADS_CHECK(
@@ -142,14 +142,14 @@ inline void recursive_mutex_init(mutex_handle &handle, bool checked = false) {
   SWIFT_PTHREADS_CHECK(::pthread_mutex_init(&handle, &attr));
   SWIFT_PTHREADS_CHECK(::pthread_mutexattr_destroy(&attr));
 }
-inline void recursive_mutex_destroy(mutex_handle &handle) {
+inline void recursive_mutex_destroy(recursive_mutex_handle &handle) {
   SWIFT_PTHREADS_CHECK(::pthread_mutex_destroy(&handle));
 }
 
-inline void recursive_mutex_lock(mutex_handle &handle) {
+inline void recursive_mutex_lock(recursive_mutex_handle &handle) {
   SWIFT_PTHREADS_CHECK(::pthread_mutex_lock(&handle));
 }
-inline void recursive_mutex_unlock(mutex_handle &handle) {
+inline void recursive_mutex_unlock(recursive_mutex_handle &handle) {
   SWIFT_PTHREADS_CHECK(::pthread_mutex_unlock(&handle));
 }
 

--- a/include/swift/Threading/Impl/Win32.h
+++ b/include/swift/Threading/Impl/Win32.h
@@ -87,6 +87,26 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
   ReleaseSRWLockExclusive(&handle);
 }
 
+// .. Recursive mutex support ................................................
+
+using recursive_mutex_handle = SWIFT_CRITICAL_SECTION;
+
+inline void recursive_mutex_init(recursive_mutex_handle &handle,
+                                 bool checked = false) {
+  InitializeCriticalSection(&handle);
+}
+
+inline void recursive_mutex_destroy(recursive_mutex_handle &handle) {
+  DeleteCriticalSection(&handle);
+}
+
+inline void recursive_mutex_lock(recursive_mutex_handle &handle) {
+  EnterCriticalSection(&handle);
+}
+inline void recursive_mutex_unlock(recursive_mutex_handle &handle) {
+  LeaveCriticalSection(&handle);
+}
+
 // .. ConditionVariable support ..............................................
 
 struct cond_handle {

--- a/include/swift/Threading/Impl/Win32/Win32Defs.h
+++ b/include/swift/Threading/Impl/Win32/Win32Defs.h
@@ -38,7 +38,11 @@ typedef int BOOL;
 typedef unsigned long DWORD;
 typedef long LONG;
 typedef unsigned long ULONG;
+#if defined(_WIN64)
+typedef unsigned __int64 ULONG_PTR;
+#else
 typedef unsigned long ULONG_PTR;
+#endif
 typedef PVOID HANDLE;
 
 typedef VOID(NTAPI *PFLS_CALLBACK_FUNCTION)(PVOID lpFlsData);

--- a/include/swift/Threading/Impl/Win32/Win32Defs.h
+++ b/include/swift/Threading/Impl/Win32/Win32Defs.h
@@ -36,7 +36,10 @@ typedef unsigned char BYTE;
 typedef BYTE BOOLEAN;
 typedef int BOOL;
 typedef unsigned long DWORD;
+typedef long LONG;
 typedef unsigned long ULONG;
+typedef unsigned long ULONG_PTR;
+typedef PVOID HANDLE;
 
 typedef VOID(NTAPI *PFLS_CALLBACK_FUNCTION)(PVOID lpFlsData);
 
@@ -45,6 +48,11 @@ typedef PRTL_SRWLOCK PSRWLOCK;
 
 typedef struct _RTL_CONDITION_VARIABLE *PRTL_CONDITION_VARIABLE;
 typedef PRTL_CONDITION_VARIABLE PCONDITION_VARIABLE;
+
+typedef struct _RTL_CRITICAL_SECTION_DEBUG *PRTL_CRITICAL_SECTION_DEBUG;
+typedef struct _RTL_CRITICAL_SECTION *PRTL_CRITICAL_SECTION;
+typedef PRTL_CRITICAL_SECTION PCRITICAL_SECTION;
+typedef PRTL_CRITICAL_SECTION LPCRITICAL_SECTION;
 
 // These have to be #defines, to avoid problems with <windows.h>
 #define RTL_SRWLOCK_INIT {0}
@@ -81,6 +89,19 @@ WINBASEAPI BOOL WINAPI SleepConditionVariableSRW(
   PSRWLOCK SRWLock,
   DWORD dwMilliseconds,
   ULONG Flags
+);
+
+WINBASEAPI VOID WINAPI InitializeCriticalSection(
+  LPCRITICAL_SECTION lpCriticalSection
+);
+WINBASEAPI VOID WINAPI DeleteCriticalSection(
+  LPCRITICAL_SECTION lpCriticalSection
+);
+WINBASEAPI VOID WINAPI EnterCriticalSection(
+  LPCRITICAL_SECTION lpCriticalSection
+);
+WINBASEAPI VOID WINAPI LeaveCriticalSection(
+  LPCRITICAL_SECTION lpCriticalSection
 );
 
 WINBASEAPI DWORD WINAPI FlsAlloc(PFLS_CALLBACK_FUNCTION lpCallback);
@@ -138,6 +159,34 @@ inline BOOL SleepConditionVariableSRW(PSWIFT_CONDITION_VARIABLE CondVar,
     reinterpret_cast<PSRWLOCK>(SRWLock),
     dwMilliseconds,
     Flags);
+}
+
+// And with CRITICAL_SECTION
+#pragma pack(push, 8)
+typedef struct SWIFT_CRITICAL_SECTION {
+  PRTL_CRITICAL_SECTION_DEBUG DebugInfo;
+  LONG LockCount;
+  LONG RecursionCount;
+  HANDLE OwningThread;
+  HANDLE LockSemaphore;
+  ULONG_PTR SpinCount;
+} SWIFT_CRITICAL_SECTION, *PSWIFT_CRITICAL_SECTION;
+#pragma pack(pop)
+
+inline VOID InitializeCriticalSection(PSWIFT_CRITICAL_SECTION CritSec) {
+  ::InitializeCriticalSection(reinterpret_cast<LPCRITICAL_SECTION>(CritSec));
+}
+
+inline VOID DeleteCriticalSection(PSWIFT_CRITICAL_SECTION CritSec) {
+  ::DeleteCriticalSection(reinterpret_cast<LPCRITICAL_SECTION>(CritSec));
+}
+
+inline VOID EnterCriticalSection(PSWIFT_CRITICAL_SECTION CritSec) {
+  ::EnterCriticalSection(reinterpret_cast<LPCRITICAL_SECTION>(CritSec));
+}
+
+inline VOID LeaveCriticalSection(PSWIFT_CRITICAL_SECTION CritSec) {
+  ::LeaveCriticalSection(reinterpret_cast<LPCRITICAL_SECTION>(CritSec));
 }
 
 } // namespace threading_impl

--- a/include/swift/Threading/Mutex.h
+++ b/include/swift/Threading/Mutex.h
@@ -241,6 +241,48 @@ private:
 using SmallMutex =
     std::conditional_t<sizeof(Mutex) <= sizeof(void *), Mutex, IndirectMutex>;
 
+/// A recursive variant of Mutex.
+class RecursiveMutex {
+
+  RecursiveMutex(const Mutex &) = delete;
+  RecursiveMutex &operator=(const Mutex &) = delete;
+  RecursiveMutex(Mutex &&) = delete;
+  RecursiveMutex &operator=(Mutex &&) = delete;
+
+public:
+  /// Constructs a non-recursive mutex.
+  ///
+  /// If `checked` is true the mutex will attempt to check for misuse and
+  /// fatalError when detected. If `checked` is false (the default) the
+  /// mutex will make little to no effort to check for misuse (more efficient).
+  explicit RecursiveMutex(bool checked = false) {
+    threading_impl::recursive_mutex_init(Handle, checked);
+  }
+  ~RecursiveMutex() { threading_impl::recursive_mutex_destroy(Handle); }
+
+  /// The lock() method has the following properties:
+  /// - Behaves as an atomic operation.
+  /// - Blocks the calling thread until exclusive ownership of the mutex
+  ///   can be obtained.
+  /// - Prior m.unlock() operations on the same mutex synchronize-with
+  ///   this lock operation.
+  /// - Does not throw exceptions but will halt on error (fatalError).
+  void lock() { threading_impl::recursive_mutex_lock(Handle); }
+
+  /// The unlock() method has the following properties:
+  /// - Behaves as an atomic operation.
+  /// - Releases the calling thread's ownership of the mutex and
+  ///   synchronizes-with the subsequent successful lock operations on
+  ///   the same object.
+  /// - The behavior is undefined if the calling thread does not own
+  ///   the mutex.
+  /// - Does not throw exceptions but will halt on error (fatalError).
+  void unlock() { threading_impl::recursive_mutex_unlock(Handle); }
+
+protected:
+  threading_impl::recursive_mutex_handle Handle;
+};
+
 } // namespace swift
 
 #endif // SWIFT_THREADING_MUTEX_H

--- a/include/swift/Threading/Mutex.h
+++ b/include/swift/Threading/Mutex.h
@@ -244,10 +244,10 @@ using SmallMutex =
 /// A recursive variant of Mutex.
 class RecursiveMutex {
 
-  RecursiveMutex(const Mutex &) = delete;
-  RecursiveMutex &operator=(const Mutex &) = delete;
-  RecursiveMutex(Mutex &&) = delete;
-  RecursiveMutex &operator=(Mutex &&) = delete;
+  RecursiveMutex(const RecursiveMutex &) = delete;
+  RecursiveMutex &operator=(const RecursiveMutex &) = delete;
+  RecursiveMutex(RecursiveMutex &&) = delete;
+  RecursiveMutex &operator=(RecursiveMutex &&) = delete;
 
 public:
   /// Constructs a non-recursive mutex.

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -36,155 +36,6 @@ ActiveTaskStatus::getStatusRecordParent(TaskStatusRecord *ptr) {
 /************************* RECORD LOCK MANAGEMENT *************************/
 /**************************************************************************/
 
-/// A lock used to protect management of task-specific status
-/// record locks.
-static LazyMutex StatusRecordLockLock;
-
-namespace {
-
-/// A lock record which can be used to protect a task's active
-/// status records.
-///
-/// For the most part, the active task status records of a task are
-/// only accessed by the task itself.  If that were always true,
-/// no synchronization would be required to change them.  However,
-/// cancellation and escalation can occur asynchronously, and they
-/// must be able to inspect the status records without worrying about
-/// their concurrent modification or destruction of the records.
-/// Therefore, these operations freeze the active status records
-/// for their duration.  They do this by (1) setting a bit in the
-/// task's `Status` field state which says that the records are
-/// locked and (2) creating a lock record as the new innermost
-/// status record.  When the operation is complete, it removes this
-/// record and clears the lock bit, then notifies the lock record that
-/// the locking operation is complete.
-///
-/// Note that this status record lock only protects concurrent
-/// modifications/access from *other* threads which may be trying to
-/// inspect/modify a task's status records. A thread which already
-/// owns the StatusRecordLock may recursively take it and modify
-/// the status record list.
-///
-/// When a task wants to iterate task status records, but
-/// it sees that the locked bit is set in the `Status` field, it
-/// must acquire the global status-record lock, find this record
-/// (which should be the innermost record), and wait for an unlock if
-/// the task is not the lock owner. If it already owns the
-/// status record lock, it may proceed.
-///
-class StatusRecordLockRecord
-    : public AtomicWaitQueue<StatusRecordLockRecord, LazyMutex>,
-      public TaskStatusRecord {
-  Thread Owner;
-public:
-
-  StatusRecordLockRecord(TaskStatusRecord *parent)
-    : TaskStatusRecord(TaskStatusRecordKind::Private_RecordLock, parent) {
-    // When we create a lock record, we always take it pre-locked
-    Owner = Thread::current();
-  }
-
-  void updateForNewArguments(TaskStatusRecord *parent) {
-    Parent = parent;
-  }
-
-  static bool classof(const TaskStatusRecord *record) {
-    return record->getKind() == TaskStatusRecordKind::Private_RecordLock;
-  }
-
-  bool isStatusRecordLockedBySelf() {
-    return Owner == Thread::current();
-  }
-
-};
-}
-
-/// If the status record is already self locked, returns true
-///
-/// If the status record is not self locked, then wait for the owner to unlock
-/// before we return. We still have to retry getting the lock ourselves and may
-/// still run into a race here.
-static bool waitForStatusRecordUnlockIfNotSelfLocked(AsyncTask *task,
-  ActiveTaskStatus &status) {
-  StatusRecordLockRecord::Waiter waiter(StatusRecordLockLock);
-
-  while (true) {
-    assert(status.isStatusRecordLocked());
-    bool selfLocked = false;
-
-    bool waited = waiter.tryReloadAndWait([&]() -> StatusRecordLockRecord* {
-      // Pairs with the store_release in installation of lock record in
-      // withStatusRecordLock so that lock record contents are visible due to
-      // load-through HW address dependency
-      status = task->_private()._status().load(SWIFT_MEMORY_ORDER_CONSUME);
-      _swift_tsan_consume(task);
-
-      if (!status.isStatusRecordLocked())
-        return nullptr;
-
-      auto record = cast<StatusRecordLockRecord>(status.getInnermostRecord());
-      // We can safely look inside the record now
-      if (record->isStatusRecordLockedBySelf()) {
-        selfLocked = true;
-        return nullptr;
-      }
-      return record;
-    });
-
-    if (!waited)
-      return selfLocked;
-
-    // Reload the status before trying to relock
-    status = task->_private()._status().load(SWIFT_MEMORY_ORDER_CONSUME);
-    _swift_tsan_consume(task);
-    if (!status.isStatusRecordLocked())
-      return false;
-  }
-}
-
-/// Wait for a task's status record lock to be unlocked. This asserts that the
-/// lock is not owned by self as that would result in a deadlock.
-///
-/// When this function returns, `status` will have been updated
-/// to the last value read and `isStatusRecordLocked()` will be false.
-/// Of course, another thread may still be concurrently trying
-/// to acquire the record lock.
-static void waitForStatusRecordUnlock(AsyncTask *task,
-                                      ActiveTaskStatus &status) {
-  // Acquire the lock.
-  StatusRecordLockRecord::Waiter waiter(StatusRecordLockLock);
-
-  while (true) {
-    assert(status.isStatusRecordLocked());
-
-    bool waited = waiter.tryReloadAndWait([&]() -> StatusRecordLockRecord* {
-      // Pairs with the store_release in installation of lock record in
-      // withStatusRecordLock so that lock record contents are visible due to
-      // load-through HW address dependency
-      status = task->_private()._status().load(SWIFT_MEMORY_ORDER_CONSUME);
-      _swift_tsan_consume(task);
-      if (!status.isStatusRecordLocked())
-        return nullptr;
-
-      // The innermost entry should be a record lock record; Verify that we are
-      // not the owner and then wait for it to be unlocked.
-      auto record = cast<StatusRecordLockRecord>(status.getInnermostRecord());
-      if (record->isStatusRecordLockedBySelf()) {
-        swift_Concurrency_fatalError(0, "Waiting on a status record lock that is owned by self");
-      }
-      return record;
-    });
-    if (!waited)
-      return;
-
-    // Reload the status before trying to relock.
-    status = task->_private()._status().load(SWIFT_MEMORY_ORDER_CONSUME);
-    _swift_tsan_consume(task);
-    if (!status.isStatusRecordLocked())
-      return;
-  }
-}
-
 /// This function grabs the status record lock of the input task and invokes
 /// `fn` while holding the StatusRecordLock of the input task.
 ///
@@ -197,63 +48,62 @@ static void waitForStatusRecordUnlock(AsyncTask *task,
 /// from the ActiveTaskStatus so that callers may make additional modifications
 /// to ActiveTaskStatus flags. `statusUpdate` can be called multiple times in a
 /// RMW loop and so much be idempotent.
-static bool withStatusRecordLock(AsyncTask *task, ActiveTaskStatus status,
-    llvm::function_ref<void(ActiveTaskStatus)>fn,
-    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)> statusUpdate = nullptr) {
+static void withStatusRecordLock(
+    AsyncTask *task, ActiveTaskStatus status,
+    llvm::function_ref<void(ActiveTaskStatus)> fn,
+    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus &)>
+        statusUpdate = nullptr) {
+  // We need to acquire the lock AND set the is-locked bit in the status so that
+  // other threads attempting lockless operations can atomically check whether
+  // another thread holds the lock. Various operations can be done with a
+  // compare and swap if nothing holds the lock, but need to wait for the lock
+  // to be released if something does hold it.
+  //
+  // Setting the bit can't be done atomically with acquiring the lock, but
+  // that's OK. If we hold the lock but haven't yet set the bit, then we haven't
+  // actually done any work and other threads can operate without violating our
+  // assumptions. Once we swap in the is-locked bit and begin work, any
+  // in-progress lockless work will fail its compare and swap operation, retry,
+  // see that the is-locked bit is now set, and then wait for the lock.
+  task->_private().statusLock.lock();
 
-  StatusRecordLockRecord::Worker worker(StatusRecordLockLock);
+  bool alreadyLocked = status.isStatusRecordLocked();
 
-  TaskStatusRecord *oldRecord;
-  StatusRecordLockRecord *lockingRecord;
+  // If it's already locked then this thread is the thread that locked it, and
+  // we can leave that bit alone here.
+  if (!alreadyLocked) {
+    while (true) {
+      ActiveTaskStatus newStatus = status.withStatusRecordLocked();
 
-  // Take the lock record
-  bool installedLockRecord = false;
-  while (true) {
-    if (status.isStatusRecordLocked() &&
-        waitForStatusRecordUnlockIfNotSelfLocked(task, status)) {
-      // Top record is status record lock and we own it.
-      SWIFT_TASK_DEBUG_LOG("[StatusRecordLock] Lock for task %p is already owned by thread", task);
-      break;
-    }
-
-    // Make (or reconfigure) a lock record
-    oldRecord = status.getInnermostRecord();
-    lockingRecord = worker.createQueue(oldRecord);
-
-    // Publish the lock record
-    // * We need an acquire to pair with release of someone else who might have
-    // unlocked
-    // * We need a store release to publish the lock record contents
-    ActiveTaskStatus newStatus = status.withLockingRecord(lockingRecord);
-    if (task->_private()._status().compare_exchange_weak(status, newStatus,
-            /*success*/ std::memory_order_acq_rel,
-            /*failure*/ std::memory_order_relaxed)) {
-      _swift_tsan_acquire(task);
-      _swift_tsan_release(task);
-
-      status = newStatus;
-
-      status.traceStatusChanged(task, false);
-      worker.flagQueueIsPublished(lockingRecord);
-      installedLockRecord = true;
-
-      // We've locked the status
-      assert(worker.isWorkerThread());
-      break;
+      // The caller may be reading a record that was locklessly emplaced. The
+      // CONSUME here pairs with the release in addStatusRecord to ensure the
+      // record's memory is visible to this thread.
+      if (task->_private()._status().compare_exchange_weak(
+              status, newStatus,
+              /*success*/ SWIFT_MEMORY_ORDER_CONSUME,
+              /*failure*/ std::memory_order_relaxed)) {
+        status = newStatus;
+        status.traceStatusChanged(task, false);
+        break;
+      }
     }
   }
 
-  // Call the function.
+  // We now hold the lock and we've set the bit (or the bit was already set).
+  // Call the function to do the work.
   fn(status);
 
-  // Release lock record if we installed it earlier and restore the old record
-  // at the top.
   while (true) {
-    auto newStatus = status;
+    // If we were already locked and there's no status update, then we can skip
+    // updating the status field.
+    if (alreadyLocked && !statusUpdate)
+      break;
 
-    assert(status.isStatusRecordLocked());
-    if (installedLockRecord) {
-      newStatus = status.withoutLockingRecord();
+    ActiveTaskStatus newStatus = status;
+
+    // If we set the is-locked bit, clear it.
+    if (!alreadyLocked) {
+      newStatus = newStatus.withoutStatusRecordLocked();
     }
 
     // If the caller of the function wanted to modify something, let them.
@@ -261,36 +111,32 @@ static bool withStatusRecordLock(AsyncTask *task, ActiveTaskStatus status,
       statusUpdate(status, newStatus);
     }
 
-    // We are releasing the status record lock, all modifications done while
-    // holding the lock should now be published to anyone else who is waiting to
-    // acquire the lock next
-    _swift_tsan_release(task);
-    if (task->_private()._status().compare_exchange_weak(status, newStatus,
-            /*success*/ std::memory_order_release,
+    // Records can only be read with the status lock held, so the lock's
+    // memory barriers will ensure that a newly emplaced record will be
+    // visible to any reader, and we can use relaxed ordering here.
+    if (task->_private()._status().compare_exchange_weak(
+            status, newStatus,
+            /*success*/ std::memory_order_relaxed,
             /*failure*/ std::memory_order_relaxed)) {
       newStatus.traceStatusChanged(task, false);
       break;
     }
   }
 
-  if (installedLockRecord) {
-    // Unblock any waiters.
-    worker.finishAndUnpublishQueue([]{});
-  }
-
-  return true;
+  task->_private().statusLock.unlock();
 }
 
 /// A convenience version of the above for contexts that haven't already
 /// done the load.
 template <class Fn>
-static bool withStatusRecordLock(
+static void withStatusRecordLock(
     AsyncTask *task, Fn &&fn,
-    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)> statusUpdate = nullptr) {
+    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus &)>
+        statusUpdate = nullptr) {
   ActiveTaskStatus status = task->_private()._status().load(std::memory_order_relaxed);
-  return withStatusRecordLock(task, status, [&](ActiveTaskStatus taskStatus) {
-    fn(taskStatus);
-  }, /*statusUpdate=*/statusUpdate);
+  withStatusRecordLock(
+      task, status, [&](ActiveTaskStatus taskStatus) { fn(taskStatus); },
+      /*statusUpdate=*/statusUpdate);
 }
 
 /**************************************************************************/
@@ -304,12 +150,28 @@ bool swift::addStatusRecord(AsyncTask *task, TaskStatusRecord *newRecord,
 
   SWIFT_TASK_DEBUG_LOG("Adding %p record to task %p", newRecord, task);
   while (true) {
-    // Wait for any active lock to be released.
     if (oldStatus.isStatusRecordLocked()) {
-      bool selfLocked = waitForStatusRecordUnlockIfNotSelfLocked(task, oldStatus);
-      static_cast<void>(selfLocked);
-      assert(!selfLocked);
+      // If the record is locked, then acquire the lock and emplace the new
+      // record with the lock held. We don't have any other work to do, so we
+      // pass an empty function for `fn`, and give a `statusUpdate` that puts
+      // the new record in place.
+      bool addRecord = false;
+      withStatusRecordLock(
+          task, oldStatus, [](ActiveTaskStatus) {},
+          [&](ActiveTaskStatus oldStatus, ActiveTaskStatus &newStatus) {
+            // Reset the parent of the new record.
+            newRecord->resetParent(newStatus.getInnermostRecord());
+            ActiveTaskStatus modifiedStatus =
+                newStatus.withInnermostRecord(newRecord);
+            addRecord = shouldAddRecord(newStatus, modifiedStatus);
+            if (addRecord)
+              newStatus = modifiedStatus;
+          });
+      return addRecord;
     }
+
+    // If the status record is not locked, try emplacing the new record without
+    // locking.
 
     // Reset the parent of the new record.
     newRecord->resetParent(oldStatus.getInnermostRecord());
@@ -317,8 +179,7 @@ bool swift::addStatusRecord(AsyncTask *task, TaskStatusRecord *newRecord,
     ActiveTaskStatus newStatus = oldStatus.withInnermostRecord(newRecord);
     if (shouldAddRecord(oldStatus, newStatus)) {
       // We have to use a release on success to make the initialization of
-      // the new record visible to an asynchronous thread trying to modify the
-      // status records.
+      // the new record visible to another thread reading the new record.
       _swift_tsan_release(task);
       if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
               /*success*/ std::memory_order_release,
@@ -354,10 +215,14 @@ bool swift::addStatusRecordToSelf(TaskStatusRecord *record, ActiveTaskStatus &st
   return addStatusRecord(swift_task_getCurrent(), record, status, testAddRecord);
 }
 
-static void removeStatusRecordLocked(ActiveTaskStatus status, TaskStatusRecord *record) {
+// Remove a status record that is not the innermost record. The status record
+// lock must be held.
+static void removeNonInnermostStatusRecordLocked(ActiveTaskStatus status,
+                                                 TaskStatusRecord *record) {
   bool removedRecord = false;
   auto cur = status.getInnermostRecord();
-  assert(cur->getKind() == TaskStatusRecordKind::Private_RecordLock);
+  assert(status.isStatusRecordLocked());
+  assert(cur != record);
 
   // Cut the record out.
   while (cur != nullptr) {
@@ -383,78 +248,55 @@ void swift::removeStatusRecord(AsyncTask *task, TaskStatusRecord *record,
   SWIFT_TASK_DEBUG_LOG("remove status record = %p, from task = %p",
                        record, task);
 
-  if (oldStatus.isStatusRecordLocked() &&
-        waitForStatusRecordUnlockIfNotSelfLocked(task, oldStatus)) {
-    SWIFT_TASK_DEBUG_LOG("[StatusRecordLock] Lock for task %p is already owned by thread", task);
-    // Case 1: Top record is status record lock and this thread owns it.
-    //
-    // Since we have the lock, we can just remove the record we care about which
-    // should be in the list somewhere and then modify the flags
-    removeStatusRecordLocked(oldStatus, record);
+  while (true) {
+    // If the record is locked, then either we wait for the lock or we own the
+    // lock. Either way, acquire the status record lock and perform the removal.
+    // If the record to be removed is not the innermost record, then we need to
+    // acquire the lock to safely remove it.
+    if (oldStatus.isStatusRecordLocked() ||
+        oldStatus.getInnermostRecord() != record) {
+      withStatusRecordLock(
+          task, oldStatus,
+          [&](ActiveTaskStatus lockedStatus) {
+            // If the record is the innermost (always was, or became that way
+            // while we waited) then we have to remove it in the status change
+            // function, since changing the head of the list requires changing
+            // the status. If it's not the innermost then we can remove it here.
+            if (lockedStatus.getInnermostRecord() != record)
+              removeNonInnermostStatusRecordLocked(lockedStatus, record);
+          },
+          [&](ActiveTaskStatus oldStatus, ActiveTaskStatus &newStatus) {
+            // We're removing the innermost record, set a new status with the
+            // record removed.
+            if (newStatus.getInnermostRecord() == record)
+              newStatus = newStatus.withInnermostRecord(record->getParent());
 
-    if (fn) {
-      // Client wants to modify the flags on the status - do it in a loop to
-      // make sure we handle other concurrent updates.
-      while (true) {
-        auto newStatus = oldStatus;
-        fn(oldStatus, newStatus);
-
-        // We should still remain status record locked no matter what since we
-        // came in with the lock already
-        assert(newStatus.isStatusRecordLocked());
-
-        if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
-               /*success*/ std::memory_order_relaxed,
-               /*failure*/ std::memory_order_relaxed)) {
-          newStatus.traceStatusChanged(task, false);
-          return;
-        }
-      }
-    } else {
-      // Client doesn't have any other flags to change on status, we came in
-      // self-locked and leave with the lock held. No other flags changed.
+            if (fn) {
+              fn(oldStatus, newStatus);
+            }
+          });
       return;
     }
-  }
 
-  assert(!oldStatus.isStatusRecordLocked());
+    // Nobody holds the lock, and the record is the innermost record. Attempt to
+    // remove it locklessly.
+    auto newStatus = oldStatus.withInnermostRecord(record->getParent());
 
-  while (true) {
-    // We raced with some *other* thread which concurrently locked this task.
-    if (oldStatus.isStatusRecordLocked()) {
-      waitForStatusRecordUnlock(task, oldStatus);
+    if (fn) {
+      fn(oldStatus, newStatus);
     }
 
-    // Case 2: No status record lock, see if the record we are trying to pop off
-    // is the topmost record and if so, just get it out and modify the status
-    // flags if needed
-    if (oldStatus.getInnermostRecord() == record) {
-      auto newStatus = oldStatus.withInnermostRecord(record->getParent());
-
-      if (fn) {
-        fn(oldStatus, newStatus);
-      }
-
-      if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
-             /*success*/ std::memory_order_relaxed,
-             /*failure*/ std::memory_order_relaxed)) {
-        newStatus.traceStatusChanged(task, false);
-        return;
-      }
-      // Restart the loop again - someone else modified status concurrently
-      continue;
+    if (task->_private()._status().compare_exchange_weak(
+            oldStatus, newStatus,
+            /*success*/ std::memory_order_relaxed,
+            /*failure*/ std::memory_order_relaxed)) {
+      newStatus.traceStatusChanged(task, false);
+      return;
     }
 
-    // Case 3: If the record is not the innermost record, we need to acquire the
-    // status record lock; there's no way to splice the record list safely
-    // otherwise
-    break;
+    // We failed to remove the record locklessly. Go back to the top and retry
+    // removing it.
   }
-
-  withStatusRecordLock(task, oldStatus, [&](ActiveTaskStatus status) {
-    removeStatusRecordLocked(status, record);
-  }, fn);
-
 }
 
 // For when we are trying to remove a record and also optionally trying to
@@ -469,51 +311,60 @@ void swift::removeStatusRecordWhere(
   SWIFT_TASK_DEBUG_LOG("remove status record where(), from task = %p",
                        task);
 
-  if (oldStatus.isStatusRecordLocked() &&
-        waitForStatusRecordUnlockIfNotSelfLocked(task, oldStatus)) {
-    SWIFT_TASK_DEBUG_LOG("[StatusRecordLock] Lock for task %p is already owned by thread", task);
-    // Case 1: Top record is status record lock and this thread owns it.
-    //
-    // Since we have the lock, we can just remove the record we care about which
-    // should be in the list somewhere and then modify the flags
-    for (auto cur : oldStatus.records()) {
-      if (condition(oldStatus, cur)) {
-        removeStatusRecordLocked(oldStatus, cur);
-      }
-    }
-
-    if (updateStatus) {
-      // Client wants to modify the flags on the status - do it in a loop to
-      // make sure we handle other concurrent updates.
-      while (true) {
-        auto newStatus = oldStatus;
-        updateStatus(oldStatus, newStatus);
-
-        // We should still remain status record locked no matter what since we
-        // came in with the lock already
-        assert(newStatus.isStatusRecordLocked());
-
-        if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
-               /*success*/ std::memory_order_relaxed,
-               /*failure*/ std::memory_order_relaxed)) {
-          newStatus.traceStatusChanged(task, false);
-          return;
+  // We're expected to look at the contents of the records, so we must hold the
+  // status record lock to do this safely.
+  bool removeInnermost = false;
+  withStatusRecordLock(
+      task, oldStatus,
+      [&](ActiveTaskStatus status) {
+        for (auto curr : status.records()) {
+          // If the record is the innermost then we have to remove it in the
+          // status change function, since changing the head of the list
+          // requires changing the status. If it's not the innermost then we can
+          // remove it here.
+          //
+          // We'll check the condition on the innermost record here so that we
+          // only call it once on the innermost record, as callers expect it to
+          // be called once per record, and the status update callback can be
+          // called more than once. We hold the record lock throughout so we
+          // know that the innermost record will be the same in the status
+          // update callback as it was here.
+          if (condition(status, curr)) {
+            if (curr == status.getInnermostRecord())
+              removeInnermost = true;
+            else
+              removeNonInnermostStatusRecordLocked(status, curr);
+          }
         }
-      }
-    }
-  }
+      },
+      [&](ActiveTaskStatus oldStatus, ActiveTaskStatus &newStatus) {
+        // Remove the innermost record here, if it's a match.
+        if (removeInnermost) {
+          auto *innermost = newStatus.getInnermostRecord();
+          newStatus = newStatus.withInnermostRecord(innermost->getParent());
+        }
 
-  assert(!oldStatus.isStatusRecordLocked());
-  // Case 2: Since we're expected to look at more than jut the innermost record,
-  // we need to acquire the status record lock; there's no way to splice the
-  // record list safely otherwise
-  withStatusRecordLock(task, oldStatus, [&](ActiveTaskStatus status) {
-    for (auto curr : status.records()) {
-      if (condition(status, curr)) {
-        removeStatusRecordLocked(status, curr);
-      }
+        if (updateStatus) {
+          updateStatus(oldStatus, newStatus);
+        }
+      });
+}
+
+// Remove and return a status record of the given type. There must be at most
+// one matching record. Returns nullptr if there are none.
+template <typename TaskStatusRecordT>
+static TaskStatusRecordT *popStatusRecordOfType(AsyncTask *task) {
+  TaskStatusRecordT *record = nullptr;
+  removeStatusRecordWhere(task, [&](ActiveTaskStatus s, TaskStatusRecord *r) {
+    if (auto *match = dyn_cast<TaskStatusRecordT>(r)) {
+      assert(!record && "two matching records found");
+      record = match;
+      return true; // Remove this record.
     }
-  }, updateStatus);
+
+    return false;
+  });
+  return record;
 }
 
 // Convenience wrapper for when client hasn't already done the load of the
@@ -743,42 +594,30 @@ void AsyncTask::dropInitialTaskExecutorPreferenceRecord() {
                        this);
   assert(hasInitialTaskExecutorPreferenceRecord());
 
-  HeapObject *executorIdentityToRelease = nullptr;
-  withStatusRecordLock(this, [&](ActiveTaskStatus status) {
-    for (auto r : status.records()) {
-      if (r->getKind() == TaskStatusRecordKind::TaskExecutorPreference) {
-        auto record = cast<TaskExecutorPreferenceStatusRecord>(r);
+  TaskExecutorPreferenceStatusRecord *record =
+      popStatusRecordOfType<TaskExecutorPreferenceStatusRecord>(this);
 
-        if (record->hasRetainedExecutor()) {
-          // Some tasks own their executor (i.e. take it consuming and guarantee
-          // its lifetime dynamically), while strictly structured tasks like
-          // async let do not retain it
-          executorIdentityToRelease =
-              record->getPreferredExecutor().getIdentity();
-        }
+  assert(record && "dropInitialTaskExecutorPreferenceRecord must only be "
+                   "called when there is an executor preference record");
 
-        removeStatusRecordLocked(status, record);
-        _swift_task_dealloc_specific(this, record);
-        return;
-      }
-    }
+  if (record->hasRetainedExecutor()) {
+    // Release the "initial" preferred task executor, because it was
+    // specifically set in a Task initializer, which retained it.
+    //
+    // This should not be done for withTaskExecutorPreference executors,
+    // however in that case, we would not enter this function here to clean up.
+    //
+    // NOTE: This MUST NOT assume that the object is a swift object (and use
+    // swift_release), because a dispatch_queue_t conforms to TaskExecutor,
+    // and may be passed in here; in which case swift_releasing it would be
+    // incorrect.
+    HeapObject *executorIdentityToRelease =
+        record->getPreferredExecutor().getIdentity();
+    SWIFT_TASK_DEBUG_LOG("Destroying executor %p", executorIdentityToRelease);
+    swift_unknownObjectRelease(executorIdentityToRelease);
+  }
 
-    // This drop mirrors the push "initial" preference during task creation;
-    // so it must always reliably always have a preference to drop.
-    assert(false && "dropInitialTaskExecutorPreferenceRecord must be "
-                    "guaranteed to drop the last preference");
-  });
-
-  // Release the "initial" preferred task executor, because it was specifically
-  // set in a Task initializer, which retained it.
-  //
-  // This should not be done for withTaskExecutorPreference executors,
-  // however in that case, we would not enter this function here to clean up.
-  //
-  // NOTE: This MUST NOT assume that the object is a swift object (and use
-  // swift_release), because a dispatch_queue_t conforms to TaskExecutor,
-  // and may be passed in here; in which case swift_releasing it would be incorrect.
-  swift_unknownObjectRelease(executorIdentityToRelease);
+  _swift_task_dealloc_specific(this, record);
 }
 
 /******************************************************************************/
@@ -816,28 +655,15 @@ void AsyncTask::dropInitialTaskNameRecord() {
   }
 
   SWIFT_TASK_DEBUG_LOG("[TaskName] Drop initial task name record for task:%p", this);
-  withStatusRecordLock(this, [&](ActiveTaskStatus status) {
-    for (auto cur : status.records()) {
-      if (cur->getKind() == TaskStatusRecordKind::TaskName) {
-        auto record = cast<TaskNameStatusRecord>(cur);
-
-        SWIFT_TASK_DEBUG_LOG("[TaskName] Drop initial task name record %p "
-                             "for task:%p", record, this);
-
-        removeStatusRecordLocked(status, record);
-        // Since we first allocated the record, and then the string copy
-        char *name = const_cast<char*>(record->getName());
-        _swift_task_dealloc_specific(this, name);
-        _swift_task_dealloc_specific(this, record);
-        return;
-      }
-    }
-
-    // This drop mirrors the push "initial" name during task creation;
-    // so it must always reliably always have a preference to drop.
-    assert(false && "dropInitialTaskNameRecord must be guaranteed to drop "
-                    "the initial task name record if it was present");
-  });
+  TaskNameStatusRecord *record =
+      popStatusRecordOfType<TaskNameStatusRecord>(this);
+  assert(record &&
+         "hasInitialTaskNameRecord is true but we did not find a name record");
+  // Since we first allocated the record, and then the string copy, deallocate
+  // in LIFO order.
+  char *name = const_cast<char *>(record->getName());
+  _swift_task_dealloc_specific(this, name);
+  _swift_task_dealloc_specific(this, record);
 }
 
 const char*
@@ -1008,11 +834,6 @@ static void performCancellationAction(TaskStatusRecord *record) {
   case TaskStatusRecordKind::EscalationNotification:
     return;
 
-  // Record locks shouldn't be found this way, but they don't have
-  // anything to do anyway.
-  case TaskStatusRecordKind::Private_RecordLock:
-    return;
-
   // No cancellation action needs to be taken for dependency status records
   case TaskStatusRecordKind::TaskDependency:
     break;
@@ -1023,6 +844,10 @@ static void performCancellationAction(TaskStatusRecord *record) {
 
   // Cancellation has no impact on task names.
   case TaskStatusRecordKind::TaskName:
+    break;
+
+  // This should never be found, but the compiler complains if we don't check.
+  case TaskStatusRecordKind::First_Reserved:
     break;
   }
 
@@ -1111,10 +936,6 @@ static void performEscalationAction(TaskStatusRecord *record,
     return;
   }
 
-  // Record locks shouldn't be found this way, but they don't have
-  // anything to do anyway.
-  case TaskStatusRecordKind::Private_RecordLock:
-    return;
   // Cancellation notifications can be ignore.
   case TaskStatusRecordKind::CancellationNotification:
     return;
@@ -1124,6 +945,9 @@ static void performEscalationAction(TaskStatusRecord *record,
   /// Task names don't matter to priority escalation.
   case TaskStatusRecordKind::TaskName:
     return;
+  // This should never be found, but the compiler complains if we don't check.
+  case TaskStatusRecordKind::First_Reserved:
+    break;
   }
 
   // Other cases can fall through here and be ignored.

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
@@ -600,6 +600,8 @@ private:
   }
 };
 
+enum { NumWords_AsyncTask = 24 };
+
 // The compiler will eventually assume these.
 static_assert(sizeof(AsyncTask) == NumWords_AsyncTask * sizeof(void*),
               "AsyncTask size is wrong");

--- a/test/embedded/concurrency-leaks.swift
+++ b/test/embedded/concurrency-leaks.swift
@@ -23,11 +23,10 @@ struct Main {
         }
         _ = await x.value
     }
-    // There should be exactly 5 allocations involved:
+    // There should be exactly 4 allocations involved:
     // - 2x 32 bytes ... closure context for swift_task_create, closure object to pass to Task.init
     // - 1x 320 bytes ... malloc(amountToAllocate) in swift_task_create_common for the Task heap object itself
     // - 1x 1016 bytes ... the initial StackAllocator slab in the task-specific allocator
-    // - 1x 40 bytes ... task status record
     // Check that they are all accounted for and free'd.
 
     // CHECK: malloc({{[0-9]+}})-> [[M1:0x[0-9a-f]+]]
@@ -36,8 +35,6 @@ struct Main {
     // CHECK: malloc({{[0-9]+}})-> [[M4:0x[0-9a-f]+]]
     // CHECK: free([[M1]])
     // CHECK: free([[M2]])
-    // CHECK: malloc({{[0-9]+}})-> [[M5:0x[0-9a-f]+]]
-    // CHECK: free([[M5]])
     // CHECK: free([[M4]])
     // CHECK: free([[M3]])
 


### PR DESCRIPTION
Draft PR, this still needs a Win32 implementation of `RecursiveMutex`.

Move to a recursive lock inline in the Task. This avoids the need to allocate a lock record and simplifies the code somewhat.

Change Task's OpaquePrivateStorage to compute its size at build time based on the sizes of its components, rather than having it be a fixed size. It appears that the fixed size was intended to be part of the ABI, but that didn't happen and we're free to change this size. We need to expand it slightly when using pthread_mutex as the recursive lock, as pthread_mutex is pretty big. Other recursive locks allow it to shrink slightly.

We don't have a recursive mutex in our Threading support code, so add a RecursiveMutex type.

rdar://113898653

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
