### PR TITLE
[Serialization] Fix serialization for InlineArray sugar

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -6319,6 +6319,7 @@ void Serializer::writeAllDeclsAndTypes() {
   registerDeclTypeAbbr<PackTypeLayout>();
   registerDeclTypeAbbr<SILPackTypeLayout>();
   registerDeclTypeAbbr<IntegerTypeLayout>();
+  registerDeclTypeAbbr<InlineArrayTypeLayout>();
 
   registerDeclTypeAbbr<ErrorFlagLayout>();
   registerDeclTypeAbbr<ErrorTypeLayout>();

--- a/test/Serialization/value_generics.swift
+++ b/test/Serialization/value_generics.swift
@@ -1,8 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -emit-module -enable-experimental-feature RawLayout -disable-availability-checking -parse-as-library -o %t
+// RUN: %target-swift-frontend %s -emit-module -enable-experimental-feature RawLayout -enable-experimental-feature InlineArrayTypeSugar -disable-availability-checking -parse-as-library -o %t
 // RUN: %target-sil-opt -enable-sil-verify-all %t/value_generics.swiftmodule -o - | %FileCheck %s
 
 // REQUIRES: swift_feature_RawLayout
+// REQUIRES: swift_feature_InlineArrayTypeSugar
 
 // CHECK: @_rawLayout(likeArrayOf: Element, count: Count) struct Vector<Element, let Count : Int> : ~Copyable where Element : ~Copyable {
 @_rawLayout(likeArrayOf: Element, count: Count)
@@ -20,3 +21,6 @@ extension Vector where Count == 2 {
 
 // CHECK: func something<let N : Int>(_: borrowing Vector<Int, N>)
 func something<let N: Int>(_: borrowing Vector<Int, N>) {}
+
+// CHECK: func hello(_: [4 x Int])
+func hello(_: [4 x Int]) {}


### PR DESCRIPTION
Looks like we forgot the call to `registerDeclTypeAbbr` for the new `InlineArrayTypeLayout` in: https://github.com/swiftlang/swift/pull/80087. Add it here.