### PR TITLE
[Concurrency] Avoid de-escalating a task when racing to escalate.

### DIFF
--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -1139,6 +1139,9 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
   auto newStatus = oldStatus;
 
   while (true) {
+    // Ensure oldPriority is up to date if we retry the compare_exchange.
+    oldPriority = oldStatus.getStoredPriority();
+
     // Fast path: check that the stored priority is already at least
     // as high as the desired priority.
     if (oldPriority >= newPriority) {


### PR DESCRIPTION
Reload oldPriority each time through the compare_exchange loop. Without this, we might race with another escalating thread and end up trying to set a priority that's lower or equal to the priority set by the other thread. This results in an assertion failure when asserts are enabled, or attempt to lower the priority of the task when asserts are not enabled.

rdar://147888768