### PR TITLE
[cxx-interop] Import non-public members of SWIFT_PRIVATE_FILEID-annotated classes

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9992,6 +9992,16 @@ static void loadAllMembersOfSuperclassIfNeeded(ClassDecl *CD) {
 void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
     NominalTypeDecl *swiftDecl, const clang::RecordDecl *clangRecord,
     ClangInheritanceInfo inheritance) {
+
+  // Whether to skip non-public members. Feature::ImportNonPublicCxxMembers says
+  // to import all non-public members by default; if that is disabled, we only
+  // import non-public members annotated with SWIFT_PRIVATE_FILEID (since those
+  // are the only classes that need non-public members.)
+  auto skipIfNonPublic =
+      !swiftDecl->getASTContext().LangOpts.hasFeature(
+          Feature::ImportNonPublicCxxMembers) &&
+      importer::getPrivateFileIDAttrs(swiftDecl->getClangDecl()).empty();
+
   // Import all of the members.
   llvm::SmallVector<Decl *, 16> members;
   for (const clang::Decl *m : clangRecord->decls()) {
@@ -9999,17 +10009,25 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
     if (!nd)
       continue;
 
-    if (!swiftDecl->getASTContext().LangOpts.hasFeature(
-            Feature::ImportNonPublicCxxMembers)) {
-      auto access = nd->getAccess();
-      if ((access == clang::AS_private || access == clang::AS_protected) &&
-          (inheritance || !isa<clang::FieldDecl>(nd)))
-        // 'nd' is a non-public member and ImportNonPublicCxxMembers is not
-        // enabled. Don't import it unless it is a non-inherited field, which
-        // we must import because it may affect implicit conformances that
-        // iterate through all of a struct's fields, e.g., Sendable (#76892).
-        continue;
-    }
+    // We should not import 'found' if the following are all true:
+    //
+    // -  Feature::ImportNonPublicCxxMembers is not enabled
+    // -  'found' is not a member of a SWIFT_PRIVATE_FILEID-annotated class
+    // -  'found' is a non-public member.
+    // -  'found' is not a non-inherited FieldDecl; we must import private
+    //    fields because they may affect implicit conformances that iterate
+    //    through all of a struct's fields, e.g., Sendable (#76892).
+    //
+    // Note that we can skip inherited FieldDecls because implicit conformances
+    // handle those separately.
+    //
+    // The first two conditions are captured by skipIfNonPublic. The next two
+    // are conveyed by the following:
+    auto nonPublic = nd->getAccess() == clang::AS_private ||
+                     nd->getAccess() == clang::AS_protected;
+    auto noninheritedField = !inheritance && isa<clang::FieldDecl>(nd);
+    if (skipIfNonPublic && nonPublic && !noninheritedField)
+      continue;
 
     // Currently, we don't import unnamed bitfields.
     if (isa<clang::FieldDecl>(m) &&
@@ -10078,9 +10096,7 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
   // If this is a C++ record, look through the base classes too.
   if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(clangRecord)) {
     for (auto base : cxxRecord->bases()) {
-      if (!swiftDecl->getASTContext().LangOpts.hasFeature(
-              Feature::ImportNonPublicCxxMembers) &&
-          base.getAccessSpecifier() != clang::AS_public)
+      if (skipIfNonPublic && base.getAccessSpecifier() != clang::AS_public)
         continue;
 
       clang::QualType baseType = base.getType();

--- a/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-executable.swift
@@ -2,12 +2,11 @@
 // Test that all accessible inherited methods can be called.
 //
 // RUN: split-file %s %t
-// RUN: %target-build-swift -module-name main %t/blessed.swift -I %S/Inputs -o %t/out -Xfrontend -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers
+// RUN: %target-build-swift -module-name main %t/blessed.swift -I %S/Inputs -o %t/out -Xfrontend -cxx-interoperability-mode=default
 // RUN: %target-codesign %t/out
 // RUN: %target-run %t/out
 //
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
 import StdlibUnittest
 import NonPublicInheritance

--- a/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
+++ b/test/Interop/Cxx/class/access/non-public-inheritance-typecheck.swift
@@ -1,7 +1,6 @@
 //--- blessed.swift
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -enable-experimental-feature ImportNonPublicCxxMembers
-// REQUIRES: swift_feature_ImportNonPublicCxxMembers
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift
 import NonPublicInheritance
 
 // Extensions of each class test whether we correctly modeled *which* members

--- a/test/Interop/Cxx/class/access/private-fileid-diagnostics.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-diagnostics.swift
@@ -1,6 +1,5 @@
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -suppress-remarks %t/some/subdir/file1.swift -verify-additional-file %t/Cxx/include/cxx-header.h -I %t/Cxx/include -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main
-// REQUIRES: swift_feature_ImportNonPublicCxxMembers
+// RUN: %target-swift-frontend -typecheck -verify -suppress-remarks %t/some/subdir/file1.swift -verify-additional-file %t/Cxx/include/cxx-header.h -I %t/Cxx/include -cxx-interoperability-mode=default -module-name main
 
 // This test uses -verify-additional-file, which do not work well on Windows:
 // UNSUPPORTED: OS=windows-msvc

--- a/test/Interop/Cxx/class/access/private-fileid-nested-typecheck.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-nested-typecheck.swift
@@ -2,9 +2,8 @@
 // works as expected.
 //
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify %t/file1.swift -I %t/include -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main
-// RUN: %target-swift-frontend -typecheck -verify %t/file2.swift -I %t/include -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main
-// REQUIRES: swift_feature_ImportNonPublicCxxMembers
+// RUN: %target-swift-frontend -typecheck -verify %t/file1.swift -I %t/include -cxx-interoperability-mode=default -module-name main
+// RUN: %target-swift-frontend -typecheck -verify %t/file2.swift -I %t/include -cxx-interoperability-mode=default -module-name main
 
 //--- include/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/class/access/private-fileid-template-typecheck.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-template-typecheck.swift
@@ -15,8 +15,7 @@
 // non-public in different contexts, and variations in module and file names.
 //
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift
-// REQUIRES: swift_feature_ImportNonPublicCxxMembers
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift
 
 //--- blessed.swift
 

--- a/test/Interop/Cxx/class/access/private-fileid-typecheck.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-typecheck.swift
@@ -3,9 +3,6 @@
 // in the contexts where they should be accessible (i.e., the files blessed by
 // the SWIFT_PRIVATE_FILEID annotation).
 //
-// For now, it requires the following feature to import private members:
-// REQUIRES: swift_feature_ImportNonPublicCxxMembers
-//
 // The private_fileid mechanism relies on fileIDs, so we need some control over
 // file names:
 //
@@ -19,37 +16,37 @@
 // members are private (default) or protected. The result should be the same
 // no matter the configuration.
 //
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift -Xcc -DTEST_CLASS=struct
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift -Xcc -DTEST_PRIVATE=protected
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -Xcc -DTEST_CLASS=struct
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
 //
 // This test also includes a "cursed.swift", which expects to not have access to
 // non-public members:
 //
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/cursed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/cursed.swift -Xcc -DTEST_CLASS=struct
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/cursed.swift -Xcc -DTEST_PRIVATE=protected
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/cursed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/cursed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/cursed.swift -Xcc -DTEST_CLASS=struct
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/cursed.swift -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/cursed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
 //
 // To check that fileID is agnostic about directory structure within a module,
 // we move blessed.swift into a subdirectory (but keep its filename).
 //
 // RUN: mkdir -p %t/subdir/subsubdir
 // RUN: mv %t/blessed.swift %t/subdir/subsubdir/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/subdir/subsubdir/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_CLASS=struct
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_PRIVATE=protected
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/subdir/subsubdir/blessed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_CLASS=struct
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name main %t/subdir/subsubdir/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
 //
 // To check that fileID is sensitive to module names, rename cursed.swift to
 // "blessed.swift", but typecheck in a module not called "main".
 //
 // RUN: mv %t/cursed.swift %t/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name brain %t/blessed.swift
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name brain %t/blessed.swift -Xcc -DTEST_CLASS=struct
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name brain %t/blessed.swift -Xcc -DTEST_PRIVATE=protected
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name brain %t/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name brain %t/blessed.swift
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name brain %t/blessed.swift -Xcc -DTEST_CLASS=struct
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name brain %t/blessed.swift -Xcc -DTEST_PRIVATE=protected
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs -cxx-interoperability-mode=default -module-name brain %t/blessed.swift -Xcc -DTEST_CLASS=struct -Xcc -DTEST_PRIVATE=protected
 
 //--- blessed.swift
 


### PR DESCRIPTION
The ImportNonPublicCxxMembers experimental feature flag was introduced to gate the importation of non-public class members, to ward off latent bugs in projects that have no need for importing private members. However that flag is required by the SWIFT_PRIVATE_FILEID feature to access said private fields.

This patch relaxes the "don't import this non-public member" condition a bit by bypassing this feature flag for non-public members of C++ classes that have the SWIFT_PRIVATE_FILEID annotation, thus allowing that feature to be used without specifying the experimental feature flag. Since that annotation is opt-in by design, ClangImporter will still skip over the private members of most C++ classes (when ImportNonPublicCxxMembers is not enabled), so that projects not using this feature are unaffected.

ImportNonPublicCxxMembers is still useful (i.e., should be enabled by default in the future) because it improves the diagnostics for when a user tries to access any non-public member in Swift.

rdar://146304086
