### PR TITLE
AST: Introduce the `AllowRuntimeSymbolDeclarations` experimental feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -517,6 +517,9 @@ EXPERIMENTAL_FEATURE(CompileTimeValues, true)
 /// Allow function body macros applied to closures.
 EXPERIMENTAL_FEATURE(ClosureBodyMacro, true)
 
+/// Allow declarations of Swift runtime symbols using @_silgen_name.
+EXPERIMENTAL_FEATURE(AllowRuntimeSymbolDeclarations, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -405,6 +405,7 @@ UNINTERESTING_FEATURE(SafeInteropWrappers)
 UNINTERESTING_FEATURE(AssumeResilientCxxTypes)
 UNINTERESTING_FEATURE(ImportNonPublicCxxMembers)
 UNINTERESTING_FEATURE(CoroutineAccessorsUnwindOnCallerError)
+UNINTERESTING_FEATURE(AllowRuntimeSymbolDeclarations)
 
 static bool usesFeatureSwiftSettings(const Decl *decl) {
   // We just need to guard `#SwiftSettings`.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2336,6 +2336,12 @@ static bool canDeclareSymbolName(StringRef symbol, ModuleDecl *fromModule) {
     return true;
   }
 
+  // Allow reserved symbols to be declared if the AllowRuntimeSymbolDeclarations
+  // experimental feature is enabled.
+  auto &ctx = fromModule->getASTContext();
+  if (ctx.LangOpts.hasFeature(Feature::AllowRuntimeSymbolDeclarations))
+    return true;
+
   // Swift runtime functions are a private contract between the compiler and
   // runtime, and attempting to access them directly without going through
   // builtins or proper language features breaks the compiler in various hard

--- a/stdlib/public/RegexParser/CMakeLists.txt
+++ b/stdlib/public/RegexParser/CMakeLists.txt
@@ -47,6 +47,7 @@ add_swift_target_library(swift_RegexParser ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     # Workaround until `_RegexParser` is imported as implementation-only
     # by `_StringProcessing`.
     -Xfrontend -disable-implicit-string-processing-module-import
+    -enable-experimental-feature AllowRuntimeSymbolDeclarations
   LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   INSTALL_IN_COMPONENT stdlib

--- a/test/attr/attr_silgen_name.swift
+++ b/test/attr/attr_silgen_name.swift
@@ -1,6 +1,8 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -verify-additional-prefix runtime-symbols-
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -enable-experimental-feature AllowRuntimeSymbolDeclarations
 
 // REQUIRES: swift_feature_Extern
+// REQUIRES: swift_feature_AllowRuntimeSymbolDeclarations
 
 @_silgen_name("foo") // expected-note {{attribute already specified here}}
 @_silgen_name("bar") // expected-error {{duplicate attribute}}
@@ -19,14 +21,14 @@ func func_with_nested__silgen_name() {
 // Ensure that magic runtime symbol names can't be declared or defined through
 // various symbol-assigning attributes
 
-@_silgen_name("swift_retain") // expected-warning{{reserved}}
+@_silgen_name("swift_retain") // expected-runtime-symbols-warning {{reserved}}
 func liveDangerously() {}
 
-@_silgen_name("swift_retain") // expected-warning{{reserved}}
+@_silgen_name("swift_retain") // expected-runtime-symbols-warning {{reserved}}
 func liveRecklessly();
 
-@_extern(c, "swift_retain") // expected-warning{{reserved}}
+@_extern(c, "swift_retain") // expected-runtime-symbols-warning {{reserved}}
 func liveEphemerally()
 
-@_cdecl("swift_retain") // expected-warning{{reserved}}
+@_cdecl("swift_retain") // expected-runtime-symbols-warning {{reserved}}
 func liveFrivolously() {}


### PR DESCRIPTION
This feature only exists as a mechanism to suppress the warning introduced in https://github.com/swiftlang/swift/pull/75378. The RegexParser module, which is effectively part of the standard library, declares a Swift runtime symbol and as a result every build of the compiler and stdlib produces warnings which there are no plans to address. Warnings that are not going to be addressed need some way of being suppressed, and an experimental features seems like a reasonable mechanism for this one.
