### PR TITLE
Revert "Fix `.swiftdeps` file deterministic issues"

### DIFF
--- a/lib/AST/Identifier.cpp
+++ b/lib/AST/Identifier.cpp
@@ -98,11 +98,6 @@ int Identifier::compare(Identifier other) const {
 }
 
 int DeclName::compare(DeclName other) const {
-  // Fast equality comparsion.
-  if (getOpaqueValue() == other.getOpaqueValue())
-    return 0;
-
-
   // Compare base names.
   if (int result = getBaseName().compare(other.getBaseName()))
     return result;
@@ -116,13 +111,10 @@ int DeclName::compare(DeclName other) const {
       return result;
   }
 
-  if (argNames.size() != otherArgNames.size())
-    return argNames.size() < otherArgNames.size() ? -1 : 1;
+  if (argNames.size() == otherArgNames.size())
+    return 0;
 
-  // Order based on if it is compound name or not.
-  assert(isSimpleName() != other.isSimpleName() &&
-         "equality should be covered by opaque value comparsion");
-  return isSimpleName() ? -1 : 1;
+  return argNames.size() < otherArgNames.size() ? -1 : 1;
 }
 
 static bool equals(ArrayRef<Identifier> idents, ArrayRef<StringRef> strings) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -26,7 +26,6 @@
 #include "swift/AST/ASTDumper.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/AvailabilityScope.h"
-#include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/FileSystem.h"
@@ -2101,11 +2100,6 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     // Setup a verfication instance to run.
     std::unique_ptr<CompilerInstance> VerifyInstance =
         std::make_unique<CompilerInstance>();
-    // Add a null diagnostic consumer to the diagnostic engine so the
-    // compilation will exercise all the diagnose code path but not emitting
-    // anything.
-    NullDiagnosticConsumer DC;
-    VerifyInstance->getDiags().addConsumer(DC);
     std::string InstanceSetupError;
     // This should not fail because it passed already.
     (void)VerifyInstance->setup(Invocation, InstanceSetupError, Args);

--- a/test/Frontend/output_determinism_check.swift
+++ b/test/Frontend/output_determinism_check.swift
@@ -37,31 +37,4 @@
 // PCM_OUTPUT: remark: produced matching output file '{{.*}}{{/|\\}}test.pcm'
 
 public var x = 1
-public func test() {
-  precondition(x == 1, "dummy check")
-}
-
-class A {
-  var a = 0
-  var b = 0
-  var c = 0
-  var d = 0
-}
-class B {
-  var a = 0
-  var b = 0
-  var c = 0
-  var d = 0
-}
-class C {
-  var a = 0
-  var b = 0
-  var c = 0
-  var d = 0
-}
-class D {
-  var a = 0
-  var b = 0
-  var c = 0
-  var d = 0
-}
+public func test() {}


### PR DESCRIPTION
Reverts swiftlang/swift#80172

Check if this is the root cause of a recent regression in ObjectMapper project.