### PR TITLE
[AST] Fix `DeclBaseName::compare()`

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -385,7 +385,11 @@ public:
   }
 
   int compare(DeclBaseName other) const {
-    return userFacingName().compare(other.userFacingName());
+    if (int result = userFacingName().compare(other.userFacingName()))
+      return result;
+    if (getKind() == other.getKind())
+      return 0;
+    return getKind() < other.getKind() ? -1 : 1;
   }
 
   bool operator==(StringRef Str) const {


### PR DESCRIPTION
Fix `DeclBaseName::compare()` to not return equal on two base names of different kinds but have the same user facing names.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
