### PR TITLE
Small fixes for new abstract conformance representation

### DIFF
--- a/include/swift/AST/TypeTransform.h
+++ b/include/swift/AST/TypeTransform.h
@@ -154,7 +154,7 @@ case TypeKind::Id:
         return *result;
 
       auto subMap = opaque->getSubstitutions();
-      auto newSubMap = asDerived().transformSubMap(subMap);
+      auto newSubMap = asDerived().transformSubstitutionMap(subMap);
       if (newSubMap == subMap)
         return t;
       if (!newSubMap)
@@ -177,7 +177,7 @@ case TypeKind::Id:
       auto subMap = env->getOuterSubstitutions();
       auto uuid = env->getOpenedExistentialUUID();
 
-      auto newSubMap = asDerived().transformSubMap(subMap);
+      auto newSubMap = asDerived().transformSubstitutionMap(subMap);
       if (newSubMap == subMap)
         return t;
       if (!newSubMap)
@@ -259,7 +259,7 @@ case TypeKind::Id:
       }
 
       auto oldSubMap = boxTy->getSubstitutions();
-      auto newSubMap = asDerived().transformSubMap(oldSubMap);
+      auto newSubMap = asDerived().transformSubstitutionMap(oldSubMap);
       if (oldSubMap && !newSubMap)
         return Type();
       changed |= (oldSubMap != newSubMap);
@@ -281,7 +281,7 @@ case TypeKind::Id:
         return fnTy;
 
       auto updateSubs = [&](SubstitutionMap &subs) -> bool {
-        auto newSubs = asDerived().transformSubMap(subs);
+        auto newSubs = asDerived().transformSubstitutionMap(subs);
         if (subs && !newSubs)
           return false;
         if (subs == newSubs)
@@ -1052,7 +1052,7 @@ case TypeKind::Id:
 
   // If original was non-empty and transformed is empty, we're
   // signaling failure, that is, a Type() return from doIt().
-  SubstitutionMap transformSubMap(SubstitutionMap subs) {
+  SubstitutionMap transformSubstitutionMap(SubstitutionMap subs) {
     if (subs.empty())
       return subs;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5521,6 +5521,12 @@ public:
       assert(conformance.isAbstract());
 
       printHead("abstract_conformance", ASTNodeColor, label);
+
+      PrintOptions PO;
+      PO.OpaqueReturnTypePrinting =
+          PrintOptions::OpaqueReturnTypePrintingMode::StableReference;
+
+      printTypeField(conformance.getType(), Label::always("type"), PO);
       printReferencedDeclField(conformance.getProtocol(),
                                Label::always("protocol"));
       printFoot();

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -139,6 +139,10 @@ ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() cons
         MakeAbstractConformanceForGenericType(),
         SubstFlags::PreservePackExpansionLevel |
         SubstFlags::SubstitutePrimaryArchetypes);
+  } else if (isAbstract()) {
+    auto *abstract = getAbstract();
+    return forAbstract(abstract->getType()->mapTypeOutOfContext(),
+                       abstract->getProtocol());
   }
 
   return *this;

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -129,21 +129,13 @@ ProtocolConformanceRef::subst(Type origType, InFlightSubstitution &IFS) const {
 ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() const {
   if (isConcrete()) {
     return getConcrete()->subst(
-        [](SubstitutableType *type) -> Type {
-          if (auto *archetypeType = type->getAs<ArchetypeType>())
-            return archetypeType->getInterfaceType();
-          return type;
-        },
+        MapTypeOutOfContext(),
         MakeAbstractConformanceForGenericType(),
         SubstFlags::PreservePackExpansionLevel |
         SubstFlags::SubstitutePrimaryArchetypes);
   } else if (isPack()) {
     return getPack()->subst(
-        [](SubstitutableType *type) -> Type {
-          if (auto *archetypeType = type->getAs<ArchetypeType>())
-            return archetypeType->getInterfaceType();
-          return type;
-        },
+        MapTypeOutOfContext(),
         MakeAbstractConformanceForGenericType(),
         SubstFlags::PreservePackExpansionLevel |
         SubstFlags::SubstitutePrimaryArchetypes);

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -381,7 +381,7 @@ SubstitutionMap SubstitutionMap::subst(InFlightSubstitution &IFS) const {
         ProtocolConformanceRef(conformance.getConcrete()->subst(IFS)));
     } else {
       auto origType = req.getFirstType();
-      auto substType = origType.subst(*this, IFS.getOptions());
+      auto substType = origType.subst(*this);
 
       newConformances.push_back(conformance.subst(substType, IFS));
     }

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -98,9 +98,9 @@ struct Generic<T> {}
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
 // CHECK-NEXT:     (builtin_conformance type="Generic<T>" protocol="Escapable"))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="Copyable"
-// CHECK-NEXT:     (abstract_conformance protocol="Copyable"))
+// CHECK-NEXT:     (abstract_conformance type="T" protocol="Copyable"))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="Escapable"
-// CHECK-NEXT:     (abstract_conformance protocol="Escapable"))
+// CHECK-NEXT:     (abstract_conformance type="T" protocol="Escapable"))
 // CHECK-NEXT:   (requirement "T" conforms_to "P1"))
 extension Generic: P1 where T: P1 {
     typealias A = T
@@ -123,9 +123,9 @@ class Super<T, U> {}
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
 // CHECK-NEXT:     (builtin_conformance type="Super<T, U>" protocol="Escapable"))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P2"
-// CHECK-NEXT:     (abstract_conformance protocol="P2"))
+// CHECK-NEXT:     (abstract_conformance type="T" protocol="P2"))
 // CHECK-NEXT:   (assoc_conformance type="Self.B" proto="P2"
-// CHECK-NEXT:     (abstract_conformance protocol="P2"))
+// CHECK-NEXT:     (abstract_conformance type="T" protocol="P2"))
 // CHECK-NEXT:   (requirement "T" conforms_to "P2")
 // CHECK-NEXT:   (requirement "U" conforms_to "P2"))
 extension Super: P2 where T: P2, U: P2 {
@@ -177,9 +177,9 @@ extension Super: P2 where T: P2, U: P2 {
 // CHECK-NEXT:       (assoc_conformance type="Self" proto="Escapable"
 // CHECK-NEXT:         (builtin_conformance type="Super<T, U>" protocol="Escapable"))
 // CHECK-NEXT:       (assoc_conformance type="Self.A" proto="P2"
-// CHECK-NEXT:         (abstract_conformance protocol="P2"))
+// CHECK-NEXT:         (abstract_conformance type="T" protocol="P2"))
 // CHECK-NEXT:       (assoc_conformance type="Self.B" proto="P2"
-// CHECK-NEXT:         (abstract_conformance protocol="P2"))
+// CHECK-NEXT:         (abstract_conformance type="T" protocol="P2"))
 // CHECK-NEXT:       (requirement "T" conforms_to "P2")
 // CHECK-NEXT:       (requirement "U" conforms_to "P2"))))
 class Sub: Super<NonRecur, Recur> {}

--- a/validation-test/SILGen/SwiftUI/opaque_result_type_erasure.swift
+++ b/validation-test/SILGen/SwiftUI/opaque_result_type_erasure.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-silgen %s -target %target-cpu-apple-macosx11 -swift-version 5
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct MyView: View {
+    @State private var isPresented = false
+
+    var body: some View {
+        NavigationView {
+            Form {
+                subsection
+            }
+            .listStyle(DefaultListStyle())
+            .navigationTitle(Text(""))
+            .sheet(isPresented: $isPresented,
+                   onDismiss: { },
+                   content: { Text("") })
+        }
+    }
+
+    private var subsection: some View {
+        Text("")
+    }
+}


### PR DESCRIPTION
- ProtocolConformanceRef::subst() and ProtocolConformanceRef::mapConformanceOutOfContext() didn't handle abstract conformances with opaque result types in them correctly. We must now substitute the opaque result type and form a new abstract conformance, instead of returning the same one.
- ProtocolConformanceRef::getAssociatedConformance() would return an abstract conformance with the original subject type and not the subject type of the requirement.
- ReplaceOpaqueTypesWithUnderlyingTypes also required some fixes to deal with new abstract conformances.
- Finally, rename TypeTransformer::transformSubMap() to transformSubstitutionMap(). Previously we weren't calling TypeSubstituter::transformSubstitutionMap(), and now we are. This exposed all of the above bugs.