### PR TITLE
[Concurrency] Never treat `nonisolated(unsafe)` properties as actor isolated.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7557,9 +7557,19 @@ ActorIsolation swift::getActorIsolationForReference(ValueDecl *decl,
   // the access is outside the module or if the property type is not
   // 'Sendable'.
   //
+  // Note that this is only allowed for source compatibility reasons.
+  // It is generally invalid to write `nonisolated` on an actor `let`
+  // if the type of the property is not Sendable. However, older compilers
+  // used to allow this, so it's only an error in the Swift 6 language
+  // mode, and it is a warning in prior language modes.
+  //
   // FIXME: getActorIsolation(decl) should treat these as isolated.
   // FIXME: Expand this out to local variables?
   if (auto var = dyn_cast<VarDecl>(decl)) {
+    // 'nonisolated(unsafe)' opts out of actor isolation.
+    if (declIsolation.isNonisolatedUnsafe())
+      return declIsolation;
+
     auto *fromModule = fromDC->getParentModule();
     ActorReferenceResult::Options options = std::nullopt;
     if (varIsSafeAcrossActors(fromModule, var, declIsolation, std::nullopt, options) &&

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -166,3 +166,14 @@ final class KlassB: Sendable {
   // expected-error@+1 {{'nonisolated' cannot be applied to mutable stored properties}}
   nonisolated var test: Int = 1
 }
+
+class NotSendable {}
+
+@MainActor
+struct UnsafeInitialization {
+  nonisolated(unsafe) let ns: NotSendable
+
+  nonisolated init(ns: NotSendable) {
+    self.ns = ns // okay
+  }
+}


### PR DESCRIPTION
The whole purpose of `nonisolated(unsafe)` is to unsafely opt out of actor isolation! This resolves a bogus diagnostic in the following code:

```swift
class NotSendable {}

@MainActor
struct S {
  nonisolated(unsafe) private let ns: NotSendable

  nonisolated init(ns: NotSendable) {
    self.ns = ns
  }
}
```

Resolves: rdar://131079862