### PR TITLE
[Concurrency] Infer `@Sendable` for global actor isolated function references.

### DIFF
--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -793,7 +793,18 @@ FunctionType *ConstraintSystem::adjustFunctionTypeForConcurrency(
         return openType(type, replacements, locator);
       });
 
-  if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
+  // Infer @Sendable for global actor isolated function types under the
+  // upcoming feature flag.
+  if (Context.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)
+      && !adjustedTy->getExtInfo().isSendable()) {
+    if (adjustedTy->getExtInfo().getIsolation().isGlobalActor()) {
+      adjustedTy =
+          adjustedTy->withExtInfo(adjustedTy->getExtInfo().withSendable());
+    }
+  }
+
+  if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures) &&
+      !adjustedTy->getExtInfo().isSendable()) {
     DeclContext *DC = nullptr;
     if (auto *FD = dyn_cast<AbstractFunctionDecl>(decl)) {
       DC = FD->getDeclContext();

--- a/test/Concurrency/global_actor_sendable_fn_type_inference.swift
+++ b/test/Concurrency/global_actor_sendable_fn_type_inference.swift
@@ -20,3 +20,8 @@ func allowNonSendableCaptures() {
     let _ = nonSendable // okay
   }
 }
+
+func testLocalFunctionReference() {
+  @MainActor func f() {}
+  _ = f as any Sendable
+}


### PR DESCRIPTION
We didn't notice this lack of inference because `InferSendableFromCaptures` covers `@Sendable` inference for many cases of global actor isolated function types for unrelated reasons. But inferring `@Sendable` from captures does not apply to local functions! This change covers that case and others by inferring `@Sendable` for global actor isolated function types in `ConstraintSystem:: adjustFunctionTypeForConcurrency`.

Resolves: https://github.com/swiftlang/swift/issues/73562