### PR TITLE
Sema: Extend `_unsafeInheritExecutor_` hack to `Clock.measure()`

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2199,8 +2199,11 @@ void swift::introduceUnsafeInheritExecutorReplacements(
   if (lookup.empty())
     return;
 
-  auto baseNominal = base->getAnyNominal();
-  if (!baseNominal || !inConcurrencyModule(baseNominal))
+  SmallVector<NominalTypeDecl *, 4> nominalTypes;
+  namelookup::tryExtractDirectlyReferencedNominalTypes(base, nominalTypes);
+  if (llvm::none_of(nominalTypes, [](NominalTypeDecl *baseNominal) {
+        return inConcurrencyModule(baseNominal);
+      }))
     return;
 
   auto isReplaceable = [&](ValueDecl *decl) {

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -72,13 +72,22 @@ extension Clock {
     isolation: isolated (any Actor)? = #isolation,
     _ work: () async throws -> Void
   ) async rethrows -> Instant.Duration {
-    try await measure(work)
+    let start = now
+    try await work()
+    let end = now
+    return start.duration(to: end)
   }
 
+  // Note: hack to stage out @_unsafeInheritExecutor forms of various functions
+  // in favor of #isolation. The _unsafeInheritExecutor_ prefix is meaningful
+  // to the type checker.
+  //
+  // This function also doubles as an ABI-compatibility shim predating the
+  // introduction of #isolation.
   @available(SwiftStdlib 5.7, *)
+  @_silgen_name("$ss5ClockPsE7measurey8DurationQzyyYaKXEYaKF")
   @_unsafeInheritExecutor // for ABI compatibility
-  @usableFromInline
-  internal func measure(
+  public func _unsafeInheritExecutor_measure(
     _ work: () async throws -> Void
   ) async rethrows -> Instant.Duration {
     let start = now


### PR DESCRIPTION
Fixes the bug in `swift::introduceUnsafeInheritExecutorReplacements()` that prevented the hack from working with `Clock.measure()`. It isn't sufficient to just check whether the nominal for the type base of a qualified lookup belongs to the Concurrency module because that type may reference multiple types. Instead, check all of the directly referenced types to match the behavior of qualified lookup.

Resolves rdar://132581483.
