### PR TITLE
[Sema] Dig out other constructor if call is wrapped in a Dot-Call

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2558,11 +2558,15 @@ static Expr* constructCallToSuperInit(ConstructorDecl *ctor,
 /// \returns true if an error occurred.
 static bool checkSuperInit(ConstructorDecl *fromCtor,
                            ApplyExpr *apply, bool implicitlyGenerated) {
+  auto Callee = apply->getSemanticFn();
+  if (auto dotCall = dyn_cast<DotSyntaxCallExpr>(Callee))
+    Callee = dotCall->getSemanticFn();
+
   // Make sure we are referring to a designated initializer.
-  auto otherCtorRef = dyn_cast<OtherConstructorDeclRefExpr>(
-                        apply->getSemanticFn());
-  if (!otherCtorRef)
+  auto otherCtorRef = dyn_cast<OtherConstructorDeclRefExpr>(Callee);
+  if (!otherCtorRef) {
     return false;
+  }
   
   auto ctor = otherCtorRef->getDecl();
   if (!ctor->isDesignatedInit()) {

--- a/test/decl/func/complete_object_init.swift
+++ b/test/decl/func/complete_object_init.swift
@@ -4,7 +4,7 @@
 // Declaration of complete object initializers and basic semantic checking
 // ---------------------------------------------------------------------------
 class A {
-  convenience init(int i: Int) { // expected-note{{convenience initializer is declared here}}
+  convenience init(int i: Int) { // expected-note 5 {{convenience initializer is declared here}}
     self.init(double: Double(i))
   }
 
@@ -38,6 +38,38 @@ class DerivesA : A {
     super.init(double: 3.14159) // expected-error{{convenience initializer for 'DerivesA' must delegate (with 'self.init') rather than chaining to a superclass initializer (with 'super.init')}}
   }
 }
+
+// Fixing https://github.com/swiftlang/swift/issues/80311
+class DerivesAWithLet : A {
+  let str: String
+  init(int i: Int) {
+    str = "foo"
+    super.init(int: i) // expected-error{{must call a designated initializer of the superclass 'A'}}
+  }
+}
+
+class DerivesAWithVar : A {
+  var str: String
+  init(int i: Int) {
+    str = "foo"
+    super.init(int: i) // expected-error{{must call a designated initializer of the superclass 'A'}}
+  }
+}
+
+class DerivesAWithDefaultLet : A {
+  let str: String = "foo"
+  init(int i: Int) {
+    super.init(int: i) // expected-error{{must call a designated initializer of the superclass 'A'}}
+  }
+}
+
+class DerivesAWithDefaultVar : A {
+  var str: String = "foo"
+  init(int i: Int) {
+    super.init(int: i) // expected-error{{must call a designated initializer of the superclass 'A'}}
+  }
+}
+
 
 struct S {
   convenience init(int i: Int) { // expected-error{{initializers in structs are not marked with 'convenience'}}


### PR DESCRIPTION
When a derived class initializer assigns to let stored properties before calling super.init(), the compiler fails to diagnose calls to convenience initializers on the superclass. The var case, default-initialized let, and no-stored-property cases all correctly error.

## Root cause
  
`BodyInitKindRequest` is evaluated early for let properties, triggered by `VarDecl::getStorageMutability()` (Decl.cpp) checking whether the let assignment is valid in a designated vs. convenience initializer. At that point the constructor body has not been fully type-checked, so the `FindReferenceToInitializer` walker encounters an `UnresolvedDotExpr` for the `super.init()` call and records the outer `ApplyExpr` as `InitExpr`.

Later, after CSApply resolves the call, the `ApplyExpr`'s semantic function is a `DotSyntaxCallExpr` wrapping the `OtherConstructorDeclRefExpr`, rather than the `OtherConstructorDeclRefExpr` directly. `checkSuperInit` only looked one level deep via `getSemanticFn()`, so it failed to find the `OtherConstructorDeclRefExpr` and silently returned `false`, skipping the designated-initializer check entirely.

This doesn't occur with var properties because they are always mutable in initializers, so `BodyInitKindRequest` is not triggered early.

## Fix
  
Unwrap the `DotSyntaxCallExpr` in `checkSuperInit` to find the `OtherConstructorDeclRefExpr` inside.

## Resolves 
* #80311, 
* #65316