### PR TITLE
[CoroutineAccessors] Move functions and add dealloc bit.

### DIFF
--- a/include/swift/ABI/Coro.h
+++ b/include/swift/ABI/Coro.h
@@ -39,6 +39,8 @@ public:
     Kind           = 0,
     Kind_width     = 8,
 
+    ShouldDeallocateImmediately = 8,
+
     // 24 reserved bits
   };
   // clang-format on
@@ -49,6 +51,9 @@ public:
 
   FLAGSET_DEFINE_FIELD_ACCESSORS(Kind, Kind_width, CoroAllocatorKind, getKind,
                                  setKind)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(ShouldDeallocateImmediately,
+                                shouldDeallocateImmediately,
+                                setShouldDeallocateImmediately)
 };
 
 using CoroAllocation = void *;
@@ -62,8 +67,8 @@ struct CoroAllocator {
 
   /// Whether the allocator should deallocate memory on calls to
   /// swift_coro_dealloc.
-  constexpr bool shouldDeallocateImmediately() {
-    // Only the "mallocator" should immediately deallocate in
+  bool shouldDeallocateImmediately() {
+    // Currently, only the "mallocator" should immediately deallocate in
     // swift_coro_dealloc.  It must because the ABI does not provide a means for
     // the callee to return its allocations to the caller.
     //
@@ -71,7 +76,7 @@ struct CoroAllocator {
     // from where swift_task_dealloc_through can be called and passed the
     // caller-allocated fixed-per-callee-sized-frame.
     // Stack allocations just pop the stack.
-    return flags.getKind() == CoroAllocatorKind::Malloc;
+    return flags.shouldDeallocateImmediately();
   }
 };
 

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -18,7 +18,6 @@
 #define SWIFT_RUNTIME_CONCURRENCY_H
 
 #include "swift/ABI/AsyncLet.h"
-#include "swift/ABI/Coro.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/TaskGroup.h"
 
@@ -127,13 +126,6 @@ void swift_task_dealloc(void *ptr);
 /// including that allocation will be deallocated.
 SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void swift_task_dealloc_through(void *ptr);
-
-// TODO: CoroutineAccessors: Move these declarations back to swiftCore {{
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void *swift_coro_alloc(CoroAllocator *allocator, size_t size);
-SWIFT_EXPORT_FROM(swift_Concurrency)
-SWIFT_CC(swift) void swift_coro_dealloc(CoroAllocator *allocator, void *ptr);
-// }} TODO: CoroutineAccessors
 
 /// Cancel a task and all of its child tasks.
 ///

--- a/include/swift/Runtime/Coro.h
+++ b/include/swift/Runtime/Coro.h
@@ -21,6 +21,12 @@
 #include "swift/Runtime/Config.h"
 #include <cstddef>
 
-namespace swift {} // end namespace swift
+namespace swift {
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift) void *swift_coro_alloc(CoroAllocator *allocator, size_t size);
+
+SWIFT_RUNTIME_EXPORT
+SWIFT_CC(swift) void swift_coro_dealloc(CoroAllocator *allocator, void *ptr);
+} // end namespace swift
 
 #endif

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -3010,7 +3010,7 @@ FUNCTION(MemsetS, c, memset_s, C_CC, AlwaysAvailable,
 
 // void *swift_coro_alloc(CoroAllocator *, size_t size);
 FUNCTION(CoroAlloc,
-         _Concurrency, swift_coro_alloc, SwiftCC,
+         Swift, swift_coro_alloc, SwiftCC,
          CoroutineAccessorsAvailability,
          RETURNS(Int8PtrTy),
          ARGS(CoroAllocatorPtrTy, SizeTy),
@@ -3020,7 +3020,7 @@ FUNCTION(CoroAlloc,
 
 // void swift_coro_dealloc(CoroAllocator *, void *ptr);
 FUNCTION(CoroDealloc,
-         _Concurrency, swift_coro_dealloc, SwiftCC,
+         Swift, swift_coro_dealloc, SwiftCC,
          CoroutineAccessorsAvailability,
          RETURNS(VoidTy),
          ARGS(CoroAllocatorPtrTy, Int8PtrTy),

--- a/stdlib/public/Concurrency/TaskAlloc.cpp
+++ b/stdlib/public/Concurrency/TaskAlloc.cpp
@@ -72,19 +72,3 @@ void swift::_swift_task_dealloc_specific(AsyncTask *task, void *ptr) {
 void swift::swift_task_dealloc_through(void *ptr) {
   allocator(swift_task_getCurrent()).deallocThrough(ptr);
 }
-
-void *swift::swift_coro_alloc(CoroAllocator *allocator, size_t size) {
-  return allocator->allocate(size);
-}
-
-void swift::swift_coro_dealloc(CoroAllocator *allocator, void *ptr) {
-  if (!allocator)
-    return;
-  // Calls to swift_coro_dealloc are emitted in resume funclets for every
-  // live-across dynamic allocation.  Whether such calls immediately deallocate
-  // memory depends on the allocator.
-  if (!allocator->shouldDeallocateImmediately()) {
-    return;
-  }
-  allocator->deallocate(ptr);
-}

--- a/stdlib/public/runtime/Coro.cpp
+++ b/stdlib/public/runtime/Coro.cpp
@@ -21,8 +21,7 @@ void *swift::swift_coro_alloc(CoroAllocator *allocator, size_t size) {
 }
 
 void swift::swift_coro_dealloc(CoroAllocator *allocator, void *ptr) {
-  if (!allocator)
-    return;
+  assert(allocator);
   // Calls to swift_coro_dealloc are emitted in resume funclets for every
   // live-across dynamic allocation.  Whether such calls immediately deallocate
   // memory depends on the allocator.

--- a/stdlib/public/runtime/Coro.cpp
+++ b/stdlib/public/runtime/Coro.cpp
@@ -15,3 +15,19 @@
 #include "swift/Basic/FlagSet.h"
 
 using namespace swift;
+
+void *swift::swift_coro_alloc(CoroAllocator *allocator, size_t size) {
+  return allocator->allocate(size);
+}
+
+void swift::swift_coro_dealloc(CoroAllocator *allocator, void *ptr) {
+  if (!allocator)
+    return;
+  // Calls to swift_coro_dealloc are emitted in resume funclets for every
+  // live-across dynamic allocation.  Whether such calls immediately deallocate
+  // memory depends on the allocator.
+  if (!allocator->shouldDeallocateImmediately()) {
+    return;
+  }
+  allocator->deallocate(ptr);
+}

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -14,7 +14,7 @@
 // CHECK-SAME:  }>
 
 // CHECK-LABEL: _swift_coro_malloc_allocator = linkonce_odr hidden constant %swift.coro_allocator {
-// CHECK-SAME:       i32 2,
+// CHECK-SAME:       i32 258,
 // CHECK-SAME:       malloc,
 // CHECK-SAME:       free
 // CHECK-SAME:  }

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -23,7 +23,7 @@
 // CHECK-SAME:      swift_task_dealloc
 // CHECK-SAME:  }
 // CHECK-LABEL: _swift_coro_malloc_allocator = linkonce_odr hidden constant %swift.coro_allocator {
-// CHECK-SAME:       i32 2,
+// CHECK-SAME:       i32 258,
 // CHECK-SAME:       malloc,
 // CHECK-SAME:       free
 // CHECK-SAME:  }

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -50,6 +50,26 @@
 // CHECK:         ret ptr [[OTHER_ALLOCATION]]
 // CHECK:       }
 
+// CHECK-LABEL: @__swift_coro_dealloc_(
+// CHECK-SAME:      ptr [[ALLOCATOR:%[^,]+]]
+// CHECK-SAME:      ptr [[ADDRESS:%[^)]+]]
+// CHECK-SAME:  )
+// CHECK-SAME:  {
+// CHECK:       entry:
+// CHECK:         [[BAIL:%[^,]+]] = icmp eq ptr [[ALLOCATOR]], null
+// CHECK:         br i1 [[USE_POPLESS]],
+// CHECK-SAME:        label %bail
+// CHECK-SAME:        label %forward
+// CHECK:       bail:
+// CHECK:         ret void
+// CHECK:       forward:
+// CHECK:         call swiftcc void @swift_coro_dealloc(
+// CHECK-SAME:        ptr [[ALLOCATOR]]
+// CHECK-SAME:        ptr [[ADDRESS]]
+// CHECK-SAME:    )
+// CHECK:         ret void
+// CHECK:       }
+
 public var _i: Int = 0
 
 public var i: Int {

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -408,10 +408,7 @@ Added: _$sScf25isIsolatingCurrentContextSbyFTj
 Added: _$sScf25isIsolatingCurrentContextSbyFTq
 Added: _$sScfsE25isIsolatingCurrentContextSbyF
 
-// add callee-allocated coro entrypoints
-// TODO: CoroutineAccessors: several of these symbols should be in swiftCore
-Added: _swift_coro_alloc
-Added: _swift_coro_dealloc
+// CoroutineAccessors
 Added: _swift_task_dealloc_through
 
 // SwiftSettings

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -942,3 +942,7 @@ Added: _$ss18EnumeratedSequenceVsSlRzrlE7isEmptySbvpMV
 Added: _$ss18EnumeratedSequenceVsSlRzrlE8endIndexABsSlRzrlE0D0Vyx_GvpMV
 Added: _$ss18EnumeratedSequenceVsSlRzrlEySi6offset_7ElementQz7elementtABsSlRzrlE5IndexVyx_GcipMV
 Added: _$ss18EnumeratedSequenceVyxGSKsSkRzrlMc
+
+// CoroutineAccessors
+Added: _swift_coro_alloc
+Added: _swift_coro_dealloc

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -408,10 +408,7 @@ Added: _$sScf25isIsolatingCurrentContextSbyFTj
 Added: _$sScf25isIsolatingCurrentContextSbyFTq
 Added: _$sScfsE25isIsolatingCurrentContextSbyF
 
-// add callee-allocated coro entrypoints
-// TODO: CoroutineAccessors: several of these symbols should be in swiftCore
-Added: _swift_coro_alloc
-Added: _swift_coro_dealloc
+// CoroutineAccessors
 Added: _swift_task_dealloc_through
 
 // SwiftSettings

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -942,3 +942,7 @@ Added: _$ss18EnumeratedSequenceVsSlRzrlE7isEmptySbvpMV
 Added: _$ss18EnumeratedSequenceVsSlRzrlE8endIndexABsSlRzrlE0D0Vyx_GvpMV
 Added: _$ss18EnumeratedSequenceVsSlRzrlEySi6offset_7ElementQz7elementtABsSlRzrlE5IndexVyx_GcipMV
 Added: _$ss18EnumeratedSequenceVyxGSKsSkRzrlMc
+
+// CoroutineAccessors
+Added: _swift_coro_alloc
+Added: _swift_coro_dealloc


### PR DESCRIPTION
Don't rely on the allocator kind to determine whether deallocation should occur in swift_coro_dealloc, use a dedicated bit.  Allow each allocator to decide for itself for future compatibility.

Move runtime functions out of Concurrency to where they're meant to be, in swiftCore.
