### PR TITLE
utils: Fix build.ps1 summary sorting.

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -494,7 +494,7 @@ function Write-Summary {
       "Elapsed Time" = $FormattedTime
       "%" = "$Percentage%"
     }
-  } | Sort-Object -Descending -Property "%"
+  } | Sort-Object -Descending -Property "Elapsed Time"
 
   $FormattedTotalTime = "{0:hh\:mm\:ss\.ff}" -f $TotalTime
   $TotalRow = [PSCustomObject]@{


### PR DESCRIPTION
Sorting by percentage gives us a lexical sort instead of a numeric sort.