### PR TITLE
[SE-0470] Prohibit isolated conformances in dynamic casts that can't safely use them

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -213,12 +213,14 @@ private extension AllocStackInst {
         builder.createCheckedCastAddrBranch(
           source: newAlloc, sourceFormalType: concreteFormalType,
           destination: cab.destination, targetFormalType: cab.targetFormalType,
+          isolatedConformances: cab.isolatedConformances,
           consumptionKind: cab.consumptionKind,
           successBlock: cab.successBlock, failureBlock: cab.failureBlock)
         context.erase(instruction: cab)
       case let ucca as UnconditionalCheckedCastAddrInst:
         let builder = Builder(before: ucca, context)
         builder.createUnconditionalCheckedCastAddr(
+          isolatedConformances: ucca.isolatedConformances,
           source: newAlloc, sourceFormalType: concreteFormalType,
           destination: ucca.destination, targetFormalType: ucca.targetFormalType)
         context.erase(instruction: ucca)

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -180,7 +180,8 @@ public struct Builder {
   public func createCheckedCastAddrBranch(
     source: Value, sourceFormalType: CanonicalType,
     destination: Value, targetFormalType: CanonicalType,
-    consumptionKind: CheckedCastAddrBranchInst.CastConsumptionKind, 
+    isolatedConformances: CastingIsolatedConformances,
+    consumptionKind: CheckedCastAddrBranchInst.CastConsumptionKind,
     successBlock: BasicBlock,
     failureBlock: BasicBlock
   ) -> CheckedCastAddrBranchInst {
@@ -191,8 +192,10 @@ public struct Builder {
       case .TakeOnSuccess: bridgedConsumption = .TakeOnSuccess
       case .CopyOnSuccess: bridgedConsumption = .CopyOnSuccess    
     }
+
     let cast = bridged.createCheckedCastAddrBranch(source.bridged, sourceFormalType.bridged,
                                                    destination.bridged, targetFormalType.bridged,
+                                                   isolatedConformances.bridged,
                                                    bridgedConsumption,
                                                    successBlock.bridged, failureBlock.bridged)
     return notifyNew(cast.getAs(CheckedCastAddrBranchInst.self))
@@ -200,11 +203,15 @@ public struct Builder {
 
   @discardableResult
   public func createUnconditionalCheckedCastAddr(
+    isolatedConformances: CastingIsolatedConformances,
     source: Value, sourceFormalType: CanonicalType,
     destination: Value, targetFormalType: CanonicalType
   ) -> UnconditionalCheckedCastAddrInst {
-    let cast = bridged.createUnconditionalCheckedCastAddr(source.bridged, sourceFormalType.bridged,
-                                                          destination.bridged, targetFormalType.bridged)
+    let cast = bridged.createUnconditionalCheckedCastAddr(
+        isolatedConformances.bridged, source.bridged,
+        sourceFormalType.bridged,
+        destination.bridged, targetFormalType.bridged
+    )
     return notifyNew(cast.getAs(UnconditionalCheckedCastAddrInst.self))
   }
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -528,6 +528,14 @@ final public class UnconditionalCheckedCastAddrInst : Instruction, SourceDestAdd
   public var isTakeOfSrc: Bool { true }
   public var isInitializationOfDest: Bool { true }
   public override var mayTrap: Bool { true }
+
+  public var isolatedConformances: CastingIsolatedConformances {
+    switch bridged.UnconditionalCheckedCastAddr_getIsolatedConformances() {
+    case .Allow: .allow
+    case .Prohibit: .prohibit
+    @unknown default: fatalError("Unhandled CastingIsolatedConformances")
+    }
+  }
 }
 
 final public class BeginDeallocRefInst : SingleValueInstruction, UnaryInstruction {
@@ -1031,6 +1039,14 @@ class UnconditionalCheckedCastInst : SingleValueInstruction, UnaryInstruction {
   }
   public var targetFormalType: CanonicalType {
     CanonicalType(bridged: bridged.UnconditionalCheckedCast_getTargetFormalType())
+  }
+
+  public var isolatedConformances: CastingIsolatedConformances {
+    switch bridged.UnconditionalCheckedCast_getIsolatedConformances() {
+    case .Allow: .allow
+    case .Prohibit: .prohibit
+    @unknown default: fatalError("Unhandled CastingIsolatedConformances")
+    }
   }
 }
 
@@ -1771,6 +1787,18 @@ final public class DynamicMethodBranchInst : TermInst {
 final public class AwaitAsyncContinuationInst : TermInst, UnaryInstruction {
 }
 
+public enum CastingIsolatedConformances {
+  case allow
+  case prohibit
+
+  var bridged: BridgedInstruction.CastingIsolatedConformances {
+    switch self {
+    case .allow: return .Allow
+    case .prohibit: return .Prohibit
+    }
+  }
+}
+
 final public class CheckedCastBranchInst : TermInst, UnaryInstruction {
   public var source: Value { operand.value }
   public var successBlock: BasicBlock { bridged.CheckedCastBranch_getSuccessBlock().block }
@@ -1778,6 +1806,14 @@ final public class CheckedCastBranchInst : TermInst, UnaryInstruction {
 
   public func updateSourceFormalTypeFromOperandLoweredType() {
     bridged.CheckedCastBranch_updateSourceFormalTypeFromOperandLoweredType()
+  }
+
+  public var isolatedConformances: CastingIsolatedConformances {
+    switch bridged.CheckedCastBranch_getIsolatedConformances() {
+    case .Allow: return .allow
+    case .Prohibit: return .prohibit
+    default: fatalError("Bad CastingIsolatedConformances value")
+    }
   }
 }
 
@@ -1817,6 +1853,14 @@ final public class CheckedCastAddrBranchInst : TermInst {
     case .CopyOnSuccess: return .CopyOnSuccess
     default:
       fatalError("invalid cast consumption kind")
+    }
+  }
+
+  public var isolatedConformances: CastingIsolatedConformances {
+    switch bridged.CheckedCastAddrBranch_getIsolatedConformances() {
+    case .Allow: .allow
+    case .Prohibit: .prohibit
+    @unknown default: fatalError("Unhandled CastingIsolatedConformances")
     }
   }
 }

--- a/docs/SIL/Instructions.md
+++ b/docs/SIL/Instructions.md
@@ -4851,7 +4851,9 @@ on whether the cast succeeds or not.
 ### unconditional_checked_cast
 
 ```
-sil-instruction ::= 'unconditional_checked_cast' sil-operand 'to' sil-type
+sil-instruction ::= 'unconditional_checked_cast' 
+                    sil-prohibit-isolated-conformances?
+                    sil-operand 'to' sil-type
 
 %1 = unconditional_checked_cast %0 : $A to $B
 %1 = unconditional_checked_cast %0 : $*A to $*B
@@ -4867,8 +4869,9 @@ ownership are unsupported.
 
 ```
 sil-instruction ::= 'unconditional_checked_cast_addr'
-                     sil-type 'in' sil-operand 'to'
-                     sil-type 'in' sil-operand
+                    sil-prohibit-isolated-conformances?
+                    sil-type 'in' sil-operand 'to'
+                    sil-type 'in' sil-operand
 
 unconditional_checked_cast_addr $A in %0 : $*@thick A to $B in %1 : $*@thick B
 // $A and $B must be both addresses
@@ -5231,10 +5234,12 @@ instruction branches to `bb2`.
 
 ```
 sil-terminator ::= 'checked_cast_br' sil-checked-cast-exact?
+                    sil-prohibit-isolated-conformances?
                     sil-type 'in'
                     sil-operand 'to' sil-type ','
                     sil-identifier ',' sil-identifier
 sil-checked-cast-exact ::= '[' 'exact' ']'
+sil-prohibit-isolated-conformances ::= '[' 'prohibit_isolated_conformances' ']'
 
 checked_cast_br A in %0 : $A to $B, bb1, bb2
 checked_cast_br *A in %0 : $*A to $*B, bb1, bb2
@@ -5253,10 +5258,14 @@ An exact cast checks whether the dynamic type is exactly the target
 type, not any possible subtype of it. The source and target types must
 be class types.
 
+A cast can specify that the runtime should prohibit all uses of isolated
+conformances when attempting to satisfy protocol requirements of existentials.
+
 ### checked_cast_addr_br
 
 ```
 sil-terminator ::= 'checked_cast_addr_br'
+                    sil-prohibit-isolated-conformances?
                     sil-cast-consumption-kind
                     sil-type 'in' sil-operand 'to'
                     sil-stype 'in' sil-operand ','

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -313,6 +313,11 @@ enum class DynamicCastFlags : size_t {
   /// True if the cast should destroy the source value on failure;
   /// false if the value should be left in place.
   DestroyOnFailure = 0x4,
+
+  /// True if the cast should prohibit the use of any isolated conformances,
+  /// for example because there is a Sendable constraint on the existential
+  /// type we're casting to.
+  ProhibitIsolatedConformances = 0x8,
 };
 inline bool operator&(DynamicCastFlags a, DynamicCastFlags b) {
   return (size_t(a) & size_t(b)) != 0;

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -103,6 +103,7 @@ bool canIRGenUseScalarCheckedCastInstructions(SILModule &M,
 /// using a scalar cast operation.
 void emitIndirectConditionalCastWithScalar(
     SILBuilder &B, ModuleDecl *M, SILLocation loc,
+    CastingIsolatedConformances isolatedConformances,
     CastConsumptionKind consumption, SILValue src, CanType sourceType,
     SILValue dest, CanType targetType, SILBasicBlock *trueBB,
     SILBasicBlock *falseBB, ProfileCounter TrueCount = ProfileCounter(),
@@ -451,6 +452,21 @@ public:
   bool canSILUseScalarCheckedCastInstructions() const {
     return swift::canSILUseScalarCheckedCastInstructions(
         getModule(), getSourceFormalType(), getTargetFormalType());
+  }
+
+  CastingIsolatedConformances getIsolatedConformances() const {
+    switch (getKind()) {
+    case SILDynamicCastKind::CheckedCastAddrBranchInst:
+      return cast<CheckedCastAddrBranchInst>(inst)->getIsolatedConformances();
+    case SILDynamicCastKind::CheckedCastBranchInst:
+      return cast<CheckedCastBranchInst>(inst)->getIsolatedConformances();
+    case SILDynamicCastKind::UnconditionalCheckedCastAddrInst:
+      return cast<UnconditionalCheckedCastAddrInst>(inst)
+          ->getIsolatedConformances();
+    case SILDynamicCastKind::UnconditionalCheckedCastInst:
+      return cast<UnconditionalCheckedCastInst>(inst)
+          ->getIsolatedConformances();
+    }
   }
 };
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -696,6 +696,11 @@ struct BridgedInstruction {
     CopyOnSuccess
   };
 
+  enum class CastingIsolatedConformances {
+    Allow,
+    Prohibit
+  };
+
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef CondFailInst_getMessage() const;
   BRIDGED_INLINE SwiftInt LoadInst_getLoadOwnership() const ;
   BRIDGED_INLINE bool LoadBorrowInst_isUnchecked() const ;
@@ -802,14 +807,22 @@ struct BridgedInstruction {
   BRIDGED_INLINE void LoadInst_setOwnership(SwiftInt ownership) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType UnconditionalCheckedCast_getSourceFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType UnconditionalCheckedCast_getTargetFormalType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CastingIsolatedConformances
+      UnconditionalCheckedCast_getIsolatedConformances() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType UnconditionalCheckedCastAddr_getSourceFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType UnconditionalCheckedCastAddr_getTargetFormalType() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CastingIsolatedConformances
+      UnconditionalCheckedCastAddr_getIsolatedConformances() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastBranch_getSuccessBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastBranch_getFailureBlock() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CastingIsolatedConformances
+      CheckedCastBranch_getIsolatedConformances() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType CheckedCastAddrBranch_getSourceFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType CheckedCastAddrBranch_getTargetFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastAddrBranch_getSuccessBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastAddrBranch_getFailureBlock() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CastingIsolatedConformances
+      CheckedCastAddrBranch_getIsolatedConformances() const;
   BRIDGED_INLINE void CheckedCastBranch_updateSourceFormalTypeFromOperandLoweredType() const;
   BRIDGED_INLINE CastConsumptionKind CheckedCastAddrBranch_getConsumptionKind() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap ApplySite_getSubstitutionMap() const;
@@ -1122,13 +1135,15 @@ struct BridgedBuilder{
                                                                                 BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUpcast(BridgedValue op, BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createCheckedCastAddrBranch(
-                                          BridgedValue source, BridgedCanType sourceFormalType,
-                                          BridgedValue destination, BridgedCanType targetFormalType,
-                                          BridgedInstruction::CastConsumptionKind consumptionKind,
-                                          BridgedBasicBlock successBlock, BridgedBasicBlock failureBlock) const;
+      BridgedValue source, BridgedCanType sourceFormalType,
+      BridgedValue destination, BridgedCanType targetFormalType,
+      BridgedInstruction::CastingIsolatedConformances isolatedConformances,
+      BridgedInstruction::CastConsumptionKind consumptionKind,
+      BridgedBasicBlock successBlock, BridgedBasicBlock failureBlock) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUnconditionalCheckedCastAddr(
-                                          BridgedValue source, BridgedCanType sourceFormalType,
-                                          BridgedValue destination, BridgedCanType targetFormalType) const;
+        BridgedInstruction::CastingIsolatedConformances isolatedConformances,
+        BridgedValue source, BridgedCanType sourceFormalType,
+        BridgedValue destination, BridgedCanType targetFormalType) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createLoad(BridgedValue op, SwiftInt ownership) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createLoadBorrow(BridgedValue op) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createBeginDeallocRef(BridgedValue reference,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1475,6 +1475,12 @@ BridgedCanType BridgedInstruction::UnconditionalCheckedCast_getTargetFormalType(
   return {getAs<swift::UnconditionalCheckedCastInst>()->getTargetFormalType()};    
 }
 
+BridgedInstruction::CastingIsolatedConformances
+BridgedInstruction::UnconditionalCheckedCast_getIsolatedConformances() const {
+  return static_cast<BridgedInstruction::CastingIsolatedConformances>(
+      getAs<swift::UnconditionalCheckedCastInst>()->getIsolatedConformances());
+}
+
 BridgedCanType BridgedInstruction::UnconditionalCheckedCastAddr_getSourceFormalType() const {
   return {getAs<swift::UnconditionalCheckedCastAddrInst>()->getSourceFormalType()};  
 }
@@ -1483,12 +1489,24 @@ BridgedCanType BridgedInstruction::UnconditionalCheckedCastAddr_getTargetFormalT
   return {getAs<swift::UnconditionalCheckedCastAddrInst>()->getTargetFormalType()};    
 }
 
+BridgedInstruction::CastingIsolatedConformances
+BridgedInstruction::UnconditionalCheckedCastAddr_getIsolatedConformances() const {
+  return static_cast<BridgedInstruction::CastingIsolatedConformances>(
+      getAs<swift::UnconditionalCheckedCastAddrInst>()->getIsolatedConformances());
+}
+
 BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getSuccessBlock() const {
   return {getAs<swift::CheckedCastBranchInst>()->getSuccessBB()};
 }
 
 BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getFailureBlock() const {
   return {getAs<swift::CheckedCastBranchInst>()->getFailureBB()};
+}
+
+BridgedInstruction::CastingIsolatedConformances
+BridgedInstruction::CheckedCastBranch_getIsolatedConformances() const {
+  return static_cast<BridgedInstruction::CastingIsolatedConformances>(
+      getAs<swift::CheckedCastBranchInst>()->getIsolatedConformances());
 }
 
 BridgedCanType BridgedInstruction::CheckedCastAddrBranch_getSourceFormalType() const {
@@ -1519,6 +1537,11 @@ BridgedInstruction::CastConsumptionKind BridgedInstruction::CheckedCastAddrBranc
            getAs<swift::CheckedCastAddrBranchInst>()->getConsumptionKind());
 }
 
+BridgedInstruction::CastingIsolatedConformances
+BridgedInstruction::CheckedCastAddrBranch_getIsolatedConformances() const {
+  return static_cast<BridgedInstruction::CastingIsolatedConformances>(
+      getAs<swift::CheckedCastAddrBranchInst>()->getIsolatedConformances());
+}
 
 BridgedSubstitutionMap BridgedInstruction::ApplySite_getSubstitutionMap() const {
   auto as = swift::ApplySite(unbridged());
@@ -2065,25 +2088,31 @@ BridgedInstruction BridgedBuilder::createUpcast(BridgedValue op, BridgedType typ
 }
 
 BridgedInstruction BridgedBuilder::createCheckedCastAddrBranch(
-                                        BridgedValue source, BridgedCanType sourceFormalType,
-                                        BridgedValue destination, BridgedCanType targetFormalType,
-                                        BridgedInstruction::CastConsumptionKind consumptionKind,
-                                        BridgedBasicBlock successBlock, BridgedBasicBlock failureBlock) const
+    BridgedValue source, BridgedCanType sourceFormalType,
+    BridgedValue destination, BridgedCanType targetFormalType,
+    BridgedInstruction::CastingIsolatedConformances isolatedConformances,
+    BridgedInstruction::CastConsumptionKind consumptionKind,
+    BridgedBasicBlock successBlock, BridgedBasicBlock failureBlock) const
 {
   return {unbridged().createCheckedCastAddrBranch(
-            regularLoc(), (swift::CastConsumptionKind)consumptionKind,
-                          source.getSILValue(), sourceFormalType.unbridged(),
-                          destination.getSILValue(), targetFormalType.unbridged(),
-                          successBlock.unbridged(), failureBlock.unbridged())};
+            regularLoc(),
+            (swift::CastingIsolatedConformances)isolatedConformances,
+            (swift::CastConsumptionKind)consumptionKind,
+            source.getSILValue(), sourceFormalType.unbridged(),
+            destination.getSILValue(), targetFormalType.unbridged(),
+            successBlock.unbridged(), failureBlock.unbridged())};
 }
 
 BridgedInstruction BridgedBuilder::createUnconditionalCheckedCastAddr(
-                                        BridgedValue source, BridgedCanType sourceFormalType,
-                                        BridgedValue destination, BridgedCanType targetFormalType) const
+    BridgedInstruction::CastingIsolatedConformances isolatedConformances,
+    BridgedValue source, BridgedCanType sourceFormalType,
+    BridgedValue destination, BridgedCanType targetFormalType) const
 {
   return {unbridged().createUnconditionalCheckedCastAddr(
-            regularLoc(), source.getSILValue(), sourceFormalType.unbridged(),
-                          destination.getSILValue(), targetFormalType.unbridged())};
+            regularLoc(),
+            (swift::CastingIsolatedConformances)isolatedConformances,
+            source.getSILValue(), sourceFormalType.unbridged(),
+            destination.getSILValue(), targetFormalType.unbridged())};
 }
 
 BridgedInstruction BridgedBuilder::createLoad(BridgedValue op, SwiftInt ownership) const {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1552,28 +1552,34 @@ public:
   }
 
   UnconditionalCheckedCastInst *
-  createUnconditionalCheckedCast(SILLocation Loc, SILValue op,
+  createUnconditionalCheckedCast(SILLocation Loc,
+                                 CastingIsolatedConformances isolatedConformances,
+                                 SILValue op,
                                  SILType destLoweredTy,
                                  CanType destFormalTy) {
-    return createUnconditionalCheckedCast(Loc, op, destLoweredTy, destFormalTy,
+    return createUnconditionalCheckedCast(Loc, isolatedConformances, op,
+                                          destLoweredTy, destFormalTy,
                                           op->getOwnershipKind());
   }
 
   UnconditionalCheckedCastInst *
-  createUnconditionalCheckedCast(SILLocation Loc, SILValue op,
+  createUnconditionalCheckedCast(SILLocation Loc,
+                                 CastingIsolatedConformances isolatedConformances,
+                                 SILValue op,
                                  SILType destLoweredTy, CanType destFormalTy,
                                  ValueOwnershipKind forwardingOwnershipKind) {
     return insert(UnconditionalCheckedCastInst::create(
-        getSILDebugLocation(Loc), op, destLoweredTy, destFormalTy,
-        getFunction(), forwardingOwnershipKind));
+        getSILDebugLocation(Loc), isolatedConformances, op, destLoweredTy,
+        destFormalTy, getFunction(), forwardingOwnershipKind));
   }
 
   UnconditionalCheckedCastAddrInst *
   createUnconditionalCheckedCastAddr(SILLocation Loc,
+                                     CastingIsolatedConformances isolatedConformances,
                                      SILValue src, CanType sourceFormalType,
                                      SILValue dest, CanType targetFormalType) {
     return insert(UnconditionalCheckedCastAddrInst::create(
-        getSILDebugLocation(Loc), src, sourceFormalType,
+        getSILDebugLocation(Loc), isolatedConformances, src, sourceFormalType,
         dest, targetFormalType, getFunction()));
   }
 
@@ -2742,16 +2748,20 @@ public:
   }
 
   CheckedCastBranchInst *
-  createCheckedCastBranch(SILLocation Loc, bool isExact, SILValue op, 
-                          CanType srcFormalTy, SILType destLoweredTy, 
+  createCheckedCastBranch(SILLocation Loc, bool isExact,
+                          CastingIsolatedConformances isolatedConformances,
+                          SILValue op,
+                          CanType srcFormalTy, SILType destLoweredTy,
                           CanType destFormalTy, SILBasicBlock *successBB,
                           SILBasicBlock *failureBB,
                           ProfileCounter Target1Count = ProfileCounter(),
                           ProfileCounter Target2Count = ProfileCounter());
 
   CheckedCastBranchInst *
-  createCheckedCastBranch(SILLocation Loc, bool isExact, SILValue op, 
-                          CanType srcFormalTy, SILType destLoweredTy, 
+  createCheckedCastBranch(SILLocation Loc, bool isExact,
+                          CastingIsolatedConformances isolatedConformances,
+                          SILValue op,
+                          CanType srcFormalTy, SILType destLoweredTy,
                           CanType destFormalTy, SILBasicBlock *successBB, 
                           SILBasicBlock *failureBB,
                           ValueOwnershipKind forwardingOwnershipKind,
@@ -2759,7 +2769,9 @@ public:
                           ProfileCounter Target2Count = ProfileCounter());
 
   CheckedCastAddrBranchInst *
-  createCheckedCastAddrBranch(SILLocation Loc, CastConsumptionKind consumption,
+  createCheckedCastAddrBranch(SILLocation Loc,
+                              CastingIsolatedConformances isolatedConformances,
+                              CastConsumptionKind consumption,
                               SILValue src, CanType sourceFormalType,
                               SILValue dest, CanType targetFormalType,
                               SILBasicBlock *successBB,
@@ -2767,9 +2779,9 @@ public:
                               ProfileCounter Target1Count = ProfileCounter(),
                               ProfileCounter Target2Count = ProfileCounter()) {
     return insertTerminator(CheckedCastAddrBranchInst::create(
-        getSILDebugLocation(Loc), consumption, src, sourceFormalType, dest,
-        targetFormalType, successBB, failureBB, Target1Count, Target2Count,
-        getFunction()));
+        getSILDebugLocation(Loc), isolatedConformances, consumption, src,
+        sourceFormalType, dest, targetFormalType, successBB, failureBB,
+        Target1Count, Target2Count, getFunction()));
   }
 
   //===--------------------------------------------------------------------===//

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2032,7 +2032,8 @@ SILCloner<ImplClass>::visitUnconditionalCheckedCastInst(
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst,
                           getBuilder().createUnconditionalCheckedCast(
-                              OpLoc, OpValue, OpLoweredType, OpFormalType,
+                              OpLoc, Inst->getIsolatedConformances(), OpValue,
+                              OpLoweredType, OpFormalType,
                               getBuilder().hasOwnership()
                                   ? Inst->getForwardingOwnershipKind()
                                   : ValueOwnershipKind(OwnershipKind::None)));
@@ -2050,7 +2051,8 @@ SILCloner<ImplClass>::visitUnconditionalCheckedCastAddrInst(
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst,
                           getBuilder().createUnconditionalCheckedCastAddr(
-                              OpLoc, SrcValue, SrcType, DestValue, TargetType));
+                              OpLoc, Inst->getIsolatedConformances(),
+                              SrcValue, SrcType, DestValue, TargetType));
 }
 
 template <typename ImplClass>
@@ -3448,6 +3450,7 @@ SILCloner<ImplClass>::visitCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createCheckedCastBranch(
                 getOpLocation(Inst->getLoc()), Inst->isExact(),
+                Inst->getIsolatedConformances(),
                 getOpValue(Inst->getOperand()),
                 getOpASTType(Inst->getSourceFormalType()),
                 getOpType(Inst->getTargetLoweredType()),
@@ -3469,6 +3472,7 @@ void SILCloner<ImplClass>::visitCheckedCastAddrBranchInst(
   auto FalseCount = Inst->getFalseBBCount();
   recordClonedInstruction(Inst, getBuilder().createCheckedCastAddrBranch(
                                     getOpLocation(Inst->getLoc()),
+                                    Inst->getIsolatedConformances(),
                                     Inst->getConsumptionKind(), SrcValue,
                                     SrcType, DestValue, TargetType, OpSuccBB,
                                     OpFailBB, TrueCount, FalseCount));

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -247,13 +247,16 @@ protected:
     if (canSILUseScalarCheckedCastInstructions(B.getModule(),
                                                sourceType, targetType)) {
       emitIndirectConditionalCastWithScalar(
-          B, SwiftMod, loc, inst->getConsumptionKind(), src, sourceType, dest,
+          B, SwiftMod, loc, inst->getIsolatedConformances(),
+          inst->getConsumptionKind(), src, sourceType, dest,
           targetType, succBB, failBB, TrueCount, FalseCount);
       return;
     }
 
     // Otherwise, use the indirect cast.
-    B.createCheckedCastAddrBranch(loc, inst->getConsumptionKind(),
+    B.createCheckedCastAddrBranch(loc,
+                                  inst->getIsolatedConformances(),
+                                  inst->getConsumptionKind(),
                                   src, sourceType,
                                   dest, targetType,
                                   succBB, failBB);

--- a/lib/IRGen/GenCast.h
+++ b/lib/IRGen/GenCast.h
@@ -28,6 +28,7 @@ namespace swift {
   class SILType;
   class ProtocolDecl;
   enum class CastConsumptionKind : unsigned char;
+  enum class CastingIsolatedConformances: uint8_t;
 
 namespace irgen {
   class Address;
@@ -46,7 +47,8 @@ namespace irgen {
                                Address dest,
                                CanType toType,
                                CastConsumptionKind consumptionKind,
-                               CheckedCastMode mode);
+                               CheckedCastMode mode,
+                              CastingIsolatedConformances isolatedConformances);
 
   void emitScalarCheckedCast(IRGenFunction &IGF, Explosion &value,
                              SILType sourceLoweredType,
@@ -54,6 +56,7 @@ namespace irgen {
                              SILType targetLoweredType,
                              CanType targetFormalType,
                              CheckedCastMode mode,
+                             CastingIsolatedConformances isolatedConformances,
                              Explosion &out);
 
   llvm::Value *emitFastClassCastIfPossible(

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7186,7 +7186,8 @@ visitUncheckedRefCastAddrInst(swift::UncheckedRefCastAddrInst *i) {
                   src, i->getSourceFormalType(),
                   dest, i->getTargetFormalType(),
                   CastConsumptionKind::TakeAlways,
-                  CheckedCastMode::Unconditional);
+                  CheckedCastMode::Unconditional,
+                  CastingIsolatedConformances::Allow);
 }
 
 void IRGenSILFunction::visitUncheckedAddrCastInst(
@@ -7416,6 +7417,7 @@ void IRGenSILFunction::visitUnconditionalCheckedCastInst(
                         i->getTargetLoweredType(),
                         i->getTargetFormalType(),
                         CheckedCastMode::Unconditional,
+                        i->getIsolatedConformances(),
                         ex);
   setLoweredExplosion(i, ex);
 }
@@ -7604,7 +7606,8 @@ void IRGenSILFunction::visitUnconditionalCheckedCastAddrInst(
                   src, i->getSourceFormalType(),
                   dest, i->getTargetFormalType(),
                   CastConsumptionKind::TakeAlways,
-                  CheckedCastMode::Unconditional);
+                  CheckedCastMode::Unconditional,
+                  i->getIsolatedConformances());
 }
 
 void IRGenSILFunction::visitCheckedCastBranchInst(
@@ -7625,6 +7628,7 @@ void IRGenSILFunction::visitCheckedCastBranchInst(
                           i->getTargetLoweredType(),
                           i->getTargetFormalType(),
                           CheckedCastMode::Conditional,
+                          i->getIsolatedConformances(),
                           ex);
     auto val = ex.claimNext();
     castResult.casted = val;
@@ -7662,7 +7666,8 @@ void IRGenSILFunction::visitCheckedCastAddrBranchInst(
     emitCheckedCast(*this,
                     src, i->getSourceFormalType(),
                     dest, i->getTargetFormalType(),
-                    i->getConsumptionKind(), CheckedCastMode::Conditional);
+                    i->getConsumptionKind(), CheckedCastMode::Conditional,
+                    i->getIsolatedConformances());
   Builder.CreateCondBr(castSucceeded,
                        getLoweredBB(i->getSuccessBB()).bb,
                        getLoweredBB(i->getFailureBB()).bb);

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -779,19 +779,24 @@ SwitchEnumInst *SILBuilder::createSwitchEnum(
 }
 
 CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
-    SILLocation Loc, bool isExact, SILValue op, CanType srcFormalTy,
+    SILLocation Loc, bool isExact,
+    CastingIsolatedConformances isolatedConformances,
+    SILValue op, CanType srcFormalTy,
     SILType destLoweredTy, CanType destFormalTy, SILBasicBlock *successBB,
     SILBasicBlock *failureBB, ProfileCounter target1Count,
     ProfileCounter target2Count) {
   auto forwardingOwnership =
       deriveForwardingOwnership(op, destLoweredTy, getFunction());
   return createCheckedCastBranch(
-      Loc, isExact, op, srcFormalTy, destLoweredTy, destFormalTy, successBB,
+      Loc, isExact, isolatedConformances, op, srcFormalTy, destLoweredTy,
+      destFormalTy, successBB,
       failureBB, forwardingOwnership, target1Count, target2Count);
 }
 
 CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
-    SILLocation Loc, bool isExact, SILValue op, CanType srcFormalTy,
+    SILLocation Loc, bool isExact,
+    CastingIsolatedConformances isolatedConformances,
+    SILValue op, CanType srcFormalTy,
     SILType destLoweredTy, CanType destFormalTy, SILBasicBlock *successBB,
     SILBasicBlock *failureBB, ValueOwnershipKind forwardingOwnershipKind,
     ProfileCounter target1Count, ProfileCounter target2Count) {
@@ -800,9 +805,9 @@ CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
          "failureBB's argument doesn't match incoming argument type");
 
   return insertTerminator(CheckedCastBranchInst::create(
-      getSILDebugLocation(Loc), isExact, op, srcFormalTy, destLoweredTy,
-      destFormalTy, successBB, failureBB, getFunction(), target1Count,
-      target2Count, forwardingOwnershipKind));
+      getSILDebugLocation(Loc), isExact, isolatedConformances, op, srcFormalTy,
+      destLoweredTy, destFormalTy, successBB, failureBB, getFunction(),
+      target1Count, target2Count, forwardingOwnershipKind));
 }
 
 BuiltinInst *SILBuilder::createZeroInitAddr(SILLocation loc, SILValue addr) {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1024,6 +1024,16 @@ public:
 
   //===--------------------------------------------------------------------===//
   // SILInstruction Printing Logic
+  void printCastingIsolatedConformancesIfNeeded(CastingIsolatedConformances flag) {
+    switch (flag) {
+    case CastingIsolatedConformances::Allow:
+      break;
+
+    case CastingIsolatedConformances::Prohibit:
+      *this << "[prohibit_isolated_conformances] ";
+      break;
+    }
+  }
 
   void printTypeDependentOperands(const SILInstruction *I) {
     ArrayRef<Operand> TypeDepOps = I->getTypeDependentOperands();
@@ -2081,11 +2091,13 @@ public:
   }
 
   void visitUnconditionalCheckedCastInst(UnconditionalCheckedCastInst *CI) {
+    printCastingIsolatedConformancesIfNeeded(CI->getIsolatedConformances());
     *this << getIDAndType(CI->getOperand()) << " to " << CI->getTargetFormalType();
     printForwardingOwnershipKind(CI, CI->getOperand());
   }
   
   void visitCheckedCastBranchInst(CheckedCastBranchInst *CI) {
+    printCastingIsolatedConformancesIfNeeded(CI->getIsolatedConformances());
     if (CI->isExact())
       *this << "[exact] ";
     *this << CI->getSourceFormalType() << " in ";
@@ -2100,12 +2112,14 @@ public:
   }
 
   void visitUnconditionalCheckedCastAddrInst(UnconditionalCheckedCastAddrInst *CI) {
+    printCastingIsolatedConformancesIfNeeded(CI->getIsolatedConformances());
     *this << CI->getSourceFormalType() << " in " << getIDAndType(CI->getSrc())
           << " to " << CI->getTargetFormalType() << " in "
           << getIDAndType(CI->getDest());
   }
 
   void visitCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *CI) {
+    printCastingIsolatedConformancesIfNeeded(CI->getIsolatedConformances());
     *this << getCastConsumptionKindName(CI->getConsumptionKind()) << ' '
           << CI->getSourceFormalType() << " in " << getIDAndType(CI->getSrc())
           << " to " << CI->getTargetFormalType() << " in "

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -1289,6 +1289,7 @@ bool swift::emitSuccessfulIndirectUnconditionalCast(
     }
 
     B.createUnconditionalCheckedCastAddr(loc,
+                                         CastingIsolatedConformances::Allow,
                                          src, sourceFormalType,
                                          dest, targetFormalType);
     return true;
@@ -1394,6 +1395,7 @@ bool swift::canIRGenUseScalarCheckedCastInstructions(SILModule &M,
 /// using a scalar cast operation.
 void swift::emitIndirectConditionalCastWithScalar(
     SILBuilder &B, ModuleDecl *M, SILLocation loc,
+    CastingIsolatedConformances isolatedConformances,
     CastConsumptionKind consumption,
     SILValue srcAddr, CanType sourceFormalType,
     SILValue destAddr, CanType targetFormalType,
@@ -1432,8 +1434,9 @@ void swift::emitIndirectConditionalCastWithScalar(
   })();
 
   auto *ccb = B.createCheckedCastBranch(
-      loc, /*exact*/ false, srcValue, sourceFormalType, targetLoweredType,
-      targetFormalType, scalarSuccBB, scalarFailBB, TrueCount, FalseCount);
+      loc, /*exact*/ false, isolatedConformances, srcValue, sourceFormalType,
+      targetLoweredType, targetFormalType, scalarSuccBB, scalarFailBB,
+      TrueCount, FalseCount);
 
   // Emit the success block.
   B.setInsertionPoint(scalarSuccBB); {

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -625,29 +625,33 @@ ManagedValue SILGenBuilder::createEnum(SILLocation loc, ManagedValue payload,
 }
 
 ManagedValue SILGenBuilder::createUnconditionalCheckedCast(
-    SILLocation loc, ManagedValue op,
-    SILType destLoweredTy, CanType destFormalTy) {
+    SILLocation loc, CastingIsolatedConformances isolatedConformances,
+    ManagedValue op, SILType destLoweredTy, CanType destFormalTy) {
   SILValue result =
-      createUnconditionalCheckedCast(loc, op.forward(SGF),
+      createUnconditionalCheckedCast(loc, isolatedConformances,
+                                     op.forward(SGF),
                                      destLoweredTy, destFormalTy);
   return SGF.emitManagedRValueWithCleanup(result);
 }
 
-void SILGenBuilder::createCheckedCastBranch(SILLocation loc, bool isExact,
-                                            ManagedValue op,
-                                            CanType sourceFormalTy,
-                                            SILType destLoweredTy,
-                                            CanType destFormalTy,
-                                            SILBasicBlock *trueBlock,
-                                            SILBasicBlock *falseBlock,
-                                            ProfileCounter Target1Count,
-                                            ProfileCounter Target2Count) {
+void SILGenBuilder::createCheckedCastBranch(
+    SILLocation loc, bool isExact,
+    CastingIsolatedConformances isolatedConformances,
+    ManagedValue op,
+    CanType sourceFormalTy,
+    SILType destLoweredTy,
+    CanType destFormalTy,
+    SILBasicBlock *trueBlock,
+    SILBasicBlock *falseBlock,
+    ProfileCounter Target1Count,
+    ProfileCounter Target2Count) {
   // Casting a guaranteed value requires ownership preservation.
   if (!doesCastPreserveOwnershipForTypes(SGF.SGM.M, op.getType().getASTType(),
                                          destFormalTy)) {
     op = op.ensurePlusOne(SGF, loc);
   }
-  createCheckedCastBranch(loc, isExact, op.forward(SGF), sourceFormalTy,
+  createCheckedCastBranch(loc, isExact, isolatedConformances,
+                          op.forward(SGF), sourceFormalTy,
                           destLoweredTy, destFormalTy, trueBlock, falseBlock,
                           Target1Count, Target2Count);
 }

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -307,13 +307,16 @@ public:
                             llvm::function_ref<void(SILValue)> rvalueEmitter);
 
   using SILBuilder::createUnconditionalCheckedCast;
-  ManagedValue createUnconditionalCheckedCast(SILLocation loc,
-                                              ManagedValue op,
-                                              SILType destLoweredTy,
-                                              CanType destFormalTy);
+  ManagedValue createUnconditionalCheckedCast(
+      SILLocation loc,
+      CastingIsolatedConformances isolatedConformances,
+      ManagedValue op,
+      SILType destLoweredTy,
+      CanType destFormalTy);
 
   using SILBuilder::createCheckedCastBranch;
   void createCheckedCastBranch(SILLocation loc, bool isExact,
+                               CastingIsolatedConformances isolatedConformances,
                                ManagedValue op,
                                CanType sourceFormalTy,
                                SILType destLoweredTy,

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -17,6 +17,7 @@
 #include "Scope.h"
 #include "ExitableFullExpr.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/AST/ConformanceLookup.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/TypeLowering.h"
@@ -36,13 +37,15 @@ namespace {
       Scalar,
     };
     CastStrategy Strategy;
+    CastingIsolatedConformances IsolatedConformances;
 
   public:
     CheckedCastEmitter(SILGenFunction &SGF, SILLocation loc,
                        Type sourceType, Type targetType)
       : SGF(SGF), Loc(loc), SourceType(sourceType->getCanonicalType()),
         TargetType(targetType->getCanonicalType()),
-        Strategy(computeStrategy()) {
+        Strategy(computeStrategy()),
+        IsolatedConformances(computedIsolatedConformances()) {
     }
 
     bool isOperandIndirect() const {
@@ -90,7 +93,7 @@ namespace {
       if (Strategy == CastStrategy::Address) {
         SILValue resultBuffer =
           createAbstractResultBuffer(hasAbstraction, origTargetTL, ctx);
-        SGF.B.createUnconditionalCheckedCastAddr(Loc,
+        SGF.B.createUnconditionalCheckedCastAddr(Loc, IsolatedConformances,
                                              operand.forward(SGF), SourceType,
                                              resultBuffer, TargetType);
         return RValue(SGF, Loc, TargetType,
@@ -99,7 +102,8 @@ namespace {
       }
 
       ManagedValue result =
-        SGF.B.createUnconditionalCheckedCast(Loc, operand,
+        SGF.B.createUnconditionalCheckedCast(Loc, IsolatedConformances,
+                                             operand,
                                              origTargetTL.getLoweredType(),
                                              TargetType);
       return RValue(SGF, Loc, TargetType,
@@ -110,7 +114,8 @@ namespace {
 
     /// Emit a conditional cast.
     void emitConditional(
-        ManagedValue operand, CastConsumptionKind consumption, SGFContext ctx,
+        ManagedValue operand,
+        CastConsumptionKind consumption, SGFContext ctx,
         llvm::function_ref<void(ManagedValue)> handleTrue,
         llvm::function_ref<void(std::optional<ManagedValue>)> handleFalse,
         ProfileCounter TrueCount = ProfileCounter(),
@@ -135,8 +140,9 @@ namespace {
         resultBuffer =
             createAbstractResultBuffer(hasAbstraction, origTargetTL, ctx);
         SGF.B.createCheckedCastAddrBranch(
-            Loc, consumption, operand.forward(SGF), SourceType, resultBuffer,
-            TargetType, trueBB, falseBB, TrueCount, FalseCount);
+            Loc, IsolatedConformances, consumption, operand.forward(SGF),
+            SourceType, resultBuffer, TargetType, trueBB, falseBB,
+            TrueCount, FalseCount);
       } else {
         // Tolerate being passed an address here.  It comes up during switch
         // emission.
@@ -150,7 +156,8 @@ namespace {
         if (!shouldDestroyOnFailure(consumption)) {
           operandValue = operandValue.borrow(SGF, Loc);
         }
-        SGF.B.createCheckedCastBranch(Loc, /*exact*/ false, operandValue,
+        SGF.B.createCheckedCastBranch(Loc, /*exact*/ false,
+                                      IsolatedConformances, operandValue,
                                       SourceType, origTargetTL.getLoweredType(),
                                       TargetType, trueBB, falseBB, TrueCount,
                                       FalseCount);
@@ -293,6 +300,27 @@ namespace {
                                                  TargetType))
         return CastStrategy::Scalar;
       return CastStrategy::Address;
+    }
+
+    CastingIsolatedConformances computedIsolatedConformances() const {
+      // Non-existential types don't carry conformances, so we always allow
+      // isolated conformances.
+      if (!TargetType->isAnyExistentialType())
+        return CastingIsolatedConformances::Allow;
+
+      // Only do this if isolated conformances are enabled.
+      ASTContext &ctx = TargetType->getASTContext();
+      if (!ctx.LangOpts.hasFeature(Feature::IsolatedConformances))
+        return CastingIsolatedConformances::Allow;
+
+      auto proto = ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+
+      // If there is a conformance to SendableMetatype, then this existential
+      // can leave the current isolation domain. Prohibit isolated conformances.
+      if (proto && lookupConformance(TargetType, proto, /*allowMissing=*/false))
+        return CastingIsolatedConformances::Prohibit;
+
+      return CastingIsolatedConformances::Allow;
     }
   };
 } // end anonymous namespace

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -949,8 +949,9 @@ public:
     auto tanDest = getTangentBuffer(bb, uccai->getDest());
 
     diffBuilder.createUnconditionalCheckedCastAddr(
-        loc, tanSrc, tanSrc->getType().getASTType(), tanDest,
-        tanDest->getType().getASTType());
+       loc, uccai->getIsolatedConformances(),
+        tanSrc, tanSrc->getType().getASTType(),
+        tanDest, tanDest->getType().getASTType());
   }
 
   /// Handle `begin_access` instruction (and do differentiability checks).

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -1822,7 +1822,8 @@ public:
     auto adjSrc = getAdjointBuffer(bb, uccai->getSrc());
     auto castBuf = builder.createAllocStack(uccai->getLoc(), adjSrc->getType());
     builder.createUnconditionalCheckedCastAddr(
-        uccai->getLoc(), adjDest, adjDest->getType().getASTType(), castBuf,
+        uccai->getLoc(), uccai->getIsolatedConformances(),
+        adjDest, adjDest->getType().getASTType(), castBuf,
         adjSrc->getType().getASTType());
     addToAdjointBuffer(bb, uccai->getSrc(), castBuf, uccai->getLoc());
     builder.emitDestroyAddrAndFold(uccai->getLoc(), castBuf);

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -424,7 +424,8 @@ public:
     auto *pbTupleVal = buildPullbackValueTupleValue(ccbi);
     // Create a new `checked_cast_branch` instruction.
     getBuilder().createCheckedCastBranch(
-        ccbi->getLoc(), ccbi->isExact(), getOpValue(ccbi->getOperand()),
+        ccbi->getLoc(), ccbi->isExact(), ccbi->getIsolatedConformances(),
+        getOpValue(ccbi->getOperand()),
         getOpASTType(ccbi->getSourceFormalType()),
         getOpType(ccbi->getTargetLoweredType()),
         getOpASTType(ccbi->getTargetFormalType()),
@@ -439,7 +440,9 @@ public:
     auto *pbTupleVal = buildPullbackValueTupleValue(ccabi);
     // Create a new `checked_cast_addr_branch` instruction.
     getBuilder().createCheckedCastAddrBranch(
-        ccabi->getLoc(), ccabi->getConsumptionKind(),
+        ccabi->getLoc(),
+        ccabi->getIsolatedConformances(),
+        ccabi->getConsumptionKind(),
         getOpValue(ccabi->getSrc()), getOpASTType(ccabi->getSourceFormalType()),
         getOpValue(ccabi->getDest()),
         getOpASTType(ccabi->getTargetFormalType()),

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2924,7 +2924,8 @@ public:
     }
 
     termBuilder.createCheckedCastAddrBranch(
-        castLoc, CastConsumptionKind::TakeOnSuccess, srcAddr,
+        castLoc, ccb->getIsolatedConformances(),
+        CastConsumptionKind::TakeOnSuccess, srcAddr,
         ccb->getSourceFormalType(), destAddr, ccb->getTargetFormalType(),
         successBB, failureBB, ccb->getTrueBBCount(), ccb->getFalseBBCount());
 
@@ -3020,7 +3021,8 @@ static UnconditionalCheckedCastAddrInst *rewriteUnconditionalCheckedCastInst(
   }
   assert(destAddr);
   auto *uccai = builder.createUnconditionalCheckedCastAddr(
-      uncondCheckedCast->getLoc(), srcAddr, srcAddr->getType().getASTType(),
+      uncondCheckedCast->getLoc(), uncondCheckedCast->getIsolatedConformances(),
+      srcAddr, srcAddr->getType().getASTType(),
       destAddr, destAddr->getType().getASTType());
   auto afterBuilder =
       pass.getBuilder(uncondCheckedCast->getNextInstruction()->getIterator());

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -163,7 +163,8 @@ static FullApplySite speculateMonomorphicTarget(SILPassManager *pm, FullApplySit
   // class instance is identical to the SILType.
 
   CCBI = Builder.createCheckedCastBranch(AI.getLoc(), /*exact*/ true,
-                                      CMI->getOperand(), 
+                                      CastingIsolatedConformances::Allow,
+                                      CMI->getOperand(),
                                       CMI->getOperand()->getType().getASTType(),
                                       SILType::getPrimitiveObjectType(SubType),
                                       SubType, Iden, Virt);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 931; // mark_dependence_addr
+const uint16_t SWIFTMODULE_VERSION_MINOR = 932; // checked cast isolated
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -614,10 +614,17 @@ bool swift::_conformsToProtocolInContext(
     const OpaqueValue *value,
     const Metadata *type,
     ProtocolDescriptorRef protocol,
-    const WitnessTable **conformance) {
+    const WitnessTable **conformance,
+    bool prohibitIsolatedConformances) {
 
   ConformanceExecutionContext context;
   if (!_conformsToProtocol(value, type, protocol, conformance, &context))
+    return false;
+
+  // If we aren't allowed to use isolated conformances and we ended up with
+  // one, fail.
+  if (prohibitIsolatedConformances &&
+      context.globalActorIsolationType)
     return false;
 
   if (!swift_isInConformanceExecutionContext(type, &context))
@@ -631,7 +638,8 @@ bool swift::_conformsToProtocolInContext(
 static bool _conformsToProtocols(const OpaqueValue *value,
                                  const Metadata *type,
                                  const ExistentialTypeMetadata *existentialType,
-                                 const WitnessTable **conformances) {
+                                 const WitnessTable **conformances,
+                                 bool prohibitIsolatedConformances) {
   if (auto *superclass = existentialType->getSuperclassConstraint()) {
     if (!swift_dynamicCastMetatype(type, superclass))
       return false;
@@ -644,7 +652,7 @@ static bool _conformsToProtocols(const OpaqueValue *value,
 
   for (auto protocol : existentialType->getProtocols()) {
     if (!_conformsToProtocolInContext(
-            value, type, protocol, conformances))
+            value, type, protocol, conformances, prohibitIsolatedConformances))
       return false;
     if (conformances != nullptr && protocol.needsWitnessTable()) {
       assert(*conformances != nullptr);
@@ -1050,9 +1058,10 @@ swift_dynamicCastMetatypeImpl(const Metadata *sourceType,
 }
 
 static const Metadata *
-swift_dynamicCastMetatypeUnconditionalImpl(const Metadata *sourceType,
-                                           const Metadata *targetType,
-                                           const char *file, unsigned line, unsigned column) {
+swift_dynamicCastMetatypeUnconditionalImpl(
+    const Metadata *sourceType,
+    const Metadata *targetType,
+    const char *file, unsigned line, unsigned column) {
   auto origSourceType = sourceType;
 
   // Identical types always succeed
@@ -1138,7 +1147,8 @@ swift_dynamicCastMetatypeUnconditionalImpl(const Metadata *sourceType,
 
   case MetadataKind::Existential: {
     auto targetTypeAsExistential = static_cast<const ExistentialTypeMetadata *>(targetType);
-    if (_conformsToProtocols(nullptr, sourceType, targetTypeAsExistential, nullptr))
+    if (_conformsToProtocols(nullptr, sourceType, targetTypeAsExistential,
+                             nullptr, /*prohibitIsolatedConformances=*/false))
       return origSourceType;
     swift_dynamicCastFailure(sourceType, targetType);
   }

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -2353,7 +2353,8 @@ tryCast(
     // Try unwrapping native __SwiftValue implementation
     auto subcastResult = tryCastUnwrappingSwiftValueSource(
       destLocation, destType, srcValue, srcType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
     if (isSuccess(subcastResult)) {
       return subcastResult;
     }

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -87,7 +87,7 @@ typedef DynamicCastResult (tryCastFunctionType)(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances
 );
 
 // Forward-declare the main top-level `tryCast()` function
@@ -401,7 +401,7 @@ tryCastUnwrappingObjCSwiftValueSource(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
     id srcObject;
     memcpy(&srcObject, srcValue, sizeof(id));
@@ -422,7 +422,7 @@ tryCastUnwrappingObjCSwiftValueSource(
       destLocation, destType,
       const_cast<OpaqueValue *>(srcInnerValue), srcInnerType,
       destFailureType, srcFailureType,
-      /*takeOnSuccess=*/ false, mayDeferChecks);
+      /*takeOnSuccess=*/ false, mayDeferChecks, prohibitIsolatedConformances);
 }
 #else
 static DynamicCastResult
@@ -430,7 +430,7 @@ tryCastUnwrappingSwiftValueSource(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType->getKind() == MetadataKind::Class);
 
@@ -452,7 +452,7 @@ tryCastToSwiftClass(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Class);
@@ -496,7 +496,7 @@ tryCastToObjectiveCClass(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::ObjCClassWrapper);
@@ -546,7 +546,7 @@ tryCastToForeignClass(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
 #if SWIFT_OBJC_INTEROP
   assert(srcType != destType);
@@ -594,7 +594,8 @@ tryCastToForeignClass(
 static DynamicCastResult tryCastToForeignReferenceType(
     OpaqueValue *destLocation, const Metadata *destType, OpaqueValue *srcValue,
     const Metadata *srcType, const Metadata *&destFailureType,
-    const Metadata *&srcFailureType, bool takeOnSuccess, bool mayDeferChecks) {
+    const Metadata *&srcFailureType, bool takeOnSuccess, bool mayDeferChecks,
+    bool prohibitIsolatedConformances) {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::ForeignReferenceType);
 
@@ -610,7 +611,7 @@ tryCastToEnum(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   // Note: Optional is handled elsewhere
@@ -783,7 +784,7 @@ tryCastToAnyHashable(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Struct);
@@ -859,7 +860,7 @@ tryCastToArray(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Struct);
@@ -899,7 +900,7 @@ tryCastToDictionary(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Struct);
@@ -940,7 +941,7 @@ tryCastToSet(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Struct);
@@ -982,7 +983,7 @@ tryCastToString(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Struct);
@@ -1013,7 +1014,7 @@ tryCastToStruct(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Struct);
@@ -1036,7 +1037,7 @@ tryCastToOptional(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Optional);
@@ -1110,7 +1111,7 @@ tryCastUnwrappingOptionalBoth(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(destType->getKind() == MetadataKind::Optional);
   assert(srcType->getKind() == MetadataKind::Optional);
@@ -1134,7 +1135,8 @@ tryCastUnwrappingOptionalBoth(
     auto destInnerLocation = destLocation; // Single-payload enum layout
     auto subcastResult = tryCast(
       destInnerLocation, destInnerType, srcValue, srcInnerType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
     if (isSuccess(subcastResult)) {
       destInnerType->vw_storeEnumTagSinglePayload(
         destLocation, /*case*/ 0, /*emptyCases*/ 1);
@@ -1153,7 +1155,7 @@ tryCastUnwrappingOptionalDestination(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(destType->getKind() == MetadataKind::Optional);
 
@@ -1162,7 +1164,8 @@ tryCastUnwrappingOptionalDestination(
   auto destInnerLocation = destLocation; // Single-payload enum layout
   auto subcastResult = tryCast(
     destInnerLocation, destInnerType, srcValue, srcType,
-    destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+    destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+    prohibitIsolatedConformances);
   if (isSuccess(subcastResult)) {
     destInnerType->vw_storeEnumTagSinglePayload(
       destLocation, /*case*/ 0, /*emptyCases*/ 1);
@@ -1179,7 +1182,7 @@ tryCastUnwrappingOptionalSource(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType->getKind() == MetadataKind::Optional);
 
@@ -1190,7 +1193,8 @@ tryCastUnwrappingOptionalSource(
   if (nonNil) {
     // Recurse with unwrapped source
     return tryCast(destLocation, destType, srcValue, srcInnerType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
   }
   return DynamicCastResult::Failure;
 }
@@ -1208,7 +1212,7 @@ tryCastToTuple(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Tuple);
@@ -1284,7 +1288,8 @@ tryCastToTuple(
       auto subcastResult = tryCast(destElt.findIn(destLocation), destElt.Type,
                                    srcElt.findIn(srcValue), srcElt.Type,
                                    destFailureType, srcFailureType,
-                                   false, mayDeferChecks);
+                                   false, mayDeferChecks,
+                                   prohibitIsolatedConformances);
       if (subcastResult == DynamicCastResult::Failure) {
         for (unsigned k = 0; k != j; ++k) {
           const auto &elt = destTupleType->getElement(k);
@@ -1310,7 +1315,7 @@ tryCastToFunction(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Function);
@@ -1372,7 +1377,8 @@ tryCastToFunction(
 static bool _conformsToProtocols(const OpaqueValue *value,
                                  const Metadata *type,
                                  const ExistentialTypeMetadata *existentialType,
-                                 const WitnessTable **conformances) {
+                                 const WitnessTable **conformances,
+                                 bool prohibitIsolatedConformances) {
   if (auto *superclass = existentialType->getSuperclassConstraint()) {
     if (!swift_dynamicCastMetatype(type, superclass))
       return false;
@@ -1385,7 +1391,7 @@ static bool _conformsToProtocols(const OpaqueValue *value,
 
   for (auto protocol : existentialType->getProtocols()) {
     if (!swift::_conformsToProtocolInContext(
-             value, type, protocol, conformances))
+            value, type, protocol, conformances, prohibitIsolatedConformances))
       return false;
     if (conformances != nullptr && protocol.needsWitnessTable()) {
       assert(*conformances != nullptr);
@@ -1402,7 +1408,7 @@ tryCastToUnconstrainedOpaqueExistential(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Existential);
@@ -1429,7 +1435,7 @@ tryCastToConstrainedOpaqueExistential(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Existential);
@@ -1443,10 +1449,12 @@ tryCastToConstrainedOpaqueExistential(
   // TODO (rdar://17033499) If the source is an existential, we should
   // be able to compare the protocol constraints more efficiently than this.
   if (_conformsToProtocols(srcValue, srcType, destExistentialType,
-                           destExistential->getWitnessTables())) {
+                           destExistential->getWitnessTables(),
+                           prohibitIsolatedConformances)) {
     return tryCastToUnconstrainedOpaqueExistential(
       destLocation, destType, srcValue, srcType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
   } else {
     return DynamicCastResult::Failure;
   }
@@ -1457,7 +1465,7 @@ tryCastToClassExistential(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Existential);
@@ -1480,7 +1488,8 @@ tryCastToClassExistential(
       auto value = reinterpret_cast<OpaqueValue *>(&tmp);
       auto type = reinterpret_cast<const Metadata *>(tmp);
       if (_conformsToProtocols(value, type, destExistentialType,
-                               destExistentialLocation->getWitnessTables())) {
+                               destExistentialLocation->getWitnessTables(),
+                               prohibitIsolatedConformances)) {
         auto object = *(reinterpret_cast<HeapObject **>(value));
         destExistentialLocation->Value = object;
         if (takeOnSuccess) {
@@ -1529,7 +1538,8 @@ tryCastToClassExistential(
     }
     if (_conformsToProtocols(srcValue, srcType,
                              destExistentialType,
-                             destExistentialLocation->getWitnessTables())) {
+                             destExistentialLocation->getWitnessTables(),
+                             prohibitIsolatedConformances)) {
       destExistentialLocation->Value = srcObject;
       if (takeOnSuccess) {
         return DynamicCastResult::SuccessViaTake;
@@ -1646,7 +1656,7 @@ tryCastToErrorExistential(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Existential);
@@ -1665,7 +1675,8 @@ tryCastToErrorExistential(
     assert(destExistentialType->NumProtocols == 1);
     const WitnessTable *errorWitness;
     if (_conformsToProtocols(
-          srcValue, srcType, destExistentialType, &errorWitness)) {
+            srcValue, srcType, destExistentialType, &errorWitness,
+            prohibitIsolatedConformances)) {
 #if SWIFT_OBJC_INTEROP
       // If it already holds an NSError, just use that.
       if (auto embedded = getErrorEmbeddedNSErrorIndirect(
@@ -1697,7 +1708,7 @@ tryCastUnwrappingExistentialSource(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(srcType->getKind() == MetadataKind::Existential);
@@ -1738,13 +1749,14 @@ tryCastUnwrappingExistentialSource(
                  srcInnerValue, srcInnerType,
                  destFailureType, srcFailureType,
                  takeOnSuccess && (srcInnerValue == srcValue),
-                 mayDeferChecks);
+                 mayDeferChecks, prohibitIsolatedConformances);
 }
 
 static DynamicCastResult tryCastUnwrappingExtendedExistentialSource(
     OpaqueValue *destLocation, const Metadata *destType, OpaqueValue *srcValue,
     const Metadata *srcType, const Metadata *&destFailureType,
-    const Metadata *&srcFailureType, bool takeOnSuccess, bool mayDeferChecks) {
+    const Metadata *&srcFailureType, bool takeOnSuccess, bool mayDeferChecks,
+    bool prohibitIsolatedConformances) {
   assert(srcType != destType);
   assert(srcType->getKind() == MetadataKind::ExtendedExistential);
 
@@ -1784,7 +1796,8 @@ static DynamicCastResult tryCastUnwrappingExtendedExistentialSource(
   srcFailureType = srcInnerType;
   return tryCast(destLocation, destType, srcInnerValue, srcInnerType,
                  destFailureType, srcFailureType,
-                 takeOnSuccess && (srcInnerValue == srcValue), mayDeferChecks);
+                 takeOnSuccess && (srcInnerValue == srcValue), mayDeferChecks,
+                 prohibitIsolatedConformances);
 }
 
 static DynamicCastResult
@@ -1792,7 +1805,7 @@ tryCastUnwrappingExistentialMetatypeSource(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(srcType->getKind() == MetadataKind::ExistentialMetatype);
@@ -1807,14 +1820,15 @@ tryCastUnwrappingExistentialMetatypeSource(
                  srcInnerValue, srcInnerType,
                  destFailureType, srcFailureType,
                  takeOnSuccess && (srcInnerValue == srcValue),
-                 mayDeferChecks);
+                 mayDeferChecks, prohibitIsolatedConformances);
 }
 
 
 static DynamicCastResult tryCastToExtendedExistential(
     OpaqueValue *destLocation, const Metadata *destType, OpaqueValue *srcValue,
     const Metadata *srcType, const Metadata *&destFailureType,
-    const Metadata *&srcFailureType, bool takeOnSuccess, bool mayDeferChecks) {
+    const Metadata *&srcFailureType, bool takeOnSuccess, bool mayDeferChecks,
+    bool prohibitIsolatedConformances) {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::ExtendedExistential);
 
@@ -1886,6 +1900,10 @@ static DynamicCastResult tryCastToExtendedExistential(
     if (error)
       return DynamicCastResult::Failure;
 
+    if (prohibitIsolatedConformances &&
+        context.globalActorIsolationType)
+      return DynamicCastResult::Failure;
+
     if (!swift_isInConformanceExecutionContext(selfType, &context))
       return DynamicCastResult::Failure;
   }
@@ -1951,7 +1969,7 @@ tryCastToOpaque(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Opaque);
@@ -1990,7 +2008,7 @@ tryCastToMetatype(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::Metatype);
@@ -2023,7 +2041,8 @@ tryCastToMetatype(
       auto srcInnerValue = reinterpret_cast<OpaqueValue *>(&metatype);
       auto srcInnerType = swift_getMetatypeMetadata(metatype);
       return tryCast(destLocation, destType, srcInnerValue, srcInnerType,
-        destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+        destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+        prohibitIsolatedConformances);
     }
 #endif
     return DynamicCastResult::Failure;
@@ -2040,7 +2059,7 @@ _dynamicCastMetatypeToExistentialMetatype(
   OpaqueValue *destLocation,  const ExistentialMetatypeMetadata *destType,
   const Metadata *srcMetatype,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   // The instance type of an existential metatype must be either an
   // existential or an existential metatype.
@@ -2057,7 +2076,7 @@ _dynamicCastMetatypeToExistentialMetatype(
       = destMetatype ? destMetatype->getWitnessTables() : nullptr;
     if (!_conformsToProtocols(nullptr, srcMetatype,
                               targetInstanceTypeAsExistential,
-                              conformance)) {
+                              conformance, prohibitIsolatedConformances)) {
       return DynamicCastResult::Failure;
     }
 
@@ -2096,7 +2115,7 @@ _dynamicCastMetatypeToExistentialMetatype(
     srcInstanceType,
     destFailureType,
     srcFailureType,
-    takeOnSuccess, mayDeferChecks);
+    takeOnSuccess, mayDeferChecks, prohibitIsolatedConformances);
 }
 
 // "ExistentialMetatype" is the metatype for an existential type.
@@ -2105,7 +2124,7 @@ tryCastToExistentialMetatype(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   assert(srcType != destType);
   assert(destType->getKind() == MetadataKind::ExistentialMetatype);
@@ -2122,7 +2141,7 @@ tryCastToExistentialMetatype(
       srcMetatype,
       destFailureType,
       srcFailureType,
-      takeOnSuccess, mayDeferChecks);
+      takeOnSuccess, mayDeferChecks, prohibitIsolatedConformances);
   }
 
   case MetadataKind::ObjCClassWrapper: {
@@ -2142,7 +2161,7 @@ tryCastToExistentialMetatype(
         metatype,
         destFailureType,
         srcFailureType,
-        takeOnSuccess, mayDeferChecks);
+        takeOnSuccess, mayDeferChecks, prohibitIsolatedConformances);
     }
 #endif
     return DynamicCastResult::Failure;
@@ -2262,7 +2281,7 @@ tryCast(
   OpaqueValue *destLocation, const Metadata *destType,
   OpaqueValue *srcValue, const Metadata *srcType,
   const Metadata *&destFailureType, const Metadata *&srcFailureType,
-  bool takeOnSuccess, bool mayDeferChecks)
+  bool takeOnSuccess, bool mayDeferChecks, bool prohibitIsolatedConformances)
 {
   destFailureType = destType;
   srcFailureType = srcType;
@@ -2295,7 +2314,8 @@ tryCast(
     return DynamicCastResult::Failure;
   }
   auto castResult = tryCastToDestType(destLocation, destType, srcValue,
-    srcType, destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+    srcType, destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+    prohibitIsolatedConformances);
   if (isSuccess(castResult)) {
     return castResult;
   }
@@ -2312,7 +2332,8 @@ tryCast(
         srcFailureType = srcDynamicType;
         auto castResult = tryCastToDestType(
           destLocation, destType, srcValue, srcDynamicType,
-          destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+          destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+          prohibitIsolatedConformances);
         if (isSuccess(castResult)) {
           return castResult;
         }
@@ -2345,7 +2366,8 @@ tryCast(
     // Try unwrapping Obj-C __SwiftValue implementation
     auto subcastResult = tryCastUnwrappingObjCSwiftValueSource(
       destLocation, destType, srcValue, srcType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
     if (isSuccess(subcastResult)) {
       return subcastResult;
     }
@@ -2379,7 +2401,8 @@ tryCast(
   case MetadataKind::Existential: {
     auto subcastResult = tryCastUnwrappingExistentialSource(
       destLocation, destType, srcValue, srcType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
     if (isSuccess(subcastResult)) {
       return subcastResult;
     }
@@ -2389,7 +2412,8 @@ tryCast(
   case MetadataKind::ExistentialMetatype: {
     auto subcastResult = tryCastUnwrappingExistentialMetatypeSource(
       destLocation, destType, srcValue, srcType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
     if (isSuccess(subcastResult)) {
       return subcastResult;
     }
@@ -2399,7 +2423,8 @@ tryCast(
   case MetadataKind::ExtendedExistential: {
     auto subcastResult = tryCastUnwrappingExtendedExistentialSource(
         destLocation, destType, srcValue, srcType, destFailureType,
-        srcFailureType, takeOnSuccess, mayDeferChecks);
+        srcFailureType, takeOnSuccess, mayDeferChecks,
+        prohibitIsolatedConformances);
     if (isSuccess(subcastResult)) {
       return subcastResult;
     }
@@ -2423,14 +2448,16 @@ tryCast(
     if (srcKind == MetadataKind::Optional) {
       auto subcastResult = tryCastUnwrappingOptionalBoth(
         destLocation, destType, srcValue, srcType,
-        destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+        destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+        prohibitIsolatedConformances);
       if (isSuccess(subcastResult)) {
         return subcastResult;
       }
     }
     auto subcastResult = tryCastUnwrappingOptionalDestination(
       destLocation, destType, srcValue, srcType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
     if (isSuccess(subcastResult)) {
       return subcastResult;
     }
@@ -2439,7 +2466,8 @@ tryCast(
   if (srcKind == MetadataKind::Optional) {
     auto subcastResult = tryCastUnwrappingOptionalSource(
       destLocation, destType, srcValue, srcType,
-      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks);
+      destFailureType, srcFailureType, takeOnSuccess, mayDeferChecks,
+      prohibitIsolatedConformances);
     if (isSuccess(subcastResult)) {
       return subcastResult;
     }
@@ -2583,6 +2611,11 @@ swift_dynamicCastImpl(OpaqueValue *destLocation,
   // actually accessed.
   bool mayDeferChecks = flags & DynamicCastFlags::Unconditional;
 
+  // Whether the compiler told us that we aren't allowed to use *any* isolated
+  // conformances, regardless of whether we are in that isolation domain.
+  bool prohibitIsolatedConformances =
+      flags & DynamicCastFlags::ProhibitIsolatedConformances;
+
   // Attempt the cast...
   const Metadata *destFailureType = destType;
   const Metadata *srcFailureType = srcType;
@@ -2590,7 +2623,7 @@ swift_dynamicCastImpl(OpaqueValue *destLocation,
     destLocation, destType,
     srcValue, srcType,
     destFailureType, srcFailureType,
-    takeOnSuccess, mayDeferChecks);
+    takeOnSuccess, mayDeferChecks, prohibitIsolatedConformances);
 
   switch (result) {
   case DynamicCastResult::Failure:

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -721,7 +721,8 @@ public:
       const OpaqueValue *value,
       const Metadata *type,
       ProtocolDescriptorRef protocol,
-      const WitnessTable **conformance);
+      const WitnessTable **conformance,
+      bool prohibitIsolatedConformances);
 
   /// Construct type metadata for the given protocol.
   const Metadata *

--- a/test/Concurrency/isolated_conformance_sil.swift
+++ b/test/Concurrency/isolated_conformance_sil.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -Xllvm -sil-print-types -emit-silgen -enable-experimental-feature IsolatedConformances -verify %s | %FileCheck %s
+
+// REQUIRES: swift_feature_IsolatedConformances
+// REQUIRES: concurrency
+
+protocol P { }
+
+protocol Q: Sendable { }
+
+// CHECK-LABEL: sil hidden [ossa] @$s24isolated_conformance_sil7castToPyyypF
+func castToP(_ value: Any) {
+  // CHECK: checked_cast_addr_br take_always Any in [[SOURCE:%[0-9]+]] : $*Any to any P
+  if let p = value as? any P {
+    _ = p
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s24isolated_conformance_sil8castToPQyyypF
+func castToPQ(_ value: Any) {
+  // CHECK: checked_cast_addr_br [prohibit_isolated_conformances] take_always Any in [[SOURCE:%[0-9]+]] : $*Any to any P & Q
+  if let pq = value as? any P & Q {
+    _ = pq
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s24isolated_conformance_sil13forceCastToPQyyypF 
+func forceCastToPQ(_ value: Any) {
+  // CHECK: unconditional_checked_cast_addr [prohibit_isolated_conformances] Any in [[SOURCE:%[0-9]+]] : $*Any to any P & Q in
+  _ = value as! any P & Q
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s24isolated_conformance_sil14objectCastToPQyyyXlF
+func objectCastToPQ(_ value: AnyObject) {
+  // CHECK: checked_cast_br [prohibit_isolated_conformances] AnyObject in [[SOURCE:%[0-9]+]] : $AnyObject to any P & Q & AnyObject
+  if let p = value as? any AnyObject & P & Q {
+    _ = p
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s24isolated_conformance_sil19objectForceCastToPQyyyXlF
+func objectForceCastToPQ(_ value: AnyObject) {
+  // CHECK: unconditional_checked_cast [prohibit_isolated_conformances] [[SOURCE:%[0-9]+]] : $AnyObject to any P & Q & AnyObject
+  _ = value as! any AnyObject & P & Q
+}


### PR DESCRIPTION
When performing a dynamic cast to an existential type that satisfies (Metatype)Sendable, it is unsafe to allow isolated conformances of any kind to satisfy protocol requirements for the existential. Identify these cases and mark the corresponding cast instructions in SIL with a new flag, `[prohibit_isolated_conformances]` that will be used to indicate to the
runtime that isolated conformances need to be rejected. Update the runtime to respect this flag, in which case it rejects all attempts to use an isolated conformance.