### PR TITLE
Runtimes: inject Windows SDK clang modules

### DIFF
--- a/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/CRT/CMakeLists.txt
@@ -14,6 +14,7 @@ target_compile_definitions(swiftCRT PRIVATE
 target_compile_options(swiftCRT PRIVATE
   "SHELL:-Xcc -D_USE_MATH_DEFINES")
 target_link_libraries(swiftCRT PRIVATE
+  ClangModules
   swiftCore)
 
 install(TARGETS swiftCRT

--- a/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/WinSDK/CMakeLists.txt
@@ -6,6 +6,7 @@ set_target_properties(swiftWinSDK PROPERTIES
 target_compile_definitions(swiftCRT PRIVATE
   $<$<BOOL:${SwiftOverlay_ENABLE_REFLECTION}>:SWIFT_ENABLE_REFLECTION>)
 target_link_libraries(swiftWinSDK PRIVATE
+  ClangModules
   swiftCore)
 
 install(TARGETS swiftWinSDK

--- a/Runtimes/Overlay/Windows/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Windows/clang/CMakeLists.txt
@@ -1,4 +1,46 @@
 
+file(TO_CMAKE_PATH "$ENV{WindowsSdkDir}" WindowsSdkDir)
+file(TO_CMAKE_PATH "$ENV{WindowsSDKVersion}" WindowsSDKVersion)
+file(TO_CMAKE_PATH "$ENV{UniversalCRTSdkDir}" UniversalCRTSdkDir)
+file(TO_CMAKE_PATH "$ENV{UCRTVersion}" UCRTVersion)
+file(TO_CMAKE_PATH "$ENV{VCToolsInstallDir}" VCToolsInstallDir)
+
+file(CONFIGURE
+  OUTPUT windows-sdk-overlay.yaml
+  CONTENT [[
+---
+version: 0
+case-sensitive: false
+use-external-names: false
+roots:
+  - name: "@WindowsSdkDir@/Include/@WindowsSDKVersion@/um"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/winsdk.modulemap"
+  - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/ucrt"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/ucrt.modulemap"
+  - name: "@VCToolsInstallDir@include"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/vcruntime.modulemap"
+      - name: vcruntime.apinotes
+        type: file
+        external-contents: "@CMAKE_CURRENT_SOURCE_DIR@/vcruntime.apinotes"
+]]
+ESCAPE_QUOTES @ONLY NEWLINE_STYLE LF)
+
+add_library(ClangModules INTERFACE)
+target_compile_options(ClangModules INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-vfsoverlay ${CMAKE_CURRENT_BINARY_DIR}/windows-sdk-overlay.yaml>")
+
 install(FILES
   ucrt.modulemap
   vcruntime.apinotes

--- a/Runtimes/Overlay/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/clang/CMakeLists.txt
@@ -9,6 +9,7 @@ set_target_properties(swift_Builtin_float PROPERTIES
 target_compile_options(swift_Builtin_float PRIVATE
   "$<$<PLATFORM_ID:Darwin>:SHELL:-Xfrontend -module-abi-name -Xfrontend Darwin>")
 target_link_libraries(swift_Builtin_float PRIVATE
+  $<$<PLATFORM_ID:Windows>:ClangModules>
   swiftCore)
 
 install(TARGETS swift_Builtin_float


### PR DESCRIPTION
When building the standard library, the SDK is not fully staged and so the compiler would not be able to inject the VFS overlay for the modularisation of the Windows SDK. Manually construct the mappings and apply them.