### PR TITLE
utils: enable swift_Concurrency on the new build

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2302,6 +2302,7 @@ function Build-ExperimentalRuntime {
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
         CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
         dispatch_DIR = (Get-ProjectCMakeModules $Platform Dispatch);
+        SwiftCore_ENABLE_CONCURRENCY = "YES";
       }
   }
 }


### PR DESCRIPTION
Enable the Concurrency runtime for the experimental runtime builds on Windows. This is required to enable the use of the static runtime to bootstrap the early swift-driver.