### PR TITLE
A couple of SourceRange fixes for `nonisolated`

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3841,7 +3841,9 @@ public:
 
   SourceLoc getAtLoc() const { return AtLoc; }
 
-  SourceLoc getStartLocImpl() const { return AtLoc; }
+  SourceLoc getStartLocImpl() const {
+    return AtLoc.isValid() ? AtLoc : getAttrLoc();
+  }
   SourceLoc getEndLocImpl() const { return getAttrLoc(); }
 };
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -319,7 +319,7 @@ ERROR(class_cannot_be_addressable_for_dependencies,none,
       "a class cannot be @_addressableForDependencies", ())
 
 ERROR(unsupported_closure_attr,none,
-      "%select{attribute |}0 '%1' is not supported on a closure",
+      "%select{attribute |}0'%1' is not supported on a closure",
       (bool, StringRef))
 
 NOTE(suggest_partial_overloads,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3741,6 +3741,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
   case DeclAttrKind::Nonisolated: {
+    AttrRange = Loc;
     std::optional<bool> isUnsafe(false);
     if (EnableParameterizedNonisolated) {
       isUnsafe =

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -177,3 +177,12 @@ struct UnsafeInitialization {
     self.ns = ns // okay
   }
 }
+
+// rdar://147965036 - Make sure we don't crash.
+func rdar147965036() {
+  func test(_: () -> Void) {}
+  test { @nonisolated in
+    // expected-error@-1 {{'nonisolated' is a declaration modifier, not an attribute}}
+    // expected-error@-2 {{'nonisolated' is not supported on a closure}}
+  }
+}


### PR DESCRIPTION
- Modifiers like `nonisolated` aren't spelled with an `@`, make sure the type attribute logic handles a missing `@`. I don't have a test case for this, but this would assert if the source range were queried.
- Make sure we correctly set the attribute range when used as a decl attribute with `@`.

rdar://147965036