### PR TITLE
Fix a comparison in an assertion

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -857,7 +857,7 @@ void swift::assertRequiredSynthesizedPropertyOrder(ASTContext &Context,
           }
           if (idIdx + actorSystemIdx + unownedExecutorIdx >= 0 + 1 + 2) {
             // we have found all the necessary fields, let's assert their order
-            assert(idIdx < actorSystemIdx < unownedExecutorIdx &&
+            assert(idIdx < actorSystemIdx && actorSystemIdx < unownedExecutorIdx &&
                    "order of fields MUST be exact.");
           }
         }


### PR DESCRIPTION
This was being caught by a newer clang in -Wparentheses by default:
```
warning: comparisons like 'X<=Y<=Z' don't have their mathematical meaning [-Wparentheses]
```