### PR TITLE
[Basic] Bail in `isBeforeInSource` if root source files mismatch

### DIFF
--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -829,9 +829,14 @@ static bool isBeforeInSource(
   auto [firstMismatch, secondMismatch] = std::mismatch(
       firstAncestors.begin(), firstAncestors.end(),
       secondAncestors.begin(), secondAncestors.end());
-  assert(firstMismatch != firstAncestors.begin() &&
-         secondMismatch != secondAncestors.begin() &&
-         "Ancestors don't have the same root source file");
+  if (firstMismatch == firstAncestors.begin() ||
+      secondMismatch == secondAncestors.begin()) {
+    // FIXME: This is currently being hit for code completion
+    // (rdar://134522702), possibly due to an invalid ASTScope node range. For
+    // now, let's bail with `false` in non-asserts builds.
+    assert(false && "Ancestors don't have the same root source file");
+    return false;
+  }
 
   SourceLoc firstLocInLCA = firstMismatch == firstAncestors.end()
       ? firstLoc


### PR DESCRIPTION
This case is currently being hit for code completion, possibly due to an invalid ASTScope node range. Let's bail in non-asserts builds rather than crashing when attempting to access the generated source info.

I'm hoping https://github.com/swiftlang/swift/pull/80339 will let us uncover the real issue here.

rdar://134522702
