### PR TITLE
[IRGen] Don't store payload in destructiveInjectEnumTag when payload …

### DIFF
--- a/test/IRGen/typelayout_based_value_witness.swift
+++ b/test/IRGen/typelayout_based_value_witness.swift
@@ -127,6 +127,11 @@ public enum ForwardEnum<T> {
 // OPT:   ret void
 // CHECK: }
 
+// OPT: define internal void @"$s30typelayout_based_value_witness2E3Owui"(ptr noalias nocapture writeonly %value, i32 %tag, ptr nocapture readonly %"E3<T>")
+// OPT:  [[IS_EMPTY:%.*]] = icmp eq i32 {{%.*}}, 0
+// OPT:  br i1 [[IS_EMPTY]], label %empty-payload, label %non-empty-payload
+// OPT: }
+
 // Let's not crash on the following example.
 public protocol P {}
 
@@ -144,4 +149,10 @@ public struct S<T: P> {
 public enum E2<T: P> {
     case first(Ref<T>)
     case second(String)
+}
+
+public enum E3<T> {
+  case empty
+  case first(T)
+  case second(T)
 }


### PR DESCRIPTION
…is empty type

rdar://142485229

In generic multi payload enums, if the payload was empty, we missed a check for that when storing the payload and always cleared out the extra tag byte.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
