### PR TITLE
Remove Malloc Type Descriptor cache

### DIFF
--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -98,7 +98,7 @@ void *swift::swift_slowAlloc(size_t size, size_t alignMask) {
 void *swift::swift_slowAllocTyped(size_t size, size_t alignMask,
                                   MallocTypeId typeId) {
 #if SWIFT_STDLIB_HAS_MALLOC_TYPE
-  if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
+  if (__builtin_available(macOS 15, iOS 17, tvOS 17, watchOS 10, *)) {
     void *p;
     // This check also forces "default" alignment to use malloc_memalign().
     if (alignMask <= MALLOC_ALIGN_MASK) {

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -145,91 +145,22 @@ static malloc_type_summary_t
 computeMallocTypeSummary(const HeapMetadata *heapMetadata) {
   assert(isHeapMetadataKind(heapMetadata->getKind()));
   auto *classMetadata = heapMetadata->getClassObject();
-  auto *typeDesc = heapMetadata->getTypeContextDescriptor();
-
-  // Pruned metadata or unclassified
-  if (!classMetadata || !typeDesc)
-    return {.type_kind = MALLOC_TYPE_KIND_SWIFT};
 
   // Objc
-  if (classMetadata->isPureObjC())
+  if (classMetadata && classMetadata->isPureObjC())
     return {.type_kind = MALLOC_TYPE_KIND_OBJC};
 
-  malloc_type_summary_t summary = {.type_kind = MALLOC_TYPE_KIND_SWIFT};
-  summary.layout_semantics.reference_count =
-      (classMetadata->getFlags() & ClassFlags::UsesSwiftRefcounting);
-
-  auto *fieldDesc = typeDesc->Fields.get();
-  if (!fieldDesc)
-    return summary;
-
-  bool isGenericData = true;
-  for (auto &field : *fieldDesc) {
-    if (field.isIndirectCase()) {
-      isGenericData = false;
-      if (field.isVar())
-        summary.layout_semantics.data_pointer = true;
-      else
-        summary.layout_semantics.immutable_pointer = true;
-    }
-  }
-  summary.layout_semantics.generic_data = isGenericData;
-
-  return summary;
-
-// FIXME: these are all the things we are potentially interested in
-//  typedef struct {
-// 	  bool data_pointer : 1;
-// 	  bool struct_pointer : 1;
-// 	  bool immutable_pointer : 1;
-// 	  bool anonymous_pointer : 1;
-// 	  bool reference_count : 1;
-// 	  bool resource_handle : 1;
-// 	  bool spatial_bounds : 1;
-// 	  bool tainted_data : 1;
-// 	  bool generic_data : 1;
-// 	  uint16_t unused : 7;
-// } malloc_type_layout_semantics_t;
+  return {.type_kind = MALLOC_TYPE_KIND_SWIFT};
 }
-
-struct MallocTypeCacheEntry {
-// union malloc_type_descriptor_t {
-//   struct {
-//     uint32_t hash;
-//     malloc_type_summary_t summary;
-//   };
-//   malloc_type_id_t type_id;
-// };
-  malloc_type_descriptor_t desc;
-
-  friend llvm::hash_code hash_value(const MallocTypeCacheEntry &entry) {
-    return hash_value(entry.desc.hash);
-  }
-  bool matchesKey(uint32_t key) const { return desc.hash == key; }
-};
-static ConcurrentReadableHashMap<MallocTypeCacheEntry> MallocTypes;
 
 static malloc_type_id_t getMallocTypeId(const HeapMetadata *heapMetadata) {
   uint64_t metadataPtrBits = reinterpret_cast<uint64_t>(heapMetadata);
-  uint32_t key = (metadataPtrBits >> 32) ^ (metadataPtrBits >> 0);
-
-  {
-    auto snapshot = MallocTypes.snapshot();
-    if (auto *entry = snapshot.find(key))
-      return entry->desc.type_id;
-  }
+  uint32_t hash = (metadataPtrBits >> 32) ^ (metadataPtrBits >> 0);
 
   malloc_type_descriptor_t desc = {
-    .hash = key,
+    .hash = hash,
     .summary = computeMallocTypeSummary(heapMetadata)
   };
-
-  MallocTypes.getOrInsert(
-      key, [desc](MallocTypeCacheEntry *entry, bool created) {
-        if (created)
-          entry->desc = desc;
-        return true;
-      });
 
   return desc.type_id;
 }


### PR DESCRIPTION
Remove Malloc Type Descriptor cache and trivialize
`computeMallocTypeSummary()` to only provide
language.  The remaining info in
`malloc_type_summary_t` are currently not used by
the allocator.

The principled, long-term solution is to have the
Swift compiler compute type descriptors for Swift
types.

rdar://137993434
