### PR TITLE
[NFC] Remove stale FIXME about importing enum variants

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3298,9 +3298,6 @@ namespace {
         // The enumeration was mapped to a high-level Swift type, and its
         // elements were created as children of that enum. They aren't available
         // independently.
-
-        // FIXME: This is gross. We shouldn't have to import
-        // everything to get at the individual constants.
         return nullptr;
       }
       }


### PR DESCRIPTION
This comment is from 940a65a994d1bf461908ecf39f1557c9ebb13a72, but is now stale.