### PR TITLE
Fix objcImpl bug causing invalid `@_hasStorage` attributes in module interfaces

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2216,6 +2216,9 @@ ERROR(invalid_decl_attribute,none,
 ERROR(attr_invalid_on_decl_kind,none,
       "'%0' attribute cannot be applied to %1 declarations",
       (DeclAttribute, DescriptiveDeclKind))
+ERROR(attr_invalid_in_context,none,
+      "'%0' attribute cannot be applied to declaration in %1",
+      (DeclAttribute, DescriptiveDeclKind))
 ERROR(invalid_decl_modifier,none,
       "%0 modifier cannot be applied to this declaration", (DeclAttribute))
 ERROR(attribute_does_not_apply_to_type,none,

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -672,7 +672,8 @@ private:
     return InterfaceSubContextDelegateImpl::diagnose(interfacePath, diagnosticLoc, SM, Diags, ID, std::move(Args)...);
   }
   void
-  inheritOptionsForBuildingInterface(const SearchPathOptions &SearchPathOpts,
+  inheritOptionsForBuildingInterface(FrontendOptions::ActionType requestedAction,
+                                     const SearchPathOptions &SearchPathOpts,
                                      const LangOptions &LangOpts,
                                      const ClangImporterOptions &clangImporterOpts,
                                      const CASOptions &casOpts,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1332,8 +1332,8 @@ void PrintAST::printAttributes(const Decl *D) {
 
       if (!Options.PrintForSIL) {
         // Don't print @_hasStorage if the value is simply stored, or the
-        // decl is resilient.
-        if (vd->isResilient() ||
+        // decl is resilient or in an `@objc @implementation` extension.
+        if (vd->isResilient() || isInObjCImpl(vd) ||
             (vd->getImplInfo().isSimpleStored() &&
              !hasLessAccessibleSetter(vd)))
           Options.ExcludeAttrList.push_back(DeclAttrKind::HasStorage);

--- a/test/ModuleInterface/has_storage_attr_bad.swiftinterface
+++ b/test/ModuleInterface/has_storage_attr_bad.swiftinterface
@@ -1,0 +1,10 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags:
+// expected-error@-2 {{failed to verify module interface of 'Test' due to the errors above}}
+
+// RUN: %target-swift-typecheck-module-from-interface(%s) -module-name Test -verify -verify-ignore-unknown
+// REQUIRES: OS=macosx
+
+extension Array {
+  @_hasStorage public var foo: Int { get set } // expected-error {{'@_hasStorage' attribute cannot be applied to declaration in extension}}
+}

--- a/test/ModuleInterface/has_storage_attr_bad.swiftinterface
+++ b/test/ModuleInterface/has_storage_attr_bad.swiftinterface
@@ -1,10 +1,9 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags:
-// expected-error@-2 {{failed to verify module interface of 'Test' due to the errors above}}
 
 // RUN: %target-swift-typecheck-module-from-interface(%s) -module-name Test -verify -verify-ignore-unknown
 // REQUIRES: OS=macosx
 
 extension Array {
-  @_hasStorage public var foo: Int { get set } // expected-error {{'@_hasStorage' attribute cannot be applied to declaration in extension}}
+  @_hasStorage public var foo: Int { get set } // expected-warning {{'@_hasStorage' attribute cannot be applied to declaration in extension}}
 }

--- a/test/ModuleInterface/objc_implementation.swift
+++ b/test/ModuleInterface/objc_implementation.swift
@@ -21,6 +21,9 @@ import Foundation
 // @objc should be omitted on extensions
 // NEGATIVE-NOT: @objc{{.*}} extension
 
+// Stored properties in objcImpl extensions shouldn't have @_hasStorage
+// NEGATIVE-NOT: @_hasStorage
+
 //
 // @_objcImplementation class
 //
@@ -41,6 +44,11 @@ import Foundation
 
   // CHECK-DAG: final public var implProperty2: ObjectiveC.NSObject? { get set }
   public final var implProperty2: NSObject?
+
+  // CHECK-DAG: final public var implProperty3: ObjectiveC.NSObject? {
+  public final var implProperty3: NSObject? {
+    didSet { }
+  }
 
   // CHECK-NOT: func mainMethod
   @objc public func mainMethod(_: Int32) { print(implProperty) }

--- a/test/SILOptimizer/keypath-folding-crash.sil
+++ b/test/SILOptimizer/keypath-folding-crash.sil
@@ -30,7 +30,7 @@ import SwiftShims
 import Builtin
 import CModule
 
-extension ObjClass {
+@objc @implementation extension ObjClass {
   @objc @_hasStorage dynamic var o: NSObject { get set }
 }
 

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -308,6 +308,9 @@ class ExclusivityAttrClass {
 class HasStorage {
   @_hasStorage var x : Int = 42  // ok, _hasStorage is allowed here
 }
+extension HasStorage {
+  @_hasStorage var y : Int { 24 } // expected-error {{'@_hasStorage' attribute cannot be applied to declaration in extension}}
+}
 
 @_show_in_interface protocol _underscored {}
 @_show_in_interface class _notapplicable {} // expected-error {{may only be used on 'protocol' declarations}}


### PR DESCRIPTION
Consider this code:

```swift
@objc @implementation extension MyObjCClass {
    public final var myProperty: Int {
        didSet { print("myProperty changed") }
    }
}
```

Because the `var` is `public final`, it needs to be printed into the module interface as part of an ordinary (non-objcImpl) extension. However, because the `didSet` observer is present, Swift would print a `@_hasStorage` attribute:

```swift
extension MyObjCClass {
    @_hasStorage public final var myProperty: Int {
        get
        set
    }
}
````

This is bad, of course, because stored properties are not allowed in ordinary extensions. But it's worse than that: because `@_hasStorage` is not particularly well validated, the compiler would not emit a diagnostic about this problem—it would simply crash. Often at a fairly arbitrary point if asserts were disabled.

This PR fixes this bug from basically all possible angles:

* Diagnoses uses of `@_hasStorage` in invalid contexts.
* Prevents emission of `@_hasStorage` for `var`s in module interfaces.
* Ignores invalid `@_hasStorage` attributes in existing module interfaces.

Fixes rdar://144811653.

