### PR TITLE
[CMake] Fix missing RegexParser dependency

### DIFF
--- a/Runtimes/Supplemental/StringProcessing/RegexBuilder/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/RegexBuilder/CMakeLists.txt
@@ -10,5 +10,6 @@ set_target_properties(swiftRegexBuilder PROPERTIES
   Swift_MODULE_NAME RegexBuilder)
 
 target_link_libraries(swiftRegexBuilder PRIVATE
+  swift_RegexParser
   swift_StringProcessing
   swiftCore)


### PR DESCRIPTION
RegexBuilder depends on RegexParser. Without the link dependency, we the swift module isn't passed to the RegexBuilder build.