### PR TITLE
[ConstraintSystem] Use `findSelectedOverloadFor` in `isArgumentGeneri…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4984,14 +4984,12 @@ bool ConstraintSystem::isArgumentGenericFunction(Type argType, Expr *argExpr) {
 
   // Have we bound an overload for the argument already?
   if (argExpr) {
-    auto locator = getConstraintLocator(argExpr);
-    auto knownOverloadBinding = ResolvedOverloads.find(locator);
-    if (knownOverloadBinding != ResolvedOverloads.end()) {
+    if (auto selectedOverload = findSelectedOverloadFor(argExpr)) {
       // If the overload choice is a generic function, then we have a generic
       // function reference.
-      auto choice = knownOverloadBinding->second;
-      if (auto func = dyn_cast_or_null<AbstractFunctionDecl>(
-              choice.choice.getDeclOrNull())) {
+      auto choice = selectedOverload->choice;
+      if (auto func =
+              dyn_cast_or_null<AbstractFunctionDecl>(choice.getDeclOrNull())) {
         if (func->isGeneric())
           return true;
       }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar137825558.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar137825558.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// rdar://137825558 - crash due to attempted existential opening
+
+protocol FS {
+  func exists(_ str: String) -> Bool
+}
+
+class Obj {
+  var property: String = ""
+}
+
+func checkFunctionCall<T, Arg0>(
+  _ lhs: T, calling functionCall: (T, Arg0) throws -> Bool, _ argument0: Arg0
+) {
+}
+
+func checkFunctionCall<T, Arg0, R>(
+  _ lhs: T, calling functionCall: (T, Arg0) throws -> R?, _ argument0: Arg0
+) {
+}
+
+func test(fs: any FS, obj: Obj!) {
+  checkFunctionCall(fs, calling: { $0.exists($1) }, obj.property)
+}


### PR DESCRIPTION
…cFunction`

Fixes a crash when existing logic cannot properly determine whether argument is resolved or not.

Instead of ad-hoc code that checks `ResolvedOverloads` directly, let's use a method that would reach of a callee locator to determine whether argument is a reference to a generic function or not.

Resolves: rdar://137825558

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
