### PR TITLE
[IRGen] Fix non-deterministic requests in addAbstractForFulfillments()

### DIFF
--- a/lib/IRGen/Fulfillment.h
+++ b/lib/IRGen/Fulfillment.h
@@ -18,9 +18,9 @@
 #ifndef SWIFT_IRGEN_FULFILLMENT_H
 #define SWIFT_IRGEN_FULFILLMENT_H
 
-#include "llvm/ADT/DenseMap.h"
-#include "swift/AST/Types.h"
+#include "llvm/ADT/MapVector.h"
 #include "swift/AST/GenericSignature.h"
+#include "swift/AST/Types.h"
 #include "swift/IRGen/GenericRequirement.h"
 #include "MetadataPath.h"
 
@@ -49,7 +49,7 @@ struct Fulfillment {
 };
 
 class FulfillmentMap {
-  llvm::DenseMap<GenericRequirement, Fulfillment> Fulfillments;
+  llvm::MapVector<GenericRequirement, Fulfillment> Fulfillments;
 
 public:
   struct InterestingKeysCallback {


### PR DESCRIPTION
In `addAbstractForFulfillments()`, FulfillmentMap (DenseMap) is iterated to compute all the cache entries. Even the non-deterministic iteration order doesn't affect the computed cache entries, the requests to the evaluator during the process will be in non-deterministic order. This will cause the fine-grain dependency file generated to be non-deterministic. Use a `MapVector` to make sure iteration order is deterministic.

rdar://147971980

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
