### PR TITLE
[concurrency] Fix a few issues with @execution(caller)/@execution(concurrent).

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3800,6 +3800,12 @@ public:
   /// Return the function type without the throwing.
   AnyFunctionType *getWithoutThrowing() const;
 
+  /// Return the function type with the given \p isolation.
+  AnyFunctionType *withIsolation(FunctionTypeIsolation isolation) const;
+
+  /// Return the function type setting sendable to \p newValue.
+  AnyFunctionType *withSendable(bool newValue) const;
+
   /// True if the parameter declaration it is attached to is guaranteed
   /// to not persist the closure for longer than the duration of the call.
   bool isNoEscape() const {
@@ -5767,6 +5773,10 @@ public:
                    getLifetimeDependencies());
   }
 
+  /// Return a new SILFunctionType that is the same as this but has \p
+  /// newExtInfo as its ext info.
+  CanSILFunctionType withExtInfo(ExtInfo newExtInfo) const;
+
   /// Returns the language-level calling convention of the function.
   Language getLanguage() const {
     return getExtInfo().getLanguage();
@@ -5815,6 +5825,10 @@ public:
   /// must have the same signature as the new substitutions.
   CanSILFunctionType
   withPatternSubstitutions(SubstitutionMap subs) const;
+
+  /// Create a new SILFunctionType that is the same as this one with its
+  /// sendable bit changed to \p newValue.
+  CanSILFunctionType withSendable(bool newValue) const;
 
   /// Create a SILFunctionType with the same structure as this one,
   /// but replacing the invocation generic signature and pattern

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -925,6 +925,15 @@ public:
     return funcTy->isCalleeConsumed() && !funcTy->isNoEscape();
   }
 
+  bool isNonIsolatedCallerFunction() const {
+    auto funcTy = getAs<SILFunctionType>();
+    if (!funcTy)
+      return false;
+    auto isolatedParam = funcTy->maybeGetIsolatedParameter();
+    return isolatedParam &&
+           isolatedParam->hasOption(SILParameterInfo::ImplicitLeading);
+  }
+
   bool isMarkedAsImmortal() const;
 
   /// True if a value of this type can have its address taken by a

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4486,6 +4486,17 @@ AnyFunctionType *AnyFunctionType::getWithoutThrowing() const {
   return withExtInfo(info);
 }
 
+AnyFunctionType *
+AnyFunctionType::withIsolation(FunctionTypeIsolation isolation) const {
+  auto info = getExtInfo().intoBuilder().withIsolation(isolation).build();
+  return withExtInfo(info);
+}
+
+AnyFunctionType *AnyFunctionType::withSendable(bool newValue) const {
+  auto info = getExtInfo().intoBuilder().withSendable(newValue).build();
+  return withExtInfo(info);
+}
+
 std::optional<Type> AnyFunctionType::getEffectiveThrownErrorType() const {
   // A non-throwing function... has no thrown interface type.
   if (!isThrowing())
@@ -4935,6 +4946,20 @@ SILFunctionType::withPatternSpecialization(CanGenericSignature sig,
                           subs, SubstitutionMap(),
                           const_cast<SILFunctionType*>(this)->getASTContext(),
                           witnessConformance);
+}
+
+CanSILFunctionType SILFunctionType::withSendable(bool newValue) const {
+  return withExtInfo(getExtInfo().withSendable(newValue));
+}
+
+CanSILFunctionType SILFunctionType::withExtInfo(ExtInfo newExtInfo) const {
+  return SILFunctionType::get(
+      getInvocationGenericSignature(), newExtInfo, getCoroutineKind(),
+      getCalleeConvention(), getParameters(), getYields(), getResults(),
+      getOptionalErrorResult(), getPatternSubstitutions(),
+      getInvocationSubstitutions(),
+      const_cast<SILFunctionType *>(this)->getASTContext(),
+      getWitnessMethodConformanceOrInvalid());
 }
 
 APInt IntegerType::getValue() const {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2601,11 +2601,19 @@ public:
                               SILType loweredResultTy,
                               SGFContext ctx = SGFContext());
 
+  enum class ThunkGenFlag {
+    None,
+    ConvertingToNonIsolatedCaller,
+    ConvertingFromNonIsolatedCaller,
+  };
+  using ThunkGenOptions = OptionSet<ThunkGenFlag>;
+
   /// Used for emitting SILArguments of bare functions, such as thunks.
   void collectThunkParams(
       SILLocation loc, SmallVectorImpl<ManagedValue> &params,
       SmallVectorImpl<ManagedValue> *indirectResultParams = nullptr,
-      SmallVectorImpl<ManagedValue> *indirectErrorParams = nullptr);
+      SmallVectorImpl<ManagedValue> *indirectErrorParams = nullptr,
+      ThunkGenOptions options = {});
 
   /// Build the type of a function transformation thunk.
   CanSILFunctionType buildThunkType(CanSILFunctionType &sourceType,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -83,6 +83,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "silgen-poly"
+
 #include "ArgumentSource.h"
 #include "ExecutorBreadcrumb.h"
 #include "FunctionInputGenerator.h"
@@ -985,7 +986,7 @@ ManagedValue Transform::transformTuple(ManagedValue inputTuple,
 void SILGenFunction::collectThunkParams(
     SILLocation loc, SmallVectorImpl<ManagedValue> &params,
     SmallVectorImpl<ManagedValue> *indirectResults,
-    SmallVectorImpl<ManagedValue> *indirectErrors) {
+    SmallVectorImpl<ManagedValue> *indirectErrors, ThunkGenOptions options) {
   // Add the indirect results.
   for (auto resultTy : F.getConventions().getIndirectSILResultTypes(
            getTypeExpansionContext())) {
@@ -1021,7 +1022,16 @@ void SILGenFunction::collectThunkParams(
     // be lowered to their underlying type if allowed by resilience.
     auto inContextParamTy = F.getLoweredType(paramTy.getASTType())
                                 .getCategoryType(paramTy.getCategory());
-    params.push_back(B.createInputFunctionArgument(inContextParamTy, loc));
+    auto functionArgument =
+        B.createInputFunctionArgument(inContextParamTy, loc);
+
+    // If we are told to not propagate the isolated parameter and this is the
+    // implicit leading/isolated parameter, continue.
+    if (options.contains(ThunkGenFlag::ConvertingToNonIsolatedCaller) &&
+        param.hasOption(SILParameterInfo::ImplicitLeading) &&
+        param.hasOption(SILParameterInfo::Isolated))
+      continue;
+    params.push_back(functionArgument);
   }
 }
 
@@ -1454,15 +1464,18 @@ class TranslateArguments : public ExpanderBase<TranslateArguments, ParamInfo> {
   CanSILFunctionType InnerTypesFuncTy;
   ArrayRef<SILParameterInfo> InnerTypes;
   InnerPackArgGenerator InnerPacks;
+  SILGenFunction::ThunkGenOptions Options;
+
 public:
   TranslateArguments(SILGenFunction &SGF, SILLocation loc,
                      ArrayRef<ManagedValue> outerArgs,
                      SmallVectorImpl<ManagedValue> &innerArgs,
                      CanSILFunctionType innerTypesFuncTy,
-                     ArrayRef<SILParameterInfo> innerTypes)
-    : ExpanderBase(SGF, loc, outerArgs), InnerArgs(innerArgs),
-      InnerTypesFuncTy(innerTypesFuncTy), InnerTypes(innerTypes),
-      InnerPacks(*this) {}
+                     ArrayRef<SILParameterInfo> innerTypes,
+                     SILGenFunction::ThunkGenOptions options = {})
+      : ExpanderBase(SGF, loc, outerArgs), InnerArgs(innerArgs),
+        InnerTypesFuncTy(innerTypesFuncTy), InnerTypes(innerTypes),
+        InnerPacks(*this), Options(options) {}
 
   void process(AbstractionPattern innerOrigFunctionType,
                AnyFunctionType::CanParamArrayRef innerSubstTypes,
@@ -2905,12 +2918,18 @@ static ManagedValue applyTrivialConversions(SILGenFunction &SGF,
 }
 
 /// Forward arguments according to a function type's ownership conventions.
-static void forwardFunctionArguments(SILGenFunction &SGF,
-                                     SILLocation loc,
-                                     CanSILFunctionType fTy,
-                                     ArrayRef<ManagedValue> managedArgs,
-                                     SmallVectorImpl<SILValue> &forwardedArgs) {
+static void
+forwardFunctionArguments(SILGenFunction &SGF, SILLocation loc,
+                         CanSILFunctionType fTy,
+                         ArrayRef<ManagedValue> managedArgs,
+                         SmallVectorImpl<SILValue> &forwardedArgs,
+                         SILGenFunction::ThunkGenOptions options = {}) {
   auto argTypes = fTy->getParameters();
+  if (options.contains(
+          SILGenFunction::ThunkGenFlag::ConvertingFromNonIsolatedCaller)) {
+    argTypes = argTypes.drop_front();
+  }
+
   for (auto index : indices(managedArgs)) {
     auto arg = managedArgs[index];
     auto argTy = argTypes[index];
@@ -5424,9 +5443,31 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
 
   FullExpr scope(SGF.Cleanups, CleanupLocation(loc));
 
+  using ThunkGenFlag = SILGenFunction::ThunkGenFlag;
+  auto options = SILGenFunction::ThunkGenOptions();
+
+  // If our original function was nonisolated caller and our eventual type is
+  // just nonisolated, pop the isolated argument.
+  //
+  // NOTE: We do this early before thunk params so that we avoid pushing the
+  // isolated parameter preventing us from having to memcpy over the array.
+  if (outputSubstType->isAsync()) {
+    if (outputSubstType->getIsolation().getKind() ==
+            FunctionTypeIsolation::Kind::NonIsolatedCaller &&
+        inputSubstType->getIsolation().getKind() !=
+            FunctionTypeIsolation::Kind::NonIsolatedCaller)
+      options |= ThunkGenFlag::ConvertingToNonIsolatedCaller;
+
+    if (outputSubstType->getIsolation().getKind() !=
+            FunctionTypeIsolation::Kind::NonIsolatedCaller &&
+        inputSubstType->getIsolation().getKind() ==
+            FunctionTypeIsolation::Kind::NonIsolatedCaller)
+      options |= ThunkGenFlag::ConvertingFromNonIsolatedCaller;
+  }
+
   SmallVector<ManagedValue, 8> params;
   SmallVector<ManagedValue, 4> indirectResultParams;
-  SGF.collectThunkParams(loc, params, &indirectResultParams);
+  SGF.collectThunkParams(loc, params, &indirectResultParams, nullptr, options);
 
   // Ignore the self parameter at the SIL level. IRGen will use it to
   // recover type metadata.
@@ -5443,6 +5484,16 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
   if (expectedType->hasErasedIsolation()) {
     outputErasedIsolation = params.pop_back_val();
   }
+
+  if (!SGF.F.maybeGetIsolatedArgument() && argTypes.size() &&
+      argTypes.front().hasOption(SILParameterInfo::Isolated) &&
+      argTypes.front().hasOption(SILParameterInfo::ImplicitLeading))
+    options |= ThunkGenFlag::ConvertingFromNonIsolatedCaller;
+
+  // If we are converting to nonisolated caller, we are going to have an extra
+  // parameter in our argTypes that we need to drop.
+  if (options.contains(ThunkGenFlag::ConvertingFromNonIsolatedCaller))
+    argTypes = argTypes.drop_front();
 
   // We may need to establish the right executor for the input function.
   // If both function types are synchronous, whoever calls this thunk is
@@ -5514,11 +5565,9 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
   // other direction (the thunk receives an Int like a T, and passes it
   // like a normal Int when calling the inner function).
   SmallVector<ManagedValue, 8> args;
-  TranslateArguments(SGF, loc, params, args, fnType, argTypes)
-    .process(inputOrigType,
-             inputSubstType.getParams(),
-             outputOrigType,
-             outputSubstType.getParams());
+  TranslateArguments(SGF, loc, params, args, fnType, argTypes, options)
+      .process(inputOrigType, inputSubstType.getParams(), outputOrigType,
+               outputSubstType.getParams());
 
   SmallVector<SILValue, 8> argValues;
 
@@ -5546,11 +5595,35 @@ static void buildThunkBody(SILGenFunction &SGF, SILLocation loc,
                               /*mandatory*/false);
   }
 
+  // If we are thunking a nonisolated caller to nonisolated or global actor, we
+  // need to load the actor.
+  if (options.contains(ThunkGenFlag::ConvertingFromNonIsolatedCaller)) {
+    auto outputIsolation = outputSubstType->getIsolation();
+    switch (outputIsolation.getKind()) {
+    case FunctionTypeIsolation::Kind::NonIsolated:
+      argValues.push_back(SGF.emitNonIsolatedIsolation(loc).getValue());
+      break;
+    case FunctionTypeIsolation::Kind::GlobalActor: {
+      auto globalActor =
+          outputIsolation.getGlobalActorType()->getCanonicalType();
+      argValues.push_back(
+          SGF.emitGlobalActorIsolation(loc, globalActor).getValue());
+      break;
+    }
+    case FunctionTypeIsolation::Kind::Parameter:
+    case FunctionTypeIsolation::Kind::Erased:
+    case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+      llvm_unreachable("Should never see this");
+      break;
+    }
+  }
+
   // Add the rest of the arguments.
-  forwardFunctionArguments(SGF, loc, fnType, args, argValues);
+  forwardFunctionArguments(SGF, loc, fnType, args, argValues, options);
 
   auto fun = fnType->isCalleeGuaranteed() ? fnValue.borrow(SGF, loc).getValue()
                                           : fnValue.forward(SGF);
+
   SILValue innerResult =
       SGF.emitApplyWithRethrow(loc, fun,
                                /*substFnType*/ fnValue.getType(),
@@ -5683,18 +5756,28 @@ static ManagedValue createThunk(SILGenFunction &SGF,
   auto toType = expectedType->getWithExtInfo(
       expectedType->getExtInfo().withNoEscape(false));
   CanType dynamicSelfType;
-  auto thunkType = SGF.buildThunkType(sourceType, toType,
-                                      inputSubstType,
-                                      outputSubstType,
-                                      genericEnv,
-                                      interfaceSubs,
-                                      dynamicSelfType);
-  // An actor-isolated non-async function can be converted to an async function
-  // by inserting a hop to the global actor.
+  auto thunkType =
+      SGF.buildThunkType(sourceType, toType, inputSubstType, outputSubstType,
+                         genericEnv, interfaceSubs, dynamicSelfType);
   CanType globalActorForThunk;
-  if (outputSubstType->isAsync()
-      && !inputSubstType->isAsync()) {
-    globalActorForThunk = CanType(inputSubstType->getGlobalActor());
+  // If our output type is async...
+  if (outputSubstType->isAsync()) {
+    // And our input type is not async, we can convert the actor-isolated
+    // non-async function to an async function by inserting a hop to the global
+    // actor.
+    if (!inputSubstType->isAsync()) {
+      globalActorForThunk = CanType(inputSubstType->getGlobalActor());
+    } else {
+      // If our inputSubstType is also async and we are converting from a
+      // nonisolated caller to a global actor from a global actor, attach the
+      // global actor for thunk so we mangle appropriately.
+      auto outputIsolation = outputSubstType->getIsolation();
+      if (outputIsolation.getKind() ==
+              FunctionTypeIsolation::Kind::GlobalActor &&
+          fn.getType().isNonIsolatedCallerFunction())
+        globalActorForThunk =
+            outputIsolation.getGlobalActorType()->getCanonicalType();
+    }
   }
 
   auto thunk = SGF.SGM.getOrCreateReabstractionThunk(

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -159,6 +159,14 @@ public:
     if (hasAddress()) return getAddress();
     return SGF.emitTemporaryAllocation(loc, getType());
   }
+  void print(llvm::raw_ostream &os) const {
+    if (hasAddress())
+      os << "Address: " << *getAddress();
+    else
+      os << "Type: " << getType();
+  }
+
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); llvm::dbgs() << '\n'; }
 };
 
 } // end anonymous namespace
@@ -1271,6 +1279,13 @@ public:
            (isIndirectFormalParameter(convention) &&
             SGF.silConv.useLoweredAddresses());
   }
+
+  void print(llvm::raw_ostream &os) const {
+    os << "ParamInfo. Slot: ";
+    slot.print(os);
+  };
+
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); llvm::dbgs() << '\n'; }
 };
 
 /// Given a list of inputs that are suited to the parameters of one

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2728,9 +2728,16 @@ namespace {
               diagnoseNonSendableParametersAndResult(toFnType);
               break;
 
-            case FunctionTypeIsolation::Kind::NonIsolatedCaller:
             case FunctionTypeIsolation::Kind::Parameter:
               llvm_unreachable("invalid conversion");
+
+            case FunctionTypeIsolation::Kind::NonIsolatedCaller:
+              // Non isolated caller is always async. This can only occur if we
+              // are converting from an `@Sendable` representation to something
+              // else. So we need to just check that we diagnose non sendable
+              // parameters and results.
+              diagnoseNonSendableParametersAndResult(toFnType);
+              break;
             }
             break;
           }

--- a/test/Concurrency/attr_execution/silgen.swift
+++ b/test/Concurrency/attr_execution/silgen.swift
@@ -1,0 +1,428 @@
+// RUN: %target-swift-emit-silgen %s -module-name attr_execution_silgen -target %target-swift-5.1-abi-triple -enable-experimental-feature ExecutionAttribute -DSWIFT_FIVE | %FileCheck -check-prefix CHECK -check-prefix FIVE %s
+// RUN: %target-swift-emit-silgen %s -swift-version 6 -module-name attr_execution_silgen -target %target-swift-5.1-abi-triple -enable-experimental-feature ExecutionAttribute | %FileCheck -check-prefix CHECK -check-prefix SIX %s
+
+// We codegen slightly differently for swift 5 vs swift 6, so we need to check
+// both.
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_ExecutionAttribute
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@execution(caller)
+func globalCallerFunc() async -> () {}
+
+@execution(concurrent)
+func globalConcurrentFunc() async -> () {}
+
+class NonSendableKlass {
+  init() {}
+}
+class SendableKlass : @unchecked Sendable {
+  init() {}
+}
+
+@execution(caller)
+func globalCallerFuncSendableKlass(_ x: SendableKlass) async -> () {}
+
+@execution(concurrent)
+func globalConcurrentFuncSendableKlass(_ x: SendableKlass) async -> () {}
+
+@execution(caller)
+func globalCallerFuncSendableKlass(_ x: SendableKlass) async -> SendableKlass { fatalError() }
+
+@execution(concurrent)
+func globalConcurrentFuncSendableKlass(_ x: SendableKlass) async -> SendableKlass { fatalError() }
+
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen33testCallerToConcurrentNonIsolatedyyyyYaYCcYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> () {
+// CHECK: bb0([[FUNC:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()):
+// CHECK:   [[FUNC_COPY:%.*]] = copy_value [[FUNC]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$sScA_pSgIegHg_IegH_TR : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> ()
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK]]([[FUNC_COPY]])
+// CHECK: } // end sil function '$s21attr_execution_silgen33testCallerToConcurrentNonIsolatedyyyyYaYCcYaF'
+public func testCallerToConcurrentNonIsolated(_ x: @escaping @execution(caller) () async -> ()) async {
+  let y: @execution(concurrent) () async -> () = x
+  await y()
+}
+
+// This thunk is used to convert a caller to a concurrent function. So, we pass in .none as the
+// isolated parameter.
+//
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sScA_pSgIegHg_IegH_TR : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> () {
+// CHECK: bb0([[FUNC:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()):
+// CHECK:   [[ENUM:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+// CHECK:   apply [[FUNC]]([[ENUM]])
+// CHECK: } // end sil function '$sScA_pSgIegHg_IegH_TR'
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen31testCallerToConcurrentMainActoryyyyYaYCcYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> () {
+// CHECK: bb0([[FUNC:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()):
+// CHECK:   [[FUNC_COPY:%.*]] = copy_value [[FUNC]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$sScA_pSgIegHg_IegH_TR : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> ()
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK]]([[FUNC_COPY]])
+// CHECK: } // end sil function '$s21attr_execution_silgen31testCallerToConcurrentMainActoryyyyYaYCcYaF'
+@MainActor
+public func testCallerToConcurrentMainActor(_ x: @escaping @execution(caller) () async -> ()) async {
+  let y: @execution(concurrent) () async -> () = x
+  await y()
+}
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen33testConcurrentToCallerNonIsolatedyyyyYacYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> () {
+// CHECK: bb0([[FUNC:%.*]] : @guaranteed $@async @callee_guaranteed () -> ()):
+// CHECK:   [[FUNC_COPY:%.*]] = copy_value [[FUNC]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$sIegH_ScA_pSgIegHg_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed @async @callee_guaranteed () -> ()) -> ()
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK]]([[FUNC_COPY]])
+// CHECK: } // end sil function '$s21attr_execution_silgen33testConcurrentToCallerNonIsolatedyyyyYacYaF'
+public func testConcurrentToCallerNonIsolated(_ x: @escaping @execution(concurrent) () async -> ()) async {
+  let y: @execution(caller) () async -> () = x
+  await y()
+}
+
+// This thunk has the "surface" of an @caller function, but just ignores the
+// isolated parameter and calls the concurrent funciton.
+//
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sIegH_ScA_pSgIegHg_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed @async @callee_guaranteed () -> ()) -> () {
+// CHECK: bb0({{%.*}} : @guaranteed $Optional<any Actor>, [[FUNC:%.*]] : @guaranteed $@async @callee_guaranteed () -> ()):
+// CHECK:   apply [[FUNC]]
+// CHECK: } // end sil function '$sIegH_ScA_pSgIegHg_TR'
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen42testConcurrentToCallerNonIsolatedMainActoryyyyYacYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> () {
+// CHECK: bb0([[FUNC:%.*]] :
+// CHECK:   [[FUNC_COPY:%.*]] = copy_value [[FUNC]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$sIegH_ScA_pSgIegHg_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed @async @callee_guaranteed () -> ()) -> ()
+// CHECK:   partial_apply [callee_guaranteed] [[THUNK]]([[FUNC_COPY]])
+// CHECK: } // end sil function '$s21attr_execution_silgen42testConcurrentToCallerNonIsolatedMainActoryyyyYacYaF'
+@MainActor
+public func testConcurrentToCallerNonIsolatedMainActor(_ x: @escaping @execution(concurrent) () async -> ()) async {
+  let y: @execution(caller) () async -> () = x
+  await y()
+}
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen016testConcurrentToE0yyyyYacYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> () {
+// CHECK: bb0([[FUNC:%.*]] : @guaranteed $@async @callee_guaranteed () -> ()):
+// CHECK:   [[COPY:%.*]] = copy_value [[FUNC]]
+// CHECK:   [[Y:%.*]] = move_value [lexical] [var_decl] [[COPY]]
+// CHECK:   [[BORROW_Y:%.*]] = begin_borrow [[Y]]
+// CHECK:   [[COPY_Y:%.*]] = copy_value [[BORROW_Y]]
+// CHECK:   [[BORROW_COPY_Y:%.*]] = begin_borrow [[COPY_Y]]
+// CHECK:   apply [[BORROW_COPY_Y]]()
+// CHECK:   [[FUNC:%.*]] = function_ref @$s21attr_execution_silgen20globalConcurrentFuncyyYaF : $@convention(thin) @async () -> ()
+// CHECK:   [[TTFI:%.*]] = thin_to_thick_function [[FUNC]]
+// FIVE:    [[Z:%.*]] = move_value [lexical] [var_decl] [[TTFI]]
+// SIX:     [[CVT_1:%.*]] = convert_function [[TTFI]] to $@Sendable @async
+// SIX:     [[CVT_2:%.*]] = convert_function [[CVT_1]] to $@async
+// SIX:     [[Z:%.*]] = move_value [lexical] [var_decl] [[CVT_2]]
+// CHECK:   [[BORROW_Z:%.*]] = begin_borrow [[Z]]
+// CHECK:   [[COPY_Z:%.*]] = copy_value [[BORROW_Z]]
+// CHECK:   [[BORROW_COPY_Z:%.*]] = begin_borrow [[COPY_Z]]
+// CHECK:   apply [[BORROW_COPY_Z]]()
+// CHECK: } // end sil function '$s21attr_execution_silgen016testConcurrentToE0yyyyYacYaF'
+public func testConcurrentToConcurrent(_ x: @escaping @execution(concurrent) () async -> ()) async {
+  let y: @execution(concurrent) () async -> () = x
+  await y()
+  let z: @execution(concurrent) () async -> () = globalConcurrentFunc
+  await z()
+}
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen012testCallerToE0yyyyYaYCcYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> () {
+// CHECK: bb0([[FUNC:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()):
+// CHECK:   [[COPY:%.*]] = copy_value [[FUNC]]
+// CHECK:   [[Y:%.*]] = move_value [lexical] [var_decl] [[COPY]]
+// CHECK:   [[BORROW_Y:%.*]] = begin_borrow [[Y]]
+// CHECK:   [[COPY_Y:%.*]] = copy_value [[BORROW_Y]]
+// CHECK:   [[BORROW_COPY_Y:%.*]] = begin_borrow [[COPY_Y]]
+// CHECK:   apply [[BORROW_COPY_Y]]({{%.*}})
+// CHECK: } // end sil function '$s21attr_execution_silgen012testCallerToE0yyyyYaYCcYaF'
+//
+// z has a round trip issue.
+public func testCallerToCaller(_ x: @escaping @execution(caller) () async -> ()) async {
+  let y: @execution(caller) () async -> () = x
+  await y()
+  let z: @execution(caller) () async -> () = globalCallerFunc
+  await z()
+}
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen24testCallerLocalVariablesyyyyYaYCcYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> () {
+// CHECK: bb0([[PARAM:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()):
+// CHECK:   [[PARAM_COPY:%.*]] = copy_value [[PARAM]]
+// CHECK:   [[Y:%.*]] = move_value [lexical] [var_decl] [[PARAM_COPY]]
+// CHECK:   [[Y_B:%.*]] = begin_borrow [[Y]]
+// CHECK:   [[Y_B_C:%.*]] = copy_value [[Y_B]]
+// CHECK:   [[Y2:%.*]] = move_value [lexical] [var_decl] [[Y_B_C]]
+// CHECK:   [[Y2_B:%.*]] = begin_borrow [[Y2]]
+// CHECK:   [[Y2_B_C:%.*]] = copy_value [[Y2_B]]
+// CHECK:   [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+// CHECK:   [[Y2_B_C_B:%.*]] = begin_borrow [[Y2_B_C]]
+// CHECK:   apply [[Y2_B_C_B]]([[ACTOR]])
+// CHECK: } // end sil function '$s21attr_execution_silgen24testCallerLocalVariablesyyyyYaYCcYaF'
+public func testCallerLocalVariables(_ x: @escaping @execution(caller) () async -> ()) async {
+  let y: @execution(caller) () async -> () = x
+  let y2: @execution(caller) () async -> () = y
+  await y2()
+}
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen28testConcurrentLocalVariablesyyyyYacYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> () {
+// CHECK:   [[PARAM_COPY:%.*]] = copy_value [[PARAM]]
+// CHECK:   [[Y:%.*]] = move_value [lexical] [var_decl] [[PARAM_COPY]]
+// CHECK:   [[Y_B:%.*]] = begin_borrow [[Y]]
+// CHECK:   [[Y_B_C:%.*]] = copy_value [[Y_B]]
+// CHECK:   [[Y2:%.*]] = move_value [lexical] [var_decl] [[Y_B_C]]
+// CHECK:   [[Y2_B:%.*]] = begin_borrow [[Y2]]
+// CHECK:   [[Y2_B_C:%.*]] = copy_value [[Y2_B]]
+// CHECK:   [[Y2_B_C_B:%.*]] = begin_borrow [[Y2_B_C]]
+// CHECK:   apply [[Y2_B_C_B]]()
+// CHECK: } // end sil function '$s21attr_execution_silgen28testConcurrentLocalVariablesyyyyYacYaF'
+public func testConcurrentLocalVariables(_ x: @escaping @execution(concurrent) () async -> ()) async {
+  let y: @execution(concurrent) () async -> () = x
+  let y2: @execution(concurrent) () async -> () = y
+  await y2()
+}
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen34testCallerConcurrentLocalVariablesyyyyYaYCcYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> () {
+// CHECK: bb0([[PARAM:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()):
+// CHECK:   [[PARAM_COPY:%.*]] = copy_value [[PARAM]]
+// CHECK:   [[THUNK_1:%.*]] = function_ref @$sScA_pSgIegHg_IegH_TR : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> ()
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK_1]]([[PARAM_COPY]])
+// CHECK:   [[Y:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// CHECK:   [[Y_B:%.*]] = begin_borrow [[Y]]
+// CHECK:   [[Y_B_C:%.*]] = copy_value [[Y_B]]
+// CHECK:   [[THUNK_2:%.*]] = function_ref @$sIegH_ScA_pSgIegHg_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed @async @callee_guaranteed () -> ()) -> ()
+// CHECK:   [[PA_2:%.*]] = partial_apply [callee_guaranteed] [[THUNK_2]]([[Y_B_C]])
+// CHECK: } // end sil function '$s21attr_execution_silgen34testCallerConcurrentLocalVariablesyyyyYaYCcYaF'
+public func testCallerConcurrentLocalVariables(_ x: @escaping @execution(caller) () async -> ()) async {
+  let y: @execution(concurrent) () async -> () = x
+  let y2: @execution(caller) () async -> () = y
+  await y2()
+}
+
+// CHECK-LABEL: sil [ossa] @$s21attr_execution_silgen34testConcurrentCallerLocalVariablesyyyyYacYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> ()) -> () {
+// CHECK: bb0([[PARAM:%.*]] : @guaranteed $@async @callee_guaranteed () -> ()):
+// CHECK:   [[PARAM_C:%.*]] = copy_value [[PARAM]]
+// CHECK:   [[THUNK_1:%.*]] = function_ref @$sIegH_ScA_pSgIegHg_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed @async @callee_guaranteed () -> ()) -> ()
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK_1]]([[PARAM_C]])
+// CHECK:   [[Y:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// CHECK:   [[Y_B:%.*]] = begin_borrow [[Y]]
+// CHECK:   [[Y_B_C:%.*]] = copy_value [[Y_B]]
+// CHECK:   [[THUNK_2:%.*]] = function_ref @$sScA_pSgIegHg_IegH_TR : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> ()
+// CHECK:   [[PA_2:%.*]] = partial_apply [callee_guaranteed] [[THUNK_2]]([[Y_B_C]])
+// CHECK: } // end sil function '$s21attr_execution_silgen34testConcurrentCallerLocalVariablesyyyyYacYaF'
+public func testConcurrentCallerLocalVariables(_ x: @escaping @execution(concurrent) () async -> ()) async {
+  let y: @execution(caller) () async -> () = x
+  let y2: @execution(concurrent) () async -> () = y
+  await y2()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s21attr_execution_silgen22globalActorConversionsyyyyYac_yyYaYCctYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed () -> (), @guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> () {
+// CHECK: bb0([[X:%.*]] : @guaranteed $@async @callee_guaranteed () -> (), [[Y:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()):
+// CHECK:   [[GLOBAL_CALLER_FUNC:%.*]] = function_ref @$s21attr_execution_silgen16globalCallerFuncyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
+// FIVE:    [[TTFI:%.*]] = thin_to_thick_function [[GLOBAL_CALLER_FUNC]] to $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
+// FIVE:    [[THUNK:%.*]] = function_ref @$sScA_pSgIegHg_IegH_TRScMTU : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> ()
+// FIVE:    [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[TTFI]]) :
+// SIX:     [[THUNK:%.*]] = function_ref @$sScA_pSgIetHg_IeghH_TRScMTU : $@convention(thin) @Sendable @async (@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> ()
+// SIX:     [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[GLOBAL_CALLER_FUNC]]) :
+// CHECK:   [[V1:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// CHECK:   [[V1_B:%.*]] = begin_borrow [[V1]]
+// CHECK:   [[V1_B_C:%.*]] = copy_value [[V1_B]]
+// CHECK:   [[V1_B_C_B:%.*]] = begin_borrow [[V1_B_C]]
+// FIVE:    apply [[V1_B_C_B]]() : $@async @callee_guaranteed () -> ()
+// SIX:     apply [[V1_B_C_B]]() : $@Sendable @async @callee_guaranteed () -> ()
+
+// CHECK:   [[GLOBAL_CONCURRENT_FUNC:%.*]] = function_ref @$s21attr_execution_silgen20globalConcurrentFuncyyYaF : $@convention(thin) @async () -> ()
+// CHECK:   [[TTFI:%.*]] = thin_to_thick_function [[GLOBAL_CONCURRENT_FUNC]]
+// FIVE:    [[V2:%.*]] = move_value [lexical] [var_decl] [[TTFI]]
+// SIX:     [[CVT:%.*]] = convert_function [[TTFI]] to $@Sendable @async @callee_guaranteed () -> ()
+// SIX:     [[V2:%.*]] = move_value [lexical] [var_decl] [[CVT]]
+// CHECK:   [[V2_B:%.*]] = begin_borrow [[V2]]
+// CHECK:   [[V2_B_C:%.*]] = copy_value [[V2_B]]
+// CHECK:   [[V2_B_C_B:%.*]] = begin_borrow [[V2_B_C]]
+// CHECK:   apply [[V2_B_C_B]]()
+
+// FIVE:   [[X_C:%.*]] = copy_value [[X]]
+// FIVE:   [[V3:%.*]] = move_value [lexical] [var_decl] [[X_C]]
+// FIVE:   [[V3_B:%.*]] = begin_borrow [[V3]]
+// FIVE:   [[V3_B_C:%.*]] = copy_value [[V3_B]]
+// FIVE:   [[V3_B_C_B:%.*]] = begin_borrow [[V3_B_C]]
+// FIVE:   apply [[V3_B_C_B]]()
+
+// FIVE:   [[Y_C:%.*]] = copy_value [[Y]]
+// FIVE:   [[THUNK:%.*]] = function_ref @$sScA_pSgIegHg_IegH_TRScMTU : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()) -> ()
+// FIVE:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[Y_C]])
+// FIVE:   [[V4:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// FIVE:   [[V4_B:%.*]] = begin_borrow [[V4]]
+// FIVE:   [[V4_B_C:%.*]] = copy_value [[V4_B]]
+// FIVE:   [[V4_B_C_B:%.*]] = begin_borrow [[V4_B_C]]
+// FIVE:   apply [[V4_B_C_B]]()
+
+// CHECK: } // end sil function '$s21attr_execution_silgen22globalActorConversionsyyyyYac_yyYaYCctYaF'
+func globalActorConversions(_ x: @escaping @execution(concurrent) () async -> (),
+                            _ y: @escaping @execution(caller) () async -> ()) async {
+  let v1: @MainActor () async -> Void = globalCallerFunc
+  await v1()
+  let v2: @MainActor () async -> Void = globalConcurrentFunc
+  await v2()
+
+  // These are invalid in swift 6 since x is not Sendable and this @MainActor
+  // is.
+#if SWIFT_FIVE
+  let v3: @MainActor () async -> Void = x
+  await v3()
+  let v4: @MainActor () async -> Void = y
+  await v4()
+#endif
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s21attr_execution_silgen23globalActorConversions2yyyAA13SendableKlassCYac_yADYaYCctYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed SendableKlass) -> (), @guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> ()) -> () {
+// CHECK: bb0([[X:%.*]] : @guaranteed $@async @callee_guaranteed (@guaranteed SendableKlass) -> (), [[Y:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> ()):
+// CHECK:   [[GLOBAL_CALLER_FUNC:%.*]] = function_ref @$s21attr_execution_silgen29globalCallerFuncSendableKlassyyAA0gH0CYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> ()
+// FIVE:    [[TTFI:%.*]] = thin_to_thick_function [[GLOBAL_CALLER_FUNC]] to $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> ()
+// FIVE:    [[THUNK:%.*]] = function_ref @$sScA_pSg21attr_execution_silgen13SendableKlassCIegHgg_ADIegHg_TRScMTU : $@convention(thin) @async (@guaranteed SendableKlass, @guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> ()) -> ()
+// FIVE:    [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[TTFI]]) :
+// SIX:     [[THUNK:%.*]] = function_ref @$sScA_pSg21attr_execution_silgen13SendableKlassCIetHgg_ADIeghHg_TRScMTU : $@convention(thin) @Sendable @async (@guaranteed SendableKlass, @convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> ()) -> ()
+// SIX:     [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[GLOBAL_CALLER_FUNC]]) :
+// CHECK:   [[V1:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// CHECK:   [[V1_B:%.*]] = begin_borrow [[V1]]
+// CHECK:   [[V1_B_C:%.*]] = copy_value [[V1_B]]
+// CHECK:   [[V1_B_C_B:%.*]] = begin_borrow [[V1_B_C]]
+// FIVE:    apply [[V1_B_C_B]]({{%.*}}) : $@async @callee_guaranteed (@guaranteed SendableKlass) -> ()
+// SIX:     apply [[V1_B_C_B]]({{%.*}}) : $@Sendable @async @callee_guaranteed (@guaranteed SendableKlass) -> ()
+
+// CHECK:   [[GLOBAL_CONCURRENT_FUNC:%.*]] = function_ref @$s21attr_execution_silgen33globalConcurrentFuncSendableKlassyyAA0gH0CYaF : $@convention(thin) @async (@guaranteed SendableKlass) -> ()
+// CHECK:   [[TTFI:%.*]] = thin_to_thick_function [[GLOBAL_CONCURRENT_FUNC]] to $@async @callee_guaranteed (@guaranteed SendableKlass) -> ()
+// FIVE:    [[V2:%.*]] = move_value [lexical] [var_decl] [[TTFI]]
+// SIX:     [[CVT:%.*]] = convert_function [[TTFI]] to $@Sendable @async @callee_guaranteed (@guaranteed SendableKlass) -> ()
+// SIX:     [[V2:%.*]] = move_value [lexical] [var_decl] [[CVT]]
+// CHECK:   [[V2_B:%.*]] = begin_borrow [[V2]]
+// CHECK:   [[V2_B_C:%.*]] = copy_value [[V2_B]]
+// CHECK:   [[V2_B_C_B:%.*]] = begin_borrow [[V2_B_C]]
+// CHECK:   apply [[V2_B_C_B]]({{%.*}})
+
+// FIVE:   [[X_C:%.*]] = copy_value [[X]]
+// FIVE:   [[V3:%.*]] = move_value [lexical] [var_decl] [[X_C]]
+// FIVE:   [[V3_B:%.*]] = begin_borrow [[V3]]
+// FIVE:   [[V3_B_C:%.*]] = copy_value [[V3_B]]
+// FIVE:   [[V3_B_C_B:%.*]] = begin_borrow [[V3_B_C]]
+// FIVE:   apply [[V3_B_C_B]]({{%.*}})
+
+// FIVE:   [[Y_C:%.*]] = copy_value [[Y]]
+// FIVE:   [[THUNK:%.*]] = function_ref @$sScA_pSg21attr_execution_silgen13SendableKlassCIegHgg_ADIegHg_TRScMTU : $@convention(thin) @async (@guaranteed SendableKlass, @guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> ()) -> ()
+// FIVE:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[Y_C]])
+// FIVE:   [[V4:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// FIVE:   [[V4_B:%.*]] = begin_borrow [[V4]]
+// FIVE:   [[V4_B_C:%.*]] = copy_value [[V4_B]]
+// FIVE:   [[V4_B_C_B:%.*]] = begin_borrow [[V4_B_C]]
+// FIVE:   apply [[V4_B_C_B]]({{%.*}})
+
+// CHECK: } // end sil function '$s21attr_execution_silgen23globalActorConversions2yyyAA13SendableKlassCYac_yADYaYCctYaF'
+func globalActorConversions2(_ x: @escaping @execution(concurrent) (SendableKlass) async -> (),
+                             _ y: @escaping @execution(caller) (SendableKlass) async -> ()) async {
+  let v1: @MainActor (SendableKlass) async -> Void = globalCallerFuncSendableKlass
+  await v1(SendableKlass())
+  let v2: @MainActor (SendableKlass) async -> Void = globalConcurrentFuncSendableKlass
+  await v2(SendableKlass())
+#if SWIFT_FIVE
+  let v3: @MainActor (SendableKlass) async -> Void = x
+  await v3(SendableKlass())
+  let v4: @MainActor (SendableKlass) async -> Void = y
+  await v4(SendableKlass())
+#endif
+  let v5: @execution(concurrent) (SendableKlass) async -> Void = y
+  await v5(SendableKlass())
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s21attr_execution_silgen23globalActorConversions3yyAA13SendableKlassCADYac_A2DYaYCctYaF : $@convention(thin) @async (@guaranteed @async @callee_guaranteed (@guaranteed SendableKlass) -> @owned SendableKlass, @guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> @owned SendableKlass) -> () {
+// CHECK: bb0([[X:%.*]] : @guaranteed $@async @callee_guaranteed (@guaranteed SendableKlass) -> @owned SendableKlass, [[Y:%.*]] : @guaranteed $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> @owned SendableKlass):
+// CHECK:   [[GLOBAL_CALLER_FUNC:%.*]] = function_ref @$s21attr_execution_silgen29globalCallerFuncSendableKlassyAA0gH0CADYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> @owned SendableKlass
+// FIVE:    [[TTFI:%.*]] = thin_to_thick_function [[GLOBAL_CALLER_FUNC]] to $@async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> @owned SendableKlass
+// FIVE:    [[THUNK:%.*]] = function_ref @$sScA_pSg21attr_execution_silgen13SendableKlassCADIegHggo_A2DIegHgo_TRScMTU : $@convention(thin) @async (@guaranteed SendableKlass, @guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> @owned SendableKlass) -> @owned SendableKlass
+// FIVE:    [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[TTFI]])
+// SIX:     [[THUNK:%.*]] = function_ref @$sScA_pSg21attr_execution_silgen13SendableKlassCADIetHggo_A2DIeghHgo_TRScMTU : $@convention(thin) @Sendable @async (@guaranteed SendableKlass, @convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> @owned SendableKlass) -> @owned SendableKlass
+// SIX:     [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[GLOBAL_CALLER_FUNC]])
+// CHECK:   [[V1:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// CHECK:   [[V1_B:%.*]] = begin_borrow [[V1]]
+// CHECK:   [[V1_B_C:%.*]] = copy_value [[V1_B]]
+// CHECK:   [[V1_B_C_B:%.*]] = begin_borrow [[V1_B_C]]
+// CHECK:   apply [[V1_B_C_B]]({{%.*}})
+
+// CHECK:   [[GLOBAL_CONCURRENT_FUNC:%.*]] = function_ref @$s21attr_execution_silgen33globalConcurrentFuncSendableKlassyAA0gH0CADYaF : $@convention(thin) @async (@guaranteed SendableKlass) -> @owned SendableKlass
+// CHECK:   [[TTFI:%.*]] = thin_to_thick_function [[GLOBAL_CONCURRENT_FUNC]] to $@async @callee_guaranteed (@guaranteed SendableKlass) -> @owned SendableKlass
+// FIVE:    [[V2:%.*]] = move_value [lexical] [var_decl] [[TTFI]]
+// SIX:     [[CVT:%.*]] = convert_function [[TTFI]] to $@Sendable @async @callee_guaranteed (@guaranteed SendableKlass) -> @owned SendableKlass
+// SIX:     [[V2:%.*]] = move_value [lexical] [var_decl] [[CVT]]
+// CHECK:   [[V2_B:%.*]] = begin_borrow [[V2]]
+// CHECK:   [[V2_B_C:%.*]] = copy_value [[V2_B]]
+// CHECK:   [[V2_B_C_B:%.*]] = begin_borrow [[V2_B_C]]
+// CHECK:   apply [[V2_B_C_B]]({{%.*}})
+
+// FIVE:   [[X_C:%.*]] = copy_value [[X]]
+// FIVE:   [[V3:%.*]] = move_value [lexical] [var_decl] [[X_C]]
+// FIVE:   [[V3_B:%.*]] = begin_borrow [[V3]]
+// FIVE:   [[V3_B_C:%.*]] = copy_value [[V3_B]]
+// FIVE:   [[V3_B_C_B:%.*]] = begin_borrow [[V3_B_C]]
+// FIVE:   apply [[V3_B_C_B]]({{%.*}})
+
+// FIVE:   [[Y_C:%.*]] = copy_value [[Y]]
+// FIVE:   [[THUNK:%.*]] = function_ref @$sScA_pSg21attr_execution_silgen13SendableKlassCADIegHggo_A2DIegHgo_TRScMTU : $@convention(thin) @async (@guaranteed SendableKlass, @guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> @owned SendableKlass) -> @owned SendableKlass
+// FIVE:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[Y_C]])
+// FIVE:   [[V4:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// FIVE:   [[V4_B:%.*]] = begin_borrow [[V4]]
+// FIVE:   [[V4_B_C:%.*]] = copy_value [[V4_B]]
+// FIVE:   [[V4_B_C_B:%.*]] = begin_borrow [[V4_B_C]]
+// FIVE:   apply [[V4_B_C_B]]({{%.*}})
+
+// CHECK:  [[Y_C:%.*]] = copy_value [[Y]]
+// CHECK:  [[THUNK:%.*]] = function_ref @$sScA_pSg21attr_execution_silgen13SendableKlassCADIegHggo_A2DIegHgo_TR : $@convention(thin) @async (@guaranteed SendableKlass, @guaranteed @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass) -> @owned SendableKlass) -> @owned SendableKlass
+// CHECK:  [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[Y_C]])
+// CHECK:  [[V5:%.*]] = move_value [lexical] [var_decl] [[PA]]
+// CHECK: } // end sil function '$s21attr_execution_silgen23globalActorConversions3yyAA13SendableKlassCADYac_A2DYaYCctYaF'
+func globalActorConversions3(_ x: @escaping @execution(concurrent) (SendableKlass) async -> SendableKlass,
+                             _ y: @escaping @execution(caller) (SendableKlass) async -> SendableKlass) async {
+  let v1: @MainActor (SendableKlass) async -> SendableKlass = globalCallerFuncSendableKlass
+  _ = await v1(SendableKlass())
+  let v2: @MainActor (SendableKlass) async -> SendableKlass = globalConcurrentFuncSendableKlass
+  _ = await v2(SendableKlass())
+#if SWIFT_FIVE
+  let v3: @MainActor (SendableKlass) async -> SendableKlass = x
+  _ = await v3(SendableKlass())
+  let v4: @MainActor (SendableKlass) async -> SendableKlass = y
+  _ = await v4(SendableKlass())
+#endif
+  let v5: @execution(concurrent) (SendableKlass) async -> SendableKlass = y
+  _ = await v5(SendableKlass())
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s21attr_execution_silgen26conversionsFromSyncToAsyncyyyAA16NonSendableKlassCYbc_yAA0jK0CYbScMYccyADYbScMYcctYaF : $@convention(thin) @async (@guaranteed @Sendable @callee_guaranteed (@guaranteed NonSendableKlass) -> (), @guaranteed @Sendable @callee_guaranteed (@guaranteed SendableKlass) -> (), @guaranteed @Sendable @callee_guaranteed (@guaranteed NonSendableKlass) -> ()) -> () {
+// CHECK: bb0([[X:%.*]] : @guaranteed $@Sendable @callee_guaranteed (@guaranteed NonSendableKlass) -> (), [[Y:%.*]] : @guaranteed $@Sendable @callee_guaranteed (@guaranteed SendableKlass) -> (), [[Z:%.*]] : @guaranteed $@Sendable @callee_guaranteed (@guaranteed NonSendableKlass) -> ()):
+
+// CHECK:   [[X_C:%.*]] = copy_value [[X]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$s21attr_execution_silgen16NonSendableKlassCIeghg_ScA_pSgACIegHgg_TR : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed NonSendableKlass, @guaranteed @Sendable @callee_guaranteed (@guaranteed NonSendableKlass) -> ()) -> ()
+// CHECK:   [[PAI:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[X_C]])
+
+// CHECK:   [[Y_C:%.*]] = copy_value [[Y]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$s21attr_execution_silgen13SendableKlassCIeghg_ScA_pSgACIegHgg_TRScMTU : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SendableKlass, @guaranteed @Sendable @callee_guaranteed (@guaranteed SendableKlass) -> ()) -> ()
+// CHECK:   [[PAI:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[Y_C]])
+
+// CHECK:   [[Y_C:%.*]] = copy_value [[Y]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$s21attr_execution_silgen13SendableKlassCIeghg_ACIegHg_TRScMTU : $@convention(thin) @async (@guaranteed SendableKlass, @guaranteed @Sendable @callee_guaranteed (@guaranteed SendableKlass) -> ()) -> ()
+// CHECK:   [[PAI:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[Y_C]])
+
+// CHECK:   [[Z_C:%.*]] = copy_value [[Z]]
+// CHECK:   [[THUNK:%.*]] = function_ref @$s21attr_execution_silgen16NonSendableKlassCIeghg_ACIegHg_TRScMTU : $@convention(thin) @async (@guaranteed NonSendableKlass, @guaranteed @Sendable @callee_guaranteed (@guaranteed NonSendableKlass) -> ()) -> ()
+// CHECK:   [[PAI:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[Z_C]])
+
+// CHECK: } // end sil function '$s21attr_execution_silgen26conversionsFromSyncToAsyncyyyAA16NonSendableKlassCYbc_yAA0jK0CYbScMYccyADYbScMYcctYaF'
+
+func conversionsFromSyncToAsync(_ x: @escaping @Sendable (NonSendableKlass) -> Void,
+                                _ y: @escaping @MainActor @Sendable (SendableKlass) -> Void,
+                                _ z: @escaping @MainActor @Sendable (NonSendableKlass) -> Void) async {
+  let _: @execution(caller) (NonSendableKlass) async -> Void = x
+  let _: @execution(caller) (SendableKlass) async -> Void = y
+  let _: @execution(concurrent) (SendableKlass) async -> Void = y
+  let _: @execution(concurrent) (NonSendableKlass) async -> Void = z
+}


### PR DESCRIPTION
Specifically:

1. I made it so that thunks from caller -> concurrent properly ignore the
isolated parameter of the thunk when calling the concurrent function.

rdar://148112362

2. I made it so that thunks from concurrent -> caller properly create a
Optional<any Actor>.none and pass that into the caller function.

rdar://148112384

3. I made it so that in cases where we are assigning an @Sendable caller to a
non-sendable caller variable, we allow for the conversion as long as the
parameters/results are sendable as well.

rdar://148112532

4. I made it so that when we generate a thunk from @execution(caller) ->
@GlobalActor, we mangle in @GlobalActor into the thunk.

rdar://148112569

5. I discovered that due to the way we handle function conversion expr/decl ref
expr, we were emitted two thunks when we assigned a global @caller function to a
local @caller variable. The result is that we would first cast from @caller ->
@concurrent and then back to @caller. The result of this would be that the
@caller function would always be called on the global queue.

rdar://148112646

I also added a bunch of basic tests as well that showed that this behavior was
broken.

----

I did these in the same PR since I was basically iterating on writing simple code and found these issues. I have found some more issues that I am going to keep iterating/fixing.