### PR TITLE
Translate Fix-Its from the C++ diagnostics into swift-syntax diagnostics

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -544,6 +544,12 @@ public:
   BridgedDiagnosticArgument(BridgedStringRef s);
 };
 
+class BridgedFixIt {
+public:
+  BridgedCharSourceRange replacementRange;
+  BridgedStringRef replacementText;
+};
+
 class BridgedDiagnosticFixIt {
 public:
   int64_t storage[7];

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -33,7 +33,8 @@ void swift_ASTGen_addQueuedDiagnostic(
     BridgedStringRef categoryName,
     BridgedStringRef documentationPath,
     const BridgedCharSourceRange *_Nullable highlightRanges,
-    ptrdiff_t numHighlightRanges);
+    ptrdiff_t numHighlightRanges,
+    BridgedArrayRef /*BridgedFixIt*/ fixIts);
 void swift_ASTGen_renderQueuedDiagnostics(
     void *_Nonnull queued, ssize_t contextSize, ssize_t colorize,
     BridgedStringRef *_Nonnull renderedString);

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Bridging/ASTGen.h"
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
@@ -66,14 +67,19 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
   if (info.EducationalNotePaths.size() > 0)
     documentationPath = info.EducationalNotePaths[0];
 
-  // FIXME: Translate Fix-Its.
-  swift_ASTGen_addQueuedDiagnostic(queuedDiagnostics, perFrontendState,
-                                   text.str(),
-                                   severity, info.Loc,
-                                   info.Category,
-                                   documentationPath,
-                                   highlightRanges.data(),
-                                   highlightRanges.size());
+  SmallVector<BridgedFixIt, 2> fixIts;
+  for (const auto &fixIt : info.FixIts) {
+    fixIts.push_back(BridgedFixIt{ fixIt.getRange(), fixIt.getText() });
+  }
+
+  swift_ASTGen_addQueuedDiagnostic(
+      queuedDiagnostics, perFrontendState,
+      text.str(),
+      severity, info.Loc,
+      info.Category,
+      documentationPath,
+      highlightRanges.data(), highlightRanges.size(),
+      llvm::ArrayRef<BridgedFixIt>(fixIts));
 
   // TODO: A better way to do this would be to pass the notes as an
   // argument to `swift_ASTGen_addQueuedDiagnostic` but that requires

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -236,6 +236,14 @@ public func addQueuedSourceFile(
   queuedDiagnostics.pointee.sourceFileIDs[bufferID] = allocatedSourceFileID
 }
 
+private struct BridgedFixItMessage: FixItMessage {
+  var message: String { "" }
+
+  var fixItID: MessageID {
+    .init(domain: "SwiftCompiler", id: "BridgedFixIt")
+  }
+}
+
 /// Add a new diagnostic to the queue.
 @_cdecl("swift_ASTGen_addQueuedDiagnostic")
 public func addQueuedDiagnostic(
@@ -247,7 +255,8 @@ public func addQueuedDiagnostic(
   categoryName: BridgedStringRef,
   documentationPath: BridgedStringRef,
   highlightRangesPtr: UnsafePointer<BridgedCharSourceRange>?,
-  numHighlightRanges: Int
+  numHighlightRanges: Int,
+  fixItsUntyped: BridgedArrayRef
 ) {
   let queuedDiagnostics = queuedDiagnosticsPtr.assumingMemoryBound(
     to: QueuedDiagnostics.self
@@ -374,6 +383,34 @@ public func addQueuedDiagnostic(
     diagnosticState.pointee.referencedCategories.insert(category)
   }
 
+  // Map the Fix-Its
+  let fixItChanges: [FixIt.Change] = fixItsUntyped.withElements(ofType: BridgedFixIt.self) { fixIts in
+    fixIts.compactMap { fixIt in
+      guard let startPos = sourceFile.position(of: fixIt.replacementRange.start),
+            let endPos = sourceFile.position(
+              of: fixIt.replacementRange.start.advanced(
+                by: fixIt.replacementRange.byteLength)),
+      let sourceFileSyntax = sourceFile.syntax.as(SourceFileSyntax.self) else {
+        return nil
+      }
+
+      return FixIt.Change.textualReplacement(
+        replacementRange: startPos..<endPos,
+        sourceFile: sourceFileSyntax,
+        newText: String(bridged: fixIt.replacementText)
+      )
+    }
+  }
+
+  let fixIts: [FixIt] = fixItChanges.isEmpty
+      ? []
+      : [
+          FixIt(
+            message: BridgedFixItMessage(),
+            changes: fixItChanges
+          )
+        ]
+
   let diagnostic = Diagnostic(
     node: node,
     position: position,
@@ -382,7 +419,8 @@ public func addQueuedDiagnostic(
       severity: severity.asSeverity,
       category: category
     ),
-    highlights: highlights
+    highlights: highlights,
+    fixIts: fixIts
   )
 
   queuedDiagnostics.pointee.grouped.addDiagnostic(diagnostic)

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -389,15 +389,14 @@ public func addQueuedDiagnostic(
       guard let startPos = sourceFile.position(of: fixIt.replacementRange.start),
             let endPos = sourceFile.position(
               of: fixIt.replacementRange.start.advanced(
-                by: fixIt.replacementRange.byteLength)),
-      let sourceFileSyntax = sourceFile.syntax.as(SourceFileSyntax.self) else {
+                by: fixIt.replacementRange.byteLength)) else {
         return nil
       }
 
-      return FixIt.Change.textualReplacement(
-        replacementRange: startPos..<endPos,
-        sourceFile: sourceFileSyntax,
-        newText: String(bridged: fixIt.replacementText)
+      return FixIt.Change.replaceText(
+        range: startPos..<endPos,
+        with: String(bridged: fixIt.replacementText),
+        in: sourceFile.syntax
       )
     }
   }

--- a/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
@@ -217,13 +217,17 @@ extension SourceManager {
         )
         newText = replacingChildData.newChild.description
 
-      case .textualReplacement(replacementRange: let replacementRange, sourceFile: let sourceFile, newText: let replacementText):
+      case .replaceText(
+        range: let replacementRange,
+        with: let replacementText,
+        in: let syntax
+      ):
         replaceStartLoc = bridgedSourceLoc(
-          for: sourceFile,
+          for: syntax,
           at: replacementRange.lowerBound
         )
         replaceEndLoc = bridgedSourceLoc(
-          for: sourceFile,
+          for: syntax,
           at: replacementRange.upperBound
         )
         newText = replacementText

--- a/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
@@ -216,6 +216,17 @@ extension SourceManager {
           at: replacementRange.upperBound
         )
         newText = replacingChildData.newChild.description
+
+      case .textualReplacement(replacementRange: let replacementRange, sourceFile: let sourceFile, newText: let replacementText):
+        replaceStartLoc = bridgedSourceLoc(
+          for: sourceFile,
+          at: replacementRange.lowerBound
+        )
+        replaceEndLoc = bridgedSourceLoc(
+          for: sourceFile,
+          at: replacementRange.upperBound
+        )
+        newText = replacementText
       }
 
       newText.withBridgedString { bridgedMessage in


### PR DESCRIPTION
The swift-syntax diagnostic formatter doesn't actually print Fix-Its,
but at least they're available now.