### PR TITLE
Point educational notes at education notes / diagnostic groups markdown on GitHub

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2629,13 +2629,8 @@ static void configureDiagnosticEngine(
 
   std::string docsPath = Options.DiagnosticDocumentationPath;
   if (docsPath.empty()) {
-    // Default to a location relative to the compiler.
-    llvm::SmallString<128> docsPathBuffer(mainExecutablePath);
-    llvm::sys::path::remove_filename(docsPathBuffer); // Remove /swift
-    llvm::sys::path::remove_filename(docsPathBuffer); // Remove /bin
-    llvm::sys::path::append(docsPathBuffer, "share", "doc", "swift",
-                            "diagnostics");
-    docsPath = docsPathBuffer.str();
+    // Point at the latest Markdown documentation on GitHub.
+    docsPath = "https://github.com/swiftlang/swift/tree/main/userdocs/diagnostics";
   }
   Diagnostics.setDiagnosticDocumentationPath(docsPath);
 


### PR DESCRIPTION
Rather than pointing at a Markdown file in the toolchain directory by default, which won't render well immediately for most users, point at the sources on GitHub, which will render it properly and will still work from (e.g.) CI systems where the toolchain content might not be accessible.

Toolchain-aware diagnostic renders can look in the installed toolchain location (share/doc/swift/diagnostics) for the markdown files for that specific version of the markdown files.
