### PR TITLE
[Concurrency] When expanding `#isolation` create a type-checked type expr for global actors.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4210,8 +4210,7 @@ namespace {
         // Form a <global actor type>.shared reference.
         Type globalActorType = getDeclContext()->mapTypeIntoContext(
             isolation.getGlobalActor());
-        auto typeExpr = TypeExpr::createForDecl(
-            DeclNameLoc(loc), globalActorType->getAnyNominal(), dc);
+        auto typeExpr = TypeExpr::createImplicit(globalActorType, ctx);
         actorExpr = new (ctx) UnresolvedDotExpr(
             typeExpr, loc, DeclNameRef(ctx.Id_shared), DeclNameLoc(loc),
             /*implicit=*/false);

--- a/test/Concurrency/isolation_macro.swift
+++ b/test/Concurrency/isolation_macro.swift
@@ -63,7 +63,7 @@ func mainActorIsolated() {
   // CHECK-NEXT: inject_into_optional
   // CHECK-NEXT: erasure_expr
   // CHECK: member_ref_expr type="MainActor" location=@__swiftmacro_{{.*}} decl="_Concurrency.(file).MainActor.shared"
-  // CHECK-NEXT: type_expr type="MainActor.Type"
+  // CHECK-NEXT: type_expr implicit type="MainActor.Type"
   _ = #isolation
 }
 
@@ -126,3 +126,19 @@ func testContextualType() {
   await concreteActorIsolation()
 }
 #endif
+
+func isolationMacroDefault(
+  isolation: isolated (any Actor)? = #isolation,
+) async -> Void {}
+
+class C {
+  @globalActor
+  actor NestedActor {
+    static let shared = NestedActor()
+  }
+
+  @NestedActor
+  func expandIsolation() async {
+    await isolationMacroDefault()
+  }
+}


### PR DESCRIPTION
This eliminates a crash when type checking `#isolation` expansions for global actors nested in other types, because the `TypeExpr` does not properly represent the type repr for nested types. It's simpler to provide the type directly instead of going through type resolution.


Resolves: rdar://136028459