### PR TITLE
More `@abi` checking

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -380,21 +380,14 @@ public:
     /// valid if they match. 
     EquivalentInABIAttr = 1ull << 18,
 
-    /// Attribute can be used in an \c \@abi attribute, but must match
-    /// equivalent on API decl; if omitted, API decl's attribute will be 
-    /// cloned. Use where you would want to use \c EquivalentInABIAttr but 
-    /// repeating the attribute is judged too burdensome.
-    InferredInABIAttr = 1ull << 19,
-
     /// Use for attributes which are \em only valid on declarations that cannot
     /// have an \c @abi attribute, such as \c ImportDecl .
-    UnreachableInABIAttr = 1ull << 20,
+    UnreachableInABIAttr = 1ull << 19,
   };
 
   enum : uint64_t {
     InABIAttrMask = ForbiddenInABIAttr | UnconstrainedInABIAttr
-                  | EquivalentInABIAttr | InferredInABIAttr
-                  | UnreachableInABIAttr
+                  | EquivalentInABIAttr | UnreachableInABIAttr
   };
 
   LLVM_READNONE

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -456,7 +456,7 @@ DECL_ATTR(_dynamicReplacement, DynamicReplacement,
 
 SIMPLE_DECL_ATTR(_borrowed, Borrowed,
   OnVar | OnSubscript,
-  UserInaccessible | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | InferredInABIAttr,
+  UserInaccessible | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   81)
 
 DECL_ATTR(_private, PrivateImport,

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -163,7 +163,7 @@ SIMPLE_DECL_ATTR(unsafe_no_objc_tagged_pointer, UnsafeNoObjCTaggedPointer,
 
 DECL_ATTR(inline, Inline,
   OnVar | OnSubscript | OnAbstractFunction,
-  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | InferredInABIAttr,
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   20)
 
 DECL_ATTR(_semantics, Semantics,
@@ -193,7 +193,7 @@ CONTEXTUAL_SIMPLE_DECL_ATTR(postfix, Postfix,
 
 SIMPLE_DECL_ATTR(_transparent, Transparent,
   OnFunc | OnAccessor | OnConstructor | OnVar | OnDestructor,
-  UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | InferredInABIAttr,
+  UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   26)
 
 SIMPLE_DECL_ATTR(requires_stored_property_inits, RequiresStoredPropertyInits,
@@ -216,7 +216,7 @@ SIMPLE_DECL_ATTR(_fixed_layout, FixedLayout,
 
 SIMPLE_DECL_ATTR(inlinable, Inlinable,
   OnVar | OnSubscript | OnAbstractFunction,
-  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | InferredInABIAttr,
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   32)
 
 DECL_ATTR(_specialize, Specialize,
@@ -466,7 +466,7 @@ DECL_ATTR(_private, PrivateImport,
 
 SIMPLE_DECL_ATTR(_alwaysEmitIntoClient, AlwaysEmitIntoClient,
   OnVar | OnSubscript | OnAbstractFunction,
-  UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | InferredInABIAttr,
+  UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   83)
 
 SIMPLE_DECL_ATTR(_implementationOnly, ImplementationOnly,

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -143,7 +143,7 @@ SIMPLE_DECL_ATTR(NSManaged, NSManaged,
 
 CONTEXTUAL_SIMPLE_DECL_ATTR(lazy, Lazy,
   OnVar,
-  DeclModifier | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | InferredInABIAttr,
+  DeclModifier | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | UnconstrainedInABIAttr,
   16)
 
 SIMPLE_DECL_ATTR(LLDBDebuggerFunction, LLDBDebuggerFunction,

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1571,6 +1571,11 @@ ERROR(attr_unsupported_on_target, none,
 ERROR(attr_name_unsupported_on_target, none,
       "attribute '%0' is unsupported on target '%1'", (StringRef, StringRef))
 
+// abi attribute
+ERROR(attr_abi_incompatible_kind,none,
+      "cannot use %0 in '@abi'",
+      (DescriptiveDeclKind))
+
 // availability
 ERROR(attr_availability_platform,none,
       "expected platform name or '*' for '%0' attribute", (StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8467,9 +8467,6 @@ ERROR(attr_abi_extra_attr,none,
 ERROR(attr_abi_forbidden_attr,none,
       "unused '%0' %select{attribute|modifier}1 in '@abi'",
       (StringRef, bool))
-REMARK(abi_attr_inferred_attribute,none,
-       "inferred '%0' in '@abi' to match %select{attribute|modifier}1 on API",
-       (StringRef, bool))
 
 ERROR(attr_abi_mismatched_attr,none,
       "'%0' %select{attribute|modifier}1 in '@abi' should match '%2'",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8512,6 +8512,9 @@ ERROR(attr_abi_no_default_arguments,none,
 ERROR(attr_abi_no_macros,none,
       "%kind0 cannot be expanded in '@abi' attribute",
       (Decl *))
+ERROR(attr_abi_no_lazy,none,
+      "'lazy' is not compatible with '@abi' attribute",
+      ())
 
 // These macros insert 'final', 'non-final', or nothing depending on both the
 // current decl and its counterpart, such that 'non-final' is used if the

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7457,7 +7457,7 @@ ERROR(property_wrapper_effectful,none,
 
 ERROR(property_with_wrapper_conflict_attribute,none,
       "property %0 with a wrapper cannot also be "
-      "%select{lazy|@NSCopying|@NSManaged|weak|unowned|unmanaged}1",
+      "%select{lazy|@NSCopying|@NSManaged|@abi|weak|unowned|unmanaged}1",
       (Identifier, int))
 ERROR(property_wrapper_not_single_var, none,
       "property wrapper can only apply to a single variable", ())
@@ -8507,6 +8507,10 @@ ERROR(attr_abi_mismatched_param_modifier,none,
 ERROR(attr_abi_no_default_arguments,none,
       "%kind0 in '@abi' should not have a default argument; it does not "
       "affect the parameter's ABI",
+      (Decl *))
+
+ERROR(attr_abi_no_macros,none,
+      "%kind0 cannot be expanded in '@abi' attribute",
       (Decl *))
 
 // These macros insert 'final', 'non-final', or nothing depending on both the

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -269,9 +269,6 @@ namespace swift {
     /// Emit a remark on early exit in explicit interface build
     bool EnableSkipExplicitInterfaceModuleBuildRemarks = false;
 
-    /// Emit a remark when \c \@abi infers an attribute or modifier.
-    bool EnableABIInferenceRemarks = false;
-
     ///
     /// Support for alternate usage modes
     ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -468,10 +468,6 @@ def remark_module_serialization : Flag<["-"], "Rmodule-serialization">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit remarks about module serialization">;
 
-def remark_abi_inference : Flag<["-"], "Rabi-inference">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Emit a remark when an '@abi' attribute adds an attribute or modifier to the ABI declaration based on its presence in the API">;
-
 def emit_tbd : Flag<["-"], "emit-tbd">,
   HelpText<"Emit a TBD file">,
   Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -61,7 +61,7 @@ static_assert(IsTriviallyDestructible<DeclAttributes>::value,
                 DeclAttribute::APIBreakingToRemove | DeclAttribute::APIStableToRemove), \
                 #Name " needs to specify either APIBreakingToRemove or APIStableToRemove"); \
   static_assert(DeclAttribute::hasOneBehaviorFor##Id(DeclAttribute::InABIAttrMask), \
-                #Name " needs to specify exactly one of ForbiddenInABIAttr, UnconstrainedInABIAttr, EquivalentInABIAttr, InferredInABIAttr, or UnreachableInABIAttr");
+                #Name " needs to specify exactly one of ForbiddenInABIAttr, UnconstrainedInABIAttr, EquivalentInABIAttr, or UnreachableInABIAttr");
 #include "swift/AST/DeclAttr.def"
 
 #define TYPE_ATTR(_, Id)                                                       \

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -709,8 +709,12 @@ FeatureSet swift::getUniqueFeaturesUsed(Decl *decl) {
   // Remove all the features used by all enclosing declarations.
   Decl *enclosingDecl = decl;
   while (!features.empty()) {
+    // If we were in an @abi attribute, collect from the API counterpart.
+    auto abiRole = ABIRoleInfo(enclosingDecl);
+    if (!abiRole.providesAPI() && abiRole.getCounterpart())
+      enclosingDecl = abiRole.getCounterpart();
     // Find the next outermost enclosing declaration.
-    if (auto accessor = dyn_cast<AccessorDecl>(enclosingDecl))
+    else if (auto accessor = dyn_cast<AccessorDecl>(enclosingDecl))
       enclosingDecl = accessor->getStorage();
     else
       enclosingDecl = enclosingDecl->getDeclContext()->getAsDecl();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2317,6 +2317,13 @@ void NominalTypeDecl::recordObjCMethod(AbstractFunctionDecl *method,
   if (!ObjCMethodLookup && !createObjCMethodLookup())
     return;
 
+  // Only record API decls.
+  Decl *abiRoleDecl = method;
+  if (auto accessor = dyn_cast<AccessorDecl>(method))
+    abiRoleDecl = accessor->getStorage();
+  if (!ABIRoleInfo(abiRoleDecl).providesAPI())
+    return;
+
   // Record the method.
   bool isInstanceMethod = method->isObjCInstanceMethod();
   auto &vec = (*ObjCMethodLookup)[{selector, isInstanceMethod}].Methods;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1422,8 +1422,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableSkipExplicitInterfaceModuleBuildRemarks = Args.hasArg(OPT_remark_skip_explicit_interface_build);
 
-  Opts.EnableABIInferenceRemarks = Args.hasArg(OPT_remark_abi_inference);
-
   if (Args.hasArg(OPT_experimental_skip_non_exportable_decls)) {
     // Only allow -experimental-skip-non-exportable-decls if either library
     // evolution is enabled (in which case the module's ABI is independent of

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1110,6 +1110,11 @@ void AttributeChecker::visitLazyAttr(LazyAttr *attr) {
   // are already lazily initialized).
   if (VD->isStatic() || varDC->isModuleScopeContext())
     diagnoseAndRemoveAttr(attr, diag::lazy_on_already_lazy_global);
+
+  // 'lazy' can't be used in or with `@abi` because it has auxiliary decls.
+  auto abiRole = ABIRoleInfo(D);
+  if (!abiRole.providesABI() || !abiRole.providesAPI())
+    diagnoseAndRemoveAttr(attr, diag::attr_abi_no_lazy);
 }
 
 bool AttributeChecker::visitAbstractAccessControlAttr(

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4406,6 +4406,12 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
         }
       }
 
+      // Macros can't be attached to ABI-only decls. (If we diagnosed above,
+      // don't bother with this.)
+      if (attr->isValid() && !ABIRoleInfo(D).providesAPI()) {
+        diagnoseAndRemoveAttr(attr, diag::attr_abi_no_macros, macro);
+      }
+
       return;
     }
 
@@ -4487,16 +4493,25 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   // function, storage with an explicit getter, or parameter of function type.
   if (nominal->getAttrs().hasAttribute<ResultBuilderAttr>()) {
     ValueDecl *decl;
+    ValueDecl *abiRelevantDecl;
     if (auto param = dyn_cast<ParamDecl>(D)) {
       decl = param;
+      abiRelevantDecl = dyn_cast<ValueDecl>(
+                            param->getDeclContext()->getAsDecl());
     } else if (auto func = dyn_cast<FuncDecl>(D)) {
       decl = func;
+      abiRelevantDecl = func;
     } else if (auto storage = dyn_cast<AbstractStorageDecl>(D)) {
       decl = storage;
+      abiRelevantDecl = storage;
 
       // Check whether this is a storage declaration that is not permitted
       // to have a result builder attached.
       auto shouldDiagnose = [&]() -> bool {
+        // We'll diagnose use in @abi later.
+        if (!ABIRoleInfo(abiRelevantDecl).providesAPI())
+          return false;
+
         // An uninitialized stored property in a struct can have a function
         // builder attached.
         if (auto var = dyn_cast<VarDecl>(decl)) {
@@ -4537,6 +4552,14 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
                diag::result_builder_attribute_not_allowed_here,
                nominal->getName());
       attr->setInvalid();
+      return;
+    }
+
+    // Result builders shouldn't be applied to an ABI-only decl because they
+    // have no ABI effect.
+    if (!ABIRoleInfo(abiRelevantDecl).providesAPI()) {
+      diagnoseAndRemoveAttr(attr, diag::attr_abi_forbidden_attr,
+                            nominal->getNameStr(), /*isModifier=*/false);
       return;
     }
 

--- a/lib/Sema/TypeCheckAttrABI.cpp
+++ b/lib/Sema/TypeCheckAttrABI.cpp
@@ -880,26 +880,6 @@ public:
 
       return false;
 
-    case DeclAttribute::InferredInABIAttr:
-      if (!abi && api->canClone()) {
-        // Infer an identical attribute.
-        abi = api->clone(ctx);
-        abi->setImplicit(true);
-        abiDecl->getAttrs().add(abi);
-
-        if (ctx.LangOpts.EnableABIInferenceRemarks) {
-          SmallString<64> scratch;
-          auto abiAttrAsString = printAttr(abi, abiDecl, scratch);
-
-          abiDecl->diagnose(diag::abi_attr_inferred_attribute,
-                            abiAttrAsString, api->isDeclModifier());
-          noteAttrHere(api, apiDecl, /*isMatch=*/true);
-        }
-      }
-
-      // Other than the cloning behavior, Inferred behaves like Equivalent.
-      LLVM_FALLTHROUGH;
-
     case DeclAttribute::EquivalentInABIAttr:
       // Diagnose if API doesn't have attribute.
       if (!api) {

--- a/lib/Sema/TypeCheckAttrABI.cpp
+++ b/lib/Sema/TypeCheckAttrABI.cpp
@@ -1152,6 +1152,7 @@ void checkABIAttrPBD(PatternBindingDecl *APBD, VarDecl *VD) {
   }
 
   // Check that each pattern has the same number of variables.
+  bool didDiagnose = false;
   for (auto i : range(PBD->getNumPatternEntries())) {
     SmallVector<VarDecl *, 8> VDs;
     SmallVector<VarDecl *, 8> AVDs;
@@ -1161,18 +1162,24 @@ void checkABIAttrPBD(PatternBindingDecl *APBD, VarDecl *VD) {
 
     if (VDs.size() < AVDs.size()) {
       for (auto AVD : drop_begin(AVDs, VDs.size())) {
-        AVD->diagnose(diag::attr_abi_mismatched_var,
-                      AVD, /*isABI=*/true);
+        AVD->diagnose(diag::attr_abi_mismatched_var, AVD, /*isABI=*/true);
+        didDiagnose = true;
       }
     }
     else if (VDs.size() > AVDs.size()) {
       for (auto VD : drop_begin(VDs, AVDs.size())) {
-        VD->diagnose(diag::attr_abi_mismatched_var,
-                     VD, /*isABI=*/false);
+        VD->diagnose(diag::attr_abi_mismatched_var, VD, /*isABI=*/false);
+        didDiagnose = true;
       }
     }
   }
+  if (didDiagnose)
+    return;
+
+  // Check the ABI PBD--this is what checks the underlying vars.
+  TypeChecker::typeCheckDecl(APBD);
 }
+
 } // end anonymous namespace
 
 void TypeChecker::checkDeclABIAttribute(Decl *D, ABIAttr *attr) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -618,15 +618,15 @@ static void checkGenericParams(GenericContext *ownerCtx) {
 /// Returns \c true if \p current and \p other are in the same source file
 /// \em and \c current appears before \p other in that file.
 static bool isBeforeInSameFile(Decl *current, Decl *other) {
-  if (current->getDeclContext()->getParentSourceFile() !=
-                  other->getDeclContext()->getParentSourceFile())
+  if (current->getDeclContext()->getOutermostParentSourceFile() !=
+                  other->getDeclContext()->getOutermostParentSourceFile())
     return false;
 
-  if (!current->getLoc().isValid())
+  if (current->getLoc().isInvalid() || other->getLoc().isInvalid())
     return false;
 
   return current->getASTContext().SourceMgr
-                        .isBeforeInBuffer(current->getLoc(), other->getLoc());
+                        .isBefore(current->getLoc(), other->getLoc());
 }
 
 template <typename T>

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1395,6 +1395,12 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
     }
   }
 
+  // Macros are so spectacularly not valid in an `@abi` attribute that we cannot
+  // even attempt to expand them.
+  if (!ABIRoleInfo(attachedTo).providesAPI()) {
+    return nullptr;
+  }
+
   ASTContext &ctx = dc->getASTContext();
 
   auto moduleDecl = dc->getParentModule();

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -481,11 +481,15 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
       continue;
     }
 
+    auto abiRole = ABIRoleInfo(var);
+    bool hasOrIsABI = !abiRole.providesAPI() || !abiRole.providesABI();
+
     // Note: Getting the semantic attrs here would trigger a request cycle.
     auto attachedAttrs = var->getAttrs();
 
     // Check for conflicting attributes.
-    if (attachedAttrs.hasAttribute<LazyAttr>() ||
+    if (hasOrIsABI ||
+        attachedAttrs.hasAttribute<LazyAttr>() ||
         attachedAttrs.hasAttribute<NSCopyingAttr>() ||
         attachedAttrs.hasAttribute<NSManagedAttr>() ||
         (attachedAttrs.hasAttribute<ReferenceOwnershipAttr>() &&
@@ -498,9 +502,11 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
         whichKind = 1;
       else if (attachedAttrs.hasAttribute<NSManagedAttr>())
         whichKind = 2;
+      else if (hasOrIsABI)
+        whichKind = 3;
       else {
         auto attr = attachedAttrs.getAttribute<ReferenceOwnershipAttr>();
-        whichKind = 2 + static_cast<unsigned>(attr->get());
+        whichKind = 3 + static_cast<unsigned>(attr->get());
       }
       var->diagnose(diag::property_with_wrapper_conflict_attribute,
                     var->getName(), whichKind);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -849,6 +849,10 @@ IsSetterMutatingRequest::evaluate(Evaluator &evaluator,
 OpaqueReadOwnership
 OpaqueReadOwnershipRequest::evaluate(Evaluator &evaluator,
                                      AbstractStorageDecl *storage) const {
+  auto abiRole = ABIRoleInfo(storage);
+  if (!abiRole.providesAPI() && abiRole.getCounterpart())
+    return abiRole.getCounterpart()->getOpaqueReadOwnership();
+
   enum class DiagKind {
     BorrowedAttr,
     NoncopyableType

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3888,6 +3888,10 @@ void HasStorageRequest::cacheResult(bool hasStorage) const {
 StorageImplInfo
 StorageImplInfoRequest::evaluate(Evaluator &evaluator,
                                  AbstractStorageDecl *storage) const {
+  auto abiRole = ABIRoleInfo(storage);
+  if (!abiRole.providesAPI() && abiRole.getCounterpart())
+    return abiRole.getCounterpart()->getImplInfo();
+
   if (auto *param = dyn_cast<ParamDecl>(storage)) {
     return StorageImplInfo::getSimpleStored(
       param->isImmutableInFunctionBody()

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -134,6 +134,24 @@ class HasStoredPropertyClassInvalid {
   #AddStoredProperty((Self.self, 0).1) // expected-note {{in expansion of macro 'AddStoredProperty' here}}
   // CHECK-DIAGS: @__swiftmacro_9MacroUser0023macro_expandswift_elFCffMX[[@LINE-2]]_2_33_{{.*}}AddStoredPropertyfMf_.swift:1:22: error: covariant 'Self' type cannot be referenced from a stored property initializer
 }
+
+// Redeclaration checking should behave as though expansions are part of the
+// source file.
+struct RedeclChecking {
+  #varValue
+
+  // expected-error@+1 {{invalid redeclaration of 'value'}}
+  var value: Int { 0 }
+}
+
+// CHECK-DIAGS: macro_expand.swift:[[@LINE-3]]:7: error: invalid redeclaration of 'value'
+// CHECK-DIAGS: @__swiftmacro_9MacroUser0023macro_expandswift_elFCffMX[[@LINE-8]]_2_33_4361AD9339943F52AE6186DD51E04E91Ll8varValuefMf_.swift:1:5: note: 'value' previously declared here
+// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser0023macro_expandswift_elFCffMX[[@LINE-9]]_2_33_4361AD9339943F52AE6186DD51E04E91Ll8varValuefMf_.swift:
+// CHECK-DIAGS: var value: Int {
+// CHECK-DIAGS:     1
+// CHECK-DIAGS: }
+// CHECK-DIAGS: END CONTENTS OF FILE
+
 #endif
 
 @freestanding(declaration)

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -85,6 +85,20 @@ public struct MutatingTest {
 @abi(func abiSpiFunc())
 @_spi(spiGroup) public func abiSpiFunc() {}
 
+// We should print feature guards outside, but not inside, an @abi attribute.
+@abi(func sendingABI() -> sending Any?)
+public func sendingABI() -> Any? { nil }
+// CHECK: #if {{.*}} && $ABIAttribute
+// CHECK: @abi(func sendingABI() -> sending Any?)
+// CHECK: public func sendingABI() -> Any?
+// CHECK: #elseif {{.*}} && $SendingArgsAndResults
+// CHECK: @_silgen_name("$s5attrs10sendingABIypSgyF")
+// CHECK: public func sendingABI() -> Any?
+// CHECK: #else
+// CHECK: @_silgen_name("$s5attrs10sendingABIypSgyF")
+// CHECK: public func sendingABI() -> Any?
+// CHECK: #endif
+
 @concurrent
 public func testExecutionConcurrent() async {}
 // CHECK: @concurrent public func testExecutionConcurrent() async

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -enable-experimental-feature ABIAttribute -enable-experimental-feature AddressableParameters -enable-experimental-feature NoImplicitCopy -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature StrictMemorySafety -enable-experimental-feature LifetimeDependence -enable-experimental-feature CImplementation -import-bridging-header %S/Inputs/attr_abi.h -parse-as-library -Rabi-inference -debugger-support
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -enable-experimental-feature ABIAttribute -enable-experimental-feature AddressableParameters -enable-experimental-feature NoImplicitCopy -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature StrictMemorySafety -enable-experimental-feature LifetimeDependence -enable-experimental-feature CImplementation -import-bridging-header %S/Inputs/attr_abi.h -parse-as-library -debugger-support
 
 // REQUIRES: swift_feature_ABIAttribute
 // REQUIRES: swift_feature_AddressableParameters
@@ -2034,15 +2034,15 @@ extension DynamicReplacement {
 
 // @_weakLinked -- tested in attr/attr_weaklinked.swift
 
-// @_borrowed -- automatically cloned into @abi
+// @_borrowed -- banned in @abi
 protocol BorrowedAttr {
-  @abi(@_borrowed var v1: Int)
+  @abi(@_borrowed var v1: Int) // expected-error {{unused '_borrowed' attribute in '@abi'}} {{8-18=}}
   @_borrowed var v1: Int { get set }
 
-  @abi(var v2: Int) // expected-remark {{inferred '@_borrowed' in '@abi' to match attribute on API}}
-  @_borrowed var v2: Int { get set } // expected-note {{matches attribute here}}
+  @abi(var v2: Int)
+  @_borrowed var v2: Int { get set }
 
-  @abi(@_borrowed var v3: Int) // expected-error {{extra '_borrowed' attribute in '@abi'}} {{8-18=}}
+  @abi(@_borrowed var v3: Int) // expected-error {{unused '_borrowed' attribute in '@abi'}} {{8-18=}}
   var v3: Int { get set }
 }
 

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1946,16 +1946,17 @@ class Required {
   required init(i3: Void) { fatalError() } // expected-note {{should match modifier here}}
 }
 
-// lazy -- automatically cloned into @abi
+// lazy -- banned both in and with @abi
+// This introduces auxiliary decls whose ABI could not be controlled.
 class Lazy {
-  @abi(lazy var v1: Int)
-  lazy var v1: Int = 0
+  @abi(lazy var v1: Int) // expected-error {{'lazy' is not compatible with '@abi' attribute}} {{8-12=}}
+  lazy var v1: Int = 0 // expected-error {{'lazy' is not compatible with '@abi' attribute}} {{3-8=}}
 
-  @abi(lazy var v2: Int) // expected-error {{extra 'lazy' modifier in '@abi'}} {{8-12=}}
+  @abi(lazy var v2: Int) // expected-error {{'lazy' is not compatible with '@abi' attribute}} {{8-12=}}
   var v2: Int = 0
 
-  @abi(var v3: Int) // expected-remark {{inferred 'lazy' in '@abi' to match modifier on API}}
-  lazy var v3: Int = 0 // expected-note {{matches modifier here}}
+  @abi(var v3: Int)
+  lazy var v3: Int = 0 // expected-error {{'lazy' is not compatible with '@abi' attribute}} {{3-8=}}
 }
 
 // @_fixed_layout -- banned in @abi

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1285,6 +1285,7 @@ struct CustomAttrPropertyWrapper {
 }
 
 // CustomAttr for attached macro -- see Macros/macro_expand_peers.swift
+// Freestanding macro in @abi -- see Macros/macro_expand.swift
 
 // CustomAttr for result builder -- banned in '@abi'
 // Has no ABI impact on either a parameter or a decl.

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1868,45 +1868,48 @@ func section2() {}
 @abi(func section3())
 @_section("fnord") func section3() {}
 
-// @inlinable -- automatically cloned into @abi
-@abi(@inlinable func inlinable1())
+// @inlinable -- banned in @abi
+// Although the inlining *does* occasionally get mangled, it's only done in the
+// SpecializationManglers, which shouldn't get their serialization from an ABI
+// attribute.
+@abi(@inlinable func inlinable1()) // expected-error {{unused 'inlinable' attribute in '@abi'}} {{6-16=}}
 @inlinable func inlinable1() {}
 
-@abi(@inlinable func inlinable2()) // expected-error {{extra 'inlinable' attribute in '@abi'}} {{6-16=}}
+@abi(@inlinable func inlinable2()) // expected-error {{unused 'inlinable' attribute in '@abi'}} {{6-16=}}
 func inlinable2() {}
 
-@abi(func inlinable3()) // expected-remark {{inferred '@inlinable' in '@abi' to match attribute on API}}
-@inlinable func inlinable3() {} // expected-note {{matches attribute here}}
+@abi(func inlinable3())
+@inlinable func inlinable3() {}
 
-// @inline -- automatically cloned into @abi
-@abi(@inline(never) func inline1())
+// @inlinable -- banned in @abi
+@abi(@inline(never) func inline1()) // expected-error {{unused 'inline(never)' attribute in '@abi'}} {{6-20=}}
 @inline(never) func inline1() {}
 
-@abi(@inline(never) func inline2()) // expected-error {{extra 'inline(never)' attribute in '@abi'}} {{6-20=}}
+@abi(@inline(never) func inline2()) // expected-error {{unused 'inline(never)' attribute in '@abi'}} {{6-20=}}
 func inline2() {}
 
-@abi(func inline3()) // expected-remark {{inferred '@inline(never)' in '@abi' to match attribute on API}}
-@inline(never) func inline3() {} // expected-note {{matches attribute here}}
+@abi(func inline3())
+@inline(never) func inline3() {}
 
-// @_transparent -- automatically cloned into @abi
-@abi(@_transparent func transparent1())
+// @_transparent -- banned in @abi
+@abi(@_transparent func transparent1()) // expected-error {{unused '_transparent' attribute in '@abi'}} {{6-19=}}
 @_transparent func transparent1() {}
 
-@abi(@_transparent func transparent2()) // expected-error {{extra '_transparent' attribute in '@abi'}} {{6-19=}}
+@abi(@_transparent func transparent2()) // expected-error {{unused '_transparent' attribute in '@abi'}} {{6-19=}}
 func transparent2() {}
 
-@abi(func transparent3()) // expected-remark {{inferred '@_transparent' in '@abi' to match attribute on API}}
-@_transparent func transparent3() {} // expected-note {{matches attribute here}}
+@abi(func transparent3())
+@_transparent func transparent3() {}
 
-// @_alwaysEmitIntoClient -- automatically cloned into @abi
-@abi(@_alwaysEmitIntoClient func alwaysEmitIntoClient1())
+// @_alwaysEmitIntoClient -- banned in @abi
+@abi(@_alwaysEmitIntoClient func alwaysEmitIntoClient1()) // expected-error {{unused '_alwaysEmitIntoClient' attribute in '@abi'}} {{6-28=}}
 @_alwaysEmitIntoClient func alwaysEmitIntoClient1() {}
 
-@abi(@_alwaysEmitIntoClient func alwaysEmitIntoClient2()) // expected-error {{extra '_alwaysEmitIntoClient' attribute in '@abi'}} {{6-28=}}
+@abi(@_alwaysEmitIntoClient func alwaysEmitIntoClient2()) // expected-error {{unused '_alwaysEmitIntoClient' attribute in '@abi'}} {{6-28=}}
 func alwaysEmitIntoClient2() {}
 
-@abi(func alwaysEmitIntoClient3()) // expected-remark {{inferred '@_alwaysEmitIntoClient' in '@abi' to match attribute on API}}
-@_alwaysEmitIntoClient func alwaysEmitIntoClient3() {} // expected-note {{matches attribute here}}
+@abi(func alwaysEmitIntoClient3())
+@_alwaysEmitIntoClient func alwaysEmitIntoClient3() {}
 
 // @_optimize(none) -- banned in @abi
 @abi(@_optimize(none) func optimize1()) // expected-error {{unused '_optimize(none)' attribute in '@abi'}} {{6-22=}}

--- a/test/attr/attr_abi_objc.swift
+++ b/test/attr/attr_abi_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ABIAttribute -parse-as-library -Rabi-inference
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ABIAttribute -parse-as-library
 
 // REQUIRES: swift_feature_ABIAttribute
 // REQUIRES: objc_interop


### PR DESCRIPTION
This PR refines the `@abi` checking added in #79466 in several ways:

* Fixes a bug where ABI-only `VarDecl`s in the primary file were not fully checked
* Adds specific behaviors for various uses of `CustomAttr`:
  * Global actor isolation attributes are permitted in `@abi` and may vary from the API counterpart
  * Result builder attributes are forbidden in `@abi` (they have no ABI impact)
  * Property wrapper attributes are forbidden both in `@abi` and on an API counterpart (more design is needed to control the ABI of the auxiliary declarations)
  * Attached macros are forbidden in `@abi` (ABI-only decls have no peers or members)
* Bans freestanding macros in the parser in `@abi`, matching SwiftParser's behavior
* Forbids `lazy` both in `@abi` and on an API counterpart (like property wrapper attributes, more design is needed to control the ABI of auxiliary declarations)
* Removes a poorly-designed attribute cloning behavior, making the attributes that used it non-ABI instead:
  * `@inlinable` and other inlining attributes
  * `@_borrowed`

These changes bring the implementation into alignment with the [revised `@abi` proposal](https://github.com/swiftlang/swift-evolution/pull/2768).

Note that the macro expansion tests in this PR will require a matching SwiftSyntax PR that makes SwiftParser parse `@abi` attributes even when the experimental feature is turned off; the recovery behavior without that patch is just too catastrophic for macro tests to emit sensible diagnostics. See https://github.com/swiftlang/swift-syntax/pull/3026.

**Reviewers**: This PR is a bit of a grab bag. You may find that the easiest way to review it is commit-by-commit, reading the individual commit message before the diff so you'll understand the intent of each change.