### PR TITLE
Prohibit isolated conformances for checked casts to potentially-SendableMetatype types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8467,9 +8467,6 @@ NOTE(note_isolate_conformance_to_global_actor,none,
 NOTE(note_depends_on_isolated_conformance,none,
      "conformance depends on %0 conformance of %1 to %kind2",
      (ActorIsolation, Type, const ValueDecl *))
-ERROR(nonisolated_conformance_depends_on_isolated_conformance,none,
-      "conformance of %0 to %1 depends on %2 conformance of %3 to %4; mark it as '%5'",
-      (Type, DeclName, ActorIsolation, Type, DeclName, StringRef))
 ERROR(isolated_conformance_with_sendable,none,
       "%4 conformance of %0 to %1 cannot satisfy conformance "
       "requirement for a %select{`Sendable`|`SendableMetatype`}2 type "

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -488,9 +488,6 @@ ADOPTABLE_EXPERIMENTAL_FEATURE(AsyncCallerExecution, false)
 /// Allow custom availability domains to be defined and referenced.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CustomAvailability, true)
 
-/// Be strict about the Sendable conformance of metatypes.
-EXPERIMENTAL_FEATURE(StrictSendableMetatypes, true)
-
 /// Allow public enumerations to be extensible by default
 /// regardless of whether the module they are declared in
 /// is resilient or not.

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -387,10 +387,10 @@ static ProtocolConformanceRef getBuiltinMetaTypeTypeConformance(
   if (auto kp = protocol->getKnownProtocolKind()) {
     switch (*kp) {
     case KnownProtocolKind::Sendable:
-      // Metatypes are generally Sendable, but under StrictSendableMetatypes we
+      // Metatypes are generally Sendable, but with isolated conformances we
       // cannot assume that metatypes based on type parameters are Sendable.
       // Therefore, check for conformance to SendableMetatype.
-      if (ctx.LangOpts.hasFeature(Feature::StrictSendableMetatypes)) {
+      if (ctx.LangOpts.hasFeature(Feature::IsolatedConformances)) {
         auto sendableMetatypeProto = 
             ctx.getProtocol(KnownProtocolKind::SendableMetatype);
         if (sendableMetatypeProto) {

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -276,7 +276,6 @@ UNINTERESTING_FEATURE(NonfrozenEnumExhaustivity)
 UNINTERESTING_FEATURE(ClosureIsolation)
 UNINTERESTING_FEATURE(Extern)
 UNINTERESTING_FEATURE(ConsumeSelfInDeinit)
-UNINTERESTING_FEATURE(StrictSendableMetatypes)
 
 static bool usesFeatureBitwiseCopyable2(Decl *decl) {
   if (!decl->getModuleContext()->isStdlibModule()) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3011,7 +3011,7 @@ namespace {
       // FIXME: When passing to a sending parameter, should this be handled
       // by region isolation? Or should it always be handled by region
       // isolation?
-      if (ctx.LangOpts.hasFeature(Feature::StrictSendableMetatypes) &&
+      if (ctx.LangOpts.hasFeature(Feature::IsolatedConformances) &&
           (mayExecuteConcurrentlyWith(
               localFunc.getAsDeclContext(), getDeclContext()) ||
            (explicitClosure && explicitClosure->isPassedToSendingParameter()))) {

--- a/test/Concurrency/isolated_conformance_inference.swift
+++ b/test/Concurrency/isolated_conformance_inference.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances -enable-experimental-feature InferIsolatedConformances %s
+
+// REQUIRES: swift_feature_IsolatedConformances
+// REQUIRES: swift_feature_InferIsolatedConformances
+// REQUIRES: concurrency
+
+protocol P {
+  func f()
+}
+
+@SomeGlobalActor
+protocol Q {
+  func g()
+}
+
+@globalActor
+actor SomeGlobalActor {
+  static let shared = SomeGlobalActor()
+}
+
+@SomeGlobalActor
+protocol R {
+  func h()
+}
+
+@SomeGlobalActor
+class CExplicit: P {
+  func f() { } // okay! conformance above is isolated
+}
+
+// If the protocol itself is isolated, don't do anything.
+extension CExplicit: Q {
+  func g() { }
+}
+
+// expected-error@+3{{conformance of 'CNonIsolated' to protocol 'P' crosses into global actor 'SomeGlobalActor'-isolated code and can cause data races}}
+// expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
+// expected-note@+1{{isolate this conformance to the global actor 'SomeGlobalActor' with '@SomeGlobalActor'}}{{33-33=@SomeGlobalActor }}
+nonisolated class CNonIsolated: P {
+  @SomeGlobalActor func f() { } // expected-note{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
+}
+
+func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }
+func acceptSendableQMeta<T: Sendable & Q>(_: T.Type) { }
+
+nonisolated func testConformancesFromNonisolated() {
+  let _: any P = CExplicit() // expected-error{{global actor 'SomeGlobalActor'-isolated conformance of 'CExplicit' to 'P' cannot be used in nonisolated context}}
+
+  let _: any P = CNonIsolated()
+
+  // Okay, these are nonisolated conformances.
+  let _: any Q = CExplicit()
+}

--- a/test/Concurrency/isolated_conformance_sil.swift
+++ b/test/Concurrency/isolated_conformance_sil.swift
@@ -1,7 +1,4 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -Xllvm -sil-print-types -emit-silgen -enable-experimental-feature IsolatedConformances -verify %s | %FileCheck %s
-
-// REQUIRES: swift_feature_IsolatedConformances
-// REQUIRES: concurrency
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -Xllvm -sil-print-types -emit-silgen -verify %s | %FileCheck %s
 
 protocol P { }
 

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature StrictSendableMetatypes -emit-sil -o /dev/null
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature IsolatedConformances -emit-sil -o /dev/null
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_StrictSendableMetatypes
+// REQUIRES: swift_feature_IsolatedConformances
 
 
 protocol Q {

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature StrictSendableMetatypes
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature IsolatedConformances
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_StrictSendableMetatypes
+// REQUIRES: swift_feature_IsolatedConformances
 
 // This test checks for typecheck-only diagnostics involving non-sendable
 // metatypes.

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -296,17 +296,17 @@ func downcasts(
   let _ = baseAndP as! Derived
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG0]] : $any Base<Int> & P
-  // CHECK-NEXT: checked_cast_br any Base<Int> & P in [[COPIED]] : $any Base<Int> & P to any Derived & R
+  // CHECK-NEXT: checked_cast_br [prohibit_isolated_conformances] any Base<Int> & P in [[COPIED]] : $any Base<Int> & P to any Derived & R
   let _ = baseAndP as? (Derived & R)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG0]] : $any Base<Int> & P
-  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $any Base<Int> & P to any Derived & R
+  // CHECK-NEXT: unconditional_checked_cast [prohibit_isolated_conformances] [[COPIED]] : $any Base<Int> & P to any Derived & R
   let _ = baseAndP as! (Derived & R)
 
-  // CHECK:      checked_cast_br Derived.Type in %3 : $@thick Derived.Type to any (Derived & R).Type
+  // CHECK:      checked_cast_br [prohibit_isolated_conformances] Derived.Type in %3 : $@thick Derived.Type to any (Derived & R).Type
   let _ = derivedType as? (Derived & R).Type
 
-  // CHECK:      unconditional_checked_cast %3 : $@thick Derived.Type to any (Derived & R).Type
+  // CHECK:      unconditional_checked_cast [prohibit_isolated_conformances] %3 : $@thick Derived.Type to any (Derived & R).Type
   let _ = derivedType as! (Derived & R).Type
 
   // CHECK:      checked_cast_br any (Base<Int> & P).Type in %2 : $@thick any (Base<Int> & P).Type to Derived.Type
@@ -315,10 +315,10 @@ func downcasts(
   // CHECK:      unconditional_checked_cast %2 : $@thick any (Base<Int> & P).Type to Derived.Type
   let _ = baseAndPType as! Derived.Type
 
-  // CHECK:      checked_cast_br any (Base<Int> & P).Type in %2 : $@thick any (Base<Int> & P).Type to any (Derived & R).Type
+  // CHECK:      checked_cast_br [prohibit_isolated_conformances] any (Base<Int> & P).Type in %2 : $@thick any (Base<Int> & P).Type to any (Derived & R).Type
   let _ = baseAndPType as? (Derived & R).Type
 
-  // CHECK:      unconditional_checked_cast %2 : $@thick any (Base<Int> & P).Type to any (Derived & R).Type
+  // CHECK:      unconditional_checked_cast [prohibit_isolated_conformances] %2 : $@thick any (Base<Int> & P).Type to any (Derived & R).Type
   let _ = baseAndPType as! (Derived & R).Type
 
   // CHECK:      return
@@ -378,33 +378,33 @@ func archetypeDowncasts<S,
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
   // CHECK-NEXT: copy_addr %0 to [init] [[COPY]] : $*S
   // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $any Base<T> & P
-  // CHECK-NEXT: checked_cast_addr_br take_always S in [[COPY]] : $*S to any Base<T> & P in [[RESULT]] : $*any Base<T> & P
+  // CHECK-NEXT: checked_cast_addr_br [prohibit_isolated_conformances] take_always S in [[COPY]] : $*S to any Base<T> & P in [[RESULT]] : $*any Base<T> & P
   let _ = s as? (Base<T> & P)
 
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
   // CHECK-NEXT: copy_addr [[ARG0]] to [init] [[COPY]] : $*S
   // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $any Base<T> & P
-  // CHECK-NEXT: unconditional_checked_cast_addr S in [[COPY]] : $*S to any Base<T> & P in [[RESULT]] : $*any Base<T> & P
+  // CHECK-NEXT: unconditional_checked_cast_addr [prohibit_isolated_conformances] S in [[COPY]] : $*S to any Base<T> & P in [[RESULT]] : $*any Base<T> & P
   let _ = s as! (Base<T> & P)
 
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
   // CHECK-NEXT: copy_addr [[ARG0]] to [init] [[COPY]] : $*S
   // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $any Base<Int> & P
-  // CHECK-NEXT: checked_cast_addr_br take_always S in [[COPY]] : $*S to any Base<Int> & P in [[RESULT]] : $*any Base<Int> & P
+  // CHECK-NEXT: checked_cast_addr_br [prohibit_isolated_conformances] take_always S in [[COPY]] : $*S to any Base<Int> & P in [[RESULT]] : $*any Base<Int> & P
   let _ = s as? (Base<Int> & P)
 
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
   // CHECK-NEXT: copy_addr [[ARG0]] to [init] [[COPY]] : $*S
   // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $any Base<Int> & P
-  // CHECK-NEXT: unconditional_checked_cast_addr S in [[COPY]] : $*S to any Base<Int> & P in [[RESULT]] : $*any Base<Int> & P
+  // CHECK-NEXT: unconditional_checked_cast_addr [prohibit_isolated_conformances] S in [[COPY]] : $*S to any Base<Int> & P in [[RESULT]] : $*any Base<Int> & P
   let _ = s as! (Base<Int> & P)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG5]] : $BaseTAndP
-  // CHECK-NEXT: checked_cast_br BaseTAndP in [[COPIED]] : $BaseTAndP to any Derived & R
+  // CHECK-NEXT: checked_cast_br [prohibit_isolated_conformances] BaseTAndP in [[COPIED]] : $BaseTAndP to any Derived & R
   let _ = baseTAndP_archetype as? (Derived & R)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG5]] : $BaseTAndP
-  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $BaseTAndP to any Derived & R
+  // CHECK-NEXT: unconditional_checked_cast [prohibit_isolated_conformances] [[COPIED]] : $BaseTAndP to any Derived & R
   let _ = baseTAndP_archetype as! (Derived & R)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG9]] : $any Base<T> & P
@@ -447,11 +447,11 @@ func archetypeDowncasts<S,
   let _ = baseTAndP_concrete as! BaseTAndP
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG6]] : $BaseIntAndP
-  // CHECK-NEXT: checked_cast_br BaseIntAndP in [[COPIED]] : $BaseIntAndP to any Derived & R
+  // CHECK-NEXT: checked_cast_br [prohibit_isolated_conformances] BaseIntAndP in [[COPIED]] : $BaseIntAndP to any Derived & R
   let _ = baseIntAndP_archetype as? (Derived & R)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG6]] : $BaseIntAndP
-  // CHECK-NEXT: unconditional_checked_cast [[COPIED]] : $BaseIntAndP to any Derived & R
+  // CHECK-NEXT: unconditional_checked_cast [prohibit_isolated_conformances] [[COPIED]] : $BaseIntAndP to any Derived & R
   let _ = baseIntAndP_archetype as! (Derived & R)
 
   // CHECK: [[COPIED:%.*]] = copy_value [[ARG10]] : $any Base<Int> & P


### PR DESCRIPTION
This removes the IsolatedConformances feature gate from SILGen for dynamic casts, such that all dynamic casts that will not work with isolated conformances are marked as such. Isolated conformances can still only come into a program when part of it enables the feature flag.

Additionally, collapse the experimental feature `StrictSendableMetatypes` into `IsolatedConformances`. We don't need them to be separate.

