### PR TITLE
[Swiftify] enable mutable span

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -4,9 +4,6 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-// Disable emitting 'MutableSpan' until it has landed
-let enableMutableSpan = false
-
 // avoids depending on SwiftifyImport.swift
 // all instances are reparsed and reinstantiated by the macro anyways,
 // so linking is irrelevant
@@ -279,36 +276,49 @@ func getUnqualifiedStdName(_ type: String) -> String? {
 func getSafePointerName(mut: Mutability, generateSpan: Bool, isRaw: Bool) -> TokenSyntax {
   switch (mut, generateSpan, isRaw) {
   case (.Immutable, true, true): return "RawSpan"
-  case (.Mutable, true, true): return if enableMutableSpan {
-    "MutableRawSpan"
-  } else {
-    "RawSpan"
-  }
+  case (.Mutable, true, true): return "MutableRawSpan"
   case (.Immutable, false, true): return "UnsafeRawBufferPointer"
   case (.Mutable, false, true): return "UnsafeMutableRawBufferPointer"
 
   case (.Immutable, true, false): return "Span"
-  case (.Mutable, true, false): return if enableMutableSpan {
-    "MutableSpan"
-  } else {
-    "Span"
-  }
+  case (.Mutable, true, false): return "MutableSpan"
   case (.Immutable, false, false): return "UnsafeBufferPointer"
   case (.Mutable, false, false): return "UnsafeMutableBufferPointer"
   }
 }
 
-func transformType(_ prev: TypeSyntax, _ generateSpan: Bool, _ isSizedBy: Bool) throws -> TypeSyntax {
+func hasOwnershipSpecifier(_ attrType: AttributedTypeSyntax) -> Bool {
+  return attrType.specifiers.contains(where: { e in
+    guard let simpleSpec = e.as(SimpleTypeSpecifierSyntax.self) else {
+      return false
+    }
+    let specifierText = simpleSpec.specifier.text
+    switch specifierText {
+    case "borrowing":
+      return true
+    case "inout":
+      return true
+    case "consuming":
+      return true
+    default:
+      return false
+    }
+  })
+}
+
+func transformType(_ prev: TypeSyntax, _ generateSpan: Bool, _ isSizedBy: Bool, _ setMutableSpanInout: Bool) throws -> TypeSyntax {
   if let optType = prev.as(OptionalTypeSyntax.self) {
     return TypeSyntax(
-      optType.with(\.wrappedType, try transformType(optType.wrappedType, generateSpan, isSizedBy)))
+      optType.with(\.wrappedType, try transformType(optType.wrappedType, generateSpan, isSizedBy, setMutableSpanInout)))
   }
   if let impOptType = prev.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
-    return try transformType(impOptType.wrappedType, generateSpan, isSizedBy)
+    return try transformType(impOptType.wrappedType, generateSpan, isSizedBy, setMutableSpanInout)
   }
   if let attrType = prev.as(AttributedTypeSyntax.self) {
+    // We insert 'inout' by default for MutableSpan, but it shouldn't override existing ownership
+    let setMutableSpanInoutNext = setMutableSpanInout && !hasOwnershipSpecifier(attrType)
     return TypeSyntax(
-      attrType.with(\.baseType, try transformType(attrType.baseType, generateSpan, isSizedBy)))
+      attrType.with(\.baseType, try transformType(attrType.baseType, generateSpan, isSizedBy, setMutableSpanInoutNext)))
   }
   let name = try getTypeName(prev)
   let text = name.text
@@ -326,10 +336,15 @@ func transformType(_ prev: TypeSyntax, _ generateSpan: Bool, _ isSizedBy: Bool) 
         + " - first type token is '\(text)'", node: name)
   }
   let token = getSafePointerName(mut: kind, generateSpan: generateSpan, isRaw: isSizedBy)
-  if isSizedBy {
-    return TypeSyntax(IdentifierTypeSyntax(name: token))
+  let mainType = if isSizedBy {
+    TypeSyntax(IdentifierTypeSyntax(name: token))
+  } else {
+    try replaceTypeName(prev, token)
   }
-  return try replaceTypeName(prev, token)
+  if setMutableSpanInout && generateSpan && kind == .Mutable {
+    return TypeSyntax("inout \(mainType)")
+  }
+  return mainType
 }
 
 func isMutablePointerType(_ type: TypeSyntax) -> Bool {
@@ -446,6 +461,7 @@ struct CxxSpanThunkBuilder: SpanBoundsThunkBuilder, ParamBoundsThunkBuilder {
   public let node: SyntaxProtocol
   public let nonescaping: Bool
   let isSizedBy: Bool = false
+  let isParameter: Bool = true
 
   func buildBoundsChecks() throws -> [CodeBlockItemSyntax.Item] {
     return try base.buildBoundsChecks()
@@ -462,8 +478,26 @@ struct CxxSpanThunkBuilder: SpanBoundsThunkBuilder, ParamBoundsThunkBuilder {
     var args = pointerArgs
     let typeName = getUnattributedType(oldType).description
     assert(args[index] == nil)
-    args[index] = ExprSyntax("\(raw: typeName)(\(raw: name))")
-    return try base.buildFunctionCall(args)
+
+    let (_, isConst) = dropCxxQualifiers(try genericArg)
+    if isConst {
+      args[index] = ExprSyntax("\(raw: typeName)(\(raw: name))")
+      return try base.buildFunctionCall(args)
+    } else {
+      let unwrappedName = TokenSyntax("_\(name)Ptr")
+      args[index] = ExprSyntax("\(raw: typeName)(\(unwrappedName))")
+      let call = try base.buildFunctionCall(args)
+
+      // MutableSpan - unlike Span - cannot be bitcast to std::span due to being ~Copyable,
+      // so unwrap it to an UnsafeMutableBufferPointer that we can cast
+      let unwrappedCall = ExprSyntax(
+        """
+          \(name).withUnsafeMutableBufferPointer { \(unwrappedName) in
+            return unsafe \(call)
+          }
+        """)
+      return unwrappedCall
+    }
   }
 }
 
@@ -472,6 +506,7 @@ struct CxxSpanReturnThunkBuilder: SpanBoundsThunkBuilder {
   public let signature: FunctionSignatureSyntax
   public let typeMappings: [String: String]
   public let node: SyntaxProtocol
+  let isParameter: Bool = false
 
   var oldType: TypeSyntax {
     return signature.returnClause!.type
@@ -490,7 +525,7 @@ struct CxxSpanReturnThunkBuilder: SpanBoundsThunkBuilder {
   func buildFunctionCall(_ pointerArgs: [Int: ExprSyntax]) throws -> ExprSyntax {
     let call = try base.buildFunctionCall(pointerArgs)
     let (_, isConst) = dropCxxQualifiers(try genericArg)
-    let cast = if isConst || !enableMutableSpan {
+    let cast = if isConst {
       "Span"
     } else {
       "MutableSpan"
@@ -508,11 +543,12 @@ protocol BoundsThunkBuilder: BoundsCheckedThunkBuilder {
 protocol SpanBoundsThunkBuilder: BoundsThunkBuilder {
   var typeMappings: [String: String] { get }
   var node: SyntaxProtocol { get }
+  var isParameter: Bool { get }
 }
 extension SpanBoundsThunkBuilder {
   var desugaredType: TypeSyntax {
     get throws {
-      let typeName = try getUnattributedType(oldType).description
+      let typeName = getUnattributedType(oldType).description
       guard let desugaredTypeName = typeMappings[typeName] else {
         throw DiagnosticError(
           "unable to desugar type with name '\(typeName)'", node: node)
@@ -547,14 +583,18 @@ extension SpanBoundsThunkBuilder {
   var newType: TypeSyntax {
     get throws {
       let (strippedArg, isConst) = dropCxxQualifiers(try genericArg)
-      let mutablePrefix = if isConst || !enableMutableSpan {
+      let mutablePrefix = if isConst {
         ""
       } else {
         "Mutable"
       }
-      return replaceBaseType(
+      let mainType = replaceBaseType(
         oldType,
         TypeSyntax("\(raw: mutablePrefix)Span<\(raw: strippedArg)>"))
+      if !isConst && isParameter {
+        return TypeSyntax("inout \(mainType)")
+      }
+      return mainType
     }
   }
 }
@@ -563,13 +603,14 @@ protocol PointerBoundsThunkBuilder: BoundsThunkBuilder {
   var nullable: Bool { get }
   var isSizedBy: Bool { get }
   var generateSpan: Bool { get }
+  var isParameter: Bool { get }
 }
 
 extension PointerBoundsThunkBuilder {
   var nullable: Bool { return oldType.is(OptionalTypeSyntax.self) }
 
   var newType: TypeSyntax { get throws {
-    return try transformType(oldType, generateSpan, isSizedBy) }
+    return try transformType(oldType, generateSpan, isSizedBy, isParameter) }
   }
 }
 
@@ -599,8 +640,9 @@ struct CountedOrSizedReturnPointerThunkBuilder: PointerBoundsThunkBuilder {
   public let nonescaping: Bool
   public let isSizedBy: Bool
   public let dependencies: [LifetimeDependence]
+  let isParameter: Bool = false
 
-  var generateSpan: Bool { !dependencies.isEmpty && (!isMutablePointerType(oldType) || enableMutableSpan)}
+  var generateSpan: Bool { !dependencies.isEmpty }
 
   var oldType: TypeSyntax {
     return signature.returnClause!.type
@@ -639,8 +681,9 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
   public let nonescaping: Bool
   public let isSizedBy: Bool
   public let skipTrivialCount: Bool
+  let isParameter: Bool = true
 
-  var generateSpan: Bool { nonescaping && (!isMutablePointerType(oldType) || enableMutableSpan) }
+  var generateSpan: Bool { nonescaping }
 
   func buildFunctionSignature(_ argTypes: [Int: TypeSyntax?], _ returnType: TypeSyntax?) throws
     -> (FunctionSignatureSyntax, Bool) {
@@ -702,7 +745,12 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
     let call = try base.buildFunctionCall(args)
     let ptrRef = unwrapIfNullable(ExprSyntax(DeclReferenceExprSyntax(baseName: name)))
 
-    let funcName = isSizedBy ? "withUnsafeBytes" : "withUnsafeBufferPointer"
+    let funcName = switch (isSizedBy, isMutablePointerType(oldType)) {
+    case (true, true): "withUnsafeMutableBytes"
+    case (true, false): "withUnsafeBytes"
+    case (false, true): "withUnsafeMutableBufferPointer"
+    case (false, false): "withUnsafeBufferPointer"
+    }
     let unwrappedCall = ExprSyntax(
       """
         \(ptrRef).\(raw: funcName) { \(unwrappedName) in
@@ -769,7 +817,7 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
             if \(name) == nil {
               unsafe \(try base.buildFunctionCall(nullArgs))
             } else {
-              \(unwrappedCall)
+              unsafe \(unwrappedCall)
             }
           """)
       }
@@ -1161,7 +1209,7 @@ public struct SwiftifyImportMacro: PeerMacro {
     }
   }
 
-  static func lifetimeAttributes(_ funcDecl: FunctionDeclSyntax,
+  static func getReturnLifetimeAttribute(_ funcDecl: FunctionDeclSyntax,
     _ dependencies: [SwiftifyExpr: [LifetimeDependence]]) -> [AttributeListSyntax.Element] {
     let returnDependencies = dependencies[.`return`, default: []]
     if returnDependencies.isEmpty {
@@ -1188,6 +1236,66 @@ public struct SwiftifyImportMacro: PeerMacro {
               leftParen: .leftParenToken(),
               arguments: .argumentList(LabeledExprListSyntax(args)),
               rightParen: .rightParenToken()))]
+  }
+
+  static func isMutableSpan(_ type: TypeSyntax) -> Bool {
+    if let optType = type.as(OptionalTypeSyntax.self) {
+      return isMutableSpan(optType.wrappedType)
+    }
+    if let impOptType = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+      return isMutableSpan(impOptType.wrappedType)
+    }
+    if let attrType = type.as(AttributedTypeSyntax.self) {
+      return isMutableSpan(attrType.baseType)
+    }
+    guard let identifierType = type.as(IdentifierTypeSyntax.self) else {
+      return false
+    }
+    let name = identifierType.name.text
+    return name == "MutableSpan" || name == "MutableRawSpan"
+  }
+
+  static func containsLifetimeAttr(_ attrs: AttributeListSyntax, for paramName: TokenSyntax) -> Bool {
+    for elem in attrs {
+      guard let attr = elem.as(AttributeSyntax.self) else {
+        continue
+      }
+      if attr.attributeName != "lifetime" {
+        continue
+      }
+      guard let args = attr.arguments?.as(LabeledExprListSyntax.self) else {
+        continue
+      }
+      for arg in args {
+        if arg.label == paramName {
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  // Mutable[Raw]Span parameters need explicit @lifetime annotations since they are inout
+  static func paramLifetimeAttributes(_ newSignature: FunctionSignatureSyntax, _ oldAttrs: AttributeListSyntax) -> [AttributeListSyntax.Element] {
+    var defaultLifetimes: [AttributeListSyntax.Element] = []
+    for param in newSignature.parameterClause.parameters {
+      if !isMutableSpan(param.type) {
+        continue
+      }
+      let paramName = param.secondName ?? param.firstName
+      if containsLifetimeAttr(oldAttrs, for: paramName) {
+        continue
+      }
+      let expr = ExprSyntax("\(paramName): copy \(paramName)")
+
+      defaultLifetimes.append(.attribute(AttributeSyntax(
+              atSign: .atSignToken(),
+              attributeName: IdentifierTypeSyntax(name: "lifetime"),
+              leftParen: .leftParenToken(),
+              arguments: .argumentList(LabeledExprListSyntax([LabeledExprSyntax(expression: expr)])),
+              rightParen: .rightParenToken())))
+    }
+    return defaultLifetimes
   }
 
   public static func expansion(
@@ -1257,7 +1365,8 @@ public struct SwiftifyImportMacro: PeerMacro {
             returnKeyword: .keyword(.return, trailingTrivia: " "),
             expression: ExprSyntax("unsafe \(try builder.buildFunctionCall([:]))"))))
       let body = CodeBlockSyntax(statements: CodeBlockItemListSyntax(checks + [call]))
-      let lifetimeAttrs = lifetimeAttributes(funcDecl, lifetimeDependencies)
+      let returnLifetimeAttribute = getReturnLifetimeAttribute(funcDecl, lifetimeDependencies)
+      let lifetimeAttrs = returnLifetimeAttribute + paramLifetimeAttributes(newSignature, funcDecl.attributes)
       let disfavoredOverload : [AttributeListSyntax.Element] = (onlyReturnTypeChanged ? [
         .attribute(
           AttributeSyntax(

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -1,8 +1,6 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_LifetimeDependence
 
-// This emits UnsafeMutableBufferPointer until MutableSpan has landed
-
 // RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
@@ -13,15 +11,23 @@
 
 import CountedByNoEscapeClang
 
-// CHECK:      @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: UnsafeMutableBufferPointer<Int{{.*}}>)
-// CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
-// CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+// CHECK:      @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_ p: inout MutableSpan<Int32>)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_ p: inout MutableSpan<Int32>)
 // CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @_alwaysEmitIntoClient public func returnLifetimeBound(_ len1: Int32, _ p: UnsafeMutableBufferPointer<Int32>) -> UnsafeMutableBufferPointer<Int32>
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_  len: Int{{.*}}) -> UnsafeMutableBufferPointer<Int{{.*}}>
-// CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int{{.*}}, _ p1: UnsafeMutableBufferPointer<Int{{.*}}>, _ p2: UnsafeMutableBufferPointer<Int{{.*}}>)
-// CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
-// CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func returnLifetimeBound(_ len1: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int32) -> UnsafeMutableBufferPointer<Int32>
+// CHECK-NEXT: @lifetime(p1: copy p1)
+// CHECK-NEXT: @lifetime(p2: copy p2)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int32, _ p1: inout MutableSpan<Int32>, _ p2: inout MutableSpan<Int32>)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_ p: inout MutableSpan<Int32>)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_ p: inout MutableSpan<Int32>)
 
 @inlinable
 public func callReturnPointer() {

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -121,6 +121,50 @@ inline ConstSpanOfInt mixedFuncWithSafeWrapper7(const int * __counted_by(len) p,
   return ConstSpanOfInt(p, len);
 }
 
+inline void FuncWithMutableSafeWrapper(SpanOfInt s [[clang::noescape]]) {}
+
+inline SpanOfInt FuncWithMutableSafeWrapper2(SpanOfInt s
+                                           [[clang::lifetimebound]]) {
+  return s;
+}
+
+inline SpanOfInt FuncWithMutableSafeWrapper3(VecOfInt &v
+                                           [[clang::lifetimebound]]) {
+  return SpanOfInt(v.data(), v.size());
+}
+
+struct Y {
+  inline void methodWithMutableSafeWrapper(SpanOfInt s [[clang::noescape]]) {}
+};
+
+inline SpanOfInt MixedFuncWithMutableSafeWrapper1(int * __counted_by(len) p
+                                           [[clang::lifetimebound]], int len) {
+  return SpanOfInt(p, len);
+}
+
+inline int * __counted_by(len) MixedFuncWithMutableSafeWrapper2(VecOfInt &v
+                                           [[clang::lifetimebound]], int len) {
+  if (v.size() <= len)
+    return v.data();
+  return nullptr;
+}
+
+inline void MixedFuncWithMutableSafeWrapper3(SpanOfInt s [[clang::noescape]],
+                                      int * __counted_by(len) p, int len) {}
+
+inline void MixedFuncWithMutableSafeWrapper4(SpanOfInt s [[clang::noescape]],
+                                      int * __counted_by(len) p [[clang::noescape]], int len) {}
+
+inline void MixedFuncWithMutableSafeWrapper5(SpanOfInt s,
+                                      int * __counted_by(len) p [[clang::noescape]], int len) {}
+
+inline void MixedFuncWithMutableSafeWrapper6(SpanOfInt s,
+                                      int * __counted_by(len) p, int len) {}
+
+inline SpanOfInt MixedFuncWithMutableSafeWrapper7(int * __counted_by(len) p, int len) {
+  return SpanOfInt(p, len);
+}
+
 struct SpanWithoutTypeAlias {
   std::span<const int> bar() [[clang::lifetimebound]];
   void foo(std::span<const int> s [[clang::noescape]]);

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -34,6 +34,29 @@ import CxxStdlib
 // CHECK-NEXT:   @_alwaysEmitIntoClient public mutating func foo(_ s: Span<CInt>)
 // CHECK-NEXT:   mutating func foo(_ s: std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>)
 // CHECK-NEXT: }
+
+// CHECK: @lifetime(s: copy s)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func FuncWithMutableSafeWrapper(_ s: inout MutableSpan<CInt>)
+// CHECK-NEXT: @lifetime(copy s)
+// CHECK-NEXT: @lifetime(s: copy s)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func FuncWithMutableSafeWrapper2(_ s: inout MutableSpan<CInt>) -> MutableSpan<CInt>
+// CHECK-NEXT: @lifetime(borrow v)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func FuncWithMutableSafeWrapper3(_ v: inout VecOfInt) -> MutableSpan<CInt>
+// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper1(_ p: inout MutableSpan<Int32>) -> MutableSpan<CInt>
+// CHECK-NEXT: @lifetime(borrow v)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func MixedFuncWithMutableSafeWrapper2(_ v: inout VecOfInt, _ len: Int32) -> MutableSpan<Int32>
+// CHECK-NEXT: @lifetime(s: copy s)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper3(_ s: inout MutableSpan<CInt>, _ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-NEXT: @lifetime(s: copy s)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper4(_ s: inout MutableSpan<CInt>, _ p: inout MutableSpan<Int32>)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper5(_ s: SpanOfInt, _ p: inout MutableSpan<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper6(_ s: SpanOfInt, _ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper7(_ p: UnsafeMutableBufferPointer<Int32>) -> SpanOfInt
+
 // CHECK: @_alwaysEmitIntoClient public func funcWithSafeWrapper(_ s: Span<CInt>)
 // CHECK-NEXT: @lifetime(copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper2(_ s: Span<CInt>) -> Span<CInt>

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -7,9 +7,9 @@
 func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 }
 
-// Emits UnsafeMutableBufferPointer until MutableSpan has landed
-
-// CHECK:      @_alwaysEmitIntoClient
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr)
+// CHECK-NEXT: func myFunc(_ ptr: inout MutableSpan<CInt>) {
+// CHECK-NEXT:     return unsafe   ptr.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -14,6 +14,10 @@ func myFunc2(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) {
 func myFunc3(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: UnsafeMutablePointer<CInt>?, _ len2: CInt) {
 }
 
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .return, count: "len"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
+func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePointer<CInt>? {
+}
+
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>?) {
 // CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
@@ -21,34 +25,66 @@ func myFunc3(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: UnsafeMuta
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr)
 // CHECK-NEXT: func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
-// CHECK-NEXT:     return unsafe if ptr == nil {
-// CHECK-NEXT:         unsafe myFunc2(nil, CInt(exactly: ptr?.count ?? 0)!)
-// CHECK-NEXT:     } else {
-// CHECK-NEXT:         unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:             return unsafe myFunc2(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:     return { () in
+// CHECK-NEXT:         return if ptr == nil {
+// CHECK-NEXT:             unsafe myFunc2(nil, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:         } else {
+// CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:                 return unsafe myFunc2(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @lifetime(ptr2: copy ptr2)
 // CHECK-NEXT: func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) {
-// CHECK-NEXT:     return unsafe if ptr2 == nil {
-// CHECK-NEXT:         unsafe if ptr == nil {
-// CHECK-NEXT:             unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:     return { () in
+// CHECK-NEXT:         return if ptr2 == nil {
+// CHECK-NEXT:             { () in
+// CHECK-NEXT:                 return  if ptr == nil {
+// CHECK-NEXT:                     unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                 } else {
+// CHECK-NEXT:                     unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:                         return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }
+// CHECK-NEXT:             }()
 // CHECK-NEXT:         } else {
-// CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                 return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:             unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
+// CHECK-NEXT:                 return { () in
+// CHECK-NEXT:                     return if ptr == nil {
+// CHECK-NEXT:                         unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                     } else {
+// CHECK-NEXT:                         unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:                             return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                     }
+// CHECK-NEXT:                 }()
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     } else {
-// CHECK-NEXT:         unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
-// CHECK-NEXT:             return unsafe if ptr == nil {
-// CHECK-NEXT:                 unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:     }()
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr)
+// CHECK-NEXT: func myFunc4(_ ptr: inout MutableSpan<CInt>?, _ len: CInt) -> MutableSpan<CInt>? {
+// CHECK-NEXT:     let _ptrCount: some BinaryInteger = len
+// CHECK-NEXT:     if ptr?.count ?? 0 < _ptrCount || _ptrCount < 0 {
+// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return { () in
+// CHECK-NEXT:         let _resultValue = { () in
+// CHECK-NEXT:             return if ptr == nil {
+// CHECK-NEXT:                 unsafe myFunc4(nil, len)
 // CHECK-NEXT:             } else {
 // CHECK-NEXT:                 unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                     return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                     return unsafe myFunc4(_ptrPtr.baseAddress, len)
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }
+// CHECK-NEXT:         }()
+// CHECK-NEXT:         if unsafe _resultValue == nil {
+// CHECK-NEXT:             return nil
+// CHECK-NEXT:         } else {
+// CHECK-NEXT:             return unsafe MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len))
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     }()
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -21,22 +21,22 @@ func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ len: CInt) -> UnsafeMutableBufferPointer<CInt> {
-// CHECK-NEXT:     return unsafe UnsafeMutableBufferPointer<CInt> (start: myFunc(len), count: Int(len))
+// CHECK-NEXT:     return unsafe UnsafeMutableBufferPointer<CInt> (start: unsafe myFunc(len), count: Int(len))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
-// CHECK-NEXT:     return unsafe UnsafeBufferPointer<CInt> (start: nonEscaping(len), count: Int(len))
+// CHECK-NEXT:     return unsafe UnsafeBufferPointer<CInt> (start: unsafe nonEscaping(len), count: Int(len))
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy p)
 // CHECK-NEXT: func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart:   p.withUnsafeBufferPointer { _pPtr in
+// CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart:   unsafe p.withUnsafeBufferPointer { _pPtr in
 // CHECK-NEXT:         return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: p.count)!, len2)
 // CHECK-NEXT:       }, count: Int(len2))
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p)
 // CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart: lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2))
+// CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2))
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CxxSpan/Inputs/std-span.h
+++ b/test/Macros/SwiftifyImport/CxxSpan/Inputs/std-span.h
@@ -3,3 +3,4 @@
 #include <span>
 
 using SpanOfInt = std::span<const int>;
+using MutableSpanOfInt = std::span<int>;

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -59,27 +59,27 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span)
 // CHECK-NEXT: func myFunc(_ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: myFunc(SpanOfInt(span))), copying: ())
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc(SpanOfInt(span))), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ vec: borrowing VecOfInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: myFunc2(vec)), copying: ())
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc2(vec)), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span1, copy span2)
 // CHECK-NEXT: func myFunc3(_ span1: Span<CInt>, _ span2: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: myFunc3(SpanOfInt(span1), SpanOfInt(span2))), copying: ())
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc3(SpanOfInt(span1), SpanOfInt(span2))), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec, copy span)
 // CHECK-NEXT: func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: myFunc4(vec, SpanOfInt(span))), copying: ())
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc4(vec, SpanOfInt(span))), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow self) @_disfavoredOverload
 // CHECK-NEXT: func myFunc5() -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: myFunc5()), copying: ())
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc5()), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span)
@@ -88,7 +88,7 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
 // CHECK-NEXT:         return unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
 // CHECK-NEXT:     }), copying: ())
 // CHECK-NEXT: }
@@ -99,7 +99,7 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
 // CHECK-NEXT:         return unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
 // CHECK-NEXT:     }), copying: ())
 // CHECK-NEXT: }
@@ -110,14 +110,14 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
 // CHECK-NEXT:         return unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)
 // CHECK-NEXT:     }), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @lifetime(span: copy span)
 // CHECK-NEXT: func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(MutableSpan(_unsafeCxxSpan: span.withUnsafeMutableBufferPointer { _spanPtr in
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
 // CHECK-NEXT:         return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
 // CHECK-NEXT:    }), copying: ())
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -11,46 +11,50 @@ import StdSpan
 
 public struct VecOfInt {}
 
-@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<__cxxConst<CInt>>"])
 func myFunc(_ span: SpanOfInt) -> SpanOfInt {
 }
 
-@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
 func myFunc2(_ vec: borrowing VecOfInt) -> SpanOfInt {
 }
 
-@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
 func myFunc3(_ span1: SpanOfInt, _ span2: SpanOfInt) -> SpanOfInt {
 }
 
-@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow), .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .borrow), .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy), typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
 func myFunc4(_ vec: borrowing VecOfInt, _ span: SpanOfInt) -> SpanOfInt {
 }
 
 struct X {
-  @_SwiftifyImport(.lifetimeDependence(dependsOn: .self, pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+  @_SwiftifyImport(.lifetimeDependence(dependsOn: .self, pointer: .return, type: .borrow), typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
   func myFunc5() -> SpanOfInt {}
 }
 
 @_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy),
                  .sizedBy(pointer: .param(2), size: "count * size"),
                  .nonescaping(pointer: .param(2)),
-                 typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+                 typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
 func myFunc6(_ span: SpanOfInt, _ ptr: UnsafeRawPointer, _ count: CInt, _ size: CInt) -> SpanOfInt {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(2), size: "count * size"),
                  .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy),
                  .nonescaping(pointer: .param(2)),
-                 typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+                 typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
 func myFunc7(_ span: SpanOfInt, _ ptr: UnsafeRawPointer, _ count: CInt, _ size: CInt) -> SpanOfInt {
 }
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "count * size"),
                  .nonescaping(pointer: .param(1)),
                  .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy),
-                 typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+                 typeMappings: ["SpanOfInt" : "std.__1.span<__cxxConst<CInt>, _CUnsignedLong_18446744073709551615>"])
 func myFunc8(_ ptr: UnsafeRawPointer, _ span: SpanOfInt, _ count: CInt, _ size: CInt) -> SpanOfInt {
+}
+
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>"])
+func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span)
@@ -109,4 +113,11 @@ func myFunc8(_ ptr: UnsafeRawPointer, _ span: SpanOfInt, _ count: CInt, _ size: 
 // CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: ptr.withUnsafeBytes { _ptrPtr in
 // CHECK-NEXT:         return unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)
 // CHECK-NEXT:     }), copying: ())
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @lifetime(span: copy span)
+// CHECK-NEXT: func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(MutableSpan(_unsafeCxxSpan: span.withUnsafeMutableBufferPointer { _spanPtr in
+// CHECK-NEXT:         return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
+// CHECK-NEXT:    }), copying: ())
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
@@ -9,11 +9,46 @@
 import CxxStdlib
 import StdSpan
 
-@_SwiftifyImport(.nonescaping(pointer: .param(1)), typeMappings: ["SpanOfInt" : "std.span<CInt>"])
+@_SwiftifyImport(.nonescaping(pointer: .param(1)), typeMappings: ["SpanOfInt" : "std.span<__cxxConst<CInt>>"])
 func myFunc(_ span: SpanOfInt, _ secondSpan: SpanOfInt) {
+}
+
+@_SwiftifyImport(.nonescaping(pointer: .param(1)), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>"])
+func myFunc2(_ span: MutableSpanOfInt, _ secondSpan: MutableSpanOfInt) {
+}
+
+@_SwiftifyImport(.nonescaping(pointer: .param(1)), .nonescaping(pointer: .param(2)), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>", "SpanOfInt" : "std.span<__cxxConst<CInt>>"])
+func myFunc3(_ span: MutableSpanOfInt, _ secondSpan: SpanOfInt) {
+}
+
+@_SwiftifyImport(.nonescaping(pointer: .param(1)), .nonescaping(pointer: .param(2)), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>"])
+func myFunc4(_ span: MutableSpanOfInt, _ secondSpan: MutableSpanOfInt) {
 }
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ span: Span<CInt>, _ secondSpan: SpanOfInt) {
 // CHECK-NEXT:     return unsafe myFunc(SpanOfInt(span), secondSpan)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(span: copy span)
+// CHECK-NEXT: func myFunc2(_ span: inout MutableSpan<CInt>, _ secondSpan: MutableSpanOfInt) {
+// CHECK-NEXT:     return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+// CHECK-NEXT:         return unsafe myFunc2(MutableSpanOfInt(_spanPtr), secondSpan)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(span: copy span)
+// CHECK-NEXT: func myFunc3(_ span: inout MutableSpan<CInt>, _ secondSpan: Span<CInt>) {
+// CHECK-NEXT:     return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+// CHECK-NEXT:         return unsafe myFunc3(MutableSpanOfInt(_spanPtr), SpanOfInt(secondSpan))
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(span: copy span) @lifetime(secondSpan: copy secondSpan)
+// CHECK-NEXT: func myFunc4(_ span: inout MutableSpan<CInt>, _ secondSpan: inout MutableSpan<CInt>) {
+// CHECK-NEXT:     return unsafe secondSpan.withUnsafeMutableBufferPointer { _secondSpanPtr in
+// CHECK-NEXT:         return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+// CHECK-NEXT:             return unsafe myFunc4(MutableSpanOfInt(_spanPtr), MutableSpanOfInt(_secondSpanPtr))
+// CHECK-NEXT:         }
+// CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -7,9 +7,9 @@
 func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 }
 
-// Emits UnsafeMutableRawBufferPointer until MutableRawSpan has landed
-
-// CHECK:      @_alwaysEmitIntoClient
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableRawBufferPointer) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr)
+// CHECK-NEXT: func myFunc(_ ptr: inout MutableRawSpan) {
+// CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -1,9 +1,6 @@
 // REQUIRES: swift_swift_parser
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -dump-macro-expansions -verify 2>&1 | %FileCheck --match-full-lines %s
-
-// FIXME: Waiting for optional to handle nonescapable types
-// RUN: not %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions -verify 2>&1 | %FileCheck --match-full-lines %s
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func nonnullUnsafeRawBufferPointer(_ ptr: OpaquePointer, _ size: CInt) {
@@ -56,7 +53,7 @@ func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 // CHECK-NEXT:     return unsafe if ptr == nil {
 // CHECK-NEXT:         unsafe nullableSpan(nil, CInt(exactly: ptr?.byteCount ?? 0)!)
 // CHECK-NEXT:     } else {
-// CHECK-NEXT:         ptr!.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:         unsafe ptr!.withUnsafeBytes { _ptrPtr in
 // CHECK-NEXT:             return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), CInt(exactly: ptr?.byteCount ?? 0)!)
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -50,13 +50,15 @@ func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func nullableSpan(_ ptr: RawSpan?) {
-// CHECK-NEXT:     return unsafe if ptr == nil {
-// CHECK-NEXT:         unsafe nullableSpan(nil, CInt(exactly: ptr?.byteCount ?? 0)!)
-// CHECK-NEXT:     } else {
-// CHECK-NEXT:         unsafe ptr!.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:             return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), CInt(exactly: ptr?.byteCount ?? 0)!)
+// CHECK-NEXT:     return { () in
+// CHECK-NEXT:         return if ptr == nil {
+// CHECK-NEXT:             unsafe nullableSpan(nil, CInt(exactly: ptr?.byteCount ?? 0)!)
+// CHECK-NEXT:         } else {
+// CHECK-NEXT:             unsafe ptr!.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:                 return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), CInt(exactly: ptr?.byteCount ?? 0)!)
+// CHECK-NEXT:             }
 // CHECK-NEXT:         }
-// CHECK-NEXT:     }
+// CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient


### PR DESCRIPTION
[Swiftify] Wrap if-expressions in Immediately Called Closures

When parameters in swiftified wrapper functions are nullable, we use
separate branches for the nil and nonnil cases, because
`withUnsafeBufferPointer` (and similar) cannot be called on nil.
If-expressions have some limitations on where they are allowed in the
grammar, and cannot be passed as arguments to a function. As such, when
the return value is also swiftified, we get an error when trying to
pass the if-expression to the UnsafeBufferPointer/Span constructor.
While it isn't pretty, the best way forward seems to be by wrapping the
if-expressions in Immediately Called Closures.

The closures have the side-effect of acting as a barrier for 'unsafe':
unsafe keywords outside the closure do not "reach" unsafe expressions
inside the closure. We therefore have to emit "unsafe" where unsafe
expressions are used, rather than just when returning.

rdar://148153063

[Swiftify] Emit Mutable[Raw]Span when possible

Previously wrappers would use UnsafeMutable[Raw]Pointer for mutable
pointers, and Span for non-const std::span, to prevent the compiler from
complaining that MutableSpan didn't exist.

Now that MutableSpan has landed we can finally emit MutableSpan without
causing compilation errors. While we had (disabled) support for MutableSpan
syntax already, some unexpected semantic errors required additional
changes:
 - Mutable[Raw]Span parameters need to be inout (for mutation)
 - inout ~Escapable paramters need explicit lifetime annotations
 - MutableSpan cannot be directly bitcast to std::span, because it is
   ~Copyable, so they need unwrapping to UnsafeMutableBufferPointer

rdar://147883022