### PR TITLE
[Concurrency] Prevent misuse of `isolated` keyword to avoid crashes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6035,6 +6035,9 @@ ERROR(isolated_deinit_on_value_type,none,
 ERROR(isolated_deinit_unavailable,none,
       "isolated deinit is only available in %0 %1 or newer",
       (AvailabilityDomain, AvailabilityRange))
+ERROR(isolated_misuse_in_decl,none,
+      "invalid use of isolated in this context",
+      ())
 
 //------------------------------------------------------------------------------
 // MARK: String Processing

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4943,6 +4943,18 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
   // If the declaration is explicitly marked 'isolated', infer actor isolation
   // from the context. Currently applies only to DestructorDecl
   if (isolatedAttr) {
+    if (auto varDecl = dyn_cast<VarDecl>(decl)) {
+      ASTContext &ctx = varDecl->getASTContext();
+      ctx.Diags.diagnose(isolatedAttr->getLocation(),
+                         diag::isolated_misuse_in_decl);
+      return std::nullopt;
+    }
+    if (auto nominalTypeDecl = dyn_cast<NominalTypeDecl>(decl)) {
+      ASTContext &ctx = nominalTypeDecl->getASTContext();
+      ctx.Diags.diagnose(isolatedAttr->getLocation(),
+                         diag::isolated_misuse_in_decl);
+      return std::nullopt;
+    }
     assert(isa<DestructorDecl>(decl));
 
     auto dc = decl->getDeclContext();

--- a/test/Concurrency/isolated_invalid_uses.swift
+++ b/test/Concurrency/isolated_invalid_uses.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker-
+
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix tns-
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+// REQUIRES: swift_swift_parser
+
+isolated struct S {} // expected-error {{invalid use of isolated in this context}}
+// expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+
+isolated class C {} // expected-error {{'isolated' may only be used on 'deinit' declarations}}
+
+func f() {
+  isolated let c = C() // expected-error {{invalid use of isolated in this context}}
+  // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+  // expected-warning@-2 {{initialization of immutable value 'c' was never used; consider replacing with assignment to '_' or removing it}}
+}
+
+actor A {
+  isolated var state: Int? // expected-error {{invalid use of isolated in this context}}
+  // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+}


### PR DESCRIPTION
Resolves #80363

Using `isolated` in unintended contexts caused the compiler to crash in many scenarios.