### PR TITLE
[CS] Dont wrap packexp in extra layer of expansion

### DIFF
--- a/test/Constraints/variadic_generic_overload_ranking.swift
+++ b/test/Constraints/variadic_generic_overload_ranking.swift
@@ -85,3 +85,13 @@ func test_ranking_with_multiple_expansions() {
   // CHECK-NEXT: {{.*}} = function_ref @$s33variadic_generic_overload_ranking05test_D25_with_multiple_expansionsyyF7BuilderL_V5buildyAaByyF5TupleL_VyxxQp_tGxxQpRvzAA1PRzlFZ : $@convention(method) <each τ_0_0 where repeat each τ_0_0 : P> (@pack_guaranteed Pack{repeat each τ_0_0}, @thin Builder.Type) -> Tuple<(repeat each τ_0_0)>
   _ = Builder.build(Empty(), Tuple<(Int, String)>((42, "")))
 }
+protocol Q: P {}
+
+func test_ranking_with_protocol_refinement() {
+  func f<each T: Q>(_ a: repeat each T) {}
+  func f<each T: P>(_ a: repeat each T) {}
+  struct S: Q {}
+  // CHECK: // function_ref f #1 <each A>(_:) in test_ranking_with_protocol_refinement()
+  // CHECK-NEXT: {{.*}} = function_ref @$s33variadic_generic_overload_ranking05test_D25_with_protocol_refinementyyF1fL_yyxxQpRvzAA1QRzlF : $@convention(thin) <each τ_0_0 where repeat each τ_0_0 : Q> (@pack_guaranteed Pack{repeat each τ_0_0}) -> ()
+  f(S())
+}


### PR DESCRIPTION
Arguments that were already pack expansions were being wrapped in a second layer--preventing some would-be unambiguous overloads from resolving. This adds a check to avoid doing that.

Resolves: [#79392](https://github.com/swiftlang/swift/issues/79392)