### PR TITLE
[Tests][Embedded] Update dependencies for embedded concurrency slightly.

### DIFF
--- a/test/embedded/dependencies-concurrency-custom-executor2.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor2.swift
@@ -17,6 +17,7 @@
 // DEP: _exit
 // DEP: _free
 // DEP: _malloc
+// DEP: _memcpy
 // DEP: _memmove
 // DEP: _memset
 // DEP: _memset_s


### PR DESCRIPTION
We should allow `_memcpy`.

rdar://148254407
