### PR TITLE
Sema: Avoid diagnosing required availability in swiftinterface files

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3456,6 +3456,12 @@ static bool declNeedsExplicitAvailability(const Decl *decl) {
   if (!ctx.supportsVersionedAvailability())
     return false;
 
+  // Don't enforce explicit availability requirements in .swiftinterface files.
+  // These diagnostics are only designed to be emitted when building from
+  // source.
+  if (decl->getDeclContext()->isInSwiftinterface())
+    return false;
+
   // Skip non-public decls.
   if (auto valueDecl = dyn_cast<const ValueDecl>(decl)) {
     AccessScope scope =

--- a/test/ModuleInterface/require_explicit_availability.swift
+++ b/test/ModuleInterface/require_explicit_availability.swift
@@ -1,0 +1,12 @@
+// -require-explicit-availability is not printed in interfaces, so no warnings
+// should be emitted when verifying the interface.
+// RUN: %target-swift-emit-module-interface(%t_require.swiftinterface) -require-explicit-availability=warn %s
+// RUN: %target-swift-typecheck-module-from-interface(%t_require.swiftinterface) -verify
+
+// -library-level=api implies -require-explicit-availability=warn and it _is_
+// printed in the interface. Still, no diagnostics about required explicit
+// availability should be emitted when verifying the interface.
+// RUN: %target-swift-emit-module-interface(%t_api.swiftinterface) -library-level=api %s
+// RUN: %target-swift-typecheck-module-from-interface(%t_api.swiftinterface) -verify
+
+public struct NoAvailability { }


### PR DESCRIPTION
The `-require-explicit-availability` compiler flag is designed to help developers find declarations that they've written with missing availability. The flag is not printed in swiftinterface files, though, so if a module has both `-library-level=api` and also has `-require-explicity-availability=ignore` (as the Swift stdlib does) then the result is that superfluous diagnostics are emitted when typechecking the emitted module interface that should have been suppressed by the `ignore` flag. Suppress these diagnostics when typechecking swiftinterface files since they are only designed to be seen by the owner of the module when they are building the module from source and they don't have much value in the context of interface verification.
