### PR TITLE
[Macros] Ensure to kill and reap plugin process

### DIFF
--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -214,7 +214,13 @@ LoadedExecutablePlugin::PluginProcess::~PluginProcess() {
   close(input);
   close(output);
 #endif
-  llvm::sys::Wait(process, /*SecondsToWait=*/0);
+
+  // Set `SecondsToWait` non-zero so it waits for the timeout and kill it after
+  // that. Usually when the pipe is closed above, the plugin detects the EOF in
+  // the stdin and exits immediately, so this usually doesn't wait for the
+  // timeout. Note that we can't use '0' because it performs a non-blocking
+  // wait, which make the plugin a zombie if it hasn't exited.
+  llvm::sys::Wait(process, /*SecondsToWait=*/1);
 }
 
 ssize_t LoadedExecutablePlugin::PluginProcess::read(void *buf,


### PR DESCRIPTION
`llvm::sys::Wait(process, /*SecondsToWait=*/0)` perform a non-blocking `wait`. That means the plugin goes a zombie if it hasn't exited. Set `SecondsToWait` non-zero  so it waits for the time out and kill it after that. Usually, when the pipe is closed, the plugins detect the EOF in stdin and exits immediately, so the parent process usually don't wait for the timeout.

rdar://148110944
