### PR TITLE
Frontend: Reinstate suppression of warnings during interface type-checking

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1741,13 +1741,11 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     genericSubInvocation.setRuntimeResourcePath(SearchPathOpts.RuntimeResourcePath);
   }
 
-  // Inhibit warnings from the genericSubInvocation since we are assuming the user
-  // is not in a position to address them. (Unless we're verifying, in which
-  // case they might.)
-  if (requestedAction != FrontendOptions::ActionType::Typecheck) {
-    genericSubInvocation.getDiagnosticOptions().SuppressWarnings = true;
-    GenericArgs.push_back("-suppress-warnings");
-  }
+  // Inhibit warnings from the genericSubInvocation since we are assuming the
+  // user is not in a position to address them.
+  genericSubInvocation.getDiagnosticOptions().SuppressWarnings = true;
+  GenericArgs.push_back("-suppress-warnings");
+
   // Inherit the parent invocation's setting on whether to suppress remarks
   if (suppressRemarks) {
     genericSubInvocation.getDiagnosticOptions().SuppressRemarks = true;

--- a/test/ModuleInterface/has_storage_attr_bad.swiftinterface
+++ b/test/ModuleInterface/has_storage_attr_bad.swiftinterface
@@ -5,5 +5,5 @@
 // REQUIRES: OS=macosx
 
 extension Array {
-  @_hasStorage public var foo: Int { get set } // expected-warning {{'@_hasStorage' attribute cannot be applied to declaration in extension}}
+  @_hasStorage public var foo: Int { get set }
 }


### PR DESCRIPTION
We're not ready to start emitting warnings when type-checking modules from interface. It is causing performance regressions and spurious diagnostics to be emitted.

Reverts a small part of https://github.com/swiftlang/swift/pull/80360.

Resolves rdar://148257136.