### PR TITLE
[embedded] Fix compilation crash with -num-threads and -mergeable-symbols

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1666,7 +1666,8 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
       llvm::Module *M = IGM->getModule();
       auto collectReference = [&](llvm::GlobalValue &G) {
         if (G.isDeclaration()
-            && (G.getLinkage() == GlobalValue::LinkOnceODRLinkage ||
+            && (G.getLinkage() == GlobalValue::WeakODRLinkage ||
+                G.getLinkage() == GlobalValue::LinkOnceODRLinkage ||
                 G.getLinkage() == GlobalValue::ExternalLinkage)) {
           referencedGlobals.insert(G.getName());
           G.setLinkage(GlobalValue::ExternalLinkage);
@@ -1693,7 +1694,8 @@ static void performParallelIRGeneration(IRGenDescriptor desc) {
       // definition (if it's not referenced in the same file).
       auto updateLinkage = [&](llvm::GlobalValue &G) {
         if (!G.isDeclaration()
-            && G.getLinkage() == GlobalValue::LinkOnceODRLinkage
+            && (G.getLinkage() == GlobalValue::WeakODRLinkage ||
+                G.getLinkage() == GlobalValue::LinkOnceODRLinkage)
             && referencedGlobals.count(G.getName()) != 0) {
           G.setLinkage(GlobalValue::WeakODRLinkage);
         }

--- a/test/embedded/Inputs/linux-rng-support.c
+++ b/test/embedded/Inputs/linux-rng-support.c
@@ -5,7 +5,15 @@
 
 #ifdef __linux__ 
 
+#ifdef __cplusplus
+extern "C"
+#endif
 ssize_t getrandom(void *buf, size_t len, unsigned int flags);
+
+#ifdef __cplusplus
+extern "C"
+#endif
+void arc4random_buf(void *buf, size_t nbytes);
 
 void arc4random_buf(void *buf, size_t nbytes) {
   while (nbytes > 0) {

--- a/test/embedded/linkage-mergeable3.swift
+++ b/test/embedded/linkage-mergeable3.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-clang %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN MyModule.swift
+
+public func module_func(n: Int) {
+  var a: [Int] = [1, 2, 3]
+  print("module_func: \(a[0])")
+}
+
+// BEGIN MainA.swift
+
+import MyModule
+
+// BEGIN MainB.swift
+
+import MyModule
+
+@main
+struct Main {
+  static func main() {
+    module_func(n: 5)
+  }
+}
+
+// CHECK: module_func: 1

--- a/test/embedded/linkage-mergeable4.swift
+++ b/test/embedded/linkage-mergeable4.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-clang %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN MyModule.swift
+
+var dict: [Int:Int] = [1: 2, 3: 4]
+
+public func module_func() {
+  print("module_func: \(dict[1]!)")
+}
+
+// BEGIN MainA.swift
+
+import MyModule
+
+fileprivate var dict: [Int:Int] = [5: 6, 7: 8]
+
+func mainA_func() {
+  print("main_func: \(dict[5]!)")
+}
+
+// BEGIN MainB.swift
+
+import MyModule
+
+fileprivate var dict: [Int:Int] = [5: 6, 7: 8]
+
+func mainB_func() {
+  print("main_func: \(dict[5]!)")
+}
+
+@main
+struct Main {
+  static func main() {
+    module_func()
+    mainA_func()
+    mainB_func()
+  }
+}
+
+// CHECK: module_func: 2
+// CHECK: main_func: 6

--- a/test/embedded/linkage-mergeable4.swift
+++ b/test/embedded/linkage-mergeable4.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %linux_rng_support_c_if_needed %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -28,3 +28,9 @@ if config.available_features.intersection(set(supported_test_os_list)) == set():
 config.environment = dict(config.environment)
 if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
 if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']
+
+# (5) Provide some useful substitutions to simplify writing tests that work across platforms (macOS, Linux, etc.)
+if "OS=linux-gnu" in config.available_features:
+  config.substitutions.append(("%linux_rng_support_c_if_needed", "%S/Inputs/linux-rng-support.c"))
+else:
+  config.substitutions.append(("%linux_rng_support_c_if_needed", ""))


### PR DESCRIPTION
In multi-threaded LLVM IR optimization mode (-num-threads > 1), the multiple LLVM modules have references to globals in other modules, and this is currently crashing the compiler when using -mergeable-symbols. Let's fix that by extending IRGen's linkage fixup behavior it currently has for `LinkOnceODRLinkage` symbols, to also apply to `WeakODRLinkage` globals.

Example of the crash:
```
...
Global is external, but doesn't have external or weak linkage!
ptr @"$es23_swiftEmptyArrayStorageSi_S3itvp"
LLVM ERROR: Broken module found, compilation aborted!
```

The two modules have (before this fix):
```
// A
@"$es23_swiftEmptyArrayStorageSi_S3itvp" = weak_odr global <{ %TSi, %TSi, %TSi, %TSi }>, align 8

// B
@"$es23_swiftEmptyArrayStorageSi_S3itvp" = weak_odr global <{ %TSi, %TSi, %TSi, %TSi }> <{ %TSi zeroinitializer, %TSi <{ i64 -1 }>, %TSi zeroinitializer, %TSi <{ i64 1 }> }>, align 8
```

Problem reported here: https://forums.swift.org/t/web-app-with-embedded-swift-poc-demo/75486/12

https://github.com/swiftlang/swift/issues/80431