### PR TITLE
[test] Require asserts for dependencies-preservation-fine.swift

### DIFF
--- a/test/Frontend/dependencies-preservation-fine.swift
+++ b/test/Frontend/dependencies-preservation-fine.swift
@@ -1,3 +1,5 @@
+// REQUIRES: asserts
+
 // This test verifies that copies of dependency files are preserved after a
 // compilation. For example, if the first compilation produces 'foo.swiftdeps',
 // a second compilation should move 'foo.swiftdeps' to 'foo.swiftdeps~', then


### PR DESCRIPTION
PR #78793 moved the code that this test was testing for into `NDEBUG` blocks, which means that only exist in assert toolchains. The test was not changed, so it was failing in non-assert toolchains.
