### PR TITLE
Revert "Sema: Allow optional-to-optional CGFloat <-> Double conversion"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7564,6 +7564,13 @@ ERROR(result_builder_buildpartialblock_accumulated_not_accessible,none,
         "this behavior is deprecated", ())
 
 //------------------------------------------------------------------------------
+// MARK: Implicit conversion diagnostics
+//------------------------------------------------------------------------------
+ERROR(cannot_implicitly_convert_in_optional_context,none,
+      "cannot implicitly convert value of type %0 to expected type %1",
+      (Type, Type))
+
+//------------------------------------------------------------------------------
 // MARK: marker protocol diagnostics
 //------------------------------------------------------------------------------
 ERROR(marker_protocol_requirement, none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2852,6 +2852,22 @@ bool ContextualFailure::diagnoseAsError() {
     break;
   }
 
+  case ConstraintLocator::OptionalInjection: {
+    // If this is an attempt at a Double <-> CGFloat conversion
+    // through optional chaining, let's produce a tailored diagnostic.
+    if (isExpr<OptionalEvaluationExpr>(getAnchor())) {
+      if ((fromType->isDouble() || fromType->isCGFloat()) &&
+          (toType->isDouble() || toType->isCGFloat())) {
+        fromType = OptionalType::get(fromType);
+        toType = OptionalType::get(toType);
+        diagnostic = diag::cannot_implicitly_convert_in_optional_context;
+        break;
+      }
+    }
+
+    return false;
+  }
+
   case ConstraintLocator::EnumPatternImplicitCastMatch: {
     // In this case, the types are reversed, as we are checking whether we
     // can convert the pattern type to the context type.

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -349,3 +349,15 @@ func test_init_validation() {
     }
   }
 }
+
+func test_ternary_and_nil_coalescing() {
+  func test(_: Double?) {}
+
+  func ternary(v: CGFloat) {
+    test(true ? v : nil) // Ok
+  }
+
+  func test_nil_coalescing(v: CGFloat?) {
+    test(v ?? 0.0) // Ok
+  }
+}

--- a/test/Constraints/implicit_double_cgfloat_conversion.swift
+++ b/test/Constraints/implicit_double_cgfloat_conversion.swift
@@ -349,8 +349,3 @@ func test_init_validation() {
     }
   }
 }
-
-// Optional-to-optional conversion
-func optional_to_optional(x: CGFloat?) -> Double? {
-  return x
-}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83666783.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83666783.swift
@@ -12,5 +12,5 @@ func compute(_: Double?) -> Double? {
 }
 
 func test(s: S?) {
-  _ = compute(s?.test)
+  _ = compute(s?.test) // expected-error {{cannot implicitly convert value of type 'CGFloat?' to expected type 'Double?'}}
 }


### PR DESCRIPTION
Reverts https://github.com/swiftlang/swift/pull/79397 and one commit from https://github.com/swiftlang/swift/pull/79619 and removed a diagnostic.

Reason: The change has source compatibility important that we cannot mitigate at the moment. I've added a few test-case to demonstrate the problem.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
