### PR TITLE
Revert "Concurrency: remove workaround for silencing UB"

### DIFF
--- a/test/embedded/dependencies-concurrency-custom-executor.swift
+++ b/test/embedded/dependencies-concurrency-custom-executor.swift
@@ -18,7 +18,6 @@
 // DEP: _exit
 // DEP: _free
 // DEP: _malloc
-// DEP: _memcpy
 // DEP: _memmove
 // DEP: _memset
 // DEP: _memset_s

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -18,7 +18,6 @@
 // DEP: _exit
 // DEP: _free
 // DEP: _malloc
-// DEP: _memcpy
 // DEP: _memmove
 // DEP: _memset
 // DEP: _memset_s

--- a/test/embedded/dependencies-concurrency2.swift
+++ b/test/embedded/dependencies-concurrency2.swift
@@ -16,7 +16,6 @@
 // DEP: _exit
 // DEP: _free
 // DEP: _malloc
-// DEP: _memcpy
 // DEP: _memmove
 // DEP: _memset
 // DEP: _memset_s


### PR DESCRIPTION
Reverts swiftlang/swift#80246

Something is wrong with the build here and we're failing the build internally on `fatal error: 'swift/Runtime/STLCompatibility.h' file not found`. 

Is the STLCompatibility.h not available in some builds perhaps?

cc @compnerd  @etcwilde 