### PR TITLE
Add remote caching option for build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -85,6 +85,10 @@ If true, use `sccache` to cache the build rules.
 .PARAMETER Cache
 The path to a directory where the `sccache` stores the cache. By default, it will point to `$BinaryCache\sccache`.
 
+.PARAMETER EnableRemoteCaching
+If true, use `sccache` to cache the build rules remotely. If set, ensure that you configure the appropriate
+remote caching backend location and credentials environment variables for sccache.
+
 .PARAMETER Clean
 If true, clean non-compiler builds while building.
 
@@ -167,9 +171,13 @@ param
   [string] $Variant = "Asserts",
   [switch] $Clean,
   [switch] $DebugInfo,
+  [parameter(ParameterSetName = "LocalCaching")]
   [switch] $EnableCaching,
+  [parameter(ParameterSetName = "RemoteCaching")]
+  [switch] $EnableRemoteCaching,
   [ValidateSet("debug", "release")]
   [string] $FoundationTestConfiguration = "debug",
+  [parameter(ParameterSetName = "LocalCaching")]
   [string] $Cache = "",
   [switch] $Summary,
   [switch] $ToBatch
@@ -1290,14 +1298,14 @@ function Build-CMakeProject {
 
     if ($UseMSVCCompilers.Contains("C")) {
       Add-KeyValueIfNew $Defines CMAKE_C_COMPILER cl
-      if ($EnableCaching) {
+      if ($EnableCaching -or $EnableRemoteCaching) {
         Add-KeyValueIfNew $Defines CMAKE_C_COMPILER_LAUNCHER sccache
       }
       Add-FlagsDefine $Defines CMAKE_C_FLAGS $CFlags
     }
     if ($UseMSVCCompilers.Contains("CXX")) {
       Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER cl
-      if ($EnableCaching) {
+      if ($EnableCaching -or $EnableRemoteCaching) {
         Add-KeyValueIfNew $Defines CMAKE_CXX_COMPILER_LAUNCHER sccache
       }
       Add-FlagsDefine $Defines CMAKE_CXX_FLAGS $CXXFlags
@@ -3155,7 +3163,7 @@ if ($Clean) {
 }
 
 if (-not $SkipBuild) {
-  if ($EnableCaching -And (-Not (Test-SCCacheAtLeast -Major 0 -Minor 7 -Patch 4))) {
+  if ($EnableCaching -or $EnableRemoteCaching) -And (-Not (Test-SCCacheAtLeast -Major 0 -Minor 7 -Patch 4))) {
     throw "Minimum required sccache version is 0.7.4"
   }
 


### PR DESCRIPTION
When setting up sccache we can choose between local disk caching or remote caching via an S3-ish blob storage engine. To allow for backward compatibility for anyone that might be using the existing option for disk caching we leave it place and instead provide a new remote caching option.

This option assumes you've read the sccache documentation for setting up the correct environment variables for telling sccache where to find the bucket and how to authenticate to it.
