### PR TITLE
stdlib: Fix StrictMemorySafety warnings

### DIFF
--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -252,7 +252,7 @@ extension AsyncStream {
     func next() async -> Element? {
       await withTaskCancellationHandler {
         unsafe await withUnsafeContinuation {
-          next($0)
+          unsafe next($0)
         }
       } onCancel: { [cancel] in
         cancel()
@@ -512,7 +512,7 @@ extension AsyncThrowingStream {
     func next() async throws -> Element? {
       try await withTaskCancellationHandler {
         try unsafe await withUnsafeThrowingContinuation {
-          next($0)
+          unsafe next($0)
         }
       } onCancel: { [cancel] in
         cancel()

--- a/stdlib/public/Concurrency/Deque/Deque+Collection.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Collection.swift
@@ -93,7 +93,7 @@ extension _Deque: Sequence {
   }
 
   __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {
-    ContiguousArray(unsafeUninitializedCapacity: _storage.count) { target, count in
+    unsafe ContiguousArray(unsafeUninitializedCapacity: _storage.count) { target, count in
       unsafe _storage.read { source in
         let segments = unsafe source.segments()
         let c = unsafe segments.first.count

--- a/stdlib/public/Concurrency/Deque/Deque+Testing.swift
+++ b/stdlib/public/Concurrency/Deque/Deque+Testing.swift
@@ -62,7 +62,7 @@ extension _Deque {
     }
     let storage = unsafe _Deque<Element>._Storage(unsafeDowncast(buffer, to: _DequeBuffer.self))
     if contents.count > 0 {
-      contents.withUnsafeBufferPointer { source in
+      unsafe contents.withUnsafeBufferPointer { source in
         unsafe storage.update { target in
           let segments = unsafe target.mutableSegments()
           let c = unsafe segments.first.count

--- a/stdlib/public/Concurrency/Task+startSynchronously.swift.gyb
+++ b/stdlib/public/Concurrency/Task+startSynchronously.swift.gyb
@@ -76,7 +76,7 @@ extension Task where Failure == ${FAILURE_TYPE} {
     #if $BuiltinCreateAsyncTaskName
     if let name {
       task =
-        name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             taskName: nameBytes.baseAddress!._rawValue,

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -731,7 +731,7 @@ extension Task where Failure == Never {
     #if $BuiltinCreateAsyncTaskName
     if let name {
       task =
-        name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,
@@ -900,7 +900,7 @@ self._task = task
   #if $BuiltinCreateAsyncTaskName
   if let name {
     task =
-      name.utf8CString.withUnsafeBufferPointer { nameBytes in
+      unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
         Builtin.createTask(
           flags: flags,
           initialSerialExecutor: builtinSerialExecutor,
@@ -1041,7 +1041,7 @@ extension Task where Failure == Never {
     #if $BuiltinCreateAsyncTaskName
     if let name {
       task =
-        name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,
@@ -1183,7 +1183,7 @@ extension Task where Failure == Error {
     #if $BuiltinCreateAsyncTaskName
     if let name {
       task =
-        name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
           Builtin.createTask(
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,

--- a/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
+++ b/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
@@ -262,7 +262,7 @@ extension ${TYPE} {
     #if $BuiltinCreateAsyncTaskName
     if let name {
       task =
-        name.utf8CString.withUnsafeBufferPointer { nameBytes in
+        unsafe name.utf8CString.withUnsafeBufferPointer { nameBytes in
           ${TASK_CREATE_FN}(
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,

--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -45,7 +45,7 @@ extension std.string {
       unsafe self.init(str, UTF8._nullCodeUnitOffset(in: str), .init())
 #endif
     } else {
-      unsafe self.init()
+      self.init()
     }
   }
 }
@@ -58,9 +58,9 @@ extension std.u16string {
   ///   Swift string.
   @_alwaysEmitIntoClient
   public init(_ string: String) {
-    unsafe self.init()
+    self.init()
     for char in string.utf16 {
-      unsafe self.push_back(char)
+      self.push_back(char)
     }
   }
 }
@@ -73,9 +73,9 @@ extension std.u32string {
   ///   Swift string.
   @_alwaysEmitIntoClient
   public init(_ string: String) {
-    unsafe self.init()
+    self.init()
     for char in string.unicodeScalars {
-      unsafe self.push_back(char)
+      self.push_back(char)
     }
   }
 }
@@ -87,7 +87,7 @@ extension std.string: ExpressibleByStringLiteral,
 
   @_alwaysEmitIntoClient
   public init(stringLiteral value: String) {
-    unsafe self.init(value)
+    self.init(value)
   }
 }
 
@@ -96,7 +96,7 @@ extension std.u16string: ExpressibleByStringLiteral,
 
   @_alwaysEmitIntoClient
   public init(stringLiteral value: String) {
-    unsafe self.init(value)
+    self.init(value)
   }
 }
 
@@ -105,7 +105,7 @@ extension std.u32string: ExpressibleByStringLiteral,
 
   @_alwaysEmitIntoClient
   public init(stringLiteral value: String) {
-    unsafe self.init(value)
+    self.init(value)
   }
 }
 
@@ -114,17 +114,17 @@ extension std.u32string: ExpressibleByStringLiteral,
 extension std.string: Equatable, Comparable {
   @_alwaysEmitIntoClient
   public static func ==(lhs: std.string, rhs: std.string) -> Bool {
-    return unsafe lhs.compare(rhs) == 0
+    return lhs.compare(rhs) == 0
   }
 
   @_alwaysEmitIntoClient
   public static func <(lhs: std.string, rhs: std.string) -> Bool {
-    return unsafe lhs.compare(rhs) < 0
+    return lhs.compare(rhs) < 0
   }
 
   @_alwaysEmitIntoClient
   public static func +=(lhs: inout std.string, rhs: std.string) {
-    unsafe lhs.append(rhs)
+    lhs.append(rhs)
   }
 
   @_alwaysEmitIntoClient
@@ -134,26 +134,26 @@ extension std.string: Equatable, Comparable {
 
   @_alwaysEmitIntoClient
   public static func +(lhs: std.string, rhs: std.string) -> std.string {
-    var copy = unsafe lhs
-    unsafe copy += rhs
-    return unsafe copy
+    var copy = lhs
+    copy += rhs
+    return copy
   }
 }
 
 extension std.u16string: Equatable, Comparable {
   @_alwaysEmitIntoClient
   public static func ==(lhs: std.u16string, rhs: std.u16string) -> Bool {
-    return unsafe lhs.compare(rhs) == 0
+    return lhs.compare(rhs) == 0
   }
 
   @_alwaysEmitIntoClient
   public static func <(lhs: std.u16string, rhs: std.u16string) -> Bool {
-    return unsafe lhs.compare(rhs) < 0
+    return lhs.compare(rhs) < 0
   }
 
   @_alwaysEmitIntoClient
   public static func +=(lhs: inout std.u16string, rhs: std.u16string) {
-    unsafe lhs.append(rhs)
+    lhs.append(rhs)
   }
 
   @_alwaysEmitIntoClient
@@ -163,26 +163,26 @@ extension std.u16string: Equatable, Comparable {
 
   @_alwaysEmitIntoClient
   public static func +(lhs: std.u16string, rhs: std.u16string) -> std.u16string {
-    var copy = unsafe lhs
-    unsafe copy += rhs
-    return unsafe copy
+    var copy = lhs
+    copy += rhs
+    return copy
   }
 }
 
 extension std.u32string: Equatable, Comparable {
   @_alwaysEmitIntoClient
   public static func ==(lhs: std.u32string, rhs: std.u32string) -> Bool {
-    return unsafe lhs.compare(rhs) == 0
+    return lhs.compare(rhs) == 0
   }
 
   @_alwaysEmitIntoClient
   public static func <(lhs: std.u32string, rhs: std.u32string) -> Bool {
-    return unsafe lhs.compare(rhs) < 0
+    return lhs.compare(rhs) < 0
   }
 
   @_alwaysEmitIntoClient
   public static func +=(lhs: inout std.u32string, rhs: std.u32string) {
-    unsafe lhs.append(rhs)
+    lhs.append(rhs)
   }
 
   @_alwaysEmitIntoClient
@@ -192,9 +192,9 @@ extension std.u32string: Equatable, Comparable {
 
   @_alwaysEmitIntoClient
   public static func +(lhs: std.u32string, rhs: std.u32string) -> std.u32string {
-    var copy = unsafe lhs
-    unsafe copy += rhs
-    return unsafe copy
+    var copy = lhs
+    copy += rhs
+    return copy
   }
 }
 
@@ -204,7 +204,7 @@ extension std.string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::string>::operator()
-    let cxxHash = unsafe __swift_interopComputeHashOfString(self)
+    let cxxHash = __swift_interopComputeHashOfString(self)
     hasher.combine(cxxHash)
   }
 }
@@ -213,7 +213,7 @@ extension std.u16string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u16string>::operator()
-    let cxxHash = unsafe __swift_interopComputeHashOfU16String(self)
+    let cxxHash = __swift_interopComputeHashOfU16String(self)
     hasher.combine(cxxHash)
   }
 }
@@ -222,7 +222,7 @@ extension std.u32string: Hashable {
   @_alwaysEmitIntoClient
   public func hash(into hasher: inout Hasher) {
     // Call std::hash<std::u32string>::operator()
-    let cxxHash = unsafe __swift_interopComputeHashOfU32String(self)
+    let cxxHash = __swift_interopComputeHashOfU32String(self)
     hasher.combine(cxxHash)
   }
 }
@@ -232,42 +232,42 @@ extension std.u32string: Hashable {
 extension std.string: CustomDebugStringConvertible {
   @_alwaysEmitIntoClient
   public var debugDescription: String {
-    return "std.string(\(unsafe String(self)))"
+    return "std.string(\(String(self)))"
   }
 }
 
 extension std.u16string: CustomDebugStringConvertible {
   @_alwaysEmitIntoClient
   public var debugDescription: String {
-    return "std.u16string(\(unsafe String(self)))"
+    return "std.u16string(\(String(self)))"
   }
 }
 
 extension std.u32string: CustomDebugStringConvertible {
   @_alwaysEmitIntoClient
   public var debugDescription: String {
-    return "std.u32string(\(unsafe String(self)))"
+    return "std.u32string(\(String(self)))"
   }
 }
 
 extension std.string: CustomStringConvertible {
   @_alwaysEmitIntoClient
   public var description: String {
-    return unsafe String(self)
+    return String(self)
   }
 }
 
 extension std.u16string: CustomStringConvertible {
   @_alwaysEmitIntoClient
   public var description: String {
-    return unsafe String(self)
+    return String(self)
   }
 }
 
 extension std.u32string: CustomStringConvertible {
   @_alwaysEmitIntoClient
   public var description: String {
-    return unsafe String(self)
+    return String(self)
   }
 }
 
@@ -289,7 +289,7 @@ extension String {
     self = unsafe buffer.withMemoryRebound(to: UInt8.self) {
       unsafe String(decoding: $0, as: UTF8.self)
     }
-    unsafe withExtendedLifetime(cxxString) {}
+    withExtendedLifetime(cxxString) {}
   }
 
   /// Creates a String having the same content as the given C++ UTF-16 string.
@@ -306,7 +306,7 @@ extension String {
       start: cxxU16String.__dataUnsafe(),
       count: cxxU16String.size())
     self = unsafe String(decoding: buffer, as: UTF16.self)
-    unsafe withExtendedLifetime(cxxU16String) {}
+    withExtendedLifetime(cxxU16String) {}
   }
 
   /// Creates a String having the same content as the given C++ UTF-32 string.
@@ -325,7 +325,7 @@ extension String {
     self = unsafe buffer.withMemoryRebound(to: UInt32.self) {
       unsafe String(decoding: $0, as: UTF32.self)
     }
-    unsafe withExtendedLifetime(cxxU32String) {}
+    withExtendedLifetime(cxxU32String) {}
   }
 }
 

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -252,7 +252,7 @@ fileprivate class _Lock {
 
   init() {
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
-    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
+    unsafe self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
     unsafe self.underlying.initialize(to: os_unfair_lock())
     #elseif os(Windows)
     self.underlying = UnsafeMutablePointer.allocate(capacity: 1)

--- a/stdlib/public/Synchronization/Atomics/AtomicLazyReference.swift
+++ b/stdlib/public/Synchronization/Atomics/AtomicLazyReference.swift
@@ -25,7 +25,7 @@ public struct AtomicLazyReference<Instance: AnyObject>: ~Copyable {
   @available(SwiftStdlib 6.0, *)
   @inlinable
   public init() {
-    storage = unsafe Atomic<Unmanaged<Instance>?>(nil)
+    unsafe storage = Atomic<Unmanaged<Instance>?>(nil)
   }
 
   @inlinable

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -659,7 +659,7 @@ extension _ArrayBuffer {
       return try unsafe body(
         UnsafeBufferPointer(start: firstElementAddress, count: count))
     }
-    return try ContiguousArray(self).withUnsafeBufferPointer(body)
+    return try unsafe ContiguousArray(self).withUnsafeBufferPointer(body)
   }
 
   /// Call `body(p)`, where `p` is an `UnsafeBufferPointer` over the

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -277,12 +277,12 @@ extension ArraySlice: _ArrayProtocol {
   @inlinable
   public var _baseAddressIfContiguous: UnsafeMutablePointer<Element>? {
     @inline(__always) // FIXME(TODO: JIRA): Hack around test failure
-    get { return _buffer.firstElementAddressIfContiguous }
+    get { return unsafe _buffer.firstElementAddressIfContiguous }
   }
 
   @inlinable
   internal var _baseAddress: UnsafeMutablePointer<Element> {
-    return _buffer.firstElementAddress
+    return unsafe _buffer.firstElementAddress
   }
 }
 
@@ -703,7 +703,7 @@ extension ArraySlice: RangeReplaceableCollection {
     if count > 0 {
       _buffer = ArraySlice._allocateBufferUninitialized(minimumCapacity: count)
       _buffer.count = count
-      var p = _buffer.firstElementAddress
+      var p = unsafe _buffer.firstElementAddress
       for _ in 0..<count {
         unsafe p.initialize(to: repeatedValue)
         unsafe p += 1
@@ -752,7 +752,7 @@ extension ArraySlice: RangeReplaceableCollection {
     _ count: Int
   ) -> (ArraySlice, UnsafeMutablePointer<Element>) {
     let result = ArraySlice(_uninitializedCount: count)
-    return (result, result._buffer.firstElementAddress)
+    return (result, unsafe result._buffer.firstElementAddress)
   }
 
   //===--- basic mutations ------------------------------------------------===//
@@ -1171,7 +1171,7 @@ extension ArraySlice {
   func withUnsafeBufferPointer<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-    return try _buffer.withUnsafeBufferPointer(body)
+    return try unsafe _buffer.withUnsafeBufferPointer(body)
   }
 
   /// Calls a closure with a pointer to the array's contiguous storage.
@@ -1207,7 +1207,7 @@ extension ArraySlice {
   public func withUnsafeBufferPointer<R, E>(
     _ body: (UnsafeBufferPointer<Element>) throws(E) -> R
   ) throws(E) -> R {
-    return try _buffer.withUnsafeBufferPointer(body)
+    return try unsafe _buffer.withUnsafeBufferPointer(body)
   }
 
   @available(SwiftStdlib 6.2, *)
@@ -1283,7 +1283,7 @@ extension ArraySlice {
     _makeMutableAndUnique()
 
     // Create an UnsafeBufferPointer that we can pass to body
-    let pointer = _buffer.firstElementAddress
+    let pointer = unsafe _buffer.firstElementAddress
     var inoutBufferPointer = unsafe UnsafeMutableBufferPointer(
       start: pointer, count: count)
 
@@ -1573,7 +1573,7 @@ extension ArraySlice {
   @_alwaysEmitIntoClient
   public func _copyToNewArray() -> [Element] {
     unsafe Array(unsafeUninitializedCapacity: self.count) { buffer, count in
-      var (it, c) = self._buffer._copyContents(initializing: buffer)
+      var (it, c) = unsafe self._buffer._copyContents(initializing: buffer)
       _precondition(it.next() == nil)
       count = c
     }

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -150,6 +150,7 @@ extension _UnsafeBitset: @unsafe Sequence {
     return unsafe Iterator(self)
   }
 
+  @unsafe
   @usableFromInline
   @frozen
   internal struct Iterator: IteratorProtocol {

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -76,7 +76,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
     let cocoaStorageBaseAddress = unsafe self.contiguousStorage(self.indices)
 
     if let cocoaStorageBaseAddress = unsafe cocoaStorageBaseAddress {
-      return _SliceBuffer(
+      return unsafe _SliceBuffer(
         owner: self.buffer,
         subscriptBaseAddress: cocoaStorageBaseAddress,
         indices: bounds,

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -995,7 +995,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return try withUnsafeMutableBufferPointer {
+    return try unsafe withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
@@ -1005,7 +1005,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   public mutating func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return try withUnsafeMutableBufferPointer {
+    return try unsafe withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(&bufferPointer)
     }
@@ -1015,7 +1015,7 @@ extension ContiguousArray: RangeReplaceableCollection {
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
-    return try withUnsafeBufferPointer {
+    return try unsafe withUnsafeBufferPointer {
       (bufferPointer) -> R in
       return try unsafe body(bufferPointer)
     }
@@ -1059,7 +1059,7 @@ extension ContiguousArray: CustomStringConvertible, CustomDebugStringConvertible
 extension ContiguousArray {
   @usableFromInline @_transparent
   internal func _cPointerArgs() -> (AnyObject?, UnsafeRawPointer?) {
-    let p = _baseAddressIfContiguous
+    let p = unsafe _baseAddressIfContiguous
     if unsafe _fastPath(p != nil || isEmpty) {
       return (_owner, UnsafeRawPointer(p))
     }
@@ -1173,7 +1173,7 @@ extension ContiguousArray {
   mutating func __abi_withUnsafeMutableBufferPointer<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R {
-    return try withUnsafeMutableBufferPointer(body)
+    return try unsafe withUnsafeMutableBufferPointer(body)
   }
 
   /// Calls the given closure with a pointer to the array's mutable contiguous
@@ -1272,7 +1272,7 @@ extension ContiguousArray {
     _precondition(self.count <= buffer.count, 
       "Insufficient space allocated to copy array contents")
 
-    if let s = _baseAddressIfContiguous {
+    if let s = unsafe _baseAddressIfContiguous {
       unsafe p.initialize(from: s, count: self.count)
       // Need a _fixLifetime bracketing the _baseAddressIfContiguous getter
       // and all uses of the pointer it returns:
@@ -1446,7 +1446,7 @@ extension ContiguousArray {
   public mutating func withUnsafeMutableBytes<R>(
     _ body: (UnsafeMutableRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try self.withUnsafeMutableBufferPointer {
+    return try unsafe self.withUnsafeMutableBufferPointer {
       return try unsafe body(UnsafeMutableRawBufferPointer($0))
     }
   }
@@ -1482,7 +1482,7 @@ extension ContiguousArray {
   public func withUnsafeBytes<R>(
     _ body: (UnsafeRawBufferPointer) throws -> R
   ) rethrows -> R {
-    return try self.withUnsafeBufferPointer {
+    return try unsafe self.withUnsafeBufferPointer {
       try unsafe body(UnsafeRawBufferPointer($0))
     }
   }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -838,7 +838,7 @@ extension Dictionary: ExpressibleByDictionaryLiteral {
     for (key, value) in elements {
       let (bucket, found) = native.find(key)
       _precondition(!found, "Dictionary literal contains duplicate keys")
-      native._insert(at: bucket, key: key, value: value)
+      unsafe native._insert(at: bucket, key: key, value: value)
     }
     self.init(_native: native)
   }
@@ -904,11 +904,11 @@ extension Dictionary {
     }
     @inline(__always)
     _modify {
-      let (bucket, found) = _variant.mutatingFind(key)
+      let (bucket, found) = unsafe _variant.mutatingFind(key)
       let native = _variant.asNative
       if !found {
         let value = defaultValue()
-        native._insert(at: bucket, key: key, value: value)
+        unsafe native._insert(at: bucket, key: key, value: value)
       }
       let address = unsafe native._values + bucket.offset
       defer { _fixLifetime(self) }
@@ -1376,7 +1376,7 @@ extension Dictionary {
       if
         lhs._variant.isNative,
         rhs._variant.isNative,
-        lhs._variant.asNative._storage === rhs._variant.asNative._storage
+        unsafe (lhs._variant.asNative._storage === rhs._variant.asNative._storage)
       {
         return true
       }
@@ -1388,7 +1388,7 @@ extension Dictionary {
         return true
       }
 #else
-      if lhs._variant.asNative._storage === rhs._variant.asNative._storage {
+      if unsafe (lhs._variant.asNative._storage === rhs._variant.asNative._storage) {
         return true
       }
 #endif
@@ -1458,7 +1458,7 @@ extension Dictionary {
       }
       _modify {
         let native = _variant.ensureUniqueNative()
-        let bucket = native.validatedBucket(for: position)
+        let bucket = unsafe native.validatedBucket(for: position)
         let address = unsafe native._values + bucket.offset
         defer { _fixLifetime(self) }
         yield unsafe &address.pointee
@@ -1491,9 +1491,9 @@ extension Dictionary {
 #endif
       let isUnique = _variant.isUniquelyReferenced()
       let native = _variant.asNative
-      let a = native.validatedBucket(for: i)
-      let b = native.validatedBucket(for: j)
-      _variant.asNative.swapValuesAt(a, b, isUnique: isUnique)
+      let a = unsafe native.validatedBucket(for: i)
+      let b = unsafe native.validatedBucket(for: j)
+      unsafe _variant.asNative.swapValuesAt(a, b, isUnique: isUnique)
     }
   }
 }
@@ -1793,7 +1793,7 @@ extension Dictionary {
     @inlinable
     @inline(__always)
     internal init(_native index: _HashTable.Index) {
-      self.init(_variant: .native(index))
+      unsafe self.init(_variant: .native(index))
     }
 
 #if _runtime(_ObjC)
@@ -1876,7 +1876,7 @@ extension Dictionary.Index {
           "Attempting to access Dictionary elements using an invalid index")
       }
       let dummy = unsafe _HashTable.Index(bucket: _HashTable.Bucket(offset: 0), age: 0)
-      _variant = .native(dummy)
+      _variant = unsafe .native(dummy)
       defer { _variant = .cocoa(cocoa) }
       yield &cocoa
     }

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -71,9 +71,9 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
     _internalInvariant(_isBridgedVerbatimToObjectiveC(Key.self))
     _internalInvariant(_orphanedFoundationSubclassesReparented)
     self.base = base
-    self.bridgedKeys = nil
-    self.nextBucket = unsafe base.hashTable.startBucket
-    self.endBucket = unsafe base.hashTable.endBucket
+    unsafe self.bridgedKeys = nil
+    unsafe self.nextBucket = base.hashTable.startBucket
+    unsafe self.endBucket = base.hashTable.endBucket
     super.init()
   }
 
@@ -82,18 +82,18 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
     _internalInvariant(!_isBridgedVerbatimToObjectiveC(Key.self))
     _internalInvariant(_orphanedFoundationSubclassesReparented)
     self.base = deferred.native
-    self.bridgedKeys = unsafe deferred.bridgeKeys()
-    self.nextBucket = unsafe base.hashTable.startBucket
-    self.endBucket = unsafe base.hashTable.endBucket
+    unsafe self.bridgedKeys = deferred.bridgeKeys()
+    unsafe self.nextBucket = base.hashTable.startBucket
+    unsafe self.endBucket = base.hashTable.endBucket
     super.init()
   }
 
   private func bridgedKey(at bucket: _HashTable.Bucket) -> AnyObject {
     unsafe _internalInvariant(base.hashTable.isOccupied(bucket))
-    if let bridgedKeys = self.bridgedKeys {
+    if let bridgedKeys = unsafe self.bridgedKeys {
       return unsafe bridgedKeys[bucket]
     }
-    return _bridgeAnythingToObjectiveC(base.uncheckedKey(at: bucket))
+    return unsafe _bridgeAnythingToObjectiveC(base.uncheckedKey(at: bucket))
   }
 
   @objc
@@ -101,9 +101,9 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
     if unsafe nextBucket == endBucket {
       return nil
     }
-    let bucket = nextBucket
-    nextBucket = unsafe base.hashTable.occupiedBucket(after: nextBucket)
-    return self.bridgedKey(at: bucket)
+    let bucket = unsafe nextBucket
+    unsafe nextBucket = base.hashTable.occupiedBucket(after: nextBucket)
+    return unsafe self.bridgedKey(at: bucket)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -128,7 +128,7 @@ final internal class _SwiftDictionaryNSEnumerator<Key: Hashable, Value>
     // enumeration, terminate it, and continue via NSEnumerator.
     let unmanagedObjects = unsafe _UnmanagedAnyObjectArray(objects)
     unsafe unmanagedObjects[0] = self.bridgedKey(at: nextBucket)
-    nextBucket = unsafe base.hashTable.occupiedBucket(after: nextBucket)
+    unsafe nextBucket = base.hashTable.occupiedBucket(after: nextBucket)
     unsafe state.pointee = theState
     return 1
   }
@@ -230,7 +230,8 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
       owner: native._storage,
       hashTable: native.hashTable)
     for unsafe bucket in unsafe native.hashTable {
-      let object = _bridgeAnythingToObjectiveC(native.uncheckedKey(at: bucket))
+      let object = unsafe _bridgeAnythingToObjectiveC(
+        native.uncheckedKey(at: bucket))
       unsafe bridged.initialize(at: bucket, to: object)
     }
 
@@ -249,7 +250,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
       owner: native._storage,
       hashTable: native.hashTable)
     for unsafe bucket in unsafe native.hashTable {
-      let value = native.uncheckedValue(at: bucket)
+      let value = unsafe native.uncheckedValue(at: bucket)
       let cocoaValue = _bridgeAnythingToObjectiveC(value)
       unsafe bridged.initialize(at: bucket, to: cocoaValue)
     }
@@ -274,7 +275,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     if let bridgedKeys = unsafe bridgedKeys {
       return unsafe bridgedKeys[bucket]
     }
-    return _bridgeAnythingToObjectiveC(native.uncheckedKey(at: bucket))
+    return unsafe _bridgeAnythingToObjectiveC(native.uncheckedKey(at: bucket))
   }
 
   @inline(__always)
@@ -285,7 +286,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     if let bridgedValues = unsafe bridgedValues {
       return unsafe bridgedValues[bucket]
     }
-    return _bridgeAnythingToObjectiveC(native.uncheckedValue(at: bucket))
+    return unsafe _bridgeAnythingToObjectiveC(native.uncheckedValue(at: bucket))
   }
 
   @objc(objectForKey:)
@@ -383,7 +384,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     count: Int
   ) -> Int {
     defer { _fixLifetime(self) }
-    let hashTable = native.hashTable
+    let hashTable = unsafe native.hashTable
 
     var theState = unsafe state.pointee
     if unsafe theState.state == 0 {
@@ -809,7 +810,7 @@ extension Dictionary {
     }
 
     if let nativeStorage = unsafe s as? _DictionaryStorage<Key, Value> {
-      return Dictionary(_native: _NativeDictionary(nativeStorage))
+      return Dictionary(_native: unsafe _NativeDictionary(nativeStorage))
     }
 
     if unsafe s === __RawDictionaryStorage.empty {

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -84,7 +84,7 @@ extension Dictionary {
       _ values: UnsafeMutableBufferPointer<Value>
     ) -> Int
   ) {
-    self.init(_native: _NativeDictionary(
+    self.init(_native: unsafe _NativeDictionary(
         _unsafeUninitializedCapacity: capacity,
         allowingDuplicates: allowingDuplicates,
         initializingWith: initializer))
@@ -151,7 +151,7 @@ extension _NativeDictionary {
           unsafe _internalInvariant(b != bucket)
           _precondition(allowingDuplicates, "Duplicate keys found")
           // Discard duplicate entry.
-          uncheckedDestroy(at: bucket)
+          unsafe uncheckedDestroy(at: bucket)
           unsafe _storage._count -= 1
           unsafe bucket.offset -= 1
           continue
@@ -166,7 +166,7 @@ extension _NativeDictionary {
       if unsafe target > bucket {
         // The target is outside the unprocessed region.  We can simply move the
         // entry, leaving behind an uninitialized bucket.
-        moveEntry(from: bucket, to: target)
+        unsafe moveEntry(from: bucket, to: target)
         // Restore invariants by lowering the region boundary.
         unsafe bucket.offset -= 1
       } else if unsafe target == bucket {
@@ -176,7 +176,7 @@ extension _NativeDictionary {
         // The target bucket is also in the unprocessed region. Swap the current
         // item into place, then try again with the swapped-in value, so that we
         // don't lose it.
-        swapEntry(target, with: bucket)
+        unsafe swapEntry(target, with: bucket)
       }
     }
     // When there are no more unprocessed entries, we're left with a valid

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -232,12 +232,14 @@ extension __RawDictionaryStorage {
     return unsafe keys[bucket.offset]
   }
 
+  @safe
   @_alwaysEmitIntoClient
   @inline(never)
   internal final func find<Key: Hashable>(_ key: Key) -> (bucket: _HashTable.Bucket, found: Bool) {
     return unsafe find(key, hashValue: key._rawHashValue(seed: _seed))
   }
 
+  @safe
   @_alwaysEmitIntoClient
   @inline(never)
   internal final func find<Key: Hashable>(_ key: Key, hashValue: Int) -> (bucket: _HashTable.Bucket, found: Bool) {
@@ -298,7 +300,7 @@ final internal class _DictionaryStorage<Key: Hashable, Value>
   }
 
   internal var asNative: _NativeDictionary<Key, Value> {
-    return _NativeDictionary(self)
+    return unsafe _NativeDictionary(self)
   }
 
 #if _runtime(_ObjC)

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -41,14 +41,14 @@ extension Dictionary {
     @inlinable
     @inline(__always)
     init(native: __owned _NativeDictionary<Key, Value>) {
-      self.object = unsafe _BridgeStorage(native: native._storage)
+      unsafe self.object = _BridgeStorage(native: native._storage)
     }
 
     @inlinable
     @inline(__always)
     init(dummy: Void) {
 #if _pointerBitWidth(_64) && !$Embedded
-      self.object = unsafe _BridgeStorage(taggedPayload: 0)
+      unsafe self.object = _BridgeStorage(taggedPayload: 0)
 #elseif _pointerBitWidth(_32) || $Embedded
       self.init(native: _NativeDictionary())
 #else
@@ -60,7 +60,7 @@ extension Dictionary {
     @inlinable
     @inline(__always)
     init(cocoa: __owned __CocoaDictionary) {
-      self.object = unsafe _BridgeStorage(objC: cocoa.object)
+      unsafe self.object = _BridgeStorage(objC: cocoa.object)
     }
 #endif
   }
@@ -83,7 +83,7 @@ extension Dictionary._Variant {
   @usableFromInline @_transparent
   internal var isNative: Bool {
     if guaranteedNative { return true }
-    return object.isUnflaggedNative
+    return unsafe object.isUnflaggedNative
   }
 #endif
 
@@ -98,7 +98,7 @@ extension Dictionary._Variant {
     _modify {
       var native = unsafe _NativeDictionary<Key, Value>(object.unflaggedNativeInstance)
       self = .init(dummy: ())
-      defer { object = unsafe .init(native: native._storage) }
+      defer { unsafe object = .init(native: native._storage) }
       yield &native
     }
   }
@@ -390,8 +390,8 @@ extension Dictionary._Variant {
     // FIXME(performance): fuse data migration and element deletion into one
     // operation.
     let native = ensureUniqueNative()
-    let bucket = native.validatedBucket(for: index)
-    return asNative.uncheckedRemove(at: bucket, isUnique: true)
+    let bucket = unsafe native.validatedBucket(for: index)
+    return unsafe asNative.uncheckedRemove(at: bucket, isUnique: true)
   }
 
   @inlinable
@@ -404,7 +404,7 @@ extension Dictionary._Variant {
       var native = _NativeDictionary<Key, Value>(cocoa)
       let (bucket, found) = native.find(key)
       _precondition(found, "Bridging did not preserve equality")
-      let old = native.uncheckedRemove(at: bucket, isUnique: true).value
+      let old = unsafe native.uncheckedRemove(at: bucket, isUnique: true).value
       self = .init(native: native)
       return old
     }
@@ -412,7 +412,7 @@ extension Dictionary._Variant {
     let (bucket, found) = asNative.find(key)
     guard found else { return nil }
     let isUnique = isUniquelyReferenced()
-    return asNative.uncheckedRemove(at: bucket, isUnique: isUnique).value
+    return unsafe asNative.uncheckedRemove(at: bucket, isUnique: isUnique).value
   }
 
   @inlinable

--- a/stdlib/public/core/Diffing.swift
+++ b/stdlib/public/core/Diffing.swift
@@ -355,7 +355,7 @@ private func _myers<C,D>(
   ) rethrows -> R {
     if let result = try values.withContiguousStorageIfAvailable(body) { return result }
     let array = ContiguousArray(values)
-    return try array.withUnsafeBufferPointer(body)
+    return try unsafe array.withUnsafeBufferPointer(body)
   }
 
   return unsafe _withContiguousStorage(for: old) { a in

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -186,6 +186,7 @@ extension _HashTable.Bucket: Comparable {
 }
 
 extension _HashTable {
+  @unsafe
   @usableFromInline
   @frozen
   internal struct Index {
@@ -231,6 +232,7 @@ extension _HashTable.Index: Comparable {
 }
 
 extension _HashTable: @unsafe Sequence {
+  @unsafe
   @usableFromInline
   @frozen
   internal struct Iterator: @unsafe IteratorProtocol {
@@ -280,6 +282,7 @@ extension _HashTable: @unsafe Sequence {
 extension _HashTable.Iterator: Sendable {}
 
 extension _HashTable {
+  @safe
   @inlinable
   @inline(__always)
   internal func isValid(_ bucket: Bucket) -> Bool {
@@ -289,7 +292,7 @@ extension _HashTable {
   @inlinable
   @inline(__always)
   internal func _isOccupied(_ bucket: Bucket) -> Bool {
-    unsafe _internalInvariant(isValid(bucket))
+    _internalInvariant(isValid(bucket))
     return unsafe words[bucket.word].uncheckedContains(bucket.bit)
   }
 
@@ -322,7 +325,7 @@ extension _HashTable {
 
   @inlinable
   internal func occupiedBucket(after bucket: Bucket) -> Bucket {
-    unsafe _internalInvariant(isValid(bucket))
+    _internalInvariant(isValid(bucket))
     let word = unsafe bucket.word
     if let bit = unsafe words[word].intersecting(elementsAbove: bucket.bit).minimum {
       return unsafe Bucket(word: word, bit: bit)
@@ -364,7 +367,7 @@ extension _HashTable {
 extension _HashTable {
   @inlinable
   internal func previousHole(before bucket: Bucket) -> Bucket {
-    unsafe _internalInvariant(isValid(bucket))
+    _internalInvariant(isValid(bucket))
     // Note that if we have only a single partial word, its out-of-bounds bits
     // are guaranteed to be all set, so the formula below gives correct results.
     var word = unsafe bucket.word
@@ -392,7 +395,7 @@ extension _HashTable {
 
   @inlinable
   internal func nextHole(atOrAfter bucket: Bucket) -> Bucket {
-    unsafe _internalInvariant(isValid(bucket))
+    _internalInvariant(isValid(bucket))
     // Note that if we have only a single partial word, its out-of-bounds bits
     // are guaranteed to be all set, so the formula below gives correct results.
     var word = unsafe bucket.word

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -147,7 +147,7 @@ extension InlineArray where Element: ~Copyable {
   public init<E: Error>(_ body: (Index) throws(E) -> Element) throws(E) {
 #if $BuiltinEmplaceTypedThrows
     self = try Builtin.emplace { (rawPtr) throws(E) -> () in
-      let buffer = Self._initializationBuffer(start: rawPtr)
+      let buffer = unsafe Self._initializationBuffer(start: rawPtr)
 
       for i in 0 ..< count {
         do throws(E) {
@@ -204,7 +204,7 @@ extension InlineArray where Element: ~Copyable {
     var o: Element? = first
 
     self = try Builtin.emplace { (rawPtr) throws(E) -> () in
-      let buffer = Self._initializationBuffer(start: rawPtr)
+      let buffer = unsafe Self._initializationBuffer(start: rawPtr)
 
       guard Self.count > 0 else {
         return
@@ -247,7 +247,7 @@ extension InlineArray where Element: Copyable {
   @_alwaysEmitIntoClient
   public init(repeating value: Element) {
     self = Builtin.emplace {
-      let buffer = Self._initializationBuffer(start: $0)
+      let buffer = unsafe Self._initializationBuffer(start: $0)
 
       unsafe buffer.initialize(repeating: value)
     }

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -356,7 +356,7 @@ public func _forEachFieldWithKeyPath<Root>(
       return KeyPath<Root, Leaf>.self
     }
     let resultSize = MemoryLayout<Int32>.size + MemoryLayout<Int>.size
-    let partialKeyPath = _openExistential(childType, do: keyPathType)
+    let partialKeyPath = unsafe _openExistential(childType, do: keyPathType)
        ._create(capacityInBytes: resultSize) {
       var destBuilder = unsafe KeyPathBuffer.Builder($0)
       unsafe destBuilder.pushHeader(KeyPathBuffer.Header(

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -231,7 +231,7 @@ extension Set: ExpressibleByArrayLiteral {
         // FIXME: Shouldn't this trap?
         continue
       }
-      native._unsafeInsertNew(element, at: bucket)
+      unsafe native._unsafeInsertNew(element, at: bucket)
     }
     self.init(_native: native)
   }
@@ -1309,7 +1309,7 @@ extension Set {
     @inlinable
     @inline(__always)
     internal init(_native index: _HashTable.Index) {
-      self.init(_variant: .native(index))
+      self.init(_variant: unsafe .native(index))
     }
 
 #if _runtime(_ObjC)
@@ -1393,7 +1393,7 @@ extension Set.Index {
           "Attempting to access Set elements using an invalid index")
       }
       let dummy = unsafe _HashTable.Index(bucket: _HashTable.Bucket(offset: 0), age: 0)
-      _variant = .native(dummy)
+      _variant = unsafe .native(dummy)
       defer { _variant = .cocoa(cocoa) }
       yield &cocoa
     }

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -70,9 +70,9 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     _internalInvariant(_isBridgedVerbatimToObjectiveC(Element.self))
     _internalInvariant(_orphanedFoundationSubclassesReparented)
     self.base = base
-    self.bridgedElements = nil
-    self.nextBucket = unsafe base.hashTable.startBucket
-    self.endBucket = unsafe base.hashTable.endBucket
+    unsafe self.bridgedElements = nil
+    unsafe self.nextBucket = base.hashTable.startBucket
+    unsafe self.endBucket = base.hashTable.endBucket
     super.init()
   }
 
@@ -81,18 +81,18 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     _internalInvariant(!_isBridgedVerbatimToObjectiveC(Element.self))
     _internalInvariant(_orphanedFoundationSubclassesReparented)
     self.base = deferred.native
-    self.bridgedElements = unsafe deferred.bridgeElements()
-    self.nextBucket = unsafe base.hashTable.startBucket
-    self.endBucket = unsafe base.hashTable.endBucket
+    unsafe self.bridgedElements = deferred.bridgeElements()
+    unsafe self.nextBucket = base.hashTable.startBucket
+    unsafe self.endBucket = base.hashTable.endBucket
     super.init()
   }
 
   private func bridgedElement(at bucket: _HashTable.Bucket) -> AnyObject {
     unsafe _internalInvariant(base.hashTable.isOccupied(bucket))
-    if let bridgedElements = self.bridgedElements {
+    if let bridgedElements = unsafe self.bridgedElements {
       return unsafe bridgedElements[bucket]
     }
-    return _bridgeAnythingToObjectiveC(base.uncheckedElement(at: bucket))
+    return unsafe _bridgeAnythingToObjectiveC(base.uncheckedElement(at: bucket))
   }
 
   //
@@ -106,9 +106,9 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     if unsafe nextBucket == endBucket {
       return nil
     }
-    let bucket = nextBucket
-    nextBucket = unsafe base.hashTable.occupiedBucket(after: nextBucket)
-    return self.bridgedElement(at: bucket)
+    let bucket = unsafe nextBucket
+    unsafe nextBucket = base.hashTable.occupiedBucket(after: nextBucket)
+    return unsafe self.bridgedElement(at: bucket)
   }
 
   @objc(countByEnumeratingWithState:objects:count:)
@@ -133,7 +133,7 @@ final internal class _SwiftSetNSEnumerator<Element: Hashable>
     // enumeration, terminate it, and continue via NSEnumerator.
     let unmanagedObjects = unsafe _UnmanagedAnyObjectArray(objects)
     unsafe unmanagedObjects[0] = self.bridgedElement(at: nextBucket)
-    nextBucket = unsafe base.hashTable.occupiedBucket(after: nextBucket)
+    unsafe nextBucket = base.hashTable.occupiedBucket(after: nextBucket)
     unsafe state.pointee = theState
     return 1
   }
@@ -198,7 +198,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
       owner: native._storage,
       hashTable: native.hashTable)
     for unsafe bucket in unsafe native.hashTable {
-      let object = _bridgeAnythingToObjectiveC(
+      let object = unsafe _bridgeAnythingToObjectiveC(
         native.uncheckedElement(at: bucket))
       unsafe bridged.initialize(at: bucket, to: object)
     }
@@ -248,7 +248,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
     count: Int
   ) -> Int {
     defer { _fixLifetime(self) }
-    let hashTable = native.hashTable
+    let hashTable = unsafe native.hashTable
 
     var theState = unsafe state.pointee
     if unsafe theState.state == 0 {
@@ -628,7 +628,7 @@ extension Set {
     }
 
     if let nativeStorage = unsafe s as? _SetStorage<Element> {
-      return Set(_native: _NativeSet(nativeStorage))
+      return unsafe Set(_native: _NativeSet(nativeStorage))
     }
 
     if unsafe s === __RawSetStorage.empty {

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -236,7 +236,7 @@ final internal class _SetStorage<Element: Hashable>
   }
 
   internal var asNative: _NativeSet<Element> {
-    return _NativeSet(self)
+    return unsafe _NativeSet(self)
   }
 
 #if _runtime(_ObjC)

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -52,7 +52,7 @@ internal struct _SliceBuffer<Element>
     endIndexAndFlags: UInt
   ) {
     self.owner = owner
-    self.subscriptBaseAddress = unsafe subscriptBaseAddress
+    unsafe self.subscriptBaseAddress = subscriptBaseAddress
     self.startIndex = startIndex
     self.endIndexAndFlags = endIndexAndFlags
   }
@@ -63,7 +63,7 @@ internal struct _SliceBuffer<Element>
     indices: Range<Int>, hasNativeBuffer: Bool
   ) {
     self.owner = owner
-    self.subscriptBaseAddress = unsafe subscriptBaseAddress
+    unsafe self.subscriptBaseAddress = subscriptBaseAddress
     self.startIndex = indices.lowerBound
     let bufferFlag = UInt(hasNativeBuffer ? 1 : 0)
     self.endIndexAndFlags = (UInt(indices.upperBound) << 1) | bufferFlag
@@ -78,7 +78,7 @@ internal struct _SliceBuffer<Element>
     #else
     self.owner = _emptyArrayStorage
     #endif
-    self.subscriptBaseAddress = unsafe empty.firstElementAddress
+    unsafe self.subscriptBaseAddress = empty.firstElementAddress
     self.startIndex = empty.startIndex
     self.endIndexAndFlags = 1
     _invariantCheck()
@@ -176,7 +176,7 @@ internal struct _SliceBuffer<Element>
   /// identity and count.
   @inlinable
   internal var identity: UnsafeRawPointer {
-    return UnsafeRawPointer(firstElementAddress)
+    return unsafe UnsafeRawPointer(firstElementAddress)
   }
 
   @inlinable
@@ -186,7 +186,7 @@ internal struct _SliceBuffer<Element>
 
   @inlinable
   internal var firstElementAddressIfContiguous: UnsafeMutablePointer<Element>? {
-    return firstElementAddress
+    return unsafe firstElementAddress
   }
 
   //===--- Non-essential bits ---------------------------------------------===//
@@ -399,7 +399,7 @@ internal struct _SliceBuffer<Element>
       _internalInvariant(bounds.lowerBound >= startIndex)
       _internalInvariant(bounds.upperBound >= bounds.lowerBound)
       _internalInvariant(bounds.upperBound <= endIndex)
-      return _SliceBuffer(
+      return unsafe _SliceBuffer(
         owner: owner,
         subscriptBaseAddress: subscriptBaseAddress,
         indices: bounds,
@@ -482,7 +482,7 @@ internal struct _SliceBuffer<Element>
     _internalInvariant(_isClassOrObjCExistential(T.self))
     let baseAddress = unsafe UnsafeMutableRawPointer(self.subscriptBaseAddress)
       .assumingMemoryBound(to: T.self)
-    return _SliceBuffer<T>(
+    return unsafe _SliceBuffer<T>(
       owner: self.owner,
       subscriptBaseAddress: baseAddress,
       startIndex: self.startIndex,

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -35,7 +35,7 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
     _unchecked pointer: UnsafeMutableRawPointer?,
     byteCount: Int
   ) {
-    _pointer = unsafe pointer
+    unsafe _pointer = pointer
     _count = byteCount
   }
 }
@@ -136,7 +136,7 @@ extension MutableRawSpan {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let pointer = _pointer, _count > 0 else {
+    guard let pointer = unsafe _pointer, _count > 0 else {
       return try unsafe body(.init(start: nil, count: 0))
     }
     return try unsafe body(.init(start: pointer, count: _count))
@@ -147,7 +147,7 @@ extension MutableRawSpan {
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let pointer = _pointer, _count > 0 else {
+    guard let pointer = unsafe _pointer, _count > 0 else {
       return try unsafe body(.init(start: nil, count: 0))
     }
     return try unsafe body(.init(start: pointer, count: _count))
@@ -160,7 +160,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(borrow mutableRawSpan)
   public init(_mutableRawSpan mutableRawSpan: borrowing MutableRawSpan) {
-    let (start, count) = (mutableRawSpan._start(), mutableRawSpan._count)
+    let (start, count) = unsafe (mutableRawSpan._start(), mutableRawSpan._count)
     let span = unsafe RawSpan(_unsafeStart: start, byteCount: count)
     self = unsafe _overrideLifetime(span, borrowing: mutableRawSpan)
   }
@@ -393,8 +393,8 @@ extension MutableRawSpan {
     fromContentsOf source: Span<Element>
   ) -> Int {
 //    update(from: source.bytes)
-    source.withUnsafeBytes {
-      update(fromContentsOf: $0)
+    unsafe source.withUnsafeBytes {
+      unsafe update(fromContentsOf: $0)
     }
   }
 
@@ -404,8 +404,8 @@ extension MutableRawSpan {
     fromContentsOf source: borrowing MutableSpan<Element>
   ) -> Int {
 //    update(from: source.span.bytes)
-    source.withUnsafeBytes {
-      update(fromContentsOf: $0)
+    unsafe source.withUnsafeBytes {
+      unsafe update(fromContentsOf: $0)
     }
   }
 
@@ -415,7 +415,7 @@ extension MutableRawSpan {
     fromContentsOf source: RawSpan
   ) -> Int {
     if source.byteCount == 0 { return 0 }
-    source.withUnsafeBytes {
+    unsafe source.withUnsafeBytes {
       unsafe _start().copyMemory(from: $0.baseAddress!, byteCount: $0.count)
     }
     return source.byteCount

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -54,7 +54,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @inline(__always)
   @lifetime(immortal)
   internal init() {
-    _pointer = nil
+    unsafe _pointer = nil
     _count = 0
   }
 
@@ -79,7 +79,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
     _unchecked pointer: UnsafeRawPointer?,
     byteCount: Int
   ) {
-    _pointer = unsafe pointer
+    unsafe _pointer = pointer
     _count = byteCount
   }
 }
@@ -316,7 +316,7 @@ extension RawSpan {
   public init<Element: BitwiseCopyable>(
     _elements span: Span<Element>
   ) {
-    let pointer = span._pointer
+    let pointer = unsafe span._pointer
     let rawSpan = unsafe RawSpan(
       _unchecked: pointer,
       byteCount: span.count == 1 ? MemoryLayout<Element>.size
@@ -491,7 +491,7 @@ extension RawSpan {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let _pointer, byteCount > 0 else {
+    guard let _pointer = unsafe _pointer, byteCount > 0 else {
       return try unsafe body(.init(start: nil, count: 0))
     }
     return try unsafe body(.init(start: _pointer, count: byteCount))
@@ -666,7 +666,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   public func byteOffsets(of other: borrowing Self) -> Range<Int>? {
     if other._count > _count { return nil }
-    guard let spanStart = other._pointer, _count > 0 else {
+    guard let spanStart = unsafe other._pointer, _count > 0 else {
       return unsafe _pointer == other._pointer ? 0..<0 : nil
     }
     let start = unsafe _start()

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -55,7 +55,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
   @inline(__always)
   @lifetime(immortal)
   internal init() {
-    _pointer = nil
+    unsafe _pointer = nil
     _count = 0
   }
 
@@ -80,7 +80,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
     _unchecked pointer: UnsafeRawPointer?,
     count: Int
   ) {
-    _pointer = unsafe pointer
+    unsafe _pointer = pointer
     _count = count
   }
 }
@@ -649,7 +649,7 @@ extension Span where Element: ~Copyable  {
   public func withUnsafeBufferPointer<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let pointer = _pointer, _count > 0 else {
+    guard let pointer = unsafe _pointer, _count > 0 else {
       return try unsafe body(.init(start: nil, count: 0))
     }
     // manual memory rebinding to avoid recalculating the alignment checks
@@ -684,7 +684,7 @@ extension Span where Element: BitwiseCopyable {
   public func withUnsafeBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
-    guard let _pointer, _count > 0 else {
+    guard let _pointer = unsafe _pointer, _count > 0 else {
       return try unsafe body(.init(start: nil, count: 0))
     }
     return try unsafe body(
@@ -711,7 +711,7 @@ extension Span where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public func indices(of other: borrowing Self) -> Range<Index>? {
     if other._count > _count { return nil }
-    guard let spanStart = other._pointer, _count > 0 else {
+    guard let spanStart = unsafe other._pointer, _count > 0 else {
       return unsafe _pointer == other._pointer ? 0..<0 : nil
     }
     let start = unsafe _start()

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -383,7 +383,7 @@ extension String {
     }
 
     let storage = unsafe buffer.baseAddress.map {
-      __SharedStringStorage(
+      unsafe __SharedStringStorage(
         _mortal: $0,
         countAndFlags: _StringObject.CountAndFlags(
           count: buffer.startIndex.distance(to: written),

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -236,7 +236,7 @@ extension _StringGuts {
     _ body: (UnsafePointer<Int8>) throws -> Result
   ) rethrows -> Result {
     _internalInvariant(!_object.isFastZeroTerminated)
-    return try String(self).utf8CString.withUnsafeBufferPointer {
+    return try unsafe String(self).utf8CString.withUnsafeBufferPointer {
       let ptr = unsafe $0.baseAddress._unsafelyUnwrappedUnchecked
       return try unsafe body(ptr)
     }

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -982,7 +982,7 @@ extension _StringObject {
       }
     }
 #endif
-    return unsafe withSharedStorage { $0.start }
+    return unsafe withSharedStorage { unsafe $0.start }
   }
 
   @usableFromInline

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -699,7 +699,7 @@ final internal class __SharedStringStorage
     countAndFlags: _StringObject.CountAndFlags
   ) {
     self._owner = nil
-    self.start = unsafe ptr
+    unsafe self.start = ptr
     self.immortal = true
 #if _pointerBitWidth(_64)
     self._countAndFlags = countAndFlags
@@ -728,7 +728,7 @@ final internal class __SharedStringStorage
   ) {
     // ptr *must* be the start of an allocation
     self._owner = nil
-    self.start = unsafe ptr
+    unsafe self.start = ptr
     self.immortal = false
 #if _pointerBitWidth(_64)
     self._countAndFlags = countAndFlags

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -312,7 +312,7 @@ extension __SharedStringStorage {
   @objc(UTF8String)
   @_effects(readonly)
   final internal func _utf8String() -> UnsafePointer<UInt8>? {
-    return start
+    return unsafe start
   }
 
   @objc(cStringUsingEncoding:)

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -278,7 +278,7 @@ extension String {
     @_effects(readonly) @_semantics("string.getUTF8CString")
     get {
       if _fastPath(_guts.isFastUTF8) {
-        var result = unsafe _guts.withFastCChar { ContiguousArray($0) }
+        var result = unsafe _guts.withFastCChar { unsafe ContiguousArray($0) }
         result.append(0)
         return result
       }


### PR DESCRIPTION
Fix all of the `#StrictMemorySafety` warnings that have crept into the standard library so that we can have a relatively clean build again.