### PR TITLE
[stdlib] Add a default argument to `dropLast(_:)`

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -376,7 +376,7 @@ extension BidirectionalCollection {
   ///   `RandomAccessCollection`; otherwise, O(*k*), where *k* is the number of
   ///   elements to drop.
   @inlinable // protocol-only
-  public __consuming func dropLast(_ k: Int) -> SubSequence {
+  public __consuming func dropLast(_ k: Int = 1) -> SubSequence {
     _precondition(
       k >= 0, "Can't drop a negative number of elements from a collection")
     let end = index(


### PR DESCRIPTION
Add a default argument to the `dropLast(_:)` method on `BidirectionalCollection`.

(The methods on [`Collection`][] and [`Sequence`][] already have a default argument.)

[`Collection`]: <https://github.com/swiftlang/swift/blob/swift-6.1-RELEASE/stdlib/public/core/Collection.swift#L1276>
[`Sequence`]:   <https://github.com/swiftlang/swift/blob/swift-6.1-RELEASE/stdlib/public/core/Sequence.swift#L1078>
