### PR TITLE
AST: Build availability scopes for custom domain conditionals

### DIFF
--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -99,10 +99,14 @@ public:
   void constrainWithContext(const AvailabilityContext &other,
                             const ASTContext &ctx);
 
-  /// Constrain the platform availability range with `platformRange`.
+  /// Constrain the platform version range with `range`.
   // FIXME: [availability] Remove; superseded by constrainWithAvailableRange().
-  void constrainWithPlatformRange(const AvailabilityRange &platformRange,
+  void constrainWithPlatformRange(const AvailabilityRange &range,
                                   const ASTContext &ctx);
+
+  /// Expand the platform version range to contain `range`.
+  void unionWithPlatformRange(const AvailabilityRange &range,
+                              const ASTContext &ctx);
 
   /// Constrain the available range for `domain` by `range`.
   void constrainWithAvailabilityRange(const AvailabilityRange &range,

--- a/include/swift/AST/AvailabilityContext.h
+++ b/include/swift/AST/AvailabilityContext.h
@@ -104,10 +104,6 @@ public:
   void constrainWithPlatformRange(const AvailabilityRange &range,
                                   const ASTContext &ctx);
 
-  /// Expand the platform version range to contain `range`.
-  void unionWithPlatformRange(const AvailabilityRange &range,
-                              const ASTContext &ctx);
-
   /// Constrain the available range for `domain` by `range`.
   void constrainWithAvailabilityRange(const AvailabilityRange &range,
                                       AvailabilityDomain domain,

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -44,7 +44,6 @@ public:
   bool isUnavailable() const { return range.isKnownUnreachable(); }
 
   bool constrainRange(const AvailabilityRange &range);
-  bool unionRange(const AvailabilityRange &range);
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddPointer(domain.getOpaqueValue());

--- a/include/swift/AST/AvailabilityContextStorage.h
+++ b/include/swift/AST/AvailabilityContextStorage.h
@@ -44,6 +44,7 @@ public:
   bool isUnavailable() const { return range.isKnownUnreachable(); }
 
   bool constrainRange(const AvailabilityRange &range);
+  bool unionRange(const AvailabilityRange &range);
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddPointer(domain.getOpaqueValue());

--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -217,6 +217,10 @@ public:
   /// compilation context.
   bool isActive(const ASTContext &ctx) const;
 
+  /// Returns true if this domain is a platform domain and is considered active
+  /// in the current compilation context.
+  bool isActivePlatform(const ASTContext &ctx) const;
+
   /// Returns the domain's minimum available range for type checking. For
   /// example, for the domain of the platform that compilation is targeting,
   /// this version is specified with the `-target` option. For the Swift

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -482,7 +482,7 @@ class alignas(8) PoundAvailableInfo final :
   
   /// The version range when this query will return true. This value is
   /// filled in by Sema.
-  VersionRange AvailableRange;
+  std::optional<VersionRange> AvailableRange;
 
   /// For zippered builds, this is the version range for the target variant
   /// that must hold for the query to return true. For example, when
@@ -490,7 +490,7 @@ class alignas(8) PoundAvailableInfo final :
   /// x86_64-ios13.0 a query of #available(macOS 10.22, iOS 20.0, *) will
   /// have a variant range of [20.0, +inf).
   /// This is filled in by Sema.
-  VersionRange VariantAvailableRange;
+  std::optional<VersionRange> VariantAvailableRange;
 
   struct {
     unsigned isInvalid : 1;
@@ -538,11 +538,13 @@ public:
   SourceLoc getLoc() const { return PoundLoc; }
   SourceRange getSourceRange() const { return SourceRange(getStartLoc(),
                                                           getEndLoc()); }
-  
-  const VersionRange &getAvailableRange() const { return AvailableRange; }
+
+  std::optional<VersionRange> getAvailableRange() const {
+    return AvailableRange;
+  }
   void setAvailableRange(const VersionRange &Range) { AvailableRange = Range; }
 
-  const VersionRange &getVariantAvailableRange() const {
+  std::optional<VersionRange> getVariantAvailableRange() const {
     return VariantAvailableRange;
   }
   void setVariantAvailableRange(const VersionRange &Range) {

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -237,7 +237,7 @@ AvailabilityContext::getAvailabilityRange(AvailabilityDomain domain,
                                           const ASTContext &ctx) const {
   DEBUG_ASSERT(domain.supportsContextRefinement());
 
-  if (domain.isActive(ctx) && domain.isPlatform())
+  if (domain.isActivePlatform(ctx))
     return storage->platformRange;
 
   for (auto domainInfo : storage->getDomainInfos()) {
@@ -315,7 +315,7 @@ void AvailabilityContext::constrainWithAvailabilityRange(
     const ASTContext &ctx) {
   DEBUG_ASSERT(domain.supportsContextRefinement());
 
-  if (domain.isActive(ctx) && domain.isPlatform()) {
+  if (domain.isActivePlatform(ctx)) {
     constrainWithPlatformRange(range, ctx);
     return;
   }
@@ -371,7 +371,7 @@ void AvailabilityContext::constrainWithDeclAndPlatformRange(
       break;
     case AvailabilityConstraint::Reason::PotentiallyUnavailable:
       if (auto introducedRange = attr.getIntroducedRange(ctx)) {
-        if (domain.isActive(ctx) && domain.isPlatform()) {
+        if (domain.isActivePlatform(ctx)) {
           isConstrained |= constrainRange(platformRange, *introducedRange);
         } else {
           declDomainInfos.push_back({domain, *introducedRange});

--- a/lib/AST/AvailabilityContext.cpp
+++ b/lib/AST/AvailabilityContext.cpp
@@ -46,15 +46,6 @@ static bool constrainRange(AvailabilityRange &existing,
   return true;
 }
 
-static bool unionRange(AvailabilityRange &existing,
-                       const AvailabilityRange &other) {
-  if (!existing.isContainedIn(other))
-    return false;
-
-  existing = other;
-  return true;
-}
-
 /// Returns true if `domainInfos` will be constrained by merging the domain
 /// availability represented by `otherDomainInfo`. Additionally, this function
 /// has a couple of side-effects:
@@ -143,11 +134,6 @@ static bool constrainDomainInfos(
 bool AvailabilityContext::DomainInfo::constrainRange(
     const AvailabilityRange &otherRange) {
   return ::constrainRange(range, otherRange);
-}
-
-bool AvailabilityContext::DomainInfo::unionRange(
-    const AvailabilityRange &otherRange) {
-  return ::unionRange(range, otherRange);
 }
 
 AvailabilityContext
@@ -293,18 +279,6 @@ void AvailabilityContext::constrainWithPlatformRange(
   auto platformRange = storage->platformRange;
   if (!constrainRange(platformRange, range))
     return;
-
-  storage = Storage::get(platformRange, storage->isDeprecated,
-                         storage->getDomainInfos(), ctx);
-}
-
-void AvailabilityContext::unionWithPlatformRange(const AvailabilityRange &range,
-                                                 const ASTContext &ctx) {
-  auto platformRange = storage->platformRange;
-  if (!unionRange(platformRange, range))
-    return;
-
-  // FIXME: [availability] Should this remove any unavailable platform domains?
 
   storage = Storage::get(platformRange, storage->isDeprecated,
                          storage->getDomainInfos(), ctx);

--- a/lib/AST/AvailabilityDomain.cpp
+++ b/lib/AST/AvailabilityDomain.cpp
@@ -100,6 +100,13 @@ bool AvailabilityDomain::isActive(const ASTContext &ctx) const {
   }
 }
 
+bool AvailabilityDomain::isActivePlatform(const ASTContext &ctx) const {
+  if (!isPlatform())
+    return false;
+
+  return isActive(ctx);
+}
+
 static std::optional<llvm::VersionTuple>
 getDeploymentVersion(const AvailabilityDomain &domain, const ASTContext &ctx) {
   switch (domain.getKind()) {

--- a/test/IRGen/availability_custom_domains.swift
+++ b/test/IRGen/availability_custom_domains.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-emit-irgen -module-name Test %s -verify \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-disabled-availability-domain DisabledDomain \
+// RUN:   -Onone | %FileCheck %s --check-prefixes=CHECK
+
+// RUN: %target-swift-emit-irgen -module-name Test %s -verify \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -define-enabled-availability-domain EnabledDomain \
+// RUN:   -define-disabled-availability-domain DisabledDomain \
+// RUN:   -O | %FileCheck %s --check-prefixes=CHECK
+
+// REQUIRES: swift_feature_CustomAvailability
+
+@_silgen_name("always")
+public func always()
+
+@_silgen_name("never")
+public func never()
+
+// CHECK-NOT: call swiftcc void @never()
+
+// CHECK: call swiftcc void @always()
+// CHECK-NOT: call swiftcc void @never()
+if #available(EnabledDomain) {
+  always()
+} else {
+  never()
+}
+
+// CHECK: call swiftcc void @always()
+// CHECK-NOT: call swiftcc void @never()
+if #available(DisabledDomain) {
+  never()
+} else {
+  always()
+}
+
+// CHECK: call swiftcc void @always()
+// CHECK-NOT: call swiftcc void @never()
+if #unavailable(EnabledDomain) {
+  never()
+} else {
+  always()
+}
+
+// CHECK: call swiftcc void @always()
+// CHECK-NOT: call swiftcc void @never()
+if #unavailable(DisabledDomain) {
+  always()
+} else {
+  never()
+}

--- a/test/Parse/availability_query_custom_domains.swift
+++ b/test/Parse/availability_query_custom_domains.swift
@@ -7,11 +7,8 @@
 // REQUIRES: swift_feature_CustomAvailability
 
 if #available(EnabledDomain) { }
-// expected-error@-1 {{condition required for target platform}}
 if #available(DisabledDomain) { }
-// expected-error@-1 {{condition required for target platform}}
 if #available(DynamicDomain) { }
-// expected-error@-1 {{condition required for target platform}}
 if #available(UnknownDomain) { } // expected-warning {{unrecognized platform name 'UnknownDomain'}}
 // expected-error@-1 {{condition required for target platform}}
 
@@ -21,15 +18,10 @@ if #unavailable(DynamicDomain) { }
 if #unavailable(UnknownDomain) { } // expected-warning {{unrecognized platform name 'UnknownDomain'}}
 
 if #available(EnabledDomain 1.0) { } // expected-error {{unexpected version number for EnabledDomain}}
-// expected-error@-1 {{condition required for target platform}}
 if #available(EnabledDomain, DisabledDomain) { } // expected-error {{EnabledDomain availability must be specified alone}}
-// expected-error@-1 {{condition required for target platform}}
 
 if #available(EnabledDomain, swift 5) { } // expected-error {{EnabledDomain availability must be specified alone}}
-// expected-error@-1 {{condition required for target platform}}
 
 while #available(EnabledDomain) { }
-// expected-error@-1 {{condition required for target platform}}
 
 guard #available(EnabledDomain) else { }
-// expected-error@-1 {{condition required for target platform}}

--- a/test/Parse/availability_query_custom_domains.swift
+++ b/test/Parse/availability_query_custom_domains.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:  -enable-experimental-feature CustomAvailability \
+// RUN:  -define-enabled-availability-domain EnabledDomain \
+// RUN:  -define-disabled-availability-domain DisabledDomain \
+// RUN:  -define-dynamic-availability-domain DynamicDomain
+
+// REQUIRES: swift_feature_CustomAvailability
+
+if #available(EnabledDomain) { }
+// expected-error@-1 {{condition required for target platform}}
+if #available(DisabledDomain) { }
+// expected-error@-1 {{condition required for target platform}}
+if #available(DynamicDomain) { }
+// expected-error@-1 {{condition required for target platform}}
+if #available(UnknownDomain) { } // expected-warning {{unrecognized platform name 'UnknownDomain'}}
+// expected-error@-1 {{condition required for target platform}}
+
+if #unavailable(EnabledDomain) { }
+if #unavailable(DisabledDomain) { }
+if #unavailable(DynamicDomain) { }
+if #unavailable(UnknownDomain) { } // expected-warning {{unrecognized platform name 'UnknownDomain'}}
+
+if #available(EnabledDomain 1.0) { } // expected-error {{unexpected version number for EnabledDomain}}
+// expected-error@-1 {{condition required for target platform}}
+if #available(EnabledDomain, DisabledDomain) { } // expected-error {{EnabledDomain availability must be specified alone}}
+// expected-error@-1 {{condition required for target platform}}
+
+if #available(EnabledDomain, swift 5) { } // expected-error {{EnabledDomain availability must be specified alone}}
+// expected-error@-1 {{condition required for target platform}}
+
+while #available(EnabledDomain) { }
+// expected-error@-1 {{condition required for target platform}}
+
+guard #available(EnabledDomain) else { }
+// expected-error@-1 {{condition required for target platform}}

--- a/test/SILGen/unavailable_decl_custom_domain.swift
+++ b/test/SILGen/unavailable_decl_custom_domain.swift
@@ -23,6 +23,9 @@
 
 // REQUIRES: swift_feature_CustomAvailability
 
+// CHECK: s4Test15alwaysAvailableyyF
+public func alwaysAvailable() { }
+
 // CHECK: s4Test24availableInEnabledDomainyyF
 @available(EnabledDomain)
 public func availableInEnabledDomain() { }
@@ -81,3 +84,42 @@ public func availableInEnabledAndDisabledDomain() { }
 @available(DisabledDomain)
 @available(EnabledDomain)
 public func availableInDisabledAndEnabledDomain() { }
+
+// CHECK-LABEL: sil{{.*}}$s4Test28testIfAvailableEnabledDomainyyF : $@convention(thin) () -> ()
+public func testIfAvailableEnabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test24availableInEnabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test26unavailableInEnabledDomainyyF
+  if #available(EnabledDomain) {
+    availableInEnabledDomain()
+  } else {
+    unavailableInEnabledDomain()
+  }
+}
+// CHECK: end sil function '$s4Test28testIfAvailableEnabledDomainyyF'
+
+// CHECK-LABEL: sil{{.*}}$s4Test29testIfAvailableDisabledDomainyyF : $@convention(thin) () -> ()
+public func testIfAvailableDisabledDomain() {
+  // CHECK: bb0:
+  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+
+  // CHECK: [[TRUE_BB]]:
+  // CHECK:   function_ref @$s4Test25availableInDisabledDomainyyF
+
+  // CHECK: [[FALSE_BB]]:
+  // CHECK:   function_ref @$s4Test27unavailableInDisabledDomainyyF
+  if #available(DisabledDomain) {
+    availableInDisabledDomain()
+  } else {
+    unavailableInDisabledDomain()
+  }
+}
+// CHECK: end sil function '$s4Test29testIfAvailableDisabledDomainyyF'
+

--- a/test/Sema/availability_custom_domains.swift
+++ b/test/Sema/availability_custom_domains.swift
@@ -12,10 +12,10 @@ func alwaysAvailable() { }
 func availableInEnabledDomain() { }
 
 @available(EnabledDomain, unavailable)
-func unavailableInEnabledDomain() { }
+func unavailableInEnabledDomain() { } // expected-note * {{'unavailableInEnabledDomain()' has been explicitly marked unavailable here}}
 
 @available(DisabledDomain, unavailable)
-func unavailableInDisabledDomain() { } // expected-note 4 {{'unavailableInDisabledDomain()' has been explicitly marked unavailable here}}
+func unavailableInDisabledDomain() { } // expected-note * {{'unavailableInDisabledDomain()' has been explicitly marked unavailable here}}
 
 @available(DynamicDomain)
 func availableInDynamicDomain() { }
@@ -23,24 +23,127 @@ func availableInDynamicDomain() { }
 @available(DynamicDomain, deprecated, message: "Use something else")
 func deprecatedInDynamicDomain() { }
 
+@available(DynamicDomain, unavailable)
+func unavailableInDynamicDomain() { } // expected-note * {{'unavailableInDynamicDomain()' has been explicitly marked unavailable here}}
+
 @available(UnknownDomain) // expected-warning {{unrecognized platform name 'UnknownDomain'}}
 func availableInUnknownDomain() { }
 
 func testDeployment() {
   alwaysAvailable()
   availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
   unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
   deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
+  unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
   availableInUnknownDomain()
 }
 
+func testIfAvailable(_ truthy: Bool) {
+  if #available(EnabledDomain) {
+    availableInEnabledDomain()
+    unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+    unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
+
+    if #available(DynamicDomain) {
+      availableInEnabledDomain()
+      unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+      availableInDynamicDomain()
+      unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
+    } else {
+      availableInEnabledDomain()
+      unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+      availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      unavailableInDynamicDomain()
+    }
+
+    if #unavailable(EnabledDomain) {
+      // Unreachable.
+      availableInEnabledDomain()
+      unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+      availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+      unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
+    }
+  } else {
+    availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    unavailableInEnabledDomain()
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+    unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
+  }
+
+  if #available(EnabledDomain), #available(DynamicDomain) {
+    availableInEnabledDomain()
+    unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+    availableInDynamicDomain()
+    unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
+  } else {
+    // In this branch, we only know that one of the domains is unavailable,
+    // but we don't know which.
+    availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+    unavailableInDynamicDomain() // expected-error {{'unavailableInDynamicDomain()' is unavailable}}
+  }
+
+  if #available(EnabledDomain), truthy {
+    availableInEnabledDomain()
+    unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+  } else {
+    // In this branch, the state of EnabledDomain remains unknown since
+    // execution will reach here if "truthy" is false.
+    availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+  }
+
+  if #unavailable(EnabledDomain) {
+    availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    unavailableInEnabledDomain()
+  } else {
+    availableInEnabledDomain()
+    unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+  }
+
+  // FIXME: [availability] Support mixed #available and #unavailable.
+  if #unavailable(EnabledDomain), #available(DynamicDomain) {
+    // expected-error@-1 {{#available and #unavailable cannot be in the same statement}}
+  }
+}
+
+func testWhileAvailable() {
+  while #available(EnabledDomain) {
+    availableInEnabledDomain()
+    unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+  }
+
+  while #unavailable(EnabledDomain) {
+    availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    unavailableInEnabledDomain()
+  }
+}
+
+func testGuardAvailable() {
+  guard #available(EnabledDomain) else {
+    availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+    unavailableInEnabledDomain()
+    availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+
+    return
+  }
+
+  availableInEnabledDomain()
+  unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+}
+
 @available(EnabledDomain)
 func testEnabledDomainAvailable() {
-  availableInEnabledDomain() // OK
+  availableInEnabledDomain()
+  unavailableInEnabledDomain() // expected-error {{'unavailableInEnabledDomain()' is unavailable}}
+
   if #available(EnabledDomain) {} // FIXME: [availability] Diagnose as redundant
-  // expected-error@-1 {{condition required for target platform}}
-  if #unavailable(EnabledDomain) {}
+  if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
 
   alwaysAvailable()
   unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
@@ -49,12 +152,12 @@ func testEnabledDomainAvailable() {
   availableInUnknownDomain()
 }
 
-
 @available(EnabledDomain, unavailable)
 func testEnabledDomainUnavailable() {
   availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
-  if #available(EnabledDomain) {} // FIXME: [availability] Maybe diagnose?
-  // expected-error@-1 {{condition required for target platform}}
+  unavailableInEnabledDomain()
+
+  if #available(EnabledDomain) {} // FIXME: [availability] Diagnose as unreachable
   if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as redundant
 
   alwaysAvailable()
@@ -62,11 +165,6 @@ func testEnabledDomainUnavailable() {
   deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
   availableInUnknownDomain()
-}
-
-@available(DisabledDomain, unavailable)
-func testDisabledDomainUnavailable() {
-  unavailableInDisabledDomain() // OK
 }
 
 @available(*, unavailable)
@@ -79,14 +177,17 @@ func testUniversallyUnavailable() {
   deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
   availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
   availableInUnknownDomain()
+
+  if #available(EnabledDomain) {} // FIXME: [availability] Diagnose?
+  if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose?
 }
 
 @available(EnabledDomain)
 struct EnabledDomainAvailable {
   @available(DynamicDomain)
   func dynamicDomainAvailableMethod() {
-    availableInEnabledDomain() // OK
-    availableInDynamicDomain() // OK
+    availableInEnabledDomain()
+    availableInDynamicDomain()
 
     alwaysAvailable()
     unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}

--- a/test/Sema/availability_custom_domains.swift
+++ b/test/Sema/availability_custom_domains.swift
@@ -1,0 +1,94 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:  -enable-experimental-feature CustomAvailability \
+// RUN:  -define-enabled-availability-domain EnabledDomain \
+// RUN:  -define-disabled-availability-domain DisabledDomain \
+// RUN:  -define-dynamic-availability-domain DynamicDomain
+
+// REQUIRES: swift_feature_CustomAvailability
+
+func alwaysAvailable() { }
+
+@available(EnabledDomain)
+func availableInEnabledDomain() { }
+
+@available(EnabledDomain, unavailable)
+func unavailableInEnabledDomain() { }
+
+@available(DisabledDomain, unavailable)
+func unavailableInDisabledDomain() { } // expected-note 4 {{'unavailableInDisabledDomain()' has been explicitly marked unavailable here}}
+
+@available(DynamicDomain)
+func availableInDynamicDomain() { }
+
+@available(DynamicDomain, deprecated, message: "Use something else")
+func deprecatedInDynamicDomain() { }
+
+@available(UnknownDomain) // expected-warning {{unrecognized platform name 'UnknownDomain'}}
+func availableInUnknownDomain() { }
+
+func testDeployment() {
+  alwaysAvailable()
+  availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
+  deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
+  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  availableInUnknownDomain()
+}
+
+@available(EnabledDomain)
+func testEnabledDomainAvailable() {
+  availableInEnabledDomain() // OK
+  if #available(EnabledDomain) {} // FIXME: [availability] Diagnose as redundant
+  // expected-error@-1 {{condition required for target platform}}
+  if #unavailable(EnabledDomain) {}
+
+  alwaysAvailable()
+  unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
+  deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
+  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  availableInUnknownDomain()
+}
+
+
+@available(EnabledDomain, unavailable)
+func testEnabledDomainUnavailable() {
+  availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  if #available(EnabledDomain) {} // FIXME: [availability] Maybe diagnose?
+  // expected-error@-1 {{condition required for target platform}}
+  if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as redundant
+
+  alwaysAvailable()
+  unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
+  deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
+  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  availableInUnknownDomain()
+}
+
+@available(DisabledDomain, unavailable)
+func testDisabledDomainUnavailable() {
+  unavailableInDisabledDomain() // OK
+}
+
+@available(*, unavailable)
+func testUniversallyUnavailable() {
+  alwaysAvailable()
+  // FIXME: [availability] Diagnostic consistency: potentially unavailable declaration shouldn't be diagnosed
+  // in contexts that are unavailable to broader domains
+  availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
+  unavailableInDisabledDomain()
+  deprecatedInDynamicDomain() // expected-warning {{'deprecatedInDynamicDomain()' is deprecated: Use something else}}
+  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
+  availableInUnknownDomain()
+}
+
+@available(EnabledDomain)
+struct EnabledDomainAvailable {
+  @available(DynamicDomain)
+  func dynamicDomainAvailableMethod() {
+    availableInEnabledDomain() // OK
+    availableInDynamicDomain() // OK
+
+    alwaysAvailable()
+    unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
+  }
+}

--- a/test/Sema/availability_scopes.swift
+++ b/test/Sema/availability_scopes.swift
@@ -94,6 +94,7 @@ extension SomeClass {
 // CHECK-NEXT: {{^}}          (condition_following_availability version=56
 // CHECK-NEXT: {{^}}          (guard_fallthrough version=56
 // CHECK-NEXT: {{^}}      (decl version=57 decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}    (decl version=53 decl=funcInOuterIfElse()
 @available(OSX 51, *)
 func functionWithStmtCondition() {
   if #available(OSX 52, *),
@@ -109,6 +110,9 @@ func functionWithStmtCondition() {
       @available(OSX 57, *)
       func funcInInnerIfElse() { }
     }
+  } else {
+    @available(OSX 53, *)
+    func funcInOuterIfElse() { }
   }
 }
 
@@ -245,6 +249,45 @@ extension SomeClass {
     }
     return 53
   }()
+}
+
+// CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl version=50 unavailable=macOS decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl version=51 unavailable=macOS decl=functionWithStmtConditionsInUnavailableExt()
+// CHECK-NEXT: {{^}}        (condition_following_availability version=52 unavailable=macOS
+// CHECK-NEXT: {{^}}          (condition_following_availability version=53 unavailable=macOS
+// CHECK-NEXT: {{^}}        (if_then version=53 unavailable=macOS
+// CHECK-NEXT: {{^}}          (condition_following_availability version=54 unavailable=macOS
+// CHECK-NEXT: {{^}}          (if_then version=54 unavailable=macOS
+// CHECK-NEXT: {{^}}            (condition_following_availability version=55 unavailable=macOS
+// CHECK-NEXT: {{^}}            (decl version=55 unavailable=macOS decl=funcInGuardElse()
+// CHECK-NEXT: {{^}}            (guard_fallthrough version=55 unavailable=macOS
+// CHECK-NEXT: {{^}}              (condition_following_availability version=56 unavailable=macOS
+// CHECK-NEXT: {{^}}              (guard_fallthrough version=56 unavailable=macOS
+// CHECK-NEXT: {{^}}          (decl version=57 unavailable=macOS decl=funcInInnerIfElse()
+// CHECK-NEXT: {{^}}        (decl version=53 unavailable=macOS decl=funcInOuterIfElse()
+@available(OSX, unavailable)
+extension SomeClass {
+  @available(OSX 51, *)
+  func functionWithStmtConditionsInUnavailableExt() {
+    if #available(OSX 52, *),
+       let x = (nil as Int?),
+       #available(OSX 53, *) {
+      if #available(OSX 54, *) {
+        guard #available(OSX 55, *) else {
+          @available(OSX 55, *)
+          func funcInGuardElse() { }
+        }
+        guard #available(OSX 56, *) else { }
+      } else {
+        @available(OSX 57, *)
+        func funcInInnerIfElse() { }
+      }
+    } else {
+      @available(OSX 53, *)
+      func funcInOuterIfElse() { }
+    }
+  }
 }
 
 // CHECK-NEXT: {{^}}  (decl_implicit version=50 decl=wrappedValue

--- a/test/Sema/availability_scopes_custom_domains.swift
+++ b/test/Sema/availability_scopes_custom_domains.swift
@@ -1,0 +1,27 @@
+// RUN:  %target-swift-frontend -typecheck %s \
+// RUN:  -enable-experimental-feature CustomAvailability \
+// RUN:  -define-enabled-availability-domain A \
+// RUN:  -define-enabled-availability-domain B \
+// RUN:  -dump-availability-scopes > %t.dump 2>&1
+// RUN: %FileCheck --strict-whitespace %s < %t.dump
+
+// REQUIRES: swift_feature_CustomAvailability
+
+// CHECK: {{^}}(root version={{.*}}
+// CHECK: {{^}}  (decl version={{.*}} available=A decl=availableInA()
+@available(A)
+func availableInA() { }
+
+// CHECK: {{^}}  (decl version={{.*}} unavailable=A decl=unavailableInA()
+@available(A, unavailable)
+func unavailableInA() { }
+
+// CHECK: {{^}}  (decl version={{.*}} available=A,B decl=availableInAB()
+@available(A)
+@available(B)
+func availableInAB() { }
+
+// FIXME: [availability] Should be "available=A"
+// CHECK: {{^}}  (decl version={{.*}} deprecated decl=deprecatedInA()
+@available(A, deprecated)
+func deprecatedInA() { }

--- a/test/attr/attr_availability_custom_domains.swift
+++ b/test/attr/attr_availability_custom_domains.swift
@@ -49,7 +49,7 @@ func deprecatedInEnabledDomain() { }
 func obsoletedInEnabledDomain() { }
 
 @available(DisabledDomain, unavailable)
-func unavailableInDisabledDomain() { } // expected-note 4 {{'unavailableInDisabledDomain()' has been explicitly marked unavailable here}}
+func unavailableInDisabledDomain() { }
 
 @available(RedefinedDomain, deprecated, message: "Use something else")
 func deprecatedInRedefinedDomain() { }
@@ -59,94 +59,3 @@ func availableInDynamicDomain() { }
 
 @available(UnknownDomain) // expected-warning {{unrecognized platform name 'UnknownDomain'}}
 func availableInUnknownDomain() { }
-
-func testQuerySyntax() {
-  if #available(EnabledDomain) {}
-  // expected-error@-1 {{condition required for target platform}}
-  if #available(RedefinedDomain) {}
-  // expected-error@-1 {{condition required for target platform}}
-  if #available(DisabledDomain) {}
-  // expected-error@-1 {{condition required for target platform}}
-  if #available(DynamicDomain) {}
-  // expected-error@-1 {{condition required for target platform}}
-  if #available(UnknownDomain) {} // expected-warning {{unrecognized platform name 'UnknownDomain'}}
-  // expected-error@-1 {{condition required for target platform}}
-
-  if #unavailable(EnabledDomain) {}
-  if #unavailable(RedefinedDomain) {}
-  if #unavailable(DisabledDomain) {}
-  if #unavailable(DynamicDomain) {}
-  if #unavailable(UnknownDomain) {} // expected-warning {{unrecognized platform name 'UnknownDomain'}}
-
-  if #available(EnabledDomain 1.0) {} // expected-error {{unexpected version number for EnabledDomain}}
-  // expected-error@-1 {{condition required for target platform}}
-  if #available(EnabledDomain, DisabledDomain) {} // expected-error {{EnabledDomain availability must be specified alone}}
-  // expected-error@-1 {{condition required for target platform}}
-}
-
-func testDeployment() {
-  alwaysAvailable()
-  availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
-  unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
-  deprecatedInRedefinedDomain() // expected-warning {{'deprecatedInRedefinedDomain()' is deprecated: Use something else}}
-  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
-  availableInUnknownDomain()
-}
-
-@available(EnabledDomain)
-func testEnabledDomainAvailable() {
-  availableInEnabledDomain() // OK
-  if #available(EnabledDomain) {} // FIXME: [availability] Diagnose as redundant
-  // expected-error@-1 {{condition required for target platform}}
-  if #unavailable(EnabledDomain) {}
-
-  alwaysAvailable()
-  unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
-  deprecatedInRedefinedDomain() // expected-warning {{'deprecatedInRedefinedDomain()' is deprecated: Use something else}}
-  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
-  availableInUnknownDomain()
-}
-
-
-@available(EnabledDomain, unavailable)
-func testEnabledDomainUnavailable() {
-  availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
-  if #available(EnabledDomain) {} // FIXME: [availability] Maybe diagnose?
-  // expected-error@-1 {{condition required for target platform}}
-  if #unavailable(EnabledDomain) {} // FIXME: [availability] Diagnose as redundant
-
-  alwaysAvailable()
-  unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
-  deprecatedInRedefinedDomain() // expected-warning {{'deprecatedInRedefinedDomain()' is deprecated: Use something else}}
-  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
-  availableInUnknownDomain()
-}
-
-@available(DisabledDomain, unavailable)
-func testDisabledDomainUnavailable() {
-  unavailableInDisabledDomain() // OK
-}
-
-@available(*, unavailable)
-func testUniversallyUnavailable() {
-  alwaysAvailable()
-  // FIXME: [availability] Diagnostic consistency: potentially unavailable declaration shouldn't be diagnosed
-  // in contexts that are unavailable to broader domains
-  availableInEnabledDomain() // expected-error {{'availableInEnabledDomain()' is only available in EnabledDomain}}
-  unavailableInDisabledDomain()
-  deprecatedInRedefinedDomain() // expected-warning {{'deprecatedInRedefinedDomain()' is deprecated: Use something else}}
-  availableInDynamicDomain() // expected-error {{'availableInDynamicDomain()' is only available in DynamicDomain}}
-  availableInUnknownDomain()
-}
-
-@available(EnabledDomain)
-struct EnabledDomainAvailable {
-  @available(DynamicDomain)
-  func dynamicDomainAvailableMethod() {
-    availableInEnabledDomain() // OK
-    availableInDynamicDomain() // OK
-
-    alwaysAvailable()
-    unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
-  }
-}

--- a/unittests/AST/AvailabilityContextTests.cpp
+++ b/unittests/AST/AvailabilityContextTests.cpp
@@ -67,19 +67,6 @@ TEST_F(AvailabilityContextTest, PlatformRange) {
   EXPECT_NE(macOS10_9, macOS10_10);
   EXPECT_TRUE(macOS10_10.isContainedIn(macOS10_9));
   EXPECT_FALSE(macOS10_9.isContainedIn(macOS10_10));
-
-  // Attempt to union the macOS version with >= 10.11. This should have no
-  // effect, since 10.11 is already contained.
-  auto stillMacOS10_10 = macOS10_10;
-  stillMacOS10_10.unionWithPlatformRange(getAvailabilityRange(10, 11), ctx);
-  EXPECT_EQ(getPlatformIntro(stillMacOS10_10), llvm::VersionTuple(10, 10));
-
-  // Attempt to union the macOS version with >= 10.9. This should expand the
-  // range.
-  auto backToMacOS10_9 = macOS10_10;
-  backToMacOS10_9.unionWithPlatformRange(getAvailabilityRange(10, 9), ctx);
-  EXPECT_EQ(getPlatformIntro(backToMacOS10_9), llvm::VersionTuple(10, 9));
-  EXPECT_EQ(backToMacOS10_9, macOS10_9);
 }
 
 TEST_F(AvailabilityContextTest, UnavailableDomains) {

--- a/unittests/AST/AvailabilityContextTests.cpp
+++ b/unittests/AST/AvailabilityContextTests.cpp
@@ -40,7 +40,7 @@ public:
   } domains;
 };
 
-TEST_F(AvailabilityContextTest, PlatformIntroduction) {
+TEST_F(AvailabilityContextTest, PlatformRange) {
   auto &ctx = defaultTestContext.Ctx;
 
   auto macOS10_9 = AvailabilityContext::forDeploymentTarget(ctx);
@@ -67,6 +67,19 @@ TEST_F(AvailabilityContextTest, PlatformIntroduction) {
   EXPECT_NE(macOS10_9, macOS10_10);
   EXPECT_TRUE(macOS10_10.isContainedIn(macOS10_9));
   EXPECT_FALSE(macOS10_9.isContainedIn(macOS10_10));
+
+  // Attempt to union the macOS version with >= 10.11. This should have no
+  // effect, since 10.11 is already contained.
+  auto stillMacOS10_10 = macOS10_10;
+  stillMacOS10_10.unionWithPlatformRange(getAvailabilityRange(10, 11), ctx);
+  EXPECT_EQ(getPlatformIntro(stillMacOS10_10), llvm::VersionTuple(10, 10));
+
+  // Attempt to union the macOS version with >= 10.9. This should expand the
+  // range.
+  auto backToMacOS10_9 = macOS10_10;
+  backToMacOS10_9.unionWithPlatformRange(getAvailabilityRange(10, 9), ctx);
+  EXPECT_EQ(getPlatformIntro(backToMacOS10_9), llvm::VersionTuple(10, 9));
+  EXPECT_EQ(backToMacOS10_9, macOS10_9);
 }
 
 TEST_F(AvailabilityContextTest, UnavailableDomains) {


### PR DESCRIPTION
When building the `AvailabilityScope` tree, construct scopes correctly for queries like this:

```
if #available(CustomDomain) {
  // CustomDomain is available at compiletime/runtime.
} else {
  // CustomDomain is unavailable.
}
```

This ensures the regions inside the then and the else branches are type-checked correctly. Also, update SILGen to handle these conditionals. If the availability of the custom domain is known at compile time, then the branches of the conditional must be compiled accordingly by constant-folding the branches.

Resolves rdar://138441307 and rdar://138441298.