### PR TITLE
Simplification: fix a crash in alloc_stack simplification

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -277,7 +277,7 @@ private extension AllocStackInst {
         // The instruction which defines the existential archetype must dominate the alloc_stack, because
         // after the transformation the alloc_stack will use the existential archetype.
         for openArchetypeOp in initExistential.typeDependentOperands {
-          if !openArchetypeOp.value.definingInstruction!.dominatesInSameBlock(self) {
+          if !openArchetypeOp.value.triviallyDominates(self) {
             return nil
           }
         }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -185,6 +185,24 @@ extension Value {
     }
     return true
   }
+
+  /// Performs a simple dominance check without using the dominator tree.
+  /// Returns true if `instruction` is in the same block as this value, but "after" this value,
+  /// or if this value is a function argument.
+  func triviallyDominates(_ instruction: Instruction) -> Bool {
+    switch self {
+    case is FunctionArgument:
+      return true
+    case let arg as Argument:
+      return arg.parentBlock == instruction.parentBlock
+    case let svi as SingleValueInstruction:
+      return svi.dominatesInSameBlock(instruction)
+    case let mvi as MultipleValueInstructionResult:
+      return mvi.parentInstruction.dominatesInSameBlock(instruction)
+    default:
+      return false
+    }
+  }
 }
 
 extension FullApplySite {

--- a/test/SILOptimizer/simplify_alloc_stack.sil
+++ b/test/SILOptimizer/simplify_alloc_stack.sil
@@ -10,6 +10,8 @@ public struct S {}
 protocol P {
 }
 
+public class C2: P {}
+
 public struct T: P {
   let c: C
   let s: S
@@ -36,6 +38,7 @@ public enum X {
 sil [ossa] @take_s : $@convention(thin) (@in S) -> ()
 sil [ossa] @take_t : $@convention(thin) (@in T) -> ()
 sil [ossa] @use_mp : $@convention(thin) (@in_guaranteed MP) -> ()
+sil [ossa] @use_c2 : $@convention(thin) (@in_guaranteed C2) -> ()
 
 // CHECK-LABEL: sil [ossa] @expand_alloc_stack_of_enum1 :
 // CHECK:        [[A:%[0-9]+]] = alloc_stack $S
@@ -346,3 +349,19 @@ bb3:
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @init_existential_with_dynamic_self :
+// CHECK:         [[S:%.*]] = alloc_stack $C2
+// CHECK:         store %0 to [init] [[S]]
+// CHECK:         apply %{{[0-9]+}}([[S]])
+// CHECK:       } // end sil function 'init_existential_with_dynamic_self'
+sil [ossa] @init_existential_with_dynamic_self : $@convention(method) (@owned C2) -> () {
+bb0(%0 : @owned $C2):
+  %1 = alloc_stack $P
+  %2 = init_existential_addr %1, $@dynamic_self C2
+  store %0 to [init] %2
+  %4 = function_ref @use_c2 : $@convention(thin) (@in_guaranteed C2) -> ()
+  %5 = apply %4(%2) : $@convention(thin) (@in_guaranteed C2) -> ()
+  destroy_addr %1
+  dealloc_stack %1
+  return %5
+}


### PR DESCRIPTION
Handle the case that a type dependent operand is a dynamic-self argument and not an open-existential instruction.

rdar://148258964
