### PR TITLE
[embedded] Re-enable dependencies-random.swift test

### DIFF
--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -30,9 +30,6 @@
 // REQUIRES: optimized_stdlib
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
-// REQUIRES: rdar121923818
-// REQUIRES: swift_feature_Embedded
-
 @_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded %s -c -o %t/a.o
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature Embedded -enable-experimental-feature Extern %s -c -o %t/a.o
 
 // RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
 
@@ -29,6 +29,9 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+
+// REQUIRES: swift_feature_Embedded
+// REQUIRES: swift_feature_Extern
 
 @_extern(c, "putchar")
 @discardableResult


### PR DESCRIPTION
Was diabled via <https://github.com/swiftlang/swift/pull/71239> due to CI failures on CentOS. We no longer support CentOS.

rdar://121923818
