### PR TITLE
Type substitution eliminates dependencies with Escapable targets.

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -350,6 +350,18 @@ public:
 std::optional<LifetimeDependenceInfo>
 getLifetimeDependenceFor(ArrayRef<LifetimeDependenceInfo> lifetimeDependencies,
                          unsigned index);
+
+/// Helper to remove lifetime dependencies whose target references an
+/// Escapable type.
+///
+/// Returns true if the set of output lifetime dependencies is different from
+/// the set of input lifetime dependencies, false if there was no change.
+bool
+filterEscapableLifetimeDependencies(GenericSignature sig,
+        ArrayRef<LifetimeDependenceInfo> inputs,
+        SmallVectorImpl<LifetimeDependenceInfo> &outputs,
+        llvm::function_ref<Type (unsigned targetIndex)> getSubstTargetType);
+
 } // namespace swift
 
 #endif

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -688,6 +688,10 @@ public:
   /// Returns true if this contextual type satisfies a conformance to Escapable.
   bool isEscapable();
 
+  /// Returns true if this type satisfies a conformance to Escapable in the
+  /// given generic signature.
+  bool isEscapable(GenericSignature sig);
+
   /// Returns true if this contextual type is (Escapable && !isNoEscape).
   bool mayEscape() { return !isNoEscape() && isEscapable(); }
 
@@ -3553,6 +3557,16 @@ protected:
     }
     Bits.AnyFunctionType.NumParams = NumParams;
     assert(Bits.AnyFunctionType.NumParams == NumParams && "Params dropped!");
+    
+    if (Info) {
+      unsigned maxLifetimeTarget = NumParams + 1;
+      if (auto outputFn = Output->getAs<AnyFunctionType>()) {
+        maxLifetimeTarget += outputFn->getNumParams();
+      }
+      for (auto &dep : Info->getLifetimeDependencies()) {
+        assert(dep.getTargetIndex() < maxLifetimeTarget);
+      }
+    }
   }
 
 public:
@@ -5147,6 +5161,16 @@ public:
       const ASTContext &ctx,
       ProtocolConformanceRef witnessMethodConformance =
           ProtocolConformanceRef());
+          
+  /// Given an existing ExtInfo, and a set of interface parameters and results
+  /// destined for a new SILFunctionType, return a new ExtInfo with only the
+  /// lifetime dependencies relevant after substitution.
+  static ExtInfo
+  getSubstLifetimeDependencies(GenericSignature genericSig,
+                               ExtInfo origExtInfo,
+                               ArrayRef<SILParameterInfo> params,
+                               ArrayRef<SILYieldInfo> yields,
+                               ArrayRef<SILResultInfo> results);
 
   /// Return a structurally-identical function type with a slightly tweaked
   /// ExtInfo.

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1566,7 +1566,9 @@ public:
   /// This may be true either because the type is structurally addressable for
   /// dependencies, or because it was explicitly marked as `@_addressable`
   /// in its declaration.
-  bool isFunctionParamAddressable(TypeConverter &TC, unsigned index) const;
+  bool isFunctionParamAddressable(unsigned index) const;
+  
+  ArrayRef<LifetimeDependenceInfo> getLifetimeDependencies() const;
 
   /// Given that the value being abstracted is a function type, and that
   /// this is not an opaque abstraction pattern, return the number of

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -916,3 +916,11 @@ bool TypeBase::isEscapable() {
   auto canType = preprocessTypeForInvertibleQuery(this);
   return conformsToInvertible(canType, InvertibleProtocolKind::Escapable);
 }
+
+bool TypeBase::isEscapable(GenericSignature sig) {
+  Type contextTy = this;
+  if (sig) {
+    contextTy = sig.getGenericEnvironment()->mapTypeIntoContext(contextTy);
+  }
+  return contextTy->isEscapable();
+}

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1650,8 +1650,7 @@ AbstractionPattern::getFunctionParamFlags(unsigned index) const {
 }
 
 bool
-AbstractionPattern::isFunctionParamAddressable(TypeConverter &TC,
-                                               unsigned index) const {
+AbstractionPattern::isFunctionParamAddressable(unsigned index) const {
   switch (getKind()) {
   case Kind::Invalid:
   case Kind::Tuple:
@@ -1661,7 +1660,7 @@ AbstractionPattern::isFunctionParamAddressable(TypeConverter &TC,
   case Kind::OpaqueDerivativeFunction:
     // If the function abstraction pattern is completely opaque, assume we
     // may need to preserve the address for dependencies.
-    return true;
+    return false;
 
   case Kind::ClangType:
   case Kind::ObjCCompletionHandlerArgumentsType:
@@ -1685,29 +1684,47 @@ AbstractionPattern::isFunctionParamAddressable(TypeConverter &TC,
     auto fnTy = cast<AnyFunctionType>(getType());
   
     // The parameter might directly be marked addressable.
-    if (fnTy.getParams()[index].getParameterFlags().isAddressable()) {
-      return true;
-    }
+    return fnTy.getParams()[index].getParameterFlags().isAddressable();
+  }
+  }
+  llvm_unreachable("bad kind");
+}
+
+ArrayRef<LifetimeDependenceInfo>
+AbstractionPattern::getLifetimeDependencies() const {
+  switch (getKind()) {
+  case Kind::Invalid:
+  case Kind::Tuple:
+    llvm_unreachable("not any kind of function!");
+  case Kind::Opaque:
+  case Kind::OpaqueFunction:
+  case Kind::OpaqueDerivativeFunction:
+    // If the function abstraction pattern is completely opaque, assume we
+    // may need to preserve the address for dependencies.
+    return {};
+
+  case Kind::ClangType:
+  case Kind::ObjCCompletionHandlerArgumentsType:
+  case Kind::CurriedObjCMethodType:
+  case Kind::PartialCurriedObjCMethodType:
+  case Kind::ObjCMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::CurriedCFunctionAsMethodType:
+  case Kind::PartialCurriedCFunctionAsMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
+  case Kind::Type:
+  case Kind::Discard: {
+    auto type = getType();
     
-    // The parameter could be of a type that is addressable for dependencies,
-    // in which case it becomes addressable when a return has a scoped
-    // dependency on it.
-    for (auto &dep : fnTy->getLifetimeDependencies()) {
-      auto scoped = dep.getScopeIndices();
-      if (!scoped) {
-        continue;
-      }
-      
-      if (scoped->contains(index)) {
-        auto paramTy = getFunctionParamType(index);
-        
-        return TC.getTypeLowering(paramTy, paramTy.getType(),
-                                  TypeExpansionContext::minimal())
-          .getRecursiveProperties().isAddressableForDependencies();
-      }
+    if (type->isTypeParameter() || type->is<ArchetypeType>()) {
+      return {};
     }
-    
-    return false;
+  
+    auto fnTy = cast<AnyFunctionType>(getType());
+  
+    return fnTy->getExtInfo().getLifetimeDependencies();
   }
   }
   llvm_unreachable("bad kind");

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleLoader.h"
 #include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/TypeTransform.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/SIL/SILModule.h"
@@ -56,6 +57,39 @@ SILType SILFunctionType::substInterfaceType(SILModule &M,
   if (auto subs = getInvocationSubstitutions())
     interfaceType = interfaceType.subst(M, subs, context);
   return interfaceType;
+}
+
+SILFunctionType::ExtInfo
+SILFunctionType::getSubstLifetimeDependencies(GenericSignature genericSig,
+                                              ExtInfo origExtInfo,
+                                              ArrayRef<SILParameterInfo> params,
+                                              ArrayRef<SILYieldInfo> yields,
+                                              ArrayRef<SILResultInfo> results) {
+  if (origExtInfo.getLifetimeDependencies().empty()) {
+    return origExtInfo;
+  }
+  SmallVector<LifetimeDependenceInfo, 2> substLifetimeDependencies;
+  bool didRemoveLifetimeDependencies
+    = filterEscapableLifetimeDependencies(genericSig,
+                                          origExtInfo.getLifetimeDependencies(),
+                                          substLifetimeDependencies,
+                                          [&](unsigned targetIndex) {
+      if (targetIndex >= params.size()) {
+        // Dependency targets a yield or return value.
+        auto targetYieldIndex = targetIndex - params.size();
+        if (targetYieldIndex >= yields.size()) {
+          return results[targetYieldIndex - yields.size()].getInterfaceType();
+        }
+        return yields[targetYieldIndex].getInterfaceType();
+      } else {
+        // Dependency targets a parameter.
+        return params[targetIndex].getInterfaceType();
+      }
+    });
+  if (didRemoveLifetimeDependencies) {
+    return origExtInfo.withLifetimeDependencies(substLifetimeDependencies);
+  }
+  return origExtInfo;
 }
 
 CanSILFunctionType SILFunctionType::getUnsubstitutedType(SILModule &M) const {
@@ -97,8 +131,12 @@ CanSILFunctionType SILFunctionType::getUnsubstitutedType(SILModule &M) const {
 
   auto signature = isPolymorphic() ? getInvocationGenericSignature()
                                    : CanGenericSignature();
+  
+  auto extInfo = getSubstLifetimeDependencies(signature, getExtInfo(),
+                                              params, yields, results);
+  
   return SILFunctionType::get(signature,
-                              getExtInfo(),
+                              extInfo,
                               getCoroutineKind(),
                               getCalleeConvention(),
                               params, yields, results, errorResult,
@@ -2394,6 +2432,7 @@ static CanSILFunctionType getSILFunctionType(
 
   std::optional<TypeConverter::GenericContextRAII> contextRAII;
   if (genericSig) contextRAII.emplace(TC, genericSig);
+  auto loweredSig = TC.getCurGenericSignature();
 
   bool unimplementable = false;
 
@@ -2518,6 +2557,7 @@ static CanSILFunctionType getSILFunctionType(
     // We'll lower the abstraction pattern type against itself, and then apply
     // those substitutions to form the substituted lowered function type.
     origType = origSubstPat;
+    loweredSig = origType.getGenericSignatureOrNull();
     substFnInterfaceType = cast<AnyFunctionType>(origType.getType());
     if (substYieldType.isValid()) {
       coroutineOrigYieldType = substYieldType;
@@ -2704,6 +2744,12 @@ static CanSILFunctionType getSILFunctionType(
       continue;
     }
     
+    // If the lowered type is escapable, then any lifetime dependencies
+    // targeting it have no effect.
+    if (inputs[i].getInterfaceType()->isEscapable(loweredSig)) {
+      continue;
+    }
+    
     auto formalParamDeps = getLifetimeDependenceFor(
                                        extInfoBuilder.getLifetimeDependencies(),
                                        parameterMap[i]);
@@ -2717,8 +2763,24 @@ static CanSILFunctionType getSILFunctionType(
   if (auto formalReturnDeps = getLifetimeDependenceFor(
                                       extInfoBuilder.getLifetimeDependencies(),
                                       substFnInterfaceType.getParams().size())){
-    loweredLifetimes.emplace_back(lowerLifetimeDependence(*formalReturnDeps,
+    // If the lowered type is escapable, then any lifetime dependencies
+    // targeting it have no effect.
+    bool resultIsEscapable;
+    if (!yields.empty()) {
+      resultIsEscapable
+        = yields[0].getInterfaceType()->isEscapable(loweredSig);
+    } else if (!results.empty()) {
+      resultIsEscapable
+        = results[0].getInterfaceType()->isEscapable(loweredSig);
+    } else {
+      // The result is `()` or some other unit type, which is always escapable.
+      resultIsEscapable = true;
+    }
+    
+    if (!resultIsEscapable) {
+      loweredLifetimes.emplace_back(lowerLifetimeDependence(*formalReturnDeps,
                                                           parameterMap.size()));
+    }
   }
   
   auto calleeConvention = ParameterConvention::Direct_Unowned;

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -253,6 +253,11 @@ public:
     auto genericSig = IFS.shouldSubstituteOpaqueArchetypes()
                         ? origType->getInvocationGenericSignature()
                         : nullptr;
+                        
+    extInfo = SILFunctionType::getSubstLifetimeDependencies(genericSig, extInfo,
+                                                            substParams,
+                                                            substYields,
+                                                            substResults);
 
     return SILFunctionType::get(genericSig, extInfo,
                                 origType->getCoroutineKind(),

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2608,7 +2608,8 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
           infoBuilder = infoBuilder.withSendingResult();
       }
 
-      if (lifetimeDependenceInfo.has_value()) {
+      // Lifetime dependencies only apply to the outer function type.
+      if (!hasSelf && lifetimeDependenceInfo.has_value()) {
         infoBuilder =
             infoBuilder.withLifetimeDependencies(*lifetimeDependenceInfo);
       }

--- a/test/SILGen/addressable_for_dependencies.swift
+++ b/test/SILGen/addressable_for_dependencies.swift
@@ -99,10 +99,10 @@ extension Bar {
     }
 }
 
-// CHECK-LABEL: sil {{.*}}@$s28addressable_for_dependencies14defaulArgument1iySi_tFfA_ :
+// CHECK-LABEL: sil {{.*}}@$s28addressable_for_dependencies14defaulArgument1iAA3DepVSi_tFfA_ :
 // CHECK-SAME: $@convention(thin) () -> Int {
 
-// CHECK-LABEL: sil {{.*}}@$s28addressable_for_dependencies14defaulArgument1iySi_tF :
-// CHECK-SAME: $@convention(thin) (Int) -> @lifetime(borrow 0) () {
+// CHECK-LABEL: sil {{.*}}@$s28addressable_for_dependencies14defaulArgument1iAA3DepVSi_tF :
+// CHECK-SAME: $@convention(thin) (Int) -> @lifetime(borrow 0) @owned Dep {
 @lifetime(borrow i)
-func defaulArgument(i: Int = 0) {}
+func defaulArgument(i: Int = 0) -> Dep {}

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -30,19 +30,17 @@ public struct NEInt: ~Escapable {
   var i: Int
 
   // Test yielding an address.
-  // CHECK-LABEL: sil hidden @$s4test5NEIntV5ipropSivM : $@yield_once @convention(method) (@inout NEInt) -> @lifetime(borrow 0) @yields @inout Int
+  // CHECK-LABEL: sil hidden @$s4test5NEIntV5iprop{{.*}}vM : $@yield_once @convention(method) (@inout NEInt) -> @lifetime(borrow 0) @yields @inout NEInt
   // CHECK: bb0(%0 : $*NEInt):
   // CHECK: [[A:%.*]] = begin_access [modify] [static] %0 : $*NEInt
-  // CHECK: [[E:%.*]] = struct_element_addr [[A]] : $*NEInt, #NEInt.i
-  // CHECK: yield [[E]] : $*Int, resume bb1, unwind bb2
+  // CHECK: yield [[A]] : $*NEInt, resume bb1, unwind bb2
   // CHECK: end_access [[A]] : $*NEInt
   // CHECK: end_access [[A]] : $*NEInt
-  // CHECK-LABEL: } // end sil function '$s4test5NEIntV5ipropSivM'
-  var iprop: Int {
+  var iprop: NEInt {
     @lifetime(copy self)
-    _read { yield i }
+    _read { yield self }
     @lifetime(borrow self)
-    _modify { yield &i }
+    _modify { yield &self }
   }
 
   @lifetime(borrow owner)

--- a/test/Sema/escapable_substitution_lifetime_dependency.swift
+++ b/test/Sema/escapable_substitution_lifetime_dependency.swift
@@ -1,0 +1,52 @@
+// RUN: %target-swift-frontend -enable-experimental-feature LifetimeDependence -emit-sil -verify %s
+
+// REQUIRES: swift_feature_LifetimeDependence
+
+@lifetime(copy x)
+func id<T: ~Escapable>(_ x: T) -> T {
+    return x
+}
+
+func double<T>(_ f: @escaping (T) -> T) -> (T) -> T {
+    return { f(f($0)) }
+}
+
+func doubleid() -> (Int) -> Int {
+    // Substituting `id` with `T = Int` renders its return type Escapable,
+    // eliminating the lifetime dependency and allowing the function to be
+    // used as a `(T) -> T` value.
+    return double(id)
+}
+
+func doubleidGeneric<U>(_: U.Type) -> (U) -> U {
+    // Substituting `id` with `T = U` renders its return type Escapable,
+    // eliminating the lifetime dependency and allowing the function to be
+    // used as a `(T) -> T` value.
+    return double(id)
+}
+
+@lifetime(x: copy y)
+func overwrite<T: ~Escapable>(_ x: inout T, _ y: T) {
+    x = y
+}
+
+func doubleInout<T>(_ f: @escaping (inout T, T) -> Void) -> (inout T, T) -> Void {
+    return {
+        f(&$0, $1)
+        f(&$0, $1)
+    }
+}
+
+func doubleOverwrite() -> (inout Int, Int) -> Void {
+    // Substituting `id` with `T = Int` renders the `inout` parameter Escapable,
+    // eliminating the lifetime dependency and allowing the function to be
+    // used as a `(inout T, T) -> T` value.
+    return doubleInout(overwrite)
+}
+
+func doubleOverwriteGeneric<U>(_: U.Type) -> (inout U, U) -> Void {
+    // Substituting `id` with `T = U` renders the `inout` parameter Escapable,
+    // eliminating the lifetime dependency and allowing the function to be
+    // used as a `(inout T, T) -> T` value.
+    return doubleInout(overwrite)
+}

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -29,7 +29,7 @@ func applyTransfer(ne: NE, transfer: (NE) ->  NE) -> NE {
 }
 
 func testTransfer(nc: consuming NC) {
-  let transferred = applyTransfer(ne: nc.ne, transfer: transfer) // expected-error{{cannot convert value of type '(NE) -> @lifetime(copy 0) NE' to expected argument type '(NE) -> NE'}}
+  let transferred = applyTransfer(ne: nc.ne, transfer: transfer) // expected-error{{does not conform to expected type 'Escapable'}} e/xpected-error{{cannot convert value of type '(NE) -> @lifetime(copy 0) NE' to expected argument type '(NE) -> NE'}}
 
   _ = consume nc
   _ = transfer(transferred)
@@ -45,7 +45,7 @@ func applyBorrow(nc: borrowing NC, borrow: (borrowing NC) -> NE) -> NE {
 }
 
 func testBorrow(nc: consuming NC) {
-  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{cannot convert value of type '(borrowing NC) -> @lifetime(borrow 0) NE' to expected argument type '(borrowing NC) -> NE}}
+  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{does not conform to expected type 'Escapable'}} ex/pected-error{{cannot convert value of type '(borrowing NC) -> @lifetime(borrow 0) NE' to expected argument type '(borrowing NC) -> NE}}
   _ = consume nc
   _ = transfer(borrowed)
 }


### PR DESCRIPTION
When a generic function has potentially Escapable outputs, those outputs declare lifetime dependencies, which have no effect when substitution leads to those types becoming `Escapable` in a concrete context. This means that type substitution should canonically eliminate lifetime dependencies targeting Escapable parameters or returns, and that type checking should allow a function value with potentially-Escapable lifetime dependencies to bind to a function type without those dependencies when the target of the dependencies is Escapable.

Fixes rdar://147533059.