### PR TITLE
Always restore old env variables

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -799,16 +799,18 @@ function Invoke-IsolatingEnvVars([scriptblock]$Block) {
   foreach ($Var in (Get-ChildItem env:*).GetEnumerator()) {
     $OldVars.Add($Var.Key, $Var.Value)
   }
-
-  & $Block
-
-  Remove-Item env:*
-  foreach ($Var in $OldVars.GetEnumerator()) {
-    New-Item -Path "env:\$($Var.Key)" -Value $Var.Value -ErrorAction Ignore | Out-Null
+  try {
+    & $Block
   }
+  finally {
+    Remove-Item env:*
+    foreach ($Var in $OldVars.GetEnumerator()) {
+      New-Item -Path "env:\$($Var.Key)" -Value $Var.Value -ErrorAction Ignore | Out-Null
+    }
 
-  if ($ToBatch) {
-    Write-Output "endlocal"
+    if ($ToBatch) {
+      Write-Output "endlocal"
+    }
   }
 }
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -801,8 +801,7 @@ function Invoke-IsolatingEnvVars([scriptblock]$Block) {
   }
   try {
     & $Block
-  }
-  finally {
+  } finally {
     Remove-Item env:*
     foreach ($Var in $OldVars.GetEnumerator()) {
       New-Item -Path "env:\$($Var.Key)" -Value $Var.Value -ErrorAction Ignore | Out-Null


### PR DESCRIPTION
When we invoke the script block it could throw an exception so we should wrap it in a try finally block to ensure that we can restore the old environment variables, otherwise you can end up back in a shell that has an incorrect set of variables set.

This is most noticable if an exception is thrown when entering the vs dev shell since without resetting the old vars you will have invalid Visual Studio env variables set meaning you need to manually reset your shell environment.