### PR TITLE
[CSBindings] Avoid delaying leading-dot inference only if chain is di…

### DIFF
--- a/test/expr/delayed-ident/member_chains.swift
+++ b/test/expr/delayed-ident/member_chains.swift
@@ -382,3 +382,30 @@ func acceptInt(_ x: Int) {}
 func postfixOpIsNotAMemberChain() {
   acceptInt(.implicit.another^)
 }
+
+// Ensure that base type doesn't get bound to a protocol type too eagerly
+do {
+  struct V : Hashable {
+    static let v1: V = V()
+    static let v2: V = V()
+  }
+
+  let _: Set = [V.v1, .v2] // Ok
+
+  struct Elements : RandomAccessCollection {
+    init() {}
+    init(_ elements: [Int]) {}
+
+    var startIndex: Int { 0 }
+    var endIndex: Int { 0 }
+    subscript(index: Int) -> Int { 0 }
+  }
+
+  struct TestNilCoalescing {
+    var data: Elements?
+
+    func test() {
+      for _ in self.data ?? .init() {} // Ok
+    }
+  }
+}


### PR DESCRIPTION
…rectly connected to a contextual type

Additional restrictions on when protocol inference could be considered viable. If the chain is connected directly to a contextual type there cannot be any other inference sources for the base type.

Resolves: rdar://148256978

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
