### PR TITLE
Fix missing refs to accesor when shadowing with if-let shorthand.

### DIFF
--- a/include/swift/Index/IndexSymbol.h
+++ b/include/swift/Index/IndexSymbol.h
@@ -65,7 +65,7 @@ struct IndexSymbol : IndexRelation {
   SmallVector<IndexRelation, 3> Relations;
   unsigned line = 0;
   unsigned column = 0;
-  const Decl *originalDecl = nullptr;
+  ValueDecl *originalDecl = nullptr;
 
   IndexSymbol() = default;
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -888,6 +888,11 @@ private:
     // Dig back to the original captured variable
     if (isa<VarDecl>(D)) {
       Info.originalDecl = firstDecl(D);
+      // When indexing locals is disabled, the reference to the original decl
+      // would be lost without overwriting the local symbol.
+      if (!IdxConsumer.indexLocals()) {
+        D = Info.originalDecl;
+      }
     }
 
     if (Data.isImplicit)

--- a/test/Index/index_shadow.swift
+++ b/test/Index/index_shadow.swift
@@ -40,7 +40,7 @@ struct ShadowedTest {
     if let shadowedVar {
       // CHECK_LOCALS-NOT: [[@LINE+3]]:11 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
       // CHECK_LOCALS: [[@LINE+2]]:11 {{.*}} s:14swift_ide_test12ShadowedTestV06shadowE0yyF11shadowedVarL_SiSgvp {{.*}}Ref
-      // CHECK-NOT: [[@LINE+1]]:11 {{.*}} shadowedVar {{.*}}Ref
+      // CHECK: [[@LINE+1]]:11 | instance-property/Swift | shadowedVar | s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
       _ = shadowedVar
 
       // CHECK_LOCALS: [[@LINE+4]]:14 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
@@ -49,7 +49,7 @@ struct ShadowedTest {
       // CHECK: [[@LINE+1]]:14 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
       if let shadowedVar {
         // CHECK_LOCALS: [[@LINE+2]]:13 {{.*}} s:14swift_ide_test12ShadowedTestV06shadowE0yyF11shadowedVarL0_Sivp {{.*}}Ref
-        // CHECK-NOT: [[@LINE+1]]:13 {{.*}} shadowedVar {{.*}}Ref
+        // CHECK: [[@LINE+1]]:13 | instance-property/Swift | shadowedVar | s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
         _ = shadowedVar
       }
     }
@@ -60,7 +60,7 @@ struct ShadowedTest {
     // CHECK: [[@LINE+1]]:12 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
     _ = { [shadowedVar] in
       // CHECK_LOCALS: [[@LINE+2]]:11 {{.*}} s:14swift_ide_test12ShadowedTestV06shadowE0yyF11shadowedVarL1_SiSgSgvp {{.*}}Ref
-      // CHECK-NOT: [[@LINE+1]]:11 {{.*}} shadowedVar {{.*}}Ref
+      // CHECK: [[@LINE+1]]:11 | instance-property/Swift | shadowedVar | s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
       _ = shadowedVar
 
       // CHECK_LOCALS: [[@LINE+4]]:14 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
@@ -69,7 +69,7 @@ struct ShadowedTest {
       // CHECK: [[@LINE+1]]:14 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
       _ = { [shadowedVar] in
         // CHECK_LOCALS: [[@LINE+2]]:13 {{.*}} s:14swift_ide_test12ShadowedTestV06shadowE0yyFyycfU_11shadowedVarL_SiSgSgvp {{.*}}Ref
-        // CHECK-NOT: [[@LINE+1]]:13 {{.*}} shadowedVar {{.*}}Ref
+        // CHECK: [[@LINE+1]]:13 | instance-property/Swift | shadowedVar | s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
         _ = shadowedVar
       }
     }


### PR DESCRIPTION
After https://github.com/swiftlang/swift/commit/ce55a854b9fc9ed5d48c0e6b4a1635d6c3442845 the references to accessors for the shadowed accessor were discarded when indexing without locals.

Related: #80394 

Not sure it fixes that issue entirely. I don't know what's causing the incorrect source locations reported.

