### PR TITLE
[ClangImporter] Let clang pick default target CPU.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -821,38 +821,14 @@ importer::addCommonInvocationArguments(
     switch (triple.getArch()) {
     case llvm::Triple::x86:
     case llvm::Triple::x86_64:
-      // `-mcpu` is deprecated and an alias for `-mtune`. We need to pass
-      // `-march` and `-mtune` to behave identically to the `apple-a\d+` cases
-      // below.
+      // For x86, `-mcpu` is deprecated and an alias of `-mtune`. We need to
+      // pass `-march` and `-mtune` to behave like `-mcpu` on other targets.
       invocationArgStrs.push_back("-march=" + importerOpts.TargetCPU);
       invocationArgStrs.push_back("-mtune=" + importerOpts.TargetCPU);
       break;
     default:
       invocationArgStrs.push_back("-mcpu=" + importerOpts.TargetCPU);
       break;
-    }
-  } else if (triple.isOSDarwin()) {
-    // Special case CPU based on known deployments:
-    //   - arm64 deploys to apple-a7
-    //   - arm64 on macOS
-    //   - arm64 for iOS/tvOS/watchOS simulators
-    //   - arm64e deploys to apple-a12
-    // and arm64e (everywhere) and arm64e macOS defaults to the "apple-a12" CPU
-    // for Darwin, but Clang only detects this if we use -arch.
-    if (triple.getArchName() == "arm64e")
-      invocationArgStrs.push_back("-mcpu=apple-a12");
-    else if (triple.isAArch64() && triple.isMacOSX())
-      invocationArgStrs.push_back("-mcpu=apple-a12");
-    else if (triple.isAArch64() && triple.isSimulatorEnvironment() &&
-             (triple.isiOS() || triple.isWatchOS()))
-      invocationArgStrs.push_back("-mcpu=apple-a12");
-    else if (triple.isAArch64() && triple.isSimulatorEnvironment() &&
-             triple.isXROS())
-      invocationArgStrs.push_back("-mcpu=apple-a12");
-    else if (triple.getArch() == llvm::Triple::aarch64 ||
-             triple.getArch() == llvm::Triple::aarch64_32 ||
-             triple.getArch() == llvm::Triple::aarch64_be) {
-      invocationArgStrs.push_back("-mcpu=apple-a7");
     }
   } else if (triple.getArch() == llvm::Triple::systemz) {
     invocationArgStrs.push_back("-march=z13");

--- a/test/ClangImporter/invocation-mcpu.swift
+++ b/test/ClangImporter/invocation-mcpu.swift
@@ -1,7 +1,12 @@
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64e-apple-macos11.0 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-M1 %s
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64-apple-ios13.0-simulator 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-M1 %s
+// CHECK-APPLE-M1: '-target-cpu' 'apple-m1' '-target-feature'
+
 // RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64e-apple-ios13.0 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A12 %s
-// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64e-apple-macos11.0 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A12 %s
-// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64e-apple-ios13.0-simulator 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A12 %s
-// CHECK-APPLE-A12: '-mcpu=apple-a12'
+// CHECK-APPLE-A12: '-target-cpu' 'apple-a12' '-target-feature'
 
 // RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64-apple-ios13.0 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A7 %s
-// CHECK-APPLE-A7: '-mcpu=apple-a7'
+// CHECK-APPLE-A7: '-target-cpu' 'apple-a7' '-target-feature'
+
+// RUN: %swift %s -typecheck -parse-stdlib -dump-clang-diagnostics -target arm64-apple-ios13.0 -target-cpu apple-a16 2>&1 | %FileCheck -check-prefix=CHECK-APPLE-A16 %s
+// CHECK-APPLE-A16: '-target-cpu' 'apple-a16' '-target-feature'


### PR DESCRIPTION
Currently, ClangImporter has some logic to pick the default arm64 target CPU (when -target-cpu isn't passed) based on the target OS and arch variant.

This was originally done long ago in 3cf3f42e9805, and later maintained through 49a6c8eb7b1c, because it was necessary when clang (targeting darwin) relied on -arch to set this sort of default.

Clang has migrated to full -target triples for a while now, and has sophisticated logic for picking default target CPUs and features based on the target triple.

Currently, we override that by passing our -mcpu explicitly. Instead, allow clang to pick its defaults, and only pass -mcpu when asked via -target-cpu.

This is visible in the test, with arm64 macOS now defaulting to M1. The same applies to simulators, per Triple::isTargetMachineMac.

rdar://148377686