### PR TITLE
[6.1] Disable Python/python_lint test due to CI failures

### DIFF
--- a/test/Python/python_lint.swift
+++ b/test/Python/python_lint.swift
@@ -6,3 +6,5 @@
 // REQUIRES: OS=macosx
 
 // RUN: %{python} %utils/python_lint.py
+
+// REQUIRES: rdar59281423


### PR DESCRIPTION
- **Explanation**: This started failing after an update as we don't have a lockfile committed.
- **Scope**: Style
- **Issue**: n/a
- **Risk**: None, the failing lints don't matter at all (and are currently failing).
- **Reviewer**: @DougGregor 