### PR TITLE
[Concurrency] Avoid inserting handler record in already cancelled task.

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -244,6 +244,16 @@ void removeStatusRecordWhere(
     llvm::function_ref<bool(ActiveTaskStatus, TaskStatusRecord*)> condition,
     llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)>updateStatus = nullptr);
 
+/// Remove and return a status record of the given type. This function removes a
+/// singlw record, and leaves subsequent records as-is if there are any.
+/// Returns `nullptr` if there are no matching records.
+///
+/// NOTE: When using this function with new record types, make sure to provide
+/// an explicit instantiation in TaskStatus.cpp.
+template <typename TaskStatusRecordT>
+SWIFT_CC(swift)
+TaskStatusRecordT* popStatusRecordOfType(AsyncTask *task);
+
 /// Remove a status record from the current task. This must be called
 /// synchronously with the task.
 SWIFT_CC(swift)

--- a/test/Concurrency/Runtime/cancellation_handler_only_once.swift
+++ b/test/Concurrency/Runtime/cancellation_handler_only_once.swift
@@ -1,0 +1,62 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -target %target-swift-5.1-abi-triple %import-libdispatch) | %FileCheck %s
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
+
+import Synchronization
+
+struct State {
+  var cancelled = 0
+  var continuation: CheckedContinuation<Void, Never>?
+}
+
+func testFunc(_ iteration: Int) async -> Task<Void, Never> {
+  let state = Mutex(State())
+
+  let task = Task {
+    await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        let cancelled = state.withLock {
+          if $0.cancelled > 0 {
+            return true
+          } else {
+            $0.continuation = continuation
+            return false
+          }
+        }
+        if cancelled {
+          continuation.resume()
+        }
+      }
+    } onCancel: {
+      let continuation = state.withLock {
+        $0.cancelled += 1
+        return $0.continuation.take()
+      }
+      continuation?.resume()
+    }
+  }
+
+  // This task cancel is racing with installing the cancellation handler,
+  // and we may either hit the cancellation handler:
+  // - after this cancel was issued, and therefore the handler runs immediately
+  task.cancel()
+  _ = await task.value
+
+  let cancelled = state.withLock { $0.cancelled }
+  precondition(cancelled == 1, "cancelled more than once, iteration: \(iteration)")
+
+  return task
+}
+
+var ts: [Task<Void, Never>] = []
+for iteration in 0..<1_000 {
+  let t = await testFunc(iteration)
+  ts.append(t)
+}
+
+print("done") // CHECK: done


### PR DESCRIPTION
This avoids the potential to race with the triggering coming from task_cancel, because we first set the cancelled flag, and only THEN take the lock and iterate over the inserted records. Because of this we could: T1 flip the cancelled bit; T2 observes that, and triggers "immediately" during installing the handler record. T1 then proceeds to lock records and trigger it again, causing a double trigger of the cancellation handler.

resolves https://github.com/swiftlang/swift/issues/80161 
resolves rdar://147493150

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
