### PR TITLE
DiagnosticEngine: Always favor the category of a wrapped diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -599,6 +599,9 @@ namespace swift {
     void setDecl(const class Decl *decl) { Decl = decl; }
     void setBehaviorLimit(DiagnosticBehavior limit){ BehaviorLimit = limit; }
 
+    /// Returns the wrapped diagnostic, if any.
+    std::optional<const DiagnosticInfo *> getWrappedDiagnostic() const;
+
     /// Returns true if this object represents a particular diagnostic.
     ///
     /// \code


### PR DESCRIPTION
We were favoring the category of a wrapped diagnostic only in the case of a diagnostic group. Do the same to other kinds of categories.