### PR TITLE
[ASTScope] Allow `try` in unfolded sequence to cover following elements

### DIFF
--- a/include/swift/AST/ASTScope.h
+++ b/include/swift/AST/ASTScope.h
@@ -1871,15 +1871,20 @@ public:
 class TryScope final : public ASTScopeImpl {
 public:
   AnyTryExpr *const expr;
-  TryScope(AnyTryExpr *e)
-      : ASTScopeImpl(ScopeKind::Try), expr(e) {}
+
+  /// The end location of the scope. This may be past the TryExpr for
+  /// cases where the `try` is at the top-level of an unfolded SequenceExpr. In
+  /// such cases, the `try` covers all elements to the right.
+  SourceLoc endLoc;
+
+  TryScope(AnyTryExpr *e, SourceLoc endLoc)
+      : ASTScopeImpl(ScopeKind::Try), expr(e), endLoc(endLoc) {
+    ASSERT(endLoc.isValid());
+  }
   virtual ~TryScope() {}
 
 protected:
   ASTScopeImpl *expandSpecifically(ScopeCreator &scopeCreator) override;
-
-private:
-  void expandAScopeThatDoesNotCreateANewInsertionPoint(ScopeCreator &);
 
 public:
   SourceRange

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -456,6 +456,22 @@ public:
     return const_cast<Expr *>(this)->getValueProvidingExpr();
   }
 
+  /// Checks whether this expression is always hoisted above a binary operator
+  /// when it appears on the left-hand side, e.g 'try x + y' becomes
+  /// 'try (x + y)'. If so, returns the sub-expression, \c nullptr otherwise.
+  ///
+  /// Note that such expressions may not appear on the right-hand side of a
+  /// binary operator, except for assignment and ternaries.
+  Expr *getAlwaysLeftFoldedSubExpr() const;
+
+  /// Checks whether this expression is always hoisted above a binary operator
+  /// when it appears on the left-hand side, e.g 'try x + y' becomes
+  /// 'try (x + y)'.
+  ///
+  /// Note that such expressions may not appear on the right-hand side of a
+  /// binary operator, except for assignment and ternaries.
+  bool isAlwaysLeftFolded() const { return bool(getAlwaysLeftFoldedSubExpr()); }
+
   /// Find the original expression value, looking through various
   /// implicit conversions.
   const Expr *findOriginalValue() const;

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -410,5 +410,5 @@ SourceLoc ast_scope::extractNearestSourceLoc(
 
 SourceRange TryScope::getSourceRangeOfThisASTNode(
     const bool omitAssertions) const {
-  return expr->getSourceRange();
+  return SourceRange(expr->getStartLoc(), endLoc);
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -3017,6 +3017,17 @@ FrontendStatsTracer::getTraceFormatter<const Expr *>() {
   return &TF;
 }
 
+Expr *Expr::getAlwaysLeftFoldedSubExpr() const {
+  if (auto *ATE = dyn_cast<AnyTryExpr>(this))
+    return ATE->getSubExpr();
+  if (auto *AE = dyn_cast<AwaitExpr>(this))
+    return AE->getSubExpr();
+  if (auto *UE = dyn_cast<UnsafeExpr>(this))
+    return UE->getSubExpr();
+
+  return nullptr;
+}
+
 const Expr *Expr::findOriginalValue() const {
   auto *expr = this;
   do {

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -1126,18 +1126,6 @@ extension ASTGenVisitor {
     var elements: [BridgedExpr] = []
     elements.reserveCapacity(node.elements.count)
 
-    // If the left-most sequence expr is a 'try', hoist it up to turn
-    // '(try x) + y' into 'try (x + y)'. This is necessary to do in the
-    // ASTGen because 'try' nodes are represented in the ASTScope tree
-    // to look up catch nodes. The scope tree must be syntactic because
-    // it's constructed before sequence folding happens during preCheckExpr.
-    // Otherwise, catch node lookup would find the incorrect catch node for
-    // 'try x + y' at the source location for 'y'.
-    //
-    // 'try' has restrictions for where it can appear within a sequence
-    // expr. This is still diagnosed in TypeChecker::foldSequence.
-    let firstTryExprSyntax = node.elements.first?.as(TryExprSyntax.self)
-
     var iter = node.elements.makeIterator()
     while let node = iter.next() {
       switch node.as(ExprSyntaxEnum.self) {
@@ -1164,24 +1152,14 @@ extension ASTGenVisitor {
       case .unresolvedTernaryExpr(let node):
         elements.append(self.generate(unresolvedTernaryExpr: node).asExpr)
       default:
-        if let firstTryExprSyntax, node.id == firstTryExprSyntax.id {
-          elements.append(self.generate(expr: firstTryExprSyntax.expression))
-        } else {
-          elements.append(self.generate(expr: node))
-        }
+        elements.append(self.generate(expr: node))
       }
     }
 
-    let seqExpr = BridgedSequenceExpr.createParsed(
+    return BridgedSequenceExpr.createParsed(
       self.ctx,
       exprs: elements.lazy.bridgedArray(in: self)
     ).asExpr
-
-    if let firstTryExprSyntax {
-      return self.generate(tryExpr: firstTryExprSyntax, overridingSubExpr: seqExpr)
-    } else {
-      return seqExpr
-    }
   }
 
   func generate(subscriptCallExpr node: SubscriptCallExprSyntax, postfixIfConfigBaseExpr: BridgedExpr? = nil) -> BridgedSubscriptExpr {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -370,23 +370,6 @@ done:
   if (SequencedExprs.size() == 1)
     return makeParserResult(SequenceStatus, SequencedExprs[0]);
 
-  // If the left-most sequence expr is a 'try', hoist it up to turn
-  // '(try x) + y' into 'try (x + y)'. This is necessary to do in the
-  // parser because 'try' nodes are represented in the ASTScope tree
-  // to look up catch nodes. The scope tree must be syntactic because
-  // it's constructed before sequence folding happens during preCheckExpr.
-  // Otherwise, catch node lookup would find the incorrect catch node for
-  // 'try x + y' at the source location for 'y'.
-  //
-  // 'try' has restrictions for where it can appear within a sequence
-  // expr. This is still diagnosed in TypeChecker::foldSequence.
-  if (auto *tryEval = dyn_cast<AnyTryExpr>(SequencedExprs[0])) {
-    SequencedExprs[0] = tryEval->getSubExpr();
-    auto *sequence = SequenceExpr::create(Context, SequencedExprs);
-    tryEval->setSubExpr(sequence);
-    return makeParserResult(SequenceStatus, tryEval);
-  }
-
   return makeParserResult(SequenceStatus,
                           SequenceExpr::create(Context, SequencedExprs));
 }

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -316,6 +316,8 @@ func takesThrowingAutoclosure(_: @autoclosure () throws(MyError) -> Int) {}
 func takesNonThrowingAutoclosure(_: @autoclosure () throws(Never) -> Int) {}
 
 func getInt() throws -> Int { 0 }
+func getIntAsync() async throws -> Int { 0 }
+func getBool() throws -> Bool { true }
 
 func throwingAutoclosures() {
   takesThrowingAutoclosure(try getInt())
@@ -336,4 +338,83 @@ func noThrow() throws(Never) {
     throw MyError.epicFailed
     // expected-error@-1 {{thrown expression type 'MyError' cannot be converted to error type 'Never'}}
   } catch {}
+}
+
+precedencegroup LowerThanAssignment {
+  lowerThan: AssignmentPrecedence
+}
+infix operator ~~~ : LowerThanAssignment
+func ~~~ <T, U> (lhs: T, rhs: U) {}
+
+func testSequenceExpr() async throws(Never) {
+  // Make sure the `try` here covers both calls in the ASTScope tree.
+  try! getInt() + getInt() // expected-warning {{result of operator '+' is unused}}
+  try! _ = getInt() + getInt()
+  _ = try! getInt() + getInt()
+  _ = try! getInt() + (getInt(), 0).0
+
+  _ = try try! getInt() + getInt()
+  // expected-warning@-1 {{no calls to throwing functions occur within 'try' expression}}
+
+  _ = await try! getIntAsync() + getIntAsync()
+  // expected-warning@-1 {{'try' must precede 'await'}}
+
+  _ = unsafe await try! getIntAsync() + getIntAsync()
+  // expected-warning@-1 {{'try' must precede 'await'}}
+
+  _ = try unsafe await try! getIntAsync() + getIntAsync()
+  // expected-warning@-1 {{'try' must precede 'await'}}
+  // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
+
+  try _ = (try! getInt()) + getInt()
+  // expected-error@-1:29 {{thrown expression type 'any Error' cannot be converted to error type 'Never'}}
+
+  // `try` on the condition covers both branches.
+  _ = try! getBool() ? getInt() : getInt()
+
+  // `try` on "then" branch doesn't cover else.
+  try _ = getBool() ? try! getInt() : getInt()
+  // expected-error@-1:11 {{thrown expression type 'any Error' cannot be converted to error type 'Never'}}
+  // expected-error@-2:39 {{thrown expression type 'any Error' cannot be converted to error type 'Never'}}
+
+  // The `try` here covers everything, even if unassignable.
+  try! getBool() ? getInt() : getInt() = getInt()
+  // expected-error@-1 {{result of conditional operator '? :' is never mutable}}
+
+  // Same here.
+  try! getBool() ? getInt() : getInt() ~~~ getInt()
+
+  try _ = getInt() + try! getInt()
+  // expected-error@-1 {{thrown expression type 'any Error' cannot be converted to error type 'Never'}}
+  // expected-error@-2 {{'try!' cannot appear to the right of a non-assignment operator}}
+
+  // The ASTScope for `try` here covers both, but isn't covered in the folded
+  // expression. This is illegal anyway.
+  _ = 0 + try! getInt() + getInt()
+  // expected-error@-1 {{'try!' cannot appear to the right of a non-assignment operator}}
+  // expected-error@-2:27 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3:27 3{{did you mean}}
+
+  try _ = 0 + try! getInt() + getInt()
+  // expected-error@-1 {{'try!' cannot appear to the right of a non-assignment operator}}
+
+  // The ASTScope for `try` here covers both, but isn't covered in the folded
+  // expression due `~~~` having a lower precedence than assignment. This is
+  // illegal anyway.
+  _ = try! getInt() ~~~ getInt()
+  // expected-error@-1 {{'try!' following assignment operator does not cover everything to its right}}
+  // expected-error@-2:25 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3:25 3{{did you mean}}
+
+  try _ = try! getInt() ~~~ getInt()
+  // expected-error@-1 {{'try!' following assignment operator does not cover everything to its right}}
+
+  // Same here.
+  true ? 0 : try! getInt() ~~~ getInt()
+  // expected-error@-1 {{'try!' following conditional operator does not cover everything to its right}}
+  // expected-error@-2:32 {{call can throw but is not marked with 'try'}}
+  // expected-note@-3:32 3{{did you mean}}
+
+  try true ? 0 : try! getInt() ~~~ getInt()
+  // expected-error@-1 {{'try!' following conditional operator does not cover everything to its right}}
 }


### PR DESCRIPTION
Rather than fixing-up in the parser, adjust the ASTScope logic such that a `try` element in a SequenceExpr is considered as covering all elements to the right of it. Cases where this isn't true are invalid, and will be diagnosed during sequence folding. e.g:

```swift
0 * try foo() + bar()
_ = try foo() ~~~ bar() // Assuming `~~~` has lower precedence than `=`
```

This ensures we correctly handle `try` in assignment sequences, and allows ASTGen to get the behavior for free.

rdar://132872235