### PR TITLE
[SymbolGraphGen] add Sendable to the allowed attributes in declaration fragments

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -88,6 +88,7 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
   ExcludeAttrs.erase("TypeAttrKind::NoEscape");
   ExcludeAttrs.erase("TypeAttrKind::Escaping");
   ExcludeAttrs.erase("TypeAttrKind::Inout");
+  ExcludeAttrs.erase("TypeAttrKind::Sendable");
 
   // Don't allow the following decl attributes:
   // These can be large and are already included elsewhere in

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Function.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Function.swift
@@ -1,111 +1,200 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name Function -emit-module -emit-module-path %t/
 // RUN: %target-swift-symbolgraph-extract -module-name Function -I %t -pretty-print -output-dir %t
-// RUN: %FileCheck %s --input-file %t/Function.symbols.json --match-full-lines --strict-whitespace
+// RUN: %FileCheck %s --input-file %t/Function.symbols.json --match-full-lines --strict-whitespace --check-prefix=FOO
+// RUN: %FileCheck %s --input-file %t/Function.symbols.json --match-full-lines --strict-whitespace --check-prefix=BAR
 
 public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) where S: Sequence {}
 
-// CHECK-LABEL:{{^      }}"declarationFragments": [
-// CHECK:        {
-// CHECK-NEXT:          "kind": "keyword",
-// CHECK-NEXT:          "spelling": "func"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": " "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "identifier",
-// CHECK-NEXT:          "spelling": "foo"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": "<"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "genericParameter",
-// CHECK-NEXT:          "spelling": "S"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": ">("
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "externalParam",
-// CHECK-NEXT:          "spelling": "f"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": ": "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "keyword",
-// CHECK-NEXT:          "spelling": "@escaping"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": " () -> (), "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "externalParam",
-// CHECK-NEXT:          "spelling": "ext"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": " "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "internalParam",
-// CHECK-NEXT:          "spelling": "int"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": ": "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "typeIdentifier",
-// CHECK-NEXT:          "spelling": "Int",
-// CHECK-NEXT:          "preciseIdentifier": "s:Si"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": " = 2, "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "externalParam",
-// CHECK-NEXT:          "spelling": "s"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": ": "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "typeIdentifier",
-// CHECK-NEXT:          "spelling": "S"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": ") "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "keyword",
-// CHECK-NEXT:          "spelling": "where"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": " "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "typeIdentifier",
-// CHECK-NEXT:          "spelling": "S"
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": " : "
-// CHECK-NEXT:        },
-// CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "typeIdentifier",
-// CHECK-NEXT:          "spelling": "Sequence",
-// CHECK-NEXT:          "preciseIdentifier": "s:ST"
-// CHECK-NEXT:        }
-// CHECK-NEXT:      ],
+// FOO-LABEL:        "precise": "s:8Function3foo1f3ext1syyyc_SixtSTRzlF",
+// FOO:{{^      }}"declarationFragments": [
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "keyword",
+// FOO-NEXT:          "spelling": "func"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": " "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "identifier",
+// FOO-NEXT:          "spelling": "foo"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": "<"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "genericParameter",
+// FOO-NEXT:          "spelling": "S"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": ">("
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "externalParam",
+// FOO-NEXT:          "spelling": "f"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": ": "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "keyword",
+// FOO-NEXT:          "spelling": "@escaping"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": " () -> (), "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "externalParam",
+// FOO-NEXT:          "spelling": "ext"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": " "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "internalParam",
+// FOO-NEXT:          "spelling": "int"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": ": "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "typeIdentifier",
+// FOO-NEXT:          "spelling": "Int",
+// FOO-NEXT:          "preciseIdentifier": "s:Si"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": " = 2, "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "externalParam",
+// FOO-NEXT:          "spelling": "s"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": ": "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "typeIdentifier",
+// FOO-NEXT:          "spelling": "S"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": ") "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "keyword",
+// FOO-NEXT:          "spelling": "where"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": " "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "typeIdentifier",
+// FOO-NEXT:          "spelling": "S"
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "text",
+// FOO-NEXT:          "spelling": " : "
+// FOO-NEXT:        },
+// FOO-NEXT:        {
+// FOO-NEXT:          "kind": "typeIdentifier",
+// FOO-NEXT:          "spelling": "Sequence",
+// FOO-NEXT:          "preciseIdentifier": "s:ST"
+// FOO-NEXT:        }
+// FOO-NEXT:      ],
+
+public func bar<T>(_ apply: () -> T, onChange: @autoclosure () -> @Sendable () -> Void) {}
+
+// BAR-LABEL:        "precise": "s:8Function3bar_8onChangeyxyXE_yyYbcyXKtlF",
+// BAR:      "declarationFragments": [
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "keyword",
+// BAR-NEXT:          "spelling": "func"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": " "
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "identifier",
+// BAR-NEXT:          "spelling": "bar"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": "<"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "genericParameter",
+// BAR-NEXT:          "spelling": "T"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": ">("
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "externalParam",
+// BAR-NEXT:          "spelling": "_"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": " "
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "internalParam",
+// BAR-NEXT:          "spelling": "apply"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": ": () -> "
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "typeIdentifier",
+// BAR-NEXT:          "spelling": "T"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": ", "
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "externalParam",
+// BAR-NEXT:          "spelling": "onChange"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": ": "
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "attribute",
+// BAR-NEXT:          "spelling": "@autoclosure "
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": "() -> "
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "attribute",
+// BAR-NEXT:          "spelling": "@Sendable"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": " () -> "
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "typeIdentifier",
+// BAR-NEXT:          "spelling": "Void",
+// BAR-NEXT:          "preciseIdentifier": "s:s4Voida"
+// BAR-NEXT:        },
+// BAR-NEXT:        {
+// BAR-NEXT:          "kind": "text",
+// BAR-NEXT:          "spelling": ")"
+// BAR-NEXT:        }
+// BAR-NEXT:      ],


### PR DESCRIPTION
Fixes rdar://142903358

This PR adds `@Sendable` to the list of allowed type attributes in declaration fragments in symbol graphs. This allows function arguments that are labeled with `@Sendable` to be correctly surfaced in documentation.