### PR TITLE
[ExplicitModuleBuild] Don't leak chained bridging header in objc header

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -912,14 +912,17 @@ SourceFile *CompilerInstance::getIDEInspectionFile() const {
 
 std::string CompilerInstance::getBridgingHeaderPath() const {
   const FrontendOptions &opts = Invocation.getFrontendOptions();
-  if (opts.ImplicitObjCPCHPath.empty())
+  if (!opts.ModuleHasBridgingHeader)
+    return std::string();
+
+  if (!opts.ImplicitObjCHeaderPath.empty())
     return opts.ImplicitObjCHeaderPath;
 
   auto clangImporter =
       static_cast<ClangImporter *>(getASTContext().getClangModuleLoader());
 
   // No clang importer created. Report error?
-  if (!clangImporter)
+  if (!clangImporter || opts.ImplicitObjCPCHPath.empty())
     return std::string();
 
   return clangImporter->getOriginalSourceFile(opts.ImplicitObjCPCHPath);

--- a/test/ScanDependencies/bridging-header-autochaining.swift
+++ b/test/ScanDependencies/bridging-header-autochaining.swift
@@ -121,7 +121,15 @@
 // RUN: %target-swift-frontend -module-name User -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -disable-implicit-swift-modules \
 // RUN:   -explicit-swift-module-map-file %t/map3.json @%t/User2.cmd %t/user2.swift \
+// RUN:   -emit-objc-header -emit-objc-header-path %t/User-Swift.h \
 // RUN:   -emit-module -o %t/User2.swiftmodule
+
+/// Generated ObjC Header should reference original header name, not the chained bridging header.
+// RUN: %FileCheck %s --check-prefix OBJC-HEADER --input-file=%t/User-Swift.h
+// OBJC-HEADER: import B
+// OBJC-HEADER: import
+// OBJC-HEADER-SAME: Bridging2.h
+// OBJC-HEADER-NOT: ChainedBridgingHeader.h
 
 // RUN: %target-swift-frontend -scan-dependencies -module-name User -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
@@ -193,6 +201,8 @@ extension Bridging2 {
     public func testA() {}
 }
 
+public class BB : B {}
+public class Foo3 : Bridging2 {}
 
 //--- Bridging.h
 #include "Foo.h"


### PR DESCRIPTION
When generating an objc header from the swift module when a bridging header is used, make sure to use the original bridging header, not the chained bridging header. This also avoids incorrectly generated a header include when no actual bridging header is used, just a chained bridging header that is coming from a dependency.

rdar://148446465

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
