### PR TITLE
tests: fix SILOptimizer/constant_fold_float.swift

### DIFF
--- a/test/SILOptimizer/constant_fold_float.swift
+++ b/test/SILOptimizer/constant_fold_float.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -parse-as-library -module-name test %s -O -emit-sil | %FileCheck %s
 
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: PTRSIZE=64
 
 // CHECK-LABEL: sil @$s4test17dont_fold_inf_cmpySbSfF :
 // CHECK:         builtin "fcmp_olt_FPIEEE32"


### PR DESCRIPTION
This test only works on 64 bit architectures

rdar://148440511
