### PR TITLE
MoveOnlyChecker: Don't follow trivial transitive uses of borrows.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1741,6 +1741,9 @@ struct CopiedLoadBorrowEliminationVisitor
         // Look through borrows.
         for (auto value : nextUse->getUser()->getResults()) {
           for (auto *use : value->getUses()) {
+            if (use->get()->getType().isTrivial(*use->getFunction())) {
+              continue;
+            }
             useWorklist.push_back(use);
           }
         }

--- a/test/SILOptimizer/moveonly_addresschecker_trivial_read.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_trivial_read.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+func use(_: Int32) {}
+
+struct NoncopyableYieldingSubscript: ~Copyable {
+    subscript() -> Int16 {
+        _read {
+            yield 0
+        }
+    }
+}
+
+func foo(component: inout NoncopyableYieldingSubscript, condition: Bool) {
+    let extracted: Int32
+
+    switch condition {
+    case true:
+        extracted = Int32(component[])
+
+    case false:
+        extracted = Int32(component[])
+
+    }
+
+    use(extracted)
+}


### PR DESCRIPTION
Trivial values don't have ownership tracked, so their uses can't affect the lifetime of the original borrow. Fixes rdar://148457155.