### PR TITLE
[Diagnostics] Support diagnostics with no location in the new formatter

### DIFF
--- a/include/swift/AST/DiagnosticBridge.h
+++ b/include/swift/AST/DiagnosticBridge.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/SourceManager.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/raw_ostream.h"
+#include <optional>
 
 namespace swift {
 /// Declare the bridge between swift-syntax and swift-frontend for diagnostics
@@ -44,7 +45,7 @@ class DiagnosticBridge {
 public:
   /// Enqueue diagnostics.
   void enqueueDiagnostic(SourceManager &SM, const DiagnosticInfo &Info,
-                         unsigned innermostBufferID);
+                         std::optional<unsigned> innermostBufferID);
 
   /// Flush all enqueued diagnostics.
   void flush(llvm::raw_ostream &OS, bool includeTrailingBreak,

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -87,9 +87,10 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
   }
 }
 
-void DiagnosticBridge::enqueueDiagnostic(SourceManager &SM,
-                                         const DiagnosticInfo &Info,
-                                         unsigned innermostBufferID) {
+void DiagnosticBridge::enqueueDiagnostic(
+    SourceManager &SM,
+    const DiagnosticInfo &Info,
+    std::optional<unsigned> innermostBufferID) {
   // If we didn't have per-frontend state before, create it now.
   if (!perFrontendState) {
     perFrontendState = swift_ASTGen_createPerFrontendDiagnosticState();
@@ -100,7 +101,8 @@ void DiagnosticBridge::enqueueDiagnostic(SourceManager &SM,
   if (!queuedDiagnostics)
     queuedDiagnostics = swift_ASTGen_createQueuedDiagnostics();
 
-  queueBuffer(SM, innermostBufferID);
+  if (innermostBufferID)
+    queueBuffer(SM, *innermostBufferID);
   addQueueDiagnostic(queuedDiagnostics, perFrontendState, Info, SM);
 }
 

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -219,7 +219,8 @@ public func emitParserDiagnostics(
     let configuredRegions = sourceFile.pointee.configuredRegions(astContext: ctx)
     for diag in diags {
       // If the diagnostic is in an unparsed #if region, don't emit it.
-      if configuredRegions.isActive(diag.node) == .unparsed {
+      if let diagNode = diag.node,
+          configuredRegions.isActive(diagNode) == .unparsed {
         continue
       }
 

--- a/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
@@ -99,9 +99,13 @@ extension SourceManager {
   /// Produce the C++ source location for a given position based on a
   /// syntax node.
   func bridgedSourceLoc<Node: SyntaxProtocol>(
-    for node: Node,
+    for node: Node?,
     at position: AbsolutePosition? = nil
   ) -> BridgedSourceLoc {
+    guard let node else {
+      return nil
+    }
+
     // Find the source file and this node's position within it.
     let (rootNode, rootPosition) = rootSyntax(of: node)
 
@@ -124,8 +128,8 @@ extension SourceManager {
   private func diagnoseSingle<Node: SyntaxProtocol>(
     message: String,
     severity: DiagnosticSeverity,
-    node: Node,
-    position: AbsolutePosition,
+    node: Node?,
+    position: AbsolutePosition?,
     highlights: [Syntax] = [],
     fixItChanges: [FixIt.Change] = []
   ) {

--- a/test/Unsafe/unsafe_command_line.swift
+++ b/test/Unsafe/unsafe_command_line.swift
@@ -1,4 +1,4 @@
 // RUN: %target-swift-frontend -typecheck -strict-memory-safety -Ounchecked -disable-access-control %s 2>&1 | %FileCheck %s
 
 // CHECK: warning: '-Ounchecked' is not memory-safe
-// CHECK: warning: '-disable-access-control' is not memory-safe
+// CHECK: warning: '-disable-access-control' is not memory-safe and should not be combined with strict memory safety checking [#StrictMemorySafety]


### PR DESCRIPTION
With the swift-syntax Diagnostic machinery now supporting diagnostics that have no associated syntax node (for location information), allow "invalid" source locations to pass in both directions across the diagnostics bridge between the C++ diagnostic machinery and the Swift diagnostic machinery. This eliminates the previous behavior where we would fall back to the LLVM diagnostic printer when there's an invalid source location on a diagnostic.

The end-user-visible change is that we'll now get consistently-rendered diagnostics between ones with source locations and ones without source locations.
