### PR TITLE
[Driver] Don't hardcode default linker on Linux

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -86,51 +86,9 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
 
   return II;
 }
-// Amazon Linux 2023 requires lld as the default linker.
-bool isAmazonLinux2023Host() {
-      std::ifstream file("/etc/os-release");
-      std::string line;
-
-      while (std::getline(file, line)) {
-        if (line.substr(0, 12) == "PRETTY_NAME=") {
-          if (line.substr(12) == "\"Amazon Linux 2023\"") {
-            file.close();
-            return true;
-          }
-        }
-      }
-      return false;
-    }
 
 std::string toolchains::GenericUnix::getDefaultLinker() const {
-  if (getTriple().isAndroid() || isAmazonLinux2023Host()
-      || (getTriple().isMusl()
-          && getTriple().getVendor() == llvm::Triple::Swift))
-    return "lld";
-
-  switch (getTriple().getArch()) {
-  case llvm::Triple::arm:
-  case llvm::Triple::aarch64:
-  case llvm::Triple::aarch64_32:
-  case llvm::Triple::armeb:
-  case llvm::Triple::thumb:
-  case llvm::Triple::thumbeb:
-    // BFD linker has issues wrt relocation of the protocol conformance
-    // section on these targets, it also generates COPY relocations for
-    // final executables, as such, unless specified, we default to gold
-    // linker.
-    return "gold";
-  case llvm::Triple::x86:
-  case llvm::Triple::x86_64:
-  case llvm::Triple::ppc64:
-  case llvm::Triple::ppc64le:
-  case llvm::Triple::systemz:
-    // BFD linker has issues wrt relocations against protected symbols.
-    return "gold";
-  default:
-    // Otherwise, use the default BFD linker.
-    return "";
-  }
+  return "";
 }
 
 bool toolchains::GenericUnix::addRuntimeRPath(const llvm::Triple &T,

--- a/test/Driver/baremetal-target.swift
+++ b/test/Driver/baremetal-target.swift
@@ -1,4 +1,4 @@
 // RUN: %swiftc_driver_plain -target aarch64-unknown-none-none -driver-print-jobs %s 2>&1 | %FileCheck %s
 
 // CHECK: {{.*}}swift{{c|c-legacy-driver|-frontend}}{{(.exe)?"?}} -frontend -c
-// CHECK: {{.*}}clang{{(.exe)?"?}} -fuse-ld=gold
+// CHECK: {{.*}}clang{{(.exe)?"?}}

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -344,7 +344,6 @@
 
 // LINUX_DYNLIB-x86_64: clang{{(\.exe)?"? }}
 // LINUX_DYNLIB-x86_64-DAG: -shared
-// LINUX_DYNLIB-x86_64-DAG: -fuse-ld=gold
 // LINUX_DYNLIB-x86_64-NOT: -pie
 // LINUX_DYNLIB-x86_64-DAG: -Xlinker -rpath -Xlinker [[STDLIB_PATH:[^ ]+(/|\\\\)lib(/|\\\\)swift(/|\\\\)linux]]
 // LINUX_DYNLIB-x86_64: [[STDLIB_PATH]]{{/|\\\\}}x86_64{{/|\\\\}}swiftrt.o


### PR DESCRIPTION
This is the C++ driver counterpart to a change that landed in the Swift driver a while ago to use the clang-linker to determine what the default linker is. This is to avoid hard-coding gold, which is deprecated and not available on some newer Linux distributions. The challenge is that these newer Linux distributions don't already have Swift so we have to use the old C++ driver implementation.