### PR TITLE
[Strict memory safety] Union member accessors are always unsafe

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2392,6 +2392,9 @@ namespace {
           // field type.
           synthesizer.makeUnionFieldAccessors(result, member);
 
+          // Union accessors are always unsafe.
+          member->getAttrs().add(new (Impl.SwiftContext) UnsafeAttr(/*Implicit=*/true));
+
           // Create labeled initializers for unions that take one of the
           // fields, which only initializes the data for that field.
           auto valueCtor =

--- a/test/Unsafe/unsafe_c_imports.swift
+++ b/test/Unsafe/unsafe_c_imports.swift
@@ -19,4 +19,9 @@ struct StoreAllTheThings {
   let ln: ListNode // expected-note{{property 'ln' involves unsafe type 'ListNode'}}
 
   let sc: SomeColor
-};
+}
+
+func readFromUnion(npu: NoPointersUnion) {
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  _ = npu.x // expected-note{{reference to unsafe property 'x'}}
+}


### PR DESCRIPTION
Union member accessors have no way to know what the "active field" is, so consider them to always be unsafe.
