### PR TITLE
Sema: Fix a regression in `-require-explicit-availability` diagnostics

### DIFF
--- a/include/swift/AST/DeclExportabilityVisitor.h
+++ b/include/swift/AST/DeclExportabilityVisitor.h
@@ -190,6 +190,10 @@ bool isExported(const ValueDecl *VD);
 /// A specialization of `isExported` for `ExtensionDecl`.
 bool isExported(const ExtensionDecl *ED);
 
+/// Returns true if the extension declares any protocol conformances that
+/// require the extension to be exported.
+bool hasConformancesToPublicProtocols(const ExtensionDecl *ED);
+
 } // end namespace swift
 
 #endif

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -1144,7 +1144,7 @@ bool swift::isExported(const ValueDecl *VD) {
   return false;
 }
 
-static bool hasConformancesToPublicProtocols(const ExtensionDecl *ED) {
+bool swift::hasConformancesToPublicProtocols(const ExtensionDecl *ED) {
   auto nominal = ED->getExtendedNominal();
   if (!nominal)
     return false;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3521,7 +3521,7 @@ void swift::checkExplicitAvailability(Decl *decl) {
       return false;
     });
 
-    if (!hasMembers && !isExported(extension))
+    if (!hasMembers && !hasConformancesToPublicProtocols(extension))
       return;
   } else if (auto pbd = dyn_cast<PatternBindingDecl>(decl)) {
     // Check the first var instead.

--- a/test/attr/require_explicit_availability_macos.swift
+++ b/test/attr/require_explicit_availability_macos.swift
@@ -3,29 +3,29 @@
 // RUN: %empty-directory(%t)
 
 /// Using the flag directly raises warnings and fixits.
-// RUN: %swiftc_driver -typecheck -parse-as-library -Xfrontend -verify %s \
-// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability \
-// RUN:   -require-explicit-availability-target "macOS 10.10"
-// RUN: %swiftc_driver -typecheck -parse-as-library -Xfrontend -verify %s \
-// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=warn \
-// RUN:   -require-explicit-availability-target "macOS 10.10"
+// RUN: %target-swift-frontend -typecheck -parse-as-library -verify %s \
+// RUN:   -target %target-cpu-apple-macosx10.10 -package-name Foo \
+// RUN:   -require-explicit-availability -require-explicit-availability-target "macOS 10.10"
+// RUN: %target-swift-frontend -typecheck -parse-as-library -verify %s \
+// RUN:   -target %target-cpu-apple-macosx10.10 -package-name Foo \
+// RUN:   -require-explicit-availability=warn -require-explicit-availability-target "macOS 10.10"
 
 /// Using -library-level api defaults to enabling warnings, without fixits.
 // RUN: sed -e "s/}} {{.*/}}/" < %s > %t/NoFixits.swift
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/NoFixits.swift \
-// RUN:   -target %target-cpu-apple-macosx10.10 -library-level api
+// RUN:   -target %target-cpu-apple-macosx10.10 -package-name Foo -library-level api
 
 /// Explicitly disable the diagnostic.
 // RUN: sed -e 's/xpected-warning/not-something-expected/' < %s > %t/None.swift
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/None.swift \
-// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=ignore \
-// RUN:   -require-explicit-availability-target "macOS 10.10" -library-level api
+// RUN:   -target %target-cpu-apple-macosx10.10 -package-name Foo -library-level api \
+// RUN:   -require-explicit-availability=ignore -require-explicit-availability-target "macOS 10.10"
 
 /// Upgrade the diagnostic to an error.
 // RUN: sed -e "s/xpected-warning/xpected-error/" < %s > %t/Errors.swift
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %t/Errors.swift \
-// RUN:   -target %target-cpu-apple-macosx10.10 -require-explicit-availability=error \
-// RUN:   -require-explicit-availability-target "macOS 10.10"
+// RUN:   -target %target-cpu-apple-macosx10.10 -package-name Foo \
+// RUN:   -require-explicit-availability=error -require-explicit-availability-target "macOS 10.10"
 
 /// Error on an invalid argument.
 // RUN: not %target-swift-frontend -typecheck %s -require-explicit-availability=NotIt 2>&1 \
@@ -58,7 +58,9 @@ public func missingIntro() { } // expected-warning {{public declarations should 
 @available(iOS 9.0, *)
 public func missingTargetPlatform() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{-1:1-1=@available(macOS 10.10, *)\n}}
 
-func privateFunc() { }
+private func privateFunc() { }
+internal func internalFunc() { }
+package func packageFunc() { }
 
 @_alwaysEmitIntoClient
 public func alwaysEmitted() { }
@@ -113,6 +115,18 @@ extension S {
 extension S {
   internal func dontWarnWithoutPublicMembers() { }
   private func dontWarnWithoutPublicMembers1() { }
+  package func dontWarnWithoutPublicMembers2() { }
+}
+
+extension S {
+  @_spi(SPIsAreOK)
+  public func dontWarnWithSPIMembers() {}
+
+  @available(macOS, unavailable)
+  public func dontWarnWithUnavailableMembers() { }
+
+  @_alwaysEmitIntoClient
+  public func dontWarnWithAEICMembers() { }
 }
 
 // An empty extension should be ok.


### PR DESCRIPTION
The changes in https://github.com/swiftlang/swift/pull/80040 caused the compiler to start diagnosing extensions containing only members that are either `@_spi`, `@_alwaysEmitIntoClient`, or unavailable when the `-require-explicit-availability` flag is passed. Extensions should not be diagnosed when they only contain members that would not be diagnosed themselves.

Resolves rdar://148275432.