### PR TITLE
AST: Simplify ProtocolConformanceRef operations a little bit

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -325,19 +325,6 @@ public:
   /// abstraction level of their associated type requirements.
   SILType mapTypeIntoContext(SILModule &M, SILType type) const;
 
-  /// Map an interface type's protocol conformance into the corresponding
-  /// conformance for the contextual type.
-  static std::pair<Type, ProtocolConformanceRef>
-  mapConformanceRefIntoContext(GenericEnvironment *genericEnv,
-                               Type conformingType,
-                               ProtocolConformanceRef conformance);
-
-  /// Map an interface type's protocol conformance into the corresponding
-  /// conformance for the contextual type.
-  std::pair<Type, ProtocolConformanceRef>
-  mapConformanceRefIntoContext(Type conformingType,
-                               ProtocolConformanceRef conformance) const;
-
   /// Returns a substitution map that sends every generic parameter to its
   /// corresponding archetype in this generic environment.
   SubstitutionMap getForwardingSubstitutionMap() const;

--- a/include/swift/AST/ProtocolAssociations.h
+++ b/include/swift/AST/ProtocolAssociations.h
@@ -23,51 +23,6 @@
 
 namespace swift {
 
-/// A type associated with a protocol.
-///
-/// This struct exists largely so that we can maybe eventually
-/// generalize it to an arbitrary path.
-class AssociatedType {
-  AssociatedTypeDecl *Association;
-  using AssociationInfo = llvm::DenseMapInfo<AssociatedTypeDecl*>;
-
-  struct SpecialValue {};
-  explicit AssociatedType(SpecialValue _, AssociatedTypeDecl *specialValue)
-      : Association(specialValue) {}
-
-public:
-  explicit AssociatedType(AssociatedTypeDecl *association)
-      : Association(association) {
-    assert(association);
-  }
-
-  ProtocolDecl *getSourceProtocol() const {
-    return Association->getProtocol();
-  }
-
-  AssociatedTypeDecl *getAssociation() const {
-    return Association;
-  }
-
-  friend bool operator==(AssociatedType lhs, AssociatedType rhs) {
-    return lhs.Association == rhs.Association;
-  }
-  friend bool operator!=(AssociatedType lhs, AssociatedType rhs) {
-    return !(lhs == rhs);
-  }
-
-  unsigned getHashValue() const {
-    return llvm::hash_value(Association);
-  }
-
-  static AssociatedType getEmptyKey() {
-    return AssociatedType(SpecialValue(), AssociationInfo::getEmptyKey());
-  }
-  static AssociatedType getTombstoneKey() {
-    return AssociatedType(SpecialValue(), AssociationInfo::getTombstoneKey());
-  }
-};
-
 /// A base conformance of a protocol.
 class BaseConformance {
   ProtocolDecl *Source;
@@ -147,24 +102,6 @@ public:
 } // end namespace swift
 
 namespace llvm {
-  template <> struct DenseMapInfo<swift::AssociatedType> {
-    static inline swift::AssociatedType getEmptyKey() {
-      return swift::AssociatedType::getEmptyKey();
-    }
-
-    static inline swift::AssociatedType getTombstoneKey() {
-      return swift::AssociatedType::getTombstoneKey();
-    }
-
-    static unsigned getHashValue(swift::AssociatedType val) {
-      return val.getHashValue();
-    }
-
-    static bool isEqual(swift::AssociatedType lhs, swift::AssociatedType rhs) {
-      return lhs == rhs;
-    }
-  };
-
   template <> struct DenseMapInfo<swift::AssociatedConformance> {
     static inline swift::AssociatedConformance getEmptyKey() {
       return swift::AssociatedConformance::getEmptyKey();

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -363,10 +363,6 @@ public:
   /// Retrieve the protocol conformance for the inherited protocol.
   ProtocolConformance *getInheritedConformance(ProtocolDecl *protocol) const;
 
-  /// Given a dependent type expressed in terms of the self parameter,
-  /// map it into the context of this conformance.
-  Type getAssociatedType(Type assocType) const;
-
   /// Given that the requirement signature of the protocol directly states
   /// that the given dependent type must conform to the given protocol,
   /// return its associated conformance.

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -242,7 +242,7 @@ public:
   /// \param type The conforming type.
   ///
   /// \param name The name of the requirement.
-  ConcreteDeclRef getWitnessByName(Type type, DeclName name) const;
+  ConcreteDeclRef getWitnessByName(DeclName name) const;
 
   /// Determine whether this conformance is canonical.
   bool isCanonical() const;

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -205,7 +205,7 @@ public:
 
   /// Look up the type witness for an associated type declaration in this
   /// conformance.
-  Type getTypeWitness(Type origType, AssociatedTypeDecl *assocType,
+  Type getTypeWitness(AssociatedTypeDecl *assocType,
                       SubstOptions options = std::nullopt) const;
 
   /// Given a dependent type (expressed in terms of this conformance's

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -215,8 +215,7 @@ public:
   /// Given a dependent type (expressed in terms of this conformance's
   /// protocol) and conformance, follow it from the conforming type.
   ProtocolConformanceRef
-  getAssociatedConformance(Type origType, Type dependentType,
-                           ProtocolDecl *requirement) const;
+  getAssociatedConformance(Type dependentType, ProtocolDecl *requirement) const;
 
   SWIFT_DEBUG_DUMP;
   void dump(llvm::raw_ostream &out, unsigned indent = 0,

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -185,11 +185,11 @@ public:
   ProtocolDecl *getProtocol() const;
   
   /// Apply a substitution to the conforming type.
-  ProtocolConformanceRef subst(Type origType, SubstitutionMap subMap,
+  ProtocolConformanceRef subst(SubstitutionMap subMap,
                                SubstOptions options = std::nullopt) const;
 
   /// Apply a substitution to the conforming type.
-  ProtocolConformanceRef subst(Type origType, TypeSubstitutionFn subs,
+  ProtocolConformanceRef subst(TypeSubstitutionFn subs,
                                LookupConformanceFn conformances,
                                SubstOptions options = std::nullopt) const;
 
@@ -197,8 +197,7 @@ public:
   ///
   /// This function should generally not be used outside of the substitution
   /// subsystem.
-  ProtocolConformanceRef subst(Type origType,
-                               InFlightSubstitution &IFS) const;
+  ProtocolConformanceRef subst(InFlightSubstitution &IFS) const;
 
   /// Map contextual types to interface types in the conformance.
   ProtocolConformanceRef mapConformanceOutOfContext() const;

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -209,7 +209,7 @@ public:
 
   /// Given a dependent type (expressed in terms of this conformance's
   /// protocol), follow it from the conforming type.
-  Type getAssociatedType(Type origType, Type dependentType) const;
+  Type getAssociatedType(Type dependentType) const;
 
   /// Given a dependent type (expressed in terms of this conformance's
   /// protocol) and conformance, follow it from the conforming type.

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -234,7 +234,7 @@ public:
     return llvm::hash_value(conformance.Union.getOpaqueValue());
   }
 
-  Type getTypeWitnessByName(Type type, Identifier name) const;
+  Type getTypeWitnessByName(Identifier name) const;
 
   /// Find a particular named function witness for a type that conforms to
   /// the given protocol.

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -189,6 +189,10 @@ public:
 
   /// Create a substitution map for a protocol conformance.
   static SubstitutionMap
+  getProtocolSubstitutions(ProtocolConformanceRef conformance);
+
+  /// Create a substitution map for a protocol conformance.
+  static SubstitutionMap
   getProtocolSubstitutions(ProtocolDecl *protocol,
                            Type selfType,
                            ProtocolConformanceRef conformance);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5026,7 +5026,7 @@ class SILFunctionConventions;
 CanType substOpaqueTypesWithUnderlyingTypes(CanType type,
                                             TypeExpansionContext context);
 ProtocolConformanceRef
-substOpaqueTypesWithUnderlyingTypes(ProtocolConformanceRef ref, Type origType,
+substOpaqueTypesWithUnderlyingTypes(ProtocolConformanceRef ref,
                                     TypeExpansionContext context);
 namespace Lowering {
   class TypeConverter;

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -576,7 +576,7 @@ protected:
           !context.shouldLookThroughOpaqueTypeArchetypes())
         return C;
 
-      return substOpaqueTypesWithUnderlyingTypes(C, Ty, context);
+      return substOpaqueTypesWithUnderlyingTypes(C, context);
     }
 
     return C;

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -564,7 +564,7 @@ protected:
       if (Functor.hasLocalArchetypes())
         options |= SubstFlags::SubstituteLocalArchetypes;
 
-      C = C.subst(Ty, Functor, Functor, options);
+      C = C.subst(Functor, Functor, options);
       if (asImpl().shouldSubstOpaqueArchetypes())
         Ty = Ty.subst(Functor, Functor, options);
     }

--- a/include/swift/SIL/SILWitnessVisitor.h
+++ b/include/swift/SIL/SILWitnessVisitor.h
@@ -100,7 +100,7 @@ public:
       // If this is a new associated type (which does not override an
       // existing associated type), add it.
       if (associatedType->getOverriddenDecls().empty())
-        asDerived().addAssociatedType(AssociatedType(associatedType));
+        asDerived().addAssociatedType(associatedType);
     }
 
     if (asDerived().shouldVisitRequirementSignatureOnly())

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6486,7 +6486,7 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
       *bridgedValueType = type;
 
     // Find the Objective-C class type we bridge to.
-    Type witnessTy = conformance.getTypeWitnessByName(type, Id_ObjectiveCType);
+    Type witnessTy = conformance.getTypeWitnessByName(Id_ObjectiveCType);
     // If Objective-C import is broken, witness type would be a dependent member
     // with `<<error type>>` base.
     return (witnessTy && !witnessTy->hasError()) ? witnessTy : Type();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1678,7 +1678,7 @@ ASTContext::getBuiltinInitDecl(NominalTypeDecl *decl,
   }
 
   auto *ctx = const_cast<ASTContext *>(this);
-  witness = builtinConformance.getWitnessByName(type, initName(*ctx));
+  witness = builtinConformance.getWitnessByName(initName(*ctx));
   if (!witness) {
     assert(false && "Missing required witness");
     witness = ConcreteDeclRef();

--- a/lib/AST/ActorIsolation.cpp
+++ b/lib/AST/ActorIsolation.cpp
@@ -61,7 +61,7 @@ ActorIsolation::forActorInstanceParameter(Expr *actor,
     if (auto globalActor = ctx.getProtocol(KnownProtocolKind::GlobalActor)) {
       auto conformance = checkConformance(baseType, globalActor);
       if (conformance &&
-          conformance.getWitnessByName(baseType, ctx.Id_shared) == declRef) {
+          conformance.getWitnessByName(ctx.Id_shared) == declRef) {
         return ActorIsolation::forGlobalActor(baseType);
       }
     }

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -203,7 +203,7 @@ Type swift::getDistributedActorSystemType(NominalTypeDecl *actor) {
   // Dig out the actor system type.
   Type selfType = actor->getSelfInterfaceType();
   auto conformance = lookupConformance(selfType, DA);
-  return conformance.getTypeWitnessByName(selfType, C.Id_ActorSystem);
+  return conformance.getTypeWitnessByName(C.Id_ActorSystem);
 }
 
 Type swift::getDistributedActorIDType(NominalTypeDecl *actor) {
@@ -220,7 +220,7 @@ static Type getTypeWitnessByName(NominalTypeDecl *type, ProtocolDecl *protocol,
   auto conformance = lookupConformance(selfType, protocol);
   if (!conformance || conformance.isInvalid())
     return Type();
-  return conformance.getTypeWitnessByName(selfType, member);
+  return conformance.getTypeWitnessByName(member);
 }
 
 Type swift::getDistributedActorSerializationType(
@@ -301,8 +301,7 @@ Type swift::getDistributedSerializationRequirementType(
   if (conformance.isInvalid())
     return Type();
 
-  return conformance.getTypeWitnessByName(selfType,
-                                          ctx.Id_SerializationRequirement);
+  return conformance.getTypeWitnessByName(ctx.Id_SerializationRequirement);
 }
 
 AbstractFunctionDecl *

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -364,11 +364,10 @@ Type swift::getAssociatedTypeOfDistributedSystemOfActor(
   auto actorConformance =
       lookupConformance(
           actorType->getDeclaredInterfaceType(), actorProtocol);
-  if (!actorConformance || actorConformance.isInvalid())
+  if (actorConformance.isInvalid())
     return Type();
 
-  auto subs = SubstitutionMap::getProtocolSubstitutions(
-      actorProtocol, actorType->getDeclaredInterfaceType(), actorConformance);
+  auto subs = SubstitutionMap::getProtocolSubstitutions(actorConformance);
 
   memberTy = memberTy.subst(subs);
 

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -766,7 +766,7 @@ std::pair<Type, ProtocolConformanceRef>
 GenericEnvironment::mapConformanceRefIntoContext(
                                      Type conformingInterfaceType,
                                      ProtocolConformanceRef conformance) const {
-  auto contextConformance = conformance.subst(conformingInterfaceType,
+  auto contextConformance = conformance.subst(
     QueryInterfaceTypeSubstitutions(this),
     LookUpConformanceInModule());
   

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -752,28 +752,6 @@ SubstitutionMap GenericEnvironment::getForwardingSubstitutionMap() const {
                               MakeAbstractConformanceForGenericType());
 }
 
-std::pair<Type, ProtocolConformanceRef>
-GenericEnvironment::mapConformanceRefIntoContext(GenericEnvironment *genericEnv,
-                                           Type conformingType,
-                                           ProtocolConformanceRef conformance) {
-  if (!genericEnv)
-    return {conformingType, conformance};
-  
-  return genericEnv->mapConformanceRefIntoContext(conformingType, conformance);
-}
-
-std::pair<Type, ProtocolConformanceRef>
-GenericEnvironment::mapConformanceRefIntoContext(
-                                     Type conformingInterfaceType,
-                                     ProtocolConformanceRef conformance) const {
-  auto contextConformance = conformance.subst(
-    QueryInterfaceTypeSubstitutions(this),
-    LookUpConformanceInModule());
-  
-  auto contextType = mapTypeIntoContext(conformingInterfaceType);
-  return {contextType, contextConformance};
-}
-
 OpenedElementContext
 OpenedElementContext::createForContextualExpansion(ASTContext &ctx,
                                        CanPackExpansionType expansionType) {

--- a/lib/AST/PackConformance.cpp
+++ b/lib/AST/PackConformance.cpp
@@ -112,8 +112,7 @@ PackType *PackConformance::getTypeWitness(
     // conformance.
     if (auto *packExpansion = packElement->getAs<PackExpansionType>()) {
       auto assocTypePattern =
-        conformances[i].getTypeWitness(packExpansion->getPatternType(),
-                                       assocType, options);
+        conformances[i].getTypeWitness(assocType, options);
 
       packElements.push_back(PackExpansionType::get(
           assocTypePattern, packExpansion->getCountType()));
@@ -121,8 +120,7 @@ PackType *PackConformance::getTypeWitness(
     // If the pack element is a scalar type, replace the scalar type with
     // the associated type witness from the pattern conformance.
     } else {
-      auto assocTypeScalar =
-        conformances[i].getTypeWitness(packElement, assocType, options);
+      auto assocTypeScalar = conformances[i].getTypeWitness(assocType, options);
       packElements.push_back(assocTypeScalar);
     }
   }

--- a/lib/AST/PackConformance.cpp
+++ b/lib/AST/PackConformance.cpp
@@ -151,8 +151,7 @@ PackConformance *PackConformance::getAssociatedConformance(
           assocTypePattern, packExpansion->getCountType()));
 
       auto assocConformancePattern =
-        conformances[i].getAssociatedConformance(packExpansion->getPatternType(),
-                                                 assocType, protocol);
+        conformances[i].getAssociatedConformance(assocType, protocol);
       packConformances.push_back(assocConformancePattern);
     } else {
       auto assocTypeScalar =
@@ -160,7 +159,7 @@ PackConformance *PackConformance::getAssociatedConformance(
       packElements.push_back(assocTypeScalar);
 
       auto assocConformanceScalar =
-        conformances[i].getAssociatedConformance(packElement, assocType, protocol);
+        conformances[i].getAssociatedConformance(assocType, protocol);
       packConformances.push_back(assocConformanceScalar);
     }
   }

--- a/lib/AST/PackConformance.cpp
+++ b/lib/AST/PackConformance.cpp
@@ -199,15 +199,12 @@ PackConformance::subst(InFlightSubstitution &IFS) const {
         // Just substitute the conformance.  We don't directly represent
         // pack expansion conformances here; it's sort of implicit in the
         // corresponding pack element type.
-        substConformances.push_back(
-            origConformances[i].subst(origExpansion->getPatternType(), IFS));
+        substConformances.push_back(origConformances[i].subst(IFS));
       });
     } else {
       // Substitute a scalar element of the original pack.
       substElementTypes.push_back(origElementType.subst(IFS));
-
-      substConformances.push_back(
-          origConformances[i].subst(origElementType, IFS));
+      substConformances.push_back(origConformances[i].subst(IFS));
     }
   }
 

--- a/lib/AST/PackConformance.cpp
+++ b/lib/AST/PackConformance.cpp
@@ -142,20 +142,20 @@ PackConformance *PackConformance::getAssociatedConformance(
     auto packElement = ConformingType->getElementType(i);
 
     if (auto *packExpansion = packElement->getAs<PackExpansionType>()) {
-      auto assocTypePattern = conformances[i].getAssociatedType(assocType);
-      packElements.push_back(PackExpansionType::get(
-          assocTypePattern, packExpansion->getCountType()));
-
       auto assocConformancePattern =
         conformances[i].getAssociatedConformance(assocType, protocol);
       packConformances.push_back(assocConformancePattern);
-    } else {
-      auto assocTypeScalar = conformances[i].getAssociatedType(assocType);
-      packElements.push_back(assocTypeScalar);
 
+      auto assocTypePattern = assocConformancePattern.getType();
+      packElements.push_back(PackExpansionType::get(
+          assocTypePattern, packExpansion->getCountType()));
+    } else {
       auto assocConformanceScalar =
         conformances[i].getAssociatedConformance(assocType, protocol);
       packConformances.push_back(assocConformanceScalar);
+
+      auto assocTypeScalar = assocConformanceScalar.getType();
+      packElements.push_back(assocTypeScalar);
     }
   }
 

--- a/lib/AST/PackConformance.cpp
+++ b/lib/AST/PackConformance.cpp
@@ -142,9 +142,7 @@ PackConformance *PackConformance::getAssociatedConformance(
     auto packElement = ConformingType->getElementType(i);
 
     if (auto *packExpansion = packElement->getAs<PackExpansionType>()) {
-      auto assocTypePattern =
-        conformances[i].getAssociatedType(packExpansion->getPatternType(),
-                                          assocType);
+      auto assocTypePattern = conformances[i].getAssociatedType(assocType);
       packElements.push_back(PackExpansionType::get(
           assocTypePattern, packExpansion->getCountType()));
 
@@ -152,8 +150,7 @@ PackConformance *PackConformance::getAssociatedConformance(
         conformances[i].getAssociatedConformance(assocType, protocol);
       packConformances.push_back(assocConformancePattern);
     } else {
-      auto assocTypeScalar =
-        conformances[i].getAssociatedType(packElement, assocType);
+      auto assocTypeScalar = conformances[i].getAssociatedType(assocType);
       packElements.push_back(assocTypeScalar);
 
       auto assocConformanceScalar =

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -623,14 +623,6 @@ void NormalProtocolConformance::setTypeWitness(AssociatedTypeDecl *assocType,
   TypeWitnesses[assocType] = {type, typeDecl};
 }
 
-Type ProtocolConformance::getAssociatedType(Type assocType) const {
-  assert(assocType->isTypeParameter() &&
-         "associated type must be a type parameter");
-
-  ProtocolConformanceRef ref(const_cast<ProtocolConformance*>(this));
-  return ref.getAssociatedType(assocType);
-}
-
 ProtocolConformanceRef
 ProtocolConformance::getAssociatedConformance(Type assocType,
                                               ProtocolDecl *protocol) const {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -896,14 +896,7 @@ SpecializedProtocolConformance::getAssociatedConformance(Type assocType,
   ProtocolConformanceRef conformance =
     GenericConformance->getAssociatedConformance(assocType, protocol);
 
-  auto subMap = getSubstitutionMap();
-
-  Type origType =
-    (conformance.isConcrete()
-       ? conformance.getConcrete()->getType()
-       : GenericConformance->getAssociatedType(assocType));
-
-  return conformance.subst(origType, subMap);
+  return conformance.subst(getSubstitutionMap());
 }
 
 ConcreteDeclRef

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -628,7 +628,7 @@ Type ProtocolConformance::getAssociatedType(Type assocType) const {
          "associated type must be a type parameter");
 
   ProtocolConformanceRef ref(const_cast<ProtocolConformance*>(this));
-  return ref.getAssociatedType(getType(), assocType);
+  return ref.getAssociatedType(assocType);
 }
 
 ProtocolConformanceRef

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -164,7 +164,7 @@ ProtocolConformanceRef::getWitnessByName(DeclName name) const {
   // For a type with dependent conformance, just return the requirement from
   // the protocol. There are no protocol conformance tables.
   if (!isConcrete()) {
-    auto subs = SubstitutionMap::getProtocolSubstitutions(proto, getType(), *this);
+    auto subs = SubstitutionMap::getProtocolSubstitutions(*this);
     return ConcreteDeclRef(requirement, subs);
   }
 
@@ -214,9 +214,7 @@ Type ProtocolConformanceRef::getAssociatedType(Type assocType) const {
   if (isInvalid())
     return ErrorType::get(assocType->getASTContext());
 
-  auto substMap =
-    SubstitutionMap::getProtocolSubstitutions(getProtocol(), getType(), *this);
-  return assocType.subst(substMap);
+  return assocType.subst(SubstitutionMap::getProtocolSubstitutions(*this));
 }
 
 ProtocolConformanceRef

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -210,15 +210,12 @@ Type ProtocolConformanceRef::getTypeWitness(AssociatedTypeDecl *assocType,
   return DependentMemberType::get(conformingType, assocType);
 }
 
-Type ProtocolConformanceRef::getAssociatedType(Type conformingType,
-                                               Type assocType) const {
+Type ProtocolConformanceRef::getAssociatedType(Type assocType) const {
   if (isInvalid())
     return ErrorType::get(assocType->getASTContext());
 
-  auto proto = getProtocol();
-
   auto substMap =
-    SubstitutionMap::getProtocolSubstitutions(proto, conformingType, *this);
+    SubstitutionMap::getProtocolSubstitutions(getProtocol(), getType(), *this);
   return assocType.subst(substMap);
 }
 

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -149,7 +149,7 @@ ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() cons
 }
 
 Type
-ProtocolConformanceRef::getTypeWitnessByName(Type type, Identifier name) const {
+ProtocolConformanceRef::getTypeWitnessByName(Identifier name) const {
   assert(!isInvalid());
 
   // Find the named requirement.

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -210,13 +210,6 @@ Type ProtocolConformanceRef::getTypeWitness(AssociatedTypeDecl *assocType,
   return DependentMemberType::get(conformingType, assocType);
 }
 
-Type ProtocolConformanceRef::getAssociatedType(Type assocType) const {
-  if (isInvalid())
-    return ErrorType::get(assocType->getASTContext());
-
-  return assocType.subst(SubstitutionMap::getProtocolSubstitutions(*this));
-}
-
 ProtocolConformanceRef
 ProtocolConformanceRef::getAssociatedConformance(Type assocType,
                                                  ProtocolDecl *protocol) const {

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -244,24 +244,25 @@ Type ProtocolConformanceRef::getAssociatedType(Type conformingType,
 }
 
 ProtocolConformanceRef
-ProtocolConformanceRef::getAssociatedConformance(Type conformingType,
-                                                 Type assocType,
+ProtocolConformanceRef::getAssociatedConformance(Type assocType,
                                                  ProtocolDecl *protocol) const {
+  if (isInvalid())
+    return *this;
+
   // If this is a pack conformance, project the associated conformances from
   // each pack element.
   if (isPack()) {
     auto *pack = getPack();
-    assert(conformingType->isEqual(pack->getType()));
     return ProtocolConformanceRef(
         pack->getAssociatedConformance(assocType, protocol));
   }
 
   // If this is a concrete conformance, project the associated conformance.
   if (isConcrete()) {
-    auto conformance = getConcrete();
-    assert(conformance->getType()->isEqual(conformingType));
-    return conformance->getAssociatedConformance(assocType, protocol);
+    return getConcrete()->getAssociatedConformance(assocType, protocol);
   }
+
+  auto conformingType = getType();
 
   auto computeSubjectType = [&](Type conformingType) -> Type {
     return assocType.transformRec(

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -164,7 +164,7 @@ ProtocolConformanceRef::getTypeWitnessByName(Identifier name) const {
 }
 
 ConcreteDeclRef
-ProtocolConformanceRef::getWitnessByName(Type type, DeclName name) const {
+ProtocolConformanceRef::getWitnessByName(DeclName name) const {
   // Find the named requirement.
   auto *proto = getProtocol();
   auto *requirement = proto->getSingleRequirement(name);
@@ -174,7 +174,7 @@ ProtocolConformanceRef::getWitnessByName(Type type, DeclName name) const {
   // For a type with dependent conformance, just return the requirement from
   // the protocol. There are no protocol conformance tables.
   if (!isConcrete()) {
-    auto subs = SubstitutionMap::getProtocolSubstitutions(proto, type, *this);
+    auto subs = SubstitutionMap::getProtocolSubstitutions(proto, getType(), *this);
     return ConcreteDeclRef(requirement, subs);
   }
 

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -302,7 +302,7 @@ ConcreteContraction::substTypeParameterRec(Type type, Position position) const {
         return std::nullopt;
       }
 
-      return conformance.getTypeWitness(*substBaseType, assocType);
+      return conformance.getTypeWitness(assocType);
     }
 
     // An unresolved DependentMemberType stores an identifier. Handle this

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -346,7 +346,7 @@ static Type substPrefixType(Type type, unsigned suffixLength, Type prefixType,
   auto *assocDecl = memberType->getAssocType();
   auto *proto = assocDecl->getProtocol();
   auto conformance = lookupConformance(substBaseType, proto);
-  return conformance.getTypeWitness(substBaseType, assocDecl);
+  return conformance.getTypeWitness(assocDecl);
 }
 
 Type RequirementMachine::getReducedTypeParameter(

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -665,7 +665,7 @@ struct InferRequirementsWalker : public TypeWalker {
         auto addSameTypeConstraint = [&](Type firstType,
                                          AssociatedTypeDecl *assocType) {
           auto conformance = lookupConformance(firstType, differentiableProtocol);
-          auto secondType = conformance.getTypeWitness(firstType, assocType);
+          auto secondType = conformance.getTypeWitness(assocType);
           reqs.push_back({Requirement(RequirementKind::SameType,
                                       firstType, secondType),
                           SourceLoc()});

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -369,23 +369,10 @@ SubstitutionMap SubstitutionMap::subst(InFlightSubstitution &IFS) const {
 
   auto genericSig = getGenericSignature();
   for (const auto &req : genericSig.getRequirements()) {
-    if (req.getKind() != RequirementKind::Conformance) continue;
+    if (req.getKind() != RequirementKind::Conformance)
+      continue;
 
-    auto conformance = oldConformances[0];
-
-    // Fast path for concrete case -- we don't need to compute substType
-    // at all.
-    if (conformance.isConcrete() &&
-        !IFS.shouldSubstituteOpaqueArchetypes()) {
-      newConformances.push_back(
-        ProtocolConformanceRef(conformance.getConcrete()->subst(IFS)));
-    } else {
-      auto origType = req.getFirstType();
-      auto substType = origType.subst(*this);
-
-      newConformances.push_back(conformance.subst(substType, IFS));
-    }
-    
+    newConformances.push_back(oldConformances[0].subst(IFS));
     oldConformances = oldConformances.slice(1);
   }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -381,6 +381,13 @@ SubstitutionMap SubstitutionMap::subst(InFlightSubstitution &IFS) const {
 }
 
 SubstitutionMap
+SubstitutionMap::getProtocolSubstitutions(ProtocolConformanceRef conformance) {
+  return getProtocolSubstitutions(conformance.getProtocol(),
+                                  conformance.getType(),
+                                  conformance);
+}
+
+SubstitutionMap
 SubstitutionMap::getProtocolSubstitutions(ProtocolDecl *protocol,
                                           Type selfType,
                                           ProtocolConformanceRef conformance) {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -176,11 +176,11 @@ SubstitutionMap SubstitutionMap::get(GenericSignature genericSig,
   for (const auto &req : genericSig.getRequirements()) {
     if (req.getKind() != RequirementKind::Conformance) continue;
 
-    CanType depTy = req.getFirstType()->getCanonicalType();
+    Type depTy = req.getFirstType();
     auto replacement = depTy.subst(IFS);
     auto *proto = req.getProtocolDecl();
-    auto conformance = IFS.lookupConformance(depTy, replacement, proto,
-                                             /*level=*/0);
+    auto conformance = IFS.lookupConformance(
+        depTy->getCanonicalType(), replacement, proto, /*level=*/0);
     conformances.push_back(conformance);
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4569,7 +4569,7 @@ TypeBase::getAutoDiffTangentSpace(LookupConformanceFn lookupConformance) {
   // Try to get the `TangentVector` associated type of `base`.
   // Return the associated type if it is valid.
   auto conformance = swift::lookupConformance(this, differentiableProtocol);
-  auto assocTy = conformance.getTypeWitness(this, assocDecl);
+  auto assocTy = conformance.getTypeWitness(assocDecl);
   if (!assocTy->hasError())
     return cache(TangentSpace::getTangentVector(assocTy));
 

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -443,7 +443,10 @@ Type TypeSubstituter::transformDependentMemberType(DependentMemberType *dependen
     IFS.lookupConformance(origBase->getCanonicalType(), substBase,
                           proto, level);
 
-  return conformance.getTypeWitness(substBase, assocType, IFS.getOptions());
+  auto result = conformance.getTypeWitness(substBase, assocType, IFS.getOptions());
+  if (result->is<ErrorType>())
+    return DependentMemberType::get(ErrorType::get(substBase), assocType);
+  return result;
 }
 
 SubstitutionMap TypeSubstituter::transformSubstitutionMap(SubstitutionMap subs) {

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1089,7 +1089,7 @@ CanType swift::substOpaqueTypesWithUnderlyingTypes(CanType ty,
 }
 
 static ProtocolConformanceRef substOpaqueTypesWithUnderlyingTypesRec(
-    ProtocolConformanceRef ref, Type origType, const DeclContext *inContext,
+    ProtocolConformanceRef ref, const DeclContext *inContext,
     ResilienceExpansion contextExpansion, bool isWholeModuleContext,
     llvm::DenseSet<ReplaceOpaqueTypesWithUnderlyingTypes::SeenDecl> &decls) {
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(inContext, contextExpansion,
@@ -1100,7 +1100,7 @@ static ProtocolConformanceRef substOpaqueTypesWithUnderlyingTypesRec(
 }
 
 ProtocolConformanceRef swift::substOpaqueTypesWithUnderlyingTypes(
-    ProtocolConformanceRef ref, Type origType, TypeExpansionContext context) {
+    ProtocolConformanceRef ref, TypeExpansionContext context) {
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(
       context.getContext(), context.getResilienceExpansion(),
       context.isWholeModuleContext());
@@ -1174,7 +1174,7 @@ operator()(CanType maybeOpaqueType, Type replacementType,
       }
 
       auto res = ::substOpaqueTypesWithUnderlyingTypesRec(
-          substRef, substTy, inContext, contextExpansion, isContextWholeModule,
+          substRef, inContext, contextExpansion, isContextWholeModule,
           *alreadySeen);
       alreadySeen->erase(seenKey);
       return res;
@@ -1184,7 +1184,7 @@ operator()(CanType maybeOpaqueType, Type replacementType,
       llvm::DenseSet<SeenDecl> seenDecls;
       seenDecls.insert(seenKey);
       return ::substOpaqueTypesWithUnderlyingTypesRec(
-          substRef, substTy, inContext, contextExpansion, isContextWholeModule,
+          substRef, inContext, contextExpansion, isContextWholeModule,
           seenDecls);
     }
   }

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1094,7 +1094,7 @@ static ProtocolConformanceRef substOpaqueTypesWithUnderlyingTypesRec(
     llvm::DenseSet<ReplaceOpaqueTypesWithUnderlyingTypes::SeenDecl> &decls) {
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(inContext, contextExpansion,
                                                  isWholeModuleContext, decls);
-  return ref.subst(origType, replacer, replacer,
+  return ref.subst(replacer, replacer,
                    SubstFlags::SubstituteOpaqueArchetypes |
                    SubstFlags::PreservePackExpansionLevel);
 }
@@ -1104,7 +1104,7 @@ ProtocolConformanceRef swift::substOpaqueTypesWithUnderlyingTypes(
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(
       context.getContext(), context.getResilienceExpansion(),
       context.isWholeModuleContext());
-  return ref.subst(origType, replacer, replacer,
+  return ref.subst(replacer, replacer,
                    SubstFlags::SubstituteOpaqueArchetypes);
 }
 
@@ -1159,8 +1159,7 @@ operator()(CanType maybeOpaqueType, Type replacementType,
   auto partialSubstRef =
       subs->lookupConformance(archetype->getInterfaceType()->getCanonicalType(),
                               protocol);
-  auto substRef =
-      partialSubstRef.subst(partialSubstTy, outerSubs);
+  auto substRef = partialSubstRef.subst(outerSubs);
 
   // If the type still contains opaque types, recur.
   if (substTy->hasOpaqueArchetype()) {

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -443,7 +443,7 @@ Type TypeSubstituter::transformDependentMemberType(DependentMemberType *dependen
     IFS.lookupConformance(origBase->getCanonicalType(), substBase,
                           proto, level);
 
-  auto result = conformance.getTypeWitness(substBase, assocType, IFS.getOptions());
+  auto result = conformance.getTypeWitness(assocType, IFS.getOptions());
   if (result->is<ErrorType>())
     return DependentMemberType::get(ErrorType::get(substBase), assocType);
   return result;

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -103,10 +103,10 @@ irgen::emitArchetypeTypeMetadataRef(IRGenFunction &IGF,
   auto parent = cast<ArchetypeType>(
     archetype->getGenericEnvironment()->mapTypeIntoContext(
       member->getBase())->getCanonicalType());
-  AssociatedType association(member->getAssocType());
+  auto *assocType = member->getAssocType();
 
   MetadataResponse response =
-    emitAssociatedTypeMetadataRef(IGF, parent, association, request);
+    emitAssociatedTypeMetadataRef(IGF, parent, assocType, request);
 
   setTypeMetadataName(IGF.IGM, response.getMetadata(), archetype);
 
@@ -321,11 +321,11 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
 MetadataResponse
 irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                      CanArchetypeType origin,
-                                     AssociatedType association,
+                                     AssociatedTypeDecl *assocType,
                                      DynamicMetadataRequest request) {
   // Find the conformance of the origin to the associated type's protocol.
   llvm::Value *wtable = emitArchetypeWitnessTableRef(IGF, origin,
-                                               association.getSourceProtocol());
+                                               assocType->getProtocol());
 
   // Find the origin's type metadata.
   llvm::Value *originMetadata =
@@ -333,7 +333,7 @@ irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
       .getMetadata();
 
   return emitAssociatedTypeMetadataRef(IGF, originMetadata, wtable,
-                                       association, request);
+                                       assocType, request);
 }
 
 const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {

--- a/lib/IRGen/GenArchetype.h
+++ b/lib/IRGen/GenArchetype.h
@@ -25,7 +25,7 @@ namespace llvm {
 }
 
 namespace swift {
-  class AssociatedType;
+  class AssociatedTypeDecl;
   class ProtocolDecl;
   class SILType;
 
@@ -51,7 +51,7 @@ namespace irgen {
   /// Emit a metadata reference for an associated type of an archetype.
   MetadataResponse emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                                  CanArchetypeType origin,
-                                                 AssociatedType association,
+                                                 AssociatedTypeDecl *assocType,
                                                  DynamicMetadataRequest request);
 
   /// Emit a dynamic metatype lookup for the given archetype.

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2877,9 +2877,10 @@ namespace {
             substitutions.lookupConformance(underlyingDependentType, P);
 
         if (underlyingType->hasTypeParameter()) {
-          std::tie(underlyingType, underlyingConformance)
-              = GenericEnvironment::mapConformanceRefIntoContext(
-                    genericEnv, underlyingType, underlyingConformance);
+          underlyingType = genericEnv->mapTypeIntoContext(
+              underlyingType);
+          underlyingConformance = underlyingConformance.subst(
+            genericEnv->getForwardingSubstitutionMap());
         }
 
         return emitWitnessTableRef(IGF, underlyingType->getCanonicalType(),

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -953,8 +953,7 @@ namespace {
         auto flags = Flags(Flags::Kind::AssociatedTypeAccessFunction);
         if (auto &schema = IGM.getOptions().PointerAuth
                               .ProtocolAssociatedTypeAccessFunctions) {
-          addDiscriminator(flags, schema,
-                           AssociatedType(entry.getAssociatedType()));
+          addDiscriminator(flags, schema, entry.getAssociatedType());
         }
 
         // Look for a default witness.

--- a/lib/IRGen/GenPointerAuth.cpp
+++ b/lib/IRGen/GenPointerAuth.cpp
@@ -160,7 +160,7 @@ struct IRGenModule::PointerAuthCachesType {
   llvm::DenseMap<SILDeclRef, llvm::ConstantInt*> Decls;
   llvm::DenseMap<CanType, llvm::ConstantInt*> Types;
   llvm::DenseMap<CanType, llvm::ConstantInt*> YieldTypes;
-  llvm::DenseMap<AssociatedType, llvm::ConstantInt*> AssociatedTypes;
+  llvm::DenseMap<AssociatedTypeDecl *, llvm::ConstantInt*> AssociatedTypes;
   llvm::DenseMap<AssociatedConformance, llvm::ConstantInt*> AssociatedConformances;
 };
 
@@ -336,9 +336,9 @@ static llvm::ConstantInt *getDiscriminatorForString(IRGenModule &IGM,
   return getDiscriminatorForHash(IGM, rawHash);
 }
 
-static std::string mangle(AssociatedType association) {
-  return IRGenMangler(association.getAssociation()->getASTContext())
-    .mangleAssociatedTypeAccessFunctionDiscriminator(association);
+static std::string mangle(AssociatedTypeDecl *assocType) {
+  return IRGenMangler(assocType->getASTContext())
+    .mangleAssociatedTypeAccessFunctionDiscriminator(assocType);
 }
 
 static std::string mangle(const AssociatedConformance &association) {
@@ -430,7 +430,7 @@ PointerAuthEntity::getDeclDiscriminator(IRGenModule &IGM) const {
   }
 
   case Kind::AssociatedType: {
-    auto association = Storage.get<AssociatedType>(StoredKind);
+    auto association = Storage.get<AssociatedTypeDecl *>(StoredKind);
     llvm::ConstantInt *&cache =
       IGM.getPointerAuthCaches().AssociatedTypes[association];
     if (cache) return cache;

--- a/lib/IRGen/GenPointerAuth.h
+++ b/lib/IRGen/GenPointerAuth.h
@@ -86,7 +86,7 @@ private:
   using Members = ExternalUnionMembers<void,
                                        Special,
                                        ValueWitness,
-                                       AssociatedType,
+                                       AssociatedTypeDecl *,
                                        AssociatedConformance,
                                        CanSILFunctionType,
                                        SILDeclRef,
@@ -105,7 +105,7 @@ private:
     case Kind::SILDeclRef:
       return Members::indexOf<SILDeclRef>();
     case Kind::AssociatedType:
-      return Members::indexOf<AssociatedType>();
+      return Members::indexOf<AssociatedTypeDecl *>();
     case Kind::AssociatedConformance:
       return Members::indexOf<AssociatedConformance>();
     case Kind::SILFunction:
@@ -139,9 +139,9 @@ public:
     assert(isValueWitnessFunction(witness));
     Storage.emplace<ValueWitness>(StoredKind, witness);
   }
-  PointerAuthEntity(AssociatedType association)
+  PointerAuthEntity(AssociatedTypeDecl *assocType)
       : StoredKind(Kind::AssociatedType) {
-    Storage.emplaceAggregate<AssociatedType>(StoredKind, association);
+    Storage.emplaceAggregate<AssociatedTypeDecl *>(StoredKind, assocType);
   }
   PointerAuthEntity(const AssociatedConformance &association)
       : StoredKind(Kind::AssociatedConformance) {

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3448,8 +3448,7 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
     auto association = entry.getAssociatedConformancePath();
     auto associatedRequirement = entry.getAssociatedConformanceRequirement();
 
-    CanType associatedType =
-      sourceConformance.getAssociatedType(sourceType, association)
+    CanType associatedType = sourceConformance.getAssociatedType(association)
         ->getCanonicalType();
     sourceKey.Type = associatedType;
 
@@ -3527,7 +3526,7 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
       // type directly.
       auto depMemType = cast<DependentMemberType>(association);
       CanType baseSubstType =
-        sourceConformance.getAssociatedType(sourceType, depMemType.getBase())
+        sourceConformance.getAssociatedType(depMemType.getBase())
           ->getCanonicalType();
       if (auto archetypeType = dyn_cast<ArchetypeType>(baseSubstType)) {
         AssociatedType baseAssocType(depMemType->getAssocType());

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3454,8 +3454,7 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
     sourceKey.Type = associatedType;
 
     auto associatedConformance =
-      sourceConformance.getAssociatedConformance(sourceType, association,
-                                                 associatedRequirement);
+      sourceConformance.getAssociatedConformance(association, associatedRequirement);
     sourceKey.Kind =
       LocalTypeDataKind::forProtocolWitnessTable(associatedConformance);
 

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -29,7 +29,7 @@ namespace llvm {
 
 namespace swift {
   class AssociatedConformance;
-  class AssociatedType;
+  class AssociatedTypeDecl;
   class CanType;
   class FuncDecl;
   enum class MetadataState : size_t;
@@ -90,11 +90,11 @@ namespace irgen {
   ///
   /// \param parentMetadata - the type metadata for T
   /// \param wtable - the witness table witnessing the conformance of T to P
-  /// \param associatedType - the declaration of X; a member of P
+  /// \param assocType - the declaration of X; a member of P
   MetadataResponse emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
                                                  llvm::Value *parentMetadata,
                                                  llvm::Value *wtable,
-                                                 AssociatedType associatedType,
+                                                 AssociatedTypeDecl *assocType,
                                                  DynamicMetadataRequest request);
 
   // Return the offset one should do on a witness table pointer to retrieve the

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -602,7 +602,7 @@ IRGenModule::emitWitnessTableRefString(CanType type,
             type = genericEnv->mapTypeIntoContext(type)->getCanonicalType();
           }
           if (origType->hasTypeParameter()) {
-            conformance = conformance.subst(origType,
+            conformance = conformance.subst(
                 genericEnv->getForwardingSubstitutionMap());
           }
           auto ret = emitWitnessTableRef(IGF, type, conformance);

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -435,10 +435,10 @@ public:
   }
 
   std::string
-  mangleAssociatedTypeAccessFunctionDiscriminator(AssociatedType association) {
+  mangleAssociatedTypeAccessFunctionDiscriminator(AssociatedTypeDecl *assocDecl) {
     beginMangling();
-    appendAnyGenericType(association.getSourceProtocol());
-    appendIdentifier(association.getAssociation()->getNameStr());
+    appendAnyGenericType(assocDecl->getProtocol());
+    appendIdentifier(assocDecl->getNameStr());
     return finalize();
   }
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -187,9 +187,8 @@ static void checkPointerAuthAssociatedTypeDiscriminator(IRGenModule &IGM, ArrayR
   auto &schema = IGM.getOptions().PointerAuth.ProtocolAssociatedTypeAccessFunctions;
   if (!schema.isEnabled()) return;
 
-  auto decl = dyn_cast_or_null<AssociatedTypeDecl>(lookupSimple(IGM.getSwiftModule(), declPath));
-  assert(decl && "decl not found");
-  auto discriminator = PointerAuthInfo::getOtherDiscriminator(IGM, schema, AssociatedType(decl));
+  auto decl = cast<AssociatedTypeDecl>(lookupSimple(IGM.getSwiftModule(), declPath));
+  auto discriminator = PointerAuthInfo::getOtherDiscriminator(IGM, schema, decl);
   assert(discriminator->getZExtValue() == expected && "discriminator value doesn't match");
 }
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -92,7 +92,6 @@ namespace clang {
 namespace swift {
   class GenericSignature;
   class AssociatedConformance;
-  class AssociatedType;
   class ASTContext;
   class BaseConformance;
   class BraceStmt;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -560,7 +560,7 @@ IRGenModule::substOpaqueTypesWithUnderlyingTypes(CanType type,
     auto context = getMaximalTypeExpansionContext();
     return std::make_pair(
        swift::substOpaqueTypesWithUnderlyingTypes(type, context),
-       swift::substOpaqueTypesWithUnderlyingTypes(conformance, type, context));
+       swift::substOpaqueTypesWithUnderlyingTypes(conformance, context));
   }
 
   return std::make_pair(type, conformance);

--- a/lib/IRGen/ProtocolInfo.h
+++ b/lib/IRGen/ProtocolInfo.h
@@ -124,9 +124,9 @@ public:
     return MethodEntry.Witness;
   }
 
-  static WitnessTableEntry forAssociatedType(AssociatedType ty) {
+  static WitnessTableEntry forAssociatedType(AssociatedTypeDecl *assocType) {
     WitnessTableEntry entry(WitnessKind::AssociatedTypeKind);
-    entry.AssociatedTypeEntry = {ty.getAssociation()};
+    entry.AssociatedTypeEntry = {assocType};
     return entry;
   }
   
@@ -134,9 +134,8 @@ public:
     return Kind == WitnessKind::AssociatedTypeKind;
   }
 
-  bool matchesAssociatedType(AssociatedType assocType) const {
-    return isAssociatedType() &&
-           AssociatedTypeEntry.Association == assocType.getAssociation();
+  bool matchesAssociatedType(AssociatedTypeDecl *assocType) const {
+    return isAssociatedType() && AssociatedTypeEntry.Association == assocType;
   }
 
   AssociatedTypeDecl *getAssociatedType() const {
@@ -293,7 +292,7 @@ public:
   /// Return the witness index for the type metadata access function
   /// for the given associated type.
   WitnessIndex getAssociatedTypeIndex(IRGenModule &IGM,
-                                      AssociatedType assocType) const;
+                                      AssociatedTypeDecl *assocType) const;
 
   /// Return the witness index for the protocol witness table access
   /// function for the given associated protocol conformance.

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2207,8 +2207,7 @@ public:
       return nullptr;
 
     // Dig out the Objective-C type.
-    Type objcType = conformance.getTypeWitnessByName(
-        declaredType, ctx.Id_ObjectiveCType);
+    Type objcType = conformance.getTypeWitnessByName(ctx.Id_ObjectiveCType);
 
     // Dig out the Objective-C class.
     return objcType->getClassOrBoundGenericClass();

--- a/lib/SIL/IR/Bridging.cpp
+++ b/lib/SIL/IR/Bridging.cpp
@@ -240,7 +240,7 @@ Type TypeConverter::getLoweredCBridgedType(AbstractionPattern pattern,
     assert(conformance && "Missing conformance?");
     Type bridgedTy =
       ProtocolConformanceRef(conformance).getTypeWitnessByName(
-        t, M.getASTContext().Id_ObjectiveCType);
+        M.getASTContext().Id_ObjectiveCType);
     if (purpose == BridgedTypePurpose::ForResult && clangTy)
       bridgedTy = OptionalType::get(bridgedTy);
     return bridgedTy;

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -852,8 +852,8 @@ public:
           }
         }
 
-        void addAssociatedType(AssociatedType associatedType) {
-          Visitor.addAssociatedTypeDescriptor(associatedType.getAssociation());
+        void addAssociatedType(AssociatedTypeDecl *assocType) {
+          Visitor.addAssociatedTypeDescriptor(assocType);
         }
 
         void addProtocolConformanceDescriptor() {

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -77,7 +77,6 @@ public:
         return substOpaqueTypesWithUnderlyingTypes(
                ProtocolConformanceRef::forAbstract(conformingReplacementType,
                                                    conformedProtocol),
-               conformingReplacementType->getCanonicalType(),
                typeExpansionContext);
       },
       SubstFlags::SubstituteOpaqueArchetypes |
@@ -292,7 +291,7 @@ public:
       });
       if (substType->hasOpaqueArchetype()) {
         substConformance = substOpaqueTypesWithUnderlyingTypes(
-            substConformance, substType, typeExpansionContext);
+            substConformance, typeExpansionContext);
       }
     }
 

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -282,7 +282,7 @@ public:
       selfType = next;
     }
 
-    auto substConformance = conformance.subst(selfType, IFS);
+    auto substConformance = conformance.subst(IFS);
 
     // Substitute the underlying conformance of opaque type archetypes if we
     // should look through opaque archetypes.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -95,7 +95,6 @@ SubstitutionMap SILGenModule::mapSubstitutionsForWitnessOverride(
   Type origProtoSelfType = origProto->getSelfInterfaceType();
   auto baseProto = cast<ProtocolDecl>(overridden->getDeclContext());
   return SubstitutionMap::getProtocolSubstitutions(
-      baseProto, origProtoSelfType.subst(subs),
       subs.lookupConformance(origProtoSelfType->getCanonicalType(), baseProto));
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4320,9 +4320,8 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
       auto hashable = index.Hashable;
       if (genericEnv) {
         formalTy = genericEnv->mapTypeIntoContext(formalTy)->getCanonicalType();
-        hashable = hashable.subst(index.FormalType,
-          [&](Type t) -> Type { return genericEnv->mapTypeIntoContext(t); },
-          LookUpConformanceInModule());
+        hashable = hashable.subst(
+          genericEnv->getForwardingSubstitutionMap());
       }
 
       // Set up a substitution of Self => IndexType.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4144,11 +4144,12 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
       
       Type formalTy = index.FormalType;
       ProtocolConformanceRef hashable = index.Hashable;
-      std::tie(formalTy, hashable)
-        = GenericEnvironment::mapConformanceRefIntoContext(genericEnv,
-                                                           formalTy,
-                                                           hashable);
-      auto formalCanTy = formalTy->getReducedType(genericSig);
+      if (genericEnv) {
+        formalTy = genericEnv->mapTypeIntoContext(formalTy);
+        hashable = hashable.subst(genericEnv->getForwardingSubstitutionMap());
+      }
+
+      auto formalCanTy = formalTy->getCanonicalType();
       
       // Get the Equatable conformance from the Hashable conformance.
       auto equatable = hashable.getAssociatedConformance(

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4152,7 +4152,6 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
       
       // Get the Equatable conformance from the Hashable conformance.
       auto equatable = hashable.getAssociatedConformance(
-          formalTy,
           GenericTypeParamType::getType(/*depth*/ 0, /*index*/ 0, C),
           equatableProtocol);
 

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -692,11 +692,11 @@ public:
     auto assocConformance =
       Conformance->getAssociatedConformance(req.getAssociation(),
                                             req.getAssociatedRequirement());
-    auto substType =
-      Conformance->getAssociatedType(req.getAssociation())->getCanonicalType();
-
     SGM.useConformance(assocConformance);
 
+    auto substType = (assocConformance
+                      ? assocConformance.getType()
+                      : ErrorType::get(SGM.getASTContext()))->getCanonicalType();
     Entries.push_back(SILWitnessTable::AssociatedConformanceWitness{
         req.getAssociation(), substType, assocConformance});
   }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -678,13 +678,12 @@ public:
                     SILWitnessTable::MethodWitness{requirementRef, witnessFn});
   }
 
-  void addAssociatedType(AssociatedType requirement) {
+  void addAssociatedType(AssociatedTypeDecl *assocType) {
     // Find the substitution info for the witness type.
-    auto td = requirement.getAssociation();
-    Type witness = Conformance->getTypeWitness(td);
+    Type witness = Conformance->getTypeWitness(assocType);
 
     // Emit the record for the type itself.
-    Entries.push_back(SILWitnessTable::AssociatedTypeWitness{td,
+    Entries.push_back(SILWitnessTable::AssociatedTypeWitness{assocType,
                                                 witness->getCanonicalType()});
   }
 
@@ -1028,7 +1027,7 @@ public:
   void addAssociatedConformance(AssociatedConformance conformance) {
     llvm_unreachable("associated conformances not supported in self-conformance");
   }
-  void addAssociatedType(AssociatedType type) {
+  void addAssociatedType(AssociatedTypeDecl *assocType) {
     llvm_unreachable("associated types not supported in self-conformance");
   }
   void addPlaceholder(MissingMemberDecl *placeholder) {
@@ -1106,14 +1105,14 @@ public:
     DefaultWitnesses.push_back(entry);
   }
 
-  void addAssociatedType(AssociatedType req) {
-    Type witness = Proto->getDefaultTypeWitness(req.getAssociation());
+  void addAssociatedType(AssociatedTypeDecl *assocType) {
+    Type witness = Proto->getDefaultTypeWitness(assocType);
     if (!witness)
       return addMissingDefault();
 
     Type witnessInContext = Proto->mapTypeIntoContext(witness);
     auto entry = SILWitnessTable::AssociatedTypeWitness{
-                                          req.getAssociation(),
+                                          assocType,
                                           witnessInContext->getCanonicalType()};
     DefaultWitnesses.push_back(entry);
   }

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -76,8 +76,7 @@ static SubstitutionMap lookupBridgeToObjCProtocolSubs(CanType target) {
   auto bridgedProto =
       target->getASTContext().getProtocol(KnownProtocolKind::ObjectiveCBridgeable);
   auto conf = lookupConformance(target, bridgedProto);
-  return SubstitutionMap::getProtocolSubstitutions(conf.getProtocol(),
-                                                   target, conf);
+  return SubstitutionMap::getProtocolSubstitutions(conf);
 }
 
 /// Given that our insertion point is at the cast that we are trying to

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2901,17 +2901,14 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
   // Check any same-type requirements in the protocol's requirement signature.
   SubstOptions options = getSubstOptionsWithCurrentTypeWitnesses();
 
-  auto typeInContext = adoptee;
   ProtocolConformanceRef conformanceInContext(conformance);
   if (auto *genericEnv = conformance->getGenericEnvironment()) {
-    typeInContext = genericEnv->mapTypeIntoContext(typeInContext);
     conformanceInContext =
       conformanceInContext.subst(genericEnv->getForwardingSubstitutionMap());
   }
 
   auto substitutions =
-    SubstitutionMap::getProtocolSubstitutions(
-      proto, typeInContext, conformanceInContext);
+    SubstitutionMap::getProtocolSubstitutions(conformanceInContext);
 
   SmallVector<Requirement, 4> sanitizedRequirements;
   auto requirements = proto->getRequirementSignature().getRequirements();
@@ -4543,8 +4540,6 @@ AssociatedConformanceRequest::evaluate(Evaluator &eval,
                                        CanType origTy, ProtocolDecl *reqProto,
                                        unsigned index) const {
   auto subMap = SubstitutionMap::getProtocolSubstitutions(
-      conformance->getProtocol(),
-      conformance->getType(),
       ProtocolConformanceRef(conformance));
   auto substTy = origTy.subst(subMap);
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2903,8 +2903,8 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
 
   ProtocolConformanceRef conformanceInContext(conformance);
   if (auto *genericEnv = conformance->getGenericEnvironment()) {
-    conformanceInContext =
-      conformanceInContext.subst(genericEnv->getForwardingSubstitutionMap());
+    conformanceInContext = conformanceInContext.subst(
+        genericEnv->getForwardingSubstitutionMap());
   }
 
   auto substitutions =

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2906,8 +2906,7 @@ bool AssociatedTypeInference::checkCurrentTypeWitnesses(
   if (auto *genericEnv = conformance->getGenericEnvironment()) {
     typeInContext = genericEnv->mapTypeIntoContext(typeInContext);
     conformanceInContext =
-      conformanceInContext.subst(conformance->getType(),
-                                 genericEnv->getForwardingSubstitutionMap());
+      conformanceInContext.subst(genericEnv->getForwardingSubstitutionMap());
   }
 
   auto substitutions =

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8106,7 +8106,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
   if (!literalType.empty()) {
     // Extract the literal type.
     Type builtinLiteralType =
-        conformance.getTypeWitnessByName(type, literalType);
+        conformance.getTypeWitnessByName(literalType);
     if (builtinLiteralType->hasError())
       return nullptr;
 
@@ -8222,9 +8222,8 @@ std::pair<Expr *, ArgumentList *> ExprRewriter::buildDynamicCallable(
     auto dictLitProto =
         ctx.getProtocol(KnownProtocolKind::ExpressibleByDictionaryLiteral);
     auto conformance = checkConformance(argumentType, dictLitProto);
-    auto keyType = conformance.getTypeWitnessByName(argumentType, ctx.Id_Key);
-    auto valueType =
-        conformance.getTypeWitnessByName(argumentType, ctx.Id_Value);
+    auto keyType = conformance.getTypeWitnessByName(ctx.Id_Key);
+    auto valueType = conformance.getTypeWitnessByName(ctx.Id_Value);
     SmallVector<Identifier, 4> names;
     SmallVector<Expr *, 4> dictElements;
     for (auto arg : *args) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2970,7 +2970,7 @@ namespace {
         DeclName constrName(ctx, DeclBaseName::createConstructor(), argLabels);
 
         ConcreteDeclRef witness =
-            conformance.getWitnessByName(type->getRValueType(), constrName);
+            conformance.getWitnessByName(constrName);
         if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
           return nullptr;
         return witness;
@@ -3108,8 +3108,7 @@ namespace {
 
       auto constrName = TypeChecker::getObjectLiteralConstructorName(ctx, expr);
 
-      ConcreteDeclRef witness = conformance.getWitnessByName(
-          conformingType->getRValueType(), constrName);
+      ConcreteDeclRef witness = conformance.getWitnessByName(constrName);
 
       auto selectedOverload = solution.getOverloadChoiceIfAvailable(
           cs.getConstraintLocator(expr, ConstraintLocator::ConstructorMember));
@@ -3822,7 +3821,7 @@ namespace {
         DeclName name(ctx, DeclBaseName::createConstructor(),
                       {ctx.Id_arrayLiteral});
         ConcreteDeclRef witness =
-            conformance.getWitnessByName(arrayTy->getRValueType(), name);
+            conformance.getWitnessByName(name);
         if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
           return nullptr;
         expr->setInitializer(witness);
@@ -3868,7 +3867,7 @@ namespace {
       DeclName name(ctx, DeclBaseName::createConstructor(),
                     {ctx.Id_dictionaryLiteral});
       ConcreteDeclRef witness =
-          conformance.getWitnessByName(dictionaryTy->getRValueType(), name);
+          conformance.getWitnessByName(name);
       if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
         return nullptr;
       expr->setInitializer(witness);
@@ -8081,7 +8080,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
       // Find the witness that we'll use to initialize the type via a builtin
       // literal.
       auto witness = builtinConformance.getWitnessByName(
-          type->getRValueType(), builtinLiteralFuncName);
+          builtinLiteralFuncName);
       if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
         return nullptr;
 
@@ -8120,7 +8119,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
 
   // Find the witness that we'll use to initialize the literal value.
   auto witness =
-      conformance.getWitnessByName(type->getRValueType(), literalFuncName);
+      conformance.getWitnessByName(literalFuncName);
   if (!witness || !isa<AbstractFunctionDecl>(witness.getDecl()))
     return nullptr;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3302,7 +3302,7 @@ bool ContextualFailure::diagnoseThrowsTypeMismatch() const {
     if (conformance && toErrorExistential) {
       Type errorType =
           conformance
-              .getTypeWitnessByName(errorCodeType, getASTContext().Id_ErrorType)
+              .getTypeWitnessByName(getASTContext().Id_ErrorType)
               ->getCanonicalType();
       if (errorType) {
         auto diagnostic = emitDiagnostic(diag::cannot_throw_error_code,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11726,7 +11726,7 @@ ConstraintSystem::simplifyValueWitnessConstraint(
     return formUnsolved();
 
   auto witness =
-      conformance.getWitnessByName(baseObjectType, requirement->getName());
+      conformance.getWitnessByName(requirement->getName());
   if (!witness)
     return fail();
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3886,7 +3886,7 @@ Type constraints::isRawRepresentable(ConstraintSystem &cs, Type type) {
   if (conformance.isInvalid())
     return Type();
 
-  return conformance.getTypeWitnessByName(type, cs.getASTContext().Id_RawValue);
+  return conformance.getTypeWitnessByName(cs.getASTContext().Id_RawValue);
 }
 
 void ConstraintSystem::generateOverloadConstraints(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1709,7 +1709,7 @@ struct TypeSimplifier {
           return memberTy;
         }
 
-        auto result = conformance.getTypeWitness(lookupBaseType, assocType);
+        auto result = conformance.getTypeWitness(assocType);
         if (result && !result->hasError())
           return result;
       }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -121,7 +121,7 @@ static Type getTangentVectorInterfaceType(Type contextualType,
   assert(conf && "Contextual type must conform to `Differentiable`");
   if (!conf)
     return nullptr;
-  auto tanType = conf.getTypeWitnessByName(contextualType, C.Id_TangentVector);
+  auto tanType = conf.getTypeWitnessByName(C.Id_TangentVector);
   return tanType->hasArchetype() ? tanType->mapTypeOutOfContext() : tanType;
 }
 
@@ -150,7 +150,7 @@ static bool canDeriveTangentVectorAsSelf(NominalTypeDecl *nominal,
     auto conf = checkConformance(fieldType, diffableProto);
     if (!conf)
       return false;
-    auto tangentType = conf.getTypeWitnessByName(fieldType, C.Id_TangentVector);
+    auto tangentType = conf.getTypeWitnessByName(C.Id_TangentVector);
     if (!fieldType->isEqual(tangentType))
       return false;
   }

--- a/lib/Sema/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformanceDifferentiable.cpp
@@ -50,10 +50,9 @@ static bool canInvokeMoveByOnProperty(
     return true;
   // When the property is a `let`, the only case that would be supported is when
   // it has a `move(by:)` protocol requirement witness that is non-mutating.
-  auto interfaceType = vd->getInterfaceType();
   auto &C = vd->getASTContext();
   auto witness = diffableConformance.getWitnessByName(
-      interfaceType, DeclName(C, C.Id_move, {C.Id_by}));
+      DeclName(C, C.Id_move, {C.Id_by}));
   if (!witness)
     return false;
   auto *decl = cast<FuncDecl>(witness.getDecl());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1951,7 +1951,7 @@ bool swift::isValidDynamicCallableMethod(FuncDecl *decl,
   auto dictConf = checkConformance(argType, dictLitProto);
   if (dictConf.isInvalid())
     return false;
-  auto keyType = dictConf.getTypeWitnessByName(argType, ctx.Id_Key);
+  auto keyType = dictConf.getTypeWitnessByName(ctx.Id_Key);
   return (bool) checkConformance(keyType, stringLitProtocol);
 }
 
@@ -5577,7 +5577,7 @@ static bool conformsToDifferentiable(Type type,
     return false;
   if (!tangentVectorEqualsSelf)
     return true;
-  auto tanType = conf.getTypeWitnessByName(type, ctx.Id_TangentVector);
+  auto tanType = conf.getTypeWitnessByName(ctx.Id_TangentVector);
   return type->isEqual(tanType);
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5127,7 +5127,6 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
         // Substitute into the global actor type.
         auto conformance = std::get<0>(isolated);
         auto requirementSubs = SubstitutionMap::getProtocolSubstitutions(
-            conformance->getProtocol(), dc->getSelfInterfaceType(),
             ProtocolConformanceRef(conformance));
         Type globalActor = isolation.getGlobalActor().subst(requirementSubs);
         if (!globalActorTypes.insert(globalActor->getCanonicalType()).second)

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1352,8 +1352,7 @@ public:
     }
   }
 
-  Classification classifyConformance(Type type,
-                                     ProtocolConformanceRef conformanceRef,
+  Classification classifyConformance(ProtocolConformanceRef conformanceRef,
                                      EffectKind kind) {
     if (conformanceRef.isInvalid())
       return Classification::forInvalidCode();
@@ -1374,8 +1373,7 @@ public:
           conditional = ConditionalEffectKind::Always;
 
         // Use the Failure type witness, when present.
-        Type thrownError = conformanceRef.getTypeWitness(
-            type, failureAssocType);
+        Type thrownError = conformanceRef.getTypeWitness(failureAssocType);
         return Classification::forThrows(
             thrownError, conditional,
             /*FIXME*/PotentialEffectReason::forConformance());
@@ -1671,13 +1669,11 @@ public:
           if (req.getKind() != RequirementKind::Conformance)
             continue;
 
-          Type type = req.getFirstType().subst(substitutions);
-
           auto conformanceRef = substitutions.lookupConformance(
               req.getFirstType()->getCanonicalType(), req.getProtocolDecl());
           assert(conformanceRef);
 
-          result.merge(classifyConformance(type, conformanceRef, kind));
+          result.merge(classifyConformance(conformanceRef, kind));
         }
 
         // 'ByConformance' is a superset of 'ByClosure', so check for

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3354,9 +3354,8 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
   // Determine the isolation of the requirement itself.
   auto requirementIsolation = getActorIsolation(requirement);
   if (requirementIsolation.requiresSubstitution()) {
-    auto substitutingType = DC->mapTypeIntoContext(Conformance->getType());
     auto subs = SubstitutionMap::getProtocolSubstitutions(
-        Proto, substitutingType, ProtocolConformanceRef(Conformance));
+        ProtocolConformanceRef(Conformance));
     requirementIsolation = requirementIsolation.subst(subs);
   }
 
@@ -3852,8 +3851,7 @@ filterProtocolRequirements(
   const auto getProtocolSubstitutionMap = [&](ValueDecl *Req) {
     auto *const PD = cast<ProtocolDecl>(Req->getDeclContext());
     auto Conformance = lookupConformance(Adoptee, PD);
-    return SubstitutionMap::getProtocolSubstitutions(
-        PD, Adoptee, Conformance);
+    return SubstitutionMap::getProtocolSubstitutions(Conformance);
   };
 
   llvm::SmallDenseMap<DeclName, llvm::SmallVector<ValueDecl *, 2>, 4>

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5237,8 +5237,7 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
   if (auto *genericEnv = conformance->getGenericEnvironment()) {
     typeInContext = genericEnv->mapTypeIntoContext(typeInContext);
     conformanceInContext =
-      conformanceInContext.subst(conformance->getType(),
-                                 genericEnv->getForwardingSubstitutionMap());
+      conformanceInContext.subst(genericEnv->getForwardingSubstitutionMap());
   }
   auto substitutions = SubstitutionMap::getProtocolSubstitutions(
       proto, typeInContext, conformanceInContext);

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -369,7 +369,6 @@ static Type inferResultBuilderType(ValueDecl *decl)  {
         // into context when applying the result builder to the
         // function body in the constraint system.
         auto subs = SubstitutionMap::getProtocolSubstitutions(
-            protocol, dc->getSelfInterfaceType(),
             ProtocolConformanceRef(conformance));
         Type subResultBuilderType = resultBuilderType.subst(subs);
 


### PR DESCRIPTION
Thanks to @DougGregor's PR https://github.com/swiftlang/swift/pull/80225, abstract conformances now store their conforming type. This means we no longer have to pass it around separately in various places that operate on `ProtocolConformanceRef`.

Now, `ProtocolConformanceRef` and `ProtocolConformance` expose the same fundamental set of operations:
- `getType()`
- `getProtocol()`
- `subst(SubstitutionMap)`
- `getTypeWitness(AssociatedTypeDecl *)`
- `getAssociatedConformance(CanType, ProtocolDecl *)`

The ProtocolConformanceRef variants of the last three used to also take an `origType` parameter, which was supposed to be the conforming type of the abstract conformance. This made them difficult and error-prone to use. All of this book-keeping is now gone.