### PR TITLE
[cxx-interop] Fix nested structs for non-opaque types

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -23,6 +23,7 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/NestedNameSpecifier.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Casting.h"
 
 using namespace swift;
@@ -127,8 +128,8 @@ void ClangSyntaxPrinter::printClangTypeReference(const clang::Decl *typeDecl) {
   }
 }
 
-bool ClangSyntaxPrinter::printNestedTypeNamespaceQualifiers(
-    const ValueDecl *D) const {
+bool ClangSyntaxPrinter::printNestedTypeNamespaceQualifiers(const ValueDecl *D,
+                                                            bool forC) const {
   bool first = true;
   while (auto parent = dyn_cast_or_null<NominalTypeDecl>(
              D->getDeclContext()->getAsDecl())) {
@@ -137,9 +138,10 @@ bool ClangSyntaxPrinter::printNestedTypeNamespaceQualifiers(
         isa<clang::NamespaceDecl>(parent->getClangNode().getAsDecl()))
       break;
     if (!first)
-      os << "::";
+      os << (forC ? "_" : "::");
     first = false;
-    os << "__";
+    if (!forC)
+      os << "__";
     printBaseName(parent);
     os << "Nested";
     D = parent;

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -96,7 +96,8 @@ public:
       const NominalTypeDecl *typeDecl);
 
   // Returns true when no qualifiers were printed.
-  bool printNestedTypeNamespaceQualifiers(const ValueDecl *D) const;
+  bool printNestedTypeNamespaceQualifiers(const ValueDecl *D,
+                                          bool forC = false) const;
 
   /// Print out the C++ class access qualifier for the given Swift  type
   /// declaration.

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1249,7 +1249,10 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
       os << "void **vtable_ = *selfPtr_;\n";
       os << "#endif\n";
       os << "struct FTypeAddress {\n";
-      os << "decltype(" << cxx_synthesis::getCxxImplNamespaceName()
+      os << "decltype(";
+      ClangSyntaxPrinter(moduleContext->getASTContext(), os)
+          .printBaseName(moduleContext);
+      os << "::" << cxx_synthesis::getCxxImplNamespaceName()
          << "::" << swiftSymbolName << ") *";
       if (auto ptrAuthDisc = dispatchInfo->getPointerAuthDiscriminator())
         os << " __ptrauth_swift_class_method_pointer(" << ptrAuthDisc->value

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -31,8 +31,9 @@ using namespace swift;
 static void printCTypeName(raw_ostream &os, const NominalTypeDecl *type) {
   ClangSyntaxPrinter printer(type->getASTContext(), os);
   printer.printModuleNameCPrefix(*type->getParentModule());
-  if (!ClangSyntaxPrinter(type->getASTContext(), os).printNestedTypeNamespaceQualifiers(type))
-    os << "::";
+  if (!ClangSyntaxPrinter(type->getASTContext(), os)
+           .printNestedTypeNamespaceQualifiers(type, /*forC=*/true))
+    os << "_";
   printer.printBaseName(type);
 }
 

--- a/test/Interop/SwiftToCxx/class/nested-classes-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/nested-classes-in-cxx.swift
@@ -1,6 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-library-evolution -typecheck -module-name Classes -clang-header-expose-decls=all-public -emit-clang-header-path %t/classes.h
+// RUN: %check-interop-cxx-header-in-clang(%t/classes.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17)
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Classes -clang-header-expose-decls=all-public -emit-clang-header-path %t/classes.h
 // RUN: %check-interop-cxx-header-in-clang(%t/classes.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17)
 
 public class RecordConfig {

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
@@ -124,7 +124,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT: void **vtable_ = *selfPtr_;
 // CHECK-NEXT: #endif
 // CHECK-NEXT: struct FTypeAddress {
-// CHECK-NEXT: decltype(_impl::$s5Class04BaseA0C13virtualMethodyyF) * func;
+// CHECK-NEXT: decltype(Class::_impl::$s5Class04BaseA0C13virtualMethodyyF) * func;
 // CHECK-NEXT: };
 // CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1:]] / sizeof(void *));
 // CHECK-NEXT: (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -138,7 +138,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT: void **vtable_ = *selfPtr_;
 // CHECK-NEXT: #endif
 // CHECK-NEXT: struct FTypeAddress {
-// CHECK-NEXT: decltype(_impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iF) * func;
+// CHECK-NEXT: decltype(Class::_impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iF) * func;
 // CHECK-NEXT: };
 // CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM2:]] / sizeof(void *));
 // CHECK-NEXT:   return (* fptrptr_->func)(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -156,7 +156,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   void **vtable_ = *selfPtr_;
 // CHECK-NEXT:   #endif
 // CHECK-NEXT:   struct FTypeAddress {
-// CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C19virtualComputedPropSivg) * func;
+// CHECK-NEXT:   decltype(Class::_impl::$s5Class04BaseA0C19virtualComputedPropSivg) * func;
 // CHECK-NEXT:   };
 // CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM3:]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -170,7 +170,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   void **vtable_ = *selfPtr_;
 // CHECK-NEXT:   #endif
 // CHECK-NEXT:   struct FTypeAddress {
-// CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C21virtualComputedGetSets5Int64Vvg) * func;
+// CHECK-NEXT:   decltype(Class::_impl::$s5Class04BaseA0C21virtualComputedGetSets5Int64Vvg) * func;
 // CHECK-NEXT:   };
 // CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM4:]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -184,7 +184,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   void **vtable_ = *selfPtr_;
 // CHECK-NEXT:   #endif
 // CHECK-NEXT:   struct FTypeAddress {
-// CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C21virtualComputedGetSets5Int64Vvs) * func;
+// CHECK-NEXT:   decltype(Class::_impl::$s5Class04BaseA0C21virtualComputedGetSets5Int64Vvs) * func;
 // CHECK-NEXT:   };
 // CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM5:]] / sizeof(void *));
 // CHECK-NEXT:   (* fptrptr_->func)(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -198,7 +198,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   void **vtable_ = *selfPtr_;
 // CHECK-NEXT:   #endif
 // CHECK-NEXT:   struct FTypeAddress {
-// CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C10storedPropSivg) * func;
+// CHECK-NEXT:   decltype(Class::_impl::$s5Class04BaseA0C10storedPropSivg) * func;
 // CHECK-NEXT:   };
 // CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM7:]] / sizeof(void *));
 // CHECK-NEXT:   return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -212,7 +212,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   void **vtable_ = *selfPtr_;
 // CHECK-NEXT:   #endif
 // CHECK-NEXT:   struct FTypeAddress {
-// CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C10storedPropSivs) * func;
+// CHECK-NEXT:   decltype(Class::_impl::$s5Class04BaseA0C10storedPropSivs) * func;
 // CHECK-NEXT:   };
 // CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM8:]] / sizeof(void *));
 // CHECK-NEXT:     (* fptrptr_->func)(value, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -226,7 +226,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:    void **vtable_ = *selfPtr_;
 // CHECK-NEXT:    #endif
 // CHECK-NEXT:    struct FTypeAddress {
-// CHECK-NEXT:    decltype(_impl::$s5Class04BaseA0CyS2icig) * func;
+// CHECK-NEXT:    decltype(Class::_impl::$s5Class04BaseA0CyS2icig) * func;
 // CHECK-NEXT:    };
 // CHECK-NEXT:    FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM10:]] / sizeof(void *));
 // CHECK-NEXT:    return (* fptrptr_->func)(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -240,7 +240,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   void **vtable_ = *selfPtr_;
 // CHECK-NEXT:   #endif
 // CHECK-NEXT:   struct FTypeAddress {
-// CHECK-NEXT:   decltype(_impl::$s5Class07DerivedA0C13virtualMethodyyF) * func;
+// CHECK-NEXT:   decltype(Class::_impl::$s5Class07DerivedA0C13virtualMethodyyF) * func;
 // CHECK-NEXT:   };
 // CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1]] / sizeof(void *));
 // CHECK-NEXT:   (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -254,7 +254,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     void **vtable_ = *selfPtr_;
 // CHECK-NEXT:     #endif
 // CHECK-NEXT:     struct FTypeAddress {
-// CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C016virtualMethodIntE0yS2iF) * func;
+// CHECK-NEXT:     decltype(Class::_impl::$s5Class07DerivedA0C016virtualMethodIntE0yS2iF) * func;
 // CHECK-NEXT:     };
 // CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM2]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -268,7 +268,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   void **vtable_ = *selfPtr_;
 // CHECK-NEXT:   #endif
 // CHECK-NEXT:   struct FTypeAddress {
-// CHECK-NEXT:   decltype(_impl::$s5Class07DerivedA0C015virtualMethodInB0yAA04BaseA0CAFF) * func;
+// CHECK-NEXT:   decltype(Class::_impl::$s5Class07DerivedA0C015virtualMethodInB0yAA04BaseA0CAFF) * func;
 // CHECK-NEXT:   };
 // CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM11:]] / sizeof(void *));
 // CHECK-NEXT:   return _impl::_impl_BaseClass::makeRetained((* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
@@ -282,7 +282,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     void **vtable_ = *selfPtr_;
 // CHECK-NEXT:     #endif
 // CHECK-NEXT:     struct FTypeAddress {
-// CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C19virtualComputedPropSivg) * func;
+// CHECK-NEXT:     decltype(Class::_impl::$s5Class07DerivedA0C19virtualComputedPropSivg) * func;
 // CHECK-NEXT:     };
 // CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM3]] / sizeof(void *));
 // CHECK-NEXT:       return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -296,7 +296,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     void **vtable_ = *selfPtr_;
 // CHECK-NEXT:     #endif
 // CHECK-NEXT:     struct FTypeAddress {
-// CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C21virtualComputedGetSets5Int64Vvg) * func;
+// CHECK-NEXT:     decltype(Class::_impl::$s5Class07DerivedA0C21virtualComputedGetSets5Int64Vvg) * func;
 // CHECK-NEXT:     };
 // CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM4]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -310,7 +310,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     void **vtable_ = *selfPtr_;
 // CHECK-NEXT:     #endif
 // CHECK-NEXT:     struct FTypeAddress {
-// CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C21virtualComputedGetSets5Int64Vvs) * func;
+// CHECK-NEXT:     decltype(Class::_impl::$s5Class07DerivedA0C21virtualComputedGetSets5Int64Vvs) * func;
 // CHECK-NEXT:     };
 // CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM5]] / sizeof(void *));
 // CHECK-NEXT:     (* fptrptr_->func)(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -324,7 +324,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     void **vtable_ = *selfPtr_;
 // CHECK-NEXT:     #endif
 // CHECK-NEXT:     struct FTypeAddress {
-// CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C10storedPropSivg) * func;
+// CHECK-NEXT:     decltype(Class::_impl::$s5Class07DerivedA0C10storedPropSivg) * func;
 // CHECK-NEXT:     };
 // CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM7]] / sizeof(void *));
 // CHECK-NEXT:       return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -338,7 +338,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     void **vtable_ = *selfPtr_;
 // CHECK-NEXT:     #endif
 // CHECK-NEXT:     struct FTypeAddress {
-// CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C10storedPropSivs) * func;
+// CHECK-NEXT:     decltype(Class::_impl::$s5Class07DerivedA0C10storedPropSivs) * func;
 // CHECK-NEXT:     };
 // CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM8]] / sizeof(void *));
 // CHECK-NEXT:     (* fptrptr_->func)(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
@@ -352,7 +352,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:    void **vtable_ = *selfPtr_;
 // CHECK-NEXT:    #endif
 // CHECK-NEXT:    struct FTypeAddress {
-// CHECK-NEXT:    decltype(_impl::$s5Class07DerivedA0CyS2icig) * func;
+// CHECK-NEXT:    decltype(Class::_impl::$s5Class07DerivedA0CyS2icig) * func;
 // CHECK-NEXT:    };
 // CHECK-NEXT:    FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM10]] / sizeof(void *));
 // CHECK-NEXT:      return (* fptrptr_->func)(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
@@ -94,7 +94,7 @@ public func createCrossModuleDerivedDerivedClass() -> CrossModuleDerivedDerivedC
 // CHECK-NEXT: void **vtable_ = *selfPtr_;
 // CHECK-NEXT: #endif
 // CHECK-NEXT: struct FTypeAddress {
-// CHECK-NEXT: decltype(_impl::$s8UseClass018CrossModuleDerivedB0C015virtualMethodInE0yyF) * func;
+// CHECK-NEXT: decltype(UseClass::_impl::$s8UseClass018CrossModuleDerivedB0C015virtualMethodInE0yyF) * func;
 // CHECK-NEXT: };
 // CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + 0) / sizeof(void *));
 // CHECK-NEXT: (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-library-evolution -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
-// RN: %FileCheck %s < %t/structs.h
+// RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17)
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name Structs -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/structs.h
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17)
 
 public enum AudioFileType {


### PR DESCRIPTION
The test for nested constructs used library evolution forcing all types to be opaque. As a result some code paths for non-opaque types were not updated to support nested types. This patch updates the rest of the code making sure we use fully qualified names (so they also work in the context of the nested classes), and generate correct names for the C compatibility structs that cannot contain "::".

Fixes #80291

rdar://147882976
