### PR TITLE
[Mangler] Include verification errors in the crash log

### DIFF
--- a/include/swift/Basic/PrettyStackTrace.h
+++ b/include/swift/Basic/PrettyStackTrace.h
@@ -50,6 +50,17 @@ public:
   void print(llvm::raw_ostream &OS) const override;
 };
 
+/// Aborts the program, printing a given message to a PrettyStackTrace frame
+/// before exiting.
+[[noreturn]]
+void abortWithPrettyStackTraceMessage(
+    llvm::function_ref<void(llvm::raw_ostream &)> message);
+
+/// Aborts the program, printing a given message to a PrettyStackTrace frame
+/// before exiting.
+[[noreturn]]
+void abortWithPrettyStackTraceMessage(llvm::StringRef message);
+
 } // end namespace swift
 
 #endif // SWIFT_BASIC_PRETTYSTACKTRACE_H

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/Stmt.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Basic/Assertions.h"
+#include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/STLExtras.h"
 #include "llvm/Support/Compiler.h"
 #include <algorithm>
@@ -71,15 +72,11 @@ void ASTScopeImpl::dumpOneScopeMapLocation(
 
 void ASTScopeImpl::abortWithVerificationError(
     llvm::function_ref<void(llvm::raw_ostream &)> messageFn) const {
-  llvm::SmallString<0> errorStr;
-  llvm::raw_svector_ostream out(errorStr);
-
-  out << "ASTScopeImpl verification error in source file '"
-      << getSourceFile()->getFilename() << "':\n";
-  messageFn(out);
-
-  llvm::PrettyStackTraceString trace(errorStr.c_str());
-  abort();
+  abortWithPrettyStackTraceMessage([&](auto &out) {
+    out << "ASTScopeImpl verification error in source file '"
+        << getSourceFile()->getFilename() << "':\n";
+    messageFn(out);
+  });
 }
 
 #pragma mark printing

--- a/lib/Basic/PrettyStackTrace.cpp
+++ b/lib/Basic/PrettyStackTrace.cpp
@@ -18,6 +18,7 @@
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/QuotedString.h"
 #include "swift/Basic/Version.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -37,4 +38,19 @@ void PrettyStackTraceFileContents::print(llvm::raw_ostream &out) const {
 
 void PrettyStackTraceSwiftVersion::print(llvm::raw_ostream &out) const {
   out << version::getSwiftFullVersion() << '\n';
+}
+
+void swift::abortWithPrettyStackTraceMessage(
+    llvm::function_ref<void(llvm::raw_ostream &)> message) {
+  llvm::SmallString<0> errorStr;
+  llvm::raw_svector_ostream out(errorStr);
+  message(out);
+  llvm::PrettyStackTraceString trace(errorStr.c_str());
+  abort();
+}
+
+void swift::abortWithPrettyStackTraceMessage(StringRef message) {
+  auto messageStr = message.str();
+  llvm::PrettyStackTraceString trace(messageStr.c_str());
+  abort();
 }

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/Module.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/LangOptions.h"
+#include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Parse/ParseVersion.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Strings.h"
@@ -697,23 +698,19 @@ std::string ModuleFileSharedCore::Dependency::getPrettyPrintedPath() const {
 }
 
 void ModuleFileSharedCore::fatal(llvm::Error error) const {
-  llvm::SmallString<0> errorStr;
-  llvm::raw_svector_ostream out(errorStr);
-
-  out << "*** DESERIALIZATION FAILURE ***\n";
-  out << "*** If any module named here was modified in the SDK, please delete the ***\n";
-  out << "*** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***\n";
-  outputDiagnosticInfo(out);
-  out << "\n";
-  if (error) {
-    handleAllErrors(std::move(error), [&](const llvm::ErrorInfoBase &ei) {
-      ei.log(out);
-      out << "\n";
-    });
-  }
-
-  llvm::PrettyStackTraceString trace(errorStr.c_str());
-  abort();
+  abortWithPrettyStackTraceMessage([&](auto &out) {
+    out << "*** DESERIALIZATION FAILURE ***\n";
+    out << "*** If any module named here was modified in the SDK, please delete the ***\n";
+    out << "*** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***\n";
+    outputDiagnosticInfo(out);
+    out << "\n";
+    if (error) {
+      handleAllErrors(std::move(error), [&](const llvm::ErrorInfoBase &ei) {
+        ei.log(out);
+        out << "\n";
+      });
+    }
+  });
 }
 
 void ModuleFileSharedCore::outputDiagnosticInfo(llvm::raw_ostream &os) const {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -46,6 +46,7 @@
 #include "swift/Basic/FileSystem.h"
 #include "swift/Basic/LLVMExtras.h"
 #include "swift/Basic/PathRemapper.h"
+#include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/Version.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -5314,8 +5315,7 @@ void Serializer::writeASTBlockEntity(const Decl *D) {
   SWIFT_DEFER {
     // This is important enough to leave on in Release builds.
     if (initialOffset == Out.GetCurrentBitNo()) {
-      llvm::PrettyStackTraceString message("failed to serialize anything");
-      abort();
+      abortWithPrettyStackTraceMessage("failed to serialize anything");
     }
   };
 
@@ -6141,8 +6141,7 @@ void Serializer::writeASTBlockEntity(Type ty) {
   SWIFT_DEFER {
     // This is important enough to leave on in Release builds.
     if (initialOffset == Out.GetCurrentBitNo()) {
-      llvm::PrettyStackTraceString message("failed to serialize anything");
-      abort();
+      abortWithPrettyStackTraceMessage("failed to serialize anything");
     }
   };
 


### PR DESCRIPTION
Factor out `abortWithPrettyStackTraceMessage`, and use it for mangler verification errors to ensure they get printed in the pretty stack trace.