### PR TITLE
[cxx-interop] Prevent Swift from importing fields marked with [[no_unique_address]]

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -373,5 +373,8 @@ NOTE(ptr_to_nonescapable,none,
      "pointer to non-escapable type %0 cannot be imported",
      (const clang::Type*))
 
+WARNING(unsupported_attribute, none, "Swift doesn't support fields marked with %0",
+     (StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4383,6 +4383,16 @@ namespace {
       std::optional<ImportedName> correctSwiftName;
       ImportedName importedName;
 
+      if (decl->hasAttr<clang::NoUniqueAddressAttr>()) {
+        // TODO: rdar://148437848 Swift doesn't support fields marked with [[no_unique_address]] 
+
+        Impl.addImportDiagnostic(
+            decl,
+            Diagnostic(diag::unsupported_attribute, "[[no_unique_address]]"),
+            decl->getLocation());
+        return nullptr;
+      }
+
       std::tie(importedName, correctSwiftName) = importFullName(decl);
       if (!importedName) {
         return nullptr;

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -11,6 +11,16 @@ struct Empty {
   int getNum() const { return 42; }
 };
 
+struct HasNoUniqueAddressField {
+  MyClass simpleField;
+#if __is_target_os(windows)
+  [[msvc::no_unique_address]]
+#else
+  [[no_unique_address]]
+#endif
+  MyClass noUniqueAddressField; // expected-warning {{Swift doesn't support fields marked with [[no_unique_address]]}}
+};
+
 struct HasZeroSizedField {
   int a;
   [[no_unique_address]] Empty b;

--- a/test/Interop/Cxx/class/member-variables-typechecker.swift
+++ b/test/Interop/Cxx/class/member-variables-typechecker.swift
@@ -1,6 +1,11 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop -verify-additional-file %S/Inputs/member-variables.h
 
 import MemberVariables
 
-var s = MyClass()
-s.const_member = 42 // expected-error {{cannot assign to property: 'const_member' setter is inaccessible}}
+var s1 = MyClass()
+s1.const_member = 42 // expected-error {{cannot assign to property: 'const_member' setter is inaccessible}}
+
+// TODO: rdar://148437848 Swift doesn't support fields marked with [[no_unique_address]] 
+var s2 = HasNoUniqueAddressField()
+_ = s2.simpleField.const_member
+_ = s2.noUniqueAddressField.const_member  // expected-error {{value of type 'HasNoUniqueAddressField' has no member 'noUniqueAddressField'}}

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -21,7 +21,8 @@ FieldsTestSuite.test("Zero sized field") {
   expectEqual(s2.c, 7)
   expectEqual(s2.c, s2.get_c())
   expectEqual(takesZeroSizedInCpp(s2), 5)
-  expectEqual(s.b.getNum(), 42)
+  // TODO: rdar://148437848 Swift doesn't support fields marked with [[no_unique_address]] 
+  // expectEqual(s.b.getNum(), 42)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/print-std-string.swift
+++ b/test/Interop/Cxx/stdlib/print-std-string.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/a.out -Xfrontend -enable-experimental-cxx-interop
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import CxxStdlib
+
+func printString(s: std.string) {
+    print(s)
+    let swiftString = String(s)
+    print(swiftString)
+}
+
+printString(s: "Hello")
+// CHECK: basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>>()
+// CHECK: Hello


### PR DESCRIPTION
From libc++ 20, `std::string` has 3 fields marked with `[[no_unique_address]]`. This attribute is not supported in Swift and was causing a runtime crash when printing a `std::string` in Swift. In this patch, we prevent Swift from importing such fields.

rdar://147263490