### PR TITLE
[AST] More JSON AST dump improvements.

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5636,11 +5636,9 @@ public:
       printTypeField(conformance->getType(), Label::always("type"));
       printReferencedDeclField(conformance->getProtocol(),
                                Label::always("protocol"));
-      if (isTypeChecked()) {
-        printField(conformance->getSourceKind(), Label::always("source_kind"));
-        printFlag(conformance->isRetroactive(), "retroactive");
-        printIsolation(conformance->getIsolation());
-      }
+      printField(conformance->getSourceKind(), Label::optional("source_kind"));
+      printFlag(conformance->isRetroactive(), "retroactive");
+      printIsolation(conformance->getIsolation());
       if (!Writer.isParsable())
         printFlag(!shouldPrintDetails, "<details printed above>");
     };

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -263,6 +263,13 @@ func sb3() {
     }
 }
 
+func nestedOpaques0() -> some BinaryInteger { 2 }
+func nestedOpaques1() -> some FixedWidthInteger & SignedInteger { 2 }
+func nestedOpaques2() -> (some BinaryInteger, some Sequence) { (2, []) }
+func nestedOpaques3() -> (some BinaryInteger, some Sequence<Double>) { (2, []) }
+func nestedOpaques4() -> (some BinaryInteger)? { Bool.random() ? 2 : nil }
+func nestedOpaques5() -> [some BinaryInteger] { [2] }
+
 // Expressions
 
 func zz1() throws {

--- a/test/Frontend/ast-dump-json-no-crash.swift
+++ b/test/Frontend/ast-dump-json-no-crash.swift
@@ -341,9 +341,8 @@ struct Pack<each T> {
     func f(_ t: repeat each T) {
         repeat g(each t)
     }
+    func g<U>(_ t: U) {}
 }
-// FIXME: USR generation crashes if this is a member of Pack<each T> above!
-func g<U>(_ t: U) {}
 
 func tuplify<each T>(_ value: repeat each T) -> (repeat each T) {
   return (repeat each value)
@@ -351,6 +350,17 @@ func tuplify<each T>(_ value: repeat each T) -> (repeat each T) {
 func example<each T>(_ value: repeat each T) {
   let abstractTuple = tuplify(repeat each value)
   repeat print(each abstractTuple)
+}
+
+func anySeq<T>(_ type: T.Type = T.self) -> any Sequence<T> { [] }
+func anySeqUser() {
+    let s = anySeq(Int.self)
+    let iter = s.makeIterator()
+}
+func opaqueSeq<T>(_ type: T.Type = T.self) -> some Sequence<T> { [] }
+func opaqueSeqUser() {
+    let s = opaqueSeq(Int.self)
+    let iter = s.makeIterator()
 }
 
 let x = 10

--- a/test/Frontend/debug-generic-signatures.swift
+++ b/test/Frontend/debug-generic-signatures.swift
@@ -34,19 +34,19 @@ struct Basic: P1 {
 // Recursive conformances should have finite output.
 
 // CHECK-LABEL: StructDecl name=Recur
-// CHECK-NEXT: (builtin_conformance type="Recur" protocol="Copyable")
-// CHECK-NEXT: (builtin_conformance type="Recur" protocol="Escapable")
+// CHECK-NEXT: (builtin_conformance type="Recur" protocol="Copyable"{{.*}})
+// CHECK-NEXT: (builtin_conformance type="Recur" protocol="Escapable"{{.*}})
 // CHECK-NEXT: (normal_conformance type="Recur" protocol="P2"
 // CHECK-NEXT:   (assoc_type req="A" type="Recur")
 // CHECK-NEXT:   (assoc_type req="B" type="Recur")
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:     (builtin_conformance type="Recur" protocol="Copyable"))
+// CHECK-NEXT:     (builtin_conformance type="Recur" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:     (builtin_conformance type="Recur" protocol="Escapable"))
+// CHECK-NEXT:     (builtin_conformance type="Recur" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P2"
-// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>))
 // CHECK-NEXT:   (assoc_conformance type="Self.B" proto="P2"
-// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>)))
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>)))
 struct Recur: P2 {
     typealias A = Recur
     typealias B = Recur
@@ -55,29 +55,29 @@ struct Recur: P2 {
 // The full information about a conformance doesn't need to be printed twice.
 
 // CHECK-LABEL: StructDecl name=NonRecur
-// CHECK-NEXT: (builtin_conformance type="NonRecur" protocol="Copyable")
-// CHECK-NEXT: (builtin_conformance type="NonRecur" protocol="Escapable")
+// CHECK-NEXT: (builtin_conformance type="NonRecur" protocol="Copyable"{{.*}})
+// CHECK-NEXT: (builtin_conformance type="NonRecur" protocol="Escapable"{{.*}})
 // CHECK-NEXT: (normal_conformance type="NonRecur" protocol="P2"
 // CHECK-NEXT:   (assoc_type req="A" type="Recur")
 // CHECK-NEXT:   (assoc_type req="B" type="Recur")
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:     (builtin_conformance type="NonRecur" protocol="Copyable"))
+// CHECK-NEXT:     (builtin_conformance type="NonRecur" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:     (builtin_conformance type="NonRecur" protocol="Escapable"))
+// CHECK-NEXT:     (builtin_conformance type="NonRecur" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P2"
 // CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2"
 // CHECK-NEXT:       (assoc_type req="A" type="Recur")
 // CHECK-NEXT:       (assoc_type req="B" type="Recur")
 // CHECK-NEXT:       (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:         (builtin_conformance type="Recur" protocol="Copyable"))
+// CHECK-NEXT:         (builtin_conformance type="Recur" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:       (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:         (builtin_conformance type="Recur" protocol="Escapable"))
+// CHECK-NEXT:         (builtin_conformance type="Recur" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:       (assoc_conformance type="Self.A" proto="P2"
-// CHECK-NEXT:         (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:         (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>))
 // CHECK-NEXT:       (assoc_conformance type="Self.B" proto="P2"
-// CHECK-NEXT:         (normal_conformance type="Recur" protocol="P2" <details printed above>))))
+// CHECK-NEXT:         (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>))))
 // CHECK-NEXT:   (assoc_conformance type="Self.B" proto="P2"
-// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2" <details printed above>)))
+// CHECK-NEXT:     (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>)))
 struct NonRecur: P2 {
     typealias A = Recur
     typealias B = Recur
@@ -94,9 +94,9 @@ struct Generic<T> {}
 // CHECK-NEXT:   (assoc_type req="A" type="T")
 // CHECK-NEXT:   (value req="f()" witness="main.(file).Generic extension.f()@{{.*}}")
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:     (builtin_conformance type="Generic<T>" protocol="Copyable"))
+// CHECK-NEXT:     (builtin_conformance type="Generic<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:     (builtin_conformance type="Generic<T>" protocol="Escapable"))
+// CHECK-NEXT:     (builtin_conformance type="Generic<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="Copyable"
 // CHECK-NEXT:     (abstract_conformance protocol="Copyable"))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="Escapable"
@@ -119,9 +119,9 @@ class Super<T, U> {}
 // CHECK-NEXT:   (assoc_type req="A" type="T")
 // CHECK-NEXT:   (assoc_type req="B" type="T")
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:     (builtin_conformance type="Super<T, U>" protocol="Copyable"))
+// CHECK-NEXT:     (builtin_conformance type="Super<T, U>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:     (builtin_conformance type="Super<T, U>" protocol="Escapable"))
+// CHECK-NEXT:     (builtin_conformance type="Super<T, U>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P2"
 // CHECK-NEXT:     (abstract_conformance protocol="P2"))
 // CHECK-NEXT:   (assoc_conformance type="Self.B" proto="P2"
@@ -135,8 +135,8 @@ extension Super: P2 where T: P2, U: P2 {
 
 // Inherited/specialized conformances.
 // CHECK-LABEL: ClassDecl name=Sub
-// CHECK-NEXT: (builtin_conformance type="Sub" protocol="Copyable")
-// CHECK-NEXT: (builtin_conformance type="Sub" protocol="Escapable")
+// CHECK-NEXT: (builtin_conformance type="Sub" protocol="Copyable"{{.*}})
+// CHECK-NEXT: (builtin_conformance type="Sub" protocol="Escapable"{{.*}})
 // CHECK-NEXT: (inherited_conformance type="Sub" protocol="P2"
 // CHECK-NEXT:   (specialized_conformance type="Super<NonRecur, Recur>" protocol="P2"
 // CHECK-NEXT:     (substitution_map generic_signature=<T, U where T : P2, U : P2>
@@ -149,33 +149,33 @@ extension Super: P2 where T: P2, U: P2 {
 // CHECK-NEXT:           (assoc_type req="A" type="Recur")
 // CHECK-NEXT:           (assoc_type req="B" type="Recur")
 // CHECK-NEXT:           (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:             (builtin_conformance type="NonRecur" protocol="Copyable"))
+// CHECK-NEXT:             (builtin_conformance type="NonRecur" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:           (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:             (builtin_conformance type="NonRecur" protocol="Escapable"))
+// CHECK-NEXT:             (builtin_conformance type="NonRecur" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:           (assoc_conformance type="Self.A" proto="P2"
 // CHECK-NEXT:             (normal_conformance type="Recur" protocol="P2"
 // CHECK-NEXT:               (assoc_type req="A" type="Recur")
 // CHECK-NEXT:               (assoc_type req="B" type="Recur")
 // CHECK-NEXT:               (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:                 (builtin_conformance type="Recur" protocol="Copyable"))
+// CHECK-NEXT:                 (builtin_conformance type="Recur" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:               (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:                 (builtin_conformance type="Recur" protocol="Escapable"))
+// CHECK-NEXT:                 (builtin_conformance type="Recur" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:               (assoc_conformance type="Self.A" proto="P2"
-// CHECK-NEXT:                 (normal_conformance type="Recur" protocol="P2" <details printed above>))
+// CHECK-NEXT:                 (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>))
 // CHECK-NEXT:               (assoc_conformance type="Self.B" proto="P2"
-// CHECK-NEXT:                 (normal_conformance type="Recur" protocol="P2" <details printed above>))))
+// CHECK-NEXT:                 (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>))))
 // CHECK-NEXT:           (assoc_conformance type="Self.B" proto="P2"
-// CHECK-NEXT:             (normal_conformance type="Recur" protocol="P2" <details printed above>))))
+// CHECK-NEXT:             (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>))))
 // CHECK-NEXT:       (conformance type="U"
-// CHECK-NEXT:         (normal_conformance type="Recur" protocol="P2" <details printed above>)))
+// CHECK-NEXT:         (normal_conformance type="Recur" protocol="P2"{{.*}} <details printed above>)))
 // CHECK-NEXT:     (<conditional requirements unable to be computed>)
 // CHECK-NEXT:     (normal_conformance type="Super<T, U>" protocol="P2"
 // CHECK-NEXT:       (assoc_type req="A" type="T")
 // CHECK-NEXT:       (assoc_type req="B" type="T")
 // CHECK-NEXT:       (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:         (builtin_conformance type="Super<T, U>" protocol="Copyable"))
+// CHECK-NEXT:         (builtin_conformance type="Super<T, U>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:       (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:         (builtin_conformance type="Super<T, U>" protocol="Escapable"))
+// CHECK-NEXT:         (builtin_conformance type="Super<T, U>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:       (assoc_conformance type="Self.A" proto="P2"
 // CHECK-NEXT:         (abstract_conformance protocol="P2"))
 // CHECK-NEXT:       (assoc_conformance type="Self.B" proto="P2"
@@ -188,44 +188,44 @@ class Sub: Super<NonRecur, Recur> {}
 // should work through SubstitutionMaps.
 
 // CHECK-LABEL: StructDecl name=RecurGeneric
-// CHECK-NEXT: (builtin_conformance type="RecurGeneric<T>" protocol="Copyable")
-// CHECK-NEXT: (builtin_conformance type="RecurGeneric<T>" protocol="Escapable")
+// CHECK-NEXT: (builtin_conformance type="RecurGeneric<T>" protocol="Copyable"{{.*}})
+// CHECK-NEXT: (builtin_conformance type="RecurGeneric<T>" protocol="Escapable"{{.*}})
 // CHECK-NEXT: (normal_conformance type="RecurGeneric<T>" protocol="P3"
 // CHECK-NEXT:   (assoc_type req="A" type="RecurGeneric<T>")
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:     (builtin_conformance type="RecurGeneric<T>" protocol="Copyable"))
+// CHECK-NEXT:     (builtin_conformance type="RecurGeneric<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:     (builtin_conformance type="RecurGeneric<T>" protocol="Escapable"))
+// CHECK-NEXT:     (builtin_conformance type="RecurGeneric<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P3"
-// CHECK-NEXT:     (normal_conformance type="RecurGeneric<T>" protocol="P3" <details printed above>)))
+// CHECK-NEXT:     (normal_conformance type="RecurGeneric<T>" protocol="P3"{{.*}} <details printed above>)))
 struct RecurGeneric<T: P3>: P3 {
     typealias A = RecurGeneric<T>
 }
 
 // CHECK-LABEL: StructDecl name=Specialize
-// CHECK-NEXT: (builtin_conformance type="Specialize" protocol="Copyable")
-// CHECK-NEXT: (builtin_conformance type="Specialize" protocol="Escapable")
+// CHECK-NEXT: (builtin_conformance type="Specialize" protocol="Copyable"{{.*}})
+// CHECK-NEXT: (builtin_conformance type="Specialize" protocol="Escapable"{{.*}})
 // CHECK-NEXT: (normal_conformance type="Specialize" protocol="P3"
 // CHECK-NEXT:   (assoc_type req="A" type="RecurGeneric<Specialize>")
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:     (builtin_conformance type="Specialize" protocol="Copyable"))
+// CHECK-NEXT:     (builtin_conformance type="Specialize" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:     (builtin_conformance type="Specialize" protocol="Escapable"))
+// CHECK-NEXT:     (builtin_conformance type="Specialize" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self.A" proto="P3"
 // CHECK-NEXT:     (specialized_conformance type="Specialize.A" protocol="P3"
 // CHECK-NEXT:       (substitution_map generic_signature=<T where T : P3>
 // CHECK-NEXT:         (substitution T ->
 // CHECK-NEXT:           (struct_type decl="main.(file).Specialize@{{.*}}"))
 // CHECK-NEXT:         (conformance type="T"
-// CHECK-NEXT:           (normal_conformance type="Specialize" protocol="P3" <details printed above>)))
+// CHECK-NEXT:           (normal_conformance type="Specialize" protocol="P3"{{.*}} <details printed above>)))
 // CHECK-NEXT:       (normal_conformance type="RecurGeneric<T>" protocol="P3"
 // CHECK-NEXT:         (assoc_type req="A" type="RecurGeneric<T>")
 // CHECK-NEXT:         (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:           (builtin_conformance type="RecurGeneric<T>" protocol="Copyable"))
+// CHECK-NEXT:           (builtin_conformance type="RecurGeneric<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:         (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:           (builtin_conformance type="RecurGeneric<T>" protocol="Escapable"))
+// CHECK-NEXT:           (builtin_conformance type="RecurGeneric<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:         (assoc_conformance type="Self.A" proto="P3"
-// CHECK-NEXT:           (normal_conformance type="RecurGeneric<T>" protocol="P3" <details printed above>))))))
+// CHECK-NEXT:           (normal_conformance type="RecurGeneric<T>" protocol="P3"{{.*}} <details printed above>))))))
 struct Specialize: P3 {
     typealias A = RecurGeneric<Specialize>
 }

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -20,9 +20,9 @@ struct Free<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Free
 // CHECK-NEXT:  (normal_conformance type="Free<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="Free<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="Free<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="Free<T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="Free<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" conforms_to "P1"))
 extension Free: P2 where T: P1 {} 
 // expected-note@-1 {{requirement from conditional conformance of 'Free<U>' to 'P2'}} 
@@ -39,9 +39,9 @@ struct Constrained<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained
 // CHECK-NEXT:  (normal_conformance type="Constrained<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="Constrained<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="Constrained<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="Constrained<T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="Constrained<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" conforms_to "P3"))
 extension Constrained: P2 where T: P3 {} // expected-note {{requirement from conditional conformance of 'Constrained<U>' to 'P2'}}
 func constrained_good<U: P1 & P3>(_: U) {
@@ -56,9 +56,9 @@ struct RedundantSame<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame
 // CHECK-NEXT: (normal_conformance type="RedundantSame<T>" protocol="P2"
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:     (builtin_conformance type="RedundantSame<T>" protocol="Copyable"))
+// CHECK-NEXT:     (builtin_conformance type="RedundantSame<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:   (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:     (builtin_conformance type="RedundantSame<T>" protocol="Escapable")))
+// CHECK-NEXT:     (builtin_conformance type="RedundantSame<T>" protocol="Escapable"{{.*}})))
 extension RedundantSame: P2 where T: P1 {}
 
 struct RedundantSuper<T: P4> {}
@@ -66,9 +66,9 @@ struct RedundantSuper<T: P4> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
 // CHECK-NEXT:  (normal_conformance type="RedundantSuper<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="RedundantSuper<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="RedundantSuper<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="RedundantSuper<T>" protocol="Escapable")))
+// CHECK-NEXT:      (builtin_conformance type="RedundantSuper<T>" protocol="Escapable"{{.*}})))
 extension RedundantSuper: P2 where T: P1 {}
 
 struct OverlappingSub<T: P1> {}
@@ -76,9 +76,9 @@ struct OverlappingSub<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
 // CHECK-NEXT:  (normal_conformance type="OverlappingSub<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="OverlappingSub<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="OverlappingSub<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="OverlappingSub<T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="OverlappingSub<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" conforms_to "P4"))
 extension OverlappingSub: P2 where T: P4 {} // expected-note {{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
 func overlapping_sub_good<U: P4>(_: U) {
@@ -94,9 +94,9 @@ struct SameType<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType
 // CHECK-NEXT:  (normal_conformance type="SameType<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="SameType<Int>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="SameType<Int>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="SameType<Int>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="SameType<Int>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" same_type "Int"))
 extension SameType: P2 where T == Int {}
 // expected-note@-1 {{requirement from conditional conformance of 'SameType<U>' to 'P2'}}
@@ -115,9 +115,9 @@ struct SameTypeGeneric<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric
 // CHECK-NEXT:  (normal_conformance type="SameTypeGeneric<T, U>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="SameTypeGeneric<T, T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="SameTypeGeneric<T, T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="SameTypeGeneric<T, T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="SameTypeGeneric<T, T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" same_type "U"))
 extension SameTypeGeneric: P2 where T == U {}
 // expected-note@-1 {{requirement from conditional conformance of 'SameTypeGeneric<U, Int>' to 'P2'}}
@@ -145,9 +145,9 @@ struct Infer<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer
 // CHECK-NEXT:  (normal_conformance type="Infer<T, U>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="Infer<Constrained<U>, U>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="Infer<Constrained<U>, U>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="Infer<Constrained<U>, U>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="Infer<Constrained<U>, U>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" same_type "Constrained<U>")
 // CHECK-NEXT:    (requirement "U" conforms_to "P1"))
 extension Infer: P2 where T == Constrained<U> {}
@@ -168,9 +168,9 @@ struct InferRedundant<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant
 // CHECK-NEXT:  (normal_conformance type="InferRedundant<T, U>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="InferRedundant<Constrained<U>, U>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="InferRedundant<Constrained<U>, U>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="InferRedundant<Constrained<U>, U>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="InferRedundant<Constrained<U>, U>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" same_type "Constrained<U>"))
 extension InferRedundant: P2 where T == Constrained<U> {}
 func infer_redundant_good<U: P1>(_: U) {
@@ -193,9 +193,9 @@ struct ClassFree<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree
 // CHECK-NEXT:  (normal_conformance type="ClassFree<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="ClassFree<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="ClassFree<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="ClassFree<T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="ClassFree<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" subclass_of "C1"))
 extension ClassFree: P2 where T: C1 {} // expected-note {{requirement from conditional conformance of 'ClassFree<U>' to 'P2'}}
 func class_free_good<U: C1>(_: U) {
@@ -211,9 +211,9 @@ struct ClassMoreSpecific<T: C1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific
 // CHECK-NEXT:  (normal_conformance type="ClassMoreSpecific<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="ClassMoreSpecific<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="ClassMoreSpecific<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="ClassMoreSpecific<T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="ClassMoreSpecific<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" subclass_of "C3"))
 extension ClassMoreSpecific: P2 where T: C3 {} // expected-note {{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
 func class_more_specific_good<U: C3>(_: U) {
@@ -230,9 +230,9 @@ struct ClassLessSpecific<T: C3> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
 // CHECK-NEXT:  (normal_conformance type="ClassLessSpecific<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="ClassLessSpecific<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="ClassLessSpecific<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="ClassLessSpecific<T>" protocol="Escapable")))
+// CHECK-NEXT:      (builtin_conformance type="ClassLessSpecific<T>" protocol="Escapable"{{.*}})))
 extension ClassLessSpecific: P2 where T: C1 {}
 
 
@@ -257,9 +257,9 @@ struct InheritEqual<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
 // CHECK-NEXT:  (normal_conformance type="InheritEqual<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="InheritEqual<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="InheritEqual<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="InheritEqual<T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="InheritEqual<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" conforms_to "P1"))
 extension InheritEqual: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual
@@ -268,9 +268,9 @@ extension InheritEqual: P2 where T: P1 {} // expected-note {{requirement from co
 // CHECK-LABEL:   (assoc_conformance type="Self" proto="P2"
 // CHECK-LABEL:     (normal_conformance type="InheritEqual<T>" protocol="P2"
 // CHECK-LABEL:       (assoc_conformance type="Self" proto="Copyable"
-// CHECK-LABEL:         (builtin_conformance type="InheritEqual<T>" protocol="Copyable"))
+// CHECK-LABEL:         (builtin_conformance type="InheritEqual<T>" protocol="Copyable"{{.*}}))
 // CHECK-LABEL:       (assoc_conformance type="Self" proto="Escapable"
-// CHECK-LABEL:         (builtin_conformance type="InheritEqual<T>" protocol="Escapable"))
+// CHECK-LABEL:         (builtin_conformance type="InheritEqual<T>" protocol="Escapable"{{.*}}))
 // CHECK-LABEL:       (requirement "T" conforms_to "P1")))
 // CHECK-LABEL:   (requirement "T" conforms_to "P1"))
 extension InheritEqual: P5 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritEqual<U>' to 'P5'}}
@@ -298,9 +298,9 @@ struct InheritMore<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
 // CHECK-NEXT:  (normal_conformance type="InheritMore<T>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="InheritMore<T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="InheritMore<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="InheritMore<T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="InheritMore<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" conforms_to "P1"))
 extension InheritMore: P2 where T: P1 {} // expected-note {{requirement from conditional conformance of 'InheritMore<U>' to 'P2'}}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore
@@ -309,9 +309,9 @@ extension InheritMore: P2 where T: P1 {} // expected-note {{requirement from con
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="P2"
 // CHECK-NEXT:      (normal_conformance type="InheritMore<T>" protocol="P2"
 // CHECK-NEXT:        (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:          (builtin_conformance type="InheritMore<T>" protocol="Copyable"))
+// CHECK-NEXT:          (builtin_conformance type="InheritMore<T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:        (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:          (builtin_conformance type="InheritMore<T>" protocol="Escapable"))
+// CHECK-NEXT:          (builtin_conformance type="InheritMore<T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:        (requirement "T" conforms_to "P1")))
 // CHECK-NEXT:    (requirement "T" conforms_to "P4"))
 extension InheritMore: P5 where T: P4 {} // expected-note 2 {{requirement from conditional conformance of 'InheritMore<U>' to 'P5'}}
@@ -398,9 +398,9 @@ struct RedundancyOrderDependenceGood<T: P1, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood
 // CHECK-NEXT:  (normal_conformance type="RedundancyOrderDependenceGood<T, U>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="RedundancyOrderDependenceGood<T, T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="RedundancyOrderDependenceGood<T, T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="RedundancyOrderDependenceGood<T, T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="RedundancyOrderDependenceGood<T, T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" same_type "U"))
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 
@@ -409,9 +409,9 @@ struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
 // CHECK-NEXT:  (normal_conformance type="RedundancyOrderDependenceBad<T, U>" protocol="P2"
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Copyable"
-// CHECK-NEXT:      (builtin_conformance type="RedundancyOrderDependenceBad<T, T>" protocol="Copyable"))
+// CHECK-NEXT:      (builtin_conformance type="RedundancyOrderDependenceBad<T, T>" protocol="Copyable"{{.*}}))
 // CHECK-NEXT:    (assoc_conformance type="Self" proto="Escapable"
-// CHECK-NEXT:      (builtin_conformance type="RedundancyOrderDependenceBad<T, T>" protocol="Escapable"))
+// CHECK-NEXT:      (builtin_conformance type="RedundancyOrderDependenceBad<T, T>" protocol="Escapable"{{.*}}))
 // CHECK-NEXT:    (requirement "T" conforms_to "P1")
 // CHECK-NEXT:    (requirement "T" same_type "U"))
 extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {}

--- a/test/Generics/inverse_extension_signatures.swift
+++ b/test/Generics/inverse_extension_signatures.swift
@@ -20,7 +20,7 @@
 // CHECK-LABEL: .Outer.InnerStruct.init()@
 // CHECK: Generic signature: <A, C where A : Escapable, C : Escapable>
 
-// CHECK: (builtin_conformance type="Outer<A>.InnerStruct<C>" protocol="Escapable")
+// CHECK: (builtin_conformance type="Outer<A>.InnerStruct<C>" protocol="Escapable"{{.*}})
 
 // CHECK-LABEL: .Outer.InnerVariation1@
 // CHECK: Generic signature: <A, D where A : Escapable, D : Escapable>

--- a/test/Generics/inverse_signatures.swift
+++ b/test/Generics/inverse_signatures.swift
@@ -197,13 +197,13 @@ extension Cond: Copyable where T: Copyable {}
 struct FullyGenericArg<T: ~Escapable & ~Copyable> {}
 
 // CHECK-LABEL: StructDecl name=FullyGenericArg
-// CHECK-NEXT:    (builtin_conformance type="FullyGenericArg<T>" protocol="Copyable")
-// CHECK-NEXT:    (builtin_conformance type="FullyGenericArg<T>" protocol="Escapable")
+// CHECK-NEXT:    (builtin_conformance type="FullyGenericArg<T>" protocol="Copyable"{{.*}})
+// CHECK-NEXT:    (builtin_conformance type="FullyGenericArg<T>" protocol="Escapable"{{.*}})
 
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=FullyGenericArg
 // CHECK: Generic signature: <T>
 // CHECK-NEXT: Canonical generic signature: <τ_0_0>
 
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=FullyGenericArg
-// CHECK-NEXT: (normal_conformance type="FullyGenericArg<T>" protocol="Empty")
+// CHECK-NEXT: (normal_conformance type="FullyGenericArg<T>" protocol="Empty"{{.*}})
 extension FullyGenericArg: Empty where T: ~Copyable, T: ~Escapable {}

--- a/test/Serialization/Recovery/conformance-xref.swift
+++ b/test/Serialization/Recovery/conformance-xref.swift
@@ -68,7 +68,7 @@ public protocol ProtoUser {
 // CHECK-REMARK-REQUIREMENT: Conformances:
 // Skipping implicits.
 // CHECK-REMARK-REQUIREMENT: (specialized_conformance type="OneToAThousand.Impl" protocol="SimpleProto"
-// CHECK-REMARK-REQUIREMENT:   (normal_conformance type="Counter<T>" protocol="SimpleProto" lazy))
+// CHECK-REMARK-REQUIREMENT:   (normal_conformance type="Counter<T>" protocol="SimpleProto"{{.*}} lazy))
   associatedtype Impl
 #else
   associatedtype Impl: SimpleProto


### PR DESCRIPTION
These improvements came about through great back-and-forth in [this forum thread](https://forums.swift.org/t/improving-the-ast-dump-format/15857). They are summarized as follows:

- Instead of using a custom-rolled type transformer, call `mapTypeOutOfContext()` to replace any primary archetypes with type parameters when computing a type USR.
- If the type still contains local archetypes, replace them with an equivalent existential.
- When dumping type inheritance, print the derived semantic information (all protocol conformances, raw type for enums, superclass/inherited protocols, etc.).
- Dump additional information about protocol conformances (safety, preconcurrency, isolation, etc.). (I also decided to do this in the default dump, since it seems useful there.)
- Add a source-file-level mapping of opaque type USRs to the USR of the equivalent existential type.