### PR TITLE
[cxx-interop] Fix not importing return type for certain functions

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3727,6 +3727,13 @@ namespace {
       return nullptr;
     }
 
+    static bool isClangNamespace(const DeclContext *dc) {
+      if (const auto *ed = dc->getSelfEnumDecl())
+        return isa<clang::NamespaceDecl>(ed->getClangDecl());
+
+      return false;
+    }
+
     Decl *importFunctionDecl(
         const clang::FunctionDecl *decl, ImportedName importedName,
         std::optional<ImportedName> correctSwiftName,
@@ -3862,7 +3869,8 @@ namespace {
 
       bool importFuncWithoutSignature =
           isa<clang::CXXMethodDecl>(decl) && Impl.importSymbolicCXXDecls;
-      if (!dc->isModuleScopeContext() && !isa<clang::CXXMethodDecl>(decl)) {
+      if (!dc->isModuleScopeContext() && !isClangNamespace(dc) &&
+          !isa<clang::CXXMethodDecl>(decl)) {
         // Handle initializers.
         if (name.getBaseName().isConstructor()) {
           assert(!accessorInfo);

--- a/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/inheritance.h
@@ -5,6 +5,13 @@
 // A wrapper around C++'s static_cast(), which allows Swift to get around interop's current lack of support for inheritance.
 template <class I, class O> O cxxCast(I i) { return static_cast<O>(i); }
 
+namespace Foo {
+template <class I, class O>
+O cxxCast(I i) {
+  return static_cast<O>(i);
+}
+} // namespace Foo
+
 // A minimal foreign reference type.
 struct
 __attribute__((swift_attr("import_reference")))

--- a/test/Interop/Cxx/foreign-reference/inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance.swift
@@ -23,7 +23,9 @@ InheritanceTestSuite.test("Templated cast to base") {
   let sc: BaseT = cast(s)
   expectFalse(sc.isBase)
   let sx: BaseT = cxxCast(s)  // should instantiate I to SubT and O to BaseT
-  expectFalse(sc.isBase)
+  expectFalse(sx.isBase)
+  let sy: BaseT = Foo.cxxCast(s)  // should instantiate I to SubT and O to BaseT
+  expectFalse(sy.isBase)
 }
 
 InheritanceTestSuite.test("Templated cast to itself") {


### PR DESCRIPTION
C++ namespaces are imported as enums. The importer triggered different code path for functions in C++ namespaces and functions in the global scope. As a result, we occasionally did not import the return type of certain C++ functions in namespace scope.
