### PR TITLE
[AST/Sema] Add `@extensible` attribute on `enum` declarations

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -735,7 +735,7 @@ protected:
     HasAnyUnavailableDuringLoweringValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+8,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -804,10 +804,7 @@ protected:
     SerializePackageEnabled : 1,
 
     /// Whether this module has enabled strict memory safety checking.
-    StrictMemorySafety : 1,
-
-    /// Whether this module has enabled `ExtensibleEnums` feature.
-    ExtensibleEnums : 1
+    StrictMemorySafety : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -879,7 +879,12 @@ SIMPLE_DECL_ATTR(constInitialized, ConstInitialized,
   168)
 DECL_ATTR_FEATURE_REQUIREMENT(ConstInitialized, CompileTimeValues)
 
-LAST_DECL_ATTR(ConstInitialized)
+SIMPLE_DECL_ATTR(extensible, Extensible,
+  OnEnum,
+  ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  169)
+
+LAST_DECL_ATTR(Extensible)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8573,6 +8573,19 @@ GROUPED_WARNING(
     (StringRef, DeclAttribute))
 
 //===----------------------------------------------------------------------===//
+// MARK: @extensible Attribute
+//===----------------------------------------------------------------------===//
+
+ERROR(extensible_attr_on_frozen_type,none,
+      "cannot use '@extensible' together with '@frozen'", ())
+
+ERROR(extensible_attr_on_internal_type,none, 
+      "'@extensible' attribute can only be applied to public or package "
+      "declarations, but %0 is "
+      "%select{private|fileprivate|internal|%error|%error|%error}1",
+      (DeclName, AccessLevel))
+
+//===----------------------------------------------------------------------===//
 //                            MARK: SwiftSettings
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -840,14 +840,6 @@ public:
     Bits.ModuleDecl.ObjCNameLookupCachePopulated = value;
   }
 
-  bool supportsExtensibleEnums() const {
-    return Bits.ModuleDecl.ExtensibleEnums;
-  }
-
-  void setSupportsExtensibleEnums(bool value = true) {
-    Bits.ModuleDecl.ExtensibleEnums = value;
-  }
-
   /// For the main module, retrieves the list of primary source files being
   /// compiled, that is, the files we're generating code for.
   ArrayRef<SourceFile *> getPrimarySourceFiles() const;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -492,11 +492,6 @@ ADOPTABLE_EXPERIMENTAL_FEATURE(AsyncCallerExecution, false)
 /// Allow custom availability domains to be defined and referenced.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(CustomAvailability, true)
 
-/// Allow public enumerations to be extensible by default
-/// regardless of whether the module they are declared in
-/// is resilient or not.
-EXPERIMENTAL_FEATURE(ExtensibleEnums, true)
-
 /// Allow isolated conformances.
 EXPERIMENTAL_FEATURE(IsolatedConformances, true)
 

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -150,7 +150,6 @@ class ExtendedValidationInfo {
     unsigned AllowNonResilientAccess: 1;
     unsigned SerializePackageEnabled: 1;
     unsigned StrictMemorySafety: 1;
-    unsigned SupportsExtensibleEnums : 1;
   } Bits;
 
 public:
@@ -271,11 +270,6 @@ public:
     if (auto genericVersion = VersionParser::parseVersionString(
             version, SourceLoc(), /*Diags=*/nullptr))
       SwiftInterfaceCompilerVersion = genericVersion.value();
-  }
-
-  bool supportsExtensibleEnums() const { return Bits.SupportsExtensibleEnums; }
-  void setSupportsExtensibleEnums(bool val) {
-    Bits.SupportsExtensibleEnums = val;
   }
 };
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4925,6 +4925,7 @@ public:
   TRIVIAL_ATTR_PRINTER(Used, used)
   TRIVIAL_ATTR_PRINTER(WarnUnqualifiedAccess, warn_unqualified_access)
   TRIVIAL_ATTR_PRINTER(WeakLinked, weak_linked)
+  TRIVIAL_ATTR_PRINTER(Extensible, extensible)
 
 #undef TRIVIAL_ATTR_PRINTER
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -402,6 +402,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
       DeclAttrKind::RestatedObjCConformance,
       DeclAttrKind::NonSendable,
       DeclAttrKind::AllowFeatureSuppression,
+      DeclAttrKind::Extensible,
   };
 
   return result;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6854,14 +6854,11 @@ bool EnumDecl::treatAsExhaustiveForDiags(const DeclContext *useDC) const {
     if (enumModule->inSamePackage(useDC->getParentModule()))
       return true;
 
-    // If the module where enum is declared supports extensible enumerations
-    // and this enum is not explicitly marked as "@frozen", cross-module
-    // access cannot be exhaustive and requires `@unknown default:`.
-    if (enumModule->supportsExtensibleEnums() &&
-        !getAttrs().hasAttribute<FrozenAttr>()) {
-      if (useDC != enumModule->getDeclContext())
-        return false;
-    }
+    // When the enum is marked as `@extensible` cross-module access
+    // cannot be exhaustive and requires `@unknown default:`.
+    if (getAttrs().hasAttribute<ExtensibleAttr>() &&
+        enumModule != useDC->getParentModule())
+      return false;
   }
 
   return isFormallyExhaustive(useDC);

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -124,7 +124,6 @@ UNINTERESTING_FEATURE(SuppressedAssociatedTypes)
 UNINTERESTING_FEATURE(StructLetDestructuring)
 UNINTERESTING_FEATURE(MacrosOnImports)
 UNINTERESTING_FEATURE(AsyncCallerExecution)
-UNINTERESTING_FEATURE(ExtensibleEnums)
 UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
 
 static bool usesFeatureNonescapableTypes(Decl *decl) {

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -228,6 +228,7 @@ extension ASTGenVisitor {
         .dynamicCallable,
         .eagerMove,
         .exported,
+        .extensible,
         .discardableResult,
         .disfavoredOverload,
         .dynamicMemberLookup,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1469,8 +1469,6 @@ ModuleDecl *CompilerInstance::getMainModule() const {
       MainModule->setSerializePackageEnabled();
     if (Invocation.getLangOptions().hasFeature(Feature::StrictMemorySafety))
       MainModule->setStrictMemorySafety(true);
-    if (Invocation.getLangOptions().hasFeature(Feature::ExtensibleEnums))
-      MainModule->setSupportsExtensibleEnums(true);
 
     configureAvailabilityDomains(getASTContext(),
                                  Invocation.getFrontendOptions(), MainModule);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -241,6 +241,21 @@ public:
     }
   }
 
+  void visitExtensibleAttr(ExtensibleAttr *attr) {
+    auto *E = cast<EnumDecl>(D);
+
+    if (D->getAttrs().hasAttribute<FrozenAttr>()) {
+      diagnoseAndRemoveAttr(attr, diag::extensible_attr_on_frozen_type);
+      return;
+    }
+
+    if (E->getFormalAccess() < AccessLevel::Package) {
+      diagnoseAndRemoveAttr(attr, diag::extensible_attr_on_internal_type,
+                            E->getName(), E->getFormalAccess());
+      return;
+    }
+  }
+
   void visitAlignmentAttr(AlignmentAttr *attr) {
     // Alignment must be a power of two.
     auto value = attr->getValue();

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1615,6 +1615,7 @@ namespace  {
     UNINTERESTING_ATTR(Isolated)
     UNINTERESTING_ATTR(Optimize)
     UNINTERESTING_ATTR(Exclusivity)
+    UNINTERESTING_ATTR(Extensible)
     UNINTERESTING_ATTR(NoLocks)
     UNINTERESTING_ATTR(NoAllocation)
     UNINTERESTING_ATTR(NoRuntime)

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1159,10 +1159,7 @@ namespace {
           auto *enumModule = theEnum->getParentModule();
           shouldIncludeFutureVersionComment =
               enumModule->isSystemModule() ||
-              enumModule->supportsExtensibleEnums();
-          // Since the module enabled `ExtensibleEnums` feature they
-          // opted-in all of their clients into exhaustivity errors.
-          shouldDowngradeToWarning = !enumModule->supportsExtensibleEnums();
+              theEnum->getAttrs().hasAttribute<ExtensibleAttr>();
         }
         DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
                     subjectType, shouldIncludeFutureVersionComment)

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -714,11 +714,6 @@ public:
   /// \c true if this module was built with strict memory safety.
   bool strictMemorySafety() const { return Core->strictMemorySafety(); }
 
-  /// \c true if this module was built with `ExtensibleEnums` feature enabled.
-  bool supportsExtensibleEnums() const {
-    return Core->supportsExtensibleEnums();
-  }
-
   /// Associates this module file with the AST node representing it.
   ///
   /// Checks that the file is compatible with the AST module it's being loaded

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -224,9 +224,6 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::STRICT_MEMORY_SAFETY:
       extendedInfo.setStrictMemorySafety(true);
       break;
-    case options_block::EXTENSIBLE_ENUMS:
-      extendedInfo.setSupportsExtensibleEnums(true);
-      break;
     default:
       // Unknown options record, possibly for use by a future version of the
       // module format.
@@ -1508,7 +1505,6 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.AllowNonResilientAccess = extInfo.allowNonResilientAccess();
       Bits.SerializePackageEnabled = extInfo.serializePackageEnabled();
       Bits.StrictMemorySafety = extInfo.strictMemorySafety();
-      Bits.SupportsExtensibleEnums = extInfo.supportsExtensibleEnums();
       MiscVersion = info.miscVersion;
       SDKVersion = info.sdkVersion;
       ModuleABIName = extInfo.getModuleABIName();

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -421,11 +421,8 @@ private:
     /// Whether this module enabled strict memory safety.
     unsigned StrictMemorySafety : 1;
 
-    /// Whether this module enabled has `ExtensibleEnums` feature enabled.
-    unsigned SupportsExtensibleEnums : 1;
-
     // Explicitly pad out to the next word boundary.
-    unsigned : 1;
+    unsigned : 2;
   } Bits = {};
   static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
 
@@ -683,8 +680,6 @@ public:
   bool isConcurrencyChecked() const { return Bits.IsConcurrencyChecked; }
 
   bool strictMemorySafety() const { return Bits.StrictMemorySafety; }
-
-  bool supportsExtensibleEnums() const { return Bits.SupportsExtensibleEnums; }
 
   /// How should \p dependency be loaded for a transitive import via \c this?
   ///

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 934; // @extensible attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 935; // remove ExtensibleEnums feature
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -974,8 +974,7 @@ namespace options_block {
     CXX_STDLIB_KIND,
     PUBLIC_MODULE_NAME,
     SWIFT_INTERFACE_COMPILER_VERSION,
-    STRICT_MEMORY_SAFETY,
-    EXTENSIBLE_ENUMS,
+    STRICT_MEMORY_SAFETY
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -1084,10 +1083,6 @@ namespace options_block {
   using SwiftInterfaceCompilerVersionLayout = BCRecordLayout<
     SWIFT_INTERFACE_COMPILER_VERSION,
     BCBlob // version tuple
-  >;
-
-  using ExtensibleEnumsLayout = BCRecordLayout<
-    EXTENSIBLE_ENUMS
   >;
 }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 933; // isConstantValue
+const uint16_t SWIFTMODULE_VERSION_MINOR = 934; // @extensible attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1186,11 +1186,6 @@ void Serializer::writeHeader() {
                            static_cast<uint8_t>(M->getCXXStdlibKind()));
       }
 
-      if (M->supportsExtensibleEnums()) {
-        options_block::ExtensibleEnumsLayout ExtensibleEnums(Out);
-        ExtensibleEnums.emit(ScratchRecord);
-      }
-
       if (Options.SerializeOptionsForDebugging) {
         options_block::SDKPathLayout SDKPath(Out);
         options_block::XCCLayout XCC(Out);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1100,8 +1100,6 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
     if (!loadedModuleFile->getModulePackageName().empty()) {
       M.setPackageName(Ctx.getIdentifier(loadedModuleFile->getModulePackageName()));
     }
-    if (loadedModuleFile->supportsExtensibleEnums())
-      M.setSupportsExtensibleEnums();
     M.setUserModuleVersion(loadedModuleFile->getUserModuleVersion());
     M.setSwiftInterfaceCompilerVersion(
         loadedModuleFile->getSwiftInterfaceCompilerVersion());

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -325,6 +325,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       freestanding[#Declaration Attribute#]; name=freestanding
 // ON_MEMBER_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // ON_MEMBER_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
+// ON_MEMBER_LAST-DAG: Keyword/None:                       extensible[#Declaration Attribute#]; name=extensible
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -397,6 +398,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // KEYWORD_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // KEYWORD_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
+// KEYWORD_LAST-DAG: Keyword/None:                       extensible[#Declaration Attribute#]; name=extensible
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyGenericPropertyWrapper[#Property Wrapper#]; name=MyGenericPropertyWrapper

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -94,3 +94,11 @@ public func testExecutionConcurrent() async {}
 @execution(caller)
 public func testExecutionCaller() async {}
 // CHECK: @execution(caller) public func testExecutionCaller() async
+
+// CHECK-NOT: @extensible
+// CHECK: public enum TestExtensible
+@extensible
+public enum TestExtensible {
+  case a
+  case b
+}

--- a/test/ModuleInterface/extensible_enums.swift
+++ b/test/ModuleInterface/extensible_enums.swift
@@ -5,8 +5,7 @@
 /// Build the library
 // RUN: %target-swift-frontend -emit-module %t/src/Lib.swift \
 // RUN:   -module-name Lib \
-// RUN:   -emit-module-path %t/Lib.swiftmodule \
-// RUN:   -enable-experimental-feature ExtensibleEnums
+// RUN:   -emit-module-path %t/Lib.swiftmodule
 
 // Check that the errors are produced when using enums from module with `ExtensibleEnums` feature enabled.
 // RUN: %target-swift-frontend -typecheck %t/src/TestChecking.swift \
@@ -19,8 +18,7 @@
 // RUN: %target-swift-frontend -emit-module %t/src/Lib.swift \
 // RUN:   -module-name Lib \
 // RUN:   -package-name Test \
-// RUN:   -emit-module-path %t/Lib.swiftmodule \
-// RUN:   -enable-experimental-feature ExtensibleEnums
+// RUN:   -emit-module-path %t/Lib.swiftmodule
 
 // Different module but the same package
 // RUN: %target-swift-frontend -typecheck %t/src/TestSamePackage.swift \
@@ -28,10 +26,9 @@
 // RUN:   -package-name Test \
 // RUN:   -verify
 
-// REQUIRES: swift_feature_ExtensibleEnums
-
 //--- Lib.swift
 
+@extensible
 public enum E {
   case a
 }
@@ -57,10 +54,10 @@ func test_same_module(e: E, f: F) {
 import Lib
 
 func test(e: E, f: F) {
-  // `E` is not marked as `@frozen` which means it gets new semantics
+  // `E` is marked as `@extensible` which means it gets new semantics
 
   switch e {
-  // expected-error@-1 {{switch covers known cases, but 'E' may have additional unknown values, possibly added in future versions}}
+  // expected-warning@-1 {{switch covers known cases, but 'E' may have additional unknown values, possibly added in future versions; this is an error in the Swift 6 language mode}}
   // expected-note@-2 {{handle unknown values using "@unknown default"}}
   case .a: break
   }
@@ -70,7 +67,7 @@ func test(e: E, f: F) {
   @unknown default: break
   }
 
-  // `F` is marked as `@frozen` which means regular rules apply even with `ExtensibleEnums` feature enabled.  
+  // `F` is marked as `@frozen` which means regular rules apply.
 
   switch f { // Ok (no errors because `F` is `@frozen`)
   case .a: break

--- a/test/attr/attr_extensible.swift
+++ b/test/attr/attr_extensible.swift
@@ -1,0 +1,38 @@
+// RUN: %target-typecheck-verify-swift
+
+@extensible
+public enum E1 { // Ok
+}
+
+@extensible // expected-error {{'@extensible' attribute can only be applied to public or package declarations, but 'E2' is fileprivate}}
+fileprivate enum E2 {}
+
+@extensible // expected-error {{cannot use '@extensible' together with '@frozen'}}
+@frozen
+public enum E3 {
+}
+
+@extensible  // expected-error {{'@extensible' attribute can only be applied to public or package declarations, but 'E4' is internal}}
+@usableFromInline
+enum E4 {}
+
+@extensible // expected-error {{@extensible may only be used on 'enum' declarations}}
+struct Test {
+  @extensible // expected-error {{@extensible may only be used on 'enum' declarations}}
+  var v: Int {
+    @extensible // expected-error {{@extensible may only be used on 'enum' declarations}}
+    get { 0 }
+  }
+
+  @extensible // expected-error {{@extensible may only be used on 'enum' declarations}}
+  var v2: String = ""
+  
+  @extensible // expected-error {{@extensible may only be used on 'enum' declarations}}
+  func test() {}
+
+  @extensible // expected-error {{@extensible may only be used on 'enum' declarations}}
+  subscript(a: Int) -> Bool {
+    get { false }
+    set { }
+  }
+}


### PR DESCRIPTION
This attribute controls whether cross-module access to the declaration
needs `@unknown default:` because it's allowed to gain new cases even
if the module is non-resilient.

The change also temporarily removes `ExtensibleEnums` experimental
feature.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
