### PR TITLE
Prepare diagnostics docs for docc generation

### DIFF
--- a/userdocs/diagnostics/.gitignore
+++ b/userdocs/diagnostics/.gitignore
@@ -1,0 +1,1 @@
+.docc-build

--- a/userdocs/diagnostics/async-caller-execution.md
+++ b/userdocs/diagnostics/async-caller-execution.md
@@ -1,14 +1,15 @@
 # `AsyncCallerExecution`
 
-Proposed in [SE-0461], this feature changes the behavior of nonisolated async
+This feature changes the behavior of nonisolated async
 functions to run on the actor to which the caller is isolated (if any) by 
 default, and provides an explicit way to express the execution semantics for
-these functions:
+these functions.
+
+This feature was proposed in [SE-0461](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md)
+
 * The `@execution(concurrent)` attribute specifies that a function must always 
   switch off of an actor to run.
   This is the default behavior without `AsyncCallerExecution`.
 * The `@execution(caller)` attribute specifies that a function must always 
   run on the caller's actor.
   This is the default behavior with `AsyncCallerExecution`.
-
-[SE-0461]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md

--- a/userdocs/diagnostics/diagnostics.md
+++ b/userdocs/diagnostics/diagnostics.md
@@ -1,0 +1,7 @@
+# Swift Compiler Diagnostics
+
+@Metadata {
+   @TechnologyRoot
+}
+
+Documentation on diagnostics emitted by the compiler.

--- a/userdocs/diagnostics/existential-any.md
+++ b/userdocs/diagnostics/existential-any.md
@@ -1,7 +1,9 @@
 # `ExistentialAny`
 
 This diagnostic group includes errors and warnings pertaining to the `any` type
-syntax proposed in [SE-0335].
+syntax.
+
+This syntax was proposed in [SE-0335](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md).
 `any` syntax draws a line between constraint types and existential or boxed
 types.
 
@@ -20,5 +22,3 @@ func sillyFunction(collection: Collection) { // error
   // ...
 }
 ```
-
-[SE-0335]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0335-existential-any.md


### PR DESCRIPTION
Update the diagostic docs so that they can be built with docc:
    * Add technologyroot (diagnostics.md) to aggregate all markdown files
    * Fixed warnings in a few diagnostics docs

This allows the creation of docc documentation with a single invocation of docc. It will generate the landing page from diagnostics.md and include all of the diagnostics as subarticles.

The subarticles are accessible via the name of the markdown file, which is being used as the ID for these diagnostics. E.g. existential-any.

The docc docs for these documents can be generated locally with the following command:
>docc preview --allow-arbitrary-catalog-directories userdocs/diagnostics

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
