### PR TITLE
Fix two bugs in alloc_stack simplification

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -257,9 +257,13 @@ private extension AllocStackInst {
       case is CheckedCastAddrBranchInst, is UnconditionalCheckedCastAddrInst:
         // To construct a new cast instruction we need a formal type.
         requiresLegalFormalType = true
-        fallthrough
-      case is UncheckedAddrCastInst:
         if use != use.instruction.operands[0] {
+          return nil
+        }
+      case is UncheckedAddrCastInst:
+        if self.type.isExistential {
+          // Bail if the address of the original existential escapes.
+          // This is not a problem if the alloc_stack already contains the opened existential.
           return nil
         }
       default:

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1346,6 +1346,7 @@ final public class AllocStackInst : SingleValueInstruction, Allocation, DebugVar
   public var hasDynamicLifetime: Bool { bridged.AllocStackInst_hasDynamicLifetime() }
   public var isFromVarDecl: Bool { bridged.AllocStackInst_isFromVarDecl() }
   public var usesMoveableValueDebugInfo: Bool { bridged.AllocStackInst_usesMoveableValueDebugInfo() }
+  public override var isLexical: Bool { bridged.AllocStackInst_isLexical() }
 
   public var varDecl: VarDecl? {
     bridged.AllocStack_getDecl().getAs(VarDecl.self)

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -772,6 +772,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool AllocStackInst_hasDynamicLifetime() const;
   BRIDGED_INLINE bool AllocStackInst_isFromVarDecl() const;
   BRIDGED_INLINE bool AllocStackInst_usesMoveableValueDebugInfo() const;
+  BRIDGED_INLINE bool AllocStackInst_isLexical() const;
   BRIDGED_INLINE bool AllocRefInstBase_isObjc() const;
   BRIDGED_INLINE bool AllocRefInstBase_canAllocOnStack() const;
   BRIDGED_INLINE SwiftInt AllocRefInstBase_getNumTailTypes() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1305,6 +1305,10 @@ bool BridgedInstruction::AllocStackInst_usesMoveableValueDebugInfo() const {
   return getAs<swift::AllocStackInst>()->usesMoveableValueDebugInfo();
 }
 
+bool BridgedInstruction::AllocStackInst_isLexical() const {
+  return getAs<swift::AllocStackInst>()->isLexical();
+}
+
 bool BridgedInstruction::AllocRefInstBase_isObjc() const {
   return getAs<swift::AllocRefInstBase>()->isObjC();
 }

--- a/test/SILOptimizer/sil_combine_concrete_existential_noncopyable.swift
+++ b/test/SILOptimizer/sil_combine_concrete_existential_noncopyable.swift
@@ -11,7 +11,7 @@ public struct S: P {
 }
 
 // CHECK-LABEL: sil @$s44sil_combine_concrete_existential_noncopyable1gyyF : $@convention(thin) () -> () {
-// CHECK: [[S_ADDR:%.*]] =  alloc_stack [var_decl] $S
+// CHECK: [[S_ADDR:%.*]] =  alloc_stack [lexical] [var_decl] $S
 // CHECK: [[INIT_FN:%.*]] = function_ref @$s44sil_combine_concrete_existential_noncopyable1SVACycfC : $@convention(method) (@thin S.Type) -> S
 // CHECK: [[S:%.*]] = apply [[INIT_FN]]({{%.*}}) : $@convention(method) (@thin S.Type) -> S
 // CHECK: store [[S]] to [[S_ADDR]]

--- a/test/SILOptimizer/simplify_alloc_stack.sil
+++ b/test/SILOptimizer/simplify_alloc_stack.sil
@@ -41,7 +41,7 @@ sil [ossa] @use_mp : $@convention(thin) (@in_guaranteed MP) -> ()
 sil [ossa] @use_c2 : $@convention(thin) (@in_guaranteed C2) -> ()
 
 // CHECK-LABEL: sil [ossa] @expand_alloc_stack_of_enum1 :
-// CHECK:        [[A:%[0-9]+]] = alloc_stack $S
+// CHECK:        [[A:%[0-9]+]] = alloc_stack [lexical] $S
 // CHECK:      bb1:
 // CHECK-NEXT:   store %0 to [trivial] [[A]]
 // CHECK:      bb2:
@@ -51,7 +51,7 @@ sil [ossa] @use_c2 : $@convention(thin) (@in_guaranteed C2) -> ()
 // CHECK:      } // end sil function 'expand_alloc_stack_of_enum1'
 sil [ossa] @expand_alloc_stack_of_enum1 : $@convention(method) (S) -> () {
 bb0(%0 : $S):
-  %1 = alloc_stack $MP
+  %1 = alloc_stack [lexical] $MP
   cond_br undef, bb1, bb2
 
 bb1:
@@ -215,7 +215,7 @@ bb0(%0 : $S):
 }
 
 // CHECK-LABEL: sil [ossa] @replace_archetype :
-// CHECK:         [[S:%.*]] = alloc_stack $T
+// CHECK:         [[S:%.*]] = alloc_stack [lexical] $T
 // CHECK:         debug_value [[S]]
 // CHECK:         unchecked_addr_cast [[S]]
 // CHECK:         destroy_addr [[S]]
@@ -225,7 +225,7 @@ bb0(%0 : @owned $T):
   %1 = metatype $@thick T.Type
   %2 = init_existential_metatype %1, $@thick P.Type
   %3 = open_existential_metatype %2 to $@thick (@opened("82105EE0-DCB0-11E5-865D-C8E0EB309913", P) Self).Type
-  %4 = alloc_stack $@opened("82105EE0-DCB0-11E5-865D-C8E0EB309913", P) Self
+  %4 = alloc_stack [lexical] $@opened("82105EE0-DCB0-11E5-865D-C8E0EB309913", P) Self
   debug_value %4, var, name "x"
   %5 = unchecked_addr_cast %4 to $*T
   store %0 to [init] %5

--- a/test/SILOptimizer/simplify_alloc_stack.sil
+++ b/test/SILOptimizer/simplify_alloc_stack.sil
@@ -365,3 +365,19 @@ bb0(%0 : @owned $C2):
   dealloc_stack %1
   return %5
 }
+
+// CHECK-LABEL: sil [ossa] @dont_replace_existential_with_escaping_addr :
+// CHECK:         alloc_stack $any P
+// CHECK:       } // end sil function 'dont_replace_existential_with_escaping_addr'
+sil [ossa] @dont_replace_existential_with_escaping_addr : $@convention(thin) <V> (@thick V.Type, @owned C2) -> @out V {
+bb0(%0 : $*V, %1 : $@thick V.Type, %2 : @owned $C2):
+  %114 = alloc_stack $any P
+  %117 = init_existential_addr %114, $C2
+  store %2 to [init] %117
+  %129 = unchecked_addr_cast %114 to $*V
+  copy_addr %129 to [init] %0
+  destroy_addr %114
+  dealloc_stack %114
+  %137 = tuple ()
+  return %137
+}


### PR DESCRIPTION
* Bail if the address of the allocated existential escapes.
* Fix `AllocStackInst.isLexical`: If wrongly returned false.

fixes a miscompile
rdar://148253142
