### PR TITLE
[CSRanking] Add a special ranking rule for SwiftUI's `overlay` and `b…

### DIFF
--- a/validation-test/Sema/SwiftUI/ambiguities.swift
+++ b/validation-test/Sema/SwiftUI/ambiguities.swift
@@ -1,0 +1,59 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx14
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+extension View {
+  func test() -> some View { EmptyView() }
+}
+
+extension ShapeStyle {
+  @_disfavoredOverload
+  func test() -> some ShapeStyle { Something() }
+}
+
+struct Something : ShapeStyle, View {
+  var body: some View {
+    EmptyView()
+  }
+}
+
+struct TestOverlay1 : View {
+  var body : some View {
+    EmptyView().overlay(Something().test())
+  }
+}
+
+struct TestOverlay2 : View {
+  var body : some View {
+    VStack {
+      Group {
+        Text("")
+      }.overlay(Something().test())
+    }
+  }
+}
+
+struct TestBackground1 : View {
+  var body : some View {
+    EmptyView().background(Something().test())
+  }
+}
+
+struct TestBackground2 : View {
+  var body : some View {
+    VStack {
+      Group {
+        Text("")
+      }.background(Something().test())
+    }
+  }
+}
+
+struct TestDisfavoring : View {
+  var body : some View {
+    Something().test()
+  }
+}


### PR DESCRIPTION
…ackground`

The disfavored overloads of `.overlay(_:alignment)` and `.background(_:alignment)` are always strictly worse for these methods. Other modifiers are overloaded on result i.e. `some View` vs. `some ShapeStyle` so introducing `@_disfavoredOverload` on them has source compatibility impact when they passed as an argument to `overlay` or `background` because they disfavor version that accepts a type that conforms to `View` over the one that accepts a `ShapeStyle`.

Resolves: rdar://148545335

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
