### PR TITLE
[stdlib][CMake] Build differentiation in new runtime build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1654,13 +1654,14 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
 
       ExternalProject_Get_Property("${stdlib_target}-core" INSTALL_DIR)
 
-      ExternalProject_Add("${stdlib_target}-StringProcessing"
-        SOURCE_DIR
-          "${CMAKE_CURRENT_SOURCE_DIR}/Runtimes/Supplemental/StringProcessing"
+      ExternalProject_Add("${stdlib_target}-Supplemental"
+        SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Runtimes/Supplemental"
         DEPENDS "${stdlib_target}-core"
         INSTALL_DIR "${INSTALL_DIR}"
-        INSTALL_COMMAND "" # No install story set up yet
+        INSTALL_COMMAND ""
+        LIST_SEPARATOR "|"
         CMAKE_ARGS
+          -DSwift_ENABLE_RUNTIMES=StringProcessing|Differentiation
           -DBUILD_SHARED_LIBS=YES
           -DCMAKE_Swift_COMPILER_WORKS:BOOLEAN=YES
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/Runtimes/Resync.cmake
+++ b/Runtimes/Resync.cmake
@@ -125,10 +125,11 @@ copy_files(public/Platform Overlay/Windows/CRT
     TiocConstants.swift
     tgmath.swift.gyb)
 
-# TODO: Add source directories for the platform overlays, supplemental
-# libraries, and test support libraries.
-
 # Supplemental Libraries
+
+# Copy Differentiation sources
+copy_library_sources("linker-support" "" "Supplemental/Differentiation")
+copy_library_sources("Differentiation" "public" "Supplemental")
 
 # Copy StringProcessing, RegexParser, RegexBuilder
 if(NOT DEFINED StringProcessing_ROOT_DIR)

--- a/Runtimes/Supplemental/CMakeLists.txt
+++ b/Runtimes/Supplemental/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.29)
+
+project(SwiftRuntime LANGUAGES Swift C CXX)
+
+include(ExternalProject)
+
+set(SwiftRuntime_SWIFTC_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../")
+
+foreach(lib ${Swift_ENABLE_RUNTIMES})
+  string(TOLOWER ${lib} name)
+  set(SwiftRuntime_ENABLE_${name} YES)
+endforeach()
+
+if(SwiftCore_DIR)
+  set(SwiftCore_DIR_FLAG "-DSwiftCore_DIR=${SwiftCore_DIR}")
+endif()
+
+if(CMAKE_MAKE_PROGRAM)
+  set(MAKE_PROGRAM_FLAG "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+endif()
+
+set(COMMON_OPTIONS
+  -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+  -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+  -DCMAKE_COLOR_DIAGNOSTICS=${CMAKE_COLOR_DIAGNOSTICS}
+  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+  -DCMAKE_Swift_COMPILER=${CMAKE_Swift_COMPILER}
+  -DCMAKE_C_COMPILER_TARGET=${CMAKE_C_COMPILER_TARGET}
+  -DCMAKE_CXX_COMPILER_TARGET=${CMAKE_CXX_COMPILER_TARGET}
+  -DCMAKE_Swift_COMPILER_TARGET=${CMAKE_Swift_COMPILER_TARGET}
+  ${SwiftCore_DIR_FLAG}
+  ${MAKE_PROGRAM_FLAG})
+
+# StringProcessing
+if(SwiftRuntime_ENABLE_stringprocessing)
+  ExternalProject_Add(StringProcessing
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/StringProcessing"
+    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
+    INSTALL_COMMAND ""
+    CMAKE_ARGS
+      ${COMMON_OPTIONS})
+endif()
+
+# Differentiation
+if(SwiftRuntime_ENABLE_differentiation)
+  ExternalProject_Add(Differentiation
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Differentiation"
+    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
+    INSTALL_COMMAND ""
+    CMAKE_ARGS
+      ${COMMON_OPTIONS})
+endif()

--- a/Runtimes/Supplemental/Differentiation/CMakeLists.txt
+++ b/Runtimes/Supplemental/Differentiation/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.29)
+
+set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
+
+if($ENV{BUILD_NUMBER})
+  math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
+  set(BUILD_NUMBER ".${BUILD_NUMBER}")
+endif()
+project(SwiftDifferentiation
+  LANGUAGES Swift C
+  VERSION 6.1.0${BUILD_NUMBER})
+
+if(NOT PROJECT_IS_TOP_LEVEL)
+  message(SEND_ERROR "Swift Differentiation must build as a standalone project")
+endif()
+
+set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
+  "${PROJECT_SOURCE_DIR}/../../../"
+  CACHE FILEPATH "Path to the root source directory of the Swift compiler")
+
+find_package(SwiftCore)
+
+include(gyb)
+
+option(SwiftDifferentiation_ENABLE_VECTOR_TYPES "Enable vector support"
+  ${SwiftCore_ENABLE_VECTOR_TYPES})
+
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
+  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  $<$<COMPILE_LANGUAGE:Swift>:-parse-stdlib>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-library-level api>"
+  $<$<COMPILE_LANGUAGE:Swift>:-enforce-exclusivity=unchecked>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-target-min-inlining-version min>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NoncopyableGenerics2>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SuppressedAssociatedTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature MemberImportVisibility>")
+
+if(SwiftDifferentiation_ENABLE_VECTOR_TYPES)
+  gyb_expand(SIMDDifferentiation.swift.gyb SIMDDifferentiation.swift)
+endif()
+gyb_expand(TgmathDerivatives.swift.gyb TgmathDerivatives.swift)
+gyb_expand(FloatingPointDifferentiation.swift.gyb
+  FloatingPointDifferentiation.swift)
+
+add_library(swift_Differentiation
+  AnyDifferentiable.swift
+  ArrayDifferentiation.swift
+  Differentiable.swift
+  DifferentialOperators.swift
+  DifferentiationUtilities.swift
+  OptionalDifferentiation.swift
+  $<$<BOOL:${SwiftDifferentiation_ENABLE_VECTOR_TYPES}>:SIMDDifferentiation.swift>
+  TgmathDerivatives.swift
+  FloatingPointDifferentiation.swift
+  linker-support/magic-symbols-for-install-name.c)
+
+set_target_properties(swift_Differentiation PROPERTIES
+  Swift_MODULE_NAME _Differentiation
+  Swift_COMPILATION_MODE wholemodule)
+
+  target_link_libraries(swift_Differentiation PRIVATE swiftCore)

--- a/Runtimes/Supplemental/Readme.md
+++ b/Runtimes/Supplemental/Readme.md
@@ -1,0 +1,52 @@
+# Swift Supplemental Libraries
+
+The supplemental libraries are all libraries that are not one of the Core or
+overlay libraries. Each supplemental library builds as an independent project.
+
+The supplemental libraries are:
+ - CxxInterop
+ - Differentiation
+ - Distributed
+ - Observation
+ - StringProcessing
+ - SwiftRuntime
+ - Synchronization
+
+The top-level Supplemental CMakeLists supplies a super-build pattern for
+configuring and compiling each of the supplemental library projects through a
+single CMake invocation. The `Swift_ENABLE_RUNTIMES` CMake option enables the
+specified supplemental libraries. All libraries configured this way are built
+with the same compilers, against the same sysroot, with the same target triple
+and installed into the same location.
+
+## Super-Build
+
+Configuring each project independently is tedious. The Supplemental directory
+contains a Super-Build CMakeLists that invokes the build of each of the
+supplemental libraries in the appropriate order, simplifying the process of
+building each library.
+
+Important configuration variables:
+ - `Swift_ENABLE_RUNTIMES`: Used to configure which runtime libraries are built.
+
+The super-build forwards the following variables to each sub-project
+unconditionally:
+ - `BUILD_SHARED_LIBS`
+ - `CMAKE_BUILD_TYPE`
+ - `CMAKE_INSTALL_PREFIX`
+ - `CMAKE_COLOR_DIAGNOSTICS`
+ - `CMAKE_C_COMPILER`
+ - `CMAKE_C_COMPILER_TARGET`
+ - `CMAKE_CXX_COMPILER`
+ - `CMAKE_CXX_COMPILER_TARGET`
+ - `CMAKE_Swift_COMPILER`
+ - `CMAKE_Swift_COMPILER_TARGET`
+
+If set, the super-build forwards the following values to each sub-project:
+
+ - `SwiftCore_DIR`: Path to the SwiftCore build directory
+ - `CMAKE_MAKE_PROGRAM`: Path to `ninja`
+
+The super-build is for convenience. If more fine-grained control is desired for
+configuring a specific runtime library, you may configure that library
+independently.

--- a/Runtimes/Supplemental/cmake/modules/gyb.cmake
+++ b/Runtimes/Supplemental/cmake/modules/gyb.cmake
@@ -1,0 +1,47 @@
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# Create a target to expand a gyb source
+# target_name: Name of the target
+# FLAGS  list of flags passed to gyb
+# DEPENDS list of dependencies
+# COMMENT Custom comment
+function(gyb_expand source output)
+  set(flags)
+  set(arguments)
+  set(multival_arguments FLAGS DEPENDS)
+  cmake_parse_arguments(GYB "${flags}" "${arguments}" "${multival_arguments}" ${ARGN})
+
+  get_filename_component(full_output_path ${output} ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  get_filename_component(dir "${full_output_path}" DIRECTORY)
+  get_filename_component(fname "${full_output_path}" NAME)
+
+  file(READ "${source}" gyb_src)
+  string(REGEX MATCHALL "\\\$\{[\r\n\t ]*gyb.expand\\\([\r\n\t ]*[\'\"]([^\'\"]*)[\'\"]" gyb_expand_matches "${gyb_src}")
+  foreach(match ${gyb_expand_matches})
+    string(REGEX MATCH "[\'\"]\([^\'\"]*\)[\'\"]" gyb_dep "${match}")
+    list(APPEND gyb_expand_deps "${CMAKE_MATCH_1}")
+  endforeach()
+  list(REMOVE_DUPLICATES gyb_expand_deps)
+
+  set(utils_dir "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/utils/")
+  set(gyb_tool "${utils_dir}/gyb")
+
+  # All the tidbits to track for changes
+  list(APPEND GYB_DEPENDS
+    "${source}"
+    "${utils_dir}/GYBUnicodeDataUtils.py"
+    "${utils_dir}/SwiftIntTypes.py"
+    "${utils_dir}/SwiftFloatingPointTypes.py"
+    "${utils_dir}/UnicodeData/GraphemeBreakProperty.txt"
+    "${utils_dir}/UnicodeData/GraphemeBreakTest.txt"
+    "${utils_dir}/gyb_stdlib_support.py")
+  add_custom_command(
+    OUTPUT  "${full_output_path}"
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${dir}"
+    COMMAND "${CMAKE_COMMAND}" -E env "$<TARGET_FILE:Python3::Interpreter>" "${gyb_tool}" ${GYB_FLAGS} -o "${full_output_path}.tmp" "${source}"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${full_output_path}.tmp" "${full_output_path}"
+    COMMAND "${CMAKE_COMMAND}" -E remove "${full_output_path}.tmp"
+    DEPENDS ${gyb_tool} ${gyb_tool}.py ${GYB_DEPENDS} ${gyb_expand_deps}
+    COMMENT "Generating GYB source ${fname} from ${source}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endfunction()


### PR DESCRIPTION
This patch set adds the initial build for the differentiation library and creates a rudimentary super-build over the supplemental libraries.

The differentiation library depends on gyb, so I've pulled the gyb module from the Core project with some minor alterations to work in a shared build. That mostly means replacing the hard-coded project name with the `${PROJECT_NAME}` variable when expanding variables. This is just a quick first-pass at getting the differentiation library build, but likely needs more flags to ensure that it's exposing the needed APIs and symbols.

The super-build pattern uses a top-level CMake file to coordinate building one or more projects using `ExternalProject_Add`. This implementation is rudimentary, only passing a few common variables to each sub-project to keep things simple and ensure that each project is built consistently with the same compilers against the same SwiftCore for the same target.