### PR TITLE
[SE-0467] add mutableBytes to MutableSpan

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -102,7 +102,7 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow elements)
+  @lifetime(&elements)
   public init<Element: BitwiseCopyable>(
     _elements elements: inout MutableSpan<Element>
   ) {

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -109,7 +109,8 @@ extension MutableRawSpan {
     let (start, count) = unsafe (elements._pointer, elements._count)
     let span = unsafe MutableRawSpan(
       _unchecked: start,
-      byteCount: count &* MemoryLayout<Element>.stride
+      byteCount: count == 1 ? MemoryLayout<Element>.size
+                 : count &* MemoryLayout<Element>.stride
     )
     self = unsafe _overrideLifetime(span, mutating: &elements)
   }

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -102,16 +102,16 @@ extension MutableRawSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(copy elements)
+  @lifetime(borrow elements)
   public init<Element: BitwiseCopyable>(
-    _elements elements: consuming MutableSpan<Element>
+    _elements elements: inout MutableSpan<Element>
   ) {
-    let bytes = unsafe UnsafeMutableRawBufferPointer(
-      start: elements._pointer,
-      count: elements.count &* MemoryLayout<Element>.stride
+    let (start, count) = unsafe (elements._pointer, elements._count)
+    let span = unsafe MutableRawSpan(
+      _unchecked: start,
+      byteCount: count &* MemoryLayout<Element>.stride
     )
-    let span = unsafe MutableRawSpan(_unsafeBytes: bytes)
-    self = unsafe _overrideLifetime(span, copying: elements)
+    self = unsafe _overrideLifetime(span, mutating: &elements)
   }
 }
 

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -241,6 +241,17 @@ extension MutableSpan where Element: BitwiseCopyable {
       RawSpan(_mutableSpan: self)
     }
   }
+
+  /// Construct a MutableRawSpan over the memory represented by this span
+  ///
+  /// - Returns: a MutableRawSpan over the memory represented by this span
+  @_alwaysEmitIntoClient
+  public var mutableBytes: MutableRawSpan {
+    @lifetime(borrow self)
+    mutating get {
+      MutableRawSpan(_elements: &self)
+    }
+  }
 }
 
 @available(SwiftStdlib 6.2, *)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -247,7 +247,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   /// - Returns: a MutableRawSpan over the memory represented by this span
   @_alwaysEmitIntoClient
   public var mutableBytes: MutableRawSpan {
-    @lifetime(borrow self)
+    @lifetime(&self)
     mutating get {
       MutableRawSpan(_elements: &self)
     }

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -122,7 +122,28 @@ suite.test("RawSpan from MutableSpan")
     let span = MutableSpan(_unsafeStart: p, count: c)
     let bytes  = span.bytes
     expectEqual(bytes.byteCount, count*MemoryLayout<Int>.stride)
+    let v = bytes.unsafeLoad(
+      fromByteOffset: MemoryLayout<Int>.stride, as: Int.self
+    )
+    expectEqual(v, 1)
   }
+}
+
+suite.test("MutableRawSpan from MutableSpan")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let count = 4
+  var array = Array(0..<count)
+  expectEqual(array[0], 0)
+  array.withUnsafeMutableBufferPointer {
+    let (p, c) = ($0.baseAddress!, $0.count)
+    var span = MutableSpan(_unsafeStart: p, count: c)
+    var bytes  = span.mutableBytes
+    expectEqual(bytes.byteCount, count*MemoryLayout<Int>.stride)
+    bytes.storeBytes(of: 1, as: Int.self)
+  }
+  expectEqual(array[0], 1)
 }
 
 suite.test("indices property")


### PR DESCRIPTION
I forgot to add the `mutableBytes` property in https://github.com/swiftlang/swift/pull/79650.

Furthers rdar://138440979