### PR TITLE
[CoroutineAccessors] Use async bit in descriptors.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -374,8 +374,6 @@ public:
     Setter,
     ModifyCoroutine,
     ReadCoroutine,
-    Read2Coroutine,
-    Modify2Coroutine,
   };
 
 private:
@@ -438,21 +436,25 @@ public:
   /// Note that 'init' is not considered an instance member.
   bool isInstance() const { return Value & IsInstanceMask; }
 
-  bool isAsync() const { return Value & IsAsyncMask; }
+  bool _hasAsyncBitSet() const { return Value & IsAsyncMask; }
 
-  bool isCalleeAllocatedCoroutine() const {
+  bool isAsync() const { return !isCoroutine() && _hasAsyncBitSet(); }
+
+  bool isCoroutine() const {
     switch (getKind()) {
     case Kind::Method:
     case Kind::Init:
     case Kind::Getter:
     case Kind::Setter:
+      return false;
     case Kind::ModifyCoroutine:
     case Kind::ReadCoroutine:
-      return false;
-    case Kind::Read2Coroutine:
-    case Kind::Modify2Coroutine:
       return true;
     }
+  }
+
+  bool isCalleeAllocatedCoroutine() const {
+    return isCoroutine() && _hasAsyncBitSet();
   }
 
   bool isData() const { return isAsync() || isCalleeAllocatedCoroutine(); }
@@ -615,8 +617,6 @@ public:
     ModifyCoroutine,
     AssociatedTypeAccessFunction,
     AssociatedConformanceAccessFunction,
-    Read2Coroutine,
-    Modify2Coroutine,
   };
 
 private:
@@ -666,24 +666,28 @@ public:
   /// Note that 'init' is not considered an instance member.
   bool isInstance() const { return Value & IsInstanceMask; }
 
-  bool isAsync() const { return Value & IsAsyncMask; }
+  bool _hasAsyncBitSet() const { return Value & IsAsyncMask; }
 
-  bool isCalleeAllocatedCoroutine() const {
+  bool isAsync() const { return !isCoroutine() && _hasAsyncBitSet(); }
+
+  bool isCoroutine() const {
     switch (getKind()) {
     case Kind::BaseProtocol:
     case Kind::Method:
     case Kind::Init:
     case Kind::Getter:
     case Kind::Setter:
-    case Kind::ReadCoroutine:
-    case Kind::ModifyCoroutine:
     case Kind::AssociatedTypeAccessFunction:
     case Kind::AssociatedConformanceAccessFunction:
       return false;
-    case Kind::Read2Coroutine:
-    case Kind::Modify2Coroutine:
+    case Kind::ReadCoroutine:
+    case Kind::ModifyCoroutine:
       return true;
     }
+  }
+
+  bool isCalleeAllocatedCoroutine() const {
+    return isCoroutine() && _hasAsyncBitSet();
   }
 
   bool isData() const { return isAsync() || isCalleeAllocatedCoroutine(); }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -6162,9 +6162,7 @@ static void initProtocolWitness(void **slot, void *witness,
   case ProtocolRequirementFlags::Kind::Getter:
   case ProtocolRequirementFlags::Kind::Setter:
   case ProtocolRequirementFlags::Kind::ReadCoroutine:
-  case ProtocolRequirementFlags::Kind::Read2Coroutine:
   case ProtocolRequirementFlags::Kind::ModifyCoroutine:
-  case ProtocolRequirementFlags::Kind::Modify2Coroutine:
     swift_ptrauth_init_code_or_data(slot, witness,
                                     reqt.Flags.getExtraDiscriminator(),
                                     !reqt.Flags.isData());
@@ -6205,9 +6203,7 @@ static void copyProtocolWitness(void **dest, void * const *src,
   case ProtocolRequirementFlags::Kind::Getter:
   case ProtocolRequirementFlags::Kind::Setter:
   case ProtocolRequirementFlags::Kind::ReadCoroutine:
-  case ProtocolRequirementFlags::Kind::Read2Coroutine:
   case ProtocolRequirementFlags::Kind::ModifyCoroutine:
-  case ProtocolRequirementFlags::Kind::Modify2Coroutine:
     swift_ptrauth_copy_code_or_data(
         dest, src, reqt.Flags.getExtraDiscriminator(), !reqt.Flags.isData(),
         /*allowNull*/ true); // NULL allowed for VFE (methods in the vtable


### PR DESCRIPTION
To facilitate back deployment, make use of the fact that the async bit has up to now never been set for read and modify accessors and claim that set bit to indicate that it is a callee-allocated coroutine.  This has the virtue of being completely back deployable because like async function pointers coro function pointers must be auth'd and signed as data.
