### PR TITLE
[Concurrency] Improve assertion to validate we pop the EXACT record we intend to

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1792,9 +1792,11 @@ static void swift_task_removeCancellationHandlerImpl(
     return;
   }
 
+  auto task = swift_task_getCurrent();
+  assert(task->_private()._status().load(std::memory_order_relaxed).getInnermostRecord() == record &&
+    "We expect that the popped record will be exactly first as well as that it is of the expected type");
   if (auto poppedRecord =
-      popStatusRecordOfType<CancellationNotificationStatusRecord>(swift_task_getCurrent())) {
-    assert(record == poppedRecord && "The removed record did not match the expected record!");
+      popStatusRecordOfType<CancellationNotificationStatusRecord>(task)) {
     swift_task_dealloc(record);
   }
 }


### PR DESCRIPTION
review [followup](https://github.com/swiftlang/swift/pull/80456), this is a more correct/strict assertion checking the exact situation we expect here.