### PR TITLE
[cxx-interop] Remove `-fno-rtti` workaround in tests

### DIFF
--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
@@ -1,8 +1,4 @@
-// With RTTI some of the objects with virtual bases / destructors in this test
-// will cause linker errors because of undefined vtables.
-// FIXME: Once we can link with libc++ we can start using RTTI.
-//
-// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir -Xcc -fno-rtti | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 import CustomDestructor
 

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 import CustomDestructor
 

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
@@ -1,9 +1,5 @@
-// With RTTI some of the objects with virtual bases / destructors in this test
-// will cause linker errors because of undefined vtables.
-// FIXME: Once we can link with libc++ we can start using RTTI.
-// 
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-rtti)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-rtti -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -O)
 //
 // REQUIRES: executable_test
 

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -O)
 //
 // REQUIRES: executable_test
 


### PR DESCRIPTION
`-Xcc -fno-rtti` flags were added to these tests back in 2020 when we could not properly link with the C++ stdlib.

This should hopefully speed up these tests, which are currently among the slowest tests in the project.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
