### PR TITLE
[test] Use release mode in `swift-xcodegen.test`

### DIFF
--- a/validation-test/BuildSystem/swift-xcodegen.test
+++ b/validation-test/BuildSystem/swift-xcodegen.test
@@ -21,8 +21,8 @@
 # RUN: ln -s %swift_src_root/../yams %t/src
 
 # Run the xcodegen test suite
-# RUN: xcrun swift-test --package-path %t/src/swift/utils/swift-xcodegen
+# RUN: xcrun swift-test -c release --disable-dependency-cache --package-path %t/src/swift/utils/swift-xcodegen
 
 # Then check to see that xcodegen can generate a project successfully
-# RUN: xcrun swift-run --package-path %t/src/swift/utils/swift-xcodegen swift-xcodegen --project-root-dir %swift_src_root/.. --output-dir %t/out %swift_obj_root/..
+# RUN: xcrun swift-run -c release --disable-dependency-cache --skip-build --package-path %t/src/swift/utils/swift-xcodegen swift-xcodegen --project-root-dir %swift_src_root/.. --output-dir %t/out %swift_obj_root/..
 # RUN: ls %t/out/Swift.xcodeproj > /dev/null


### PR DESCRIPTION
This takes about twice as long to build in CI, but xcodegen itself runs significantly quicker (~22x). The exact time taken varies quite a bit between runs, but this brings the worst-case overall run-time down from ~500s to ~200s. While here, make sure we pass `--skip-build` to the second invocation to ensure we avoid building twice. Also disable using the dependency cache since we want to test a clean build, and we just want swiftpm to use the local deps.