### PR TITLE
[6.2] Sema: Fix regression with 'Failure' type witness inference hack

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2496,7 +2496,11 @@ AssociatedTypeInference::computeFailureTypeWitness(
     if (!isAsyncIteratorProtocolNext(witness.first))
       continue;
 
-    if (!witness.second || witness.second->getDeclContext() != dc)
+    // Different extensions of the same nominal are OK, but if the witness is in
+    // a protocol extension or a superclass or something, give up.
+    if (!witness.second ||
+        witness.second->getDeclContext()->getSelfNominalTypeDecl()
+            != dc->getSelfNominalTypeDecl())
       continue;
 
     if (auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness.second)) {

--- a/test/AssociatedTypeInference/issue-79367.swift
+++ b/test/AssociatedTypeInference/issue-79367.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/79367
+
+// 'Failure' type witness inference should still take place when
+// the 'next()' witness is in a different extension than the
+// conformance.
+
+struct AsyncIteratorImpl<Element>: AsyncIteratorProtocol {}
+
+extension AsyncIteratorImpl {
+  func next() async throws -> Element? {
+    fatalError()
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/80511

* **Description:** Fixes a regression where a compatibility hack for `AsyncIteratorProtocol` stopped working if `next()` was declared in a different extension of the same nominal type.

* **Origination:** This regressed in 6.1 when I added the condition to prevent crashes in the case that the witness is in a protocol extension or superclass with a different generic signature. The condition was too narrow.

* **Radar:** rdar://problem/145341658.

* **Risk:** Low.

* **Reviewed by:** @DougGregor 