### PR TITLE
Tests: Use `#include` instead of `#import` for compatibility on Windows

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/availability-domains/Oceans.h
+++ b/test/ClangImporter/Inputs/custom-modules/availability-domains/Oceans.h
@@ -1,4 +1,4 @@
-#import <Rivers.h>
+#include <Rivers.h>
 #include <feature-availability.h>
 
 int arctic_pred(void);

--- a/test/ClangImporter/availability_custom_domains.swift
+++ b/test/ClangImporter/availability_custom_domains.swift
@@ -5,7 +5,6 @@
 // RUN:   %s %S/Inputs/availability_custom_domains_other.swift
 
 // REQUIRES: swift_feature_CustomAvailability
-// UNSUPPORTED: OS=windows-msvc
 
 // https://github.com/swiftlang/swift/issues/80058
 // UNSUPPORTED: OS=linux-android


### PR DESCRIPTION
The `#import` directive is not supported by Clang in MSVC compatibility mode, so use `#include` instead for compatibility in the ClangImporter tests for custom availability domains.

Resolves rdar://147122406.