### PR TITLE
[cxx-interop] Switch to non-experimental flag in tests

### DIFF
--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -50,7 +50,7 @@ if get_target_os() in ['linux-gnu']:
 
 # Enable C++ interop when compiling Swift sources.
 config.substitutions.insert(0, ('%target-interop-build-swift',
-                                '%target-build-swift -Xfrontend -enable-experimental-cxx-interop '))
+                                '%target-build-swift -cxx-interoperability-mode=default '))
 
 # Build C files disallowing implicit functions and with matching link settings, if required by the target.
 config.substitutions.insert(0, ('%target-interop-build-clang',  '%target-clang -x c -Werror=implicit-function-declaration ' + clang_opt))


### PR DESCRIPTION
This gets rid of the flag deprecation warning that was printed for `enable-experimental-cxx-interop`.

Inspired by a comment from @j-hui: https://github.com/swiftlang/swift/pull/80531#pullrequestreview-2743393643