### PR TITLE
[6.1][Test] Disable flakey cursor info cancellation

### DIFF
--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -412,7 +412,9 @@ TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
     llvm::report_fatal_error("Did not receive a response for the first request");
 }
 
-TEST_F(CursorInfoTest, CursorInfoCancellation) {
+TEST_F(CursorInfoTest, DISABLED_CursorInfoCancellation) {
+  // Disabled due to a race condition (rdar://88652757)
+
   // TODO: This test case relies on the following snippet being slow to type
   // check so that the first cursor info request takes longer to execute than it
   // takes time to schedule the second request. If that is fixed, we need to


### PR DESCRIPTION
  - **Explanation**: Disables a flakey test
  - **Scope**: Tests
  - **Issues**: rdar://147871813
  - **Original PRs**: https://github.com/swiftlang/swift/pull/80029
  - **Risk**: None