### PR TITLE
[Mangler] Avoid mangling local discriminator for attached macros

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -453,7 +453,8 @@ protected:
                   const ValueDecl *forDecl = nullptr);
   
   void appendDeclName(
-      const ValueDecl *decl, DeclBaseName name = DeclBaseName());
+      const ValueDecl *decl, DeclBaseName name = DeclBaseName(),
+      bool skipLocalDiscriminator = false);
 
   GenericTypeParamType *appendAssocType(DependentMemberType *DepTy,
                                         GenericSignature sig,


### PR DESCRIPTION
If we're using the macro-specific local discriminator, we need to make sure we avoid mangling the regular local discriminator in `appendDeclName`, since that could prematurely kick local discriminator assignment before type-checking has finished.

rdar://143834482