### PR TITLE
Serialization: Bring back shadowing but only after the filtering

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2766,6 +2766,12 @@ giveUpFastPath:
   if (M)
     return diagnoseFatal();
 
+  if (values.size() > 1) {
+    // Apply shadowing filtering after other local filters so we don't rule out
+    // valid candidates shadowed by invalid ones.
+    removeShadowedDecls(values, baseModule);
+  }
+
   // When all is said and done, we should have a single value here to return.
   if (values.size() != 1) {
     return llvm::make_error<XRefError>("result is ambiguous", pathTrace,

--- a/test/Serialization/shadowed-class-vs-protocol.swift
+++ b/test/Serialization/shadowed-class-vs-protocol.swift
@@ -1,0 +1,50 @@
+/// Ensure cross references to shadowed decls take into account the shadowing
+/// after the custom deserialization filtering.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// REQUIRES: objc_interop
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %t/SwiftLib.swift -I %t -emit-module-path %t/SwiftLib.swiftmodule
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   -typecheck %t/Client.swift -I %t
+
+//--- module.modulemap
+module RootLib {
+  header "RootLib.h"
+}
+
+module MiddleLib {
+  header "MiddleLib.h"
+  export *
+}
+
+//--- RootLib.h
+__attribute__((swift_name("ShadowedProtocol")))
+@protocol Shadowed
+@end
+
+//--- MiddleLib.h
+@import Foundation;
+#include "RootLib.h"
+
+@interface Shadowed: NSObject <Shadowed>
+@end
+
+//--- SwiftLib.swift
+import MiddleLib
+
+public func funcRef() -> Shadowed { fatalError() }
+
+extension Shadowed {
+    public func method() -> Shadowed { fatalError() }
+}
+
+//--- Client.swift
+import SwiftLib
+
+@inlinable
+public func bar() {
+    let _ = funcRef().method()
+}


### PR DESCRIPTION
Followup fix to #80009. We can still get ambiguities from colliding decls across modules with the deserialization filtering. Bring back calling the general lookup shadowing after the filtering. This way it won't use filtered out decls to hide potential candidates.

rdar://148286345