### PR TITLE
Use -z,nobtcfi when BTCFI is disabled on OpenBSD.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -965,6 +965,11 @@ function(add_swift_host_tool executable)
     endif()
   endif()
 
+  # Opt-out of OpenBSD BTCFI if instructed where it is enforced by default.
+  if(SWIFT_HOST_VARIANT_SDK STREQUAL "OPENBSD" AND SWIFT_HOST_VARIANT_ARCH STREQUAL "aarch64" AND NOT SWIFT_OPENBSD_BTCFI)
+    target_link_options(${executable} PRIVATE "LINKER:-z,nobtcfi")
+  endif()
+
   if(SWIFT_BUILD_SWIFT_SYNTAX)
     set(extra_relative_rpath "")
     if(NOT "${ASHT_BOOTSTRAPPING}" STREQUAL "")


### PR DESCRIPTION
This was accidentally left off from #80389, and will properly ensure BTCFI enforcement is disabled on the platform when required.

(unfortunately, I should pick this onto `release/6.2` once approved as well.)