### PR TITLE
6.2: [CoroutineAccessors] Use async bit in descriptors.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -374,8 +374,6 @@ public:
     Setter,
     ModifyCoroutine,
     ReadCoroutine,
-    Read2Coroutine,
-    Modify2Coroutine,
   };
 
 private:
@@ -438,21 +436,25 @@ public:
   /// Note that 'init' is not considered an instance member.
   bool isInstance() const { return Value & IsInstanceMask; }
 
-  bool isAsync() const { return Value & IsAsyncMask; }
+  bool _hasAsyncBitSet() const { return Value & IsAsyncMask; }
 
-  bool isCalleeAllocatedCoroutine() const {
+  bool isAsync() const { return !isCoroutine() && _hasAsyncBitSet(); }
+
+  bool isCoroutine() const {
     switch (getKind()) {
     case Kind::Method:
     case Kind::Init:
     case Kind::Getter:
     case Kind::Setter:
+      return false;
     case Kind::ModifyCoroutine:
     case Kind::ReadCoroutine:
-      return false;
-    case Kind::Read2Coroutine:
-    case Kind::Modify2Coroutine:
       return true;
     }
+  }
+
+  bool isCalleeAllocatedCoroutine() const {
+    return isCoroutine() && _hasAsyncBitSet();
   }
 
   bool isData() const { return isAsync() || isCalleeAllocatedCoroutine(); }
@@ -615,8 +617,6 @@ public:
     ModifyCoroutine,
     AssociatedTypeAccessFunction,
     AssociatedConformanceAccessFunction,
-    Read2Coroutine,
-    Modify2Coroutine,
   };
 
 private:
@@ -666,24 +666,28 @@ public:
   /// Note that 'init' is not considered an instance member.
   bool isInstance() const { return Value & IsInstanceMask; }
 
-  bool isAsync() const { return Value & IsAsyncMask; }
+  bool _hasAsyncBitSet() const { return Value & IsAsyncMask; }
 
-  bool isCalleeAllocatedCoroutine() const {
+  bool isAsync() const { return !isCoroutine() && _hasAsyncBitSet(); }
+
+  bool isCoroutine() const {
     switch (getKind()) {
     case Kind::BaseProtocol:
     case Kind::Method:
     case Kind::Init:
     case Kind::Getter:
     case Kind::Setter:
-    case Kind::ReadCoroutine:
-    case Kind::ModifyCoroutine:
     case Kind::AssociatedTypeAccessFunction:
     case Kind::AssociatedConformanceAccessFunction:
       return false;
-    case Kind::Read2Coroutine:
-    case Kind::Modify2Coroutine:
+    case Kind::ReadCoroutine:
+    case Kind::ModifyCoroutine:
       return true;
     }
+  }
+
+  bool isCalleeAllocatedCoroutine() const {
+    return isCoroutine() && _hasAsyncBitSet();
   }
 
   bool isData() const { return isAsync() || isCalleeAllocatedCoroutine(); }

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -6162,9 +6162,7 @@ static void initProtocolWitness(void **slot, void *witness,
   case ProtocolRequirementFlags::Kind::Getter:
   case ProtocolRequirementFlags::Kind::Setter:
   case ProtocolRequirementFlags::Kind::ReadCoroutine:
-  case ProtocolRequirementFlags::Kind::Read2Coroutine:
   case ProtocolRequirementFlags::Kind::ModifyCoroutine:
-  case ProtocolRequirementFlags::Kind::Modify2Coroutine:
     swift_ptrauth_init_code_or_data(slot, witness,
                                     reqt.Flags.getExtraDiscriminator(),
                                     !reqt.Flags.isData());
@@ -6205,9 +6203,7 @@ static void copyProtocolWitness(void **dest, void * const *src,
   case ProtocolRequirementFlags::Kind::Getter:
   case ProtocolRequirementFlags::Kind::Setter:
   case ProtocolRequirementFlags::Kind::ReadCoroutine:
-  case ProtocolRequirementFlags::Kind::Read2Coroutine:
   case ProtocolRequirementFlags::Kind::ModifyCoroutine:
-  case ProtocolRequirementFlags::Kind::Modify2Coroutine:
     swift_ptrauth_copy_code_or_data(
         dest, src, reqt.Flags.getExtraDiscriminator(), !reqt.Flags.isData(),
         /*allowNull*/ true); // NULL allowed for VFE (methods in the vtable


### PR DESCRIPTION
**Explanation**: Enable back deployment of coroutine accessors on platforms with ptrauth (without requiring a back deployment library).

Method descriptors and protocol requirement descriptors specify characteristics of class and protocol members.  They are used at runtime to instantiate class vtables and protocol wtables.  On platforms with ptrauth, their flags specify whether the members should be copied into vtable/wtable as code or data.  In the case of protocols, how this copying should be done is determined by a switch over the kind.  Already deployed runtimes can't know about new kinds.

Previously, new kinds had been added for the new accessor kinds.  In order for back-deploying binaries--i.e. those built to be run in contexts featuring already deployed runtimes--to use new kinds, they would need a back deployment runtime.  Otherwise, that already deployed runtime's implementation of copying witness implementations in vtables which relies on a switch over the kind would fall through the switch and hit a fatal error.

Here, instead of adding a back deployment library, those new kinds are removed.  Because these new coroutines are referred to via "coroutine function pointers" (much like how async functions are referred to via async function pointers) which are global structs containing a relative pointer to the function and a frame size, they use data ptrauth key (asda) rather than the code key (asia).  Runtimes already deployed and forthcoming all use this key to sign async function pointers: in particular, they check whether the MethodDescriptorFlags/ProtocolDescriptorFlags have the async bit set.  

Cause all runtimes to use the appropriate key for coroutine function pointers by reusing the old preexisting (i.e. "old ABI") coroutine accesor kinds on the flags and setting the async bit.  This also eliminates the problem of falling through the switch on already deployed runtimes because no new kinds are added.

Doing this doesn't collide with any other meaning of the flags because the combination of Kind=Read/Modify and IsAsync=true is not used on any deployed or forthcoming runtimes.  Here, that combination is reserved to indicate "new ABI read/modify coroutine accessor".  If in the future async read/modify accessors were to be added to the language, they would use the new ABI and consequently _still_ not use the Kind=Read/Modify and IsAsync=true pairing, even if the old kinds were kept on the flags.  So if such a feature were to be added in the future, either (1) a back deployment library containing new kinds might at that point need to be added (worst case) or (2) it might again be sufficient to use this pairing (Kind=Read/Modify and IsAsync=true) to indicate that the member is referenced via data rather than code (best case).
**Scope**: Affects the experimental CoroutineAccessors feature.
**Issue**: rdar://148628149
**Original PR**: https://github.com/swiftlang/swift/pull/80520
**Risk**: Low, removes newly-added cases from the runtime, only affects the coroutine accessors feature.
**Testing**: CI.
**Reviewer**: Arnold Schwaighofer ( @aschwaighofer )
