### PR TITLE
[SIL] Fix bridged begin_apply results.

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1532,14 +1532,15 @@ final public class EndUnpairedAccessInst : Instruction {}
 
 final public class BeginApplyInst : MultipleValueInstruction, FullApplySite {
   public var numArguments: Int { bridged.BeginApplyInst_numArguments() }
+  public var isCalleeAllocated: Bool { bridged.BeginApplyInst_isCalleeAllocated() }
 
   public var singleDirectResult: Value? { nil }
   public var singleDirectErrorResult: Value? { nil }
 
-  public var token: Value { getResult(index: resultCount - 1) }
+  public var token: Value { getResult(index: resultCount - (isCalleeAllocated ? 2 : 1)) }
 
   public var yieldedValues: Results {
-    Results(inst: self, numResults: resultCount - 1)
+    Results(inst: self, numResults: resultCount - (isCalleeAllocated ? 2 : 1))
   }
 }
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -779,6 +779,7 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSILTypeArray AllocRefInstBase_getTailAllocatedTypes() const;
   BRIDGED_INLINE bool AllocRefDynamicInst_isDynamicTypeDeinitAndSizeKnownEquivalentToBaseType() const;
   BRIDGED_INLINE SwiftInt BeginApplyInst_numArguments() const;
+  BRIDGED_INLINE bool BeginApplyInst_isCalleeAllocated() const;
   BRIDGED_INLINE SwiftInt TryApplyInst_numArguments() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock BranchInst_getTargetBlock() const;
   BRIDGED_INLINE SwiftInt SwitchEnumInst_getNumCases() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1333,6 +1333,10 @@ SwiftInt BridgedInstruction::BeginApplyInst_numArguments() const {
   return getAs<swift::BeginApplyInst>()->getNumArguments();
 }
 
+bool BridgedInstruction::BeginApplyInst_isCalleeAllocated() const {
+  return getAs<swift::BeginApplyInst>()->isCalleeAllocated();
+}
+
 SwiftInt BridgedInstruction::TryApplyInst_numArguments() const {
   return getAs<swift::TryApplyInst>()->getNumArguments();
 }

--- a/test/SILOptimizer/copy-to-borrow-optimization.sil
+++ b/test/SILOptimizer/copy-to-borrow-optimization.sil
@@ -87,6 +87,7 @@ sil @use_inguaranteed : $@convention(thin) (@in_guaranteed Klass) -> ()
 sil @guaranteed_fakeoptional_klass_user : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
 sil @guaranteed_fakeoptional_classlet_user : $@convention(thin) (@guaranteed FakeOptional<ClassLet>) -> ()
 sil @closure : $@convention(thin) (@inout_aliasable Klass) -> ()
+sil @lendC : $@yield_once_2 @convention(thin) () -> @yields @guaranteed C
 sil @useC : $@convention(thin) (@guaranteed C) -> () {
 [global:]
 }
@@ -2201,4 +2202,21 @@ bb2:
 bb3:
   %r = tuple ()
   return %r
+}
+
+
+// CHECK-LABEL: sil [ossa] @keep_yield2ed_copy : {{.*}} {
+// CHECK:         copy_value
+// CHECK:       } // end sil function 'keep_yield2ed_copy'
+sil [ossa] @keep_yield2ed_copy : $@convention(thin) () -> () {
+  %lendC = function_ref @lendC : $@yield_once_2 @convention(thin) () -> @yields @guaranteed C
+  (%c, %token, %alloc) = begin_apply %lendC()  : $@yield_once_2 @convention(thin) () -> @yields @guaranteed C
+  %copy = copy_value %c : $C
+  end_apply %token as $()
+  dealloc_stack %alloc : $*Builtin.SILToken
+  %useC = function_ref @useC : $@convention(thin) (@guaranteed C) -> ()
+  apply %useC(%copy) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %copy : $C
+  %retval = tuple ()
+  return %retval : $()
 }


### PR DESCRIPTION
The `yield_once_2` adds an extra result at the end, the allocation. Fix the indexing for the token and yielded results.
