### PR TITLE
[NFC] Convert SwiftDeclSynthesizer methods into free functions

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4643,12 +4643,12 @@ void ClangImporter::getMangledName(raw_ostream &os,
   if (!Impl.Mangler)
     Impl.Mangler.reset(getClangASTContext().createMangleContext());
 
-  return Impl.getMangledName(Impl.Mangler.get(), clangDecl, os);
+  return importer::getMangledName(Impl.Mangler.get(), clangDecl, os);
 }
 
-void ClangImporter::Implementation::getMangledName(
-    clang::MangleContext *mangler, const clang::NamedDecl *clangDecl,
-    raw_ostream &os) {
+void importer::getMangledName(clang::MangleContext *mangler,
+                              const clang::NamedDecl *clangDecl,
+                              raw_ostream &os) {
   if (auto ctor = dyn_cast<clang::CXXConstructorDecl>(clangDecl)) {
     auto ctorGlobalDecl =
         clang::GlobalDecl(ctor, clang::CXXCtorType::Ctor_Complete);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5563,18 +5563,17 @@ const clang::CXXMethodDecl *getCalledBaseCxxMethod(FuncDecl *baseMember) {
 
 // Construct a Swift method that represents the synthesized C++ method
 // that invokes the base C++ method.
-FuncDecl *synthesizeBaseFunctionDeclCall(ClangImporter &impl, ASTContext &ctx,
-                                         NominalTypeDecl *derivedStruct,
-                                         NominalTypeDecl *baseStruct,
-                                         FuncDecl *baseMember) {
+static FuncDecl *synthesizeBaseFunctionDeclCall(ASTContext &ctx,
+                                                NominalTypeDecl *derivedStruct,
+                                                NominalTypeDecl *baseStruct,
+                                                FuncDecl *baseMember) {
   auto *cxxMethod = getCalledBaseCxxMethod(baseMember);
   if (!cxxMethod)
     return nullptr;
-  auto *newClangMethod =
-      SwiftDeclSynthesizer(&impl).synthesizeCXXForwardingMethod(
-          cast<clang::CXXRecordDecl>(derivedStruct->getClangDecl()),
-          cast<clang::CXXRecordDecl>(baseStruct->getClangDecl()), cxxMethod,
-          ForwardingMethodKind::Base);
+  auto *newClangMethod = SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
+      ctx, cast<clang::CXXRecordDecl>(derivedStruct->getClangDecl()),
+      cast<clang::CXXRecordDecl>(baseStruct->getClangDecl()), cxxMethod,
+      ForwardingMethodKind::Base);
   if (!newClangMethod)
     return nullptr;
   return cast_or_null<FuncDecl>(
@@ -5597,9 +5596,8 @@ synthesizeBaseClassMethodBody(AbstractFunctionDecl *afd, void *context) {
   auto baseStruct =
       cast<NominalTypeDecl>(baseMember->getDeclContext()->getAsDecl());
 
-  auto forwardedFunc = synthesizeBaseFunctionDeclCall(
-      *static_cast<ClangImporter *>(ctx.getClangModuleLoader()), ctx,
-      derivedStruct, baseStruct, baseMember);
+  auto forwardedFunc = synthesizeBaseFunctionDeclCall(ctx, derivedStruct,
+                                                      baseStruct, baseMember);
   if (!forwardedFunc) {
     ctx.Diags.diagnose(SourceLoc(), diag::failed_base_method_call_synthesis,
                          funcDecl, baseStruct);
@@ -5833,22 +5831,19 @@ synthesizeBaseClassFieldGetterOrAddressGetterBody(AbstractFunctionDecl *afd,
   if (auto *md = dyn_cast_or_null<clang::CXXMethodDecl>(baseClangDecl)) {
     // Subscript operator, or `.pointee` wrapper is represented through a
     // generated C++ method call that calls the base operator.
-    baseGetterCxxMethod =
-        SwiftDeclSynthesizer(
-            static_cast<ClangImporter *>(ctx.getClangModuleLoader()))
-            .synthesizeCXXForwardingMethod(
-                cast<clang::CXXRecordDecl>(derivedStruct->getClangDecl()),
-                cast<clang::CXXRecordDecl>(baseStruct->getClangDecl()), md,
-                ForwardingMethodKind::Base,
-                getterDecl->getResultInterfaceType()->isForeignReferenceType()
-                    ? ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                          RemoveReferenceIfPointer
-                    : (kind != AccessorKind::Get
-                           ? ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                                 KeepReference
-                           : ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                                 RemoveReference),
-                /*forceConstQualifier=*/kind != AccessorKind::MutableAddress);
+    baseGetterCxxMethod = SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
+        ctx, cast<clang::CXXRecordDecl>(derivedStruct->getClangDecl()),
+        cast<clang::CXXRecordDecl>(baseStruct->getClangDecl()), md,
+        ForwardingMethodKind::Base,
+        getterDecl->getResultInterfaceType()->isForeignReferenceType()
+            ? ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                  RemoveReferenceIfPointer
+            : (kind != AccessorKind::Get
+                   ? ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                         KeepReference
+                   : ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                         RemoveReference),
+        /*forceConstQualifier=*/kind != AccessorKind::MutableAddress);
   } else if (auto *fd = dyn_cast_or_null<clang::FieldDecl>(baseClangDecl)) {
     ValueDecl *retainOperationFn = nullptr;
     // Check if this field getter is returning a retainable FRT.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -136,10 +136,9 @@ createFuncOrAccessor(ClangImporter::Implementation &impl, SourceLoc funcLoc,
   return decl;
 }
 
-void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
-                                                 AccessorDecl *getter,
-                                                 AccessorDecl *setter) {
-  assert(getter);
+void importer::makeComputed(AbstractStorageDecl *storage, AccessorDecl *getter,
+                            AccessorDecl *setter) {
+  assert(getter && "computed property must have non-null getter");
   // The synthesized computed property can either use a `get` or an
   // `unsafeAddress` accessor.
   auto isAddress = getter->getAccessorKind() == AccessorKind::Address;
@@ -656,7 +655,7 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
   getterDecl->setIsTransparent(false);
 
   swiftDecl->addMember(errorDomainPropertyDecl);
-  importer.makeComputed(errorDomainPropertyDecl, getterDecl, nullptr);
+  importer::makeComputed(errorDomainPropertyDecl, getterDecl, nullptr);
 
   getterDecl->setImplicit();
   getterDecl->setAccess(AccessLevel::Public);
@@ -4916,7 +4915,7 @@ namespace {
 
       // FIXME: Fake locations for '{' and '}'?
       propDecl->setIsSetterMutating(false);
-      Impl.makeComputed(propDecl, getter, /*setter=*/nullptr);
+      importer::makeComputed(propDecl, getter, /*setter=*/nullptr);
       addObjCAttribute(propDecl, Impl.importIdentifier(decl->getIdentifier()));
       applyPropertyOwnership(propDecl, inferredObjCPropertyAttrs);
 
@@ -6071,7 +6070,7 @@ namespace {
       // Turn this into a computed property.
       // FIXME: Fake locations for '{' and '}'?
       result->setIsSetterMutating(false);
-      Impl.makeComputed(result, getter, setter);
+      importer::makeComputed(result, getter, setter);
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
       applyPropertyOwnership(result, decl->getPropertyAttributesAsWritten());
 
@@ -7097,7 +7096,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   if (swiftSetter) property->setIsSetterMutating(swiftSetter->isMutating());
 
   // Make this a computed property.
-  Impl.makeComputed(property, swiftGetter, swiftSetter);
+  importer::makeComputed(property, swiftGetter, swiftSetter);
 
   // Make the property the alternate declaration for the getter.
   Impl.addAlternateDecl(swiftGetter, property);
@@ -7849,7 +7848,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
     Impl.importAttributes(setterObjCMethod, setterThunk);
 
   subscript->setIsSetterMutating(false);
-  Impl.makeComputed(subscript, getterThunk, setterThunk);
+  importer::makeComputed(subscript, getterThunk, setterThunk);
 
   Impl.recordImplicitUnwrapForDecl(subscript, isIUO);
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2617,8 +2617,8 @@ namespace {
             continue;
 
           auto getterAndSetter = subscriptInfo.second;
-          auto subscript = synthesizer.makeSubscript(getterAndSetter.first,
-                                                     getterAndSetter.second);
+          auto subscript = SwiftDeclSynthesizer::makeSubscript(
+              getterAndSetter.first, getterAndSetter.second);
           // Also add subscripts directly because they won't be found from the
           // clang decl.
           result->addMember(subscript);
@@ -7800,7 +7800,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
       if (existingSubscript->hasClangNode() &&
           !existingSubscript->supportsMutation()) {
         // Create the setter thunk.
-        auto setterThunk = synthesizer.buildSubscriptSetterDecl(
+        auto setterThunk = SwiftDeclSynthesizer::buildSubscriptSetterDecl(
             existingSubscript, setter, elementTy, setter->getDeclContext(),
             setterIndex);
 
@@ -7850,12 +7850,12 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   subscript->setSetterAccess(access);
 
   // Build the thunks.
-  AccessorDecl *getterThunk = synthesizer.buildSubscriptGetterDecl(
+  AccessorDecl *getterThunk = SwiftDeclSynthesizer::buildSubscriptGetterDecl(
       subscript, getter, elementTy, dc, getterIndex);
 
   AccessorDecl *setterThunk = nullptr;
   if (setter)
-    setterThunk = synthesizer.buildSubscriptSetterDecl(
+    setterThunk = SwiftDeclSynthesizer::buildSubscriptSetterDecl(
         subscript, setter, elementTy, dc, setterIndex);
 
   // Record the subscript as an alternative declaration.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3697,7 +3697,8 @@ namespace {
         if (func->getParameters()->size() == 0 && !isa<ClassDecl>(typeDecl)) {
           // This is a pre-increment operator. We synthesize a
           // non-mutating function called `successor() -> Self`.
-          FuncDecl *successorFunc = synthesizer.makeSuccessorFunc(func);
+          FuncDecl *successorFunc =
+              SwiftDeclSynthesizer::makeSuccessorFunc(func);
 
           // Import the clang decl attributes to synthesized successor function.
           Impl.importAttributesFromClangDeclToSynthesizedSwiftDecl(func, successorFunc);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1738,10 +1738,10 @@ namespace {
           // Create the _nsError initializer.
           //   public init(_nsError error: NSError)
           VarDecl *members[1] = {nsErrorProp};
-          auto nsErrorInit =
-              synthesizer.createValueConstructor(errorWrapper, members,
-                                                 /*wantCtorParamNames=*/true,
-                                                 /*wantBody=*/true);
+          auto nsErrorInit = SwiftDeclSynthesizer::createValueConstructor(
+              errorWrapper, members,
+              /*wantCtorParamNames=*/true,
+              /*wantBody=*/true);
           errorWrapper->addMember(nsErrorInit);
 
           // Add the domain error member.
@@ -2415,10 +2415,10 @@ namespace {
 
           // Create labeled initializers for unions that take one of the
           // fields, which only initializes the data for that field.
-          auto valueCtor =
-              synthesizer.createValueConstructor(result, member,
-                                                 /*want param names*/ true,
-                                                 /*wantBody=*/true);
+          auto valueCtor = SwiftDeclSynthesizer::createValueConstructor(
+              result, member,
+              /*want param names*/ true,
+              /*wantBody=*/true);
 
           if (isNonEscapable)
             markReturnsUnsafeNonescapable(valueCtor);
@@ -2462,7 +2462,7 @@ namespace {
         //    interop and might rely on the fact that C structs have a default
         //    constructor available in Swift.
         ConstructorDecl *defaultCtor =
-            synthesizer.createDefaultConstructor(result);
+            SwiftDeclSynthesizer::createDefaultConstructor(result);
         if (cxxRecordDecl) {
           auto attr = AvailableAttr::createUniversallyDeprecated(
               defaultCtor->getASTContext(),
@@ -2495,7 +2495,7 @@ namespace {
         //
         // If we can completely represent the struct in SIL, leave the body
         // implicit, otherwise synthesize one to call property setters.
-        auto valueCtor = synthesizer.createValueConstructor(
+        auto valueCtor = SwiftDeclSynthesizer::createValueConstructor(
             result, members,
             /*want param names*/ true,
             /*want body*/ hasUnreferenceableStorage);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2604,8 +2604,8 @@ namespace {
                   cxxMethodBridging.importNameAsCamelCaseName()))
             continue;
 
-          auto p =
-              synthesizer.makeComputedPropertyFromCXXMethods(getter, setter);
+          auto p = SwiftDeclSynthesizer::makeComputedPropertyFromCXXMethods(
+              getter, setter);
           // Add computed properties directly because they won't be found from
           // the clang decl during lazy member lookup.
           result->addMember(p);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2534,9 +2534,9 @@ namespace {
                              });
                 });
             if (!hasUserProvidedStaticFactory) {
-              if (auto generatedCxxMethodDecl =
-                      synthesizer.synthesizeStaticFactoryForCXXForeignRef(
-                          cxxRecordDecl)) {
+              if (auto generatedCxxMethodDecl = SwiftDeclSynthesizer::
+                      synthesizeStaticFactoryForCXXForeignRef(
+                          Impl.getClangSema(), cxxRecordDecl)) {
                 if (Decl *importedInitDecl =
                         Impl.SwiftContext.getClangModuleLoader()
                             ->importDeclDirectly(generatedCxxMethodDecl))

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3717,7 +3717,8 @@ namespace {
       // call / subscript / dereference / increment. Those
       // operators do not need static versions.
       if (cxxOperatorKind != clang::OverloadedOperatorKind::OO_Call) {
-        auto opFuncDecl = synthesizer.makeOperator(func, cxxOperatorKind);
+        auto opFuncDecl =
+            SwiftDeclSynthesizer::makeOperator(func, cxxOperatorKind);
         Impl.addAlternateDecl(func, opFuncDecl);
 
         Impl.markUnavailable(

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2636,7 +2636,7 @@ namespace {
           auto getterAndSetter = getterAndSetterIt->second;
 
           VarDecl *pointeeProperty =
-              synthesizer.makeDereferencedPointeeProperty(
+              SwiftDeclSynthesizer::makeDereferencedPointeeProperty(
                   getterAndSetter.first, getterAndSetter.second);
 
           // Import the attributes from clang decl of dereference operator to

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2393,7 +2393,7 @@ namespace {
             hasUnreferenceableStorage = true;
             isBitField = true;
 
-            synthesizer.makeBitFieldAccessors(
+            SwiftDeclSynthesizer::makeBitFieldAccessors(
                 const_cast<clang::RecordDecl *>(decl), result,
                 const_cast<clang::FieldDecl *>(field), member);
           }
@@ -2402,13 +2402,14 @@ namespace {
         if (auto ind = dyn_cast<clang::IndirectFieldDecl>(nd)) {
           // Indirect fields are created as computed property accessible the
           // fields on the anonymous field from which they are injected.
-          synthesizer.makeIndirectFieldAccessors(ind, members, result, member);
+          SwiftDeclSynthesizer::makeIndirectFieldAccessors(ind, members, result,
+                                                           member);
         } else if (decl->isUnion() && !isBitField) {
           // Union fields should only be available indirectly via a computed
           // property. Since the union is made of all of the fields at once,
           // this is a trivial accessor that casts self to the correct
           // field type.
-          synthesizer.makeUnionFieldAccessors(result, member);
+          SwiftDeclSynthesizer::makeUnionFieldAccessors(result, member);
 
           // Union accessors are always unsafe.
           member->getAttrs().add(new (Impl.SwiftContext) UnsafeAttr(/*Implicit=*/true));

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -28,6 +28,7 @@
 #include "swift/AST/DiagnosticsClangImporter.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/LifetimeDependence.h"
@@ -4339,8 +4340,9 @@ namespace {
               clang::OverloadedOperatorKind::OO_Call &&
           decl->isStatic()) {
         auto *clangDC = decl->getParent();
-        auto newMethod = synthesizer.synthesizeCXXForwardingMethod(
-            clangDC, clangDC, decl, ForwardingMethodKind::Base,
+        auto newMethod = SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
+            Impl.SwiftContext, clangDC, clangDC, decl,
+            ForwardingMethodKind::Base,
             ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
             /*forceConstQualifier*/ true);
 
@@ -4391,11 +4393,13 @@ namespace {
                    "C++ virtual functions cannot be static");
             auto clangDC = decl->getParent();
 
-            auto newMethod = synthesizer.synthesizeCXXForwardingMethod(
-                clangDC, clangDC, decl, ForwardingMethodKind::Virtual,
-                ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                    KeepReference,
-                /*forceConstQualifier*/ false);
+            auto newMethod =
+                SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
+                    Impl.SwiftContext, clangDC, clangDC, decl,
+                    ForwardingMethodKind::Virtual,
+                    ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                        KeepReference,
+                    /*forceConstQualifier*/ false);
 
             auto *result = dyn_cast_or_null<FuncDecl>(
                 Impl.importDecl(newMethod, Impl.CurrentVersion));

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1813,7 +1813,7 @@ namespace {
             C, StaticSpellingKind::None, varPattern, /*InitExpr*/ nullptr,
             enumDecl);
 
-        synthesizer.makeEnumRawValueGetter(enumDecl, rawValue);
+        SwiftDeclSynthesizer::makeEnumRawValueGetter(enumDecl, rawValue);
 
         enumDecl->addMember(rawValueConstructor);
         enumDecl->addMember(rawValue);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1794,7 +1794,7 @@ namespace {
         // C enum without additional knowledge that the type has no
         // undeclared values, and won't ever add cases.
         auto rawValueConstructor =
-            synthesizer.makeEnumRawValueConstructor(enumDecl);
+            SwiftDeclSynthesizer::makeEnumRawValueConstructor(enumDecl);
 
         auto varName = C.Id_rawValue;
         auto rawValue = new (C) VarDecl(/*IsStatic*/false,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3338,7 +3338,7 @@ namespace {
 
         // Create the global constant.
         bool isStatic = dc->isTypeContext();
-        auto result = synthesizer.createConstant(
+        auto result = Impl.createConstant(
             name, dc, type, clang::APValue(decl->getInitVal()),
             enumKind == EnumKind::Unknown ? ConstantConvertKind::Construction
                                           : ConstantConvertKind::None,
@@ -6715,7 +6715,7 @@ SwiftDeclConverter::importOptionConstant(const clang::EnumConstantDecl *decl,
   auto convertKind = ConstantConvertKind::Construction;
   if (isa<EnumDecl>(theStruct))
     convertKind = ConstantConvertKind::ConstructionWithUnwrap;
-  Decl *CD = synthesizer.createConstant(
+  Decl *CD = Impl.createConstant(
       name, theStruct, theStruct->getDeclaredInterfaceType(),
       clang::APValue(decl->getInitVal()), convertKind, /*isStatic*/ true, decl,
       importer::convertClangAccess(clangEnum->getAccess()));
@@ -6782,7 +6782,7 @@ Decl *SwiftDeclConverter::importEnumCaseAlias(
     result->setType(original->getInterfaceType());
   }
 
-  Decl *CD = synthesizer.createConstant(
+  Decl *CD = Impl.createConstant(
       name, importIntoDC, importedEnumTy, result, ConstantConvertKind::None,
       /*isStatic*/ true, alias,
       importer::convertClangAccess(clangEnum->getAccess()));

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1643,11 +1643,11 @@ namespace {
         options -= MakeStructRawValuedFlags::IsLet;
         options -= MakeStructRawValuedFlags::IsImplicit;
 
-        synthesizer.makeStructRawValued(structDecl, underlyingType,
-                                        {KnownProtocolKind::RawRepresentable,
-                                         KnownProtocolKind::Equatable,
-                                         KnownProtocolKind::Hashable},
-                                        options, /*setterAccess=*/access);
+        Impl.makeStructRawValued(structDecl, underlyingType,
+                                 {KnownProtocolKind::RawRepresentable,
+                                  KnownProtocolKind::Equatable,
+                                  KnownProtocolKind::Hashable},
+                                 options, /*setterAccess=*/access);
 
         result = structDecl;
         break;
@@ -6622,12 +6622,12 @@ SwiftDeclConverter::importSwiftNewtype(const clang::TypedefNameDecl *decl,
     if (unlabeledCtor)
       options |= MakeStructRawValuedFlags::MakeUnlabeledValueInit;
 
-    synthesizer.makeStructRawValued(structDecl, storedUnderlyingType,
-                                    synthesizedProtocols, options);
+    Impl.makeStructRawValued(structDecl, storedUnderlyingType,
+                             synthesizedProtocols, options);
   } else {
     // We need to make a stored rawValue or storage type, and a
     // computed one of bridged type.
-    synthesizer.makeStructRawValuedWithBridge(
+    Impl.makeStructRawValuedWithBridge(
         structDecl, storedUnderlyingType, computedPropertyUnderlyingType,
         synthesizedProtocols,
         /*makeUnlabeledValueInit=*/unlabeledCtor);
@@ -6811,8 +6811,8 @@ SwiftDeclConverter::importAsOptionSetType(DeclContext *dc, Identifier name,
   if (!underlyingType)
     return nullptr;
 
-  synthesizer.makeStructRawValued(structDecl, underlyingType,
-                                  {KnownProtocolKind::OptionSet});
+  Impl.makeStructRawValued(structDecl, underlyingType,
+                           {KnownProtocolKind::OptionSet});
   auto selfType = structDecl->getDeclaredInterfaceType();
   Impl.addSynthesizedTypealias(structDecl, ctx.Id_Element, selfType);
   Impl.addSynthesizedTypealias(structDecl, ctx.Id_ArrayLiteralElement,

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -75,9 +75,8 @@ createMacroConstant(ClangImporter::Implementation &Impl,
                     bool isStatic,
                     ClangNode ClangN) {
   Impl.ImportedMacroConstants[macro] = {value, type};
-  return SwiftDeclSynthesizer(Impl).createConstant(name, dc, type, value,
-                                                   convertKind, isStatic,
-                                                   ClangN, AccessLevel::Public);
+  return Impl.createConstant(name, dc, type, value, convertKind, isStatic,
+                             ClangN, AccessLevel::Public);
 }
 
 static ValueDecl *importNumericLiteral(ClangImporter::Implementation &Impl,
@@ -204,9 +203,9 @@ static ValueDecl *importStringLiteral(ClangImporter::Implementation &Impl,
   if (!unicode::isWellFormedUTF8(text))
     return nullptr;
 
-  return SwiftDeclSynthesizer(Impl).createConstant(
-      name, DC, importTy, text, ConstantConvertKind::None,
-      /*static*/ false, ClangN, AccessLevel::Public);
+  return Impl.createConstant(name, DC, importTy, text,
+                             ConstantConvertKind::None,
+                             /*static*/ false, ClangN, AccessLevel::Public);
 }
 
 static ValueDecl *importLiteral(ClangImporter::Implementation &Impl,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2714,7 +2714,8 @@ static ParamDecl *getParameterInfo(ClangImporter::Implementation *impl,
                              : (isBorrowing ? ParamSpecifier::Borrowing
                                             : ParamSpecifier::Default)));
   paramInfo->setInterfaceType(swiftParamTy);
-  impl->recordImplicitUnwrapForDecl(paramInfo, isParamTypeImplicitlyUnwrapped);
+  importer::recordImplicitUnwrapForDecl(paramInfo,
+                                        isParamTypeImplicitlyUnwrapped);
 
   // Import the default expression for this parameter if possible.
   // Swift doesn't support default values of inout parameters.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -612,10 +612,6 @@ public:
     return Instance.get();
   }
 
-  /// Writes the mangled name of \p clangDecl to \p os.
-  void getMangledName(clang::MangleContext *mangler,
-                      const clang::NamedDecl *clangDecl, raw_ostream &os);
-
   /// Whether the C++ interoperability compatibility version is at least
   /// 'major'.
   ///
@@ -1874,6 +1870,9 @@ public:
 };
 
 namespace importer {
+/// Writes the mangled name of \p clangDecl to \p os.
+void getMangledName(clang::MangleContext *mangler,
+                    const clang::NamedDecl *clangDecl, raw_ostream &os);
 
 /// Make \a storage a computed property with the given \a getter and \a setter.
 ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -877,25 +877,6 @@ public:
   ModuleDecl *loadModule(SourceLoc importLoc,
                          ImportPath::Module path);
 
-  void recordImplicitUnwrapForDecl(ValueDecl *decl, bool isIUO) {
-    if (!isIUO)
-      return;
-
-#if !defined(NDEBUG)
-    Type ty;
-    if (auto *FD = dyn_cast<FuncDecl>(decl)) {
-      ty = FD->getResultInterfaceType();
-    } else if (auto *CD = dyn_cast<ConstructorDecl>(decl)) {
-      ty = CD->getResultInterfaceType();
-    } else {
-      ty = cast<AbstractStorageDecl>(decl)->getValueInterfaceType();
-    }
-    assert(ty->getOptionalObjectType());
-#endif
-
-    decl->setImplicitlyUnwrappedOptional(true);
-  }
-
   /// Retrieve the Clang AST context.
   clang::ASTContext &getClangASTContext() const {
     return Instance->getASTContext();
@@ -1908,6 +1889,9 @@ bool recordHasReferenceSemantics(const clang::RecordDecl *decl,
 /// Returns true if the given C/C++ reference type uses "immortal"
 /// retain/release functions.
 bool hasImmortalAttrs(const clang::RecordDecl *decl);
+
+/// Set \a decl as an implicitly unwrapped optional if \a isUIO.
+void recordImplicitUnwrapForDecl(ValueDecl *decl, bool isIUO);
 
 /// Whether this is a forward declaration of a type. We ignore forward
 /// declarations in certain cases, and instead process the real declarations.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1218,9 +1218,6 @@ public:
       ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
       bool isUnchecked = false);
 
-  void makeComputed(AbstractStorageDecl *storage, AccessorDecl *getter,
-                    AccessorDecl *setter);
-
   /// Retrieve the standard library module.
   ModuleDecl *getStdlibModule();
 
@@ -1897,6 +1894,12 @@ public:
 
 namespace importer {
 
+/// Make \a storage a computed property with the given \a getter and \a setter.
+///
+/// \a getter must be non-null.
+void makeComputed(AbstractStorageDecl *storage, AccessorDecl *getter,
+                  AccessorDecl *setter);
+
 /// Returns true if the given C/C++ record should be imported as a reference
 /// type into Swift.
 bool recordHasReferenceSemantics(const clang::RecordDecl *decl,
@@ -2082,7 +2085,6 @@ bool hasNonEscapableAttr(const clang::RecordDecl *decl);
 bool hasEscapableAttr(const clang::RecordDecl *decl);
 
 bool isViewType(const clang::CXXRecordDecl *decl);
-
 } // end namespace importer
 } // end namespace swift
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1851,6 +1851,51 @@ public:
       return *SinglePCHImport;
     return StringRef();
   }
+
+  /// Create a new named constant with the given value.
+  ///
+  /// \param name The name of the constant.
+  /// \param dc The declaration context into which the name will be introduced.
+  /// \param type The type of the named constant.
+  /// \param value The value of the named constant.
+  /// \param convertKind How to convert the constant to the given type.
+  /// \param isStatic Whether the constant should be a static member of \p dc.
+  /// \param access What access level should be given to the constant.
+  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
+                            const clang::APValue &value,
+                            ConstantConvertKind convertKind, bool isStatic,
+                            ClangNode ClangN, AccessLevel access);
+
+  /// Create a new named constant with the given value.
+  ///
+  /// \param name The name of the constant.
+  /// \param dc The declaration context into which the name will be introduced.
+  /// \param type The type of the named constant.
+  /// \param value The value of the named constant.
+  /// \param convertKind How to convert the constant to the given type.
+  /// \param isStatic Whether the constant should be a static member of \p dc.
+  /// \param access What access level should be given to the constant.
+  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
+                            StringRef value, ConstantConvertKind convertKind,
+                            bool isStatic, ClangNode ClangN,
+                            AccessLevel access);
+
+  /// Create a new named constant using the given expression.
+  ///
+  /// \param name The name of the constant.
+  /// \param dc The declaration context into which the name will be introduced.
+  /// \param type The type of the named constant.
+  /// \param valueExpr An expression to use as the value of the constant.
+  /// \param convertKind How to convert the constant to the given type.
+  /// \param isStatic Whether the constant should be a static member of \p dc.
+  /// \param access What access level should be given to the constant.
+  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
+                            Expr *valueExpr, ConstantConvertKind convertKind,
+                            bool isStatic, ClangNode ClangN,
+                            AccessLevel access);
+
+private:
+  Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
 };
 
 class ImportDiagnosticAdder {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -360,6 +360,26 @@ private:
 using LookupTableMap =
     llvm::DenseMap<StringRef, std::unique_ptr<SwiftLookupTable>>;
 
+enum class MakeStructRawValuedFlags {
+  /// whether to also create an unlabeled init
+  MakeUnlabeledValueInit = 0x01,
+
+  /// whether the raw value should be a let
+  IsLet = 0x02,
+
+  /// whether to mark the rawValue as implicit
+  IsImplicit = 0x04,
+};
+using MakeStructRawValuedOptions = OptionSet<MakeStructRawValuedFlags>;
+
+inline MakeStructRawValuedOptions getDefaultMakeStructRawValuedOptions() {
+  MakeStructRawValuedOptions opts;
+  opts -= MakeStructRawValuedFlags::MakeUnlabeledValueInit; // default off
+  opts |= MakeStructRawValuedFlags::IsLet;                  // default on
+  opts |= MakeStructRawValuedFlags::IsImplicit;             // default on
+  return opts;
+}
+
 /// The result of importing a clang type. It holds both the Swift Type
 /// as well as a bool in which 'true' indicates either:
 ///   This is an Optional type.
@@ -1896,6 +1916,43 @@ public:
 
 private:
   Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
+
+public:
+  /// Make a struct declaration into a raw-value-backed struct, with
+  /// bridged computed rawValue property which differs from stored backing
+  ///
+  /// \param structDecl the struct to make a raw value for
+  /// \param storedUnderlyingType the type of the stored raw value
+  /// \param bridgedType the type of the 'rawValue' computed property bridge
+  /// \param synthesizedProtocolAttrs synthesized protocol attributes to add
+  ///
+  /// This will perform most of the work involved in making a new Swift struct
+  /// be backed by a stored raw value and computed raw value of bridged type.
+  /// This will populated derived protocols and synthesized protocols, add the
+  /// new variable and pattern bindings, and create the inits parameterized
+  /// over a bridged type that will cast to the stored type, as appropriate.
+  void makeStructRawValuedWithBridge(
+      StructDecl *structDecl, Type storedUnderlyingType, Type bridgedType,
+      ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
+      bool makeUnlabeledValueInit = false);
+
+  /// Make a struct declaration into a raw-value-backed struct
+  ///
+  /// \param structDecl the struct to make a raw value for
+  /// \param underlyingType the type of the raw value
+  /// \param synthesizedProtocolAttrs synthesized protocol attributes to add
+  /// \param setterAccess the access level of the raw value's setter
+  ///
+  /// This will perform most of the work involved in making a new Swift struct
+  /// be backed by a raw value. This will populated derived protocols and
+  /// synthesized protocols, add the new variable and pattern bindings, and
+  /// create the inits parameterized over a raw value
+  ///
+  void makeStructRawValued(StructDecl *structDecl, Type underlyingType,
+                           ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
+                           MakeStructRawValuedOptions options =
+                               getDefaultMakeStructRawValuedOptions(),
+                           AccessLevel setterAccess = AccessLevel::Private);
 };
 
 class ImportDiagnosticAdder {

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1929,7 +1929,7 @@ synthesizeSuccessorFuncBody(AbstractFunctionDecl *afd, void *context) {
 }
 
 FuncDecl *SwiftDeclSynthesizer::makeSuccessorFunc(FuncDecl *incrementFunc) {
-  auto &ctx = ImporterImpl.SwiftContext;
+  auto &ctx = incrementFunc->getASTContext();
   auto dc = incrementFunc->getDeclContext();
 
   auto returnTy = incrementFunc->getImplicitSelfDecl()->getInterfaceType();

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2505,7 +2505,7 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
   std::unique_ptr<clang::ItaniumMangleContext> mangler{
       clang::ItaniumMangleContext::create(clangCtx, clangCtx.getDiagnostics())};
   os << "__defaultArg_" << param->getFunctionScopeIndex() << "_";
-  ImporterImpl.getMangledName(mangler.get(), clangFunc, os);
+  importer::getMangledName(mangler.get(), clangFunc, os);
 
   // Synthesize `func __defaultArg_XYZ() -> ParamTy { ... }`.
   DeclName funcName(ctx, DeclBaseName(ctx.getIdentifier(s)),

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1771,10 +1771,10 @@ SwiftDeclSynthesizer::makeDereferencedPointeeProperty(FuncDecl *getter,
                                                       FuncDecl *setter) {
   assert((getter || setter) &&
          "getter or setter required to generate a pointee property");
-  auto &ctx = ImporterImpl.SwiftContext;
   FuncDecl *getterImpl = getter ? getter : setter;
   FuncDecl *setterImpl = setter;
   auto dc = getterImpl->getDeclContext();
+  auto &ctx = getterImpl->getASTContext();
 
   // Get the return type wrapped in `Unsafe(Mutable)Pointer<T>`.
   const auto rawElementTy = getterImpl->getResultInterfaceType();

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -441,7 +441,7 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
   var->getAttrs().add(nonisolatedAttr);
 
   // Set the function up as the getter.
-  ImporterImpl.makeComputed(var, func, nullptr);
+  importer::makeComputed(var, func, nullptr);
 
   return var;
 }
@@ -756,7 +756,7 @@ void SwiftDeclSynthesizer::makeStructRawValuedWithBridge(
   // Create the getter for the computed value variable.
   auto computedVarGetter =
       makeStructRawValueGetter(structDecl, computedVar, storedVar);
-  ImporterImpl.makeComputed(computedVar, computedVarGetter, nullptr);
+  importer::makeComputed(computedVar, computedVarGetter, nullptr);
 
   // Create a pattern binding to describe the variable.
   Pattern *computedBindingPattern = createTypedNamedPattern(computedVar);
@@ -957,7 +957,7 @@ SwiftDeclSynthesizer::makeUnionFieldAccessors(
                                  importedFieldDecl);
   setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
 
-  ImporterImpl.makeComputed(importedFieldDecl, getterDecl, setterDecl);
+  importer::makeComputed(importedFieldDecl, getterDecl, setterDecl);
   return {getterDecl, setterDecl};
 }
 
@@ -1022,7 +1022,7 @@ std::pair<FuncDecl *, FuncDecl *> SwiftDeclSynthesizer::makeBitFieldAccessors(
   auto setterDecl = makeFieldSetterDecl(ImporterImpl, importedStructDecl,
                                         importedFieldDecl, cSetterDecl);
 
-  ImporterImpl.makeComputed(importedFieldDecl, getterDecl, setterDecl);
+  importer::makeComputed(importedFieldDecl, getterDecl, setterDecl);
 
   // Synthesize the getter body
   {
@@ -1191,7 +1191,7 @@ SwiftDeclSynthesizer::makeIndirectFieldAccessors(
       makeFieldSetterDecl(ImporterImpl, importedStructDecl, importedFieldDecl);
   setterDecl->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
 
-  ImporterImpl.makeComputed(importedFieldDecl, getterDecl, setterDecl);
+  importer::makeComputed(importedFieldDecl, getterDecl, setterDecl);
 
   auto containingField = indirectField->chain().front();
   VarDecl *anonymousFieldDecl = nullptr;
@@ -1365,7 +1365,7 @@ void SwiftDeclSynthesizer::makeEnumRawValueGetter(EnumDecl *enumDecl,
 
   getterDecl->copyFormalAccessFrom(enumDecl);
   getterDecl->setBodySynthesizer(synthesizeEnumRawValueGetterBody, enumDecl);
-  ImporterImpl.makeComputed(rawValueDecl, getterDecl, nullptr);
+  importer::makeComputed(rawValueDecl, getterDecl, nullptr);
 }
 
 // MARK: Struct RawValue getters
@@ -1755,7 +1755,7 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
     }
   }
 
-  ImporterImpl.makeComputed(subscript, getterDecl, setterDecl);
+  importer::makeComputed(subscript, getterDecl, setterDecl);
 
   // Implicitly unwrap Optional types for T *operator[].
   ImporterImpl.recordImplicitUnwrapForDecl(
@@ -1860,7 +1860,7 @@ SwiftDeclSynthesizer::makeDereferencedPointeeProperty(FuncDecl *getter,
     }
   }
 
-  ImporterImpl.makeComputed(result, getterDecl, setterDecl);
+  importer::makeComputed(result, getterDecl, setterDecl);
   return result;
 }
 
@@ -2411,7 +2411,7 @@ SwiftDeclSynthesizer::makeComputedPropertyFromCXXMethods(FuncDecl *getter,
     }
   }
 
-  ImporterImpl.makeComputed(result, getterDecl, setterDecl);
+  importer::makeComputed(result, getterDecl, setterDecl);
 
   return result;
 }

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2348,7 +2348,7 @@ synthesizeComputedSetterFromCXXMethod(AbstractFunctionDecl *afd,
 VarDecl *
 SwiftDeclSynthesizer::makeComputedPropertyFromCXXMethods(FuncDecl *getter,
                                                          FuncDecl *setter) {
-  auto &ctx = ImporterImpl.SwiftContext;
+  auto &ctx = getter->getASTContext();
   auto dc = getter->getDeclContext();
 
   assert(isa<clang::CXXMethodDecl>(getter->getClangDecl()) &&

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1437,7 +1437,7 @@ AccessorDecl *SwiftDeclSynthesizer::makeStructRawValueGetter(
 AccessorDecl *SwiftDeclSynthesizer::buildSubscriptGetterDecl(
     SubscriptDecl *subscript, const FuncDecl *getter, Type elementTy,
     DeclContext *dc, ParamDecl *index) {
-  auto &C = ImporterImpl.SwiftContext;
+  auto &C = subscript->getASTContext();
   auto loc = getter->getLoc();
 
   auto *params = ParameterList::create(C, index);
@@ -1466,7 +1466,7 @@ AccessorDecl *SwiftDeclSynthesizer::buildSubscriptGetterDecl(
 AccessorDecl *SwiftDeclSynthesizer::buildSubscriptSetterDecl(
     SubscriptDecl *subscript, const FuncDecl *setter, Type elementInterfaceTy,
     DeclContext *dc, ParamDecl *index) {
-  auto &C = ImporterImpl.SwiftContext;
+  auto &C = subscript->getASTContext();
   auto loc = setter->getLoc();
 
   // Objective-C subscript setters are imported with a function type
@@ -1689,7 +1689,7 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
                              ? rawElementTy->getAnyPointerElementType()
                              : rawElementTy;
 
-  auto &ctx = ImporterImpl.SwiftContext;
+  auto &ctx = getterImpl->getASTContext();
 
   assert(getterImpl->getParameters()->size() == 1 &&
          "subscript can only have 1 parameter");

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2200,7 +2200,7 @@ SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
   assert(opKind != clang::OverloadedOperatorKind::OO_None &&
          "expected a C++ operator");
 
-  auto &ctx = ImporterImpl.SwiftContext;
+  auto &ctx = operatorMethod->getASTContext();
   auto opName = clang::getOperatorSpelling(opKind);
   auto paramList = operatorMethod->getParameters();
   auto genericParamList = operatorMethod->getGenericParams();

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2539,10 +2539,9 @@ SwiftDeclSynthesizer::makeDefaultArgument(const clang::ParmVarDecl *param,
 
 clang::CXXMethodDecl *
 SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
-    const clang::CXXRecordDecl *cxxRecordDecl) {
+    clang::Sema &clangSema, const clang::CXXRecordDecl *cxxRecordDecl) {
 
   clang::ASTContext &clangCtx = cxxRecordDecl->getASTContext();
-  clang::Sema &clangSema = ImporterImpl.getClangSema();
 
   clang::QualType cxxRecordTy = clangCtx.getRecordType(cxxRecordDecl);
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -619,8 +619,8 @@ ConstructorDecl *SwiftDeclSynthesizer::createValueConstructor(
                                 var->getName(), structDecl);
     param->setSpecifier(ParamSpecifier::Default);
     param->setInterfaceType(var->getInterfaceType());
-    ImporterImpl.recordImplicitUnwrapForDecl(
-        param, var->isImplicitlyUnwrappedOptional());
+    importer::recordImplicitUnwrapForDecl(param,
+                                          var->isImplicitlyUnwrappedOptional());
 
     // Don't allow the parameter to accept temporary pointer conversions.
     param->setNonEphemeralIfPossible();
@@ -1758,7 +1758,7 @@ SubscriptDecl *SwiftDeclSynthesizer::makeSubscript(FuncDecl *getter,
   importer::makeComputed(subscript, getterDecl, setterDecl);
 
   // Implicitly unwrap Optional types for T *operator[].
-  ImporterImpl.recordImplicitUnwrapForDecl(
+  importer::recordImplicitUnwrapForDecl(
       subscript, getterImpl->isImplicitlyUnwrappedOptional());
 
   return subscript;

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -710,7 +710,7 @@ synthesizeRawValueBridgingConstructorBody(AbstractFunctionDecl *afd,
   return {body, /*isTypeChecked=*/true};
 }
 
-ConstructorDecl *SwiftDeclSynthesizer::createRawValueBridgingConstructor(
+static ConstructorDecl *createRawValueBridgingConstructor(
     StructDecl *structDecl, VarDecl *computedRawValue, VarDecl *storedRawValue,
     bool wantLabel, bool wantBody) {
   auto init = SwiftDeclSynthesizer::createValueConstructor(

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -178,13 +178,13 @@ using ConstantGetterBodyContextData =
     llvm::PointerIntPair<Expr *, 2, ConstantConvertKind>;
 }
 
-Type SwiftDeclSynthesizer::getConstantLiteralType(
+Type ClangImporter::Implementation::getConstantLiteralType(
     Type type, ConstantConvertKind convertKind) {
   switch (convertKind) {
   case ConstantConvertKind::Construction:
   case ConstantConvertKind::ConstructionWithUnwrap: {
-    auto found = ImporterImpl.RawTypes.find(type->getAnyNominal());
-    assert(found != ImporterImpl.RawTypes.end());
+    auto found = RawTypes.find(type->getAnyNominal());
+    assert(found != RawTypes.end());
     return found->second;
   }
 
@@ -193,13 +193,11 @@ Type SwiftDeclSynthesizer::getConstantLiteralType(
   }
 }
 
-ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
-                                                DeclContext *dc, Type type,
-                                                const clang::APValue &value,
-                                                ConstantConvertKind convertKind,
-                                                bool isStatic, ClangNode ClangN,
-                                                AccessLevel access) {
-  auto &context = ImporterImpl.SwiftContext;
+ValueDecl *ClangImporter::Implementation::createConstant(
+    Identifier name, DeclContext *dc, Type type, const clang::APValue &value,
+    ConstantConvertKind convertKind, bool isStatic, ClangNode ClangN,
+    AccessLevel access) {
+  auto &context = SwiftContext;
 
   // Create the integer literal value.
   Expr *expr = nullptr;
@@ -297,13 +295,11 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
                         access);
 }
 
-ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
-                                                DeclContext *dc, Type type,
-                                                StringRef value,
-                                                ConstantConvertKind convertKind,
-                                                bool isStatic, ClangNode ClangN,
-                                                AccessLevel access) {
-  ASTContext &ctx = ImporterImpl.SwiftContext;
+ValueDecl *ClangImporter::Implementation::createConstant(
+    Identifier name, DeclContext *dc, Type type, StringRef value,
+    ConstantConvertKind convertKind, bool isStatic, ClangNode ClangN,
+    AccessLevel access) {
+  auto &ctx = SwiftContext;
 
   auto expr = new (ctx) StringLiteralExpr(value, SourceRange());
 
@@ -390,17 +386,15 @@ synthesizeConstantGetterBody(AbstractFunctionDecl *afd, void *voidContext) {
           /*isTypeChecked=*/true};
 }
 
-ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
-                                                DeclContext *dc, Type type,
-                                                Expr *valueExpr,
-                                                ConstantConvertKind convertKind,
-                                                bool isStatic, ClangNode ClangN,
-                                                AccessLevel access) {
-  auto &C = ImporterImpl.SwiftContext;
+ValueDecl *ClangImporter::Implementation::createConstant(
+    Identifier name, DeclContext *dc, Type type, Expr *valueExpr,
+    ConstantConvertKind convertKind, bool isStatic, ClangNode ClangN,
+    AccessLevel access) {
+  auto &C = SwiftContext;
 
   VarDecl *var = nullptr;
   if (ClangN) {
-    var = ImporterImpl.createDeclWithClangNode<VarDecl>(
+    var = createDeclWithClangNode<VarDecl>(
         ClangN, access,
         /*IsStatic*/ isStatic, VarDecl::Introducer::Var, SourceLoc(), name, dc);
   } else {

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1340,7 +1340,7 @@ synthesizeEnumRawValueConstructorBody(AbstractFunctionDecl *afd,
 
 ConstructorDecl *
 SwiftDeclSynthesizer::makeEnumRawValueConstructor(EnumDecl *enumDecl) {
-  ASTContext &C = ImporterImpl.SwiftContext;
+  ASTContext &C = enumDecl->getASTContext();
   auto rawTy = enumDecl->getRawType();
 
   auto param = new (C) ParamDecl(SourceLoc(), SourceLoc(), C.Id_rawValue,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2019,12 +2019,15 @@ synthesizeOperatorMethodBody(AbstractFunctionDecl *afd, void *context) {
 }
 
 clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
-    const clang::CXXRecordDecl *derivedClass,
+    ASTContext &ctx, const clang::CXXRecordDecl *derivedClass,
     const clang::CXXRecordDecl *baseClass, const clang::CXXMethodDecl *method,
     ForwardingMethodKind forwardingMethodKind,
     ReferenceReturnTypeBehaviorForBaseMethodSynthesis
         referenceReturnTypeBehavior,
     bool forceConstQualifier) {
+
+  auto &ImporterImpl =
+      static_cast<ClangImporter *>(ctx.getClangModuleLoader())->Impl;
 
   auto &clangCtx = ImporterImpl.getClangASTContext();
   auto &clangSema = ImporterImpl.getClangSema();

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2274,47 +2274,6 @@ SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
   return topLevelStaticFuncDecl;
 }
 
-// MARK: C++ virtual methods
-
-FuncDecl *SwiftDeclSynthesizer::makeVirtualMethod(
-    const clang::CXXMethodDecl *clangMethodDecl) {
-  auto clangDC = clangMethodDecl->getParent();
-  auto &ctx = ImporterImpl.SwiftContext;
-
-  assert(!clangMethodDecl->isStatic() &&
-         "C++ virtual functions cannot be static");
-
-  auto newMethod = synthesizeCXXForwardingMethod(
-      clangDC, clangDC, clangMethodDecl, ForwardingMethodKind::Virtual,
-      ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
-      /*forceConstQualifier*/ false);
-
-  auto result = dyn_cast_or_null<FuncDecl>(
-      ctx.getClangModuleLoader()->importDeclDirectly(newMethod));
-  return result;
-}
-
-// MARK: C++ operators
-
-FuncDecl *SwiftDeclSynthesizer::makeInstanceToStaticOperatorCallMethod(
-    const clang::CXXMethodDecl *clangMethodDecl) {
-  auto clangDC = clangMethodDecl->getParent();
-  auto &ctx = ImporterImpl.SwiftContext;
-
-  assert(clangMethodDecl->isStatic() && "Expected a static operator");
-
-  auto newMethod = synthesizeCXXForwardingMethod(
-      clangDC, clangDC, clangMethodDecl, ForwardingMethodKind::Base,
-      ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
-      /*forceConstQualifier*/ true);
-  newMethod->addAttr(clang::SwiftNameAttr::CreateImplicit(
-      clangMethodDecl->getASTContext(), "callAsFunction"));
-
-  auto result = dyn_cast_or_null<FuncDecl>(
-      ctx.getClangModuleLoader()->importDeclDirectly(newMethod));
-  return result;
-}
-
 // MARK: C++ properties
 
 static std::pair<BraceStmt *, bool>

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -1416,7 +1416,7 @@ synthesizeEnumRawValueGetterBody(AbstractFunctionDecl *afd, void *context) {
 // cast in order to preserve unknown or future cases from C.
 void SwiftDeclSynthesizer::makeEnumRawValueGetter(EnumDecl *enumDecl,
                                                   VarDecl *rawValueDecl) {
-  ASTContext &C = ImporterImpl.SwiftContext;
+  ASTContext &C = enumDecl->getASTContext();
 
   auto rawTy = enumDecl->getRawType();
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -119,13 +119,13 @@ public:
                             AccessLevel access);
 
   /// Create a default constructor that initializes a struct to zero.
-  ConstructorDecl *createDefaultConstructor(NominalTypeDecl *structDecl);
+  static ConstructorDecl *createDefaultConstructor(NominalTypeDecl *structDecl);
 
   /// Create a constructor that initializes a struct from its members.
-  ConstructorDecl *createValueConstructor(NominalTypeDecl *structDecl,
-                                          ArrayRef<VarDecl *> members,
-                                          bool wantCtorParamNames,
-                                          bool wantBody);
+  static ConstructorDecl *createValueConstructor(NominalTypeDecl *structDecl,
+                                                 ArrayRef<VarDecl *> members,
+                                                 bool wantCtorParamNames,
+                                                 bool wantBody);
 
   /// Create a rawValue-ed constructor that bridges to its underlying storage.
   ConstructorDecl *createRawValueBridgingConstructor(StructDecl *structDecl,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -127,13 +127,6 @@ public:
                                                  bool wantCtorParamNames,
                                                  bool wantBody);
 
-  /// Create a rawValue-ed constructor that bridges to its underlying storage.
-  ConstructorDecl *createRawValueBridgingConstructor(StructDecl *structDecl,
-                                                     VarDecl *computedRawValue,
-                                                     VarDecl *storedRawValue,
-                                                     bool wantLabel,
-                                                     bool wantBody);
-
   /// Make a struct declaration into a raw-value-backed struct, with
   /// bridged computed rawValue property which differs from stored backing
   ///

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -323,8 +323,8 @@ public:
   FuncDecl *makeInstanceToStaticOperatorCallMethod(
       const clang::CXXMethodDecl *clangMethodDecl);
 
-  VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
-                                              FuncDecl *setter);
+  static VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
+                                                     FuncDecl *setter);
 
   CallExpr *makeDefaultArgument(const clang::ParmVarDecl *param,
                                 const swift::Type &swiftParamTy,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -253,20 +253,6 @@ public:
   /// reinterpret cast in order to preserve unknown or future cases from C.
   void makeEnumRawValueGetter(EnumDecl *enumDecl, VarDecl *rawValueDecl);
 
-  /// Build the rawValue getter for a struct type.
-  ///
-  /// \code
-  /// struct SomeType: RawRepresentable {
-  ///   private var _rawValue: ObjCType
-  ///   var rawValue: SwiftType {
-  ///     return _rawValue as SwiftType
-  ///   }
-  /// }
-  /// \endcode
-  AccessorDecl *makeStructRawValueGetter(StructDecl *structDecl,
-                                         VarDecl *computedVar,
-                                         VarDecl *storedVar);
-
   /// Build a declaration for an Objective-C subscript getter.
   static AccessorDecl *buildSubscriptGetterDecl(SubscriptDecl *subscript,
                                                 const FuncDecl *getter,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -179,7 +179,7 @@ public:
   /// \endcode
   ///
   /// \returns a pair of the getter and setter function decls.
-  std::pair<AccessorDecl *, AccessorDecl *>
+  static std::pair<AccessorDecl *, AccessorDecl *>
   makeUnionFieldAccessors(NominalTypeDecl *importedUnionDecl,
                           VarDecl *importedFieldDecl);
 
@@ -195,7 +195,7 @@ public:
   /// \endcode
   ///
   /// \returns a pair of the getter and setter function decls.
-  std::pair<FuncDecl *, FuncDecl *> makeBitFieldAccessors(
+  static std::pair<FuncDecl *, FuncDecl *> makeBitFieldAccessors(
       clang::RecordDecl *structDecl, NominalTypeDecl *importedStructDecl,
       clang::FieldDecl *fieldDecl, VarDecl *importedFieldDecl);
 
@@ -219,7 +219,7 @@ public:
   /// \endcode
   ///
   /// \returns a pair of getter and setter function decls.
-  std::pair<AccessorDecl *, AccessorDecl *>
+  static std::pair<AccessorDecl *, AccessorDecl *>
   makeIndirectFieldAccessors(const clang::IndirectFieldDecl *indirectField,
                              ArrayRef<VarDecl *> members,
                              NominalTypeDecl *importedStructDecl,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -306,7 +306,7 @@ public:
 
   /// Given a C++ pre-increment operator (`operator++()`). create a non-mutating
   /// function `successor() -> Self`.
-  FuncDecl *makeSuccessorFunc(FuncDecl *incrementFunc);
+  static FuncDecl *makeSuccessorFunc(FuncDecl *incrementFunc);
 
   FuncDecl *makeOperator(FuncDecl *operatorMethod,
                          clang::OverloadedOperatorKind opKind);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -333,8 +333,8 @@ public:
   /// Synthesize a static factory method for a C++ foreign reference type,
   /// returning a `CXXMethodDecl*` or `nullptr` if the required constructor or
   /// allocation function is not found.
-  clang::CXXMethodDecl *synthesizeStaticFactoryForCXXForeignRef(
-      const clang::CXXRecordDecl *cxxRecordDecl);
+  static clang::CXXMethodDecl *synthesizeStaticFactoryForCXXForeignRef(
+      clang::Sema &clangSema, const clang::CXXRecordDecl *cxxRecordDecl);
 
 private:
   Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -301,7 +301,8 @@ public:
   /// \param getter function returning `UnsafePointer<T>`
   /// \param setter function returning `UnsafeMutablePointer<T>`
   /// \return computed property declaration
-  VarDecl *makeDereferencedPointeeProperty(FuncDecl *getter, FuncDecl *setter);
+  static VarDecl *makeDereferencedPointeeProperty(FuncDecl *getter,
+                                                  FuncDecl *setter);
 
   /// Given a C++ pre-increment operator (`operator++()`). create a non-mutating
   /// function `successor() -> Self`.

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -275,15 +275,17 @@ public:
                                          VarDecl *storedVar);
 
   /// Build a declaration for an Objective-C subscript getter.
-  AccessorDecl *buildSubscriptGetterDecl(SubscriptDecl *subscript,
-                                         const FuncDecl *getter, Type elementTy,
-                                         DeclContext *dc, ParamDecl *index);
+  static AccessorDecl *buildSubscriptGetterDecl(SubscriptDecl *subscript,
+                                                const FuncDecl *getter,
+                                                Type elementTy, DeclContext *dc,
+                                                ParamDecl *index);
 
   /// Build a declaration for an Objective-C subscript setter.
-  AccessorDecl *buildSubscriptSetterDecl(SubscriptDecl *subscript,
-                                         const FuncDecl *setter,
-                                         Type elementInterfaceTy,
-                                         DeclContext *dc, ParamDecl *index);
+  static AccessorDecl *buildSubscriptSetterDecl(SubscriptDecl *subscript,
+                                                const FuncDecl *setter,
+                                                Type elementInterfaceTy,
+                                                DeclContext *dc,
+                                                ParamDecl *index);
 
   /// Given either the getter, the setter, or both getter & setter
   /// for a subscript operation, create the Swift subscript declaration.
@@ -291,7 +293,7 @@ public:
   /// \param getter function returning `UnsafePointer<T>`
   /// \param setter function returning `UnsafeMutablePointer<T>`
   /// \return subscript declaration
-  SubscriptDecl *makeSubscript(FuncDecl *getter, FuncDecl *setter);
+  static SubscriptDecl *makeSubscript(FuncDecl *getter, FuncDecl *setter);
 
   /// Given an imported C++ dereference operator (`operator*()`), create a
   /// `pointee` computed property.

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -308,9 +308,9 @@ public:
   /// function `successor() -> Self`.
   static FuncDecl *makeSuccessorFunc(FuncDecl *incrementFunc);
 
-  FuncDecl *makeOperator(FuncDecl *operatorMethod,
-                         clang::OverloadedOperatorKind opKind);
-  
+  static FuncDecl *makeOperator(FuncDecl *operatorMethod,
+                                clang::OverloadedOperatorKind opKind);
+
   // Synthesize a C++ method that invokes the method from the base
   // class. This lets Clang take care of the cast from the derived class
   // to the base class during the invocation of the method.

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -20,26 +20,6 @@ namespace swift {
 
 class CallExpr;
 
-enum class MakeStructRawValuedFlags {
-  /// whether to also create an unlabeled init
-  MakeUnlabeledValueInit = 0x01,
-
-  /// whether the raw value should be a let
-  IsLet = 0x02,
-
-  /// whether to mark the rawValue as implicit
-  IsImplicit = 0x04,
-};
-using MakeStructRawValuedOptions = OptionSet<MakeStructRawValuedFlags>;
-
-inline MakeStructRawValuedOptions getDefaultMakeStructRawValuedOptions() {
-  MakeStructRawValuedOptions opts;
-  opts -= MakeStructRawValuedFlags::MakeUnlabeledValueInit; // default off
-  opts |= MakeStructRawValuedFlags::IsLet;                  // default on
-  opts |= MakeStructRawValuedFlags::IsImplicit;             // default on
-  return opts;
-}
-
 inline AccessLevel getOverridableAccessLevel(const DeclContext *dc) {
   return (dc->getSelfClassDecl() ? AccessLevel::Open : AccessLevel::Public);
 }
@@ -84,42 +64,6 @@ public:
                                                  ArrayRef<VarDecl *> members,
                                                  bool wantCtorParamNames,
                                                  bool wantBody);
-
-  /// Make a struct declaration into a raw-value-backed struct, with
-  /// bridged computed rawValue property which differs from stored backing
-  ///
-  /// \param structDecl the struct to make a raw value for
-  /// \param storedUnderlyingType the type of the stored raw value
-  /// \param bridgedType the type of the 'rawValue' computed property bridge
-  /// \param synthesizedProtocolAttrs synthesized protocol attributes to add
-  ///
-  /// This will perform most of the work involved in making a new Swift struct
-  /// be backed by a stored raw value and computed raw value of bridged type.
-  /// This will populated derived protocols and synthesized protocols, add the
-  /// new variable and pattern bindings, and create the inits parameterized
-  /// over a bridged type that will cast to the stored type, as appropriate.
-  void makeStructRawValuedWithBridge(
-      StructDecl *structDecl, Type storedUnderlyingType, Type bridgedType,
-      ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
-      bool makeUnlabeledValueInit = false);
-
-  /// Make a struct declaration into a raw-value-backed struct
-  ///
-  /// \param structDecl the struct to make a raw value for
-  /// \param underlyingType the type of the raw value
-  /// \param synthesizedProtocolAttrs synthesized protocol attributes to add
-  /// \param setterAccess the access level of the raw value's setter
-  ///
-  /// This will perform most of the work involved in making a new Swift struct
-  /// be backed by a raw value. This will populated derived protocols and
-  /// synthesized protocols, add the new variable and pattern bindings, and
-  /// create the inits parameterized over a raw value
-  ///
-  void makeStructRawValued(StructDecl *structDecl, Type underlyingType,
-                           ArrayRef<KnownProtocolKind> synthesizedProtocolAttrs,
-                           MakeStructRawValuedOptions options =
-                               getDefaultMakeStructRawValuedOptions(),
-                           AccessLevel setterAccess = AccessLevel::Private);
 
   /// Build the union field getter and setter.
   ///

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -251,7 +251,7 @@ public:
   ///
   /// Unlike a standard init(rawValue:) enum initializer, this does a
   /// reinterpret cast in order to preserve unknown or future cases from C.
-  void makeEnumRawValueGetter(EnumDecl *enumDecl, VarDecl *rawValueDecl);
+  static void makeEnumRawValueGetter(EnumDecl *enumDecl, VarDecl *rawValueDecl);
 
   /// Build a declaration for an Objective-C subscript getter.
   static AccessorDecl *buildSubscriptGetterDecl(SubscriptDecl *subscript,

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -237,7 +237,7 @@ public:
   ///
   /// Unlike a standard init(rawValue:) enum initializer, this does a
   /// reinterpret cast in order to preserve unknown or future cases from C.
-  ConstructorDecl *makeEnumRawValueConstructor(EnumDecl *enumDecl);
+  static ConstructorDecl *makeEnumRawValueConstructor(EnumDecl *enumDecl);
 
   /// Build the rawValue getter for an imported NS_ENUM.
   ///

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -76,48 +76,6 @@ public:
   static Expr *synthesizeReturnReinterpretCast(ASTContext &ctx, Type givenType,
                                                Type exprType, Expr *baseExpr);
 
-  /// Create a new named constant with the given value.
-  ///
-  /// \param name The name of the constant.
-  /// \param dc The declaration context into which the name will be introduced.
-  /// \param type The type of the named constant.
-  /// \param value The value of the named constant.
-  /// \param convertKind How to convert the constant to the given type.
-  /// \param isStatic Whether the constant should be a static member of \p dc.
-  /// \param access What access level should be given to the constant.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
-                            const clang::APValue &value,
-                            ConstantConvertKind convertKind, bool isStatic,
-                            ClangNode ClangN, AccessLevel access);
-
-  /// Create a new named constant with the given value.
-  ///
-  /// \param name The name of the constant.
-  /// \param dc The declaration context into which the name will be introduced.
-  /// \param type The type of the named constant.
-  /// \param value The value of the named constant.
-  /// \param convertKind How to convert the constant to the given type.
-  /// \param isStatic Whether the constant should be a static member of \p dc.
-  /// \param access What access level should be given to the constant.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
-                            StringRef value, ConstantConvertKind convertKind,
-                            bool isStatic, ClangNode ClangN,
-                            AccessLevel access);
-
-  /// Create a new named constant using the given expression.
-  ///
-  /// \param name The name of the constant.
-  /// \param dc The declaration context into which the name will be introduced.
-  /// \param type The type of the named constant.
-  /// \param valueExpr An expression to use as the value of the constant.
-  /// \param convertKind How to convert the constant to the given type.
-  /// \param isStatic Whether the constant should be a static member of \p dc.
-  /// \param access What access level should be given to the constant.
-  ValueDecl *createConstant(Identifier name, DeclContext *dc, Type type,
-                            Expr *valueExpr, ConstantConvertKind convertKind,
-                            bool isStatic, ClangNode ClangN,
-                            AccessLevel access);
-
   /// Create a default constructor that initializes a struct to zero.
   static ConstructorDecl *createDefaultConstructor(NominalTypeDecl *structDecl);
 
@@ -315,9 +273,6 @@ public:
   /// allocation function is not found.
   static clang::CXXMethodDecl *synthesizeStaticFactoryForCXXForeignRef(
       clang::Sema &clangSema, const clang::CXXRecordDecl *cxxRecordDecl);
-
-private:
-  Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
 };
 
 } // namespace swift

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -293,8 +293,8 @@ public:
   // Synthesize a C++ method that invokes the method from the base
   // class. This lets Clang take care of the cast from the derived class
   // to the base class during the invocation of the method.
-  clang::CXXMethodDecl *synthesizeCXXForwardingMethod(
-      const clang::CXXRecordDecl *derivedClass,
+  static clang::CXXMethodDecl *synthesizeCXXForwardingMethod(
+      ASTContext &ctx, const clang::CXXRecordDecl *derivedClass,
       const clang::CXXRecordDecl *baseClass, const clang::CXXMethodDecl *method,
       ForwardingMethodKind forwardingMethodKind,
       ReferenceReturnTypeBehaviorForBaseMethodSynthesis

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -312,9 +312,10 @@ public:
   static VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
                                                      FuncDecl *setter);
 
-  CallExpr *makeDefaultArgument(const clang::ParmVarDecl *param,
-                                const swift::Type &swiftParamTy,
-                                SourceLoc paramLoc);
+  static std::pair<FuncDecl *, CallExpr *>
+  makeDefaultArgument(const clang::ParmVarDecl *param,
+                      const swift::Type &swiftParamTy, SourceLoc paramLoc,
+                      DeclContext *funcDC);
 
   /// Synthesize a static factory method for a C++ foreign reference type,
   /// returning a `CXXMethodDecl*` or `nullptr` if the required constructor or

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -302,13 +302,6 @@ public:
               ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
       bool forceConstQualifier = false);
 
-  /// Given an overload of a C++ virtual method on a reference type, create a
-  /// method that dispatches the call dynamically.
-  FuncDecl *makeVirtualMethod(const clang::CXXMethodDecl *clangMethodDecl);
-
-  FuncDecl *makeInstanceToStaticOperatorCallMethod(
-      const clang::CXXMethodDecl *clangMethodDecl);
-
   static VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
                                                      FuncDecl *setter);
 


### PR DESCRIPTION
`SwiftDeclSynthesizer` is a class that was created to extract the synthesis logic out of `ClangImporter.cpp`. However, it is artificially stateful, since each instance only contains a `ClangImporter::Implementation &ImporterImpl`. This makes it very cumbersome to call its helper methods anywhere beyond the original call sites in `ClangImporter.cpp`.

This patch set aims to convert all of its methods into free functions, and---eventually---convert `SwiftDeclSynthesizer` into a namespace. Most of the time, `ImporterImpl` is only being used to summon a Swift `ASTContext`; this can instead be obtained using the `getASTContext()` method attached to most Swift objects. This patch set includes various other NFC tweaks, such as removing unnecessary helper methods or simplifying `SwiftDeclSynthesizer` method APIs (sometimes necessary to factor out internal uses of `ImporterImpl`). Some `ClangImporter` methods are also converted to static/free functions.

For the most part, I've tried to avoid moving around load-bearing blocks of code to preserve as much of the Git blame as possible. Also, each intermediate patch is formatted and compiles, so it should be easy to revert/cherry-pick them independently. They should also be much easier to review independently. I won't squash these commits, and I don't plan on actually turning `SwiftDeclSynthesizer` into a namespace until I'm confident I didn't accidentally break anything here.

~~At this time of writing, the only non-static method left is `createConstant()`. That one is the trickiest and I plan to make it a method of `ClangImporter::Implementation` (but leave it in `SwiftDeclSynthesizer.cpp`) rather than completely rewrite it, but it should probably be split up in a future patch.~~ Update: this is done now.