### PR TITLE
Parse/Sema: Add source locations to implicit code for `MemberImportVisibility` diagnostics

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1972,7 +1972,7 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
         new (Context) UnresolvedDotExpr(InterpolationVarRef,
                                         /*dotloc=*/SourceLoc(),
                                         appendLiteral,
-                                        /*nameloc=*/DeclNameLoc(), 
+                                        /*nameloc=*/DeclNameLoc(TokenLoc),
                                         /*Implicit=*/true);
       auto *ArgList = ArgumentList::forImplicitUnlabeled(Context, {Literal});
       auto AppendLiteralCall =

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4602,8 +4602,9 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
     FuncDecl *makeIterator = isAsync ? ctx.getAsyncSequenceMakeAsyncIterator()
                                      : ctx.getSequenceMakeIterator();
 
-    auto *makeIteratorRef = UnresolvedDotExpr::createImplicit(
-        ctx, sequenceExpr, makeIterator->getName());
+    auto *makeIteratorRef = new (ctx) UnresolvedDotExpr(
+        sequenceExpr, SourceLoc(), DeclNameRef(makeIterator->getName()),
+        DeclNameLoc(stmt->getForLoc()), /*implicit=*/true);
     makeIteratorRef->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
 
     Expr *makeIteratorCall =
@@ -4666,11 +4667,13 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
     TinyPtrVector<Identifier> labels;
     if (nextFn && nextFn->getParameters()->size() == 1)
       labels.push_back(ctx.Id_isolation);
-    auto *nextRef = UnresolvedDotExpr::createImplicit(
-        ctx,
+    auto *makeIteratorVarRef =
         new (ctx) DeclRefExpr(makeIteratorVar, DeclNameLoc(stmt->getForLoc()),
-                              /*Implicit=*/true),
-        nextId, labels);
+                              /*Implicit=*/true);
+    auto *nextRef = new (ctx)
+        UnresolvedDotExpr(makeIteratorVarRef, SourceLoc(),
+                          DeclNameRef(DeclName(ctx, nextId, labels)),
+                          DeclNameLoc(stmt->getForLoc()), /*implicit=*/true);
     nextRef->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
 
     ArgumentList *nextArgs;

--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
@@ -168,11 +168,11 @@ enum Tree : Differentiable & AdditiveArithmetic {
 // (`Collection.makeIterator` and `IteratorProtocol.next`).
 // expected-error @+1 {{function is not differentiable}}
 @differentiable(reverse)
-// expected-note @+2 {{when differentiating this function definition}}
-// expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}} {{+2:12-12=withoutDerivative(at: }} {{+2:17-17=)}}
 func loop_array(_ array: [Float]) -> Float {
+  // expected-note@-1 {{when differentiating this function definition}}
   var result: Float = 1
   for x in array {
+    // expected-note@-1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'}}
     result = result * x
   }
   return result

--- a/test/NameLookup/members_transitive_compiler_protocols.swift
+++ b/test/NameLookup/members_transitive_compiler_protocols.swift
@@ -9,16 +9,52 @@
 //--- main.swift
 
 import Swift
-// expected-note 6 {{add import of module 'lib'}}
+// expected-note 15 {{add import of module 'lib'}}
 
 for _ in makeSequence() { }
 // expected-error@-1 {{instance method 'makeIterator()' is not available due to missing import of defining module 'lib'}}
 // expected-error@-2 {{instance method 'next()' is not available due to missing import of defining module 'lib'}}
 
+takesNilExpressible(nil)
+// expected-error@-1 {{initializer 'init(nilLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesIntExpressible(1)
+// expected-error@-1 {{initializer 'init(integerLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesFloatExpressible(1.0)
+// expected-error@-1 {{initializer 'init(floatLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesBoolExpressible(true)
+// expected-error@-1 {{initializer 'init(booleanLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesUnicodeScalarExpressible("🐦")
+// expected-error@-1 {{initializer 'init(unicodeScalarLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesExtendedGraphemeClusterExpressible("🦸🏾‍♀️")
+// expected-error@-1 {{initializer 'init(extendedGraphemeClusterLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesStringLiteralExpressible("Hello world")
+// expected-error@-1 {{initializer 'init(stringLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesArrayExpressible([1])
+// expected-error@-1 {{initializer 'init(arrayLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesDictionaryExpressible(["one": 1])
+// expected-error@-1 {{initializer 'init(dictionaryLiteral:)' is not available due to missing import of defining module 'lib'}}
+
 takesMessage("\(1)")
 // expected-error@-1 {{initializer 'init(stringInterpolation:)' is not available due to missing import of defining module 'lib'}}
 // expected-error@-2 {{instance method 'appendInterpolation' is not available due to missing import of defining module 'lib'}}
 // expected-error@-3 2 {{instance method 'appendLiteral' is not available due to missing import of defining module 'lib'}}
+
+takesColorExpressible(#colorLiteral(red: 0.0, green: 0.0, blue: 0.0, alpha: 1))
+// FIXME: Missing diangostic
+
+takesImageExpressible(#imageLiteral(resourceName: "image.png"))
+// FIXME: Missing diangostic
+
+takesFileReferenceExpressible(#fileLiteral(resourceName: "file.txt"))
+// FIXME: Missing diangostic
 
 //--- other.swift
 
@@ -28,7 +64,19 @@ func makeSequence() -> EmptySequence {
   return MySequence()
 }
 
+func takesNilExpressible(_ x: NilExpressible) { }
+func takesIntExpressible(_ x: IntExpressible) { }
+func takesFloatExpressible(_ x: FloatExpressible) { }
+func takesBoolExpressible(_ x: BoolExpressible) { }
+func takesUnicodeScalarExpressible(_ x: UnicodeScalarExpressible) { }
+func takesExtendedGraphemeClusterExpressible(_ x: ExtendedGraphemeClusterExpressible) { }
+func takesStringLiteralExpressible(_ x: StringExpressible) { }
+func takesArrayExpressible<E>(_ x: ArrayExpressible<E>) { }
+func takesDictionaryExpressible<K, V>(_ x: DictionaryExpressible<K, V>) { }
 func takesMessage(_ x: Message) { }
+func takesColorExpressible(_ x: ColorExpressible) { }
+func takesImageExpressible(_ x: ImageExpressible) { }
+func takesFileReferenceExpressible(_ x: FileReferenceExpressible) { }
 
 //--- lib.swift
 
@@ -41,6 +89,42 @@ public struct EmptySequence: Sequence {
   public init() { }
 }
 
+public struct NilExpressible: ExpressibleByNilLiteral {
+  public init(nilLiteral: ()) { }
+}
+
+public struct IntExpressible: ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Int) { }
+}
+
+public struct FloatExpressible: ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Float) { }
+}
+
+public struct BoolExpressible: ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Bool) { }
+}
+
+public struct UnicodeScalarExpressible: ExpressibleByUnicodeScalarLiteral {
+  public init(unicodeScalarLiteral value: Unicode.Scalar) { }
+}
+
+public struct ExtendedGraphemeClusterExpressible: ExpressibleByExtendedGraphemeClusterLiteral {
+  public init(extendedGraphemeClusterLiteral value: Character) { }
+}
+
+public struct StringExpressible: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) { }
+}
+
+public struct ArrayExpressible<Element>: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: Element...) { }
+}
+
+public struct DictionaryExpressible<Key, Value>: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (Key, Value)...) { }
+}
+
 public struct MessageInterpolation: StringInterpolationProtocol {
   public init(literalCapacity: Int, interpolationCount: Int) { }
   public mutating func appendInterpolation(_ value: @autoclosure () -> Int) { }
@@ -50,4 +134,16 @@ public struct MessageInterpolation: StringInterpolationProtocol {
 public struct Message: ExpressibleByStringInterpolation {
   public init(stringInterpolation: MessageInterpolation) { }
   public init(stringLiteral: String) { }
+}
+
+public struct ColorExpressible: _ExpressibleByColorLiteral {
+  public init(_colorLiteralRed red: Float, green: Float, blue: Float, alpha: Float) { }
+}
+
+public struct ImageExpressible: _ExpressibleByImageLiteral {
+  public init(imageLiteralResourceName path: String) { }
+}
+
+public struct FileReferenceExpressible: _ExpressibleByFileReferenceLiteral {
+  public init(fileReferenceLiteralResourceName path: String) { }
 }

--- a/test/NameLookup/members_transitive_compiler_protocols.swift
+++ b/test/NameLookup/members_transitive_compiler_protocols.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t %t/lib.swift
+// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %t/other.swift -I %t -verify -enable-upcoming-feature MemberImportVisibility
+
+// REQUIRES: swift_feature_MemberImportVisibility
+
+//--- main.swift
+
+import Swift
+// expected-note 2 {{add import of module 'lib'}}
+
+for _ in makeSequence() { }
+// expected-error@-1 {{instance method 'makeIterator()' is not available due to missing import of defining module 'lib'}}
+// expected-error@-2 {{instance method 'next()' is not available due to missing import of defining module 'lib'}}
+
+//--- other.swift
+
+import lib
+
+func makeSequence() -> EmptySequence {
+  return MySequence()
+}
+
+//--- lib.swift
+
+public struct EmptySequence: Sequence {
+  public struct Iterator: IteratorProtocol {
+    public mutating func next() -> Int? { nil }
+  }
+
+  public func makeIterator() -> Iterator { Iterator() }
+  public init() { }
+}

--- a/test/NameLookup/members_transitive_compiler_protocols.swift
+++ b/test/NameLookup/members_transitive_compiler_protocols.swift
@@ -9,11 +9,16 @@
 //--- main.swift
 
 import Swift
-// expected-note 2 {{add import of module 'lib'}}
+// expected-note 6 {{add import of module 'lib'}}
 
 for _ in makeSequence() { }
 // expected-error@-1 {{instance method 'makeIterator()' is not available due to missing import of defining module 'lib'}}
 // expected-error@-2 {{instance method 'next()' is not available due to missing import of defining module 'lib'}}
+
+takesMessage("\(1)")
+// expected-error@-1 {{initializer 'init(stringInterpolation:)' is not available due to missing import of defining module 'lib'}}
+// expected-error@-2 {{instance method 'appendInterpolation' is not available due to missing import of defining module 'lib'}}
+// expected-error@-3 2 {{instance method 'appendLiteral' is not available due to missing import of defining module 'lib'}}
 
 //--- other.swift
 
@@ -22,6 +27,8 @@ import lib
 func makeSequence() -> EmptySequence {
   return MySequence()
 }
+
+func takesMessage(_ x: Message) { }
 
 //--- lib.swift
 
@@ -32,4 +39,15 @@ public struct EmptySequence: Sequence {
 
   public func makeIterator() -> Iterator { Iterator() }
   public init() { }
+}
+
+public struct MessageInterpolation: StringInterpolationProtocol {
+  public init(literalCapacity: Int, interpolationCount: Int) { }
+  public mutating func appendInterpolation(_ value: @autoclosure () -> Int) { }
+  public mutating func appendLiteral(_ literal: String) { }
+}
+
+public struct Message: ExpressibleByStringInterpolation {
+  public init(stringInterpolation: MessageInterpolation) { }
+  public init(stringLiteral: String) { }
 }


### PR DESCRIPTION
Implicitly generated calls to `makeIterator()`, `next()`, and `appendLiteral(_:)` were all missing source locations, which made `MemberImportVisibility` diagnostics about missing imports hard to understand.

Resolves rdar://144535697.