### PR TITLE
[cxx-interop] Fix -verify-additional-file on Windows

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -145,6 +145,9 @@ private:
   unsigned IDEInspectionTargetOffset;
 
   /// Associates buffer identifiers to buffer IDs.
+  ///
+  /// On Windows, '/' and '\' are both valid path separators, so '/' is
+  /// normalized to '\' to ensure a consistent mapping.
   llvm::DenseMap<StringRef, unsigned> BufIdentIDMap;
 
   /// A cache mapping buffer identifiers to vfs Status entries.

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -101,7 +101,8 @@ SourceManager::addNewSourceBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
   assert(Buffer);
   StringRef BufIdentifier = Buffer->getBufferIdentifier();
   auto ID = LLVMSourceMgr.AddNewSourceBuffer(std::move(Buffer), llvm::SMLoc());
-  BufIdentIDMap[llvm::sys::path::convert_to_slash(BufIdentifier)] = ID;
+  auto Key = llvm::sys::path::convert_to_slash(BufIdentifier);
+  BufIdentIDMap[Key] = ID;
   return ID;
 }
 
@@ -209,8 +210,9 @@ SourceManager::getVirtualFile(SourceLoc Loc) const {
 }
 
 std::optional<unsigned>
-SourceManager::getIDForBufferIdentifier(StringRef BufIdent) const {
-  auto It = BufIdentIDMap.find(llvm::sys::path::convert_to_slash(BufIdent));
+SourceManager::getIDForBufferIdentifier(StringRef BufIdentifier) const {
+  auto Key = llvm::sys::path::convert_to_slash(BufIdentifier);
+  auto It = BufIdentIDMap.find(Key);
   if (It == BufIdentIDMap.end())
     return std::nullopt;
   return It->second;
@@ -707,7 +709,8 @@ std::optional<unsigned> SourceManager::resolveFromLineCol(unsigned BufferId,
 }
 
 unsigned SourceManager::getExternalSourceBufferID(StringRef Path) {
-  auto It = BufIdentIDMap.find(llvm::sys::path::convert_to_slash(Path));
+  auto Key = llvm::sys::path::convert_to_slash(Path);
+  auto It = BufIdentIDMap.find(Key);
   if (It != BufIdentIDMap.end()) {
     return It->getSecond();
   }

--- a/test/ClangImporter/attr-swift_name_renaming-objc.swift
+++ b/test/ClangImporter/attr-swift_name_renaming-objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -I %/S/Inputs/custom-modules -Xcc -w -typecheck -verify %s -verify-additional-file %/S/Inputs/custom-modules%{fs-sep}SwiftName.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -I %/S/Inputs/custom-modules -Xcc -w -typecheck -verify %s -verify-additional-file %S/Inputs/custom-modules/SwiftName.h
 
 import SwiftName
 

--- a/test/Interop/Cxx/class/access/private-fileid-diagnostics.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-diagnostics.swift
@@ -2,9 +2,6 @@
 // RUN: %target-swift-frontend -typecheck -verify -suppress-remarks %t/some/subdir/file1.swift -verify-additional-file %t/Cxx/include/cxx-header.h -I %t/Cxx/include -cxx-interoperability-mode=default -enable-experimental-feature ImportNonPublicCxxMembers -module-name main
 // REQUIRES: swift_feature_ImportNonPublicCxxMembers
 
-// This test uses -verify-additional-file, which do not work well on Windows:
-// UNSUPPORTED: OS=windows-msvc
-
 //--- Cxx/include/module.modulemap
 module CxxModule {
     requires cplusplus

--- a/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs %s -enable-experimental-cxx-interop -verify -verify-additional-file %S/Inputs/mutability-annotations.h
 
-// REQUIRES: rdar100876534
-
 import MutabilityAnnotations
 
 let obj = HasConstMethodAnnotatedAsMutating(a: 42) // expected-note {{change 'let' to 'var' to make it mutable}}

--- a/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
@@ -1,9 +1,6 @@
 // RUN: rm -rf %t
 // RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -verify-additional-file %S/Inputs/inheritance.h -Xcc -Wno-return-type -Xcc -Wno-inaccessible-base
 
-// TODO: Fix this lit test failure on windows rdar://145218056
-// XFAIL: OS=windows-msvc
-
 import Inheritance
 
 let _ = ImmortalRefereceExample.returnImmortalRefType()

--- a/test/ModuleInterface/BadStdlib.swiftinterface
+++ b/test/ModuleInterface/BadStdlib.swiftinterface
@@ -14,6 +14,3 @@
 import ClangMod
 
 public func useHasPointer(_: HasPointer)
-
-// FIXME: https://github.com/apple/swift/issues/56844
-// UNSUPPORTED: OS=windows-msvc


### PR DESCRIPTION
SourceManager uses associates paths to buffer IDs using BufIdentIDMap. However, on Windows, both '\' and '/' are valid path separators, so foo\bar\baz.cpp foo/bar\baz.cpp and foo/bar/baz.cpp all refer to the same file, but will be stored as separate entries in BufIdentIDMap. This led -verify-additional-file to misbehave because it would create multiple buffer ID numbers for the same path, which confused the diagnostic verifier logic.

This patch normalizes paths before looking them up in BufIdentIDMap, so that buffer IDs are uniquely associated with each file rather than each path.