### PR TITLE
[6.2] `MemberImportVisibility` bug fixes

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1972,7 +1972,7 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
         new (Context) UnresolvedDotExpr(InterpolationVarRef,
                                         /*dotloc=*/SourceLoc(),
                                         appendLiteral,
-                                        /*nameloc=*/DeclNameLoc(), 
+                                        /*nameloc=*/DeclNameLoc(TokenLoc),
                                         /*Implicit=*/true);
       auto *ArgList = ArgumentList::forImplicitUnlabeled(Context, {Literal});
       auto AppendLiteralCall =

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4602,8 +4602,9 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
     FuncDecl *makeIterator = isAsync ? ctx.getAsyncSequenceMakeAsyncIterator()
                                      : ctx.getSequenceMakeIterator();
 
-    auto *makeIteratorRef = UnresolvedDotExpr::createImplicit(
-        ctx, sequenceExpr, makeIterator->getName());
+    auto *makeIteratorRef = new (ctx) UnresolvedDotExpr(
+        sequenceExpr, SourceLoc(), DeclNameRef(makeIterator->getName()),
+        DeclNameLoc(stmt->getForLoc()), /*implicit=*/true);
     makeIteratorRef->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
 
     Expr *makeIteratorCall =
@@ -4666,11 +4667,13 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
     TinyPtrVector<Identifier> labels;
     if (nextFn && nextFn->getParameters()->size() == 1)
       labels.push_back(ctx.Id_isolation);
-    auto *nextRef = UnresolvedDotExpr::createImplicit(
-        ctx,
+    auto *makeIteratorVarRef =
         new (ctx) DeclRefExpr(makeIteratorVar, DeclNameLoc(stmt->getForLoc()),
-                              /*Implicit=*/true),
-        nextId, labels);
+                              /*Implicit=*/true);
+    auto *nextRef = new (ctx)
+        UnresolvedDotExpr(makeIteratorVarRef, SourceLoc(),
+                          DeclNameRef(DeclName(ctx, nextId, labels)),
+                          DeclNameLoc(stmt->getForLoc()), /*implicit=*/true);
     nextRef->setFunctionRefInfo(FunctionRefInfo::singleBaseNameApply());
 
     ArgumentList *nextArgs;

--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
@@ -168,11 +168,11 @@ enum Tree : Differentiable & AdditiveArithmetic {
 // (`Collection.makeIterator` and `IteratorProtocol.next`).
 // expected-error @+1 {{function is not differentiable}}
 @differentiable(reverse)
-// expected-note @+2 {{when differentiating this function definition}}
-// expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}} {{+2:12-12=withoutDerivative(at: }} {{+2:17-17=)}}
 func loop_array(_ array: [Float]) -> Float {
+  // expected-note@-1 {{when differentiating this function definition}}
   var result: Float = 1
   for x in array {
+    // expected-note@-1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'}}
     result = result * x
   }
   return result

--- a/test/Concurrency/async_sequence_existential.swift
+++ b/test/Concurrency/async_sequence_existential.swift
@@ -4,6 +4,9 @@
 
 // REQUIRES: concurrency
 
+// https://github.com/swiftlang/swift/issues/80582
+// UNSUPPORTED: OS=windows-msvc
+
 extension Error {
   func printMe() { }
 }

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_A.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_A.h
@@ -1,6 +1,13 @@
 @import Foundation;
 
-@interface X
+@interface Base
+- (void)overriddenInOverlayForA __attribute__((deprecated("Categories_A.h")));
+- (void)overriddenInOverlayForB __attribute__((deprecated("Categories_A.h")));
+- (void)overriddenInOverlayForC __attribute__((deprecated("Categories_A.h")));
+- (void)overriddenInSubclassInOverlayForC __attribute__((deprecated("Categories_A.h")));
+@end
+
+@interface X : Base
 @end
 
 @interface X (A)

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_A.swift
@@ -3,4 +3,7 @@
 extension X {
   public func fromOverlayForA() {}
   @objc public func fromOverlayForAObjC() {}
+
+  @available(*, deprecated, message: "Categories_A.swift")
+  public override func overriddenInOverlayForA() {}
 }

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_B.swift
@@ -3,4 +3,7 @@
 extension X {
   public func fromOverlayForB() {}
   @objc public func fromOverlayForBObjC() {}
+
+  @available(*, deprecated, message: "Categories_B.swift")
+  public override func overriddenInOverlayForB() {}
 }

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_C.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_C.h
@@ -3,3 +3,7 @@
 @interface X (C)
 - (void)fromC;
 @end
+
+@interface SubclassFromC : X
+- (instancetype)init;
+@end

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_C.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_C.swift
@@ -3,4 +3,12 @@
 extension X {
   public func fromOverlayForC() {}
   @objc public func fromOverlayForCObjC() {}
+
+  @available(*, deprecated, message: "Categories_C.swift")
+  public override func overriddenInOverlayForC() {}
+}
+
+extension SubclassFromC {
+  @available(*, deprecated, message: "Categories_C.swift")
+  public override func overriddenInSubclassInOverlayForC() {}
 }

--- a/test/NameLookup/Inputs/MemberImportVisibility/Categories_E.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/Categories_E.swift
@@ -1,2 +1,4 @@
 import Categories_C
 import Categories_D.Submodule
+
+public func makeSubclassFromC() -> SubclassFromC { SubclassFromC() }

--- a/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/Branch.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/Branch.h
@@ -1,0 +1,9 @@
+@import Root;
+
+@interface BranchObject : RootObject
+- (void)overridden1 __attribute__((deprecated("Branch.h")));
+@end
+
+@interface BranchObject (Branch)
+- (void)overridden3 __attribute__((deprecated("Branch.h")));
+@end

--- a/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/Fruit.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/Fruit.h
@@ -1,0 +1,5 @@
+@import Branch;
+
+@interface FruitObject : BranchObject
+- (void)overridden1 __attribute__((deprecated("Fruit.h")));
+@end

--- a/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/Leaf.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/Leaf.h
@@ -1,0 +1,14 @@
+@import Branch;
+
+@interface LeafObject : BranchObject
+- (void)overridden1 __attribute__((deprecated("Leaf.h")));
+@end
+
+@interface BranchObject (Leaf)
+- (void)overridden2 __attribute__((deprecated("Leaf.h")));
+@end
+
+@interface LeafObject (Leaf)
+- (void)overridden3 __attribute__((deprecated("Leaf.h")));
+@end
+

--- a/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/Root.h
+++ b/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/Root.h
@@ -1,0 +1,9 @@
+@interface RootObject
+- (instancetype)init;
+- (void)overridden1 __attribute__((deprecated("Root.h")));
+- (void)overridden2 __attribute__((deprecated("Root.h")));
+@end
+
+@interface RootObject (Root)
+- (void)overridden3 __attribute__((deprecated("Root.h")));
+@end

--- a/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/module.modulemap
+++ b/test/NameLookup/Inputs/MemberImportVisibility/ObjCOverloads/module.modulemap
@@ -1,0 +1,19 @@
+module Root {
+  header "Root.h"
+  export *
+}
+
+module Branch {
+  header "Branch.h"
+  export *
+}
+
+module Leaf {
+  header "Leaf.h"
+  export *
+}
+
+module Fruit {
+  header "Fruit.h"
+  export *
+}

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_A.swift
@@ -35,8 +35,8 @@ public enum EnumInA {
 }
 
 open class BaseClassInA {
-  public init() {}
   open func methodInA() {}
+  open func overriddenMethod() {}
 }
 
 public protocol ProtocolInA {

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_B.swift
@@ -37,6 +37,7 @@ package enum EnumInB_package {
 
 open class DerivedClassInB: BaseClassInA {
   open func methodInB() {}
+  open override func overriddenMethod() {}
 }
 
 extension ProtocolInA {

--- a/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
+++ b/test/NameLookup/Inputs/MemberImportVisibility/members_C.swift
@@ -31,6 +31,8 @@ public enum EnumInC {
 
 open class DerivedClassInC: DerivedClassInB {
   open func methodInC() {}
+  open override func overriddenMethod() {}
+  public func asDerivedClassInB() -> DerivedClassInB { return self }
 }
 
 extension ProtocolInA {

--- a/test/NameLookup/members_transitive.swift
+++ b/test/NameLookup/members_transitive.swift
@@ -9,7 +9,7 @@
 // REQUIRES: swift_feature_MemberImportVisibility
 
 import members_C
-// expected-member-visibility-note 16{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
+// expected-member-visibility-note 18{{add import of module 'members_B'}}{{1-1=internal import members_B\n}}
 
 
 func testExtensionMembers(x: X, y: Y<Z>) {
@@ -96,8 +96,22 @@ class DerivedFromClassInC: DerivedClassInC {
 
 struct ConformsToProtocolInA: ProtocolInA {} // expected-member-visibility-error{{type 'ConformsToProtocolInA' does not conform to protocol 'ProtocolInA'}} expected-member-visibility-note {{add stubs for conformance}}
 
-func testDerivedMethodAccess() {
-  DerivedClassInC().methodInC()
-  DerivedClassInC().methodInB() // expected-member-visibility-error{{instance method 'methodInB()' is not available due to missing import of defining module 'members_B'}}
-  DerivedFromClassInC().methodInB()
+func testInheritedMethods(
+  a: BaseClassInA,
+  c: DerivedClassInC,
+) {
+  let b = c.asDerivedClassInB()
+
+  a.methodInA()
+  b.methodInA()
+  c.methodInA()
+
+  b.methodInB() // expected-member-visibility-error{{instance method 'methodInB()' is not available due to missing import of defining module 'members_B'}}
+  c.methodInB() // expected-member-visibility-error{{instance method 'methodInB()' is not available due to missing import of defining module 'members_B'}}
+
+  c.methodInC()
+
+  a.overriddenMethod()
+  b.overriddenMethod() // expected-member-visibility-error{{instance method 'overriddenMethod()' is not available due to missing import of defining module 'members_B'}}
+  c.overriddenMethod()
 }

--- a/test/NameLookup/members_transitive_compiler_protocols.swift
+++ b/test/NameLookup/members_transitive_compiler_protocols.swift
@@ -9,16 +9,52 @@
 //--- main.swift
 
 import Swift
-// expected-note 6 {{add import of module 'lib'}}
+// expected-note 15 {{add import of module 'lib'}}
 
 for _ in makeSequence() { }
 // expected-error@-1 {{instance method 'makeIterator()' is not available due to missing import of defining module 'lib'}}
 // expected-error@-2 {{instance method 'next()' is not available due to missing import of defining module 'lib'}}
 
+takesNilExpressible(nil)
+// expected-error@-1 {{initializer 'init(nilLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesIntExpressible(1)
+// expected-error@-1 {{initializer 'init(integerLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesFloatExpressible(1.0)
+// expected-error@-1 {{initializer 'init(floatLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesBoolExpressible(true)
+// expected-error@-1 {{initializer 'init(booleanLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesUnicodeScalarExpressible("🐦")
+// expected-error@-1 {{initializer 'init(unicodeScalarLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesExtendedGraphemeClusterExpressible("🦸🏾‍♀️")
+// expected-error@-1 {{initializer 'init(extendedGraphemeClusterLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesStringLiteralExpressible("Hello world")
+// expected-error@-1 {{initializer 'init(stringLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesArrayExpressible([1])
+// expected-error@-1 {{initializer 'init(arrayLiteral:)' is not available due to missing import of defining module 'lib'}}
+
+takesDictionaryExpressible(["one": 1])
+// expected-error@-1 {{initializer 'init(dictionaryLiteral:)' is not available due to missing import of defining module 'lib'}}
+
 takesMessage("\(1)")
 // expected-error@-1 {{initializer 'init(stringInterpolation:)' is not available due to missing import of defining module 'lib'}}
 // expected-error@-2 {{instance method 'appendInterpolation' is not available due to missing import of defining module 'lib'}}
 // expected-error@-3 2 {{instance method 'appendLiteral' is not available due to missing import of defining module 'lib'}}
+
+takesColorExpressible(#colorLiteral(red: 0.0, green: 0.0, blue: 0.0, alpha: 1))
+// FIXME: Missing diangostic
+
+takesImageExpressible(#imageLiteral(resourceName: "image.png"))
+// FIXME: Missing diangostic
+
+takesFileReferenceExpressible(#fileLiteral(resourceName: "file.txt"))
+// FIXME: Missing diangostic
 
 //--- other.swift
 
@@ -28,7 +64,19 @@ func makeSequence() -> EmptySequence {
   return MySequence()
 }
 
+func takesNilExpressible(_ x: NilExpressible) { }
+func takesIntExpressible(_ x: IntExpressible) { }
+func takesFloatExpressible(_ x: FloatExpressible) { }
+func takesBoolExpressible(_ x: BoolExpressible) { }
+func takesUnicodeScalarExpressible(_ x: UnicodeScalarExpressible) { }
+func takesExtendedGraphemeClusterExpressible(_ x: ExtendedGraphemeClusterExpressible) { }
+func takesStringLiteralExpressible(_ x: StringExpressible) { }
+func takesArrayExpressible<E>(_ x: ArrayExpressible<E>) { }
+func takesDictionaryExpressible<K, V>(_ x: DictionaryExpressible<K, V>) { }
 func takesMessage(_ x: Message) { }
+func takesColorExpressible(_ x: ColorExpressible) { }
+func takesImageExpressible(_ x: ImageExpressible) { }
+func takesFileReferenceExpressible(_ x: FileReferenceExpressible) { }
 
 //--- lib.swift
 
@@ -41,6 +89,42 @@ public struct EmptySequence: Sequence {
   public init() { }
 }
 
+public struct NilExpressible: ExpressibleByNilLiteral {
+  public init(nilLiteral: ()) { }
+}
+
+public struct IntExpressible: ExpressibleByIntegerLiteral {
+  public init(integerLiteral value: Int) { }
+}
+
+public struct FloatExpressible: ExpressibleByFloatLiteral {
+  public init(floatLiteral value: Float) { }
+}
+
+public struct BoolExpressible: ExpressibleByBooleanLiteral {
+  public init(booleanLiteral value: Bool) { }
+}
+
+public struct UnicodeScalarExpressible: ExpressibleByUnicodeScalarLiteral {
+  public init(unicodeScalarLiteral value: Unicode.Scalar) { }
+}
+
+public struct ExtendedGraphemeClusterExpressible: ExpressibleByExtendedGraphemeClusterLiteral {
+  public init(extendedGraphemeClusterLiteral value: Character) { }
+}
+
+public struct StringExpressible: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) { }
+}
+
+public struct ArrayExpressible<Element>: ExpressibleByArrayLiteral {
+  public init(arrayLiteral elements: Element...) { }
+}
+
+public struct DictionaryExpressible<Key, Value>: ExpressibleByDictionaryLiteral {
+  public init(dictionaryLiteral elements: (Key, Value)...) { }
+}
+
 public struct MessageInterpolation: StringInterpolationProtocol {
   public init(literalCapacity: Int, interpolationCount: Int) { }
   public mutating func appendInterpolation(_ value: @autoclosure () -> Int) { }
@@ -50,4 +134,16 @@ public struct MessageInterpolation: StringInterpolationProtocol {
 public struct Message: ExpressibleByStringInterpolation {
   public init(stringInterpolation: MessageInterpolation) { }
   public init(stringLiteral: String) { }
+}
+
+public struct ColorExpressible: _ExpressibleByColorLiteral {
+  public init(_colorLiteralRed red: Float, green: Float, blue: Float, alpha: Float) { }
+}
+
+public struct ImageExpressible: _ExpressibleByImageLiteral {
+  public init(imageLiteralResourceName path: String) { }
+}
+
+public struct FileReferenceExpressible: _ExpressibleByFileReferenceLiteral {
+  public init(fileReferenceLiteralResourceName path: String) { }
 }

--- a/test/NameLookup/members_transitive_compiler_protocols.swift
+++ b/test/NameLookup/members_transitive_compiler_protocols.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t %t/lib.swift
+// RUN: %target-swift-frontend -typecheck -primary-file %t/main.swift %t/other.swift -I %t -verify -enable-upcoming-feature MemberImportVisibility
+
+// REQUIRES: swift_feature_MemberImportVisibility
+
+//--- main.swift
+
+import Swift
+// expected-note 2 {{add import of module 'lib'}}
+
+for _ in makeSequence() { }
+// expected-error@-1 {{instance method 'makeIterator()' is not available due to missing import of defining module 'lib'}}
+// expected-error@-2 {{instance method 'next()' is not available due to missing import of defining module 'lib'}}
+
+//--- other.swift
+
+import lib
+
+func makeSequence() -> EmptySequence {
+  return MySequence()
+}
+
+//--- lib.swift
+
+public struct EmptySequence: Sequence {
+  public struct Iterator: IteratorProtocol {
+    public mutating func next() -> Int? { nil }
+  }
+
+  public func makeIterator() -> Iterator { Iterator() }
+  public init() { }
+}

--- a/test/NameLookup/members_transitive_compiler_protocols.swift
+++ b/test/NameLookup/members_transitive_compiler_protocols.swift
@@ -9,11 +9,16 @@
 //--- main.swift
 
 import Swift
-// expected-note 2 {{add import of module 'lib'}}
+// expected-note 6 {{add import of module 'lib'}}
 
 for _ in makeSequence() { }
 // expected-error@-1 {{instance method 'makeIterator()' is not available due to missing import of defining module 'lib'}}
 // expected-error@-2 {{instance method 'next()' is not available due to missing import of defining module 'lib'}}
+
+takesMessage("\(1)")
+// expected-error@-1 {{initializer 'init(stringInterpolation:)' is not available due to missing import of defining module 'lib'}}
+// expected-error@-2 {{instance method 'appendInterpolation' is not available due to missing import of defining module 'lib'}}
+// expected-error@-3 2 {{instance method 'appendLiteral' is not available due to missing import of defining module 'lib'}}
 
 //--- other.swift
 
@@ -22,6 +27,8 @@ import lib
 func makeSequence() -> EmptySequence {
   return MySequence()
 }
+
+func takesMessage(_ x: Message) { }
 
 //--- lib.swift
 
@@ -32,4 +39,15 @@ public struct EmptySequence: Sequence {
 
   public func makeIterator() -> Iterator { Iterator() }
   public init() { }
+}
+
+public struct MessageInterpolation: StringInterpolationProtocol {
+  public init(literalCapacity: Int, interpolationCount: Int) { }
+  public mutating func appendInterpolation(_ value: @autoclosure () -> Int) { }
+  public mutating func appendLiteral(_ literal: String) { }
+}
+
+public struct Message: ExpressibleByStringInterpolation {
+  public init(stringInterpolation: MessageInterpolation) { }
+  public init(stringLiteral: String) { }
 }

--- a/test/NameLookup/members_transitive_objc.swift
+++ b/test/NameLookup/members_transitive_objc.swift
@@ -3,8 +3,8 @@
 // RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/MemberImportVisibility -o %t %S/Inputs/MemberImportVisibility/Categories_B.swift
 // RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/MemberImportVisibility -o %t %S/Inputs/MemberImportVisibility/Categories_C.swift
 // RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/MemberImportVisibility -o %t %S/Inputs/MemberImportVisibility/Categories_E.swift
-// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 5
-// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 6
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 5 -verify-additional-prefix no-member-visibility-
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 6 -verify-additional-prefix no-member-visibility-
 // RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/MemberImportVisibility -import-objc-header %S/Inputs/MemberImportVisibility/Bridging.h -verify -swift-version 5 -enable-upcoming-feature MemberImportVisibility -verify-additional-prefix member-visibility-
 
 // REQUIRES: objc_interop
@@ -13,30 +13,43 @@
 import Categories_B
 import Categories_E
 
-// expected-member-visibility-note@-1 2 {{add import of module 'Categories_C'}}{{1-1=internal import Categories_C\n}}
+// expected-member-visibility-note@-1 3 {{add import of module 'Categories_C'}}{{1-1=internal import Categories_C\n}}
 // expected-member-visibility-note@-2 {{add import of module 'Categories_D'}}{{1-1=internal import Categories_D\n}}
 func test(x: X) {
   x.fromA()
   x.fromOverlayForA()
+  x.overriddenInOverlayForA() // expected-warning {{'overriddenInOverlayForA()' is deprecated: Categories_A.swift}}
   x.fromB()
   x.fromOverlayForB()
+  x.overriddenInOverlayForB() // expected-warning {{'overriddenInOverlayForB()' is deprecated: Categories_B.swift}}
   x.fromC() // expected-member-visibility-error {{instance method 'fromC()' is not available due to missing import of defining module 'Categories_C'}}
   x.fromOverlayForC() // expected-member-visibility-error {{instance method 'fromOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
+  x.overriddenInOverlayForC()
+  // expected-no-member-visibility-warning@-1 {{'overriddenInOverlayForC()' is deprecated: Categories_C.swift}}
+  // expected-member-visibility-warning@-2 {{'overriddenInOverlayForC()' is deprecated: Categories_A.h}}
   x.fromSubmoduleOfD() // expected-member-visibility-error {{instance method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
   x.fromBridgingHeader()
   x.overridesCategoryMethodOnNSObject()
+
+  let subclassFromC = makeSubclassFromC()
+  subclassFromC.overriddenInSubclassInOverlayForC()
+  // expected-warning@-1 {{'overriddenInSubclassInOverlayForC()' is deprecated: Categories_C.swift}}
+  // expected-member-visibility-error@-2 {{instance method 'overriddenInSubclassInOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
 }
 
 func testAnyObject(a: AnyObject) {
   a.fromA()
   a.fromOverlayForAObjC()
+  a.overriddenInOverlayForA() // expected-warning {{'overriddenInOverlayForA()' is deprecated: Categories_A.h}}
   a.fromB()
   a.fromOverlayForBObjC()
+  a.overriddenInOverlayForB() // expected-warning {{'overriddenInOverlayForB()' is deprecated: Categories_A.h}}
   // FIXME: Better diagnostics?
   // Name lookup for AnyObject already ignored transitive imports, so
   // `MemberImportVisibility` has no effect on these diagnostics.
   a.fromC() // expected-error {{value of type 'AnyObject' has no member 'fromC'}}
   a.fromOverlayForCObjC() // expected-error {{value of type 'AnyObject' has no member 'fromOverlayForCObjC'}}
+  a.overriddenInOverlayForC() // expected-warning {{'overriddenInOverlayForC()' is deprecated: Categories_A.h}}
   a.fromBridgingHeader()
   a.overridesCategoryMethodOnNSObject()
 }

--- a/test/NameLookup/members_transitive_objc_overrides.swift
+++ b/test/NameLookup/members_transitive_objc_overrides.swift
@@ -1,0 +1,253 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck \
+// RUN:   -primary-file %t/file1.swift \
+// RUN:   -primary-file %t/file2.swift \
+// RUN:   -primary-file %t/file3.swift \
+// RUN:   -primary-file %t/file4.swift \
+// RUN:   -primary-file %t/file5.swift \
+// RUN:   -I %S/Inputs/MemberImportVisibility/ObjCOverloads \
+// RUN:   -verify -verify-additional-prefix no-member-visibility-
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck \
+// RUN:   -primary-file %t/file1.swift \
+// RUN:   -primary-file %t/file2.swift \
+// RUN:   -primary-file %t/file3.swift \
+// RUN:   -primary-file %t/file4.swift \
+// RUN:   -primary-file %t/file5.swift \
+// RUN:   -I %S/Inputs/MemberImportVisibility/ObjCOverloads \
+// RUN:   -enable-upcoming-feature MemberImportVisibility \
+// RUN:   -verify -verify-additional-prefix member-visibility-
+
+// REQUIRES: objc_interop
+// REQUIRES: swift_feature_MemberImportVisibility
+
+//--- file1.swift
+
+import Root
+// expected-member-visibility-note 3 {{add import of module 'Branch'}}
+// expected-member-visibility-note@-1 2 {{add import of module 'Leaf'}}
+// expected-member-visibility-note@-2 {{add import of module 'Fruit'}}
+
+func testImportRoot_overridden1() {
+  makeRootObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Branch.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Branch'}}
+
+  makeLeafObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Leaf'}}
+
+  makeFruitObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Fruit'}}
+}
+
+func testImportRoot_overridden2() {
+  makeRootObject().overridden2()
+  // expected-warning@-1 {{'overridden2()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+
+  makeLeafObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+
+  makeFruitObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+}
+
+func testImportRoot_overridden3() {
+  makeRootObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Branch'}}
+
+  makeLeafObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Leaf'}}
+
+  makeFruitObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Branch'}}
+}
+
+
+//--- file2.swift
+
+import Branch
+// expected-member-visibility-note 2 {{add import of module 'Leaf'}}
+// expected-member-visibility-note@-1 {{add import of module 'Fruit'}}
+
+func testImportBranch_overridden1() {
+  makeRootObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Branch.h}}
+
+  makeLeafObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Leaf'}}
+
+  makeFruitObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Fruit'}}
+}
+
+func testImportBranch_overridden2() {
+  makeRootObject().overridden2()
+  // expected-warning@-1 {{'overridden2()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+
+  makeLeafObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+
+  makeFruitObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+}
+
+func testImportBranch_overridden3() {
+  makeRootObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+
+  makeLeafObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Leaf'}}
+
+  makeFruitObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+}
+
+
+//--- file3.swift
+
+import Leaf
+// expected-member-visibility-note {{add import of module 'Fruit'}}
+
+func testImportLeaf_overridden1() {
+  makeRootObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Branch.h}}
+
+  makeLeafObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
+
+  makeFruitObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Fruit'}}
+}
+
+func testImportLeaf_overridden2() {
+  makeRootObject().overridden2()
+  // expected-warning@-1 {{'overridden2()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden2()
+  // expected-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+
+  makeLeafObject().overridden2()
+  // expected-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+
+  makeFruitObject().overridden2()
+  // expected-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+}
+
+func testImportLeaf_overridden3() {
+  makeRootObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+
+  makeLeafObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
+
+  makeFruitObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+}
+
+
+//--- file4.swift
+
+import Fruit
+// expected-member-visibility-note 2 {{add import of module 'Leaf'}}
+
+func testImportFruit_overridden1() {
+  makeRootObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Branch.h}}
+
+  makeLeafObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Leaf.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden1()' is not available due to missing import of defining module 'Leaf'}}
+
+  makeFruitObject().overridden1()
+  // expected-warning@-1 {{'overridden1()' is deprecated: Fruit.h}}
+}
+
+func testImportFruit_overridden2() {
+  makeRootObject().overridden2()
+  // expected-warning@-1 {{'overridden2()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+
+  makeLeafObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+
+  makeFruitObject().overridden2()
+  // expected-no-member-visibility-warning@-1 {{'overridden2()' is deprecated: Leaf.h}}
+  // expected-member-visibility-warning@-2 {{'overridden2()' is deprecated: Root.h}}
+}
+
+func testImportFruit_overridden3() {
+  makeRootObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Root.h}}
+
+  makeBranchObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+
+  makeLeafObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Leaf.h}}
+  // expected-member-visibility-error@-2 {{instance method 'overridden3()' is not available due to missing import of defining module 'Leaf'}}
+
+  makeFruitObject().overridden3()
+  // expected-warning@-1 {{'overridden3()' is deprecated: Branch.h}}
+}
+
+
+//--- file5.swift
+
+import Root
+import Branch
+import Leaf
+import Fruit
+
+func makeRootObject() -> RootObject { RootObject() }
+func makeBranchObject() -> BranchObject { BranchObject() }
+func makeLeafObject() -> LeafObject { LeafObject() }
+func makeFruitObject() -> FruitObject { FruitObject() }


### PR DESCRIPTION
- **Explanation:** First, filter out Obj-C method overrides when they are declared in a module that isn't imported in the source file and the extended type is from a different module. This narrow fix helps ensure that unwanted overrides don't hijack name lookup and cause the compiler to insist that the developer import a module that they don't want to import in order to call an overridden method. Second, add source locations to more implicitly generated AST nodes so that diagnostics about missing imports get rendered correctly for them.
- **Scope:** Fixes two bugs that are frequently encountered while adopting the upcoming `MemberImportVisibility` feature.
- **Issue/Radar:** rdar://145329988 and rdar://144535697
- **Original PRs:** https://github.com/swiftlang/swift/pull/80563 and https://github.com/swiftlang/swift/pull/80560
- **Risk:** Low. Filtering out the un-imported Obj-C method overrides should only allow more code to type-check by preventing those overrides from shadowing other overrides that have been imported. And adding source locations to more AST nodes should generally only affect whether diagnostics are emitted at a known source location or not. 
- **Testing:** New compiler test cases.