### PR TITLE
[cxx-interop] Fix calling rvalue ref of a trivial type

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1543,6 +1543,9 @@ static bool isClangTypeMoreIndirectThanSubstType(TypeConverter &TC,
   if (importer::isCxxConstReferenceType(clangTy))
     return true;
 
+  if (clangTy->isRValueReferenceType())
+    return true;
+
   return false;
 }
 

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -103,4 +103,9 @@ ReferenceTestSuite.test("const reference to template") {
   expectEqual(53, ref.pointee)
 }
 
+ReferenceTestSuite.test("rvalue reference of trivial type") {
+  setStaticIntRvalueRef(consuming: 2)
+  expectEqual(2, getStaticInt())
+}
+
 runAllTests()


### PR DESCRIPTION
The Swift compiler used to generate a direct call to functions taking rvalue references to trivial types even though they expected an indirect calling conventions. This PR changes the calling convention on the Swift side to match C++.

rdar://148585343
