### PR TITLE
[CS] Allow binding closure param to pack expansion

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3115,6 +3115,8 @@ ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
                                      ConstraintKind kind, TypeMatchOptions flags,
                                      ConstraintLocatorBuilder locator) {
+  func1 = simplifyType(func1)->castTo<FunctionType>();
+  func2 = simplifyType(func2)->castTo<FunctionType>();
   // Match the 'throws' effect.
   TypeMatchResult throwsResult =
       matchFunctionThrowing(*this, func1, func2, kind, flags, locator);
@@ -12071,11 +12073,6 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
     if (contextualTy->isTypeVariableOrMember())
       return false;
 
-    // Cannot propagate pack expansion type from context,
-    // it has to be handled by type matching logic.
-    if (isPackExpansionType(contextualTy))
-      return false;
-
     // If contextual type has an error, let's wait for inference,
     // otherwise contextual would interfere with diagnostics.
     if (contextualTy->hasError())
@@ -12241,8 +12238,19 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
       // choices in the body.
       if (auto contextualParam = getContextualParamAt(i)) {
         auto paramTy = simplifyType(contextualParam->getOldType());
-        if (isSuitableContextualType(paramTy))
+        auto isSuitable = isSuitableContextualType(paramTy);
+        if (isSuitable && !paramTy->is<PackExpansionType>())
           addConstraint(ConstraintKind::Bind, externalType, paramTy, paramLoc);
+        else if (isSuitable) {
+          // If we have an unbound type variable and the contextual parameter
+          // type is a pack expansion, we must bind it here. Otherwise, it will
+          // never get bound.
+          if (auto externalTypeVar =
+                  getFixedTypeRecursive(externalType, /*wantRValue=*/true)
+                      ->getAs<TypeVariableType>()) {
+            assignFixedType(externalTypeVar, paramTy);
+          }
+        }
       }
 
       addConstraint(

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -617,6 +617,7 @@ Type ConstraintSystem::getUnopenedTypeOfReference(
 
   requestedType =
       requestedType->getWithoutSpecifierType()->getReferenceStorageReferent();
+  requestedType = simplifyType(requestedType);
 
   // Strip pack expansion types off of pack references.
   if (auto *expansion = requestedType->getAs<PackExpansionType>())

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -798,3 +798,13 @@ do {
     }
   }
 }
+
+// https://github.com/swiftlang/swift/issues/78426
+func test_pack_param_inference_closure<each T>(_: repeat each T) {
+  func takesGeneric<U>(_: U) {}
+  let _: (repeat each T) -> Void = { x in }
+  let _: (repeat each T) -> Void = { repeat takesGeneric(each $0) }
+  let _: (Any, repeat each T) -> Void = { _,x in repeat takesGeneric(each x) }
+  let _ = { x in repeat takesGeneric(each x) }
+  // expected-error@-1{{cannot infer type of closure parameter 'x' without a type annotation}}
+}


### PR DESCRIPTION
In `resolveClosureType` allow binding a closure parameter (when it's a free type variable)  to a contextual type that is a pack expansion and otherwise valid.

Resolves: [#78426](https://github.com/swiftlang/swift/issues/78426)