### PR TITLE
[6.2] CastOptimizer: handle isolated conformances

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCheckedCast.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCheckedCast.swift
@@ -81,7 +81,9 @@ private extension UnconditionalCheckedCastInst {
       return
     }
     let conformance = sourceFormalType.instanceTypeOfMetatype.checkConformance(to: proto)
-    guard conformance.isValid else {
+    guard conformance.isValid,
+          conformance.matchesActorIsolation(in: parentFunction)
+    else {
       return
     }
     

--- a/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
+++ b/SwiftCompilerSources/Sources/SIL/ASTExtensions.swift
@@ -54,3 +54,11 @@ extension SubstitutionMap {
     return SubstitutionMap(bridged: method.bridged.getMethodSubstitutions(bridged))
   }
 }
+
+extension Conformance {
+  /// Returns true if the conformance is not isolated or if its isolation matches
+  /// the isolation in `function`.
+  public func matchesActorIsolation(in function: Function) -> Bool {
+    return function.bridged.conformanceMatchesActorIsolation(bridged)
+  }
+}

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -69,6 +69,10 @@ DynamicCastFeasibility classifyDynamicCast(
     bool isSourceTypeExact = false,
     bool isWholeModuleOpts = false);
 
+/// Returns true if the conformance is not isolated or if its isolation matches
+/// the isolation `inFunction`.
+bool matchesActorIsolation(ProtocolConformanceRef conformance, SILFunction *inFunction);
+
 SILValue emitSuccessfulScalarUnconditionalCast(SILBuilder &B, SILLocation loc,
                                                SILDynamicCastInst inst);
 

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -64,7 +64,7 @@ atBest(DynamicCastFeasibility feasibility, DynamicCastFeasibility bestCase) {
 /// Classify the feasibility of a dynamic cast.  The source and target
 /// types should be unlowered formal types.
 DynamicCastFeasibility classifyDynamicCast(
-    ModuleDecl *context,
+    SILFunction *function,
     CanType sourceType, CanType targetType,
     bool isSourceTypeExact = false,
     bool isWholeModuleOpts = false);
@@ -390,7 +390,7 @@ public:
 
   DynamicCastFeasibility classifyFeasibility(bool allowWholeModule) const {
     return swift::classifyDynamicCast(
-        getModule().getSwiftModule(),
+        getFunction(),
         getSourceFormalType(), getTargetFormalType(),
         isSourceTypeExact(), allowWholeModule && getModule().isWholeModule());
   }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -507,6 +507,7 @@ struct BridgedFunction {
   BRIDGED_INLINE BridgedLinkage getLinkage() const;
   BRIDGED_INLINE void setLinkage(BridgedLinkage linkage) const;
   BRIDGED_INLINE void setIsSerialized(bool isSerialized) const;
+  BRIDGED_INLINE bool conformanceMatchesActorIsolation(BridgedConformance conformance) const;
   bool isTrapNoReturn() const;
   bool isConvertPointerToPointerArgument() const;
   bool isAutodiffVJP() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -28,6 +28,7 @@
 #include "swift/Basic/BasicBridging.h"
 #include "swift/Basic/Nullability.h"
 #include "swift/SIL/ApplySite.h"
+#include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/InstWrappers.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILDefaultWitnessTable.h"
@@ -821,6 +822,10 @@ void BridgedFunction::setLinkage(BridgedLinkage linkage) const {
 
 void BridgedFunction::setIsSerialized(bool isSerialized) const {
   getFunction()->setSerializedKind(isSerialized ? swift::IsSerialized : swift::IsNotSerialized);
+}
+
+bool BridgedFunction::conformanceMatchesActorIsolation(BridgedConformance conformance) const {
+  return swift::matchesActorIsolation(conformance.unbridged(), getFunction());
 }
 
 bool BridgedFunction::isResilientNominalDecl(BridgedDeclObj decl) const {

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -115,8 +115,12 @@ classifyDynamicCastToProtocol(SILFunction *function, CanType source, CanType tar
 
   // If checkConformance() returns a valid conformance, then all conditional
   // requirements were satisfied.
-  if (checkConformance(source, TargetProtocol))
+  if (auto conformance = checkConformance(source, TargetProtocol)) {
+    if (!matchesActorIsolation(conformance, function))
+      return DynamicCastFeasibility::MaySucceed;
+
     return DynamicCastFeasibility::WillSucceed;
+  }
 
   auto *SourceNominalTy = source.getAnyNominal();
   if (!SourceNominalTy)

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -93,7 +93,7 @@ static CanType unwrapExistential(CanType e) {
 /// into an existential type by performing a static check
 /// of protocol conformances if it is possible.
 static DynamicCastFeasibility
-classifyDynamicCastToProtocol(CanType source, CanType target,
+classifyDynamicCastToProtocol(SILFunction *function, CanType source, CanType target,
                               bool isWholeModuleOpts) {
   assert(target.isExistentialType() &&
          "target should be an existential type");
@@ -468,7 +468,7 @@ static bool isCFBridgingConversion(CanType sourceFormalType,
 
 /// Try to classify the dynamic-cast relationship between two types.
 DynamicCastFeasibility
-swift::classifyDynamicCast(ModuleDecl *M,
+swift::classifyDynamicCast(SILFunction *function,
                            CanType source,
                            CanType target,
                            bool isSourceTypeExact,
@@ -481,19 +481,20 @@ swift::classifyDynamicCast(ModuleDecl *M,
 
   auto sourceObject = source.getOptionalObjectType();
   auto targetObject = target.getOptionalObjectType();
+  ModuleDecl *M = function->getModule().getSwiftModule();
 
   // A common level of optionality doesn't affect the feasibility,
   // except that we can't fold things to failure because nil inhabits
   // both types.
   if (sourceObject && targetObject) {
-    return atWorst(classifyDynamicCast(M, sourceObject, targetObject),
+    return atWorst(classifyDynamicCast(function, sourceObject, targetObject),
                    DynamicCastFeasibility::MaySucceed);
 
   // Casting to a more optional type follows the same rule unless we
   // know that the source cannot dynamically be an optional value,
   // in which case we'll always just cast and inject into an optional.
   } else if (targetObject) {
-    auto result = classifyDynamicCast(M, source, targetObject,
+    auto result = classifyDynamicCast(function, source, targetObject,
                                       /* isSourceTypeExact */ false,
                                       isWholeModuleOpts);
     if (canDynamicallyStoreOptional(source))
@@ -502,12 +503,12 @@ swift::classifyDynamicCast(ModuleDecl *M,
 
   // Casting to a less-optional type can always fail.
   } else if (sourceObject) {
-    auto result = atBest(classifyDynamicCast(M, sourceObject, target,
+    auto result = atBest(classifyDynamicCast(function, sourceObject, target,
                                              /* isSourceTypeExact */ false,
                                              isWholeModuleOpts),
                          DynamicCastFeasibility::MaySucceed);
     if (target.isExistentialType()) {
-      result = atWorst(result, classifyDynamicCastToProtocol(
+      result = atWorst(result, classifyDynamicCastToProtocol(function,
                                    source, target, isWholeModuleOpts));
     }
     return result;
@@ -522,7 +523,7 @@ swift::classifyDynamicCast(ModuleDecl *M,
     // Check conversions from non-protocol types into protocol types.
     if (!source.isExistentialType() &&
         target.isExistentialType())
-      return classifyDynamicCastToProtocol(source, target,
+      return classifyDynamicCastToProtocol(function, source, target,
                                            isWholeModuleOpts);
 
     // Check conversions from protocol types to non-protocol types.
@@ -552,7 +553,7 @@ swift::classifyDynamicCast(ModuleDecl *M,
       // Hashable is not actually a legal existential type right now, but
       // the check doesn't care about that.
       if (auto hashable = getHashableExistentialType(M)) {
-        return classifyDynamicCastToProtocol(source, hashable,
+        return classifyDynamicCastToProtocol(function, source, hashable,
                                              isWholeModuleOpts);
       }
     }
@@ -589,7 +590,7 @@ swift::classifyDynamicCast(ModuleDecl *M,
 
     if (targetMetatype.isAnyExistentialType() && target->isExistentialType()) {
       auto Feasibility =
-          classifyDynamicCastToProtocol(source, target, isWholeModuleOpts);
+          classifyDynamicCastToProtocol(function, source, target, isWholeModuleOpts);
       // Cast from existential metatype to existential metatype may still
       // succeed, even if we cannot prove anything statically.
       if (Feasibility != DynamicCastFeasibility::WillFail ||
@@ -699,7 +700,7 @@ swift::classifyDynamicCast(ModuleDecl *M,
 
         // Combine the result of prior elements with this element type.
         result = std::max(result,
-                          classifyDynamicCast(M,
+                          classifyDynamicCast(function,
                             sourceElt.getType()->getCanonicalType(),
                             targetElt.getType()->getCanonicalType(),
                             isSourceTypeExact,
@@ -758,7 +759,7 @@ swift::classifyDynamicCast(ModuleDecl *M,
       // question there.
       if (bridgedSource) source = bridgedSource;
       if (bridgedTarget) target = bridgedTarget;
-      return classifyDynamicCast(M, source, target, false, isWholeModuleOpts);
+      return classifyDynamicCast(function, source, target, false, isWholeModuleOpts);
     }
 
     // Casts from a class into a non-class can never succeed if the target must
@@ -833,7 +834,7 @@ swift::classifyDynamicCast(ModuleDecl *M,
     if (Type ObjCTy = M->getASTContext().getBridgedToObjC(M, source)) {
       // If the bridged ObjC type is known, check if
       // this type can be cast into target type.
-      return classifyDynamicCast(M,
+      return classifyDynamicCast(function,
           ObjCTy->getCanonicalType(),
           target,
           /* isSourceTypeExact */ false, isWholeModuleOpts);
@@ -861,16 +862,16 @@ swift::classifyDynamicCast(ModuleDecl *M,
         // Arrays and sets.
         if (sourceStruct->isArray() || sourceStruct->isSet()) {
           auto valueFeasibility =
-            classifyDynamicCast(M, sourceArgs[0], targetArgs[0]);
+            classifyDynamicCast(function, sourceArgs[0], targetArgs[0]);
           return atWorst(valueFeasibility,
                          DynamicCastFeasibility::MaySucceed);
 
         // Dictionaries.
         } else if (sourceStruct->isDictionary()) {
           auto keyFeasibility =
-            classifyDynamicCast(M, sourceArgs[0], targetArgs[0]);
+            classifyDynamicCast(function, sourceArgs[0], targetArgs[0]);
           auto valueFeasibility =
-            classifyDynamicCast(M, sourceArgs[1], targetArgs[1]);
+            classifyDynamicCast(function, sourceArgs[1], targetArgs[1]);
           return atWorst(atBest(keyFeasibility, valueFeasibility),
                          DynamicCastFeasibility::MaySucceed);
         }
@@ -1240,7 +1241,7 @@ swift::emitSuccessfulScalarUnconditionalCast(SILBuilder &B, ModuleDecl *M,
                                              CanType sourceFormalType,
                                              CanType targetFormalType,
                                              SILInstruction *existingCast) {
-  assert(classifyDynamicCast(M, sourceFormalType, targetFormalType)
+  assert(classifyDynamicCast(&B.getFunction(), sourceFormalType, targetFormalType)
            == DynamicCastFeasibility::WillSucceed);
 
   // Casts to/from existential types cannot be further improved.
@@ -1277,7 +1278,7 @@ bool swift::emitSuccessfulIndirectUnconditionalCast(
     SILBuilder &B, ModuleDecl *M, SILLocation loc, SILValue src,
     CanType sourceFormalType, SILValue dest, CanType targetFormalType,
     SILInstruction *existingCast) {
-  assert(classifyDynamicCast(M, sourceFormalType, targetFormalType)
+  assert(classifyDynamicCast(&B.getFunction(), sourceFormalType, targetFormalType)
            == DynamicCastFeasibility::WillSucceed);
 
   assert(src->getType().isAddress());

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1482,6 +1482,9 @@ static bool optimizeStaticallyKnownProtocolConformance(
     if (Conformance.isInvalid())
       return false;
 
+    if (!matchesActorIsolation(Conformance, Inst->getFunction()))
+      return false;
+
     auto layout = TargetType->getExistentialLayout();
     if (layout.getProtocols().size() != 1)
       return false;

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1874,7 +1874,7 @@ ConstExprFunctionState::evaluateInstructionAndGetNext(
     CanType targetType = substituteGenericParamsAndSimplify(
         checkedCastInst->getTargetFormalType());
     DynamicCastFeasibility castResult = classifyDynamicCast(
-        inst->getModule().getSwiftModule(), sourceType, targetType);
+        inst->getFunction(), sourceType, targetType);
     if (castResult == DynamicCastFeasibility::MaySucceed) {
       return {std::nullopt, getUnknown(evaluator, inst->asSILNode(),
                                        UnknownReason::UnknownCastResult)};

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -530,10 +530,7 @@ BridgedDynamicCastResult classifyDynamicCastBridged(BridgedCanType sourceTy, Bri
   static_assert((int)DynamicCastFeasibility::WillFail    == (int)BridgedDynamicCastResult::willFail);
 
   return static_cast<BridgedDynamicCastResult>(
-    classifyDynamicCast(function.getFunction()->getModule().getSwiftModule(),
-                        sourceTy.unbridged(),
-                        destTy.unbridged(),
-                        sourceTypeIsExact));
+    classifyDynamicCast(function.getFunction(), sourceTy.unbridged(), destTy.unbridged(), sourceTypeIsExact));
 }
 
 BridgedDynamicCastResult classifyDynamicCastBridged(BridgedInstruction inst) {

--- a/test/SILOptimizer/constant_propagation_casts_ossa.sil
+++ b/test/SILOptimizer/constant_propagation_casts_ossa.sil
@@ -1,7 +1,14 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation -enable-experimental-feature IsolatedConformances | %FileCheck %s
+
+// REQUIRES: swift_feature_IsolatedConformances
+// REQUIRES: concurrency
+
 sil_stage canonical
 
-//import Swift
+import Builtin
+import Swift
+import _Concurrency
+import SwiftShims
 
 class Klass {
 }
@@ -10,6 +17,15 @@ class SubKlass : Klass {
 }
 
 class NoSubKlass {
+}
+
+protocol P {
+  func f() -> Int
+}
+
+struct X : @MainActor P {
+  func f() -> Int
+  init()
 }
 
 sil [noinline] @blackhole1 : $@convention(thin) (@guaranteed SubKlass) -> ()
@@ -92,5 +108,28 @@ bb3:
   destroy_value %0 : $NoSubKlass
   %r = tuple ()
   return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @isolated_conf_ucca :
+// CHECK:         unconditional_checked_cast_addr
+// CHECK-LABEL: } // end sil function 'isolated_conf_ucca'
+sil [ossa] @isolated_conf_ucca : $@convention(thin) (@in X) -> @out P {
+bb0(%0 : $*P, %1 : $*X):
+  unconditional_checked_cast_addr X in %1 to any P in %0
+  %2 = tuple ()
+  return %2
+}
+
+// CHECK-LABEL: sil [ossa] @isolated_conf_ccab :
+// CHECK:         checked_cast_addr_br
+// CHECK-LABEL: } // end sil function 'isolated_conf_ccab'
+sil [ossa] @isolated_conf_ccab : $@convention(thin) (@in X) -> @out P {
+bb0(%0 : $*P, %1 : $*X):
+  checked_cast_addr_br take_always X in %1 to any P in %0, bb1, bb2
+bb1:
+  %2 = tuple ()
+  return %2
+bb2:
+  unreachable
 }
 

--- a/test/SILOptimizer/isolated_conformances.swift
+++ b/test/SILOptimizer/isolated_conformances.swift
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -parse-as-library -O %s -enable-experimental-feature IsolatedConformances -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --check-prefix=CHECK-OUTPUT
+
+// RUN: %target-build-swift -parse-as-library -O %s -enable-experimental-feature IsolatedConformances -Xllvm -sil-disable-pass=function-signature-opts -emit-sil | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+// REQUIRES: swift_feature_IsolatedConformances
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+
+protocol P {
+  func f() -> Int
+}
+
+struct X: @MainActor P {
+  func f() -> Int { 17 }
+}
+
+// CHECK-LABEL: sil hidden [noinline] @$s21isolated_conformances12castAnywhereySiSgAA1XVF :
+// CHECK:         checked_cast_addr_br take_always X in %{{[0-9]+}} to any P in %{{[0-9]+}}, bb1, bb2
+// CHECK:       } // end sil function '$s21isolated_conformances12castAnywhereySiSgAA1XVF'
+@inline(never)
+nonisolated func castAnywhere(_ value: X) -> Int? {
+  if let value = value as? P {
+    return value.f()
+  }
+  return nil
+}
+
+// CHECK-LABEL: sil hidden [noinline] @$s21isolated_conformances15castOnMainActorySiSgAA1XVF :
+// CHECK:         [[L:%.*]] = integer_literal {{.*}} 17
+// CHECK:         [[I:%.*]] = struct $Int ([[L]])
+// CHECK:         [[O:%.*]] = enum $Optional<Int>, #Optional.some!enumelt, [[I]]
+// CHECK:         return [[O]]
+// CHECK:       } // end sil function '$s21isolated_conformances15castOnMainActorySiSgAA1XVF'
+@MainActor
+@inline(never)
+func castOnMainActor(_ value: X) -> Int? {
+  if let value = value as? P {
+    return value.f()
+  }
+  return nil
+}
+
+
+@main
+struct Main {
+  static func main() async {
+    await Task.detached {
+      // CHECK-OUTPUT: nil
+      print(castAnywhere(X()))
+    }.value
+  }
+}

--- a/test/SILOptimizer/simplify_unconditional_check_cast.sil
+++ b/test/SILOptimizer/simplify_unconditional_check_cast.sil
@@ -1,7 +1,11 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=unconditional_checked_cast | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=unconditional_checked_cast -enable-experimental-feature IsolatedConformances | %FileCheck %s
+
+// REQUIRES: swift_feature_IsolatedConformances
+// REQUIRES: concurrency
 
 import Swift
 import Builtin
+import _Concurrency
 
 protocol P {}
 protocol PC: AnyObject {}
@@ -11,6 +15,8 @@ struct S : P {}
 struct T {}
 
 class C {}
+
+struct X : @MainActor P {}
 
 // CHECK-LABEL: sil [ossa] @test_conforming_struct :
 // CHECK:         %1 = init_existential_metatype %0, $@thick any P.Type
@@ -52,3 +58,14 @@ bb0(%0 : $@thick S.Type):
   %1 = unconditional_checked_cast %0 to Int.Type
   return %1
 }
+
+// CHECK-LABEL: sil [ossa] @test_isolated_conformance :
+// CHECK:         %1 = unconditional_checked_cast %0
+// CHECK-NEXT:    return %1
+// CHECK:       } // end sil function 'test_isolated_conformance'
+sil [ossa] @test_isolated_conformance : $@convention(thin) (@thick X.Type) -> @thick any P.Type {
+bb0(%0 : $@thick X.Type):
+  %1 = unconditional_checked_cast %0 to any P.Type
+  return %1
+}
+


### PR DESCRIPTION
* **Explanation**: The introduction of isolated conformances (rdar://120374912) can violate some assumptions that cast optimization can make. The cast optimizer must not assume that when a type conforms to an isolated conformance, the cast always succeeds. This change is required to  avoid mis-compiles when using isolated conformances.
* **Risk**: Low. It only affects code which uses the experimental feature of isolated conformances
* **Testing**: Tested by lit tests.
* **Issue**: rdar://147417762
* **Reviewer**:  @DougGregor  
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/80543