### PR TITLE
[6.2] embedded: fix two problems in the SILLinker

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -342,8 +342,10 @@ void SILLinkerVisitor::visitProtocolConformance(
     // reading in most conformances until we need them for devirtualization.
     // However, we *must* pull in shared clang-importer-derived conformances
     // we potentially use, since we may not otherwise have a local definition.
-    if (mustDeserializeProtocolConformance(Mod, c))
+    if ((isEmbedded && referencedFromInitExistential) ||
+        mustDeserializeProtocolConformance(Mod, c)) {
       visitProtocolConformance(c, referencedFromInitExistential);
+    }
   };
   
   // For each entry in the witness table...

--- a/lib/SIL/IR/Linker.h
+++ b/lib/SIL/IR/Linker.h
@@ -129,6 +129,7 @@ public:
   }
   void visitInitExistentialAddrInst(InitExistentialAddrInst *IEI);
   void visitInitExistentialRefInst(InitExistentialRefInst *IERI);
+  void visitBuiltinInst(BuiltinInst *bi);
   void visitAllocRefInst(AllocRefInst *ARI);
   void visitAllocRefDynamicInst(AllocRefDynamicInst *ARI);
   void visitMetatypeInst(MetatypeInst *MI);

--- a/test/embedded/concurrency-modules.swift
+++ b/test/embedded/concurrency-modules.swift
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o -parse-as-library
+// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN MyModule.swift
+
+import _Concurrency
+
+nonisolated(unsafe) var glob: UnsafeMutableRawPointer? = nil
+nonisolated(unsafe) var job: UnownedJob? = nil
+
+public final class MyCustomExecutor: SerialExecutor, @unchecked Sendable {
+    private init() {}
+
+    nonisolated(unsafe)
+    public static var shared: MyCustomExecutor = MyCustomExecutor()
+
+    public static func installGlobalExecutor() {
+        let fn: @convention(thin) () -> () = {
+            MyCustomExecutor.shared.unsafeEnqueue(job!)
+        }
+        glob = unsafeBitCast(fn, to: UnsafeMutableRawPointer?.self)
+    }
+
+    private func enqueue(_ job: UnownedJob, withDelay nanoseconds: UInt64) {}
+
+    private func unsafeEnqueue(_ job: UnownedJob) {
+        job.runSynchronously(on: self.asUnownedSerialExecutor())
+    }
+
+    public func enqueue(_ job: consuming ExecutorJob) {
+        unsafeEnqueue(UnownedJob(job))
+    }
+
+    public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+        return UnownedSerialExecutor(ordinary: self)
+    }
+}
+
+// BEGIN Main.swift
+
+import MyModule
+import _Concurrency
+
+@main
+struct Entrypoint {
+    static func main() async {
+        MyCustomExecutor.installGlobalExecutor()
+        print("OK!")
+    }
+}
+
+// CHECK: OK!

--- a/test/embedded/existential-class-bound8.swift
+++ b/test/embedded/existential-class-bound8.swift
@@ -9,7 +9,11 @@
 
 // BEGIN MyModule.swift
 
-public protocol ClassBound: AnyObject {
+public protocol Base: AnyObject {
+    func bar()
+}
+
+public protocol ClassBound: Base {
     func foo()
 }
 
@@ -18,6 +22,7 @@ class MyGenericClass<T> {
     init(typ: String) { self.typ = typ }
 }
 extension MyGenericClass: ClassBound {
+    func bar() { print("MyGenericClass<\(typ)>.bar()") }
     func foo() { print("MyGenericClass<\(typ)>.foo()") }
 }
 
@@ -32,3 +37,5 @@ import MyModule
 var arr: [any ClassBound] = [factory()]
 arr[0].foo()
 // CHECK: MyGenericClass<String>.foo()
+arr[0].foo()
+// CHECK: MyGenericClass<String>.bar()


### PR DESCRIPTION
* **Explanation**: This fixes two problem in the SILLinker, which resulted in unresolved linker symbols in embedded mode. The first fix is to de-serialize base protocol witness tables. The second fix is to de-serialize Executor witness tables for the ExecutorRef builtins
* **Risk**: Low. It only affects embedded swift when working with concurrency or using existentials with base protocols.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://148538336
* **Reviewer**:  @MaxDesiatov  
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/80530
