### PR TITLE
[6.2] [Mangler] Avoid mangling local discriminator for attached macros

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -453,7 +453,8 @@ protected:
                   const ValueDecl *forDecl = nullptr);
   
   void appendDeclName(
-      const ValueDecl *decl, DeclBaseName name = DeclBaseName());
+      const ValueDecl *decl, DeclBaseName name = DeclBaseName(),
+      bool skipLocalDiscriminator = false);
 
   GenericTypeParamType *appendAssocType(DependentMemberType *DepTy,
                                         GenericSignature sig,


### PR DESCRIPTION
*6.2 cherry-pick of #80546*

- Explanation: Fixes a crash that could occur when using an attached macro in a local context that contains a use of an autoclosure
- Scope: Affects attached macros in local contexts
- Issue: rdar://143834482
- Risk: Low, this a straightforward targeted fix
- Testing: Added tests to test suite
- Reviewer: Doug Gregor