### PR TITLE
[CS] Make sure macro arguments go through `coerceCallArguments`

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5577,6 +5577,18 @@ namespace {
       E->setMacroRef(macroRef);
       E->setType(expandedType);
 
+      auto fnType =
+          simplifyType(overload.adjustedOpenedType)->castTo<FunctionType>();
+
+      auto newArgs = coerceCallArguments(
+          E->getArgs(), fnType, macroRef, /*applyExpr=*/nullptr,
+          cs.getConstraintLocator(E, ConstraintLocator::ApplyArgument),
+          solution.getAppliedPropertyWrappers(E));
+      if (!newArgs)
+        return nullptr;
+
+      E->setArgs(newArgs);
+
       // FIXME: Expansion should be lazy.
       // i.e. 'ExpandMacroExpansionExprRequest' should be sinked into
       // 'getRewritten()', and performed on-demand. Unfortunately that requires

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -659,6 +659,28 @@ func testLocalAccessorMacroWithAutoclosure() {
   takesAutoclosure(1)
 }
 
+@propertyWrapper
+struct SomePropertyWrapper<T> {
+  var wrappedValue: T
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+  init(projectedValue: Self) {
+    self = projectedValue
+  }
+  var projectedValue: Self { self }
+}
+
+// Property wrappers on macros probably aren't all that useful, but make sure
+// we don't crash.
+@freestanding(expression)
+macro hasPropertyWrapperParam(@SomePropertyWrapper x: Int) = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+
+func testPropertyWrapperMacro() {
+  #hasPropertyWrapperParam(x: 0)
+  #hasPropertyWrapperParam($x: .init(wrappedValue: 0))
+}
+
 #if TEST_DIAGNOSTICS
 @freestanding(expression)
 macro missingMacro() = #externalMacro(module: "MacroDefinition", type: "BluhBlah")


### PR DESCRIPTION
Previously we would avoid rewriting the arguments in CSApply, but that can result in incorrect behavior in MiscDiagnostics passes, e.g incorrectly treating all closure arguments as escaping. Make sure we rewrite the arguments as we would in regular type-checking.

rdar://148665502
Resolves #80561