### PR TITLE
[6.2][cxx-interop] Fix calling rvalue ref of a trivial type

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1543,6 +1543,9 @@ static bool isClangTypeMoreIndirectThanSubstType(TypeConverter &TC,
   if (importer::isCxxConstReferenceType(clangTy))
     return true;
 
+  if (clangTy->isRValueReferenceType())
+    return true;
+
   return false;
 }
 

--- a/test/Interop/Cxx/reference/reference.swift
+++ b/test/Interop/Cxx/reference/reference.swift
@@ -103,4 +103,9 @@ ReferenceTestSuite.test("const reference to template") {
   expectEqual(53, ref.pointee)
 }
 
+ReferenceTestSuite.test("rvalue reference of trivial type") {
+  setStaticIntRvalueRef(consuming: 2)
+  expectEqual(2, getStaticInt())
+}
+
 runAllTests()


### PR DESCRIPTION
Explanation: Fixes a runtime crash in the generated binary due to mismatched calling convention when calling a function taking an rvalue reference.
Scope: Affects C++ APIs taking rvalue references to directly passed types (e.g., trivially destructible types).
Issue: rdar://148585343
Risk: Low, targeted to rvalue references which is a newly supported feature.
Testing: Added tests to test suite
Reviewer: @j-hui 
