### PR TITLE
[Distributed] Reproducer for generics and library evolution mode

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1000,8 +1000,7 @@ namespace {
 
       // Emit the dispatch thunk.
       auto shouldEmitDispatchThunk =
-          (Resilient || IGM.getOptions().WitnessMethodElimination) &&
-          (!func.isDistributed() || !func.isDistributedThunk());
+          (Resilient || IGM.getOptions().WitnessMethodElimination);
       if (shouldEmitDispatchThunk) {
         IGM.emitDispatchThunk(func);
       }
@@ -1082,14 +1081,10 @@ namespace {
             // Define the method descriptor.
             SILDeclRef func(entry.getFunction());
 
-            /// Distributed thunks don't need method descriptors
-            if (!func.isDistributedThunk()) {
-              auto *descriptor =
-                B.getAddrOfCurrentPosition(
-                  IGM.ProtocolRequirementStructTy);
-              IGM.defineMethodDescriptor(func, Proto, descriptor,
-                                         IGM.ProtocolRequirementStructTy);
-            }
+            auto *descriptor =
+                B.getAddrOfCurrentPosition(IGM.ProtocolRequirementStructTy);
+            IGM.defineMethodDescriptor(func, Proto, descriptor,
+                                       IGM.ProtocolRequirementStructTy);
           }
         }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2348,12 +2348,6 @@ namespace {
               LinkEntity::forBaseConformanceDescriptor(requirement));
           B.addRelativeAddress(baseConformanceDescriptor);
         } else if (entry.getKind() == SILWitnessTable::Method) {
-          // distributed thunks don't need resilience
-          if (entry.getMethodWitness().Requirement.isDistributedThunk()) {
-            witnesses = witnesses.drop_back();
-            continue;
-          }
-
           // Method descriptor.
           auto declRef = entry.getMethodWitness().Requirement;
           auto requirement =

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -157,14 +157,6 @@ public:
   }
 
   void addMethodDescriptor(SILDeclRef declRef) override {
-    if (declRef.isDistributedThunk()) {
-      auto afd = declRef.getAbstractFunctionDecl();
-      auto DC = afd->getDeclContext();
-      if (isa<ProtocolDecl>(DC)) {
-        return;
-      }
-    }
-
     addLinkEntity(LinkEntity::forMethodDescriptor(declRef));
   }
 

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -835,7 +835,6 @@ public:
                   V.Ctx.getOpts().WitnessMethodElimination} {}
 
         void addMethod(SILDeclRef declRef) {
-          // TODO: alternatively maybe prevent adding distributed thunk here rather than inside those?
           if (Resilient || WitnessMethodElimination) {
             Visitor.addDispatchThunk(declRef);
             Visitor.addMethodDescriptor(declRef);

--- a/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
+++ b/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
@@ -1,0 +1,66 @@
+// REQUIRES: VENDOR=apple
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -enable-library-evolution -target %target-cpu-apple-macosx13.0 -parse-as-library -emit-library -emit-module-path %t/Library.swiftmodule -module-name Library %t/library.swift -o %t/%target-library-name(Library)
+// RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -target %target-cpu-apple-macosx13.0 -parse-as-library -lLibrary -module-name main -I %t -L %t %t/main.swift -o %t/a.out
+
+
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+//--- library.swift
+import Distributed
+
+//public protocol NormalProtocol {
+//  func NORMAL() async -> Int
+//}
+
+public protocol SimpleProtocol: DistributedActor
+    where ActorSystem == LocalTestingDistributedActorSystem {
+
+  // nonisolated override var id: ID { get } // comes from DistributedActor
+
+  // Has to have a distributed method to fail
+  distributed func test() -> Int
+}
+
+//--- main.swift
+import Distributed
+import Library
+
+//actor NormalActor: NormalProtocol {
+//  func NORMAL() async -> Int { 1 }
+//}
+
+public distributed actor SimpleActor: SimpleProtocol {
+  public distributed func test() -> Int { 1 }
+}
+
+// Passes
+public func makeFromPass<Act: DistributedActor>(_ act: Act) {
+  print(act.id)
+}
+
+// Fails
+public func makeFromFail<Act: SimpleProtocol>(_ act: Act) async {
+  print(act.id)
+  try! await print(act.test())
+}
+
+@main
+struct TestSwiftFrameworkTests {
+  static func main() async {
+    let system = LocalTestingDistributedActorSystem()
+
+    // let norm = NormalActor()
+
+    let simpleActor = SimpleActor(actorSystem: system)
+//    makeFromPass(simpleActor)
+
+    await makeFromFail(simpleActor)
+  }
+}


### PR DESCRIPTION
This corrects how we were dealing with dispatch thunks -- mostly be
removing a lot of special casing we did but doesn't seem necessary and
instead we correct and emit all the necessary information int TBD.

This builds on  https://github.com/swiftlang/swift/pull/74935 by further refining how we fixed that issue, and adds more regression tests. It also removes a load of special casing of distributed thunks in library evolution mode, which is great.

Resolves and adds regression test for for rdar://145292018

This is also a more proper fix to the previously resolved but in a not-great-way which caused other issues:
- refs rdar://128284016
- refs rdar://128310903