### PR TITLE
SIL: Tiny conformance substitution cleanups

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/GenericSpecialization.swift
@@ -144,7 +144,7 @@ func specializeWitnessTable(forConformance conformance: Conformance,
     case .associatedType(let requirement, let witness):
       let substType = witness.subst(with: conformance.specializedSubstitutions)
       return .associatedType(requirement: requirement, witness: substType)
-    case .associatedConformance(let requirement, let substType, let assocConf):
+    case .associatedConformance(let requirement, let assocConf):
       // FIXME: let concreteAssociateConf = assocConf.subst(with: conformance.specializedSubstitutions)
       let concreteAssociateConf = conformance.getAssociatedConformance(ofAssociatedType: requirement.rawType, to: assocConf.proto)
       if concreteAssociateConf.isSpecialized {
@@ -153,7 +153,6 @@ func specializeWitnessTable(forConformance conformance: Conformance,
                                context, notifyNewWitnessTable)
       }
       return .associatedConformance(requirement: requirement,
-                                    substType: substType.subst(with: conformance.specializedSubstitutions),
                                     witness: concreteAssociateConf)
     }
   }

--- a/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
+++ b/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
@@ -31,7 +31,7 @@ public struct WitnessTable : CustomStringConvertible, NoReflectionChildren {
     case associatedType(requirement: AssociatedTypeDecl, witness: CanonicalType)
 
     /// A witness table entry describing the witness for an associated type's protocol requirement.
-    case associatedConformance(requirement: CanonicalType, substType: CanonicalType, witness: Conformance)
+    case associatedConformance(requirement: CanonicalType, witness: Conformance)
 
     /// A witness table entry referencing the protocol conformance for a refined base protocol.
     case baseProtocol(requirement: ProtocolDecl, witness: Conformance)
@@ -48,7 +48,6 @@ public struct WitnessTable : CustomStringConvertible, NoReflectionChildren {
                                witness: CanonicalType(bridged: bridged.getAssociatedTypeWitness()))
       case .associatedConformance:
         self = .associatedConformance(requirement: CanonicalType(bridged: bridged.getAssociatedConformanceRequirement()),
-                                      substType: CanonicalType(bridged: bridged.getAssociatedConformanceSubstType()),
                                       witness: Conformance(bridged: bridged.getAssociatedConformanceWitness()))
       case .baseProtocol:
         self = .baseProtocol(requirement: bridged.getBaseProtocolRequirement().getAs(ProtocolDecl.self),
@@ -71,9 +70,8 @@ public struct WitnessTable : CustomStringConvertible, NoReflectionChildren {
                                                      OptionalBridgedFunction(obj: witness?.bridged.obj))
       case .associatedType(let requirement, let witness):
         return BridgedWitnessTableEntry.createAssociatedType(requirement.bridged, witness.bridged)
-      case .associatedConformance(let requirement, let substType, let witness):
+      case .associatedConformance(let requirement, let witness):
         return BridgedWitnessTableEntry.createAssociatedConformance(requirement.bridged,
-                                                                    substType.bridged,
                                                                     witness.bridged)
       case .baseProtocol(let requirement, let witness):
         return BridgedWitnessTableEntry.createBaseProtocol(requirement.bridged, witness.bridged)

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -1062,7 +1062,6 @@ struct BridgedWitnessTableEntry {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getAssociatedTypeRequirement() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getAssociatedTypeWitness() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getAssociatedConformanceRequirement() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getAssociatedConformanceSubstType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getAssociatedConformanceWitness() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getBaseProtocolRequirement() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance getBaseProtocolWitness() const;
@@ -1077,7 +1076,6 @@ struct BridgedWitnessTableEntry {
                                                        BridgedCanType witness);
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   static BridgedWitnessTableEntry createAssociatedConformance(BridgedCanType requirement,
-                                                              BridgedCanType substType,
                                                               BridgedConformance witness);
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE
   static BridgedWitnessTableEntry createBaseProtocol(BridgedDeclObj requirement,

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1922,10 +1922,6 @@ BridgedCanType BridgedWitnessTableEntry::getAssociatedConformanceRequirement() c
   return unbridged().getAssociatedConformanceWitness().Requirement;
 }
 
-BridgedCanType BridgedWitnessTableEntry::getAssociatedConformanceSubstType() const {
-  return {unbridged().getAssociatedConformanceWitness().SubstType};
-}
-
 BridgedConformance BridgedWitnessTableEntry::getAssociatedConformanceWitness() const {
   return {unbridged().getAssociatedConformanceWitness().Witness};
 }
@@ -1957,11 +1953,9 @@ BridgedWitnessTableEntry BridgedWitnessTableEntry::createAssociatedType(BridgedD
 }
 
 BridgedWitnessTableEntry BridgedWitnessTableEntry::createAssociatedConformance(BridgedCanType requirement,
-                                                                               BridgedCanType substType,
                                                                                BridgedConformance witness) {
   return bridge(swift::SILWitnessTable::Entry(
     swift::SILWitnessTable::AssociatedConformanceWitness{requirement.unbridged(),
-                                                         substType.unbridged(),
                                                          witness.unbridged()}));
 }
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -409,32 +409,16 @@ public:
       VarInfo->Scope = getOpScope(VarInfo->Scope);
   }
 
-  ProtocolConformanceRef getOpConformance(Type ty,
-                                          ProtocolConformanceRef conformance) {
-    auto substConf = asImpl().remapConformance(ty, conformance);
-
-#ifndef NDEBUG
-    if (substConf.isInvalid()) {
-      llvm::errs() << "Invalid conformance in SIL cloner:\n";
-      Functor.dump(llvm::errs());
-      llvm::errs() << "\nconformance:\n";
-      conformance.dump(llvm::errs());
-      llvm::errs() << "\noriginal type:\n";
-      ty.dump(llvm::errs());
-      abort();
-    }
-#endif
-
-    return substConf;
+  ProtocolConformanceRef getOpConformance(ProtocolConformanceRef conformance) {
+    return asImpl().remapConformance(conformance);
   }
 
   ArrayRef<ProtocolConformanceRef>
-  getOpConformances(Type ty,
-                    ArrayRef<ProtocolConformanceRef> conformances) {
+  getOpConformances(ArrayRef<ProtocolConformanceRef> conformances) {
     SmallVector<ProtocolConformanceRef, 4> newConformances;
     for (auto conformance : conformances)
-      newConformances.push_back(getOpConformance(ty, conformance));
-    return ty->getASTContext().AllocateCopy(newConformances);
+      newConformances.push_back(getOpConformance(conformance));
+    return getBuilder().getASTContext().AllocateCopy(newConformances);
   }
 
   bool isValueCloned(SILValue OrigValue) const {
@@ -558,28 +542,35 @@ protected:
     return ty;
   }
 
-  ProtocolConformanceRef remapConformance(Type Ty, ProtocolConformanceRef C) {
-    if (Functor.SubsMap || Ty->hasLocalArchetype()) {
+  ProtocolConformanceRef remapConformance(ProtocolConformanceRef conformance) {
+    auto substConf = conformance;
+
+    if (Functor.SubsMap || substConf.getType()->hasLocalArchetype()) {
       SubstOptions options = SubstFlags::SubstitutePrimaryArchetypes;
       if (Functor.hasLocalArchetypes())
         options |= SubstFlags::SubstituteLocalArchetypes;
 
-      C = C.subst(Functor, Functor, options);
-      if (asImpl().shouldSubstOpaqueArchetypes())
-        Ty = Ty.subst(Functor, Functor, options);
+      substConf = substConf.subst(Functor, Functor, options);
+    }
+
+    if (substConf.isInvalid()) {
+      llvm::errs() << "Invalid substituted conformance in SIL cloner:\n";
+      Functor.dump(llvm::errs());
+      llvm::errs() << "\noriginal conformance:\n";
+      conformance.dump(llvm::errs());
+      abort();
     }
 
     if (asImpl().shouldSubstOpaqueArchetypes()) {
       auto context = getBuilder().getTypeExpansionContext();
 
-      if (!Ty->hasOpaqueArchetype() ||
-          !context.shouldLookThroughOpaqueTypeArchetypes())
-        return C;
-
-      return substOpaqueTypesWithUnderlyingTypes(C, context);
+      if (substConf.getType()->hasOpaqueArchetype() &&
+          context.shouldLookThroughOpaqueTypeArchetypes()) {
+        return substOpaqueTypesWithUnderlyingTypes(substConf, context);
+      }
     }
 
-    return C;
+    return substConf;
   }
 
   SubstitutionMap remapSubstitutionMap(SubstitutionMap Subs) {
@@ -1135,8 +1126,7 @@ SILCloner<ImplClass>::visitAllocExistentialBoxInst(
   auto origExistentialType = Inst->getExistentialType();
   auto origFormalType = Inst->getFormalConcreteType();
 
-  auto conformances = getOpConformances(origFormalType,
-                                        Inst->getConformances());
+  auto conformances = getOpConformances(Inst->getConformances());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
@@ -2659,29 +2649,28 @@ SILCloner<ImplClass>::visitObjCSuperMethodInst(ObjCSuperMethodInst *Inst) {
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitWitnessMethodInst(WitnessMethodInst *Inst) {
-  auto lookupType = Inst->getLookupType();
-  auto conformance = getOpConformance(lookupType, Inst->getConformance());
-  auto newLookupType = getOpASTType(lookupType);
+  auto conformance = getOpConformance(Inst->getConformance());
+  auto lookupType = getOpASTType(Inst->getLookupType());
 
   if (conformance.isConcrete()) {
-    CanType Ty = conformance.getConcrete()->getType()->getCanonicalType();
+    auto conformingType = conformance.getConcrete()->getType()->getCanonicalType();
 
-    if (Ty != newLookupType) {
+    if (conformingType != lookupType) {
       assert(
-          (Ty->isExactSuperclassOf(newLookupType) ||
+          (conformingType->isExactSuperclassOf(lookupType) ||
            getBuilder().getModule().Types.getLoweredRValueType(
-               getBuilder().getTypeExpansionContext(), Ty) == newLookupType) &&
+               getBuilder().getTypeExpansionContext(), conformingType) == lookupType) &&
           "Should only create upcasts for sub class.");
 
       // We use the super class as the new look up type.
-      newLookupType = Ty;
+      lookupType = conformingType;
     }
   }
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst,
                           getBuilder().createWitnessMethod(
-                              getOpLocation(Inst->getLoc()), newLookupType,
+                              getOpLocation(Inst->getLoc()), lookupType,
                               conformance, Inst->getMember(), getOpType(Inst->getType())));
 }
 
@@ -2790,8 +2779,7 @@ void
 SILCloner<ImplClass>::visitInitExistentialAddrInst(InitExistentialAddrInst *Inst) {
   CanType origFormalType = Inst->getFormalConcreteType();
 
-  auto conformances = getOpConformances(origFormalType,
-                                        Inst->getConformances());
+  auto conformances = getOpConformances(Inst->getConformances());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
@@ -2806,8 +2794,7 @@ void SILCloner<ImplClass>::visitInitExistentialValueInst(
     InitExistentialValueInst *Inst) {
   CanType origFormalType = Inst->getFormalConcreteType();
 
-  auto conformances = getOpConformances(origFormalType,
-                                        Inst->getConformances());
+  auto conformances = getOpConformances(Inst->getConformances());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(
@@ -2821,9 +2808,7 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::
 visitInitExistentialMetatypeInst(InitExistentialMetatypeInst *Inst) {
-  auto origFormalType = Inst->getFormalErasedObjectType();
-  auto conformances = getOpConformances(origFormalType,
-                                        Inst->getConformances());
+  auto conformances = getOpConformances(Inst->getConformances());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst, getBuilder().createInitExistentialMetatype(
@@ -2837,8 +2822,7 @@ void
 SILCloner<ImplClass>::
 visitInitExistentialRefInst(InitExistentialRefInst *Inst) {
   CanType origFormalType = Inst->getFormalConcreteType();
-  auto conformances = getOpConformances(origFormalType,
-                                        Inst->getConformances());
+  auto conformances = getOpConformances(Inst->getConformances());
 
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -590,11 +590,7 @@ protected:
           !context.shouldLookThroughOpaqueTypeArchetypes())
         return Subs;
 
-      ReplaceOpaqueTypesWithUnderlyingTypes replacer(
-        context.getContext(), context.getResilienceExpansion(),
-        context.isWholeModuleContext());
-      return Subs.subst(replacer, replacer,
-                        SubstFlags::SubstituteOpaqueArchetypes);
+      return Subs.mapIntoTypeExpansionContext(context);
     }
 
     return Subs;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8077,20 +8077,6 @@ class InitExistentialMetatypeInst final
          SILFunction *parent);
 
 public:
-  /// Return the object type which was erased.  That is, if this
-  /// instruction erases Decoder<T>.Type.Type to Printable.Type.Type,
-  /// this method returns Decoder<T>.
-  CanType getFormalErasedObjectType() const {
-    auto exType = getType().getASTType();
-    auto concreteType = getOperand()->getType().getASTType();
-    while (auto exMetatype = dyn_cast<ExistentialMetatypeType>(exType)) {
-      exType = exMetatype->getExistentialInstanceType()->getCanonicalType();
-      concreteType = cast<MetatypeType>(concreteType).getInstanceType();
-    }
-    assert(exType.isExistentialType());
-    return concreteType;
-  }
-
   ArrayRef<ProtocolConformanceRef> getConformances() const;
 };
 

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -66,8 +66,6 @@ public:
   struct AssociatedConformanceWitness {
     /// The subject type of the associated requirement.
     CanType Requirement;
-    /// FIXME: Temporary.
-    CanType SubstType;
     /// The ProtocolConformanceRef satisfying the requirement.
     ProtocolConformanceRef Witness;
   };

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -154,15 +154,6 @@ public:
                const PrintOptions &options) const;
   };
 
-  /// An entry for a conformance requirement that makes the requirement
-  /// conditional. These aren't public, but any witness thunks need to feed them
-  /// into the true witness functions.
-  struct ConditionalConformance {
-    /// FIXME: Temporary.
-    CanType Requirement;
-    ProtocolConformanceRef Conformance;
-  };
-
 private:
   /// The module which contains the SILWitnessTable.
   SILModule &Mod;
@@ -186,7 +177,7 @@ private:
   ///
   /// (If other private entities are introduced this could/should be switched
   /// into a private version of Entries.)
-  MutableArrayRef<ConditionalConformance> ConditionalConformances;
+  MutableArrayRef<ProtocolConformanceRef> ConditionalConformances;
 
   /// Whether or not this witness table is a declaration. This is separate from
   /// whether or not entries is empty since you can have an empty witness table
@@ -201,7 +192,7 @@ private:
   SILWitnessTable(SILModule &M, SILLinkage Linkage, SerializedKind_t Serialized,
                   StringRef name, ProtocolConformance *conformance,
                   ArrayRef<Entry> entries,
-                  ArrayRef<ConditionalConformance> conditionalConformances);
+                  ArrayRef<ProtocolConformanceRef> conditionalConformances);
 
   /// Private constructor for making SILWitnessTable declarations.
   SILWitnessTable(SILModule &M, SILLinkage Linkage, StringRef Name,
@@ -214,7 +205,7 @@ public:
   static SILWitnessTable *
   create(SILModule &M, SILLinkage Linkage, SerializedKind_t SerializedKind,
          ProtocolConformance *conformance, ArrayRef<Entry> entries,
-         ArrayRef<ConditionalConformance> conditionalConformances);
+         ArrayRef<ProtocolConformanceRef> conditionalConformances);
 
   /// Create a new SILWitnessTable declaration.
   static SILWitnessTable *create(SILModule &M, SILLinkage Linkage,
@@ -271,7 +262,7 @@ public:
   ArrayRef<Entry> getEntries() const { return Entries; }
 
   /// Return all of the conditional conformances.
-  ArrayRef<ConditionalConformance> getConditionalConformances() const {
+  ArrayRef<ProtocolConformanceRef> getConditionalConformances() const {
     return ConditionalConformances;
   }
 
@@ -300,7 +291,7 @@ public:
   /// Change a SILWitnessTable declaration into a SILWitnessTable definition.
   void
   convertToDefinition(ArrayRef<Entry> newEntries,
-                      ArrayRef<ConditionalConformance> conditionalConformances,
+                      ArrayRef<ProtocolConformanceRef> conditionalConformances,
                       SerializedKind_t serializedKind);
 
   // Gets conformance serialized kind.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1522,8 +1522,7 @@ public:
       SpecializedBaseConformances;
 
     ArrayRef<SILWitnessTable::Entry> SILEntries;
-    ArrayRef<SILWitnessTable::ConditionalConformance>
-        SILConditionalConformances;
+    ArrayRef<ProtocolConformanceRef> SILConditionalConformances;
 
     const ProtocolInfo &PI;
 
@@ -2107,10 +2106,10 @@ llvm::Function *FragileWitnessTableBuilder::buildInstantiationFunction() {
     const auto &condConformance = SILConditionalConformances[idx];
     CanType reqTypeInContext =
       Conformance.getDeclContext()
-        ->mapTypeIntoContext(condConformance.Requirement)
+        ->mapTypeIntoContext(condConformance.getType())
         ->getCanonicalType();
     if (auto archetype = dyn_cast<ArchetypeType>(reqTypeInContext)) {
-      auto condProto = condConformance.Conformance.getProtocol();
+      auto condProto = condConformance.getProtocol();
       IGF.setUnscopedLocalTypeData(
              archetype,
              LocalTypeDataKind::forAbstractProtocolWitnessTable(condProto),

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -4350,7 +4350,7 @@ void SILWitnessTable::Entry::print(llvm::raw_ostream &out, bool verbose,
       conformance.getConcrete()->printName(out, options);
     else {
       out << "dependent ";
-      assocProtoWitness.SubstType->print(out, options);
+      assocProtoWitness.Witness.getType()->print(out, options);
     }
     break;
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -4392,18 +4392,21 @@ void SILWitnessTable::print(llvm::raw_ostream &OS, bool Verbose) const {
   for (auto conditionalConformance : getConditionalConformances()) {
     // conditional_conformance (TypeName: Protocol):
     // <conformance>
-    if (conditionalConformance.Conformance.isInvalid())
+    if (conditionalConformance.isInvalid()) {
+      OS << "  conditional_conformance invalid";
       continue;
+    }
 
     OS << "  conditional_conformance (";
-    conditionalConformance.Requirement.print(OS, Options);
-    OS << ": " << conditionalConformance.Conformance.getProtocol()->getName()
+    conditionalConformance.getType().print(OS, Options);
+    OS << ": " << conditionalConformance.getProtocol()->getName()
        << "): ";
-    if (conditionalConformance.Conformance.isConcrete())
-      conditionalConformance.Conformance.getConcrete()->printName(OS, Options);
+    if (conditionalConformance.isConcrete())
+      conditionalConformance.getConcrete()->printName(OS, Options);
     else {
+      ASSERT(conditionalConformance.isAbstract() && "Handle pack conformance here");
       OS << "dependent ";
-      conditionalConformance.Requirement->print(OS, Options);
+      conditionalConformance.getType()->print(OS, Options);
     }
 
     OS << '\n';

--- a/lib/SIL/IR/SILWitnessTable.cpp
+++ b/lib/SIL/IR/SILWitnessTable.cpp
@@ -61,7 +61,7 @@ SILWitnessTable *SILWitnessTable::create(
     SILModule &M, SILLinkage Linkage, SerializedKind_t SerializedKind,
     ProtocolConformance *Conformance,
     ArrayRef<SILWitnessTable::Entry> entries,
-    ArrayRef<ConditionalConformance> conditionalConformances) {
+    ArrayRef<ProtocolConformanceRef> conditionalConformances) {
   assert(Conformance && "Cannot create a witness table for a null "
          "conformance.");
 
@@ -106,7 +106,7 @@ SILWitnessTable::create(SILModule &M, SILLinkage Linkage,
 SILWitnessTable::SILWitnessTable(
     SILModule &M, SILLinkage Linkage, SerializedKind_t SerializedKind, StringRef N,
     ProtocolConformance *Conformance, ArrayRef<Entry> entries,
-    ArrayRef<ConditionalConformance> conditionalConformances)
+    ArrayRef<ProtocolConformanceRef> conditionalConformances)
     : Mod(M), Name(N), Linkage(Linkage), Conformance(Conformance), Entries(),
       ConditionalConformances(), IsDeclaration(true),
       SerializedKind(SerializedKind) {
@@ -142,7 +142,7 @@ SILWitnessTable::~SILWitnessTable() {
 
 void SILWitnessTable::convertToDefinition(
     ArrayRef<Entry> entries,
-    ArrayRef<ConditionalConformance> conditionalConformances,
+    ArrayRef<ProtocolConformanceRef> conditionalConformances,
     SerializedKind_t serializedKind) {
   assert(isDeclaration() && "Definitions should never call this method.");
   IsDeclaration = false;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -8157,8 +8157,7 @@ static bool parseSILWitnessTableEntry(
          GenericParamList *witnessParams,
          SILParser &witnessState,
          std::vector<SILWitnessTable::Entry> &witnessEntries,
-         std::vector<SILWitnessTable::ConditionalConformance>
-           &conditionalConformances) {
+         std::vector<ProtocolConformanceRef> &conditionalConformances) {
   Identifier EntryKeyword;
   SourceLoc KeywordLoc;
   if (P.parseIdentifier(EntryKeyword, KeywordLoc,
@@ -8273,9 +8272,7 @@ static bool parseSILWitnessTableEntry(
                                                         substType,
                                                         conformance});
     else
-      conditionalConformances.push_back(
-          SILWitnessTable::ConditionalConformance{assocOrSubject,
-                                                  conformance});
+      conditionalConformances.push_back(conformance);
 
     return false;
   }
@@ -8420,7 +8417,7 @@ bool SILParserState::parseSILWitnessTable(Parser &P) {
   Lexer::SILBodyRAII Tmp(*P.L);
   // Parse the entry list.
   std::vector<SILWitnessTable::Entry> witnessEntries;
-  std::vector<SILWitnessTable::ConditionalConformance> conditionalConformances;
+  std::vector<ProtocolConformanceRef> conditionalConformances;
 
   if (P.Tok.isNot(tok::r_brace)) {
     do {
@@ -8481,7 +8478,7 @@ bool SILParserState::parseSILDefaultWitnessTable(Parser &P) {
 
   // Parse the entry list.
   std::vector<SILWitnessTable::Entry> witnessEntries;
-  std::vector<SILWitnessTable::ConditionalConformance> conditionalConformances;
+  std::vector<ProtocolConformanceRef> conditionalConformances;
 
   if (P.Tok.isNot(tok::r_brace)) {
     do {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -8229,7 +8229,6 @@ static bool parseSILWitnessTableEntry(
         P.parseToken(tok::colon, diag::expected_sil_witness_colon))
       return true;
 
-    CanType substType;
     ProtocolConformanceRef conformance;
     if (P.Tok.getText() != "dependent") {
       auto concrete =
@@ -8237,7 +8236,6 @@ static bool parseSILWitnessTableEntry(
       // Ignore invalid and abstract witness entries.
       if (concrete.isInvalid() || !concrete.isConcrete())
         return false;
-      substType = concrete.getConcrete()->getType()->getCanonicalType();
       conformance = concrete;
     } else {
       P.consumeToken();
@@ -8261,7 +8259,6 @@ static bool parseSILWitnessTableEntry(
       if (Ty->hasError())
         return true;
 
-      substType = Ty->getCanonicalType();
       conformance = ProtocolConformanceRef::forAbstract(
           Ty->getCanonicalType(), proto);
     }
@@ -8269,7 +8266,6 @@ static bool parseSILWitnessTableEntry(
     if (EntryKeyword.str() == "associated_conformance")
       witnessEntries.push_back(
           SILWitnessTable::AssociatedConformanceWitness{assocOrSubject,
-                                                        substType,
                                                         conformance});
     else
       conditionalConformances.push_back(conformance);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -540,7 +540,7 @@ public:
   SILGenModule &SGM;
   NormalProtocolConformance *Conformance;
   std::vector<SILWitnessTable::Entry> Entries;
-  std::vector<SILWitnessTable::ConditionalConformance> ConditionalConformances;
+  std::vector<ProtocolConformanceRef> ConditionalConformances;
   SILLinkage Linkage;
   SerializedKind_t SerializedKind;
 
@@ -708,8 +708,7 @@ public:
           assert(conformance &&
                  "unable to find conformance that should be known");
 
-          ConditionalConformances.push_back(
-              SILWitnessTable::ConditionalConformance{type, conformance});
+          ConditionalConformances.push_back(conformance);
 
           return /*finished?*/ false;
         });

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -692,12 +692,8 @@ public:
       Conformance->getAssociatedConformance(req.getAssociation(),
                                             req.getAssociatedRequirement());
     SGM.useConformance(assocConformance);
-
-    auto substType = (assocConformance
-                      ? assocConformance.getType()
-                      : ErrorType::get(SGM.getASTContext()))->getCanonicalType();
     Entries.push_back(SILWitnessTable::AssociatedConformanceWitness{
-        req.getAssociation(), substType, assocConformance});
+        req.getAssociation(), assocConformance});
   }
 
   void addConditionalRequirements() {
@@ -1125,7 +1121,7 @@ public:
       return addMissingDefault();
 
     auto entry = SILWitnessTable::AssociatedConformanceWitness{
-        req.getAssociation(), req.getAssociation(), witness};
+        req.getAssociation(), witness};
     DefaultWitnesses.push_back(entry);
   }
 };

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -219,8 +219,8 @@ class DeadFunctionAndGlobalElimination {
     }
 
     for (const auto &conf : WT->getConditionalConformances()) {
-      if (conf.Conformance.isConcrete())
-        ensureAliveConformance(conf.Conformance.getConcrete());
+      if (conf.isConcrete())
+        ensureAliveConformance(conf.getConcrete());
     }
   }
 

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -201,26 +201,12 @@ class DeadFunctionAndGlobalElimination {
           }
         } break;
 
-        case SILWitnessTable::AssociatedConformance: {
-          ProtocolConformanceRef CRef =
-             entry.getAssociatedConformanceWitness().Witness;
-          if (CRef.isConcrete())
-            ensureAliveConformance(CRef.getConcrete());
-          break;
-        }
+        case SILWitnessTable::AssociatedConformance:
         case SILWitnessTable::BaseProtocol:
-          ensureAliveConformance(entry.getBaseProtocolWitness().Witness);
-          break;
-
         case SILWitnessTable::Invalid:
         case SILWitnessTable::AssociatedType:
           break;
       }
-    }
-
-    for (const auto &conf : WT->getConditionalConformances()) {
-      if (conf.isConcrete())
-        ensureAliveConformance(conf.getConcrete());
     }
   }
 
@@ -279,14 +265,6 @@ class DeadFunctionAndGlobalElimination {
       makeAlive(global);
   }
 
-  /// Marks a witness table as alive if it is not alive yet.
-  void ensureAliveConformance(const ProtocolConformance *C) {
-    SILWitnessTable *WT = Module->lookUpWitnessTable(C);
-    if (!WT || isAlive(WT))
-      return;
-    makeAlive(WT);
-  }
-
   /// Returns true if the implementation of method \p FD in class \p ImplCl
   /// may be called when the type of the class_method's operand is \p MethodCl.
   /// Both, \p MethodCl and \p ImplCl, may by null if not known or if it's a
@@ -322,7 +300,7 @@ class DeadFunctionAndGlobalElimination {
       if (!isAlive(FImpl.F) &&
           canHaveSameImplementation(FD, MethodCl,
                                     FImpl.Impl.get<ClassDecl *>())) {
-        makeAlive(FImpl.F);
+        ensureAlive(FImpl.F);
       } else {
         allImplsAreCalled = false;
       }
@@ -341,9 +319,9 @@ class DeadFunctionAndGlobalElimination {
       if (auto Conf = FImpl.Impl.dyn_cast<ProtocolConformance *>()) {
         SILWitnessTable *WT = Module->lookUpWitnessTable(Conf);
         if (!WT || isAlive(WT))
-          makeAlive(FImpl.F);
+          ensureAlive(FImpl.F);
       } else {
-        makeAlive(FImpl.F);
+        ensureAlive(FImpl.F);
       }
     }
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -4488,15 +4488,12 @@ void SILDeserializer::readWitnessTableEntries(
       });
     } else if (kind == SIL_WITNESS_ASSOC_PROTOCOL) {
       TypeID origTypeId;
-      DeclID substTypeId;
       ProtocolConformanceID conformanceId;
-      WitnessAssocProtocolLayout::readRecord(scratch, origTypeId, substTypeId,
-                                             conformanceId);
+      WitnessAssocProtocolLayout::readRecord(scratch, origTypeId, conformanceId);
       CanType origType = MF->getType(origTypeId)->getCanonicalType();
-      CanType substType = MF->getType(substTypeId)->getCanonicalType();
       auto conformance = MF->getConformance(conformanceId);
       witnessEntries.push_back(SILWitnessTable::AssociatedConformanceWitness{
-        origType, substType, conformance
+        origType, conformance
       });
     } else if (kind == SIL_WITNESS_ASSOC_ENTRY) {
       DeclID assocId;

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -179,8 +179,7 @@ namespace swift {
     void readWitnessTableEntries(
            llvm::BitstreamEntry &entry,
            std::vector<SILWitnessTable::Entry> &witnessEntries,
-           std::vector<SILWitnessTable::ConditionalConformance>
-             &conditionalConformances);
+           std::vector<ProtocolConformanceRef> &conditionalConformances);
     SILProperty *readProperty(serialization::DeclID);
     SILDefaultWitnessTable *
     readDefaultWitnessTable(serialization::DeclID,

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 936; // Remove SILWitnessTable::ConditionalConformance
+const uint16_t SWIFTMODULE_VERSION_MINOR = 937; // Simplify SILWitnessTable
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 935; // remove ExtensibleEnums feature
+const uint16_t SWIFTMODULE_VERSION_MINOR = 936; // Remove SILWitnessTable::ConditionalConformance
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -261,7 +261,6 @@ namespace sil_block {
 
   using WitnessConditionalConformanceLayout = BCRecordLayout<
     SIL_WITNESS_CONDITIONAL_CONFORMANCE,
-    TypeIDField, // ID of associated type
     ProtocolConformanceIDField // ID of conformance
   >;
 

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -249,7 +249,6 @@ namespace sil_block {
   using WitnessAssocProtocolLayout = BCRecordLayout<
     SIL_WITNESS_ASSOC_PROTOCOL,
     TypeIDField, // ID of requirement subject type
-    TypeIDField, // ID of substituted subject type
     ProtocolConformanceIDField
   >;
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -3374,12 +3374,11 @@ void SILSerializer::writeSILWitnessTable(const SILWitnessTable &wt) {
   }
 
   for (auto conditional : wt.getConditionalConformances()) {
-    auto requirementID = S.addTypeRef(conditional.Requirement);
-    auto conformanceID = S.addConformanceRef(conditional.Conformance);
+    auto conformanceID = S.addConformanceRef(conditional);
     WitnessConditionalConformanceLayout::emitRecord(
         Out, ScratchRecord,
         SILAbbrCodes[WitnessConditionalConformanceLayout::Code],
-        requirementID, conformanceID);
+        conformanceID);
   }
 }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -3401,13 +3401,12 @@ void SILSerializer::writeSILWitnessTableEntry(
     auto &assoc = entry.getAssociatedConformanceWitness();
 
     auto requirementID = S.addTypeRef(assoc.Requirement);
-    auto substTypeID = S.addTypeRef(assoc.SubstType);
     auto conformanceID = S.addConformanceRef(assoc.Witness);
 
     WitnessAssocProtocolLayout::emitRecord(
       Out, ScratchRecord,
       SILAbbrCodes[WitnessAssocProtocolLayout::Code],
-      requirementID, substTypeID, conformanceID);
+      requirementID, conformanceID);
     return;
   }
 


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/80482 that removes origType plumbing from a few more places in SIL.