### PR TITLE
[6.1] TypeCheckType: Do not fail after emitting a warning

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -892,22 +892,7 @@ static Type applyGenericArguments(Type type,
       argTys.push_back(argTy);
     }
 
-    auto parameterized =
-        ParameterizedProtocolType::get(ctx, protoType, argTys);
-
-    // FIXME: Can this not be done in ExistentialTypeSyntaxChecker?
-    if (resolution.getOptions().isConstraintImplicitExistential() &&
-        !ctx.LangOpts.hasFeature(Feature::ImplicitSome)) {
-      diags
-          .diagnose(loc, diag::existential_requires_any, parameterized,
-                    ExistentialType::get(parameterized),
-                    /*isAlias=*/isa<TypeAliasType>(type.getPointer()))
-          .warnUntilSwiftVersion(7);
-
-      return ErrorType::get(ctx);
-    }
-
-    return parameterized;
+    return ParameterizedProtocolType::get(ctx, protoType, argTys);
   }
   
   // Builtins have special handling.

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -159,13 +159,13 @@ protocol Collection<T> {
 struct TestParameterizedProtocol<T> : Collection {
   typealias T = T
 
-  let x : Collection<T> // expected-warning {{use of protocol 'Collection<T>' as a type must be written 'any Collection<T>'}}
+  let x : Collection<T> // expected-warning {{use of protocol 'Collection' as a type must be written 'any Collection'}}
 }
 
 func acceptAny(_: Collection<Int>) {}
-// expected-warning@-1 {{use of protocol 'Collection<Int>' as a type must be written 'any Collection<Int>'}}
+// expected-warning@-1 {{use of protocol 'Collection' as a type must be written 'any Collection'}}
 func returnsAny() -> Collection<Int> {}
-// expected-warning@-1 {{use of protocol 'Collection<Int>' as a type must be written 'any Collection<Int>'}}
+// expected-warning@-1 {{use of protocol 'Collection' as a type must be written 'any Collection'}}
 
 func testInvalidAny() {
   struct S: HasAssoc {
@@ -357,8 +357,8 @@ func testAnyFixIt() {
   let _: Optional<HasAssoc>
   // expected-warning@+1 {{constraint that suppresses conformance requires 'any'}}{{19-28=any ~Copyable}}
   let _: Optional<~Copyable>
-  // FIXME: No fix-it + generic argument not diagnosed.
-  // expected-warning@+1 {{use of protocol 'HasAssocGeneric<any HasAssoc>' as a type must be written 'any HasAssocGeneric<any HasAssoc>'}}{{none}}
+  // expected-warning@+2:10 {{use of protocol 'HasAssocGeneric' as a type must be written 'any HasAssocGeneric'}}{{10-35=any HasAssocGeneric<HasAssoc>}}
+  // expected-warning@+1:26 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{26-34=any HasAssoc}}
   let _: HasAssocGeneric<HasAssoc>
   // expected-warning@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{14-22=any HasAssoc}}
   let _: S.G<HasAssoc>
@@ -390,8 +390,8 @@ func testAnyFixIt() {
   // expected-warning@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{13-21=any HasAssoc}}
   // expected-warning@+1 {{constraint that suppresses conformance requires 'any'}}{{10-37=any ~G<HasAssoc>.Copyable_Alias}}
   let _: ~G<HasAssoc>.Copyable_Alias
-  // FIXME: No fix-it + generic argument not diagnosed.
-  // expected-warning@+1 {{use of 'HasAssocGeneric<any HasAssoc>' as a type must be written 'any HasAssocGeneric<any HasAssoc>}}{{none}}
+  // expected-warning@+2:12 {{use of 'S.HasAssocGeneric_Alias' (aka 'HasAssocGeneric') as a type must be written 'any S.HasAssocGeneric_Alias' (aka 'any HasAssocGeneric')}} {{10-43=any S.HasAssocGeneric_Alias<HasAssoc>}}
+  // expected-warning@+1:34 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{34-42=any HasAssoc}}
   let _: S.HasAssocGeneric_Alias<HasAssoc>
   // FIXME: No diagnostic.
   let _: HasAssoc.Int_Alias
@@ -525,6 +525,8 @@ func testAnyFixIt() {
 
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc)?'}}{{10-23=(any HasAssoc)?}}
   let _: any HasAssoc?
+  // expected-error@+1:10 {{optional 'any' type must be written '(any HasAssocGeneric<Int>)?'}}{{10-35=(any HasAssocGeneric<Int>)?}}
+  let _: any HasAssocGeneric<Int>?
   // FIXME: Better recovery
   // expected-error@+1 {{type '(any Copyable)?' cannot be suppressed}}
   let _: any ~Copyable?

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -7,10 +7,10 @@ protocol Sequence<Element> { // expected-note {{'Sequence' declared here}}
 // 'any' is required here
 
 func takesSequenceOfInt1(_: Sequence<Int>) {}
-// expected-warning@-1 {{use of protocol 'Sequence<Int>' as a type must be written 'any Sequence<Int>'}}
+// expected-warning@-1 {{use of protocol 'Sequence' as a type must be written 'any Sequence'}}
 
 func returnsSequenceOfInt1() -> Sequence<Int> {}
-// expected-warning@-1 {{use of protocol 'Sequence<Int>' as a type must be written 'any Sequence<Int>'}}
+// expected-warning@-1 {{use of protocol 'Sequence' as a type must be written 'any Sequence'}}
 
 struct ConcreteSequence<Element> : Sequence {}
 
@@ -74,7 +74,7 @@ func saturation(_ dry: any Sponge, _ wet: any Sponge<Int, Int>) {
 
 func typeExpr() {
   _ = Sequence<Int>.self
-  // expected-warning@-1 {{use of protocol 'Sequence<Int>' as a type must be written 'any Sequence<Int>'}}
+  // expected-warning@-1 {{use of protocol 'Sequence' as a type must be written 'any Sequence'}}
 
   _ = any Sequence<Int>.self
   // expected-error@-1 {{'self' is not a member type of protocol 'parameterized_existential.Sequence<Swift.Int>'}}
@@ -102,4 +102,13 @@ func genericIncrement<T: Numeric>(_ n : any Collection<T>) {
   for value in n {
     _ = value + 1
   }
+}
+
+protocol TextContainerViewProtocol {
+    // expected-error@+1 {{optional 'any' type must be written '(any TextContainerViewDelegate<Self>)?'}}
+    var delegate: any TextContainerViewDelegate<Self>? { get set}
+}
+
+protocol TextContainerViewDelegate<View> {
+    associatedtype View: TextContainerViewProtocol
 }

--- a/test/type/parameterized_existential_valid.swift
+++ b/test/type/parameterized_existential_valid.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.7-abi-triple
+
+// expected-warning@+1 {{use of protocol 'Collection' as a type must be written 'any Collection'; this will be an error in a future Swift language mode}}
+func test(c: Collection<Int>) -> Int {
+  c.count
+}


### PR DESCRIPTION
- **Explanation**: We forgot to remove a return of an error type after emitting a diagnostic that had been downgraded to a warning. This omission caused code that became valid to still contain an error type despite not producing an error and trip the AST verifier or crash later down the line with a no-asserts configuration.

  The issue was introduced in #78389.
- **Scope**: Syntax diagnosis for constrained existential types.
- **Issues**: Resolves #79916.
- **Original PRs**: #79934.
- **Risk**: Very low. The removed diagnosis is already fully covered for in the existential syntax checker and must not impede successful compilation.
- **Testing**: Added regression test.
- **Reviewers**: I merged the original PR without a peer review as a code owner.
