### PR TITLE
[cxx-interop] Fix a rare compilation error in reverse interop header

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -773,6 +773,9 @@ getPrivateFileIDAttrs(const clang::CXXRecordDecl *decl);
 ///
 /// Returns false if \a decl was not imported by ClangImporter.
 bool declIsCxxOnly(const Decl *decl);
+
+/// Is this DeclContext an `enum` that represents a C++ namespace?
+bool isClangNamespace(const DeclContext *dc);
 } // namespace importer
 
 struct ClangInvocationFileMapping {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8793,3 +8793,10 @@ bool importer::declIsCxxOnly(const Decl *decl) {
   }
   return false;
 }
+
+bool importer::isClangNamespace(const DeclContext *dc) {
+  if (const auto *ed = dc->getSelfEnumDecl())
+    return isa_and_nonnull<clang::NamespaceDecl>(ed->getClangDecl());
+
+  return false;
+}

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -75,6 +75,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/TinyPtrVector.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Path.h"
 
 #include <algorithm>
@@ -3728,13 +3729,6 @@ namespace {
           return attr;
       }
       return nullptr;
-    }
-
-    static bool isClangNamespace(const DeclContext *dc) {
-      if (const auto *ed = dc->getSelfEnumDecl())
-        return isa<clang::NamespaceDecl>(ed->getClangDecl());
-
-      return false;
     }
 
     Decl *importFunctionDecl(

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -207,7 +207,8 @@ void ClangSyntaxPrinter::printNamespace(
 void ClangSyntaxPrinter::printParentNamespaceForNestedTypes(
     const ValueDecl *D, llvm::function_ref<void(raw_ostream &OS)> bodyPrinter,
     NamespaceTrivia trivia) const {
-  if (!isa_and_nonnull<NominalTypeDecl>(D->getDeclContext()->getAsDecl())) {
+  if (!isa_and_nonnull<NominalTypeDecl>(D->getDeclContext()->getAsDecl()) ||
+      importer::isClangNamespace(D->getDeclContext())) {
     bodyPrinter(os);
     return;
   }

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -630,18 +630,21 @@ void ClangValueTypePrinter::printTypeGenericTraits(
     bool isOpaqueLayout) {
   auto *NTD = dyn_cast<NominalTypeDecl>(typeDecl);
   ClangSyntaxPrinter printer(typeDecl->getASTContext(), os);
+  if (typeDecl->hasClangNode()) {
+    /// Print a reference to the type metadata function for a C++ type.
+    printer.printParentNamespaceForNestedTypes(typeDecl, [&](raw_ostream &os) {
+      printer.printNamespace(
+          cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
+            ClangSyntaxPrinter(typeDecl->getASTContext(), os)
+                .printCTypeMetadataTypeFunction(typeDecl, typeMetadataFuncName,
+                                                typeMetadataFuncRequirements);
+          });
+    });
+  }
+
   // FIXME: avoid popping out of the module's namespace here.
   os << "} // end namespace \n\n";
   os << "namespace swift SWIFT_PRIVATE_ATTR {\n";
-
-  if (typeDecl->hasClangNode()) {
-    /// Print a reference to the type metadata function for a C++ type.
-    ClangSyntaxPrinter(typeDecl->getASTContext(), os).printNamespace(
-        cxx_synthesis::getCxxImplNamespaceName(), [&](raw_ostream &os) {
-          ClangSyntaxPrinter(typeDecl->getASTContext(), os).printCTypeMetadataTypeFunction(
-              typeDecl, typeMetadataFuncName, typeMetadataFuncRequirements);
-        });
-  }
   auto classDecl = dyn_cast<ClassDecl>(typeDecl);
   bool addPointer =
       typeDecl->isObjC() || (classDecl && classDecl->isForeignReferenceType());
@@ -676,10 +679,11 @@ void ClangValueTypePrinter::printTypeGenericTraits(
   ClangSyntaxPrinter(typeDecl->getASTContext(), os).printInlineForHelperFunction();
   os << "void * _Nonnull getTypeMetadata() {\n";
   os << "    return ";
-  if (!typeDecl->hasClangNode()) {
+  if (typeDecl->hasClangNode())
+    printer.printBaseName(moduleContext);
+  else
     printer.printBaseName(typeDecl->getModuleContext());
-    os << "::";
-  }
+  os << "::";
   if (!printer.printNestedTypeNamespaceQualifiers(typeDecl))
     os << "::";
   os << cxx_synthesis::getCxxImplNamespaceName() << "::";

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -200,10 +200,7 @@ public struct Strct {
 // CHECK:  ns::ImmortalTemplate<int> *_Nonnull retImmortalTemplate() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: return UseCxxTy::_impl::$s8UseCxxTy19retImmortalTemplateSo2nsO0028ImmortalTemplateCInt_jBAGgnbVyF();
 // CHECK-NEXT: }
-
-// CHECK: } // end namespace
 // CHECK-EMPTY:
-// CHECK-NEXT: namespace swift SWIFT_PRIVATE_ATTR {
 // CHECK-NEXT: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: // Type metadata accessor for NonTrivialTemplateInt
@@ -212,6 +209,9 @@ public struct Strct {
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
 // CHECK-EMPTY:
+// CHECK-NEXT: } // end namespace
+// CHECK-EMPTY:
+// CHECK-NEXT: namespace swift SWIFT_PRIVATE_ATTR {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
@@ -219,7 +219,7 @@ public struct Strct {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateInt> {
 // CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo2nsO0030NonTrivialTemplateCInt_hHAFhrbVMa(0)._0;
+// CHECK-NEXT:     return UseCxxTy::_impl::$sSo2nsO0030NonTrivialTemplateCInt_hHAFhrbVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
@@ -240,9 +240,6 @@ public struct Strct {
 // CHECK-NEXT: return result;
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK-NEXT: } // end namespace
-// CHECK-EMPTY:
-// CHECK-NEXT: namespace swift SWIFT_PRIVATE_ATTR {
 // CHECK-NEXT: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: // Type metadata accessor for NonTrivialTemplateTrivial
@@ -251,6 +248,9 @@ public struct Strct {
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
 // CHECK-EMPTY:
+// CHECK-NEXT: } // end namespace
+// CHECK-EMPTY:
+// CHECK-NEXT: namespace swift SWIFT_PRIVATE_ATTR {
 // CHECK-NEXT: #pragma clang diagnostic push
 // CHECK-NEXT: #pragma clang diagnostic ignored "-Wc++17-extensions"
 // CHECK-NEXT: template<>
@@ -258,7 +258,7 @@ public struct Strct {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateTrivial> {
 // CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo2nsO0042NonTrivialTemplatensTrivialinNS_HlGFlenawcVMa(0)._0;
+// CHECK-NEXT:     return UseCxxTy::_impl::$sSo2nsO0042NonTrivialTemplatensTrivialinNS_HlGFlenawcVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{

--- a/test/Interop/CxxToSwiftToCxx/nested-cxx-class-back-to-swift.swift
+++ b/test/Interop/CxxToSwiftToCxx/nested-cxx-class-back-to-swift.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/use-cxx-types.swift -module-name UseCxxTy -typecheck -verify -emit-clang-header-path %t/UseCxxTy.h -I %t -enable-experimental-cxx-interop -clang-header-expose-decls=all-public -disable-availability-checking
+// RUN: cat %t/header.h >> %t/full-header.h
+// RUN: cat %t/UseCxxTy.h >> %t/full-header.h
+// RUN: %target-interop-build-clangxx -std=c++20 -c -xc++-header %t/full-header.h -o %t/o.o
+
+//--- header.h
+
+struct Cell { class Visitor {}; };
+
+//--- module.modulemap
+module CxxTest {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- use-cxx-types.swift
+import CxxTest
+
+public extension Cell.Visitor {
+    func visit() {}
+}
+
+public func f() -> [Cell.Visitor] {
+}

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -94,7 +94,7 @@ public func retObjCClassArray() -> [ObjCKlass] {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ObjCKlass*> {
 // CHECK-NEXT:   static SWIFT_INLINE_PRIVATE_HELPER void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo9ObjCKlassCMa(0)._0;
+// CHECK-NEXT:     return UseObjCTy::_impl::$sSo9ObjCKlassCMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
@@ -68,3 +68,11 @@ public class TestObject {
         case invalid
     }
 }
+
+extension RecordConfig.File {
+    public func getFileExtension() -> String { ".wav" }
+}
+
+public func getFiles() -> [RecordConfig.File] {
+    []
+}


### PR DESCRIPTION
To trigger this error one needs to import a nested type from C++, use it in a generic context in Swift, and export it back to C++. We were inconsisent in what namespace did we declare the functions to get the type metadata for types. It was in the swift namespace for foreign types and in the module namespace for Swift types. This PR standardizes on how the metadata function is declared and called to fix the issue.

Fixes #80538.

rdar://148597079