### PR TITLE
[6.2][NFC] Sema: Factor out derived conformance sources into subdirectory

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -30,12 +30,13 @@
 //   a global conformance lookup.
 //
 //===----------------------------------------------------------------------===//
-#include "TypeCheckProtocol.h"
-#include "DerivedConformances.h"
+
+#include "DerivedConformance/DerivedConformance.h"
 #include "TypeAccessScopeChecker.h"
-#include "TypeChecker.h"
 #include "TypeCheckAvailability.h"
+#include "TypeCheckProtocol.h"
 #include "TypeCheckType.h"
+#include "TypeChecker.h"
 
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/ConformanceLookup.h"

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -24,18 +24,18 @@ add_swift_host_library(swiftSema STATIC
   ConstraintSystem.cpp
   CompletionContextFinder.cpp
   DebuggerTestingTransform.cpp
-  DerivedConformanceActor.cpp
-  DerivedConformanceDistributedActor.cpp
-  DerivedConformanceAdditiveArithmetic.cpp
-  DerivedConformanceCaseIterable.cpp
-  DerivedConformanceCodable.cpp
-  DerivedConformanceCodingKey.cpp
-  DerivedConformanceDifferentiable.cpp
-  DerivedConformanceEquatableHashable.cpp
-  DerivedConformanceComparable.cpp
-  DerivedConformanceError.cpp
-  DerivedConformanceRawRepresentable.cpp
-  DerivedConformances.cpp
+  DerivedConformance/DerivedConformance.cpp
+  DerivedConformance/DerivedConformanceActor.cpp
+  DerivedConformance/DerivedConformanceAdditiveArithmetic.cpp
+  DerivedConformance/DerivedConformanceCaseIterable.cpp
+  DerivedConformance/DerivedConformanceCodable.cpp
+  DerivedConformance/DerivedConformanceCodingKey.cpp
+  DerivedConformance/DerivedConformanceComparable.cpp
+  DerivedConformance/DerivedConformanceDifferentiable.cpp
+  DerivedConformance/DerivedConformanceDistributedActor.cpp
+  DerivedConformance/DerivedConformanceEquatableHashable.cpp
+  DerivedConformance/DerivedConformanceError.cpp
+  DerivedConformance/DerivedConformanceRawRepresentable.cpp
   ImportResolution.cpp
   InstrumenterSupport.cpp
   LookupVisibleDecls.cpp

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,12 +16,12 @@
 
 #include "CodeSynthesis.h"
 
+#include "DerivedConformance/DerivedConformance.h"
 #include "TypeCheckDecl.h"
 #include "TypeCheckDistributed.h"
 #include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
-#include "DerivedConformances.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/AvailabilityInference.h"

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -13,7 +13,7 @@
 #include "TypeCheckDistributed.h"
 
 #include "CodeSynthesis.h"
-#include "DerivedConformances.h"
+#include "DerivedConformance/DerivedConformance.h"
 #include "TypeChecker.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTPrinter.h"

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformances.cpp - Derived conformance utilities ----------===//
+//===--- DerivedConformance.cpp ---------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,21 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "TypeChecker.h"
+#include "DerivedConformance.h"
 #include "TypeCheckConcurrency.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"
-#include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/ClangImporter/ClangModule.h"
-#include "DerivedConformances.h"
 
 using namespace swift;
 

--- a/lib/Sema/DerivedConformance/DerivedConformance.h
+++ b/lib/Sema/DerivedConformance/DerivedConformance.h
@@ -1,8 +1,8 @@
-//===--- DerivedConformances.h - Derived protocol conformance ---*- C++ -*-===//
+//===--- DerivedConformance.h -----------------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,11 +15,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SEMA_DERIVEDCONFORMANCES_H
-#define SWIFT_SEMA_DERIVEDCONFORMANCES_H
+#ifndef SWIFT_SEMA_DERIVEDCONFORMANCE_DERIVEDCONFORMANCE_H
+#define SWIFT_SEMA_DERIVEDCONFORMANCE_DERIVEDCONFORMANCE_H
 
-#include "swift/Basic/LLVM.h"
 #include "swift/AST/Builtins.h"
+#include "swift/Basic/LLVM.h"
 #include <utility>
 
 namespace swift {

--- a/lib/Sema/DerivedConformance/DerivedConformanceActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceActor.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceActor.cpp --------------------------------------===//
+//===--- DerivedConformanceActor.cpp ----------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -19,7 +19,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
-#include "DerivedConformances.h"
+#include "DerivedConformance.h"
 #include "TypeChecker.h"
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/Decl.h"

--- a/lib/Sema/DerivedConformance/DerivedConformanceAdditiveArithmetic.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceAdditiveArithmetic.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceAdditiveArithmetic.cpp -------------------------===//
+//===--- DerivedConformanceAdditiveArithmetic.cpp ---------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2018 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -22,6 +22,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
+#include "DerivedConformance.h"
 #include "TypeChecker.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
@@ -33,7 +34,6 @@
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
-#include "DerivedConformances.h"
 
 using namespace swift;
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCaseIterable.cpp
@@ -1,11 +1,12 @@
+//===--- DerivedConformanceCaseIterable.cpp ---------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2016 Apple Inc. and the Swift project authors
+// Copyright (c) 2018 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
-// See http://swift.org/LICENSE.txt for license information
-// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
 //
@@ -13,13 +14,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "DerivedConformance.h"
 #include "TypeChecker.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "llvm/Support/raw_ostream.h"
-#include "DerivedConformances.h"
 
 using namespace swift;
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceCodable.cpp - Derived Codable ------------------===//
+//===--- DerivedConformanceCodable.cpp --------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,8 +16,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
+#include "DerivedConformance.h"
 #include "TypeChecker.h"
-#include "llvm/ADT/STLExtras.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -28,7 +28,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/StringExtras.h"
-#include "DerivedConformances.h"
+#include "llvm/ADT/STLExtras.h"
 
 using namespace swift;
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodingKey.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceCodingKey.cpp - Derived CodingKey --------------===//
+//===--- DerivedConformanceCodingKey.cpp ------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "DerivedConformance.h"
 #include "TypeChecker.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
@@ -22,7 +23,6 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
-#include "DerivedConformances.h"
 
 using namespace swift;
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceComparable.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceComparable.cpp - Derived Comparable -===//
+//===--- DerivedConformanceComparable.cpp -----------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,25 +11,26 @@
 //===----------------------------------------------------------------------===//
 //
 //  This file implements implicit derivation of the Comparable protocol.
-//  (Most of this code is similar to code in `DerivedConformanceEquatableHashable.cpp`)
+//  (Most of this code is similar to code in
+//  `DerivedConformanceEquatableHashable.cpp`)
 //
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
+#include "DerivedConformance.h"
 #include "TypeChecker.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
-#include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/raw_ostream.h"
-#include "DerivedConformances.h"
 
 using namespace swift;
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceDifferentiable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDifferentiable.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceDifferentiable.cpp - Derived Differentiable ----===//
+//===--- DerivedConformanceDifferentiable.cpp -------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2019 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2019 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,9 +16,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
-#include "TypeChecker.h"
+#include "DerivedConformance.h"
 #include "TypeCheckType.h"
-#include "llvm/ADT/SmallPtrSet.h"
+#include "TypeChecker.h"
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
@@ -32,7 +32,7 @@
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
-#include "DerivedConformances.h"
+#include "llvm/ADT/SmallPtrSet.h"
 
 using namespace swift;
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceActor.cpp - Derived Actor Conformance ----------===//
+//===--- DerivedConformanceActor.cpp ----------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
-#include "DerivedConformances.h"
+#include "DerivedConformance.h"
 #include "TypeCheckDistributed.h"
 #include "TypeChecker.h"
 #include "swift/AST/AvailabilityInference.h"

--- a/lib/Sema/DerivedConformance/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceEquatableHashable.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceEquatableHashable.cpp - Derived Equatable & co -===//
+//===--- DerivedConformanceEquatableHashable.cpp ----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,25 +11,25 @@
 //===----------------------------------------------------------------------===//
 //
 //  This file implements implicit derivation of the Equatable and Hashable
-//  protocols. 
+//  protocols.
 //
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
+#include "DerivedConformance.h"
 #include "TypeChecker.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
-#include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/Stmt.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/raw_ostream.h"
-#include "DerivedConformances.h"
 
 using namespace swift;
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceError.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceError.cpp - Derived Error ----------------------===//
+//===--- DerivedConformanceError.cpp ----------------------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,14 +16,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
+#include "DerivedConformance.h"
 #include "TypeChecker.h"
-#include "DerivedConformances.h"
 #include "swift/AST/Decl.h"
-#include "swift/AST/Stmt.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
-#include "swift/AST/Types.h"
+#include "swift/AST/Stmt.h"
 #include "swift/AST/SwiftNameTranslation.h"
+#include "swift/AST/Types.h"
 
 using namespace swift;
 using namespace swift::objc_translation;

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -1,8 +1,8 @@
-//===--- DerivedConformanceRawRepresentable.cpp - Derived RawRepresentable ===//
+//===--- DerivedConformanceRawRepresentable.cpp -----------------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,7 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
-#include "DerivedConformances.h"
+#include "DerivedConformance.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckDecl.h"
 #include "TypeChecker.h"

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -16,7 +16,7 @@
 
 #include "TypeCheckDecl.h"
 #include "CodeSynthesis.h"
-#include "DerivedConformances.h"
+#include "DerivedConformance/DerivedConformance.h"
 #include "MiscDiagnostics.h"
 #include "TypeCheckAccess.h"
 #include "TypeCheckAvailability.h"

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -17,7 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CodeSynthesis.h"
-#include "DerivedConformances.h"
+#include "DerivedConformance/DerivedConformance.h"
 #include "MiscDiagnostics.h"
 #include "TypeCheckAccess.h"
 #include "TypeCheckAvailability.h"

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckProtocol.h"
-#include "DerivedConformances.h"
+#include "DerivedConformance/DerivedConformance.h"
 #include "MiscDiagnostics.h"
 #include "OpenedExistentials.h"
 #include "TypeAccessScopeChecker.h"


### PR DESCRIPTION
- **Explanation**: Places the various source files that deal with generating conformances in a dedicated subdirectory. Cherry-picked to prevent conflicts in this area for later cherry-picks.
- **Scope**: Project structure.
- **Issues**: —
- **Original PRs**: #80529.
- **Risk**: Infinitesimal.
- **Testing**: No additional tests required.
- **Reviewers**: @xedin