### PR TITLE
[6.2][Runtime] Handle relative witness tables in _checkWitnessTableIsolation.

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -444,8 +444,15 @@ static bool _checkWitnessTableIsolation(
   llvm::ArrayRef<const void *> conditionalArgs,
   ConformanceExecutionContext &context
 ) {
-  // If there's no protocol conformance descriptor, do nothing.
+#if SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES && SWIFT_PTRAUTH
+  auto description = lookThroughOptionalConditionalWitnessTable(
+                         reinterpret_cast<const RelativeWitnessTable *>(wtable))
+                         ->getDescription();
+#else
   auto description = wtable->getDescription();
+#endif
+
+  // If there's no protocol conformance descriptor, do nothing.
   if (!description)
     return false;
 


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/80600 to `release/6.2`.

We need to use lookThroughOptionalConditionalWitnessTable when relative witness tables are being used.

rdar://148687148