### PR TITLE
6.2: [IRGen] Fix type of deleted coro error func.

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4625,7 +4625,7 @@ namespace {
         } else if (accessor && requiresFeatureCoroutineAccessors(
                                    accessor->getAccessorKind())) {
           ptr = llvm::ConstantExpr::getBitCast(
-              IGM.getDeletedCalleeAllocatedCoroutineMethodErrorAsyncFunctionPointer(),
+              IGM.getDeletedCalleeAllocatedCoroutineMethodErrorCoroFunctionPointer(),
               IGM.FunctionPtrTy);
         } else {
           ptr = llvm::ConstantExpr::getBitCast(IGM.getDeletedMethodErrorFn(),

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1680,7 +1680,7 @@ public:
               IGM.FunctionPtrTy);
         } else if (isCalleeAllocatedCoroutineRequirement) {
           witness = llvm::ConstantExpr::getBitCast(
-              IGM.getDeletedCalleeAllocatedCoroutineMethodErrorAsyncFunctionPointer(),
+              IGM.getDeletedCalleeAllocatedCoroutineMethodErrorCoroFunctionPointer(),
               IGM.CoroFunctionPointerPtrTy);
         } else {
           witness = llvm::ConstantExpr::getBitCast(

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1234,9 +1234,9 @@ llvm::Constant *IRGenModule::getDeletedAsyncMethodErrorAsyncFunctionPointer() {
 }
 
 llvm::Constant *IRGenModule::
-    getDeletedCalleeAllocatedCoroutineMethodErrorAsyncFunctionPointer() {
+    getDeletedCalleeAllocatedCoroutineMethodErrorCoroFunctionPointer() {
   return getAddrOfLLVMVariableOrGOTEquivalent(
-             LinkEntity::forKnownAsyncFunctionPointer(
+             LinkEntity::forKnownCoroFunctionPointer(
                  "swift_deletedCalleeAllocatedCoroutineMethodError"))
       .getValue();
 }

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1538,7 +1538,7 @@ public:
   llvm::AttributeList getAllocAttrs();
   llvm::Constant *getDeletedAsyncMethodErrorAsyncFunctionPointer();
   llvm::Constant *
-  getDeletedCalleeAllocatedCoroutineMethodErrorAsyncFunctionPointer();
+  getDeletedCalleeAllocatedCoroutineMethodErrorCoroFunctionPointer();
 
 private:
   llvm::Constant *EmptyTupleMetadata = nullptr;


### PR DESCRIPTION
**Explanation**: Fix link entity kind for `swift_deletedCalleeAllocatedCoroutineMethodError`.

When methods are eliminated from wtables/vtables, they need to be replaced with something.  In the case of async functions, that's `swift_deletedAsyncMethodError`--when an async method is deleted, a pointer to the async function pointer of `swift_deletedAsyncMethodError` is put into the wtable/vtable.  An analogous consideration applies to callee-allocated coroutines: when they're deleted from vtables/wtables, they need to be replaced with a coroutine function pointer to `swift_deletedCalleeAllocatedCoroutineMethodError`.

Previously, though, an attempt was made to replace them with an _async_ function pointer to that method.  No such entity exists.

Here, this is fixed so they are replaced with a _coroutine_ function pointer.
**Scope**: Affects the experimental CoroutineAccessors feature.
**Issue**: rdar://148760489
**Original PR**: https://github.com/swiftlang/swift/pull/80556
**Risk**: Low, only affects the coroutine accessors feature.
**Testing**: CI.
**Reviewer**: Arnold Schwaighofer ( @aschwaighofer )

