### PR TITLE
[6.2][Test] Correctly gate new VarArgs test on new runtime.

### DIFF
--- a/test/stdlib/VarArgs.swift
+++ b/test/stdlib/VarArgs.swift
@@ -174,7 +174,7 @@ test_varArgs6()
 
 func test_varArgs7() {
 #if canImport(Darwin) && arch(arm64)
-  let canTest = if #available(SwiftStdlib 6.2, *) { false } else { true }
+  let canTest = if #available(SwiftStdlib 6.2, *) { true } else { false }
 #else
   // va_list is more complicated on other targets so that behavior is not the
   // same, skip the test by doing a fake print of the expected output. Also


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/80607 to `release/6.2`.

The empty-arguments test fails when run against an older runtime, so don't test it there.

I tried to do this before, but got the condition backwards.

rdar://146839898