### PR TITLE
Sema: Fix another `-require-explicit-availability` regression

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3511,6 +3511,11 @@ void swift::checkExplicitAvailability(Decl *decl) {
       !isa<ExtensionDecl>(decl->getDeclContext())) return;
 
   if (auto extension = dyn_cast<ExtensionDecl>(decl)) {
+    // Skip extensions that extend non-public types.
+    auto extended = extension->getExtendedNominal();
+    if (!extended || !extended->getFormalAccessScope().isPublic())
+      return;
+
     // Skip extensions when none of their members need availability.
     auto members = extension->getMembers();
     auto hasMembers = std::any_of(members.begin(), members.end(),

--- a/test/attr/require_explicit_availability_macos.swift
+++ b/test/attr/require_explicit_availability_macos.swift
@@ -144,6 +144,8 @@ private class PrivateClass { }
 
 extension PrivateClass { }
 
+extension PrivateClass : P { }
+
 @available(macOS 10.1, *)
 public protocol PublicProtocol { }
 
@@ -161,6 +163,8 @@ public struct spiStruct {
 extension spiStruct {
   public func spiExtensionMethod() {}
 }
+
+extension spiStruct : P { }
 
 public var publicVar = S() // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 


### PR DESCRIPTION
Extensions that extend non-public types should never be required to have explicit availability, even if they declare conformances to public protocols.

Resolves rdar://148697770.
