### PR TITLE
Silence diagnostic when @lifetime(borrow) is used on inout parameters in swiftinterface files only

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -490,7 +490,8 @@ protected:
   }
 
   bool isCompatibleWithOwnership(ParsedLifetimeDependenceKind kind, Type type,
-                                 ValueOwnership ownership) const {
+                                 ValueOwnership ownership,
+                                 bool isInterfaceFile = false) const {
     if (kind == ParsedLifetimeDependenceKind::Inherit) {
       return true;
     }
@@ -503,6 +504,10 @@ protected:
       ? ownership : getLoweredOwnership(afd);
 
     if (kind == ParsedLifetimeDependenceKind::Borrow) {
+      if (isInterfaceFile) {
+        return loweredOwnership == ValueOwnership::Shared ||
+               loweredOwnership == ValueOwnership::InOut;
+      }
       return loweredOwnership == ValueOwnership::Shared;
     }
     assert(kind == ParsedLifetimeDependenceKind::Inout);
@@ -634,8 +639,8 @@ protected:
     case ParsedLifetimeDependenceKind::Inout: {
     // @lifetime(borrow x) is valid only for borrowing parameters.
     // @lifetime(inout x) is valid only for inout parameters.
-    if (!isCompatibleWithOwnership(parsedLifetimeKind, type,
-                                   loweredOwnership)) {
+    if (!isCompatibleWithOwnership(parsedLifetimeKind, type, loweredOwnership,
+                                   isInterfaceFile())) {
       diagnose(loc,
                diag::lifetime_dependence_cannot_use_parsed_borrow_consuming,
                getNameForParsedLifetimeDependenceKind(parsedLifetimeKind),

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1302,7 +1302,7 @@ extension ArraySlice {
 
   @available(SwiftStdlib 6.2, *)
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(/*inout*/&self)
+    @lifetime(&self)
     @_alwaysEmitIntoClient
     mutating get {
       _makeMutableAndUnique()


### PR DESCRIPTION
We need to support `@lifetime(borrow arg)` in old swiftinterface files to be compiled with new compilers. 