### PR TITLE
SILGen: Use [unsafe] access markers for move-only storage when exclusivity enforcement is disabled.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -245,8 +245,9 @@ static LValueTypeData getPhysicalStorageTypeData(TypeExpansionContext context,
 }
 
 static bool shouldUseUnsafeEnforcement(VarDecl *var) {
-  if (var->isDebuggerVar())
+  if (var->isDebuggerVar()) {
     return true;
+  }
 
   return false;
 }
@@ -277,6 +278,22 @@ SILGenFunction::getDynamicEnforcement(VarDecl *var) {
   } else if (hasExclusivityAttr(var, ExclusivityAttr::Checked)) {
     return SILAccessEnforcement::Dynamic;
   }
+
+  // Access markers are especially load-bearing for the move-only checker,
+  // so we also emit `begin_access` markers for cases where storage
+  // is move-only.
+  // TODO: It seems useful to do this for all unchecked declarations, since
+  // access scopes are useful semantic information.
+  if (var->getTypeInContext()->isNoncopyable()) {
+    return SILAccessEnforcement::Unsafe;
+  }
+  if (auto param = dyn_cast<ParamDecl>(var)) {
+    if (param->getSpecifier() == ParamSpecifier::Borrowing
+        || param->getSpecifier() == ParamSpecifier::Consuming) {
+      return SILAccessEnforcement::Unsafe;
+    }
+  }
+  
   return std::nullopt;
 }
 

--- a/test/SILOptimizer/moveonly_unchecked_exclusivity.swift
+++ b/test/SILOptimizer/moveonly_unchecked_exclusivity.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -enforce-exclusivity=unchecked -emit-sil %s | %FileCheck %s
+
+struct Foo: ~Copyable {
+    var x: Any
+}
+
+final class Bar {
+    init() { fatalError() }
+
+    // Ensure that noncopyable bindings still get [unsafe] exclusivity markers
+    // and get checked properly by the move-only checker.
+
+    // Bar.foo.setter:
+    // CHECK-LABEL: sil {{.*}} @$s{{.*}}3BarC3foo{{.*}}vs
+    // CHECK:         [[FIELD:%.*]] = ref_element_addr {{.*}}, #Bar.foo
+    // CHECK:         [[FIELD_ACCESS:%.*]] = begin_access [modify] [unsafe] [[FIELD]]
+    // CHECK-NEXT:    destroy_addr [[FIELD_ACCESS]]
+    // CHECK-NEXT:    copy_addr [take] {{.*}} to [init] [[FIELD_ACCESS]]
+    // CHECK-NEXT:    end_access [[FIELD_ACCESS]]
+    // CHECK-NOT:     [[FIELD]]
+    // CHECK-NOT:     [[FIELD_ACCESS]]
+    // CHECK: } // end sil {{.*}} '$s{{.*}}3BarC3foo{{.*}}vs'
+
+    var foo: Foo
+}


### PR DESCRIPTION
The move-only checker relies on access markers to understand access scopes, so eliding them entirely leads to miscompiles. We can emit `begin_access [unsafe]` to semantically delimit exclusivity scopes while still doing no runtime checking. Fixes rdar://147546262.