### PR TITLE
[abi-digester] Fixed order of parameters

### DIFF
--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -1988,7 +1988,7 @@ static int diagnoseModuleChange(StringRef LeftPath, StringRef RightPath,
   return diagnoseModuleChange(
       Ctx, LeftCollector.getSDKRoot(), RightCollector.getSDKRoot(), OutputPath,
       std::move(ProtocolReqAllowlist), DisableFailOnError,
-      ExplicitErrOnABIBreakage, CompilerStyleDiags, SerializedDiagPath,
+      CompilerStyleDiags, ExplicitErrOnABIBreakage, SerializedDiagPath,
       BreakageAllowlistPath, DebugMapping);
 }
 


### PR DESCRIPTION
Fixed handling for flags `-compiler-style-diags` and `-error-on-abi-breakage`