### PR TITLE
[6.2] [Sema] Ignore types with type variables in `filterEscapableLifetimeDependencies`

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -58,7 +58,12 @@ filterEscapableLifetimeDependencies(GenericSignature sig,
   for (auto &depInfo : inputs) {
     auto targetIndex = depInfo.getTargetIndex();
     Type substTy = getSubstTargetType(targetIndex);
-    
+
+    // If the type still contains type variables we don't know whether we
+    // can drop the dependency.
+    if (substTy->hasTypeVariable())
+      continue;
+
     // Drop the dependency if the target type is Escapable.
     if (sig || !substTy->hasTypeParameter()) {
       if (substTy->isEscapable(sig)) {

--- a/test/IDE/issue-80591.swift
+++ b/test/IDE/issue-80591.swift
@@ -1,0 +1,18 @@
+// RUN: %batch-code-completion -enable-experimental-feature LifetimeDependence
+
+// REQUIRES: swift_feature_LifetimeDependence
+
+infix operator ^^^
+
+extension Optional where Wrapped: ~Escapable & ~Copyable {
+  @lifetime(copy self) mutating func foo() -> Self { fatalError() }
+}
+
+func ^^^ <T: ~Escapable & ~Copyable> (_ x: Int, _ y: borrowing T?) {}
+
+// https://github.com/swiftlang/swift/issues/80591 - Make sure we don't crash
+// here.
+func foo() {
+  _ = 1 ^^^ .#^COMPLETE^#
+  // COMPLETE: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: foo({#(self): &Optional<~Copyable & ~Escapable>#})[#() -> Optional<~Copyable & ~Escapable>#]; name=foo(:)
+}

--- a/validation-test/IDE/stress_tester_issues_fixed/issue-80591.swift
+++ b/validation-test/IDE/stress_tester_issues_fixed/issue-80591.swift
@@ -1,0 +1,9 @@
+// RUN: %batch-code-completion
+
+// https://github.com/apple/swift/issues/80591
+
+// Just make sure we don't crash.
+var foo: Bool {
+  baz == .#^COMPLETE^#
+  // COMPLETE: Begin completions
+}


### PR DESCRIPTION
*6.2 cherry-pick of https://github.com/swiftlang/swift/pull/80634*

- Explanation: Fixes an assertion failure that could occur when performing a completion on Optional 
- Scope: Fixes lifetime filtering logic to ignore types with type variables
- Issue: rdar://148749815
- Risk: Low, the fix is straightforward
- Testing: Added tests to test suite
- Reviewer: Joe Groff, Pavel Yaskevich