### PR TITLE
[6.2] Add support for inout lifetime dependencies

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1086,7 +1086,7 @@ BridgedInlineAttr BridgedInlineAttr_createParsed(BridgedASTContext cContext,
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedParsedLifetimeDependenceKind {
   BridgedParsedLifetimeDependenceKindDefault,
-  BridgedParsedLifetimeDependenceKindScope,
+  BridgedParsedLifetimeDependenceKindBorrow,
   BridgedParsedLifetimeDependenceKindInherit,
   BridgedParsedLifetimeDependenceKindInout
 };

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1088,6 +1088,7 @@ enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedParsedLifetimeDependenceKind {
   BridgedParsedLifetimeDependenceKindDefault,
   BridgedParsedLifetimeDependenceKindScope,
   BridgedParsedLifetimeDependenceKindInherit,
+  BridgedParsedLifetimeDependenceKindInout
 };
 
 class BridgedLifetimeDescriptor {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8171,6 +8171,9 @@ ERROR(lifetime_dependence_invalid_inherit_escapable_type, none,
 ERROR(lifetime_dependence_cannot_use_parsed_borrow_consuming, none,
       "invalid use of borrow dependence with consuming ownership",
       ())
+ERROR(lifetime_dependence_cannot_use_default_escapable_consuming, none,
+      "invalid lifetime dependence on an Escapable value with %0 ownership",
+      (StringRef))
 ERROR(lifetime_dependence_cannot_use_parsed_borrow_inout, none,
       "invalid use of borrow dependence on the same inout parameter",
       ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8169,8 +8169,8 @@ ERROR(lifetime_dependence_invalid_inherit_escapable_type, none,
       "'@lifetime(borrow %0)' instead",
       (StringRef))
 ERROR(lifetime_dependence_cannot_use_parsed_borrow_consuming, none,
-      "invalid use of borrow dependence with consuming ownership",
-      ())
+      "invalid use of %0 dependence with %1 ownership",
+      (StringRef, StringRef))
 ERROR(lifetime_dependence_cannot_use_default_escapable_consuming, none,
       "invalid lifetime dependence on an Escapable value with %0 ownership",
       (StringRef))

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -183,6 +183,7 @@ public:
          ArrayRef<LifetimeDescriptor> sources,
          std::optional<LifetimeDescriptor> targetDescriptor = std::nullopt);
 
+  std::string getString() const;
   SourceLoc getLoc() const { return startLoc; }
   SourceLoc getStartLoc() const { return startLoc; }
   SourceLoc getEndLoc() const { return endLoc; }
@@ -193,38 +194,6 @@ public:
 
   std::optional<LifetimeDescriptor> getTargetDescriptor() const {
     return targetDescriptor;
-  }
-
-  std::string getString() const {
-    std::string result = "@lifetime(";
-    if (targetDescriptor.has_value()) {
-      result += targetDescriptor->getString();
-      result += ": ";
-    }
-
-    bool firstElem = true;
-    for (auto source : getSources()) {
-      if (!firstElem) {
-        result += ", ";
-      }
-      switch (source.getParsedLifetimeDependenceKind()) {
-      case ParsedLifetimeDependenceKind::Borrow:
-        result += "borrow ";
-        break;
-      case ParsedLifetimeDependenceKind::Inherit:
-        result += "copy ";
-        break;
-      case ParsedLifetimeDependenceKind::InOut:
-        result += "inout ";
-        break;
-      default:
-        break;
-      }
-      result += source.getString();
-      firstElem = false;
-    }
-    result += ")";
-    return result;
   }
 };
 
@@ -369,6 +338,9 @@ filterEscapableLifetimeDependencies(GenericSignature sig,
         ArrayRef<LifetimeDependenceInfo> inputs,
         SmallVectorImpl<LifetimeDependenceInfo> &outputs,
         llvm::function_ref<Type (unsigned targetIndex)> getSubstTargetType);
+
+StringRef
+getNameForParsedLifetimeDependenceKind(ParsedLifetimeDependenceKind kind);
 
 } // namespace swift
 

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -39,7 +39,8 @@ class SILResultInfo;
 enum class ParsedLifetimeDependenceKind : uint8_t {
   Default = 0,
   Scope,
-  Inherit // Only used with deserialized decls
+  Inherit, // Only used with deserialized decls
+  Inout
 };
 
 enum class LifetimeDependenceKind : uint8_t { Inherit = 0, Scope };

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -38,7 +38,7 @@ class SILResultInfo;
 
 enum class ParsedLifetimeDependenceKind : uint8_t {
   Default = 0,
-  Scope,
+  Borrow,
   Inherit, // Only used with deserialized decls
   Inout
 };
@@ -208,11 +208,14 @@ public:
         result += ", ";
       }
       switch (source.getParsedLifetimeDependenceKind()) {
-      case ParsedLifetimeDependenceKind::Scope:
+      case ParsedLifetimeDependenceKind::Borrow:
         result += "borrow ";
         break;
       case ParsedLifetimeDependenceKind::Inherit:
         result += "copy ";
+        break;
+      case ParsedLifetimeDependenceKind::InOut:
+        result += "inout ";
         break;
       default:
         break;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -416,6 +416,9 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 /// Enable returning non-escapable types from functions.
 EXPERIMENTAL_FEATURE(LifetimeDependence, true)
 
+/// Enable inout lifetime dependence - @lifetime(&arg)
+EXPERIMENTAL_FEATURE(InoutLifetimeDependence, true)
+
 /// Enable the `@_staticExclusiveOnly` attribute.
 EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)
 

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -470,8 +470,8 @@ unbridged(BridgedParsedLifetimeDependenceKind kind) {
   switch (kind) {
   case BridgedParsedLifetimeDependenceKindDefault:
     return swift::ParsedLifetimeDependenceKind::Default;
-  case BridgedParsedLifetimeDependenceKindScope:
-    return swift::ParsedLifetimeDependenceKind::Scope;
+  case BridgedParsedLifetimeDependenceKindBorrow:
+    return swift::ParsedLifetimeDependenceKind::Borrow;
   case BridgedParsedLifetimeDependenceKindInherit:
     return swift::ParsedLifetimeDependenceKind::Inherit;
   case BridgedParsedLifetimeDependenceKindInout:

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -474,6 +474,8 @@ unbridged(BridgedParsedLifetimeDependenceKind kind) {
     return swift::ParsedLifetimeDependenceKind::Scope;
   case BridgedParsedLifetimeDependenceKindInherit:
     return swift::ParsedLifetimeDependenceKind::Inherit;
+  case BridgedParsedLifetimeDependenceKindInout:
+    return swift::ParsedLifetimeDependenceKind::Inout;
   }
   llvm_unreachable("unhandled enum value");
 }

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -272,15 +272,26 @@ static bool usesFeatureLifetimeDependence(Decl *decl) {
 }
 
 static bool usesFeatureInoutLifetimeDependence(Decl *decl) {
-  for (auto attr : decl->getAttrs().getAttributes<LifetimeAttr>()) {
-    for (auto source : attr->getLifetimeEntry()->getSources()) {
-      if (source.getParsedLifetimeDependenceKind() ==
-          ParsedLifetimeDependenceKind::Inout) {
-        return true;
+  auto hasInoutLifetimeDependence = [](Decl *decl) {
+    for (auto attr : decl->getAttrs().getAttributes<LifetimeAttr>()) {
+      for (auto source : attr->getLifetimeEntry()->getSources()) {
+        if (source.getParsedLifetimeDependenceKind() ==
+            ParsedLifetimeDependenceKind::Inout) {
+          return true;
+        }
       }
     }
+    return false;
+  };
+
+  switch (decl->getKind()) {
+  case DeclKind::Var: {
+    auto *var = cast<VarDecl>(decl);
+    return llvm::any_of(var->getAllAccessors(), hasInoutLifetimeDependence);
   }
-  return false;
+  default:
+    return hasInoutLifetimeDependence(decl);
+  }
 }
 
 UNINTERESTING_FEATURE(DynamicActorIsolation)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -271,6 +271,18 @@ static bool usesFeatureLifetimeDependence(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureInoutLifetimeDependence(Decl *decl) {
+  for (auto attr : decl->getAttrs().getAttributes<LifetimeAttr>()) {
+    for (auto source : attr->getLifetimeEntry()->getSources()) {
+      if (source.getParsedLifetimeDependenceKind() ==
+          ParsedLifetimeDependenceKind::Inout) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 UNINTERESTING_FEATURE(DynamicActorIsolation)
 UNINTERESTING_FEATURE(NonfrozenEnumExhaustivity)
 UNINTERESTING_FEATURE(ClosureIsolation)

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -37,6 +37,35 @@ LifetimeEntry::create(const ASTContext &ctx, SourceLoc startLoc,
   return new (mem) LifetimeEntry(startLoc, endLoc, sources, targetDescriptor);
 }
 
+std::string LifetimeEntry::getString() const {
+  std::string result = "@lifetime(";
+  if (targetDescriptor.has_value()) {
+    result += targetDescriptor->getString();
+    result += ": ";
+  }
+
+  bool firstElem = true;
+  for (auto source : getSources()) {
+    if (!firstElem) {
+      result += ", ";
+    }
+    auto lifetimeKind = source.getParsedLifetimeDependenceKind();
+    auto kindString = getNameForParsedLifetimeDependenceKind(lifetimeKind);
+    bool printSpace = (lifetimeKind == ParsedLifetimeDependenceKind::Borrow ||
+                       lifetimeKind == ParsedLifetimeDependenceKind::Inherit);
+    if (!kindString.empty()) {
+      result += kindString;
+    }
+    if (printSpace) {
+      result += " ";
+    }
+    result += source.getString();
+    firstElem = false;
+  }
+  result += ")";
+  return result;
+}
+
 std::optional<LifetimeDependenceInfo>
 getLifetimeDependenceFor(ArrayRef<LifetimeDependenceInfo> lifetimeDependencies,
                          unsigned index) {
@@ -87,7 +116,7 @@ getNameForParsedLifetimeDependenceKind(ParsedLifetimeDependenceKind kind) {
   case ParsedLifetimeDependenceKind::Inherit:
     return "copy";
   case ParsedLifetimeDependenceKind::Inout:
-    return "inout";
+    return "&";
   default:
     return "";
   }
@@ -577,7 +606,7 @@ protected:
   std::optional<LifetimeDependenceKind>
   getDependenceKindFromDescriptor(LifetimeDescriptor descriptor,
                                   ParamDecl *decl) {
-    auto loc = decl->getLoc();
+    auto loc = descriptor.getLoc();
     auto type = decl->getTypeInContext();
     auto parsedLifetimeKind = descriptor.getParsedLifetimeDependenceKind();
     auto ownership = decl->getValueOwnership();
@@ -607,9 +636,12 @@ protected:
 
     // @lifetime(borrow x) is valid only for borrowing parameters.
     // @lifetime(inout x) is valid only for inout parameters.
-    if (!isCompatibleWithOwnership(parsedLifetimeKind, type, ownership)) {
+    if (!isCompatibleWithOwnership(parsedLifetimeKind, type,
+                                   loweredOwnership)) {
       diagnose(loc,
-               diag::lifetime_dependence_cannot_use_parsed_borrow_consuming);
+               diag::lifetime_dependence_cannot_use_parsed_borrow_consuming,
+               getNameForParsedLifetimeDependenceKind(parsedLifetimeKind),
+               getOwnershipSpelling(loweredOwnership));
       return std::nullopt;
     }
     // @lifetime(copy x) is only invalid for Escapable types.

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -82,7 +82,7 @@ filterEscapableLifetimeDependencies(GenericSignature sig,
 StringRef
 getNameForParsedLifetimeDependenceKind(ParsedLifetimeDependenceKind kind) {
   switch (kind) {
-  case ParsedLifetimeDependenceKind::Scope:
+  case ParsedLifetimeDependenceKind::Borrow:
     return "borrow";
   case ParsedLifetimeDependenceKind::Inherit:
     return "copy";
@@ -478,7 +478,7 @@ protected:
     auto loweredOwnership = ownership != ValueOwnership::Default
       ? ownership : getLoweredOwnership(afd);
 
-    if (kind == ParsedLifetimeDependenceKind::Scope) {
+    if (kind == ParsedLifetimeDependenceKind::Borrow) {
       return loweredOwnership == ValueOwnership::Shared;
     }
     assert(kind == ParsedLifetimeDependenceKind::Inout);
@@ -1189,7 +1189,7 @@ static std::optional<LifetimeDependenceInfo> checkSILTypeModifiers(
       auto loc = descriptor.getLoc();
       auto kind = descriptor.getParsedLifetimeDependenceKind();
 
-      if (kind == ParsedLifetimeDependenceKind::Scope &&
+      if (kind == ParsedLifetimeDependenceKind::Borrow &&
           isConsumedParameterInCallee(paramConvention)) {
         diags.diagnose(loc, diag::lifetime_dependence_cannot_use_kind, "_scope",
                        getStringForParameterConvention(paramConvention));
@@ -1204,7 +1204,7 @@ static std::optional<LifetimeDependenceInfo> checkSILTypeModifiers(
       if (kind == ParsedLifetimeDependenceKind::Inherit) {
         inheritLifetimeParamIndices.set(paramIndexToSet);
       } else {
-        assert(kind == ParsedLifetimeDependenceKind::Scope);
+        assert(kind == ParsedLifetimeDependenceKind::Borrow);
         scopeLifetimeParamIndices.set(paramIndexToSet);
       }
       return false;

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -79,6 +79,20 @@ filterEscapableLifetimeDependencies(GenericSignature sig,
   return didRemoveLifetimeDependencies;
 }
 
+StringRef
+getNameForParsedLifetimeDependenceKind(ParsedLifetimeDependenceKind kind) {
+  switch (kind) {
+  case ParsedLifetimeDependenceKind::Scope:
+    return "borrow";
+  case ParsedLifetimeDependenceKind::Inherit:
+    return "copy";
+  case ParsedLifetimeDependenceKind::Inout:
+    return "inout";
+  default:
+    return "";
+  }
+}
+
 std::string LifetimeDependenceInfo::getString() const {
   std::string lifetimeDependenceString = "@lifetime(";
   auto addressable = getAddressableIndices();
@@ -451,6 +465,26 @@ protected:
     }
   }
 
+  bool isCompatibleWithOwnership(ParsedLifetimeDependenceKind kind, Type type,
+                                 ValueOwnership ownership) const {
+    if (kind == ParsedLifetimeDependenceKind::Inherit) {
+      return true;
+    }
+    // Lifetime dependence always propagates through temporary BitwiseCopyable
+    // values, even if the dependence is scoped.
+    if (isBitwiseCopyable(type, ctx)) {
+      return true;
+    }
+    auto loweredOwnership = ownership != ValueOwnership::Default
+      ? ownership : getLoweredOwnership(afd);
+
+    if (kind == ParsedLifetimeDependenceKind::Scope) {
+      return loweredOwnership == ValueOwnership::Shared;
+    }
+    assert(kind == ParsedLifetimeDependenceKind::Inout);
+    return loweredOwnership == ValueOwnership::InOut;
+  }
+
   bool isCompatibleWithOwnership(LifetimeDependenceKind kind, Type type,
                                  ValueOwnership ownership) const {
     if (kind == LifetimeDependenceKind::Inherit) {
@@ -461,16 +495,13 @@ protected:
     if (isBitwiseCopyable(type, ctx)) {
       return true;
     }
-    assert(kind == LifetimeDependenceKind::Scope);
     auto loweredOwnership = ownership != ValueOwnership::Default
-      ? ownership : getLoweredOwnership(afd);
+                                ? ownership
+                                : getLoweredOwnership(afd);
 
-    if (loweredOwnership == ValueOwnership::InOut ||
-        loweredOwnership == ValueOwnership::Shared) {
-      return true;
-    }
-    assert(loweredOwnership == ValueOwnership::Owned);
-    return false;
+    assert(kind == LifetimeDependenceKind::Scope);
+    return loweredOwnership == ValueOwnership::Shared ||
+           loweredOwnership == ValueOwnership::InOut;
   }
 
   struct TargetDeps {
@@ -546,44 +577,51 @@ protected:
   std::optional<LifetimeDependenceKind>
   getDependenceKindFromDescriptor(LifetimeDescriptor descriptor,
                                   ParamDecl *decl) {
-    auto loc = descriptor.getLoc();
-
-    auto ownership = decl->getValueOwnership();
+    auto loc = decl->getLoc();
     auto type = decl->getTypeInContext();
+    auto parsedLifetimeKind = descriptor.getParsedLifetimeDependenceKind();
+    auto ownership = decl->getValueOwnership();
+    auto loweredOwnership = ownership != ValueOwnership::Default
+                                ? ownership
+                                : getLoweredOwnership(afd);
 
-    LifetimeDependenceKind kind;
-    switch (descriptor.getParsedLifetimeDependenceKind()) {
-    case ParsedLifetimeDependenceKind::Default:
+    if (parsedLifetimeKind == ParsedLifetimeDependenceKind::Default) {
       if (type->isEscapable()) {
-        kind = LifetimeDependenceKind::Scope;
+        if (loweredOwnership == ValueOwnership::Shared ||
+            loweredOwnership == ValueOwnership::InOut) {
+          return LifetimeDependenceKind::Scope;
+        } else {
+          diagnose(
+              loc,
+              diag::lifetime_dependence_cannot_use_default_escapable_consuming,
+              getOwnershipSpelling(loweredOwnership));
+          return std::nullopt;
+        }
       } else if (useLazyInference()) {
-        kind = LifetimeDependenceKind::Inherit;
-      } else {
-        diagnose(loc, diag::lifetime_dependence_cannot_infer_kind,
-                 diagnosticQualifier(), descriptor.getString());
-        return std::nullopt;
+        return LifetimeDependenceKind::Inherit;
       }
-      break;
-    case ParsedLifetimeDependenceKind::Scope:
-      kind = LifetimeDependenceKind::Scope;
-      break;
-    case ParsedLifetimeDependenceKind::Inherit:
-      kind = LifetimeDependenceKind::Inherit;
-      break;
+      diagnose(loc, diag::lifetime_dependence_cannot_infer_kind,
+               diagnosticQualifier(), descriptor.getString());
+      return std::nullopt;
     }
-    // @lifetime(borrow x) is invalid for consuming parameters.
-    if (!isCompatibleWithOwnership(kind, type, ownership)) {
+
+    // @lifetime(borrow x) is valid only for borrowing parameters.
+    // @lifetime(inout x) is valid only for inout parameters.
+    if (!isCompatibleWithOwnership(parsedLifetimeKind, type, ownership)) {
       diagnose(loc,
                diag::lifetime_dependence_cannot_use_parsed_borrow_consuming);
       return std::nullopt;
     }
     // @lifetime(copy x) is only invalid for Escapable types.
-    if (kind == LifetimeDependenceKind::Inherit && type->isEscapable()) {
+    if (parsedLifetimeKind == ParsedLifetimeDependenceKind::Inherit &&
+        type->isEscapable()) {
       diagnose(loc, diag::lifetime_dependence_invalid_inherit_escapable_type,
                descriptor.getString());
       return std::nullopt;
     }
-    return kind;
+    return parsedLifetimeKind == ParsedLifetimeDependenceKind::Inherit
+               ? LifetimeDependenceKind::Inherit
+               : LifetimeDependenceKind::Scope;
   }
 
   // Finds the ParamDecl* and its index from a LifetimeDescriptor

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -614,19 +614,20 @@ protected:
                                 ? ownership
                                 : getLoweredOwnership(afd);
 
-    if (parsedLifetimeKind == ParsedLifetimeDependenceKind::Default) {
+    switch (parsedLifetimeKind) {
+    case ParsedLifetimeDependenceKind::Default: {
       if (type->isEscapable()) {
         if (loweredOwnership == ValueOwnership::Shared ||
             loweredOwnership == ValueOwnership::InOut) {
           return LifetimeDependenceKind::Scope;
-        } else {
-          diagnose(
-              loc,
-              diag::lifetime_dependence_cannot_use_default_escapable_consuming,
-              getOwnershipSpelling(loweredOwnership));
-          return std::nullopt;
         }
-      } else if (useLazyInference()) {
+        diagnose(
+            loc,
+            diag::lifetime_dependence_cannot_use_default_escapable_consuming,
+            getOwnershipSpelling(loweredOwnership));
+        return std::nullopt;
+      }
+      if (useLazyInference()) {
         return LifetimeDependenceKind::Inherit;
       }
       diagnose(loc, diag::lifetime_dependence_cannot_infer_kind,
@@ -634,6 +635,8 @@ protected:
       return std::nullopt;
     }
 
+    case ParsedLifetimeDependenceKind::Borrow: LLVM_FALLTHROUGH;
+    case ParsedLifetimeDependenceKind::Inout: {
     // @lifetime(borrow x) is valid only for borrowing parameters.
     // @lifetime(inout x) is valid only for inout parameters.
     if (!isCompatibleWithOwnership(parsedLifetimeKind, type,
@@ -644,16 +647,17 @@ protected:
                getOwnershipSpelling(loweredOwnership));
       return std::nullopt;
     }
+    return LifetimeDependenceKind::Scope;
+  }
+  case ParsedLifetimeDependenceKind::Inherit:
     // @lifetime(copy x) is only invalid for Escapable types.
-    if (parsedLifetimeKind == ParsedLifetimeDependenceKind::Inherit &&
-        type->isEscapable()) {
+    if (type->isEscapable()) {
       diagnose(loc, diag::lifetime_dependence_invalid_inherit_escapable_type,
                descriptor.getString());
       return std::nullopt;
     }
-    return parsedLifetimeKind == ParsedLifetimeDependenceKind::Inherit
-               ? LifetimeDependenceKind::Inherit
-               : LifetimeDependenceKind::Scope;
+    return LifetimeDependenceKind::Inherit;
+  }
   }
 
   // Finds the ParamDecl* and its index from a LifetimeDescriptor

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -143,16 +143,6 @@ void LifetimeDependenceInfo::Profile(llvm::FoldingSetNodeID &ID) const {
   }
 }
 
-// Infer the kind of dependence that would be implied by assigning into a stored
-// property of 'sourceType'.
-static LifetimeDependenceKind
-inferLifetimeDependenceKindFromType(Type sourceType) {
-  if (sourceType->isEscapable()) {
-    return LifetimeDependenceKind::Scope;
-  }
-  return LifetimeDependenceKind::Inherit;
-}
-
 // Warning: this is incorrect for Setter 'newValue' parameters. It should only
 // be called for a Setter's 'self'.
 static ValueOwnership getLoweredOwnership(AbstractFunctionDecl *afd) {
@@ -834,15 +824,35 @@ protected:
         return;
       }
     }
-    auto kind = inferLifetimeDependenceKindFromType(selfTypeInContext);
-    auto selfOwnership = afd->getImplicitSelfDecl()->getValueOwnership();
-    if (!isCompatibleWithOwnership(kind, selfTypeInContext, selfOwnership)) {
+    auto kind = inferLifetimeDependenceKind(
+        selfTypeInContext, afd->getImplicitSelfDecl()->getValueOwnership());
+    if (!kind) {
       diagnose(returnLoc,
                diag::lifetime_dependence_cannot_infer_scope_ownership,
                "self", diagnosticQualifier());
       return;
     }
-    pushDeps(createDeps(resultIndex).add(selfIndex, kind));
+    pushDeps(createDeps(resultIndex).add(selfIndex, *kind));
+  }
+
+  std::optional<LifetimeDependenceKind>
+  inferLifetimeDependenceKind(Type sourceType, ValueOwnership ownership) {
+    if (!sourceType->isEscapable()) {
+      return LifetimeDependenceKind::Inherit;
+    }
+    // Lifetime dependence always propagates through temporary BitwiseCopyable
+    // values, even if the dependence is scoped.
+    if (isBitwiseCopyable(sourceType, ctx)) {
+      return LifetimeDependenceKind::Scope;
+    }
+    auto loweredOwnership = ownership != ValueOwnership::Default
+                                ? ownership
+                                : getLoweredOwnership(afd);
+    if (loweredOwnership != ValueOwnership::Shared &&
+        loweredOwnership != ValueOwnership::InOut) {
+      return std::nullopt;
+    }
+    return LifetimeDependenceKind::Scope;
   }
 
   // Infer implicit initialization. The dependence kind can be inferred, similar
@@ -866,16 +876,15 @@ protected:
       if (paramTypeInContext->hasError()) {
         continue;
       }
-      auto kind = inferLifetimeDependenceKindFromType(paramTypeInContext);
-      auto paramOwnership = param->getValueOwnership();
-      if (!isCompatibleWithOwnership(kind, paramTypeInContext, paramOwnership))
-      {
+      auto kind = inferLifetimeDependenceKind(paramTypeInContext,
+                                              param->getValueOwnership());
+      if (!kind) {
         diagnose(returnLoc,
                  diag::lifetime_dependence_cannot_infer_scope_ownership,
                  param->getParameterName().str(), diagnosticQualifier());
         continue;
       }
-      targetDeps = std::move(targetDeps).add(paramIndex, kind);
+      targetDeps = std::move(targetDeps).add(paramIndex, *kind);
     }
     pushDeps(std::move(targetDeps));
   }
@@ -959,9 +968,8 @@ protected:
       }
 
       candidateLifetimeKind =
-        inferLifetimeDependenceKindFromType(paramTypeInContext);
-      if (!isCompatibleWithOwnership(
-            *candidateLifetimeKind, paramTypeInContext, paramOwnership)) {
+          inferLifetimeDependenceKind(paramTypeInContext, paramOwnership);
+      if (!candidateLifetimeKind) {
         continue;
       }
       if (candidateParamIndex) {
@@ -1037,11 +1045,12 @@ protected:
       if (paramTypeInContext->hasError()) {
         return;
       }
-      auto kind = inferLifetimeDependenceKindFromType(paramTypeInContext);
+      auto kind = inferLifetimeDependenceKind(paramTypeInContext,
+                                              param->getValueOwnership());
 
       pushDeps(createDeps(selfIndex)
-               .add(selfIndex, LifetimeDependenceKind::Inherit)
-               .add(newValIdx, kind));
+                   .add(selfIndex, LifetimeDependenceKind::Inherit)
+                   .add(newValIdx, *kind));
       break;
     }
     case AccessorKind::MutableAddress:

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -1106,6 +1106,9 @@ extension ASTGenVisitor {
     } else if let borrowExpr = node.as(BorrowExprSyntax.self) {
       lifetimeDependenceKind = .scope
       descriptorExpr = borrowExpr.expression
+    } else if let inoutExpr = node.as(InOutExprSyntax.self) {
+      lifetimeDependenceKind = .inout
+      descriptorExpr = inoutExpr.expression
     } else {
       lifetimeDependenceKind = .default
       descriptorExpr = node

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -1104,7 +1104,7 @@ extension ASTGenVisitor {
       lifetimeDependenceKind = .inherit
       descriptorExpr = copyExpr.expression
     } else if let borrowExpr = node.as(BorrowExprSyntax.self) {
-      lifetimeDependenceKind = .scope
+      lifetimeDependenceKind = .borrow
       descriptorExpr = borrowExpr.expression
     } else if let inoutExpr = node.as(InOutExprSyntax.self) {
       lifetimeDependenceKind = .inout

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5019,7 +5019,7 @@ ParserResult<LifetimeEntry> Parser::parseLifetimeEntry(SourceLoc loc) {
     if (Tok.isContextualKeyword("borrow") &&
         peekToken().isAny(tok::identifier, tok::integer_literal,
                           tok::kw_self)) {
-      return ParsedLifetimeDependenceKind::Scope;
+      return ParsedLifetimeDependenceKind::Borrow;
     }
     if (Tok.is(tok::amp_prefix) &&
         peekToken().isAny(tok::identifier, tok::integer_literal,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5021,6 +5021,11 @@ ParserResult<LifetimeEntry> Parser::parseLifetimeEntry(SourceLoc loc) {
                           tok::kw_self)) {
       return ParsedLifetimeDependenceKind::Scope;
     }
+    if (Tok.is(tok::amp_prefix) &&
+        peekToken().isAny(tok::identifier, tok::integer_literal,
+                          tok::kw_self)) {
+      return ParsedLifetimeDependenceKind::Inout;
+    }
     return std::nullopt;
   };
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -631,6 +631,7 @@ function(_compile_swift_files
 
   list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")
   list(APPEND swift_flags "-enable-experimental-feature" "LifetimeDependence")
+  list(APPEND swift_flags "-enable-experimental-feature" "InoutLifetimeDependence")
 
   list(APPEND swift_flags "-enable-upcoming-feature" "MemberImportVisibility")
 

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1732,7 +1732,7 @@ extension Array {
 
   @available(SwiftStdlib 6.2, *)
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(/*inout*/borrow self)
+    @lifetime(&self)
     @_alwaysEmitIntoClient
     mutating get {
       _makeMutableAndUnique()

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1302,7 +1302,7 @@ extension ArraySlice {
 
   @available(SwiftStdlib 6.2, *)
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(/*inout*/borrow self)
+    @lifetime(/*inout*/&self)
     @_alwaysEmitIntoClient
     mutating get {
       _makeMutableAndUnique()

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1244,7 +1244,7 @@ extension ContiguousArray {
 
   @available(SwiftStdlib 6.2, *)
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(/*inout*/borrow self)
+    @lifetime(&self)
     @_alwaysEmitIntoClient
     mutating get {
       _makeMutableAndUnique()

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -325,7 +325,7 @@ internal func _overrideLifetime<
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
-@lifetime(borrow source)
+@lifetime(&source)
 internal func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -190,7 +190,7 @@ extension MutableRawSpan {
 
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   public mutating func _unsafeMutableView<T: BitwiseCopyable>(
     as type: T.Type
   ) -> MutableSpan<T> {
@@ -448,7 +448,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(_ bounds: Range<Int>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
@@ -475,7 +475,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
     let newSpan = unsafe Self(_unchecked: newStart, byteCount: bounds.count)
@@ -496,7 +496,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(
     _ bounds: some RangeExpression<Int>
   ) -> Self {
@@ -520,7 +520,7 @@ extension MutableRawSpan {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(unchecked bounds: ClosedRange<Int>) -> Self {
     let range = unsafe Range(
       _uncheckedBounds: (bounds.lowerBound, bounds.upperBound+1)
@@ -538,7 +538,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(_: UnboundedRange) -> Self {
     let newSpan = unsafe Self(_unchecked: _start(), byteCount: _count)
     return unsafe _overrideLifetime(newSpan, mutating: &self)
@@ -565,7 +565,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, byteCount)
@@ -588,7 +588,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, byteCount)
@@ -613,7 +613,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
     let newCount = min(maxLength, byteCount)
@@ -637,7 +637,7 @@ extension MutableRawSpan {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -666,7 +666,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(_ bounds: Range<Index>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
@@ -693,7 +693,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(unchecked bounds: Range<Index>) -> Self {
     let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
     let newStart = unsafe _pointer?.advanced(by: delta)
@@ -715,7 +715,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(
     _ bounds: some RangeExpression<Index>
   ) -> Self {
@@ -739,7 +739,7 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @unsafe
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(
     unchecked bounds: ClosedRange<Index>
   ) -> Self {
@@ -759,7 +759,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(_: UnboundedRange) -> Self {
     let newSpan = unsafe Self(_unchecked: _start(), count: _count)
     return unsafe _overrideLifetime(newSpan, mutating: &self)
@@ -786,7 +786,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, count)
@@ -809,7 +809,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, count)
@@ -834,7 +834,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
     let newCount = min(maxLength, count)
@@ -859,7 +859,7 @@ extension MutableSpan where Element: ~Copyable {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, count)

--- a/test/SILOptimizer/Inputs/SpanExtras.swift
+++ b/test/SILOptimizer/Inputs/SpanExtras.swift
@@ -40,7 +40,7 @@ internal func _overrideLifetime<
 @_unsafeNonescapableResult
 @_alwaysEmitIntoClient
 @_transparent
-@lifetime(borrow source)
+@lifetime(&source)
 internal func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(
@@ -310,7 +310,7 @@ extension MutableSpan where Element: ~Copyable {
       precondition(indices.contains(position), "index out of bounds")
       yield self[unchecked: position]
     }
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify {
       precondition(indices.contains(position), "index out of bounds")
       yield &self[unchecked: position]

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -39,7 +39,7 @@ public struct NEInt: ~Escapable {
   var iprop: NEInt {
     @lifetime(copy self)
     _read { yield self }
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify { yield &self }
   }
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
@@ -41,7 +41,7 @@ internal func _overrideLifetime<
 /// the `source` argument.
 @_unsafeNonescapableResult
 @_transparent
-@lifetime(borrow source)
+@lifetime(&source)
 internal func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(
@@ -112,7 +112,7 @@ struct NC : ~Copyable {
   let c: Int
 
   // Requires a mutable borrow.
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating func getMutableSpan() -> MutableSpan {
     MutableSpan(p, c)
   }

--- a/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
+++ b/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
@@ -36,7 +36,7 @@ public struct NonEscapableSelf : ~Swift.Escapable {
   @lifetime(copy self)
   public mutating func mutatingMethodNoParamCopy() -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(borrow self)
+  @lifetime(&self)
   public mutating func mutatingMethodNoParamBorrow() -> lifetime_depend_infer.NonEscapableSelf
   
   public func methodOneParam(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf
@@ -56,7 +56,7 @@ public struct NonEscapableSelf : ~Swift.Escapable {
   @lifetime(copy self)
   public mutating func mutatingMethodOneParamCopy(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(borrow self)
+  @lifetime(&self)
   public mutating func mutatingMethodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf 
 }
 
@@ -79,7 +79,7 @@ public struct EscapableTrivialSelf {
   @lifetime(self)
   public mutating func mutatingMethodNoParamLifetime() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(borrow self)
+  @lifetime(&self)
   public mutating func mutatingMethodNoParamBorrow() -> lifetime_depend_infer.NEImmortal
   
   @lifetime(self)
@@ -91,7 +91,7 @@ public struct EscapableTrivialSelf {
   @lifetime(self)
   public mutating func mutatingMethodOneParamLifetime(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(borrow self)
+  @lifetime(&self)
   public mutating func mutatingMethodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
 }
@@ -110,7 +110,7 @@ public struct EscapableNonTrivialSelf {
   @lifetime(self)
   public mutating func mutatingMethodNoParamLifetime() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(borrow self)
+  @lifetime(&self)
   public mutating func mutatingMethodNoParamBorrow() -> lifetime_depend_infer.NEImmortal
   
   public func methodOneParam(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
@@ -126,7 +126,7 @@ public struct EscapableNonTrivialSelf {
   @lifetime(self)
   public mutating func mutatingMethodOneParamLifetime(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(borrow self)
+  @lifetime(&self)
   public mutating func mutatingMethodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
 }
@@ -209,7 +209,7 @@ public struct NonescapableSelfAccessors : ~Swift.Escapable {
   
   public var neYielded: lifetime_depend_infer.NE {
     _read
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify
   }
   
@@ -223,7 +223,7 @@ public struct NoncopyableSelfAccessors : ~Copyable & ~Escapable {
   
   public var neYielded: lifetime_depend_infer.NE {
     _read
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify
   }
   
@@ -258,14 +258,14 @@ public struct NoncopyableSelfAccessors : ~Copyable & ~Escapable {
   public var neComputedBorrow: lifetime_depend_infer.NE {
     @lifetime(borrow self)
     get
-    @lifetime(borrow self)
+    @lifetime(&self)
     set
   }
   
   public var neYieldedBorrow: lifetime_depend_infer.NE {
     @lifetime(borrow self)
     _read
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify
   }
 }
@@ -285,7 +285,7 @@ public struct NonEscapableMutableSelf : ~Swift.Escapable {
   @lifetime(copy self)
   public mutating func mutatingMethodOneParamCopy(_: lifetime_depend_infer.NE)
   
-  @lifetime(borrow self)
+  @lifetime(&self)
   public mutating func mutatingMethodOneParamBorrow(_: lifetime_depend_infer.NE)
 }
 #endif

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -63,3 +63,9 @@ do {
 // rdar://146401190 ([nonescapable] implement non-inout parameter dependencies)
 @lifetime(span: borrow holder)
 func testParameterDep(holder: AnyObject, span: Span<Int>) {}  // expected-error{{lifetime-dependent parameter must be 'inout'}}
+
+@lifetime(&ne)
+func inoutLifetimeDependence(_ ne: inout NE) -> NE {
+  ne
+}
+

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -137,7 +137,7 @@ struct EscapableNonTrivialSelf {
   @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
   mutating func mutatingMethodNoParamCopy() -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating func mutatingMethodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
   func methodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a method with a ~Escapable result requires '@lifetime(...)'}}
@@ -159,7 +159,7 @@ struct EscapableNonTrivialSelf {
   @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
   mutating func mutatingMethodOneParamCopy(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating func mutatingMethodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 }
 
@@ -224,7 +224,7 @@ func oneParamLifetime(c: C) -> NEImmortal { NEImmortal() }
 
 func oneParamConsume(c: consuming C) -> NEImmortal { NEImmortal() } // expected-error{{cannot borrow the lifetime of 'c', which has consuming ownership on a function}}
 
-@lifetime(c) // expected-error{{invalid use of borrow dependence with consuming ownership}}
+@lifetime(c) // expected-error{{invalid lifetime dependence on an Escapable value with consuming ownership}}
 func oneParamConsumeLifetime(c: consuming C) -> NEImmortal { NEImmortal() }
 
 func oneParamBorrow(c: borrowing C) -> NEImmortal { NEImmortal() } // OK
@@ -424,7 +424,7 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
       yield ne
     }
 
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify {
       yield &ne
     }
@@ -484,7 +484,7 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
       ne
     }
 
-    @lifetime(borrow self)
+    @lifetime(&self)
     set {
       ne = newValue
     }
@@ -496,7 +496,7 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
       yield ne
     }
 
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify {
       yield &ne
     }

--- a/test/Sema/lifetime_depend_infer_lazy.swift
+++ b/test/Sema/lifetime_depend_infer_lazy.swift
@@ -106,7 +106,7 @@ struct EscapableNonTrivialSelf {
   @lifetime(self)
   mutating func mutatingMethodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @lifetime(&self)
   mutating func mutatingMethodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
   func methodOneParam(_: Int) -> NEImmortal { NEImmortal() } // OK
@@ -122,7 +122,7 @@ struct EscapableNonTrivialSelf {
   @lifetime(self) // OK
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self) // OK
+  @lifetime(&self) // OK
   mutating func mutatingMethodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 }
 
@@ -351,7 +351,7 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
       yield ne
     }
 
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify {
       yield &ne
     }
@@ -411,7 +411,7 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
       ne
     }
 
-    @lifetime(borrow self)
+    @lifetime(&self)
     set {
       ne = newValue
     }
@@ -423,7 +423,7 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
       yield ne
     }
 
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify {
       yield &ne
     }

--- a/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
@@ -72,7 +72,7 @@ public struct Wrapper : ~Escapable {
     _read {
       yield _view
     }
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify {
       yield &_view
     }

--- a/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
@@ -62,7 +62,7 @@ public struct Wrapper : ~Escapable {
     _read {
       yield _view
     }
-    @lifetime(borrow self)
+    @lifetime(&self)
     _modify {
       yield &_view
     }


### PR DESCRIPTION
Add support for spelling lifetime dependencies on mutable sources as `@lifetime(&arg)`. Previously this was spelled as `@lifetime(borrow arg)` and caused some confusion to developers. This is purely a syntactic change and does not change how these dependencies are represented in SIL.

rdar://146310571

Cherry pick from https://github.com/swiftlang/swift/pull/80452,  https://github.com/swiftlang/swift/pull/80534 and https://github.com/swiftlang/swift/pull/80618