### PR TITLE
6.1: [Test] Codesign lib on same line as binary.

### DIFF
--- a/test/Interpreter/coroutine_accessors_default_implementations.swift
+++ b/test/Interpreter/coroutine_accessors_default_implementations.swift
@@ -38,7 +38,7 @@
 // RUN:     %target-rpath(%t) \
 // RUN:     -o %t/main
 
-// RUN: %target-codesign %t/main
+// RUN: %target-codesign %t/main %t/%target-library-name(Library)
 // RUN: %target-run %t/main %t/%target-library-name(Library) | %FileCheck %s
 
 // REQUIRES: swift_feature_CoroutineAccessors

--- a/test/Interpreter/typed_throws_abi.swift
+++ b/test/Interpreter/typed_throws_abi.swift
@@ -1,7 +1,7 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(TypedThrowsABI)) -enable-library-evolution %S/Inputs/typed_throws_abi_impl.swift -emit-module -emit-module-path %t/TypedThrowsABI.swiftmodule -module-name TypedThrowsABI
 
 // RUN: %target-build-swift -parse-as-library -Xfrontend -disable-availability-checking %s -lTypedThrowsABI -I %t -L %t -o %t/main %target-rpath(%t)
-// RUN: %target-codesign %t/main
+// RUN: %target-codesign %t/main %t/%target-library-name(TypedThrowsABI)
 // RUN: %target-run %t/main %t/%target-library-name(TypedThrowsABI) | %FileCheck %s
 
 // REQUIRES: executable_test


### PR DESCRIPTION
**Explanation**: Code sign these libraries used in execution tests.
**Scope**: Affects these two test cases.
**Issue**: rdar://148641825
**Original PR**: https://github.com/swiftlang/swift/pull/80603
**Risk**: None, this is a test-only change.
**Testing**: CI.
**Reviewer**: Dario Rexin ( @drexin )
