### PR TITLE
[6.1 🍒][Dependency Scanning] Refine cross-import overlay detection algorithm

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -966,7 +966,7 @@ public:
   llvm::StringMap<llvm::SmallSetVector<Identifier, 4>>
   collectCrossImportOverlayNames(
       ASTContext &ctx, StringRef moduleName,
-      std::vector<std::pair<std::string, std::string>> &overlayFiles) const;
+      std::set<std::pair<std::string, std::string>> &overlayFiles) const;
 };
 
 using ModuleDependencyVector =

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -152,12 +152,14 @@ struct ScannerImportStatementInfo {
     uint32_t columnNumber;
   };
 
-  ScannerImportStatementInfo(std::string importIdentifier)
-      : importLocations(), importIdentifier(importIdentifier) {}
+  ScannerImportStatementInfo(std::string importIdentifier, bool isExported)
+      : importLocations(), importIdentifier(importIdentifier),
+        isExported(isExported) {}
 
-  ScannerImportStatementInfo(std::string importIdentifier,
+  ScannerImportStatementInfo(std::string importIdentifier, bool isExported,
                              ImportDiagnosticLocationInfo location)
-      : importLocations({location}), importIdentifier(importIdentifier) {}
+      : importLocations({location}), importIdentifier(importIdentifier),
+        isExported(isExported) {}
 
   void addImportLocation(ImportDiagnosticLocationInfo location) {
     importLocations.push_back(location);
@@ -167,6 +169,8 @@ struct ScannerImportStatementInfo {
   SmallVector<ImportDiagnosticLocationInfo, 4> importLocations;
   /// Imported module string. e.g. "Foo.Bar" in 'import Foo.Bar'
   std::string importIdentifier;
+  /// Is this an @_exported import
+  bool isExported;
 };
 
 /// Base class for the variant storage of ModuleDependencyInfo.
@@ -909,7 +913,7 @@ public:
 
   /// Add a dependency on the given module, if it was not already in the set.
   void
-  addOptionalModuleImport(StringRef module,
+  addOptionalModuleImport(StringRef module, bool isExported,
                           llvm::StringSet<> *alreadyAddedModules = nullptr);
 
   /// Add all of the module imports in the given source
@@ -919,13 +923,13 @@ public:
                         const SourceManager *sourceManager);
 
   /// Add a dependency on the given module, if it was not already in the set.
-  void addModuleImport(ImportPath::Module module,
+  void addModuleImport(ImportPath::Module module, bool isExported,
                        llvm::StringSet<> *alreadyAddedModules = nullptr,
                        const SourceManager *sourceManager = nullptr,
                        SourceLoc sourceLocation = SourceLoc());
 
   /// Add a dependency on the given module, if it was not already in the set.
-  void addModuleImport(StringRef module,
+  void addModuleImport(StringRef module, bool isExported,
                        llvm::StringSet<> *alreadyAddedModules = nullptr,
                        const SourceManager *sourceManager = nullptr,
                        SourceLoc sourceLocation = SourceLoc());

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -100,36 +100,33 @@ private:
   /// closure for the given module.
   /// 1. Swift modules imported directly or via another Swift dependency
   /// 2. Clang modules imported directly or via a Swift dependency
-  /// 3. Clang modules imported via textual header inputs to Swift modules (bridging headers)
-  /// 4. Swift overlay modules of all of the transitively imported Clang modules that have one
+  /// 3. Clang modules imported via textual header inputs to Swift modules
+  /// (bridging headers)
+  /// 4. Swift overlay modules of all of the transitively imported Clang modules
+  /// that have one
   ModuleDependencyIDSetVector
   resolveImportedModuleDependencies(const ModuleDependencyID &rootModuleID,
                                     ModuleDependenciesCache &cache);
-  void
-  resolveSwiftModuleDependencies(const ModuleDependencyID &rootModuleID,
-                                 ModuleDependenciesCache &cache,
-                                 ModuleDependencyIDSetVector &discoveredSwiftModules);
-  void
-  resolveAllClangModuleDependencies(ArrayRef<ModuleDependencyID> swiftModules,
-                                    ModuleDependenciesCache &cache,
-                                    ModuleDependencyIDSetVector &discoveredClangModules);
-  void
-  resolveHeaderDependencies(ArrayRef<ModuleDependencyID> swiftModules,
-                            ModuleDependenciesCache &cache,
-                            ModuleDependencyIDSetVector &discoveredHeaderDependencyClangModules);
-  void
-  resolveSwiftOverlayDependencies(ArrayRef<ModuleDependencyID> swiftModules,
-                                  ModuleDependenciesCache &cache,
-                                  ModuleDependencyIDSetVector &discoveredDependencies);
+  void resolveSwiftModuleDependencies(
+      const ModuleDependencyID &rootModuleID, ModuleDependenciesCache &cache,
+      ModuleDependencyIDSetVector &discoveredSwiftModules);
+  void resolveAllClangModuleDependencies(
+      ArrayRef<ModuleDependencyID> swiftModules, ModuleDependenciesCache &cache,
+      ModuleDependencyIDSetVector &discoveredClangModules);
+  void resolveHeaderDependencies(
+      ArrayRef<ModuleDependencyID> swiftModules, ModuleDependenciesCache &cache,
+      ModuleDependencyIDSetVector &discoveredHeaderDependencyClangModules);
+  void resolveSwiftOverlayDependencies(
+      ArrayRef<ModuleDependencyID> swiftModules, ModuleDependenciesCache &cache,
+      ModuleDependencyIDSetVector &discoveredDependencies);
 
   /// Resolve all of a given module's imports to a Swift module, if one exists.
-  void
-  resolveSwiftImportsForModule(const ModuleDependencyID &moduleID,
-                               ModuleDependenciesCache &cache,
-                               ModuleDependencyIDSetVector &importedSwiftDependencies);
+  void resolveSwiftImportsForModule(
+      const ModuleDependencyID &moduleID, ModuleDependenciesCache &cache,
+      ModuleDependencyIDSetVector &importedSwiftDependencies);
 
-  /// If a module has a bridging header or other header inputs, execute a dependency scan
-  /// on it and record the dependencies.
+  /// If a module has a bridging header or other header inputs, execute a
+  /// dependency scan on it and record the dependencies.
   void resolveHeaderDependenciesForModule(
       const ModuleDependencyID &moduleID, ModuleDependenciesCache &cache,
       ModuleDependencyIDSetVector &headerClangModuleDependencies);
@@ -137,15 +134,13 @@ private:
   /// Resolve all module dependencies comprised of Swift overlays
   /// of this module's Clang module dependencies.
   void resolveSwiftOverlayDependenciesForModule(
-      const ModuleDependencyID &moduleID,
-      ModuleDependenciesCache &cache,
+      const ModuleDependencyID &moduleID, ModuleDependenciesCache &cache,
       ModuleDependencyIDSetVector &swiftOverlayDependencies);
 
-  /// Identify all cross-import overlay modules of the specified
-  /// dependency set and apply an action for each.
-  void discoverCrossImportOverlayDependencies(
-      StringRef mainModuleName, ArrayRef<ModuleDependencyID> allDependencies,
-      ModuleDependenciesCache &cache,
+  /// Identify all cross-import overlay module dependencies of the
+  /// source module under scan and apply an action for each.
+  void resolveCrossImportOverlayDependencies(
+      StringRef mainModuleName, ModuleDependenciesCache &cache,
       llvm::function_ref<void(ModuleDependencyID)> action);
 
   /// Perform an operation utilizing one of the Scanning workers

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -57,7 +57,7 @@ using IsFrameworkField = BCFixed<1>;
 using IsSystemField = BCFixed<1>;
 /// A bit that indicates whether or not a module is that of a static archive
 using IsStaticField = BCFixed<1>;
-/// A bit taht indicates whether or not an import statement is @_exported
+/// A bit that indicates whether or not an import statement is @_exported
 using IsExportedImport = BCFixed<1>;
 
 /// Source location fields

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -57,6 +57,13 @@ using IsFrameworkField = BCFixed<1>;
 using IsSystemField = BCFixed<1>;
 /// A bit that indicates whether or not a module is that of a static archive
 using IsStaticField = BCFixed<1>;
+/// A bit taht indicates whether or not an import statement is @_exported
+using IsExportedImport = BCFixed<1>;
+
+/// Source location fields
+using LineNumberField = BCFixed<32>;
+using ColumnNumberField = BCFixed<32>;
+
 
 /// Arrays of various identifiers, distinguished for readability
 using IdentifierIDArryField = llvm::BCArray<IdentifierIDField>;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -169,6 +169,7 @@ protected:
 
   struct BinaryModuleImports {
     llvm::StringSet<> moduleImports;
+    llvm::StringSet<> exportedModules;
     std::string headerImport;
   };
 
@@ -183,7 +184,7 @@ protected:
 
   /// If the module has a package name matching the one
   /// specified, return a set of package-only imports for this module.
-  static llvm::ErrorOr<llvm::StringSet<>>
+  static llvm::ErrorOr<std::vector<ScannerImportStatementInfo>>
   getMatchingPackageOnlyImportsOfModule(Twine modulePath,
                                         bool isFramework,
                                         bool isRequiredOSSAModules,

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -115,16 +115,16 @@ bool ModuleDependencyInfo::isTestableImport(StringRef moduleName) const {
 }
 
 void ModuleDependencyInfo::addOptionalModuleImport(
-    StringRef module, llvm::StringSet<> *alreadyAddedModules) {
+    StringRef module, bool isExported, llvm::StringSet<> *alreadyAddedModules) {
   if (!alreadyAddedModules || alreadyAddedModules->insert(module).second)
-    storage->optionalModuleImports.push_back(module.str());
+    storage->optionalModuleImports.push_back({module.str(), isExported});
 }
 
 void ModuleDependencyInfo::addModuleImport(
-    StringRef module, llvm::StringSet<> *alreadyAddedModules,
+    StringRef module, bool isExported, llvm::StringSet<> *alreadyAddedModules,
     const SourceManager *sourceManager, SourceLoc sourceLocation) {
   auto scannerImportLocToDiagnosticLocInfo =
-      [&sourceManager](SourceLoc sourceLocation) {
+      [&sourceManager, isExported](SourceLoc sourceLocation) {
         auto lineAndColumnNumbers =
             sourceManager->getLineAndColumnInBuffer(sourceLocation);
         return ScannerImportStatementInfo::ImportDiagnosticLocationInfo(
@@ -135,14 +135,16 @@ void ModuleDependencyInfo::addModuleImport(
                              sourceManager->isOwning(sourceLocation);
 
   if (alreadyAddedModules && alreadyAddedModules->contains(module)) {
-    if (validSourceLocation) {
-      // Find a prior import of this module and add import location
-      for (auto &existingImport : storage->moduleImports) {
-        if (existingImport.importIdentifier == module) {
+    // Find a prior import of this module and add import location
+    // and adjust whether or not this module is ever imported as exported
+    for (auto &existingImport : storage->moduleImports) {
+      if (existingImport.importIdentifier == module) {
+        if (validSourceLocation) {
           existingImport.addImportLocation(
-              scannerImportLocToDiagnosticLocInfo(sourceLocation));
-          break;
+            scannerImportLocToDiagnosticLocInfo(sourceLocation));
         }
+        existingImport.isExported |= isExported;
+        break;
       }
     }
   } else {
@@ -151,15 +153,15 @@ void ModuleDependencyInfo::addModuleImport(
 
     if (validSourceLocation)
       storage->moduleImports.push_back(ScannerImportStatementInfo(
-          module.str(), scannerImportLocToDiagnosticLocInfo(sourceLocation)));
+          module.str(), isExported, scannerImportLocToDiagnosticLocInfo(sourceLocation)));
     else
       storage->moduleImports.push_back(
-          ScannerImportStatementInfo(module.str()));
+         ScannerImportStatementInfo(module.str(), isExported));
   }
 }
 
 void ModuleDependencyInfo::addModuleImport(
-    ImportPath::Module module, llvm::StringSet<> *alreadyAddedModules,
+    ImportPath::Module module, bool isExported, llvm::StringSet<> *alreadyAddedModules,
     const SourceManager *sourceManager, SourceLoc sourceLocation) {
   std::string ImportedModuleName = module.front().Item.str().str();
   auto submodulePath = module.getSubmodulePath();
@@ -172,7 +174,7 @@ void ModuleDependencyInfo::addModuleImport(
                               alreadyAddedModules);
   }
 
-  addModuleImport(ImportedModuleName, alreadyAddedModules,
+  addModuleImport(ImportedModuleName, isExported, alreadyAddedModules,
                   sourceManager, sourceLocation);
 }
 
@@ -201,7 +203,8 @@ void ModuleDependencyInfo::addModuleImports(
               importDecl->isExported()))
         continue;
 
-      addModuleImport(realPath, &alreadyAddedModules, sourceManager,
+      addModuleImport(realPath, importDecl->isExported(),
+                      &alreadyAddedModules, sourceManager,
                       importDecl->getLoc());
 
       // Additionally, keep track of which dependencies of a Source

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -124,7 +124,7 @@ void ModuleDependencyInfo::addModuleImport(
     StringRef module, bool isExported, llvm::StringSet<> *alreadyAddedModules,
     const SourceManager *sourceManager, SourceLoc sourceLocation) {
   auto scannerImportLocToDiagnosticLocInfo =
-      [&sourceManager, isExported](SourceLoc sourceLocation) {
+      [&sourceManager](SourceLoc sourceLocation) {
         auto lineAndColumnNumbers =
             sourceManager->getLineAndColumnInBuffer(sourceLocation);
         return ScannerImportStatementInfo::ImportDiagnosticLocationInfo(

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -208,7 +208,7 @@ void ModuleLoader::findOverlayFiles(SourceLoc diagLoc, ModuleDecl *module,
 llvm::StringMap<llvm::SmallSetVector<Identifier, 4>>
 ModuleDependencyInfo::collectCrossImportOverlayNames(
     ASTContext &ctx, StringRef moduleName,
-    std::vector<std::pair<std::string, std::string>> &overlayFiles) const {
+    std::set<std::pair<std::string, std::string>> &overlayFiles) const {
   using namespace llvm::sys;
   using namespace file_types;
   std::optional<std::string> modulePath;
@@ -260,7 +260,7 @@ ModuleDependencyInfo::collectCrossImportOverlayNames(
       ModuleDecl::collectCrossImportOverlay(ctx, file, moduleName,
                                             bystandingModule);
     result[bystandingModule] = std::move(overlayNames);
-    overlayFiles.push_back({moduleName.str(), file.str()});
+    overlayFiles.insert({moduleName.str(), file.str()});
   });
   return result;
 }

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -302,7 +302,10 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
 
     std::vector<ModuleDependencyID> directDependencyIDs;
     for (const auto &moduleName : clangModuleDep.ClangModuleDeps) {
-      dependencies.addModuleImport(moduleName.ModuleName, &alreadyAddedModules);
+      // FIXME: This assumes, conservatively, that all Clang module imports
+      // are exported. We need to fix this once the clang scanner gains the appropriate
+      // API to query this.
+      dependencies.addModuleImport(moduleName.ModuleName, /* isExported */ true, &alreadyAddedModules);
       // It is safe to assume that all dependencies of a Clang module are Clang modules.
       directDependencyIDs.push_back({moduleName.ModuleName, ModuleDependencyKind::Clang});
     }

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -228,16 +228,6 @@ bool ModuleDependenciesCacheDeserializer::readGraph(SwiftDependencyScanningServi
       currentContextHashID = contextHashID;
       auto importStrings = getStringArray(moduleImportsArrayID);
       auto optionalImportStrings = getStringArray(optionalModuleImportsArrayID);
-      if (importStrings.has_value()) {
-        for (const auto &is : importStrings.value())
-          currentModuleImports.push_back(is);
-      }
-
-      if (optionalImportStrings.has_value()) {
-        for (const auto &ois : optionalImportStrings.value())
-          currentOptionalModuleImports.push_back(ois);
-      }
-
       auto optionalCurrentModuleDependencyIDs = getModuleDependencyIDArray(moduleDependencyIDArrayID);
       if (!optionalCurrentModuleDependencyIDs)
         llvm::report_fatal_error("Bad direct dependencies: no qualified dependencies");
@@ -319,10 +309,10 @@ bool ModuleDependenciesCacheDeserializer::readGraph(SwiftDependencyScanningServi
 
       // Add imports of this module
       for (const auto &moduleName : currentModuleImports)
-        moduleDep.addModuleImport(moduleName.importIdentifier);
+        moduleDep.addModuleImport(moduleName.importIdentifier, false);
       // Add optional imports of this module
       for (const auto &moduleName : currentOptionalModuleImports)
-        moduleDep.addOptionalModuleImport(moduleName.importIdentifier);
+        moduleDep.addOptionalModuleImport(moduleName.importIdentifier, false);
 
       // Add qualified dependencies of this module
       std::vector<ModuleDependencyID> swiftDeps;
@@ -442,10 +432,10 @@ bool ModuleDependenciesCacheDeserializer::readGraph(SwiftDependencyScanningServi
 
       // Add dependencies of this module
       for (const auto &moduleName : currentModuleImports)
-        moduleDep.addModuleImport(moduleName.importIdentifier);
+        moduleDep.addModuleImport(moduleName.importIdentifier, false);
       // Add optional imports of this module
       for (const auto &moduleName : currentOptionalModuleImports)
-        moduleDep.addOptionalModuleImport(moduleName.importIdentifier);
+        moduleDep.addOptionalModuleImport(moduleName.importIdentifier, false);
 
       // Add bridging header file path
       if (bridgingHeaderFileID != 0) {
@@ -600,10 +590,10 @@ bool ModuleDependenciesCacheDeserializer::readGraph(SwiftDependencyScanningServi
 
       // Add dependencies of this module
       for (const auto &moduleName : currentModuleImports)
-        moduleDep.addModuleImport(moduleName.importIdentifier);
+        moduleDep.addModuleImport(moduleName.importIdentifier, false);
       // Add optional imports of this module
       for (const auto &moduleName : currentOptionalModuleImports)
-        moduleDep.addOptionalModuleImport(moduleName.importIdentifier);
+        moduleDep.addOptionalModuleImport(moduleName.importIdentifier, false);
 
       cache.recordDependency(currentModuleName, std::move(moduleDep),
                              getContextHash());
@@ -663,10 +653,10 @@ bool ModuleDependenciesCacheDeserializer::readGraph(SwiftDependencyScanningServi
 
       // Add dependencies of this module
       for (const auto &moduleName : currentModuleImports)
-        moduleDep.addModuleImport(moduleName.importIdentifier);
+        moduleDep.addModuleImport(moduleName.importIdentifier, false);
       // Add optional imports of this module
       for (const auto &moduleName : currentOptionalModuleImports)
-        moduleDep.addOptionalModuleImport(moduleName.importIdentifier);
+        moduleDep.addOptionalModuleImport(moduleName.importIdentifier, false);
 
       cache.recordDependency(currentModuleName, std::move(moduleDep),
                              getContextHash());

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -532,42 +532,141 @@ ModuleDependencyScanner::getNamedSwiftModuleDependencyInfo(
   return cache.findDependency(moduleName);
 }
 
+/// For the dependency set of the main module, discover all
+/// cross-import overlays and their corresponding '.swiftcrossimport'
+/// files. Cross-import overlay dependencies are required when
+/// the two constituent modules are imported *from the same source file*,
+/// directly or indirectly.
+///
+/// Given a complete module dependency graph in this stage of the scan,
+/// the algorithm for discovering cross-import overlays is:
+/// 1. For each source file of the module under scan construct a
+///    set of module dependnecies only reachable from this source file.
+/// 2. For each module set constructed in (1), perform pair-wise lookup
+///    of cross import files for each pair of modules in the set.
+///
+/// Notably, if for some pair of modules 'A' and 'B' there exists
+/// a cross-import overlay '_A_B', and these two modules are not reachable
+/// from any single source file via direct or indirect imports, then
+/// the cross-import overlay module is not required for compilation.
 static void discoverCrossImportOverlayFiles(
-    StringRef mainModuleName, ArrayRef<ModuleDependencyID> allDependencies,
-    ModuleDependenciesCache &cache, ASTContext &scanASTContext,
-    llvm::SetVector<Identifier> &newOverlays,
+    StringRef mainModuleName, ModuleDependenciesCache &cache,
+    ASTContext &scanASTContext, llvm::SetVector<Identifier> &newOverlays,
     std::vector<std::pair<std::string, std::string>> &overlayFiles) {
-  for (auto moduleID : allDependencies) {
-    auto moduleName = moduleID.ModuleName;
-    // Do not look for overlays of main module under scan
-    if (moduleName == mainModuleName)
-      continue;
+  auto mainModuleInfo = cache.findKnownDependency(ModuleDependencyID{
+      mainModuleName.str(), ModuleDependencyKind::SwiftSource});
 
-    auto dependencies = cache.findDependency(moduleName, moduleID.Kind).value();
-    // Collect a map from secondary module name to cross-import overlay names.
-    auto overlayMap = dependencies->collectCrossImportOverlayNames(
-        scanASTContext, moduleName, overlayFiles);
-    if (overlayMap.empty())
-      continue;
-    for (const auto &dependencyId : allDependencies) {
-      auto moduleName = dependencyId.ModuleName;
-      // Do not look for overlays of main module under scan
-      if (moduleName == mainModuleName)
-        continue;
-      // check if any explicitly imported modules can serve as a
-      // secondary module, and add the overlay names to the
-      // dependencies list.
-      for (auto overlayName : overlayMap[moduleName]) {
-        if (overlayName.str() != mainModuleName &&
-            std::find_if(allDependencies.begin(), allDependencies.end(),
-                         [&](ModuleDependencyID Id) {
-                           return moduleName == overlayName.str();
-                         }) == allDependencies.end()) {
-          newOverlays.insert(overlayName);
+  llvm::StringMap<ModuleDependencyIDSet> perSourceFileDependencies;
+  const ModuleDependencyIDSet directSwiftDepsSet{
+      mainModuleInfo.getImportedSwiftDependencies().begin(),
+      mainModuleInfo.getImportedSwiftDependencies().end()};
+  const ModuleDependencyIDSet directClangDepsSet{
+      mainModuleInfo.getImportedClangDependencies().begin(),
+      mainModuleInfo.getImportedClangDependencies().end()};
+
+  // A utility to map an import identifier to one of the
+  // known resolved module dependencies
+  auto getModuleIDForImportIdentifier =
+      [directSwiftDepsSet, directClangDepsSet](
+          const std::string &importIdentifierStr) -> ModuleDependencyID {
+    if (auto textualDepIt = directSwiftDepsSet.find(
+            {importIdentifierStr, ModuleDependencyKind::SwiftInterface});
+        textualDepIt != directSwiftDepsSet.end())
+      return *textualDepIt;
+    else if (auto binaryDepIt = directSwiftDepsSet.find(
+                 {importIdentifierStr, ModuleDependencyKind::SwiftBinary});
+             binaryDepIt != directSwiftDepsSet.end())
+      return *binaryDepIt;
+    else if (auto clangDepIt = directClangDepsSet.find(
+                 {importIdentifierStr, ModuleDependencyKind::Clang});
+             clangDepIt != directClangDepsSet.end())
+      return *clangDepIt;
+    llvm_unreachable(
+        "Unresolved import during cross-import overlay resolution");
+  };
+
+  // Collect the set of directly-imported module dependencies
+  // for each source file in the source module under scan.
+  for (const auto &import : mainModuleInfo.getModuleImports()) {
+    auto importResolvedModuleID =
+        getModuleIDForImportIdentifier(import.importIdentifier);
+    for (const auto &importLocation : import.importLocations)
+      perSourceFileDependencies[importLocation.bufferIdentifier].insert(
+          importResolvedModuleID);
+  }
+
+  // For each source-file, build a set of module dependencies of the
+  // module under scan corresponding to a sub-graph of modules only reachable
+  // from this source file's direct imports.
+  for (auto &keyValPair : perSourceFileDependencies) {
+    const auto &bufferIdentifier = keyValPair.getKey();
+    auto &directDependencyIDs = keyValPair.second;
+    SmallVector<ModuleDependencyID, 8> worklist{directDependencyIDs.begin(),
+                                                directDependencyIDs.end()};
+    while (!worklist.empty()) {
+      auto moduleID = worklist.pop_back_val();
+      perSourceFileDependencies[bufferIdentifier].insert(moduleID);
+      if (isSwiftDependencyKind(moduleID.Kind)) {
+        for (const auto &directSwiftDepID :
+             cache.getImportedSwiftDependencies(moduleID)) {
+          if (perSourceFileDependencies[bufferIdentifier].count(directSwiftDepID))
+            continue;
+          worklist.push_back(directSwiftDepID);
         }
+      }
+      for (const auto &directClangDepID :
+           cache.getImportedClangDependencies(moduleID)) {
+        if (perSourceFileDependencies[bufferIdentifier].count(directClangDepID))
+          continue;
+        worklist.push_back(directClangDepID);
       }
     }
   }
+
+  // Within a provided set of module dependencies reachable via
+  // direct imports from a given file, determine the available and required
+  // cross-import overlays.
+  auto discoverCrossImportOverlayFilesForModuleSet =
+      [&mainModuleName, &cache, &scanASTContext, &newOverlays,
+       &overlayFiles](const ModuleDependencyIDSet &inputDependencies) {
+        for (auto moduleID : inputDependencies) {
+          auto moduleName = moduleID.ModuleName;
+          // Do not look for overlays of main module under scan
+          if (moduleName == mainModuleName)
+            continue;
+
+          auto dependencies =
+              cache.findDependency(moduleName, moduleID.Kind).value();
+          // Collect a map from secondary module name to cross-import overlay
+          // names.
+          auto overlayMap = dependencies->collectCrossImportOverlayNames(
+              scanASTContext, moduleName, overlayFiles);
+          if (overlayMap.empty())
+            continue;
+          for (const auto &dependencyId : inputDependencies) {
+            auto moduleName = dependencyId.ModuleName;
+            // Do not look for overlays of main module under scan
+            if (moduleName == mainModuleName)
+              continue;
+            // check if any explicitly imported modules can serve as a
+            // secondary module, and add the overlay names to the
+            // dependencies list.
+            for (auto overlayName : overlayMap[moduleName]) {
+              if (overlayName.str() != mainModuleName &&
+                  std::find_if(inputDependencies.begin(),
+                               inputDependencies.end(),
+                               [&](ModuleDependencyID Id) {
+                                 return moduleName == overlayName.str();
+                               }) == inputDependencies.end()) {
+                newOverlays.insert(overlayName);
+              }
+            }
+          }
+        }
+      };
+
+  for (const auto &keyValPair : perSourceFileDependencies)
+    discoverCrossImportOverlayFilesForModuleSet(keyValPair.second);
 }
 
 std::vector<ModuleDependencyID>
@@ -598,8 +697,8 @@ ModuleDependencyScanner::performDependencyScan(
   // binary Swift modules already encode their dependencies on cross-import overlays
   // with explicit imports.
   if (ScanCompilerInvocation.getLangOptions().EnableCrossImportOverlays)
-    discoverCrossImportOverlayDependencies(
-        rootModuleID.ModuleName, allModules.getArrayRef().slice(1), cache,
+    resolveCrossImportOverlayDependencies(
+        rootModuleID.ModuleName, cache,
         [&](ModuleDependencyID id) { allModules.insert(id); });
 
   return allModules.takeVector();
@@ -1154,15 +1253,15 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
   cache.setSwiftOverlayDependencies(moduleID, swiftOverlayDependencies.getArrayRef());
 }
 
-void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
-    StringRef mainModuleName, ArrayRef<ModuleDependencyID> allDependencies,
+void ModuleDependencyScanner::resolveCrossImportOverlayDependencies(
+    StringRef mainModuleName,
     ModuleDependenciesCache &cache,
     llvm::function_ref<void(ModuleDependencyID)> action) {
   // Modules explicitly imported. Only these can be secondary module.
   llvm::SetVector<Identifier> newOverlays;
   std::vector<std::pair<std::string, std::string>> overlayFiles;
-  discoverCrossImportOverlayFiles(mainModuleName, allDependencies, cache,
-                                  ScanASTContext, newOverlays, overlayFiles);
+  discoverCrossImportOverlayFiles(mainModuleName, cache, ScanASTContext,
+                                  newOverlays, overlayFiles);
 
   // No new cross-import overlays are found, return.
   if (newOverlays.empty())
@@ -1184,11 +1283,10 @@ void ModuleDependencyScanner::discoverCrossImportOverlayDependencies(
 
   // Record the dummy main module's direct dependencies. The dummy main module
   // only directly depend on these newly discovered overlay modules.
-  if (cache.findDependency(dummyMainName, ModuleDependencyKind::SwiftSource)) {
+  if (cache.findDependency(dummyMainID))
     cache.updateDependency(dummyMainID, dummyMainDependencies);
-  } else {
+  else
     cache.recordDependency(dummyMainName, dummyMainDependencies);
-  }
 
   ModuleDependencyIDSetVector allModules =
     resolveImportedModuleDependencies(dummyMainID, cache);

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -561,18 +561,19 @@ static void discoverCrossImportOverlayFiles(
       mainModuleName.str(), ModuleDependencyKind::SwiftSource});
 
   llvm::StringMap<ModuleDependencyIDSet> perSourceFileDependencies;
-  const ModuleDependencyIDSet directSwiftDepsSet{
+  const ModuleDependencyIDSet mainModuleDirectSwiftDepsSet{
       mainModuleInfo.getImportedSwiftDependencies().begin(),
       mainModuleInfo.getImportedSwiftDependencies().end()};
-  const ModuleDependencyIDSet directClangDepsSet{
+  const ModuleDependencyIDSet mainModuleDirectClangDepsSet{
       mainModuleInfo.getImportedClangDependencies().begin(),
       mainModuleInfo.getImportedClangDependencies().end()};
 
   // A utility to map an import identifier to one of the
   // known resolved module dependencies
   auto getModuleIDForImportIdentifier =
-      [directSwiftDepsSet, directClangDepsSet](
-          const std::string &importIdentifierStr) -> ModuleDependencyID {
+      [](const std::string &importIdentifierStr,
+         const ModuleDependencyIDSet &directSwiftDepsSet,
+         const ModuleDependencyIDSet &directClangDepsSet) -> ModuleDependencyID {
     if (auto textualDepIt = directSwiftDepsSet.find(
             {importIdentifierStr, ModuleDependencyKind::SwiftInterface});
         textualDepIt != directSwiftDepsSet.end())
@@ -592,8 +593,9 @@ static void discoverCrossImportOverlayFiles(
   // Collect the set of directly-imported module dependencies
   // for each source file in the source module under scan.
   for (const auto &import : mainModuleInfo.getModuleImports()) {
-    auto importResolvedModuleID =
-        getModuleIDForImportIdentifier(import.importIdentifier);
+    auto importResolvedModuleID = getModuleIDForImportIdentifier(
+        import.importIdentifier, mainModuleDirectSwiftDepsSet,
+        mainModuleDirectClangDepsSet);
     for (const auto &importLocation : import.importLocations)
       perSourceFileDependencies[importLocation.bufferIdentifier].insert(
           importResolvedModuleID);
@@ -611,18 +613,28 @@ static void discoverCrossImportOverlayFiles(
       auto moduleID = worklist.pop_back_val();
       perSourceFileDependencies[bufferIdentifier].insert(moduleID);
       if (isSwiftDependencyKind(moduleID.Kind)) {
-        for (const auto &directSwiftDepID :
-             cache.getImportedSwiftDependencies(moduleID)) {
-          if (perSourceFileDependencies[bufferIdentifier].count(directSwiftDepID))
-            continue;
-          worklist.push_back(directSwiftDepID);
+        auto moduleInfo = cache.findKnownDependency(moduleID);
+        if (llvm::any_of(moduleInfo.getModuleImports(),
+                         [](const ScannerImportStatementInfo &importInfo) {
+                           return importInfo.isExported;
+                         })) {
+          const ModuleDependencyIDSet directSwiftDepsSet{
+              moduleInfo.getImportedSwiftDependencies().begin(),
+              moduleInfo.getImportedSwiftDependencies().end()};
+          const ModuleDependencyIDSet directClangDepsSet{
+              moduleInfo.getImportedClangDependencies().begin(),
+              moduleInfo.getImportedClangDependencies().end()};
+          for (const auto &import : moduleInfo.getModuleImports()) {
+            if (import.isExported) {
+              auto importResolvedDepID = getModuleIDForImportIdentifier(
+                  import.importIdentifier, directSwiftDepsSet,
+                  directClangDepsSet);
+              if (!perSourceFileDependencies[bufferIdentifier].count(
+                      importResolvedDepID))
+                worklist.push_back(importResolvedDepID);
+            }
+          }
         }
-      }
-      for (const auto &directClangDepID :
-           cache.getImportedClangDependencies(moduleID)) {
-        if (perSourceFileDependencies[bufferIdentifier].count(directClangDepID))
-          continue;
-        worklist.push_back(directClangDepID);
       }
     }
   }

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -556,7 +556,7 @@ ModuleDependencyScanner::getNamedSwiftModuleDependencyInfo(
 static void discoverCrossImportOverlayFiles(
     StringRef mainModuleName, ModuleDependenciesCache &cache,
     ASTContext &scanASTContext, llvm::SetVector<Identifier> &newOverlays,
-    std::vector<std::pair<std::string, std::string>> &overlayFiles) {
+    std::set<std::pair<std::string, std::string>> &overlayFiles) {
   auto mainModuleInfo = cache.findKnownDependency(ModuleDependencyID{
       mainModuleName.str(), ModuleDependencyKind::SwiftSource});
 
@@ -1275,7 +1275,7 @@ void ModuleDependencyScanner::resolveCrossImportOverlayDependencies(
     llvm::function_ref<void(ModuleDependencyID)> action) {
   // Modules explicitly imported. Only these can be secondary module.
   llvm::SetVector<Identifier> newOverlays;
-  std::vector<std::pair<std::string, std::string>> overlayFiles;
+  std::set<std::pair<std::string, std::string>> overlayFiles;
   discoverCrossImportOverlayFiles(mainModuleName, cache, ScanASTContext,
                                   newOverlays, overlayFiles);
 

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -269,6 +269,7 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
         auto &imInfo = mainMod->getImplicitImportInfo();
         for (auto import : imInfo.AdditionalUnloadedImports) {
           Result->addModuleImport(import.module.getModulePath(),
+                                  import.options.contains(ImportFlags::Exported),
                                   &alreadyAddedModules, &Ctx.SourceMgr);
         }
 
@@ -294,8 +295,9 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
                return adjacentBinaryModulePackageOnlyImports.getError();
 
              for (const auto &requiredImport : *adjacentBinaryModulePackageOnlyImports)
-               if (!alreadyAddedModules.contains(requiredImport.getKey()))
-                 Result->addModuleImport(requiredImport.getKey(),
+               if (!alreadyAddedModules.contains(requiredImport.importIdentifier))
+                 Result->addModuleImport(requiredImport.importIdentifier,
+                                         requiredImport.isExported,
                                          &alreadyAddedModules);
            }
          }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -304,7 +304,7 @@ SerializedModuleLoaderBase::getModuleName(ASTContext &Ctx, StringRef modulePath,
   return ModuleFile::getModuleName(Ctx, modulePath, Name);
 }
 
-llvm::ErrorOr<llvm::StringSet<>>
+llvm::ErrorOr<std::vector<ScannerImportStatementInfo>>
 SerializedModuleLoaderBase::getMatchingPackageOnlyImportsOfModule(
     Twine modulePath, bool isFramework, bool isRequiredOSSAModules,
     StringRef SDKName, StringRef packageName, llvm::vfs::FileSystem *fileSystem,
@@ -313,7 +313,7 @@ SerializedModuleLoaderBase::getMatchingPackageOnlyImportsOfModule(
   if (!moduleBuf)
     return moduleBuf.getError();
 
-  llvm::StringSet<> importedModuleNames;
+  std::vector<ScannerImportStatementInfo> importedModuleNames;
   // Load the module file without validation.
   std::shared_ptr<const ModuleFileSharedCore> loadedModuleFile;
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
@@ -336,7 +336,7 @@ SerializedModuleLoaderBase::getMatchingPackageOnlyImportsOfModule(
     if (dotPos != std::string::npos)
       moduleName = moduleName.slice(0, dotPos);
 
-    importedModuleNames.insert(moduleName);
+    importedModuleNames.push_back({moduleName.str(), dependency.isExported()});
   }
 
   return importedModuleNames;
@@ -442,6 +442,7 @@ SerializedModuleLoaderBase::getImportsOfModule(
     ModuleLoadingBehavior transitiveBehavior, StringRef packageName,
     bool isTestableImport) {
   llvm::StringSet<> importedModuleNames;
+  llvm::StringSet<> importedExportedModuleNames;
   std::string importedHeader = "";
   for (const auto &dependency : loadedModuleFile.getDependencies()) {
     if (dependency.isHeader()) {
@@ -476,9 +477,12 @@ SerializedModuleLoaderBase::getImportsOfModule(
       moduleName = "std";
 
     importedModuleNames.insert(moduleName);
+    if (dependency.isExported())
+      importedExportedModuleNames.insert(moduleName);
   }
 
   return SerializedModuleLoaderBase::BinaryModuleImports{importedModuleNames,
+                                                         importedExportedModuleNames,
                                                          importedHeader};
 }
 
@@ -553,17 +557,23 @@ SerializedModuleLoaderBase::scanModuleFile(Twine modulePath, bool isFramework,
   auto importedModuleSet = binaryModuleImports->moduleImports;
   std::vector<ScannerImportStatementInfo> moduleImports;
   moduleImports.reserve(importedModuleSet.size());
-  llvm::transform(
-      importedModuleSet.keys(), std::back_inserter(moduleImports),
-      [](llvm::StringRef N) { return ScannerImportStatementInfo(N.str()); });
+  llvm::transform(importedModuleSet.keys(), std::back_inserter(moduleImports),
+                  [&binaryModuleImports](llvm::StringRef N) {
+                    return ScannerImportStatementInfo(
+                        N.str(),
+                        binaryModuleImports->exportedModules.contains(N));
+                  });
 
   auto importedHeader = binaryModuleImports->headerImport;
   auto &importedOptionalModuleSet = binaryModuleOptionalImports->moduleImports;
+  auto &importedExportedOptionalModuleSet =
+      binaryModuleOptionalImports->exportedModules;
   std::vector<ScannerImportStatementInfo> optionalModuleImports;
   for (const auto optionalImportedModule : importedOptionalModuleSet.keys())
     if (!importedModuleSet.contains(optionalImportedModule))
       optionalModuleImports.push_back(
-          ScannerImportStatementInfo(optionalImportedModule.str()));
+          {optionalImportedModule.str(),
+           importedExportedOptionalModuleSet.contains(optionalImportedModule)});
 
   std::vector<LinkLibrary> linkLibraries;
   {

--- a/test/CAS/cross_import.swift
+++ b/test/CAS/cross_import.swift
@@ -32,11 +32,11 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: %FileCheck %s --input-file=%t/MyApp.cmd --check-prefix CMD
 // CMD: -swift-module-cross-import
-// CMD-NEXT: B
-// CMD-NEXT: A.swiftoverlay
-// CMD-NEXT: -swift-module-cross-import
-// CMD-NEXT: C
-// CMD-NEXT: A.swiftoverlay
+// CMD-NEXT: [[CMI1:[B|C]]]
+// CMD-NEXT: [[CMI1]].swiftcrossimport{{/|\\}}A.swiftoverlay
+// CMD: -swift-module-cross-import
+// CMD-NEXT: [[CMI2:[B|C]]]
+// CMD-NEXT: [[CMI2]].swiftcrossimport{{/|\\}}A.swiftoverlay
 
 // RUN: %target-swift-frontend -emit-module -o %t/Test.swiftmodule  \
 // RUN:   -emit-module-interface-path %t/Test.swiftinterface \

--- a/test/ScanDependencies/Inputs/Swift/EWrapper.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/EWrapper.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name EWrapper
 import Swift
-import E
+@_exported import E
 public func funcEWrapper() { }

--- a/test/ScanDependencies/Inputs/Swift/EWrapperNonExported.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/EWrapperNonExported.swiftinterface
@@ -1,0 +1,5 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name EWrapperNonExported
+import Swift
+import E
+public func funcEWrapperNonExported() { }

--- a/test/ScanDependencies/Inputs/Swift/SubEWrapper.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/SubEWrapper.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
 // swift-module-flags: -module-name SubEWrapper
 import Swift
-import SubE
+@_exported import SubE
 public func funcSubEWrapper() { }

--- a/test/ScanDependencies/fine_grained_cross_import_overlays.swift
+++ b/test/ScanDependencies/fine_grained_cross_import_overlays.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: split-file %s %t
+
+// Run a dependency scan on a source file that imports both constituents of a cross-import overlay to ensure the cross-import overlay dependency is registered
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/C.swift -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -module-name FineGrainedCrossImportTestModule -enable-cross-import-overlays
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json | %FileCheck %s --check-prefix CHECK-TOGETHER
+
+// Run a dependency scan on two source files that separately import constituents of a cross-import overlay and ensure that the cross-import overlay dependency is *not* registered
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/A.swift %t/B.swift -o %t/deps_disjoint.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -module-name FineGrainedCrossImportTestModule -enable-cross-import-overlays
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps_disjoint.json | %FileCheck %s --check-prefix CHECK-DISJOINT
+
+//--- A.swift
+import E
+
+//--- B.swift
+import SubE
+
+//--- C.swift
+import E
+import SubE
+
+// CHECK-TOGETHER: "swift": "_cross_import_E"
+// CHECK-DISJOINT-NOT: "swift": "_cross_import_E"

--- a/test/ScanDependencies/module_deps_cross_import_overlay.swift
+++ b/test/ScanDependencies/module_deps_cross_import_overlay.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/clang-module-cache
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -module-name CrossImportTestModule -enable-cross-import-overlays
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -module-name CrossImportTestModule -enable-cross-import-overlays
 // Check the contents of the JSON output
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // Ensure that round-trip serialization does not affect result
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -emit-dependencies -emit-dependencies-path %t/deps.d -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -module-name CrossImportTestModule -enable-cross-import-overlays
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4 -module-name CrossImportTestModule -enable-cross-import-overlays
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/ScanDependencies/module_deps_no_cross_import_overlay_transitive.swift
+++ b/test/ScanDependencies/module_deps_no_cross_import_overlay_transitive.swift
@@ -1,0 +1,16 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/clang-module-cache)
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -module-name CrossImportTestModule -enable-cross-import-overlays
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+// Ensure that round-trip serialization does not affect result
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-interface -test-dependency-scan-cache-serialization -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -module-name CrossImportTestModule -enable-cross-import-overlays
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+// Ensure that if one of the two components of a cross-import overlay is a transitive (non-exported) Swift dependency, then no overlay is required to be brought in.
+import EWrapperNonExported
+import SubEWrapper
+
+// CHECK-NOT: "swift": "_cross_import_E"

--- a/test/ScanDependencies/unique_fine_grained_cross_import_overlays.swift
+++ b/test/ScanDependencies/unique_fine_grained_cross_import_overlays.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: split-file %s %t
+
+// Run a dependency scan on a source file that imports both constituents of a cross-import overlay to ensure the cross-import overlay dependency is registered
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/A.swift %t/B.swift -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %S/Inputs/CHeaders/ExtraCModules -module-name FineGrainedCrossImportTestModule -enable-cross-import-overlays
+
+// Check the contents of the JSON output
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+//--- A.swift
+import E
+import SubE
+
+//--- B.swift
+import E
+import SubE
+
+// CHECK: "swift": "_cross_import_E"
+// CHECK-COUNT-1: -swift-module-cross-import


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/79550, https://github.com/swiftlang/swift/pull/79676, https://github.com/swiftlang/swift/pull/79809
----------------------------------
**Explanation**: Previous implementation took the entire transitive dependency set and cross-referenced all of its members to determine which ones introduce requried cross-import overlays. That implementation differed from the cross-import overlay loading logic during source compilation, where a corresponding cross-import overlay module is only requested if the two constituent modules are reachable via direct 'import's from the same source file or an indirect `@_exported` import from a direct import. Meaning the dependency scanner before this change would report cross-import overlay dependencies which never got loaded by the corresponding client source compile.

This change implements a new implementation of cross-import overlay discovery which first computes sub-graphs of module dependencies directly reachable by 'import's for each source file of the module under scan and then performs pairwise cross-import overlay query per each such subgraph.

**Issue**: [rdar://145157171](rdar://145157171)

**Risk**: Minimal where explicitly-built modules are not enabled, Low where they are enabled - this change reduces the set of brought-in cross-import overlays in the scanner to match the behavior during the actual source compile. Still, it is a significant change to the cross-import overlay discovery functionality in the scanner to achieve the resulting sound outcome. 

**Testing**: Added tests to test suite

**Original PRs**: https://github.com/swiftlang/swift/pull/79550, https://github.com/swiftlang/swift/pull/79676, https://github.com/swiftlang/swift/pull/79809

**Reviewers**: @xymus, @cachemeifyoucan 
