### PR TITLE
[Test] Disable this test for old runtimes.

### DIFF
--- a/test/Interpreter/coroutine_accessors_default_implementations.swift
+++ b/test/Interpreter/coroutine_accessors_default_implementations.swift
@@ -41,6 +41,11 @@
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: executable_test
 
+// This test verifies the backwards compatibility of binaries built against old
+// SDKs running on newer OSes (where CoroutineAccessors has been enabled).
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 //--- Library.swift
 public protocol P {
   @_borrowed


### PR DESCRIPTION
The test verifies back compatibility of old binaries with new runtimes and depends on new runtime support.

rdar://148852062
