### PR TITLE
6.2: [Test] Disable this test for old runtimes.

### DIFF
--- a/test/Interpreter/coroutine_accessors_default_implementations.swift
+++ b/test/Interpreter/coroutine_accessors_default_implementations.swift
@@ -42,6 +42,11 @@
 // REQUIRES: swift_feature_CoroutineAccessors
 // REQUIRES: executable_test
 
+// This test verifies the backwards compatibility of binaries built against old
+// SDKs running on newer OSes (where CoroutineAccessors has been enabled).
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 //--- Library.swift
 public protocol P {
   @_borrowed


### PR DESCRIPTION
**Explanation**: Disable this test on old runtimes.

The test verifies backward compatibility of new runtimes with old binaries and relies on new runtime support.  As such it doesn't make sense to run on old OSes and it can't pass there.
**Scope**: Affects this test.
**Issue**: rdar://148852062
**Original PR**: https://github.com/swiftlang/swift/pull/80654
**Risk**: None, test only change.
**Testing**: Yes, this is a test change.
**Reviewer**: Artem Chikin ( @artemcm )
