### PR TITLE
Tests: Disable `async_sequence_existential.swift` on Windows

### DIFF
--- a/test/Concurrency/async_sequence_existential.swift
+++ b/test/Concurrency/async_sequence_existential.swift
@@ -4,6 +4,9 @@
 
 // REQUIRES: concurrency
 
+// https://github.com/swiftlang/swift/issues/80582
+// UNSUPPORTED: OS=windows-msvc
+
 extension Error {
   func printMe() { }
 }


### PR DESCRIPTION
Unblocks the Windows toolchain build, which is experiencing a weird symptom that causes this test to fail only in that context. The failure is tracked by https://github.com/swiftlang/swift/issues/80582.