### PR TITLE
[Sema] Try limit kicking interface type in `filterForEnumElement`

### DIFF
--- a/validation-test/compiler_crashers_2/issue-80657.swift
+++ b/validation-test/compiler_crashers_2/issue-80657.swift
@@ -1,0 +1,17 @@
+// RUN: not --crash %target-swift-frontend -emit-sil %s
+
+// https://github.com/swiftlang/swift/issues/80657
+enum E {
+  case e
+
+  static func foo() {
+    _ = { [self] in
+      switch e {
+      case e:
+        break
+      default:
+        break
+      }
+    }
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar146952007.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar146952007.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+// These cases are similar to https://github.com/swiftlang/swift/issues/80657,
+// but we can avoid hitting the same issue for non-enum members.
+
+struct S {
+  let y = 0
+  func foo(_ x: Int) {
+    let _ = { [self] in
+      switch x {
+      case y: break
+      default: break
+      }
+    }
+  }
+}
+
+class C {
+  let y = 0
+  func foo(_ x: Int) {
+    let _ = { [self] in
+      switch x {
+      case y: break
+      default: break
+      }
+    }
+  }
+}
+
+enum E {
+  case e
+
+  func bar() -> Int {0}
+
+  func foo() {
+    _ = { [self] in
+      switch 0 {
+      case bar():
+        break
+      default:
+        break
+      }
+    }
+  }
+}


### PR DESCRIPTION
Kicking the interface type request of the base decl here is wrong if the decl is e.g a `self` capture in a closure, since we'll be in the middle of type-checking the closure. I'm planning on properly fixing this by folding the lookup into the constraint system, but for now let's at least avoid kicking the request if we don't have an enum case or enum var. That at least prevents it from affecting cases where e.g you're pattern matching against a property in a class.

We could potentially tighten up the checking here even further, but that could potentially impact source compatibility for ambiguous cases. I'd like to keep this patch low risk, and then deal with any fallout as part of the pattern type-checking work.

rdar://146952007