### PR TITLE
[6.2] IRGen: Fix silly mistake in MetadataPath::followComponent()

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3410,16 +3410,15 @@ MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
     assert(entry.isOutOfLineBase());
     auto inheritedProtocol = entry.getBase();
 
-    sourceKey.Kind =
-      LocalTypeDataKind::forAbstractProtocolWitnessTable(inheritedProtocol);
     if (sourceKey.Kind.isConcreteProtocolConformance()) {
       auto inheritedConformance =
         sourceKey.Kind.getConcreteProtocolConformance()
           ->getInheritedConformance(inheritedProtocol);
-      if (inheritedConformance) {
-        sourceKey.Kind = LocalTypeDataKind::forConcreteProtocolWitnessTable(
-                                                          inheritedConformance);
-      }
+      sourceKey.Kind = LocalTypeDataKind::forConcreteProtocolWitnessTable(
+                                                        inheritedConformance);
+    } else {
+      sourceKey.Kind =
+        LocalTypeDataKind::forAbstractProtocolWitnessTable(inheritedProtocol);
     }
 
     if (!source) return MetadataResponse();

--- a/lib/IRGen/LocalTypeDataKind.h
+++ b/lib/IRGen/LocalTypeDataKind.h
@@ -117,19 +117,19 @@ public:
   /// same function.
   static LocalTypeDataKind
   forAbstractProtocolWitnessTable(ProtocolDecl *protocol) {
-    assert(protocol && "protocol reference may not be null");
+    ASSERT(protocol && "protocol reference may not be null");
     return LocalTypeDataKind(uintptr_t(protocol) | Kind_Decl);
   }
 
   /// A reference to a protocol witness table for a concrete type.
   static LocalTypeDataKind
   forConcreteProtocolWitnessTable(ProtocolConformance *conformance) {
-    assert(conformance && "conformance reference may not be null");
+    ASSERT(conformance && "conformance reference may not be null");
     return LocalTypeDataKind(uintptr_t(conformance) | Kind_Conformance);
   }
 
   static LocalTypeDataKind forProtocolWitnessTablePack(PackConformance *pack) {
-    assert(pack && "pack conformance reference may not be null");
+    ASSERT(pack && "pack conformance reference may not be null");
     return LocalTypeDataKind(uintptr_t(pack) | Kind_PackConformance);
   }
 

--- a/test/IRGen/conformance_path_with_concrete_steps.swift
+++ b/test/IRGen/conformance_path_with_concrete_steps.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -emit-ir %s
+
+public protocol P1 {
+  associatedtype A: P3
+}
+
+public protocol P2: P1 where A.B == G<C> {
+  associatedtype C where C == A.B.C
+}
+
+public protocol P3 {
+  associatedtype B: P4
+}
+
+public protocol P4: P5 {}
+
+public protocol P5 {
+  associatedtype C: P6
+}
+
+public protocol P6 {
+  func foo()
+}
+
+public struct G<C: P6>: P4 {}
+
+public func f<T: P2>(_: T, c: T.C) {
+  return c.foo()
+}


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/80675.

* **Description:** Fixes an IRGen crash when following a conformance path where some of the intermediate steps are concrete.

* **Origination:** Introduced by https://github.com/swiftlang/swift/pull/80107 right before 6.2 branch.

* **Radar:** rdar://148698142

* **Risk:** Low.

* **Tested:** Added test case for uncovered code path.

* **Reviewed by:** @hborla 