### PR TITLE
CompatibilitySpan: Fix stdlib build on visionOS

### DIFF
--- a/Runtimes/Core/cmake/modules/AvailabilityMacros.cmake
+++ b/Runtimes/Core/cmake/modules/AvailabilityMacros.cmake
@@ -1,4 +1,7 @@
-file(STRINGS "${SwiftCore_SWIFTC_SOURCE_DIR}/utils/availability-macros.def" availability_defs)
+configure_file("${SwiftCore_SWIFTC_SOURCE_DIR}/utils/availability-macros.def"
+               "${CMAKE_CURRENT_BINARY_DIR}/availability-macros.def"
+               COPYONLY)
+file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/availability-macros.def" availability_defs)
 list(FILTER availability_defs EXCLUDE REGEX "^\\s*(#.*)?$")
 foreach(def ${availability_defs})
   add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"${def}\">")

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -18,7 +18,7 @@ import Swift
 // contains initialized `Element` instances.
 @safe
 @frozen
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 public struct MutableRawSpan: ~Copyable & ~Escapable {
   @usableFromInline
@@ -45,11 +45,11 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan: @unchecked Sendable {}
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
@@ -122,7 +122,7 @@ extension MutableRawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
   @_alwaysEmitIntoClient
@@ -137,7 +137,7 @@ extension MutableRawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
@@ -163,7 +163,7 @@ extension MutableRawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
@@ -176,7 +176,7 @@ extension RawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
@@ -213,7 +213,7 @@ extension MutableRawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
@@ -355,7 +355,7 @@ extension MutableRawSpan {
 #if !SPAN_COMPATIBILITY_STUB
 
 //MARK: copyMemory
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
@@ -449,7 +449,7 @@ extension MutableRawSpan {
 #endif
 
 // MARK: sub-spans
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 
@@ -565,7 +565,7 @@ extension MutableRawSpan {
 }
 
 // MARK: prefixes and suffixes
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableRawSpan {
 

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -18,7 +18,7 @@ import Swift
 // contains initialized `Element` instances.
 @safe
 @frozen
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 public struct MutableSpan<Element: ~Copyable>
 : ~Copyable, ~Escapable {
@@ -46,11 +46,11 @@ public struct MutableSpan<Element: ~Copyable>
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan: @unchecked Sendable where Element: Sendable {}
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -94,7 +94,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan {
 
@@ -110,7 +110,7 @@ extension MutableSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: BitwiseCopyable {
 
@@ -163,7 +163,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
 
@@ -180,7 +180,7 @@ extension Span where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -193,7 +193,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
@@ -210,7 +210,7 @@ extension RawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -224,7 +224,7 @@ extension MutableSpan where Element: ~Copyable {
 }
 
 //MARK: Collection, RandomAccessCollection
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -242,7 +242,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: BitwiseCopyable {
 
@@ -258,7 +258,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -312,7 +312,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -336,7 +336,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: BitwiseCopyable {
 
@@ -386,7 +386,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -418,7 +418,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: BitwiseCopyable {
 
@@ -445,7 +445,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 }
 
 //MARK: bulk-update functions
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan {
 
@@ -531,7 +531,7 @@ extension MutableSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -565,7 +565,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan {
 
@@ -578,7 +578,7 @@ extension MutableSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: BitwiseCopyable {
 
@@ -673,7 +673,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 }
 
 // MARK: sub-spans
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 
@@ -792,7 +792,7 @@ extension MutableSpan where Element: ~Copyable {
 }
 
 // MARK: prefixes and suffixes
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension MutableSpan where Element: ~Copyable {
 

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -22,7 +22,7 @@ import Swift
 /// owning the contiguous memory, ensuring temporal safety and avoiding
 /// use-after-free errors. Operations on `RawSpan` are bounds-checked,
 /// ensuring spcial safety and avoiding buffer overflow errors.
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 @frozen
 @safe
@@ -85,11 +85,11 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan: @unchecked Sendable {}
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
@@ -329,7 +329,7 @@ extension RawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
@@ -359,7 +359,7 @@ extension RawSpan {
 }
 
 // MARK: extracting sub-spans
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
@@ -473,7 +473,7 @@ extension RawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
@@ -504,7 +504,7 @@ extension RawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
@@ -537,7 +537,7 @@ extension RawSpan {
 }
 
 // MARK: load
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 
@@ -654,7 +654,7 @@ extension RawSpan {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
   /// Returns a Boolean value indicating whether two `RawSpan` instances
@@ -687,7 +687,7 @@ extension RawSpan {
 }
 
 // MARK: prefixes and suffixes
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension RawSpan {
 

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -24,7 +24,7 @@ import Swift
 /// ensuring spcial safety and avoiding buffer overflow errors.
 @frozen
 @safe
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
 
@@ -86,11 +86,11 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span: @unchecked Sendable where Element: Sendable & ~Copyable {}
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
 
@@ -168,7 +168,7 @@ extension Span where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span /*where Element: Copyable*/ {
 
@@ -215,7 +215,7 @@ extension Span /*where Element: Copyable*/ {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
 
@@ -379,7 +379,7 @@ extension Span where Element: BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
 
@@ -412,7 +412,7 @@ extension Span where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
   @_semantics("fixed_storage.check_index")
@@ -466,7 +466,7 @@ extension Span where Element: ~Copyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
   /// Accesses the element at the specified position in the `Span`.
@@ -517,7 +517,7 @@ extension Span where Element: BitwiseCopyable {
 }
 
 // MARK: sub-spans
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
 
@@ -637,7 +637,7 @@ extension Span where Element: ~Copyable {
 }
 
 // MARK: UnsafeBufferPointer access hatch
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable  {
 
@@ -671,7 +671,7 @@ extension Span where Element: ~Copyable  {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: BitwiseCopyable {
 
@@ -704,7 +704,7 @@ extension Span where Element: BitwiseCopyable {
   }
 }
 
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
   /// Returns a Boolean value indicating whether two `Span` instances
@@ -740,7 +740,7 @@ extension Span where Element: ~Copyable {
 }
 
 // MARK: prefixes and suffixes
-@available(SwiftStdlib 5.0, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 @_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension Span where Element: ~Copyable {
 

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -39,6 +39,9 @@ SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
 SwiftStdlib 6.2:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
 
+# Like SwiftStdlib 5.0, but also the oldest visionOS from SwiftStdlib 5.10.
+SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1
+
 # Note: This cannot be 9999, so use the last non-placeholder entry instead.
 # This will go away once 'SwiftStdlib 6.2' is filled in.
 SwiftCompatibilitySpan 6.2:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0


### PR DESCRIPTION
Swift CI tests visionOS, but PR testing does not. Oops.