### PR TITLE
[embedded] Add back LosslessStringConvertible to Bool and integer types

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -197,7 +197,6 @@ extension Bool: Hashable {
   }
 }
 
-@_unavailableInEmbedded
 extension Bool: LosslessStringConvertible {
   /// Creates a new Boolean value from the given string.
   ///

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -252,7 +252,7 @@ split_embedded_sources(
   OUT_LIST_NORMAL SWIFTLIB_GYB_SOURCES
 
     NORMAL AtomicInt.swift.gyb
-    NORMAL FloatingPointParsing.swift.gyb
+  EMBEDDED FloatingPointParsing.swift.gyb
   EMBEDDED FloatingPointTypes.swift.gyb
   EMBEDDED IntegerTypes.swift.gyb
   EMBEDDED LegacyInt128.swift.gyb

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1705,12 +1705,6 @@ extension BinaryInteger {
   }
 }
 
-#if !$Embedded
-public typealias _LosslessStringConvertibleOrNone = LosslessStringConvertible
-#else
-public protocol _LosslessStringConvertibleOrNone {}
-#endif
-
 //===----------------------------------------------------------------------===//
 //===--- FixedWidthInteger ------------------------------------------------===//
 //===----------------------------------------------------------------------===//
@@ -1779,7 +1773,7 @@ public protocol _LosslessStringConvertibleOrNone {}
 /// customization points for arithmetic operations. When you provide just those
 /// methods, the standard library provides default implementations for all
 /// other arithmetic methods and operators.
-public protocol FixedWidthInteger: BinaryInteger, _LosslessStringConvertibleOrNone
+public protocol FixedWidthInteger: BinaryInteger, LosslessStringConvertible
 where Magnitude: FixedWidthInteger & UnsignedInteger,
       Stride: FixedWidthInteger & SignedInteger {
   /// The number of bits used for the underlying binary representation of

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -30,8 +30,16 @@ config.environment = dict(config.environment)
 if 'SWIFT_USE_OLD_DRIVER' in config.environment: del config.environment['SWIFT_USE_OLD_DRIVER']
 if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.environment['SWIFT_AVOID_WARNING_USING_OLD_DRIVER']
 
+target_cpu = [y for (x, y) in config.substitutions if x == "%target-cpu"][0]
+target_triple = [y for (x, y) in config.substitutions if x == "%target-triple"][0]
+
 # (5) Provide some useful substitutions to simplify writing tests that work across platforms (macOS, Linux, etc.)
 if "OS=linux-gnu" in config.available_features:
   config.substitutions.append(("%target-embedded-link", config.target_clang + " -x c %S/Inputs/linux-rng-support.c -x none"))
+  config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_cpu}-unknown-linux-gnu/libswiftUnicodeDataTables.a"))
+elif "OS=macosx" in config.available_features:
+  config.substitutions.append(("%target-embedded-link", config.target_clang))
+  config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_cpu}-apple-macos/libswiftUnicodeDataTables.a"))
 else:
   config.substitutions.append(("%target-embedded-link", config.target_clang))
+  config.substitutions.append(("%embedded-unicode-tables", f"-Xlinker {config.swift_obj_root}/lib/swift/embedded/{target_triple}/libswiftUnicodeDataTables.a"))

--- a/test/embedded/stdlib-strings-lossless-convertible.swift
+++ b/test/embedded/stdlib-strings-lossless-convertible.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -wmo %embedded-unicode-tables) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+
+func f<T: LosslessStringConvertible>(t: inout T?, s: String) {
+  t = .init(s)
+}
+
+@main
+struct Main {
+  static func main() {
+    if let b = Bool.init("true"), b == true { print("OK 1") } // CHECK: OK 1
+    var b: Bool?
+    f(t: &b, s: "false")
+    if let b, b == false { print("OK 2") } // CHECK: OK 2
+
+    if let i = Int.init("17"), i == 17 { print("OK 3") } // CHECK: OK 3
+    var i: Int?
+    f(t: &i, s: "777")
+    if let i, i == 777 { print("OK 4") } // CHECK: OK 4
+
+    // TODO: Add float parsing to Embedded Swift that does not rely on libc
+    // if let fl = Float.init("42.42"), fl == 42.42 { print("OK 5") } // XXX: OK 5
+    // var fl: Float?
+    // f(t: &fl, s: "12.34")
+    // if let fl, fl == 12.34 { print("OK 6") } // XXX: OK 6
+  }
+}


### PR DESCRIPTION
Now that String is available in Embedded Swift, we have no reason to exclude LosslessStringConvertible from types. This PR fixes that for Bool and int types (FixedWidthInteger).

rdar://148866128
