### PR TITLE
Tests: Use `-o` instead of stdout redirect in `async_sequence_existential.swift`

### DIFF
--- a/test/Concurrency/async_sequence_existential.swift
+++ b/test/Concurrency/async_sequence_existential.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -emit-sil -o /dev/null -verify
 
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple %s -dump-ast 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -primary-file %s -dump-ast -o %t.ast.txt
+// RUN: %FileCheck %s < %t.ast.txt
 
 // REQUIRES: concurrency
 


### PR DESCRIPTION
This will hopefully prevent random line breaks from being inserted into the `-dump-ast` output and interfering with FileCheck's matching.

Resolves rdar://148855879.
