### PR TITLE
Enable new runtime build in macOS PR testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1627,11 +1627,7 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
         set(stdlib_cache_file_flag -C ${SWIFT_SDK_${sdk}_${arch}_CACHE})
       endif()
 
-      set(stdlib_target_triple ${SWIFT_SDK_${sdk}_ARCH_${arch}_TRIPLE})
-      if(SWIFT_SDK_${sdk}_DEPLOYMENT_VERSION)
-        string(APPEND stdlib_target_triple ${SWIFT_SDK_${sdk}_DEPLOYMENT_VERSION})
-        set(stdlib_deployment_version_flag -DCMAKE_OSX_DEPLOYMENT_TARGET=${SWIFT_SDK_${sdk}_DEPLOYMENT_VERSION})
-      endif()
+      set(stdlib_target_triple ${SWIFT_SDK_${sdk}_${arch}_TRIPLE})
 
       ExternalProject_Add("${stdlib_target}-core"
         SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Runtimes/Core"

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -43,6 +43,7 @@ function(_report_sdk prefix)
   foreach(arch ${SWIFT_SDK_${prefix}_ARCHITECTURES})
     message(STATUS "  ${arch} triple: ${SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE}")
     message(STATUS "  Module triple: ${SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE}")
+    message(STATUS "  Full triple: ${SWIFT_SDK_${prefix}_${arch}_TRIPLE}")
   endforeach()
   if("${prefix}" STREQUAL "WINDOWS")
     foreach(arch ${SWIFT_SDK_${prefix}_ARCHITECTURES})
@@ -258,16 +259,20 @@ macro(configure_sdk_darwin
     set(SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE
         "${arch}-apple-${module_name}")
 
+    set(SWIFT_SDK_${prefix}_${arch}_TRIPLE
+        "${SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE}${SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION}")
     # If this is a simulator target, append -simulator.
     if (SWIFT_SDK_${prefix}_IS_SIMULATOR)
-      set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
-          "${SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE}-simulator")
+      string(APPEND SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE "-simulator")
+      string(APPEND SWIFT_SDK_${prefix}_${arch}_TRIPLE "-simulator")
     endif ()
 
     if(SWIFT_ENABLE_MACCATALYST AND "${prefix}" STREQUAL "OSX")
       # For macCatalyst append the '-macabi' environment to the target triple.
       set(SWIFT_SDK_MACCATALYST_ARCH_${arch}_TRIPLE "${arch}-apple-ios-macabi")
       set(SWIFT_SDK_MACCATALYST_ARCH_${arch}_MODULE "${arch}-apple-ios-macabi")
+      set(SWIFT_SDK_MACCATALYST_${arch}_TRIPLE
+        "${arch}-apple-ios${SWIFT_DARWIN_DEPLOYMENT_VERSION_MACCATALYST}-macabi")
 
       # For macCatalyst, the xcrun_name is "macosx" since it uses that sdk.
       # Hard code the library subdirectory to "maccatalyst" in that case.
@@ -476,6 +481,8 @@ macro(configure_sdk_unix name architectures)
     if(NOT SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE)
       set(SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE "${SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE}")
     endif()
+    set(SWIFT_SDK_${prefix}_${arch}_TRIPLE
+      ${SWIFT_SDK_${prefix}_ARCH_${prefix}_TRIPLE})
   endforeach()
 
   # Add this to the list of known SDKs.
@@ -519,6 +526,7 @@ macro(configure_sdk_windows name environment architectures)
     endif()
 
     set(SWIFT_SDK_${prefix}_ARCH_${arch}_MODULE "${SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE}")
+    set(SWIFT_SDK_${prefix}_${arch}_TRIPLE "${SWIFT_SDK_${prefix}_ARCH_${prefix}_TRIPLE}")
 
     # NOTE: set the path to / to avoid a spurious `--sysroot` from being passed
     # to the driver -- rely on the `INCLUDE` AND `LIB` environment variables

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1717,6 +1717,7 @@ swiftformat
 swiftdocc
 
 build-minimal-stdlib
+enable-new-runtime-build
 
 # Don't generate the SwiftSyntax gyb files. Instead verify that up-to-date ones
 # are checked in.


### PR DESCRIPTION
The new runtime build had been enabled on macOS smoke testing, but not on the full macOS PR testing. Apparently the full PR testing does not run both, even though it checks both check boxes.