### PR TITLE
[cxx-interop] Enable -verify-additional-file tests on Windows

### DIFF
--- a/test/Interop/Cxx/class/access/private-fileid-diagnostics.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-diagnostics.swift
@@ -1,8 +1,5 @@
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend -typecheck -verify -suppress-remarks %t/some/subdir/file1.swift -verify-additional-file %t/Cxx/include/cxx-header.h -I %t/Cxx/include -cxx-interoperability-mode=default -module-name main
-
-// This test uses -verify-additional-file, which do not work well on Windows:
-// UNSUPPORTED: OS=windows-msvc
+// RUN: %target-swift-frontend -typecheck -verify -suppress-remarks %t%{fs-sep}some%{fs-sep}subdir%{fs-sep}file1.swift -verify-additional-file %t%{fs-sep}Cxx%{fs-sep}include%{fs-sep}cxx-header.h -I %t%{fs-sep}Cxx%{fs-sep}include -cxx-interoperability-mode=default -module-name main
 
 //--- Cxx/include/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S%{fs-sep}Inputs %s -enable-experimental-cxx-interop -verify -verify-additional-file %S%{fs-sp}Inputs%{fs-sep}mutability-annotations.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S%{fs-sep}Inputs %s -enable-experimental-cxx-interop -verify -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}mutability-annotations.h
 
 import MutabilityAnnotations
 

--- a/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
+++ b/test/Interop/Cxx/class/mutability-annotations-typechecker.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs %s -enable-experimental-cxx-interop -verify -verify-additional-file %S/Inputs/mutability-annotations.h
-
-// REQUIRES: rdar100876534
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S%{fs-sep}Inputs %s -enable-experimental-cxx-interop -verify -verify-additional-file %S%{fs-sp}Inputs%{fs-sep}mutability-annotations.h
 
 import MutabilityAnnotations
 

--- a/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance-diagnostics.swift
@@ -1,8 +1,5 @@
 // RUN: rm -rf %t
-// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -verify-additional-file %S/Inputs/inheritance.h -Xcc -Wno-return-type -Xcc -Wno-inaccessible-base
-
-// TODO: Fix this lit test failure on windows rdar://145218056
-// XFAIL: OS=windows-msvc
+// RUN: %target-swift-frontend -typecheck -verify -I %S%{fs-sep}Inputs  %s -cxx-interoperability-mode=upcoming-swift -verify-additional-file %S%{fs-sep}Inputs%{fs-sep}inheritance.h -Xcc -Wno-return-type -Xcc -Wno-inaccessible-base
 
 import Inheritance
 


### PR DESCRIPTION
These previously failed because they used '/' as the path separator instead of '\'. While both are accepted on Windows, the latter is preferred and used to construct new paths, such as the path of imported header files. This inconsistency led to distinct buffer ID numbers being created (since paths are not canonicalized in BufferIdentIDMap), leading -verify to fail to associate the error emitted from the included file with the error expected in the -verify-additional-file file.

This patch re-enables these tests but uses %{fs-sep} in place of '/', to ensure the appropriate path separator is used for the platform where the test is run.

rdar://148928101

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
