### PR TITLE
[LLDB] Fix conditional to also support AccessLevel::Open

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -8398,7 +8398,7 @@ void IRGenSILFunction::visitClassMethodInst(swift::ClassMethodInst *i) {
   // debugger.
   bool shouldUseDispatchThunkIfInDebugger =
       !classDecl->getASTContext().LangOpts.DebuggerSupport ||
-      methodAccess == AccessLevel::Public;
+      methodAccess >= AccessLevel::Public;
   if (IGM.hasResilientMetadata(classDecl, ResilienceExpansion::Maximal) &&
       shouldUseDispatchThunkIfInDebugger) {
     shouldUseDispatchThunk = true;


### PR DESCRIPTION
This fixes crashes in LLDB expression evaluation when calling virtual Open functions.

rdar://147797657
(cherry picked from commit f4a0f4b33990a400dffbea1c5eb77e22ac51c934)

See https://github.com/swiftlang/swift/pull/80691

Description: Fixes a crash in LLDB when calling an open resilient function from an expression.

Origination: Introduced by https://github.com/swiftlang/swift/commit/bceb8176dd6f7a64fadef01f51ae1ef1db346c6a

Radar: rdar://147797657

Risk: Low.

Tested: Needs to be tested in LLDB

Reviewed by: @aschwaighofer @augusto2112 @slavapestov 