### PR TITLE
[CoroutineAccessors] Use yield_once_2 on Darwin and Linux.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -338,6 +338,10 @@ public:
   // Whether to allow merging traps and cond_fails.
   bool MergeableTraps = false;
 
+  /// Whether the @yield_once_2 convention is used by accessors added with the
+  /// CoroutineAccessors feature (i.e. read2/modify2).
+  bool CoroutineAccessorsUseYieldOnce2 = false;
+
   SILOptions() {}
 
   /// Return a hash code of any components from these options that should

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1175,6 +1175,12 @@ def enable_arm64_corocc : Flag<["-"], "enable-arm64-corocc">,
 def disable_arm64_corocc : Flag<["-"], "disable-arm64-corocc">,
   HelpText<"Don't use swiftcorocc for yield_once_2 routines on arm64 variants.">;
 
+def enable_callee_allocated_coro_abi : Flag<["-"], "enable-callee-allocated-coro-abi">,
+  HelpText<"Override per-platform settings and use yield_once_2.">;
+
+def disable_callee_allocated_coro_abi : Flag<["-"], "disable-callee-allocated-coro-abi">,
+  HelpText<"Override per-platform settings and don't use yield_once_2.">;
+
 def enable_cond_fail_message_annotation : Flag<["-"], "enable-cond-fail-message-annotation">,
   HelpText<"Enable cond_fail message annotation. Will serialize a .o.yaml file per .o file.">;
 

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -597,6 +597,16 @@ struct SILOptOptions {
       "enable-address-dependencies",
       llvm::cl::desc("Enable enforcement of lifetime dependencies on addressable values."));
 
+  llvm::cl::opt<bool> EnableCalleeAllocatedCoroAbi = llvm::cl::opt<bool>(
+      "enable-callee-allocated-coro-abi",
+      llvm::cl::desc("Override per-platform settings and use yield_once_2."),
+      llvm::cl::init(false));
+  llvm::cl::opt<bool> DisableCalleeAllocatedCoroAbi = llvm::cl::opt<bool>(
+      "disable-callee-allocated-coro-abi",
+      llvm::cl::desc(
+          "Override per-platform settings and don't use yield_once_2."),
+      llvm::cl::init(false));
+
   llvm::cl::opt<bool> MergeableTraps = llvm::cl::opt<bool>(
       "mergeable-traps",
       llvm::cl::desc("Enable cond_fail merging."));
@@ -918,6 +928,10 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
       options.EnablePackMetadataStackPromotion;
 
   SILOpts.EnableAddressDependencies = options.EnableAddressDependencies;
+  if (options.EnableCalleeAllocatedCoroAbi)
+    SILOpts.CoroutineAccessorsUseYieldOnce2 = true;
+  if (options.DisableCalleeAllocatedCoroAbi)
+    SILOpts.CoroutineAccessorsUseYieldOnce2 = false;
   SILOpts.MergeableTraps = options.MergeableTraps;
 
   if (options.OptModeFlag == OptimizationMode::NotSet) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3130,6 +3130,16 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   Opts.EnableAddressDependencies = Args.hasFlag(
       OPT_enable_address_dependencies, OPT_disable_address_dependencies,
       Opts.EnableAddressDependencies);
+
+  if (LangOpts.Target.isOSDarwin() || LangOpts.Target.isOSLinux()) {
+    // On Darwin and Linux, use yield_once_2 by default.
+    Opts.CoroutineAccessorsUseYieldOnce2 = true;
+  }
+  Opts.CoroutineAccessorsUseYieldOnce2 =
+      Args.hasFlag(OPT_enable_callee_allocated_coro_abi,
+                   OPT_disable_callee_allocated_coro_abi,
+                   Opts.CoroutineAccessorsUseYieldOnce2);
+
   Opts.MergeableTraps = Args.hasArg(OPT_mergeable_traps);
 
   return false;

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1855,5 +1855,8 @@ bool SILDeclRef::isCalleeAllocatedCoroutine() const {
   if (!accessor)
     return false;
 
-  return requiresFeatureCoroutineAccessors(accessor->getAccessorKind());
+  if (!requiresFeatureCoroutineAccessors(accessor->getAccessorKind()))
+    return false;
+
+  return getASTContext().SILOpts.CoroutineAccessorsUseYieldOnce2;
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2481,8 +2481,10 @@ static CanSILFunctionType getSILFunctionType(
   
   if (auto accessor = getAsCoroutineAccessor(constant)) {
     auto origAccessor = cast<AccessorDecl>(origConstant->getDecl());
+    auto &ctx = origAccessor->getASTContext();
     coroutineKind =
-        requiresFeatureCoroutineAccessors(accessor->getAccessorKind())
+        (requiresFeatureCoroutineAccessors(accessor->getAccessorKind()) &&
+         ctx.SILOpts.CoroutineAccessorsUseYieldOnce2)
             ? SILCoroutineKind::YieldOnce2
             : SILCoroutineKind::YieldOnce;
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2034,6 +2034,7 @@ public:
       PreparedArguments &&optionalSubscripts,
       SILType addressType, bool isOnSelfParameter);
 
+  bool canUnwindAccessorDeclRef(SILDeclRef accessorRef);
   CleanupHandle emitCoroutineAccessor(SILLocation loc, SILDeclRef accessor,
                                       SubstitutionMap substitutions,
                                       ArgumentSource &&optionalSelfValue,
@@ -2301,8 +2302,9 @@ public:
                                         PreparedArguments &&args, Type overriddenSelfType,
                                         SGFContext ctx);
 
-  CleanupHandle emitBeginApply(SILLocation loc, ManagedValue fn,
-                               SubstitutionMap subs, ArrayRef<ManagedValue> args,
+  CleanupHandle emitBeginApply(SILLocation loc, ManagedValue fn, bool canUnwind,
+                               SubstitutionMap subs,
+                               ArrayRef<ManagedValue> args,
                                CanSILFunctionType substFnType,
                                ApplyOptions options,
                                SmallVectorImpl<ManagedValue> &yields);
@@ -2315,7 +2317,8 @@ public:
   std::tuple<MultipleValueInstructionResult *, CleanupHandle, SILValue,
              CleanupHandle>
   emitBeginApplyWithRethrow(SILLocation loc, SILValue fn, SILType substFnType,
-                            SubstitutionMap subs, ArrayRef<SILValue> args,
+                            bool canUnwind, SubstitutionMap subs,
+                            ArrayRef<SILValue> args,
                             SmallVectorImpl<SILValue> &yields);
   void emitEndApplyWithRethrow(SILLocation loc,
                                MultipleValueInstructionResult *token,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2518,9 +2518,9 @@ namespace {
 
       // Perform the begin_apply.
       SmallVector<ManagedValue, 1> yields;
-      auto cleanup =
-        SGF.emitBeginApply(loc, projectFnRef, subs, { base, keyPathValue },
-                           substFnType, ApplyOptions(), yields);
+      auto cleanup = SGF.emitBeginApply(loc, projectFnRef, /*canUnwind=*/true,
+                                        subs, {base, keyPathValue}, substFnType,
+                                        ApplyOptions(), yields);
 
       // Push an operation to do the end_apply.
       pushEndApplyWriteback(SGF, loc, cleanup, getTypeData());

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -7046,8 +7046,8 @@ SILGenFunction::emitVTableThunk(SILDeclRef base,
   case SILCoroutineKind::YieldOnce2: {
     SmallVector<SILValue, 4> derivedYields;
     auto tokenAndCleanups = emitBeginApplyWithRethrow(
-        loc, derivedRef, SILType::getPrimitiveObjectType(derivedFTy), subs,
-        args, derivedYields);
+        loc, derivedRef, SILType::getPrimitiveObjectType(derivedFTy),
+        canUnwindAccessorDeclRef(base), subs, args, derivedYields);
     auto token = std::get<0>(tokenAndCleanups);
     auto abortCleanup = std::get<1>(tokenAndCleanups);
     auto allocation = std::get<2>(tokenAndCleanups);
@@ -7441,7 +7441,8 @@ void SILGenFunction::emitProtocolWitness(
   case SILCoroutineKind::YieldOnce2: {
     SmallVector<SILValue, 4> witnessYields;
     auto tokenAndCleanups = emitBeginApplyWithRethrow(
-        loc, witnessFnRef, witnessSILTy, witnessSubs, args, witnessYields);
+        loc, witnessFnRef, witnessSILTy, canUnwindAccessorDeclRef(requirement),
+        witnessSubs, args, witnessYields);
     auto token = std::get<0>(tokenAndCleanups);
     auto abortCleanup = std::get<1>(tokenAndCleanups);
     auto allocation = std::get<2>(tokenAndCleanups);

--- a/test/IRGen/coroutine_accessors.swift
+++ b/test/IRGen/coroutine_accessors.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-irgen                                            \
 // RUN:     %s                                                              \
+// RUN:     -enable-callee-allocated-coro-abi                               \
 // RUN:     -enable-experimental-feature CoroutineAccessors                 \
 // RUN: | %IRGenFileCheck %s
 

--- a/test/IRGen/coroutine_accessors_backdeploy_async_56.swift
+++ b/test/IRGen/coroutine_accessors_backdeploy_async_56.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-irgen                                            \
 // RUN:     %s                                                              \
+// RUN:     -enable-callee-allocated-coro-abi                               \
 // RUN:     -module-name backdep                                            \
 // RUN:     -target %target-swift-5.6-abi-triple                            \
 // RUN:     -Onone                                                          \

--- a/test/IRGen/coroutine_accessors_backdeploy_async_57.swift
+++ b/test/IRGen/coroutine_accessors_backdeploy_async_57.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-irgen                                            \
 // RUN:     %s                                                              \
+// RUN:     -enable-callee-allocated-coro-abi                               \
 // RUN:     -module-name backdep                                            \
 // RUN:     -target %target-swift-5.7-abi-triple                            \
 // RUN:     -Onone                                                          \

--- a/test/IRGen/coroutine_accessors_popless.swift
+++ b/test/IRGen/coroutine_accessors_popless.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-emit-irgen                                            \
 // RUN:     %s                                                              \
 // RUN:     -Onone                                                          \
+// RUN:     -enable-callee-allocated-coro-abi                               \
 // RUN:     -enable-experimental-feature CoroutineAccessors                 \
 // RUN:     -enable-arm64-corocc                                            \
 // RUN:     -enable-x86_64-corocc                                           \

--- a/test/IRGen/default_override.sil
+++ b/test/IRGen/default_override.sil
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend \
 // RUN:     %s \
+// RUN:     -enable-callee-allocated-coro-abi \
 // RUN:     -module-name Library \
 // RUN:     -emit-ir \
 // RUN:     -enable-experimental-feature CoroutineAccessors \

--- a/test/IRGen/run-coroutine_accessors.swift
+++ b/test/IRGen/run-coroutine_accessors.swift
@@ -94,8 +94,6 @@
 // UNSUPPORTED: wasm
 // UNSUPPORTED: OS=wasi
 // UNSUPPORTED: CPU=wasm32
-// TODO: CoroutineAccessors: Enable on Windows.
-// UNSUPPORTED: OS=windows-msvc
 
 // REQUIRES: swift_feature_CoroutineAccessors
 

--- a/test/Interpreter/coroutine_accessors_default_implementations.swift
+++ b/test/Interpreter/coroutine_accessors_default_implementations.swift
@@ -5,6 +5,7 @@
 // RUN: %target-swift-frontend \
 // RUN:     %t/Library.swift   \
 // RUN:     %t/LibImpl.underscored.swift   \
+// RUN:     -enable-callee-allocated-coro-abi \
 // RUN:     -emit-module       \
 // RUN:     -module-name Library \
 // RUN:     -parse-as-library  \
@@ -13,6 +14,7 @@
 
 // RUN: %target-swift-frontend \
 // RUN:     %t/Executable.swift \
+// RUN:     -enable-callee-allocated-coro-abi \
 // RUN:     -c \
 // RUN:     -parse-as-library \
 // RUN:     -module-name Executable \
@@ -22,6 +24,7 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(Library)) \
 // RUN:     %t/Library.swift \
 // RUN:     %t/LibImpl.nonunderscored.swift   \
+// RUN:     -Xfrontend -enable-callee-allocated-coro-abi \
 // RUN:     -emit-module \
 // RUN:     -enable-library-evolution \
 // RUN:     -enable-experimental-feature CoroutineAccessors \

--- a/test/Interpreter/coroutine_accessors_old_abi_nounwind.swift
+++ b/test/Interpreter/coroutine_accessors_old_abi_nounwind.swift
@@ -1,0 +1,41 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-callee-allocated-coro-abi -enable-experimental-feature CoroutineAccessors) | %FileCheck %s
+
+// REQUIRES: swift_feature_CoroutineAccessors
+// REQUIRES: executable_test
+
+struct AirOr : Error {
+}
+
+struct Thrower {
+  mutating func doit() throws {
+    throw AirOr()
+  }
+}
+
+struct S {
+  var _thrower = Thrower()
+  var thrower: Thrower {
+    read {
+      yield _thrower
+    }
+    modify {
+      // CHECK: first
+      print("first")
+      yield &_thrower
+      // CHECK: also ran
+      print("also ran")
+    }
+  }
+}
+
+func doit() {
+  do {
+    var s = S()
+    try s.thrower.doit()
+  } catch let error {
+    // CHECK: AirOr
+    print(error)
+  }
+}
+
+doit()

--- a/test/SILGen/coroutine_accessors.swift
+++ b/test/SILGen/coroutine_accessors.swift
@@ -1,11 +1,13 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types                           \
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types   \
 // RUN:     %s                                              \
+// RUN:     -enable-callee-allocated-coro-abi               \
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NOUNWIND
 
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types                                              \
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types                      \
 // RUN:     %s                                                                 \
+// RUN:     -enable-callee-allocated-coro-abi                                  \
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                    \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \

--- a/test/SILGen/coroutine_accessors_new_abi.swift
+++ b/test/SILGen/coroutine_accessors_new_abi.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types   \
+// RUN:     %s                                              \
+// RUN:     -enable-callee-allocated-coro-abi               \
+// RUN:     -enable-library-evolution                       \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NORMAL
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// CHECK: yield_once_2
+
+struct S {
+
+var one: Int = 1
+var i: Int {
+  read {
+    yield one
+  }
+}
+
+}
+

--- a/test/SILGen/coroutine_accessors_old_abi.swift
+++ b/test/SILGen/coroutine_accessors_old_abi.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types   \
+// RUN:     %s                                              \
+// RUN:     -disable-callee-allocated-coro-abi              \
+// RUN:     -enable-library-evolution                       \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NORMAL
+
+// REQUIRES: swift_feature_CoroutineAccessors
+
+// CHECK: yield_once
+// CHECK-NOT: yield_once_2
+
+struct S {
+
+var zero: Int = 0
+var i: Int {
+  read {
+    yield zero
+  }
+}
+
+}

--- a/test/SILGen/coroutine_accessors_skip.swift
+++ b/test/SILGen/coroutine_accessors_skip.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen                            \
 // RUN:     %s                                               \
+// RUN:     -enable-callee-allocated-coro-abi                \
 // RUN:     -experimental-skip-non-inlinable-function-bodies \
 // RUN:     -enable-library-evolution                        \
 // RUN:     -enable-experimental-feature CoroutineAccessors  \
@@ -7,6 +8,7 @@
 
 // RUN: %target-swift-emit-silgen                                              \
 // RUN:     %s                                                                 \
+// RUN:     -enable-callee-allocated-coro-abi                                  \
 // RUN:     -experimental-skip-non-inlinable-function-bodies                   \
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                    \

--- a/test/SILGen/default_override.swift
+++ b/test/SILGen/default_override.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen                           \
 // RUN:     %s                                              \
+// RUN:     -enable-callee-allocated-coro-abi               \
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature BuiltinModule      \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
@@ -7,6 +8,7 @@
 
 // RUN: %target-swift-emit-silgen                           \
 // RUN:     %s                                              \
+// RUN:     -enable-callee-allocated-coro-abi               \
 // RUN:     -enable-experimental-feature BuiltinModule      \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN: | %FileCheck %s --check-prefix=CHECK-FRAGILE

--- a/test/SILGen/read_requirements.swift
+++ b/test/SILGen/read_requirements.swift
@@ -1,11 +1,13 @@
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types                           \
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types   \
 // RUN:     %s                                              \
+// RUN:     -enable-callee-allocated-coro-abi               \
 // RUN:     -enable-library-evolution                       \
 // RUN:     -enable-experimental-feature CoroutineAccessors \
 // RUN: | %FileCheck %s --check-prefixes=CHECK,CHECK-NORMAL,CHECK-%target-abi-stability
 
-// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types                                              \
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types                      \
 // RUN:     %s                                                                 \
+// RUN:     -enable-callee-allocated-coro-abi                                  \
 // RUN:     -enable-library-evolution                                          \
 // RUN:     -enable-experimental-feature CoroutineAccessors                    \
 // RUN:     -enable-experimental-feature CoroutineAccessorsUnwindOnCallerError \

--- a/test/SILOptimizer/devirtualize_coroutine_accessors.sil
+++ b/test/SILOptimizer/devirtualize_coroutine_accessors.sil
@@ -1,5 +1,6 @@
 // RUN: %target-sil-opt \
 // RUN:     -devirtualizer \
+// RUN:     -enable-callee-allocated-coro-abi\
 // RUN:     %s \
 // RUN:     -enable-sil-verify-all \
 // RUN:     -enable-experimental-feature CoroutineAccessors \

--- a/test/TBD/coroutine_accessors.swift
+++ b/test/TBD/coroutine_accessors.swift
@@ -1,5 +1,6 @@
 // RUN: %target-build-swift-dylib(%t/%target-library-name(thing)) \
 // RUN:     %s                                                    \
+// RUN:     -Xfrontend -enable-callee-allocated-coro-abi          \
 // RUN:     -emit-tbd                                             \
 // RUN:     -Xfrontend -validate-tbd-against-ir=all               \
 // RUN:     -enable-library-evolution                             \


### PR DESCRIPTION
Key functions' coroutine kind off the platform and provide optional flags for overriding.

rdar://148941214
