### PR TITLE
[SE-0470] Enable isolated conformances by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,34 @@
   strategy, given that the code would eventually become ambiguous anyways when
   the deployment target is raised.
 
+* [SE-0470][]:
+  A protocol conformance can be isolated to a specific global actor, meaning that the conformance can only be used by code running on that actor. Isolated conformances are expressed by specifying the global actor on the conformance itself:
+
+  ```swift
+  protocol P {
+    func f()
+  }
+
+  @MainActor
+  class MyType: @MainActor P {
+    /*@MainActor*/ func f() {
+      // must be called on the main actor
+    }
+  }
+  ```
+
+  Swift will produce diagnostics if the conformance is directly accessed in code that isn't guaranteed to execute in the same global actor. For example:
+
+  ```swift
+  func acceptP<T: P>(_ value: T) { }
+
+  /*nonisolated*/ func useIsolatedConformance(myType: MyType) {
+    acceptP(myType) // error: main actor-isolated conformance of 'MyType' to 'P' cannot be used in nonisolated context
+  }
+  ```
+
+  To address such issues, only use an isolated conformance from code that executes on the same global actor.
+
 * [SE-0419][]:
   Introduced the new `Runtime` module, which contains a public API that can
   generate backtraces, presently supported on macOS and Linux.  Capturing a
@@ -10759,6 +10787,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 [SE-0442]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0442-allow-taskgroup-childtaskresult-type-to-be-inferred.md
 [SE-0444]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
 [SE-0458]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0458-strict-memory-safety.md
+[SE-0470]: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0470-isolated-conformances.md
 [#64927]: <https://github.com/apple/swift/issues/64927>
 [#42697]: <https://github.com/apple/swift/issues/42697>
 [#42728]: <https://github.com/apple/swift/issues/42728>

--- a/include/swift/AST/ASTContextGlobalCache.h
+++ b/include/swift/AST/ASTContextGlobalCache.h
@@ -55,6 +55,7 @@ struct WitnessIsolationError {
 /// Describes an isolation error involving an associated conformance.
 struct AssociatedConformanceIsolationError {
   ProtocolConformance *isolatedConformance;
+  DiagnosticBehavior behavior = DiagnosticBehavior::Unspecified;
 
   /// Diagnose this associated conformance isolation error.
   void diagnose(const NormalProtocolConformance *conformance) const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8526,10 +8526,6 @@ ERROR(attr_abi_failable_mismatch,none,
 //===----------------------------------------------------------------------===//
 // MARK: Isolated conformances
 //===----------------------------------------------------------------------===//
-GROUPED_ERROR(isolated_conformance_experimental_feature,IsolatedConformances,
-      none,
-      "isolated conformances require experimental feature "
-      " 'IsolatedConformances'", ())
 NOTE(note_isolate_conformance_to_global_actor,none,
      "isolate this conformance to the %select{global actor %0|main actor}1 "
      "with '@%2'", (Type, bool, StringRef))

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -105,6 +105,9 @@ struct ExistentialLayout {
   /// calling this on a temporary is likely to be incorrect.
   ArrayRef<ProtocolDecl*> getProtocols() const && = delete;
 
+  /// Determine whether this refers to any non-marker protocols.
+  bool containsNonMarkerProtocols() const;
+
   ArrayRef<ParameterizedProtocolType *> getParameterizedProtocols() const & {
     return parameterized;
   }

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -376,6 +376,19 @@ public:
   /// the given protocol.
   bool requiresProtocol(Type type, ProtocolDecl *proto) const;
 
+  /// Determine whether a conformance requirement of the given type to the
+  /// given protocol prohibits the use of an isolated conformance.
+  ///
+  /// The use of an isolated conformance to satisfy a requirement T: P is
+  /// prohibited when T is a type parameter and T, or some type that can be
+  /// used to reach T, also conforms to Sendable or SendableMetatype. In that
+  /// case, the conforming type and the protocol (Sendable or SendableMetatype)
+  /// is returned.
+  ///
+  /// If there is no such requirement, returns std::nullopt.
+  std::optional<std::pair<Type, ProtocolDecl *>>
+  prohibitsIsolatedConformance(Type type) const;
+
   /// Determine whether the given dependent type is equal to a concrete type.
   bool isConcreteType(Type type) const;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -255,6 +255,7 @@ LANGUAGE_FEATURE(ValueGenerics, 452, "Value generics feature (integer generics)"
 LANGUAGE_FEATURE(RawIdentifiers, 451, "Raw identifiers")
 LANGUAGE_FEATURE(SendableCompletionHandlers, 463, "Objective-C completion handler parameters are imported as @Sendable")
 LANGUAGE_FEATURE(AsyncExecutionBehaviorAttributes, 0, "@concurrent and nonisolated(nonsending)")
+LANGUAGE_FEATURE(IsolatedConformances, 407, "Global-actor isolated conformances")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -277,6 +278,7 @@ UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
 ADOPTABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
 UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
+UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
 
 // Optional language features / modes
 
@@ -491,12 +493,6 @@ ADOPTABLE_EXPERIMENTAL_FEATURE(AsyncCallerExecution, false)
 
 /// Allow custom availability domains to be defined and referenced.
 EXPERIMENTAL_FEATURE(CustomAvailability, true)
-
-/// Allow isolated conformances.
-EXPERIMENTAL_FEATURE(IsolatedConformances, true)
-
-/// Infer conformance isolation on global-actor-conforming types.
-EXPERIMENTAL_FEATURE(InferIsolatedConformances, true)
 
 /// Allow SwiftSettings
 EXPERIMENTAL_FEATURE(SwiftSettings, false)

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -158,7 +158,7 @@ swift::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
   // If the protocol is SendableMetatype, and there are no non-marker protocol
   // requirements, allow it via self-conformance.
   if (protocol->isSpecificProtocol(KnownProtocolKind::SendableMetatype) &&
-      !containsNonMarkerProtocols(layout.getProtocols()))
+      !layout.containsNonMarkerProtocols())
     return ProtocolConformanceRef(ctx.getSelfConformance(protocol));
 
   // We didn't find our protocol in the existential's list; it doesn't

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -66,6 +66,15 @@ swift::collectExistentialConformances(CanType fromType,
   return fromType->getASTContext().AllocateCopy(conformances);
 }
 
+static bool containsNonMarkerProtocols(ArrayRef<ProtocolDecl *> protocols) {
+  for (auto proto : protocols) {
+    if (!proto->isMarkerProtocol())
+      return true;
+  }
+
+  return false;
+}
+
 ProtocolConformanceRef
 swift::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
   ASTContext &ctx = protocol->getASTContext();
@@ -145,6 +154,12 @@ swift::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
   // concretely.
   if (auto conformance = lookupSuperclassConformance(layout.getSuperclass()))
     return conformance;
+
+  // If the protocol is SendableMetatype, and there are no non-marker protocol
+  // requirements, allow it via self-conformance.
+  if (protocol->isSpecificProtocol(KnownProtocolKind::SendableMetatype) &&
+      !containsNonMarkerProtocols(layout.getProtocols()))
+    return ProtocolConformanceRef(ctx.getSelfConformance(protocol));
 
   // We didn't find our protocol in the existential's list; it doesn't
   // conform.
@@ -377,6 +392,48 @@ static ProtocolConformanceRef getBuiltinFunctionTypeConformance(
   return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
 }
 
+/// Given the instance type of a metatype, determine whether the metatype is
+/// Sendable.
+///
+// Metatypes are generally Sendable, but with isolated conformances we
+// cannot assume that metatypes based on type parameters are Sendable.
+// Therefore, check for conformance to SendableMetatype.
+static bool metatypeWithInstanceTypeIsSendable(Type instanceType) {
+  ASTContext &ctx = instanceType->getASTContext();
+
+  // If we don't have the SendableMetatype protocol at all, just assume all
+  // metatypes are Sendable.
+  auto sendableMetatypeProto =
+      ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+  if (!sendableMetatypeProto)
+    return true;
+
+  // If the instance type is a type parameter, it is not necessarily
+  // SendableMetatype. There will need to be a SendableMetatype requirement,
+  // but we do not have the generic environment to check that.
+  if (instanceType->isTypeParameter())
+    return false;
+
+  // If the instance type conforms to SendableMetatype, then its
+  // metatype is Sendable.
+  auto instanceConformance = lookupConformance(
+      instanceType, sendableMetatypeProto);
+  if (!instanceConformance.isInvalid() &&
+      !instanceConformance.hasMissingConformance())
+    return true;
+
+  // If this is an archetype that is non-SendableMetatype, but there are no
+  // non-marker protocol requirements that could carry conformances, treat
+  // the metatype as Sendable.
+  if (auto archetype = instanceType->getAs<ArchetypeType>()) {
+    if (!containsNonMarkerProtocols(archetype->getConformsTo()))
+      return true;
+  }
+
+  // The instance type is non-Sendable.
+  return false;
+}
+
 /// Synthesize a builtin metatype type conformance to the given protocol, if
 /// appropriate.
 static ProtocolConformanceRef getBuiltinMetaTypeTypeConformance(
@@ -386,30 +443,11 @@ static ProtocolConformanceRef getBuiltinMetaTypeTypeConformance(
   // All metatypes are Copyable, Escapable, and BitwiseCopyable.
   if (auto kp = protocol->getKnownProtocolKind()) {
     switch (*kp) {
-    case KnownProtocolKind::Sendable: {
-      // Metatypes are generally Sendable, but with isolated conformances we
-      // cannot assume that metatypes based on type parameters are Sendable.
-      // Therefore, check for conformance to SendableMetatype.
-      auto sendableMetatypeProto =
-          ctx.getProtocol(KnownProtocolKind::SendableMetatype);
-      if (sendableMetatypeProto) {
-        Type instanceType = metatypeType->getInstanceType();
+    case KnownProtocolKind::Sendable:
+      if (!metatypeWithInstanceTypeIsSendable(metatypeType->getInstanceType()))
+        break;
 
-        // If the instance type is a type parameter, it is not necessarily
-        // Sendable. There will need to be a Sendable requirement.
-        if (instanceType->isTypeParameter())
-          break;
-
-        // If the instance type conforms to SendableMetatype, then its
-        // metatype is Sendable.
-        auto instanceConformance = lookupConformance(
-            instanceType, sendableMetatypeProto);
-        if (instanceConformance.isInvalid() ||
-            instanceConformance.hasMissingConformance())
-          break;
-      }
       LLVM_FALLTHROUGH;
-    }
 
     case KnownProtocolKind::Copyable:
     case KnownProtocolKind::Escapable:

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -386,33 +386,30 @@ static ProtocolConformanceRef getBuiltinMetaTypeTypeConformance(
   // All metatypes are Copyable, Escapable, and BitwiseCopyable.
   if (auto kp = protocol->getKnownProtocolKind()) {
     switch (*kp) {
-    case KnownProtocolKind::Sendable:
+    case KnownProtocolKind::Sendable: {
       // Metatypes are generally Sendable, but with isolated conformances we
       // cannot assume that metatypes based on type parameters are Sendable.
       // Therefore, check for conformance to SendableMetatype.
-      if (ctx.LangOpts.hasFeature(Feature::IsolatedConformances)) {
-        auto sendableMetatypeProto = 
-            ctx.getProtocol(KnownProtocolKind::SendableMetatype);
-        if (sendableMetatypeProto) {
-          Type instanceType = metatypeType->getInstanceType();
+      auto sendableMetatypeProto =
+          ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+      if (sendableMetatypeProto) {
+        Type instanceType = metatypeType->getInstanceType();
 
-          // If the instance type is a type parameter, it is not necessarily
-          // Sendable. There will need to be a Sendable requirement.
-          if (instanceType->isTypeParameter())
-            break;
+        // If the instance type is a type parameter, it is not necessarily
+        // Sendable. There will need to be a Sendable requirement.
+        if (instanceType->isTypeParameter())
+          break;
 
-          // If the instance type conforms to SendableMetatype, then its
-          // metatype is Sendable.
-          auto instanceConformance = lookupConformance(
-              instanceType, sendableMetatypeProto);
-          if (instanceConformance.isInvalid() ||
-              instanceConformance.hasMissingConformance())
-            break;
-        }
-
-        // Every other metatype is Sendable.
+        // If the instance type conforms to SendableMetatype, then its
+        // metatype is Sendable.
+        auto instanceConformance = lookupConformance(
+            instanceType, sendableMetatypeProto);
+        if (instanceConformance.isInvalid() ||
+            instanceConformance.hasMissingConformance())
+          break;
       }
       LLVM_FALLTHROUGH;
+    }
 
     case KnownProtocolKind::Copyable:
     case KnownProtocolKind::Escapable:

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -371,6 +371,44 @@ bool GenericSignatureImpl::requiresProtocol(Type type,
   return getRequirementMachine()->requiresProtocol(type, proto);
 }
 
+std::optional<std::pair<Type, ProtocolDecl *>>
+GenericSignatureImpl::prohibitsIsolatedConformance(Type type) const {
+  type = getReducedType(type);
+
+  if (!type->isTypeParameter())
+    return std::nullopt;
+
+  // An isolated conformance cannot be used in a context where the type
+  // parameter can escape the isolation domain in which the conformance
+  // was formed. To establish this, we look for Sendable or SendableMetatype
+  // requirements on the type parameter itself.
+  ASTContext &ctx = type->getASTContext();
+  auto sendableProto = ctx.getProtocol(KnownProtocolKind::Sendable);
+  auto sendableMetatypeProto =
+      ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+
+  // Check for a conformance requirement to SendableMetatype, which is
+  // implied by Sendable.
+  if (sendableMetatypeProto && requiresProtocol(type, sendableMetatypeProto)) {
+    // Check for a conformance requirement to Sendable and return that if
+    // it exists, because it's more recognizable and specific.
+    if (sendableProto && requiresProtocol(type, sendableProto))
+      return std::make_pair(type, sendableProto);
+
+    return std::make_pair(type, sendableMetatypeProto);
+  }
+
+  // If this is a nested type, also check whether the parent type conforms to
+  // SendableMetatype, because one can derive this type from the parent type.
+  // FIXME: This is not a complete check, because there are other ways in which
+  // one might be able to derive this type. This needs to determine whether
+  // there is any path from a SendableMetatype-conforming type to this type.
+  if (auto depMemTy = type->getAs<DependentMemberType>())
+    return prohibitsIsolatedConformance(depMemTy->getBase());
+
+  return std::nullopt;
+}
+
 /// Determine whether the given dependent type is equal to a concrete type.
 bool GenericSignatureImpl::isConcreteType(Type type) const {
   assert(type->isTypeParameter() && "Expected a type parameter");

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -5006,11 +5006,15 @@ StringRef swift::getNameForParamSpecifier(ParamSpecifier specifier) {
   llvm_unreachable("bad ParamSpecifier");
 }
 
-std::optional<DiagnosticBehavior>
-TypeBase::getConcurrencyDiagnosticBehaviorLimit(DeclContext *declCtx) const {
-  auto *self = const_cast<TypeBase *>(this);
+static std::optional<DiagnosticBehavior>
+getConcurrencyDiagnosticBehaviorLimitRec(
+    Type type, DeclContext *declCtx,
+    llvm::SmallPtrSetImpl<NominalTypeDecl *> &visited) {
+  if (auto *nomDecl = type->getNominalOrBoundGenericNominal()) {
+    // If we have already seen this type, treat it as having no limit.
+    if (!visited.insert(nomDecl).second)
+      return std::nullopt;
 
-  if (auto *nomDecl = self->getNominalOrBoundGenericNominal()) {
     // First try to just grab the exact concurrency diagnostic behavior.
     if (auto result =
             swift::getConcurrencyDiagnosticBehaviorLimit(nomDecl, declCtx)) {
@@ -5021,11 +5025,12 @@ TypeBase::getConcurrencyDiagnosticBehaviorLimit(DeclContext *declCtx) const {
     // merging our fields if we have a struct.
     if (auto *structDecl = dyn_cast<StructDecl>(nomDecl)) {
       std::optional<DiagnosticBehavior> diagnosticBehavior;
-      auto substMap = self->getContextSubstitutionMap();
+      auto substMap = type->getContextSubstitutionMap();
       for (auto storedProperty : structDecl->getStoredProperties()) {
         auto lhs = diagnosticBehavior.value_or(DiagnosticBehavior::Unspecified);
         auto astType = storedProperty->getInterfaceType().subst(substMap);
-        auto rhs = astType->getConcurrencyDiagnosticBehaviorLimit(declCtx);
+        auto rhs = getConcurrencyDiagnosticBehaviorLimitRec(astType, declCtx,
+                                                            visited);
         auto result = lhs.merge(rhs.value_or(DiagnosticBehavior::Unspecified));
         if (result != DiagnosticBehavior::Unspecified)
           diagnosticBehavior = result;
@@ -5036,13 +5041,14 @@ TypeBase::getConcurrencyDiagnosticBehaviorLimit(DeclContext *declCtx) const {
 
   // When attempting to determine the diagnostic behavior limit of a tuple, just
   // merge for each of the elements.
-  if (auto *tupleType = self->getAs<TupleType>()) {
+  if (auto *tupleType = type->getAs<TupleType>()) {
     std::optional<DiagnosticBehavior> diagnosticBehavior;
     for (auto tupleType : tupleType->getElements()) {
       auto lhs = diagnosticBehavior.value_or(DiagnosticBehavior::Unspecified);
 
       auto type = tupleType.getType()->getCanonicalType();
-      auto rhs = type->getConcurrencyDiagnosticBehaviorLimit(declCtx);
+      auto rhs = getConcurrencyDiagnosticBehaviorLimitRec(type, declCtx,
+                                                          visited);
       auto result = lhs.merge(rhs.value_or(DiagnosticBehavior::Unspecified));
       if (result != DiagnosticBehavior::Unspecified)
         diagnosticBehavior = result;
@@ -5050,7 +5056,21 @@ TypeBase::getConcurrencyDiagnosticBehaviorLimit(DeclContext *declCtx) const {
     return diagnosticBehavior;
   }
 
-  return {};
+  // Metatypes that aren't Sendable were introduced in Swift 6.2, so downgrade
+  // them to warnings prior to Swift 7.
+  if (type->is<AnyMetatypeType>()) {
+    if (!type->getASTContext().LangOpts.isSwiftVersionAtLeast(7))
+      return DiagnosticBehavior::Warning;
+  }
+
+  return std::nullopt;
+}
+
+std::optional<DiagnosticBehavior>
+TypeBase::getConcurrencyDiagnosticBehaviorLimit(DeclContext *declCtx) const {
+  auto *self = const_cast<TypeBase *>(this);
+  llvm::SmallPtrSet<NominalTypeDecl *, 16> visited;
+  return getConcurrencyDiagnosticBehaviorLimitRec(Type(self), declCtx, visited);
 }
 
 GenericTypeParamKind

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1186,6 +1186,15 @@ bool ExistentialLayout::isExistentialWithError(ASTContext &ctx) const {
   return false;
 }
 
+bool ExistentialLayout::containsNonMarkerProtocols() const {
+  for (auto proto : getProtocols()) {
+    if (!proto->isMarkerProtocol())
+      return true;
+  }
+
+  return false;
+}
+
 LayoutConstraint ExistentialLayout::getLayoutConstraint() const {
   if (hasExplicitAnyObject) {
     return LayoutConstraint::getLayoutConstraint(

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -167,9 +167,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
     Diag<> MessageID, ParseTypeReason reason) {
   ParserResult<TypeRepr> ty;
 
-  if (isParameterSpecifier() &&
-      !(!Context.LangOpts.hasFeature(Feature::IsolatedConformances) &&
-        Tok.isContextualKeyword("isolated"))) {
+  if (isParameterSpecifier()) {
     // Type specifier should already be parsed before here. This only happens
     // for construct like 'P1 & inout P2'.
     diagnose(Tok.getLoc(), diag::attr_only_on_parameters, Tok.getRawText());

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -18,6 +18,7 @@
 #include "ExitableFullExpr.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/AST/ConformanceLookup.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/TypeLowering.h"
@@ -302,6 +303,15 @@ namespace {
       return CastStrategy::Address;
     }
 
+    static bool containsNonMarkerProtocols(ArrayRef<ProtocolDecl *> protocols) {
+      for (auto proto : protocols) {
+        if (!proto->isMarkerProtocol())
+          return true;
+      }
+
+      return false;
+    }
+
     CastingIsolatedConformances computedIsolatedConformances() const {
       // Non-existential types don't carry conformances, so we always allow
       // isolated conformances.
@@ -309,7 +319,7 @@ namespace {
         return CastingIsolatedConformances::Allow;
 
       // If there is a conformance to SendableMetatype, then this existential
-      // can leave the current isolation domain. Prohibit isolated conformances.
+      // can leave the current isolation domain.
       ASTContext &ctx = TargetType->getASTContext();
       Type checkType;
       if (auto existentialMetatype = TargetType->getAs<ExistentialMetatypeType>())
@@ -317,6 +327,14 @@ namespace {
       else
         checkType = TargetType;
 
+      // If there are no non-marker protocols in the existential, there's no
+      // need to prohibit isolated conformances.
+      auto layout = checkType->getExistentialLayout();
+      if (!containsNonMarkerProtocols(layout.getProtocols()))
+        return CastingIsolatedConformances::Allow;
+
+      // If the type conforms to SendableMetatype, prohibit isolated
+      // conformances.
       auto proto = ctx.getProtocol(KnownProtocolKind::SendableMetatype);
       if (proto && lookupConformance(checkType, proto, /*allowMissing=*/false))
         return CastingIsolatedConformances::Prohibit;

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -303,15 +303,6 @@ namespace {
       return CastStrategy::Address;
     }
 
-    static bool containsNonMarkerProtocols(ArrayRef<ProtocolDecl *> protocols) {
-      for (auto proto : protocols) {
-        if (!proto->isMarkerProtocol())
-          return true;
-      }
-
-      return false;
-    }
-
     CastingIsolatedConformances computedIsolatedConformances() const {
       // Non-existential types don't carry conformances, so we always allow
       // isolated conformances.
@@ -330,7 +321,7 @@ namespace {
       // If there are no non-marker protocols in the existential, there's no
       // need to prohibit isolated conformances.
       auto layout = checkType->getExistentialLayout();
-      if (!containsNonMarkerProtocols(layout.getProtocols()))
+      if (!layout.containsNonMarkerProtocols())
         return CastingIsolatedConformances::Allow;
 
       // If the type conforms to SendableMetatype, prohibit isolated

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1949,7 +1949,7 @@ namespace {
             solution.setExprTypes(base);
             auto capture = new (ctx) VarDecl(/*static*/ false,
                                              VarDecl::Introducer::Let,
-                                             SourceLoc(),
+                                             base->getEndLoc(),
                                              ctx.getIdentifier("$base$"),
                                              dc);
             capture->setImplicit();

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7995,7 +7995,8 @@ namespace {
           firstConformance->getIsolation(),
           firstConformance->getType(),
           firstConformance->getProtocol()->getName(),
-          getContextIsolation());
+          getContextIsolation())
+        .warnUntilSwiftVersion(6);
       return true;
     }
   };

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -878,6 +878,12 @@ SendableCheckContext::preconcurrencyBehavior(
   return std::nullopt;
 }
 
+std::optional<DiagnosticBehavior>
+SendableCheckContext::preconcurrencyBehavior(Type type) const {
+  return type->getConcurrencyDiagnosticBehaviorLimit(
+      const_cast<DeclContext *>(fromDC));
+}
+
 static bool shouldDiagnosePreconcurrencyImports(SourceFile &sf) {
   switch (sf.Kind) {
   case SourceFileKind::Interface:
@@ -6671,8 +6677,7 @@ static bool checkSendableInstanceStorage(
           propertyType, context,
           /*inDerivedConformance*/Type(), property->getLoc(),
           [&](Type type, DiagnosticBehavior behavior) {
-            auto preconcurrency =
-                context.preconcurrencyBehavior(type->getAnyNominal());
+            auto preconcurrency = context.preconcurrencyBehavior(type);
             if (isImplicitSendableCheck(check)) {
               // If this is for an externally-visible conformance, fail.
               if (check == SendableCheck::ImplicitForExternallyVisible) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3020,10 +3020,9 @@ namespace {
       // FIXME: When passing to a sending parameter, should this be handled
       // by region isolation? Or should it always be handled by region
       // isolation?
-      if (ctx.LangOpts.hasFeature(Feature::IsolatedConformances) &&
-          (mayExecuteConcurrentlyWith(
+      if (mayExecuteConcurrentlyWith(
               localFunc.getAsDeclContext(), getDeclContext()) ||
-           (explicitClosure && explicitClosure->isPassedToSendingParameter()))) {
+          (explicitClosure && explicitClosure->isPassedToSendingParameter())) {
         GenericSignature genericSig;
         if (auto afd = localFunc.getAbstractFunctionDecl())
           genericSig = afd->getGenericSignature();
@@ -7917,8 +7916,6 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
 
   auto dc = rootNormal->getDeclContext();
   ASTContext &ctx = dc->getASTContext();
-  if (!ctx.LangOpts.hasFeature(Feature::IsolatedConformances))
-    return ActorIsolation::forNonisolated(false);
 
   // If the protocol itself is isolated, don't infer isolation for the
   // conformance.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3023,9 +3023,13 @@ namespace {
       if (mayExecuteConcurrentlyWith(
               localFunc.getAsDeclContext(), getDeclContext()) ||
           (explicitClosure && explicitClosure->isPassedToSendingParameter())) {
-        GenericSignature genericSig;
-        if (auto afd = localFunc.getAbstractFunctionDecl())
-          genericSig = afd->getGenericSignature();
+        auto innermostGenericDC = localFunc.getAsDeclContext();
+        while (innermostGenericDC && !innermostGenericDC->isGenericContext())
+          innermostGenericDC = innermostGenericDC->getParent();
+
+        GenericSignature genericSig = innermostGenericDC
+            ? innermostGenericDC->getGenericSignatureOfContext()
+            : GenericSignature();
 
         for (const auto &capturedType :
                  localFunc.getCaptureInfo().getCapturedTypes()) {
@@ -3036,8 +3040,6 @@ namespace {
                 ->getDepth();
           } else if (type->isTypeParameter()) {
             genericDepth = type->getRootGenericParam()->getDepth();
-
-            type = localFunc.getAsDeclContext()->mapTypeIntoContext(type);
           } else {
             continue;
           }
@@ -3047,6 +3049,9 @@ namespace {
           if (genericSig.getNextDepth() > 0 &&
               genericDepth < genericSig.getNextDepth() - 1)
             continue;
+
+          if (type->isTypeParameter() && innermostGenericDC)
+            type = innermostGenericDC->mapTypeIntoContext(type);
 
           // Check that the metatype is sendable.
           SendableCheckContext sendableContext(getDeclContext(), preconcurrency);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7928,7 +7928,7 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
     return ActorIsolation::forNonisolated(false);
 
   // If we are inferring isolated conformances and the conforming type is
-  // isolated to a global actor,
+  // isolated to a global actor, use the conforming type's isolation.
   auto nominal = dc->getSelfNominalTypeDecl();
   if (ctx.LangOpts.hasFeature(Feature::InferIsolatedConformances) &&
       nominal) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6721,8 +6721,7 @@ static bool checkSendableInstanceStorage(
           elementType, context,
           /*inDerivedConformance*/Type(), element->getLoc(),
           [&](Type type, DiagnosticBehavior behavior) {
-            auto preconcurrency =
-                context.preconcurrencyBehavior(type->getAnyNominal());
+            auto preconcurrency = context.preconcurrencyBehavior(type);
             if (isImplicitSendableCheck(check)) {
               // If this is for an externally-visible conformance, fail.
               if (check == SendableCheck::ImplicitForExternallyVisible) {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1064,17 +1064,19 @@ CheckGenericArgumentsResult TypeChecker::checkGenericArgumentsForDiagnostics(
       break;
     }
 
-    if (!isolatedConformances.empty()) {
+    if (!isolatedConformances.empty() && signature) {
       // Dig out the original type parameter for the requirement.
       // FIXME: req might not be the right pre-substituted requirement,
       // if this came from a conditional requirement.
-      if (auto failedProtocol =
-              typeParameterProhibitsIsolatedConformance(req.getFirstType(),
-                                                        signature)) {
-          return CheckGenericArgumentsResult::createIsolatedConformanceFailure(
-            req, substReq,
-            TinyPtrVector<ProtocolConformanceRef>(isolatedConformances),
-            *failedProtocol);
+      for (const auto &isolatedConformance : isolatedConformances) {
+        (void)isolatedConformance;
+        if (auto failed =
+                signature->prohibitsIsolatedConformance(req.getFirstType())) {
+            return CheckGenericArgumentsResult::createIsolatedConformanceFailure(
+              req, substReq,
+              TinyPtrVector<ProtocolConformanceRef>(isolatedConformances),
+              failed->second);
+        }
       }
     }
   }
@@ -1180,29 +1182,4 @@ Type StructuralTypeRequest::evaluate(Evaluator &evaluator,
   }
 
   return TypeAliasType::get(typeAlias, parent, genericArgs, result);
-}
-
-std::optional<ProtocolDecl *> swift::typeParameterProhibitsIsolatedConformance(
-    Type type, GenericSignature signature) {
-  if (!type->isTypeParameter())
-    return std::nullopt;
-
-  // An isolated conformance cannot be used in a context where the type
-  // parameter can escape the isolation domain in which the conformance
-  // was formed. To establish this, we look for Sendable or SendableMetatype
-  // requirements on the type parameter itself.
-  ASTContext &ctx = type->getASTContext();
-  auto sendableProto = ctx.getProtocol(KnownProtocolKind::Sendable);
-  auto sendableMetatypeProto =
-      ctx.getProtocol(KnownProtocolKind::SendableMetatype);
-
-  if (sendableProto &&
-      signature->requiresProtocol(type, sendableProto))
-    return sendableProto;
-
-  if (sendableMetatypeProto &&
-          signature->requiresProtocol(type, sendableMetatypeProto))
-    return sendableMetatypeProto;
-
-  return std::nullopt;
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2567,13 +2567,6 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
       ComplainLoc, diag::unchecked_conformance_not_special, ProtoType);
   }
 
-  // Complain if the global-actor-isolated conformances are not enabled.
-  if (conformance->isIsolated() &&
-      !Context.LangOpts.hasFeature(Feature::IsolatedConformances)) {
-    Context.Diags.diagnose(
-        ComplainLoc, diag::isolated_conformance_experimental_feature);
-  }
-  
   bool allowImpliedConditionalConformance = false;
   if (Proto->isSpecificProtocol(KnownProtocolKind::Sendable)) {
     // In -swift-version 5 mode, a conditional conformance to a protocol can imply
@@ -4994,8 +4987,7 @@ static void diagnoseConformanceIsolationErrors(
     }
 
     // Suggest isolating the conformance, if possible.
-    if (ctx.LangOpts.hasFeature(Feature::IsolatedConformances) &&
-        potentialIsolation && potentialIsolation->isGlobalActor() &&
+    if (potentialIsolation && potentialIsolation->isGlobalActor() &&
         !conformance->isIsolated()) {
       bool isMainActor = false;
       Type globalActorIsolation = potentialIsolation->getGlobalActor();

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1535,14 +1535,6 @@ bool maybeDiagnoseMissingImportForMember(const ValueDecl *decl,
 /// source file.
 void diagnoseMissingImports(SourceFile &sf);
 
-/// Determine whether the type parameter has requirements that would prohibit
-/// it from using any isolated conformances.
-///
-/// Returns the protocol to which the type conforms that causes the conflict,
-/// which can be either Sendable or SendableMetatype.
-std::optional<ProtocolDecl *> typeParameterProhibitsIsolatedConformance(
-    Type type, GenericSignature signature);
-
 } // end namespace swift
 
 #endif

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1230,8 +1230,8 @@ void ConstraintSystem::openGenericRequirement(
 
     // Check whether the given type parameter has requirements that
     // prohibit it from using an isolated conformance.
-    if (typeParameterProhibitsIsolatedConformance(req.getFirstType(),
-                                                  signature))
+    if (signature &&
+        signature->prohibitsIsolatedConformance(req.getFirstType()))
       prohibitIsolatedConformance = true;
 
     openedReq = Requirement(kind, openedFirst, req.getSecondType());

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -849,19 +849,27 @@ FunctionType *ConstraintSystem::adjustFunctionTypeForConcurrency(
       } else if (numApplies < decl->getNumCurryLevels() &&
                  decl->hasCurriedSelf() ) {
         auto shouldMarkMemberTypeSendable = [&]() {
-          // Static member types are @Sendable on both levels because
-          // they only capture a metatype "base" that is always Sendable.
-          // For example, `(S.Type) -> () -> Void`.
-          if (!decl->isInstanceMember())
-            return true;
+          Type capturedBaseType = baseType;
 
-          // For instance members we need to check whether instance type
-          // is Sendable because @Sendable function values cannot capture
-          // non-Sendable values (base instance type in this case).
-          // For example, `(C) -> () -> Void` where `C` should be Sendable
-          // for the inner function type to be Sendable as well.
-          return baseType &&
-                 baseType->getMetatypeInstanceType()->isSendableType();
+          if (!decl->isInstanceMember()) {
+            // Static member types are Sendable when the metatype of their
+            // base type is Sendable, because they capture that metatype.
+            // For example, `(S.Type) -> () -> Void`.
+            if (!capturedBaseType)
+              capturedBaseType = decl->getDeclContext()->getSelfTypeInContext();
+
+            if (!capturedBaseType->is<AnyMetatypeType>())
+              capturedBaseType = MetatypeType::get(capturedBaseType);
+          } else if (capturedBaseType) {
+            // For instance members we need to check whether instance type
+            // is Sendable because @Sendable function values cannot capture
+            // non-Sendable values (base instance type in this case).
+            // For example, `(C) -> () -> Void` where `C` should be Sendable
+            // for the inner function type to be Sendable as well.
+            capturedBaseType = capturedBaseType->getMetatypeInstanceType();
+          }
+
+          return capturedBaseType && capturedBaseType->isSendableType();
         };
 
         auto referenceTy = adjustedTy->getResult()->castTo<FunctionType>();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1058,8 +1058,11 @@ ProtocolConformanceDeserializer::readNormalProtocolConformance(
   auto globalActorType = globalActorTypeOrError.get();
 
   TypeExpr *globalActorTypeExpr = nullptr;
-  if (globalActorType)
+  if (globalActorType) {
     globalActorTypeExpr = TypeExpr::createImplicit(globalActorType, ctx);
+    rawOptions |=
+        static_cast<unsigned>(ProtocolConformanceFlags::GlobalActorIsolated);
+  }
 
   auto conformance = ctx.getNormalConformance(
       conformingType, proto, SourceLoc(), dc,

--- a/test/Concurrency/Runtime/isolated_conformance.swift
+++ b/test/Concurrency/Runtime/isolated_conformance.swift
@@ -1,9 +1,8 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature IsolatedConformances -target %target-swift-5.1-abi-triple) | %FileCheck %s
+// RUN: %target-run-simple-swift(-target %target-swift-5.1-abi-triple) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
-// REQUIRES: swift_feature_IsolatedConformances
 // UNSUPPORTED: back_deployment_runtime
 
 // FIXME: WebAssembly doesn't currently have a good way to install the

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -305,7 +305,7 @@ var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil // expected-wa
 // ----------------------------------------------------------------------
 func acceptConcurrentUnary<T>(_: @Sendable (T) -> T) { }
 
-func concurrentClosures<T>(_: T) { // expected-note{{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{26-26=: Sendable}}
+func concurrentClosures<T: SendableMetatype>(_: T) { // expected-note{{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{44-44= & Sendable}}
   acceptConcurrentUnary { (x: T) in
     _ = x // ok
     acceptConcurrentUnary { _ in x } // expected-warning{{capture of 'x' with non-sendable type 'T' in a '@Sendable' closure}}

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -127,6 +127,7 @@ protocol Interface {
 @MainActor
 class Object: Interface {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{15-15=@preconcurrency }}
+  // expected-note@-2{{isolate this conformance to the main actor with '@MainActor'}}
 
   var baz: Int = 42 // expected-note{{main actor-isolated property 'baz' cannot satisfy nonisolated requirement}}
 }

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -207,6 +207,7 @@ protocol InferenceConflictWithSuperclass: MainActorSuperclass, InferSomeGlobalAc
 class C2: MainActorSuperclass, InferenceConflictWithSuperclass {
   //expected-note@-1 {{turn data races into runtime errors with '@preconcurrency'}}
   // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
+  // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
 
   func f() {}
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances %s
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 5 -strict-concurrency=complete -enable-experimental-feature IsolatedConformances %s
 
 // REQUIRES: swift_feature_IsolatedConformances
 // REQUIRES: concurrency
@@ -11,7 +11,7 @@ protocol P {
 // Definition of isolated conformances
 // ----------------------------------------------------------------------------
 
-// expected-error@+4{{conformance of 'CWithNonIsolated' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
+// expected-warning@+4{{conformance of 'CWithNonIsolated' to protocol 'P' crosses into main actor-isolated code and can cause data races}}
 // expected-note@+3{{mark all declarations used in the conformance 'nonisolated'}}
 // expected-note@+2{{isolate this conformance to the main actor with '@MainActor'}}{{25-25=@MainActor }}
 @MainActor
@@ -54,7 +54,7 @@ protocol Q {
   associatedtype A: P
 }
 
-// expected-error@+2{{conformance of 'SMissingIsolation' to protocol 'Q' crosses into main actor-isolated code and can cause data races}}
+// expected-warning@+2{{conformance of 'SMissingIsolation' to protocol 'Q' crosses into main actor-isolated code and can cause data races}}
 @MainActor
 struct SMissingIsolation: Q {
   // expected-note@-1{{conformance depends on main actor-isolated conformance of 'C' to protocol 'P'}}
@@ -66,7 +66,7 @@ struct PWrapper<T: P>: P {
   func f() { }
 }
 
-// expected-error@+2{{conformance of 'SMissingIsolationViaWrapper' to protocol 'Q' crosses into main actor-isolated code and can cause data races}}
+// expected-warning@+2{{conformance of 'SMissingIsolationViaWrapper' to protocol 'Q' crosses into main actor-isolated code and can cause data races}}
 @MainActor
 struct SMissingIsolationViaWrapper: Q {
   // expected-note@-1{{conformance depends on main actor-isolated conformance of 'C' to protocol 'P'}}
@@ -84,7 +84,7 @@ struct S: @MainActor Q {
   typealias A = C
 }
 
-// expected-error@+3{{conformance of 'SMismatchedActors' to protocol 'Q' crosses into global actor 'SomeGlobalActor'-isolated code and can cause data races}}
+// expected-warning@+3{{conformance of 'SMismatchedActors' to protocol 'Q' crosses into global actor 'SomeGlobalActor'-isolated code and can cause data races}}
 // expected-note@+2{{conformance depends on global actor 'SomeGlobalActor'-isolated conformance of 'C2' to protocol 'P'}}
 @MainActor
 struct SMismatchedActors: @MainActor Q {
@@ -149,9 +149,9 @@ func testIsolatedConformancesOfOtherGlobalActor(c: CMismatchedIsolation) {
 }
 
 func testIsolationConformancesFromOutside(c: C) {
-  acceptP(c) // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
-  let _: any P = c // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
-  let _ = PWrapper<C>() // expected-error{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  acceptP(c) // expected-warning{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  let _: any P = c // expected-warning{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
+  let _ = PWrapper<C>() // expected-warning{{main actor-isolated conformance of 'C' to 'P' cannot be used in nonisolated context}}
 }
 
 protocol HasAssociatedType {

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 5 -strict-concurrency=complete -enable-experimental-feature IsolatedConformances %s
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 5 -strict-concurrency=complete %s
 
-// REQUIRES: swift_feature_IsolatedConformances
 // REQUIRES: concurrency
 
 protocol P {

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances -default-isolation MainActor %s
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -default-isolation MainActor %s
 
-// REQUIRES: swift_feature_IsolatedConformances
 // REQUIRES: concurrency
 
 nonisolated

--- a/test/Concurrency/isolated_conformance_inference.swift
+++ b/test/Concurrency/isolated_conformance_inference.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature InferIsolatedConformances %s
 
 // REQUIRES: concurrency
+// REQUIRES: swift_feature_InferIsolatedConformances
 
 protocol P {
   func f()

--- a/test/Concurrency/isolated_conformance_inference.swift
+++ b/test/Concurrency/isolated_conformance_inference.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances -enable-experimental-feature InferIsolatedConformances %s
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature InferIsolatedConformances %s
 
-// REQUIRES: swift_feature_IsolatedConformances
-// REQUIRES: swift_feature_InferIsolatedConformances
 // REQUIRES: concurrency
 
 protocol P {

--- a/test/Concurrency/preconcurrency_conformances.swift
+++ b/test/Concurrency/preconcurrency_conformances.swift
@@ -108,6 +108,7 @@ final class K : @preconcurrency Initializable {
 final class MainActorK: Initializable {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}{{25-25=@preconcurrency }}
   // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
+  // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
   init() { } // expected-note{{main actor-isolated initializer 'init()' cannot satisfy nonisolated requirement}}
 }
 
@@ -236,6 +237,7 @@ do {
     // expected-warning@-1:21 {{@preconcurrency attribute on conformance to 'P3' has no effect}}
     // expected-note@-2:45 {{turn data races into runtime errors with '@preconcurrency'}}
     // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
+    // expected-note@-4{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
   }
@@ -244,6 +246,7 @@ do {
     // expected-warning@-1:21 {{@preconcurrency attribute on conformance to 'P3' has no effect}}
     // expected-note@-2:25 {{turn data races into runtime errors with '@preconcurrency'}}
     // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
+    // expected-note@-4{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
   }
@@ -304,6 +307,7 @@ do {
     // expected-warning@-1:21 {{@preconcurrency attribute on conformance to 'P5' has no effect}}
     // expected-note@-2{{turn data races into runtime errors with '@preconcurrency'}}
     // expected-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
+    // expected-note@-4{{isolate this conformance to the main actor with '@MainActor'}}
     func foo() {}
     // expected-note@-1 {{main actor-isolated instance method 'foo()' cannot satisfy nonisolated requirement}}
   }

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -234,6 +234,7 @@ extension MainActorPreconcurrency: NotIsolated {
   // expected-complete-note@-1{{add '@preconcurrency' to the 'NotIsolated' conformance to suppress isolation-related diagnostics}}{{36-36=@preconcurrency }}
   // expected-complete-tns-note@-2{{turn data races into runtime errors with '@preconcurrency'}}{{36-36=@preconcurrency }}
   // expected-complete-tns-note@-3{{mark all declarations used in the conformance 'nonisolated'}}
+  // expected-complete-tns-note@-4{{isolate this conformance to the main actor with '@MainActor'}}
   func requirement() {}
   // expected-complete-tns-note@-1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
   // expected-complete-tns-note@-2 {{calls to instance method 'requirement()' from outside of its actor context are implicitly asynchronous}}

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -19,14 +19,14 @@ func acceptMetaOnMainActor<T>(_: T.Type) { }
 // -------------------------------------------------------------------------
 nonisolated func staticCallThroughMetaSmuggled<T: Q>(_: T.Type) {
   let x: Q.Type = T.self
-  Task.detached { // expected-error{{risks causing data races}}
+  Task.detached { // expected-warning{{risks causing data races}}
     x.g() // expected-note{{closure captures 'x' which is accessible to code in the current task}}
   }
 }
 
 nonisolated func passMetaSmuggled<T: Q>(_: T.Type) {
   let x: Q.Type = T.self
-  Task.detached { // expected-error{{risks causing data races}}
+  Task.detached { // expected-warning{{risks causing data races}}
     acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
   }
 }
@@ -79,7 +79,7 @@ nonisolated func passSendableToMainActorSmuggledAny<T: Sendable>(_: T.Type) asyn
 // -------------------------------------------------------------------------
 nonisolated func passMetaSmuggledAnyFromExistential(_ pqT: (P & Q).Type) {
   let x: P.Type = pqT
-  Task.detached { // expected-error{{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
+  Task.detached { // expected-warning{{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
     acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
   }
 }

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -1,7 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature IsolatedConformances -emit-sil -o /dev/null
+// RUN: %target-typecheck-verify-swift -swift-version 6 -emit-sil -o /dev/null
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_IsolatedConformances
 
 
 protocol Q {

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -2,6 +2,8 @@
 
 // REQUIRES: concurrency
 
+protocol P {
+}
 
 protocol Q {
   static func g()
@@ -31,15 +33,21 @@ nonisolated func passMetaSmuggled<T: Q>(_: T.Type) {
 
 nonisolated func passMetaSmuggledAny<T: Q>(_: T.Type) {
   let x: Any.Type = T.self
-  Task.detached { // expected-error{{risks causing data races}}
-    acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
+  Task.detached {
+    acceptMeta(x)
+  }
+}
+
+nonisolated func captureThroughMetaValMoReqs<T>(_: T.Type) {
+  let x = T.self
+  Task.detached {
+    _ = x
   }
 }
 
 nonisolated func passToMainActorSmuggledAny<T: Q>(_: T.Type) async {
   let x: Any.Type = T.self
-  await acceptMetaOnMainActor(x) // expected-error{{sending value of non-Sendable type '(Any).Type' risks causing data races}}
-  // expected-note@-1{{sending task-isolated value of non-Sendable type '(Any).Type' to main actor-isolated global function}}
+  await acceptMetaOnMainActor(x)
 }
 
 // -------------------------------------------------------------------------
@@ -69,9 +77,9 @@ nonisolated func passSendableToMainActorSmuggledAny<T: Sendable>(_: T.Type) asyn
 // -------------------------------------------------------------------------
 // Existential opening
 // -------------------------------------------------------------------------
-nonisolated func passMetaSmuggledAnyFromExistential(_ qT: Q.Type) {
-  let x: Any.Type = qT
-  Task.detached { // expected-error{{risks causing data races}}
+nonisolated func passMetaSmuggledAnyFromExistential(_ pqT: (P & Q).Type) {
+  let x: P.Type = pqT
+  Task.detached { // expected-error{{passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure}}
     acceptMeta(x) // expected-note{{closure captures 'x' which is accessible to code in the current task}}
   }
 }

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -87,3 +87,15 @@ nonisolated func passMetaWithMetaSendableVal<T: SendableMetatype & Q>(_: T.Type)
     x.g() // okay, because T is Sendable implies T.Type: Sendable
   }
 }
+
+struct GenericThingy<Element> {
+  func searchMe(_: (Element, Element) -> Bool) { }
+
+  func test() where Element: Comparable {
+    // Ensure that this we infer a non-@Sendable function type for Comparable.<
+    searchMe(<)
+
+    let _: (Element, Element) -> Bool = (>)
+    let _: @Sendable (Element, Element) -> Bool = (>) // expected-error{{converting non-sendable function value to '@Sendable (Element, Element) -> Bool' may introduce data races}}
+  }
+}

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -1,7 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature IsolatedConformances
+// RUN: %target-typecheck-verify-swift -swift-version 6
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_IsolatedConformances
 
 // This test checks for typecheck-only diagnostics involving non-sendable
 // metatypes.

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -117,3 +117,11 @@ class Holder: @unchecked Sendable {
     2: String.self,
   ]
 }
+
+enum E: Sendable {
+case q(Q.Type, Int) // expected-warning{{associated value 'q' of 'Sendable'-conforming enum 'E' has non-sendable type 'any Q.Type'}}
+}
+
+struct S: Sendable {
+  var tuple: ([Q.Type], Int) // expected-warning{{stored property 'tuple' of 'Sendable'-conforming struct 'S' has non-sendable type '([any Q.Type], Int)'}}
+}

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -9,12 +9,28 @@ protocol Q {
   static func g()
 }
 
+
+// Sendability of existential metatypes
+fileprivate nonisolated let anyObjectArray: [AnyClass] = []
+
+func testSendableExistential() {
+  _ = anyObjectArray
+}
+
+
 nonisolated func acceptMeta<T>(_: T.Type) { }
 
 nonisolated func staticCallThroughMetaVal<T: Q>(_: T.Type) {
   let x = T.self // expected-error{{capture of non-sendable type 'T.Type' in an isolated closure}}
   Task.detached {
     x.g() // expected-error{{capture of non-sendable type 'T.Type' in an isolated closure}}
+  }
+}
+
+nonisolated func captureThroughMetaValMoReqs<T>(_: T.Type) {
+  let x = T.self
+  Task.detached {
+    _ = x
   }
 }
 

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -125,3 +125,25 @@ case q(Q.Type, Int) // expected-warning{{associated value 'q' of 'Sendable'-conf
 struct S: Sendable {
   var tuple: ([Q.Type], Int) // expected-warning{{stored property 'tuple' of 'Sendable'-conforming struct 'S' has non-sendable type '([any Q.Type], Int)'}}
 }
+
+extension Q {
+  static func h() -> Self { }
+}
+
+extension Array: Q where Element: Q {
+  static func g() { }
+}
+
+struct GenericS<T> { }
+
+extension GenericS: Q where T: Q {
+  static func g() { }
+}
+
+extension GenericS: Sendable where T: Sendable { }
+
+final class TestStaticMembers<T> {
+  init(_: T) {
+    let _: @Sendable () -> GenericS<Int> = GenericS.h // Ok
+  }
+}

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -307,24 +307,24 @@ func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ 
 
   await transferToMainIndirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
-  print(ns) // expected-tns-note {{access can happen concurrently}}
+  print(ns)
 
   await transferToMainIndirect(ns2)
   print(ns2)
 
   await transferToMainIndirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
-  print(ns3) // expected-tns-note {{access can happen concurrently}}
+  print(ns3)
 
   await transferToMainIndirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
-  // expected-tns-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
-  print(ns4) // expected-tns-note {{access can happen concurrently}}
+  print(ns4)
 }
 
 ////////////////////////

--- a/test/IRGen/isolated_conformance.swift
+++ b/test/IRGen/isolated_conformance.swift
@@ -1,8 +1,7 @@
-// RUN: %target-swift-frontend -primary-file %s -emit-ir -swift-version 6 -enable-experimental-feature IsolatedConformances | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -swift-version 6 | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: PTRSIZE=64
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_IsolatedConformances
 // UNSUPPORTED: CPU=arm64e
 
 protocol P {

--- a/test/ModuleInterface/isolated_conformance.swift
+++ b/test/ModuleInterface/isolated_conformance.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 6 -enable-library-evolution -module-name isolated_conformance -enable-experimental-feature IsolatedConformances -emit-module-interface-path - %s | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -swift-version 6 -enable-library-evolution -module-name isolated_conformance -emit-module-interface-path - %s | %FileCheck %s
 
-// REQUIRES: swift_feature_IsolatedConformances
 // REQUIRES: concurrency
 
 public protocol MyProtocol {

--- a/test/SILOptimizer/constant_propagation_casts_ossa.sil
+++ b/test/SILOptimizer/constant_propagation_casts_ossa.sil
@@ -1,6 +1,5 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation -enable-experimental-feature IsolatedConformances | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -diagnostic-constant-propagation | %FileCheck %s
 
-// REQUIRES: swift_feature_IsolatedConformances
 // REQUIRES: concurrency
 
 sil_stage canonical

--- a/test/SILOptimizer/isolated_conformances.swift
+++ b/test/SILOptimizer/isolated_conformances.swift
@@ -1,14 +1,13 @@
 // RUN: %empty-directory(%t) 
-// RUN: %target-build-swift -parse-as-library -O %s -enable-experimental-feature IsolatedConformances -o %t/a.out
+// RUN: %target-build-swift -parse-as-library -O %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --check-prefix=CHECK-OUTPUT
 
-// RUN: %target-build-swift -parse-as-library -O %s -enable-experimental-feature IsolatedConformances -Xllvm -sil-disable-pass=function-signature-opts -emit-sil | %FileCheck %s
+// RUN: %target-build-swift -parse-as-library -O %s -Xllvm -sil-disable-pass=function-signature-opts -emit-sil | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
-// REQUIRES: swift_feature_IsolatedConformances
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 // UNSUPPORTED: back_deployment_runtime

--- a/test/SILOptimizer/simplify_unconditional_check_cast.sil
+++ b/test/SILOptimizer/simplify_unconditional_check_cast.sil
@@ -1,6 +1,5 @@
-// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=unconditional_checked_cast -enable-experimental-feature IsolatedConformances | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-verify-all %s -simplification -simplify-instruction=unconditional_checked_cast | %FileCheck %s
 
-// REQUIRES: swift_feature_IsolatedConformances
 // REQUIRES: concurrency
 
 import Swift

--- a/test/Serialization/Inputs/def_isolated_conformance.swift
+++ b/test/Serialization/Inputs/def_isolated_conformance.swift
@@ -8,3 +8,8 @@ public class MyClass { }
 extension MyClass: @MainActor MyProtocol {
   @MainActor public func f() { }
 }
+
+public protocol OtherProtocol {
+}
+
+extension MyClass: OtherProtocol { }

--- a/test/Serialization/isolated_conformance.swift
+++ b/test/Serialization/isolated_conformance.swift
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances -o %t/def_isolated_conformance.swiftmodule %S/Inputs/def_isolated_conformance.swift
+// RUN: %target-swift-frontend -emit-module -target %target-swift-5.1-abi-triple -swift-version 6 -o %t/def_isolated_conformance.swiftmodule %S/Inputs/def_isolated_conformance.swift
 
-// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature IsolatedConformances %s -I %t
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 %s -I %t
 
-// REQUIRES: swift_feature_IsolatedConformances
 // REQUIRES: concurrency
 
 import def_isolated_conformance

--- a/test/Serialization/isolated_conformance.swift
+++ b/test/Serialization/isolated_conformance.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -target %target-swift-5.1-abi-triple -swift-version 6 -o %t/def_isolated_conformance.swiftmodule %S/Inputs/def_isolated_conformance.swift
+// RUN: %target-swift-frontend -emit-module -target %target-swift-5.1-abi-triple -swift-version 6 -o %t/def_isolated_conformance.swiftmodule %S/Inputs/def_isolated_conformance.swift -default-isolation=MainActor
 
 // RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 %s -I %t
 
@@ -8,8 +8,11 @@
 import def_isolated_conformance
 
 func acceptMyProtocol(_: some MyProtocol) { }
+func acceptOtherProtocol(_: some MyProtocol) { }
 
 nonisolated func f(mc: MyClass) {
   acceptMyProtocol(mc)
+  // expected-error@-1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
+  acceptOtherProtocol(mc)
   // expected-error@-1{{main actor-isolated conformance of 'MyClass' to 'MyProtocol' cannot be used in nonisolated context}}
 }

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -32,6 +32,7 @@ protocol P2 {
 // expected-warning@+1{{conformance of 'C1' to protocol 'P1' crosses into global actor 'GlobalActor'-isolated code and can cause data races}}
 class C1 : P1, P2 {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
+  // expected-note@-2{{isolate this conformance to the global actor 'GlobalActor' with '@GlobalActor'}}
 
   typealias Assoc = String
 
@@ -57,6 +58,7 @@ protocol NonIsolatedRequirement {
 extension OnMain: NonIsolatedRequirement {
   // expected-note@-1{{turn data races into runtime errors with '@preconcurrency'}}
   // expected-note@-2{{mark all declarations used in the conformance 'nonisolated'}}
+  // expected-note@-3{{isolate this conformance to the main actor with '@MainActor'}}
   // expected-note@+1 {{main actor-isolated instance method 'requirement()' cannot satisfy nonisolated requirement}}
   func requirement() {}
 }


### PR DESCRIPTION
The IsolatedConformances feature moves to a normal, supported feature. Remove all of the experimental-feature flags on test cases and such.

The InferIsolatedConformances feature moves to an upcoming feature for Swift 7. This should become an adoptable feature, adding "nonisolated" where needed.

There are a number of bug fixes and cleanups here to the isolated conformances code as well, including:
* Allow metatypes of some generic type (or existential) to be considered Sendable when they do not conform to any non-marker protocols 
* Fix `@Sendable` inference for references to static methods to properly check for sendability of the metatype
* Downgrade sendable-related diagnostics involving existential metatypes from errors to warnings until "Swift 7"

This finalizes the implementation of SE-0470, tracked by rdar://146116559.