### PR TITLE
[6.2] Fix IRGen for @_addressable params which may be "captured".

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5452,6 +5452,10 @@ public:
     return getParameters().back();
   }
 
+  unsigned getSelfParameterIndex() const {
+    return NumParameters - 1;
+  }
+
   /// Return SILParameterInfo for the isolated parameter in this SILFunctionType
   /// if one exists. Returns None otherwise.
   std::optional<SILParameterInfo> maybeGetIsolatedParameter() const {
@@ -5655,6 +5659,17 @@ public:
   ///
   /// Defined in SILType.cpp.
   bool isAddressable(unsigned paramIdx, SILFunction *caller);
+
+  /// Return true of the specified parameter is addressable based on its type
+  /// lowering. This includes @_addressableForDependencies parameter types.
+  ///
+  /// 'genericEnv' may be null.
+  ///
+  /// Defined in SILType.cpp.
+  bool isAddressable(unsigned paramIdx, SILModule &module,
+                     GenericEnvironment *genericEnv,
+                     Lowering::TypeConverter &typeConverter,
+                     TypeExpansionContext expansion);
 
   /// Returns true if the function type stores a Clang type that cannot
   /// be derived from its Swift type. Returns false otherwise, including if

--- a/test/IRGen/addressable.swift
+++ b/test/IRGen/addressable.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -module-name A -emit-ir -primary-file %s \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature AddressableTypes \
+// RUN: | %FileCheck %s
+
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_LifetimeDependence
+
+public struct NE: ~Escapable {}
+
+@_addressableForDependencies
+public struct Holder {}
+
+@_silgen_name("holder_NE")
+@lifetime(borrow holder)
+func getNE(_ holder: Holder) -> NE
+
+@_silgen_name("holder_mut_NE")
+@lifetime(&holder)
+func getMutNE(_ holder: inout Holder) -> NE
+
+// The parameter cannot be 'nocapture'.
+//
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s1A17testAddressableInyAA2NEVAA6HolderVF"(ptr noalias %0)
+public func testAddressableIn(_ holder: Holder) -> NE {
+  getNE(holder)
+}
+
+// The parameter cannot be 'nocapture'.
+//
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s1A20testAddressableInoutyAA2NEVAA6HolderVzF"(ptr %0)
+public func testAddressableInout(_ holder: inout Holder) -> NE {
+  getMutNE(&holder)
+}


### PR DESCRIPTION
Simply omit the 'nocapture' attribute on the parameter.

Fixes rdar://148039510 ([nonescapable] IRGen: lower addressable
params to LLVM: captures(ret: address, provenance))

(cherry picked from commit e40a34dba1ebd9e31c46d80a0a6d5faf423bf289)

main PR: https://github.com/swiftlang/swift/pull/80708