### PR TITLE
[6.2][cxx-interop] Diagnose Escapable C++ types with non-escapable fields

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -373,5 +373,9 @@ NOTE(ptr_to_nonescapable,none,
      "pointer to non-escapable type %0 cannot be imported",
      (const clang::Type*))
 
+NOTE(nonescapable_field_of_escapable, none,
+     "escapable record %0 cannot have non-escapable field '%1'",
+     (const clang::NamedDecl *, StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2359,7 +2359,23 @@ namespace {
           continue;
         }
 
-        members.push_back(cast<VarDecl>(member));
+        auto *vd = cast<VarDecl>(member);
+        if (!isNonEscapable) {
+          if (const auto *fd = dyn_cast<clang::FieldDecl>(nd))
+            if (evaluateOrDefault(
+                    Impl.SwiftContext.evaluator,
+                    ClangTypeEscapability({fd->getType().getTypePtr(), &Impl}),
+                    CxxEscapability::Unknown) ==
+                CxxEscapability::NonEscapable) {
+              Impl.addImportDiagnostic(
+                  decl,
+                  Diagnostic(diag::nonescapable_field_of_escapable, decl,
+                             nd->getName()),
+                  decl->getLocation());
+              return nullptr;
+            }
+        }
+        members.push_back(vd);
       }
 
       bool hasReferenceableFields = !members.empty();

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -95,12 +95,21 @@ const View* usedToCrash(const View* p) {
     return p;
 }
 
+struct SWIFT_ESCAPABLE Invalid {
+    View v;
+};
+
 //--- test.swift
 import Test
 import CxxStdlib
 
+// CHECK: error: cannot find type 'Invalid' in scope
+// CHECK: note: escapable record 'Invalid' cannot have non-escapable field 'v'
+public func importInvalid(_ x: Invalid) {
+}
+
 // CHECK: error: a function with a ~Escapable result needs a parameter to depend on
-// CHECK-NO-LIFETIMES: test.swift:6:32: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: test.swift:11:32: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
 public func noAnnotations() -> View {
     // CHECK: nonescapable.h:16:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies
     // CHECK-NO-LIFETIMES: nonescapable.h:16:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies


### PR DESCRIPTION
Explanation: In Swift, Escapable types cannot have non-escapable stored properties. Unfortunately, these checks could be circumvented via C++ interop, constructing invalid Swift code. This patch errors out on importing C++ code of this shape.
Issue: rdar://148899224
Risk: Low, the fix is fairly targeted to the affected scenario.
Testing: Added tests to test suite
Original PR: #80671
Reviewer: John Hui
