### PR TITLE
Add  @_transparent to some more Integer operations

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -2158,6 +2158,7 @@ where Magnitude: FixedWidthInteger & UnsignedInteger,
 
 extension FixedWidthInteger {
   @inlinable
+  @_transparent
   public var bitWidth: Int { return Self.bitWidth }
 
   @inlinable
@@ -2770,7 +2771,7 @@ extension FixedWidthInteger {
   }
 
   @inlinable // FIXME(inline-always)
-  @inline(__always)
+  @_transparent
   public init<T: BinaryInteger>(truncatingIfNeeded source: T) {
     if Self.bitWidth <= Int.bitWidth {
       self = Self(_truncatingBits: source._lowWord)
@@ -3015,7 +3016,7 @@ extension UnsignedInteger {
   /// This property is always `false` for unsigned integer types.
   @inlinable // FIXME(inline-always)
   public static var isSigned: Bool {
-    @inline(__always)
+    @_transparent
     get { return false }
   }
 }
@@ -3228,7 +3229,7 @@ extension SignedInteger {
   /// This property is always `true` for signed integer types.
   @inlinable // FIXME(inline-always)
   public static var isSigned: Bool {
-    @inline(__always)
+    @_transparent
     get { return true }
   }
 }


### PR DESCRIPTION
https://github.com/swiftlang/swift/pull/79707 made some integer operations transparent enabling them to be inlined during `MandatoryInlining`. With this `OSLogOptimization` needs to analyze the inlined function bodies of these integer operations since it runs after `MandatoryInlining`.  

In certain configurations, stdlib's `FixedWidthInteger.bitwidth` and others are not inlined and `OSLogOptimization` misses to determine these calls as constants. 

`OSLogOptimization`  can look through calls to functions annotated with ` @_semantics(constant_evaluable)`. 
But annotating with `@_semantics(constant_evaluable)` seems to require annotating with `@_optimize(none)`. Instead annotate with `@_transparent`.


Fixes oslog tests when stdlib is built with -Osize/-Onone - rdar://148256435 and rdar://148302110 