### PR TITLE
🍒 [6.2] Fix interop private debug symbols 6.2

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2577,8 +2577,13 @@ private:
 
     // Scope outermost fileprivate decls in an inline private discriminator
     // namespace.
+    //
+    // We need to don't do this for decls imported from Clang modules because
+    // the scopes of C/C++ symbols are not restricted to a particular file unit.
     if (auto *Decl = DbgTy.getDecl())
-      if (Decl->isOutermostPrivateOrFilePrivateScope())
+      if (Decl->isOutermostPrivateOrFilePrivateScope() &&
+          !isa<ClangModuleUnit>(
+              Decl->getDeclContext()->getModuleScopeContext()))
         Scope = getFilePrivateScope(Scope, Decl);
 
     return Scope;

--- a/test/Interop/Cxx/class/access/Inputs/non-public.h
+++ b/test/Interop/Cxx/class/access/Inputs/non-public.h
@@ -21,15 +21,26 @@ public:
   void publMethod(void) const {}
   void publMutatingMethod(void) {}
   int publVar;
-  static void publStaticFunc(void);
-  static int publStaticVar;
+  static void publStaticFunc(void) {};
+  static inline int publStaticVar = 0;
 
   typedef int publTypedef;
-  struct publStruct {};
+  publTypedef publTypedefMake(void) const { return 42; }
+  void publTypedefTake(publTypedef x) const { }
+
+  struct publStruct { int x; };
+  publStruct publStructMake(void) const { return publStruct{}; }
+  void publStructTake(publStruct x) const { }
 
   enum publEnum { variantPublEnum };
-  enum { publEnumAnonValue1 };
+  publEnum publEnumMake(void) const { return variantPublEnum; }
+  void publEnumTake(publEnum x) const { }
+
   enum class publEnumClass { variantPublEnumClass };
+  publEnumClass publEnumClassMake(void) const { return publEnumClass::variantPublEnumClass; }
+  void publEnumClassTake(publEnumClass x) const { }
+
+  enum { publEnumAnonValue1 };
   enum publEnumClosed {
     variantPublEnumClosed
   } __attribute__((enum_extensibility(closed)));
@@ -42,15 +53,26 @@ TEST_PRIVATE:
   void privMethod(void) const {}
   void privMutatingMethod(void) {}
   int privVar;
-  static void privStaticFunc(void);
-  static int privStaticVar;
+  static void privStaticFunc(void) {};
+  static inline int privStaticVar = 0;
 
   typedef int privTypedef;
-  struct privStruct {};
+  privTypedef privTypedefMake(void) const { return 42; }
+  void privTypedefTake(privTypedef x) const { }
+
+  struct privStruct { int x; };
+  privStruct privStructMake(void) const { return privStruct{}; }
+  void privStructTake(privStruct x) const { }
 
   enum privEnum { variantPrivEnum };
-  enum { privEnumAnonValue1 };
+  privEnum privEnumMake(void) const { return variantPrivEnum; }
+  void privEnumTake(privEnum x) const { }
+
   enum class privEnumClass { variantPrivEnumClass };
+  privEnumClass privEnumClassMake(void) const { return privEnumClass::variantPrivEnumClass; }
+  void privEnumClassTake(privEnumClass x) const { }
+
+  enum { privEnumAnonValue1 };
   enum privEnumClosed {
     variantPrivEnumClosed
   } __attribute__((enum_extensibility(closed)));

--- a/test/Interop/Cxx/class/access/private-fileid-irgen.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-irgen.swift
@@ -1,0 +1,111 @@
+//--- blessed.swift
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-ir -module-name main %t/blessed.swift -I %S/Inputs -cxx-interoperability-mode=default -Onone | %FileCheck %s
+
+import NonPublic
+
+// These extension methods are just here to make it clear what we are doing to
+// each Int32-typed member.
+extension Int32 {
+    func read() { }
+    mutating func write() { }
+}
+
+extension MyClass {
+    public func extMethod() {
+        publMethod()
+        privMethod()
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extMethod{{.*}}"
+// CHECK:   {{invoke|call}} void @{{.*}}publMethod{{.*}}
+// CHECK:   {{invoke|call}} void @{{.*}}privMethod{{.*}}
+
+    public mutating func extMutatingMethod() {
+        publMutatingMethod()
+        privMutatingMethod()
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extMutatingMethod{{.*}}"
+// CHECK:   {{invoke|call}} void @{{.*}}publMutatingMethod{{.*}}
+// CHECK:   {{invoke|call}} void @{{.*}}privMutatingMethod{{.*}}
+
+    public func extVarRead() {
+        publVar.read()
+        privVar.read()
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extVarRead{{.*}}"
+
+    public mutating func extVarWrite() {
+        publVar.write()
+        privVar.write()
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extVarWrite{{.*}}"
+
+    public func extStaticFunc() {
+        MyClass.publStaticFunc()
+        MyClass.privStaticFunc()
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extStaticFunc{{.*}}"
+// CHECK:   {{invoke|call}} void @{{.*}}publStaticFunc
+// CHECK:   {{invoke|call}} void @{{.*}}privStaticFunc
+
+    public func extStaticVarRead() {
+        MyClass.publStaticVar.read()
+        MyClass.privStaticVar.read()
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extStaticVarRead{{.*}}"
+
+    public func extStaticVarWrite() {
+        MyClass.publStaticVar.write()
+        MyClass.privStaticVar.write()
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extStaticVarWrite{{.*}}"
+
+    public func extTypedef() {
+      let u: publTypedef = publTypedefMake()
+      publTypedefTake(u)
+      let i: privTypedef = privTypedefMake()
+      privTypedefTake(i)
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extTypedef{{.*}}"
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}publTypedefMake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}publTypedefTake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}privTypedefMake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}privTypedefTake{{.*}}
+
+    public func extStruct() {
+      let u: publStruct = publStructMake()
+      publStructTake(u)
+      let i: privStruct = privStructMake()
+      privStructTake(i)
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extStruct{{.*}}"
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}publStructMake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}publStructTake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}privStructMake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}privStructTake{{.*}}
+
+    public func extEnum() {
+      let u: publEnum = publEnumMake()
+      publEnumTake(u)
+      let i: privEnum = privEnumMake()
+      privEnumTake(i)
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extEnum{{.*}}"
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}publEnumMake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}publEnumTake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}privEnumMake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}privEnumTake{{.*}}
+
+    // If we call this extEnumClass, the name gets mangled to something else.
+    public func extEnumCls() {
+      let u: publEnumClass = publEnumClassMake()
+      publEnumClassTake(u)
+      let i: privEnumClass = privEnumClassMake()
+      privEnumClassTake(i)
+    }
+// CHECK: define {{.*}}swiftcc void @"{{.*}}extEnumCls{{.*}}"
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}publEnumClassMake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}publEnumClassTake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}privEnumClassMake{{.*}}
+// CHECK:   {{invoke|call}} {{.*}} @{{.*}}privEnumClassTake{{.*}}
+}

--- a/test/Interop/Cxx/class/access/private-fileid-irgen.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-irgen.swift
@@ -1,6 +1,7 @@
 //--- blessed.swift
 // RUN: split-file %s %t
 // RUN: %target-swift-frontend -emit-ir -module-name main %t/blessed.swift -I %S/Inputs -cxx-interoperability-mode=default -Onone | %FileCheck %s
+// RUN: %target-swift-frontend -emit-ir -module-name main %t/blessed.swift -I %S/Inputs -cxx-interoperability-mode=default -Onone -g | %FileCheck %s
 
 import NonPublic
 

--- a/test/Interop/Cxx/class/access/private-fileid-typecheck.swift
+++ b/test/Interop/Cxx/class/access/private-fileid-typecheck.swift
@@ -120,8 +120,27 @@ extension MyClass {
         let _ = privEnumOpen.variantPrivEnumOpen
     }
 
-    func fcutd(_ _: publTypedef) { }
-    private func fcitd(_ _: privTypedef) { }
+    // Make sure these types are usable in type signatures too
+    func publTypedefFunc(_ _: publTypedef) { }
+    private func privTypedefFunc(_ _: privTypedef) { }
+
+    func publStructFunc(_ _: publStruct) { }
+    private func privStructFunc(_ _: privStruct) { }
+
+    func publEnumFunc(_ _: publEnum) { }
+    private func privEnumFunc(_ _: privEnum) { }
+
+    func publEnumClassFunc(_ _: publEnumClass) { }
+    private func privEnumClassFunc(_ _: privEnumClass) { }
+
+    func publEnumClosedFunc(_ _: publEnumClosed) { }
+    private func privEnumClosedFunc(_ _: privEnumClosed) { }
+
+    func publEnumOpenFunc(_ _: publEnumOpen) { }
+    private func privEnumOpenFunc(_ _: privEnumOpen) { }
+
+    func publEnumFlagFunc(_ _: publEnumFlag) { }
+    private func privEnumFlagFunc(_ _: privEnumFlag) { }
 }
 
 func notExt(_ c: inout MyClass) {


### PR DESCRIPTION
# Cherry-pick of #80515, #80485 

**Explanation**: The patch from #80485 fixes an assertion failure/compiler crash that is hit when the compiler tries to generate debug info for a private type decl imported from Clang. The assertion failure typically happens when we deliberately import private nested types (e.g., with the `ImportNonPublicCxxMembers` flag), but has been reported to occur in at least one adopter project that isn't using this feature flag.

The assertion failure is [here](https://github.com/swiftlang/swift/blob/1e964664ab33b4b351294a51d0d160e1bcaf4eca/include/swift/ClangImporter/ClangModule.h#L113), and is reached when one calls `getFilePrivateScope()` with a Clang decl. When it is compiled out in a no-assertions build, the compiler simply segfaults.

The `getFilePrivateScope()` function is normally necessary to disambiguate the debug info generated for Swift types with `private` or `fileprivate` access, because multiple such types of the same name may exist in different files due to Swift's scoping rules. This is not so for types imported from Clang, because access specifiers do not affect lexical scope in C/C++.

#80515 is a precursor to #80485 that does not modify the compiler. I'm including #80515 in this cherry-pick because it introduces a test case that #80485 builds upon.

**Issue**: rdar://148481025

**Risk**: Low. The only compiler adjustment in this patch is an additional check that avoids generating a discriminator for Clang decls. Any call to `getFilePrivateScope()` that used to happen successfully will continue to do so.

**Testing**: Added test to test suite

**Original PRs**: #80515, #80485

**Reviewers**: @egorzhdan @Xazax-hun @fahadnayyar 