### PR TITLE
[6.2][cxx-interop] Make safe interop wrapper accessible in production compilers

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -457,7 +457,7 @@ EXPERIMENTAL_FEATURE(TrailingComma, false)
 
 // Import bounds safety and lifetime attributes from interop headers to
 // generate Swift wrappers with safe pointer types.
-EXPERIMENTAL_FEATURE(SafeInteropWrappers, false)
+EXPERIMENTAL_FEATURE(SafeInteropWrappers, true)
 
 /// Ignore resilience errors due to C++ types.
 EXPERIMENTAL_FEATURE(AssumeResilientCxxTypes, true)


### PR DESCRIPTION
Explanation: The experimental feature flag was not available for production compilers. There is no reason for that.
Issue: rdar://148961491
Risk: Low, no functional changes other than making the flag available.
Original PR: #80713
Reviewer: @egorzhdan 
