### PR TITLE
[6.1] Update SwiftStdlib 6.1 availability macro

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -152,7 +152,10 @@ RUNTIME_VERSION(
 
 RUNTIME_VERSION(
   (6, 1),
-  FUTURE
+  PLATFORM(macOS,   (15, 4, 0))
+  PLATFORM(iOS,     (18, 4, 0))
+  PLATFORM(watchOS, (11, 4, 0))
+  PLATFORM(xrOS,    (2, 4, 0))
 )
 
 END_MAJOR_VERSION(6)

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -36,9 +36,10 @@ SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
 SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
 SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
-SwiftStdlib 6.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
-# TODO: Also update ASTContext::getSwift510Availability when needed
-# TODO: Also update ASTContext::getSwift60Availability when needed
+SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
+
+# TODO: When you add a new version, remember to tell the compiler about it
+# by also adding it to include/swift/AST/RuntimeVersions.def.
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
6.1 cherry-pick of https://github.com/swiftlang/swift/pull/80596.

* **Description:** Fill in the real version numbers now that Swift 6.1 has shipped.

* **Reviewed by:** @hborla 