### PR TITLE
[embedded] Start building Concurrency.swiftmodule/.a for non-Darwin target triples too

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -280,7 +280,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         continue()
       endif()
     elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      if(NOT "${mod}" MATCHES "arm64|arm64e|armv7|armv7m|armv7em")
+      if(NOT "${mod}" MATCHES "x86_64|arm64|arm64e|armv7|armv7m|armv7em")
         continue()
       endif()
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -272,31 +272,23 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     list(GET list 1 mod)
     list(GET list 2 triple)
 
+    set(extra_c_compile_flags)
+    set(extra_swift_compile_flags)
+
     if (SWIFT_HOST_VARIANT STREQUAL "linux")
       if(NOT "${mod}" MATCHES "-linux-gnu$")
         continue()
       endif()
-      set(extra_c_compile_flags)
-      set(extra_swift_compile_flags)
     elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      if(NOT "${mod}" MATCHES "-macos$")
-        continue()
-      endif()
-      if("${mod}" MATCHES "riscv")
-        continue()
-      endif()
-      if("${mod}" MATCHES "armv6m")
+      if(NOT "${mod}" MATCHES "arm64|arm64e|armv7|armv7m|armv7em")
         continue()
       endif()
 
-      if("${mod}" MATCHES "-macos$")
-        set(extra_c_compile_flags -ffreestanding -stdlib=libc++)
-        set(extra_swift_compile_flags -Xcc -ffreestanding)
+      if(NOT "${mod}" MATCHES "-apple-" OR "${mod}" MATCHES "-none-macho")
+        # Host is macOS with a macOS SDK. To be able to build the C++ Concurrency runtime for non-Darwin targets using the macOS SDK,
+        # we need to pass some extra flags and search paths.
+        set(extra_c_compile_flags -stdlib=libc++ -I${SWIFT_SDK_OSX_PATH}/usr/include/c++/v1 -I${SWIFT_SDK_OSX_PATH}/usr/include -D__APPLE__)
       endif()
-
-    elseif (SWIFT_HOST_VARIANT STREQUAL "wasi")
-      set(extra_c_compile_flags)
-      set(extra_swift_compile_flags)
     endif()
 
     set(SWIFT_SDK_embedded_THREADING_PACKAGE none)

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -287,7 +287,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       if(NOT "${mod}" MATCHES "-apple-" OR "${mod}" MATCHES "-none-macho")
         # Host is macOS with a macOS SDK. To be able to build the C++ Concurrency runtime for non-Darwin targets using the macOS SDK,
         # we need to pass some extra flags and search paths.
-        set(extra_c_compile_flags -stdlib=libc++ -I${SWIFT_SDK_OSX_PATH}/usr/include/c++/v1 -I${SWIFT_SDK_OSX_PATH}/usr/include -D__APPLE__)
+        set(extra_c_compile_flags -stdlib=libc++ -isystem${SWIFT_SDK_OSX_PATH}/usr/include/c++/v1 -isystem${SWIFT_SDK_OSX_PATH}/usr/include -D__APPLE__)
       endif()
     endif()
 


### PR DESCRIPTION
We have been only building the Embedded Swift Concurrency module+runtime for the -macos target triple. Let's start building it for the non-Darwin target triples too (e.g. -apple-none-macho and -none-none-eabi). This should be a step towards being able to use Embedded Swift Concurrency on embedded HW targets like the Pico or ESP32.