### PR TITLE
[6.2] [Sema] Try limit kicking interface type in `filterForEnumElement`

### DIFF
--- a/validation-test/compiler_crashers_2/issue-80657.swift
+++ b/validation-test/compiler_crashers_2/issue-80657.swift
@@ -1,0 +1,17 @@
+// RUN: not --crash %target-swift-frontend -emit-sil %s
+
+// https://github.com/swiftlang/swift/issues/80657
+enum E {
+  case e
+
+  static func foo() {
+    _ = { [self] in
+      switch e {
+      case e:
+        break
+      default:
+        break
+      }
+    }
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/rdar146952007.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar146952007.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+// These cases are similar to https://github.com/swiftlang/swift/issues/80657,
+// but we can avoid hitting the same issue for non-enum members.
+
+struct S {
+  let y = 0
+  func foo(_ x: Int) {
+    let _ = { [self] in
+      switch x {
+      case y: break
+      default: break
+      }
+    }
+  }
+}
+
+class C {
+  let y = 0
+  func foo(_ x: Int) {
+    let _ = { [self] in
+      switch x {
+      case y: break
+      default: break
+      }
+    }
+  }
+}
+
+enum E {
+  case e
+
+  func bar() -> Int {0}
+
+  func foo() {
+    _ = { [self] in
+      switch 0 {
+      case bar():
+        break
+      default:
+        break
+      }
+    }
+  }
+}


### PR DESCRIPTION
*6.2 cherry-pick of #80672*

- Explanation: Fixes a crash that could occur when pattern matching a non-enum member in a closure with an explicit `self` capture
- Scope: Affects pattern matching
- Issue: rdar://146952007
- Risk: Low, this is a pretty targeted workaround
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich