### PR TITLE
[run-test] failing on linking without dep

### DIFF
--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -6,7 +6,8 @@ target_link_libraries(swiftSIL PRIVATE
   swiftAST
   swiftClangImporter
   swiftSema
-  swiftSerialization)
+  swiftSerialization
+  swiftSILOptimizer)
 
 add_subdirectory(IR)
 add_subdirectory(Utils)


### PR DESCRIPTION
Running tests on my normal dev cycle started breaking when building tests Looks like there's a missing dep on libSILOptimizer in libSIL?

```
Undefined symbols for architecture arm64:
  "swift::ConstExprEvaluator::ConstExprEvaluator(swift::SymbolicValueAllocator&, unsigned int, bool)", referenced from:
      BridgedConstExprFunctionState::create() in libswiftSIL.a[63](SILBridging.cpp.o)
  "swift::ConstExprEvaluator::~ConstExprEvaluator()", referenced from:
      BridgedConstExprFunctionState::deinitialize() in libswiftSIL.a[63](SILBridging.cpp.o)
  "swift::ConstExprFunctionState::getConstantValue(swift::SILValue)", referenced from:
      BridgedConstExprFunctionState::isConstantValue(BridgedValue) in libswiftSIL.a[63](SILBridging.cpp.o)
  "swift::ConstExprFunctionState::ConstExprFunctionState(swift::ConstExprEvaluator&, swift::SILFunction*, swift::SubstitutionMap, unsigned int&, bool)", referenced from:
      BridgedConstExprFunctionState::create() in libswiftSIL.a[63](SILBridging.cpp.o)
ld: symbol(s) not found for architecture arm64
```

Unsure why this isn't showing up for others but I'm able to use run-test with this patch again
