### PR TITLE
Fix lifetime_dependence/specialize.sil; requires 64-bit

### DIFF
--- a/test/SILOptimizer/lifetime_dependence/specialize.sil
+++ b/test/SILOptimizer/lifetime_dependence/specialize.sil
@@ -11,6 +11,8 @@
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_AddressableTypes
 
+// REQUIRES: PTRSIZE=64
+
 // Test the SIL representation for lifetime dependence scope fixup.
 
 sil_stage raw


### PR DESCRIPTION
Fixes rdar://148958163
