### PR TITLE
[6.2] Fix lifetime_dependence/specialize.sil; requires 64-bit

### DIFF
--- a/test/SILOptimizer/lifetime_dependence/specialize.sil
+++ b/test/SILOptimizer/lifetime_dependence/specialize.sil
@@ -11,6 +11,8 @@
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_AddressableTypes
 
+// REQUIRES: PTRSIZE=64
+
 // Test the SIL representation for lifetime dependence scope fixup.
 
 sil_stage raw


### PR DESCRIPTION
Fixes rdar://148958163

(cherry picked from commit d92b20fcf44bc158e28e97a091c8e072de138606)
