### PR TITLE
[BlockList] Fix a crash if block is empty

### DIFF
--- a/lib/Basic/BlockList.cpp
+++ b/lib/Basic/BlockList.cpp
@@ -115,8 +115,10 @@ void swift::BlockListStore::Implementation::addConfigureFilePath(StringRef path)
                       SM.getLLVMSourceMgr());
   for (auto DI = Stream.begin(); DI != Stream.end(); ++ DI) {
     assert(DI != Stream.end() && "Failed to read a document");
-    yaml::Node *N = DI->getRoot();
-    for (auto &pair: *dyn_cast<yaml::MappingNode>(N)) {
+    auto *MapNode = dyn_cast<yaml::MappingNode>(DI->getRoot());
+    if (!MapNode)
+      continue;
+    for (auto &pair: *MapNode) {
       std::string key = getScalaString(pair.getKey());
       auto action = llvm::StringSwitch<BlockListAction>(key)
 #define BLOCKLIST_ACTION(X) .Case(#X, BlockListAction::X)


### PR DESCRIPTION
Check if the root node is a mapping node before iterating. This fixes a crash when the YAML file is not the expected format.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
