### PR TITLE
[DNM][Dependency Scanning] Remove Swift overlay dependencies from the reported 'direct dependencies' set

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -927,7 +927,8 @@ static swiftscan_dependency_graph_t generateFullDependencyGraph(
     moduleInfo->module_name = ttt;
     moduleInfo->module_path = create_clone(modulePath.c_str());
     moduleInfo->source_files = create_set(sourceFiles);
-    moduleInfo->direct_dependencies = create_set(bridgeDependencyIDs(cache.getAllDependencies(moduleID)));
+    moduleInfo->direct_dependencies = create_set(
+        bridgeDependencyIDs(cache.getDirectImportedDependencies(moduleID)));
     moduleInfo->details = getModuleDetails();
 
     // Create a link libraries set for this module


### PR DESCRIPTION
Instead, Swift overlay dependencies have been getting reported as a separate field for Swift module dependencies and the clients have had sufficient time to begin using it (e.g. https://github.com/swiftlang/swift-driver/pull/1365).
