### PR TITLE
[IRGen] Set generic context before getting call emission in visitFull…

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3861,6 +3861,10 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
     }
   }
 
+  // Lower the arguments and return value in the callee's generic context.
+  GenericContextScope scope(IGM,
+                            origCalleeType->getInvocationGenericSignature());
+
   Explosion llArgs;
   WitnessMetadata witnessMetadata;
   auto emission = getCallEmissionForLoweredValue(
@@ -3872,9 +3876,6 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
   }
 
   emission->begin();
-
-  // Lower the arguments and return value in the callee's generic context.
-  GenericContextScope scope(IGM, origCalleeType->getInvocationGenericSignature());
 
   auto &calleeFP = emission->getCallee().getFunctionPointer();
 

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -359,3 +359,15 @@ struct SomeStruct {
 func someFunc() async throws(SmallError) -> SomeStruct {
     SomeStruct(x: 42, y: 23, z: 25)
 }
+
+// Used to crash the compiler -- https://github.com/swiftlang/swift/issues/80732
+protocol PAssoc<T>: AnyObject {
+    associatedtype T
+    func foo() async throws(SmallError) -> (any PAssoc<T>)
+}
+
+class MyProtocolImpl<T>: PAssoc {
+    func foo() async throws(SmallError) -> (any PAssoc<T>) {
+        fatalError()
+    }
+}


### PR DESCRIPTION
…ApplySite

rdar://149007227

Without the generic context, the result type can't be mapped into the current context, causing the compiler to crash.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
