### PR TITLE
[6.2][Test][Concurrency] Fix isIsolatingCurrentContext tests

### DIFF
--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_isIsolatingCurrentContext_swift62_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_isIsolatingCurrentContext_swift62_mode.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %import-libdispatch -parse-as-library %s -o %t/a.out
+// RUN: %target-build-swift %import-libdispatch -Xfrontend -disable-availability-checking -parse-as-library %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
@@ -93,25 +93,22 @@ actor ActorOnIsCheckImplementingExecutor<Ex: SerialExecutor> {
 
 @main struct Main {
   static func main() async {
-    if #available(SwiftStdlib 6.2, *) {
+    let hasIsIsolatingCurrentContextExecutor = IsIsolatingExecutor()
+    let justCheckIsolatedExecutor = JustCheckIsolatedExecutor()
 
-      let hasIsIsolatingCurrentContextExecutor = IsIsolatingExecutor()
-      let justCheckIsolatedExecutor = JustCheckIsolatedExecutor() 
-      
-      print("=== do not crash with executor which implements isIsolatingCurrentContext")
-      let hasIsCheckActor = ActorOnIsCheckImplementingExecutor(on: hasIsIsolatingCurrentContextExecutor)
-      await hasIsCheckActor.checkPreconditionIsolated()
-      // CHECK: Before preconditionIsolated
-      // CHECK-NOT: called: checkIsolated
-      // CHECK: called: isIsolatingCurrentContext
-      // CHECK-NOT: called: checkIsolated
-      // CHECK: After preconditionIsolated
+    print("=== do not crash with executor which implements isIsolatingCurrentContext")
+    let hasIsCheckActor = ActorOnIsCheckImplementingExecutor(on: hasIsIsolatingCurrentContextExecutor)
+    await hasIsCheckActor.checkPreconditionIsolated()
+    // CHECK: Before preconditionIsolated
+    // CHECK-NOT: called: checkIsolated
+    // CHECK: called: isIsolatingCurrentContext
+    // CHECK-NOT: called: checkIsolated
+    // CHECK: After preconditionIsolated
 
-      // CHECK: Before assumeIsolated
-      // CHECK-NOT: called: checkIsolated
-      // CHECK: called: isIsolatingCurrentContext
-      // CHECK-NOT: called: checkIsolated
-      // CHECK: After assumeIsolated
-    }
+    // CHECK: Before assumeIsolated
+    // CHECK-NOT: called: checkIsolated
+    // CHECK: called: isIsolatingCurrentContext
+    // CHECK-NOT: called: checkIsolated
+    // CHECK: After assumeIsolated
   }
 }

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_not_implemented_isIsolatingCurrentContext_swift62_mode.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_not_implemented_isIsolatingCurrentContext_swift62_mode.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %import-libdispatch -parse-as-library %s -o %t/a.out
+// RUN: %target-build-swift %import-libdispatch -Xfrontend -disable-availability-checking -parse-as-library %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
@@ -80,25 +80,22 @@ actor ActorOnIsCheckImplementingExecutor<Ex: SerialExecutor> {
 
 @main struct Main {
   static func main() async {
-    if #available(SwiftStdlib 6.2, *) {
+    let hasIsIsolatingCurrentContextExecutor = IsIsolatingExecutor()
+    let justCheckIsolatedExecutor = JustCheckIsolatedExecutor()
 
-      let hasIsIsolatingCurrentContextExecutor = IsIsolatingExecutor()
-      let justCheckIsolatedExecutor = JustCheckIsolatedExecutor() 
-      
-      print("do checkIsolated with executor which does NOT implement isIsolatingCurrentContext")
-      let checkIsolatedActor = ActorOnIsCheckImplementingExecutor(on: justCheckIsolatedExecutor)
-      await checkIsolatedActor.checkPreconditionIsolated()
-      // CHECK: Before preconditionIsolated
-      // CHECK-NOT: called: isIsolatingCurrentContext
-      // CHECK: called: checkIsolated
-      // CHECK-NOT: called: isIsolatingCurrentContext
-      // CHECK: After preconditionIsolated
+    print("do checkIsolated with executor which does NOT implement isIsolatingCurrentContext")
+    let checkIsolatedActor = ActorOnIsCheckImplementingExecutor(on: justCheckIsolatedExecutor)
+    await checkIsolatedActor.checkPreconditionIsolated()
+    // CHECK: Before preconditionIsolated
+    // CHECK-NOT: called: isIsolatingCurrentContext
+    // CHECK: called: checkIsolated
+    // CHECK-NOT: called: isIsolatingCurrentContext
+    // CHECK: After preconditionIsolated
 
-      // CHECK: Before assumeIsolated
-      // CHECK-NOT: called: isIsolatingCurrentContext
-      // CHECK: called: checkIsolated
-      // CHECK-NOT: called: isIsolatingCurrentContext
-      // CHECK: After assumeIsolated
-    }
+    // CHECK: Before assumeIsolated
+    // CHECK-NOT: called: isIsolatingCurrentContext
+    // CHECK: called: checkIsolated
+    // CHECK-NOT: called: isIsolatingCurrentContext
+    // CHECK: After assumeIsolated
   }
 }


### PR DESCRIPTION
**Description:**
These tests can fail when testing on an older OS version than the one that will ship with Swift 6.2. Fix by disabling availability checking.

Details: Since tests may run on an OS that correspond to an older Swift runtime, and if the build has real availability values and not the 9999 hardcoded ones, the `#if available` test will fail, and thus not execute the code guarded by it. The CHECK lines are still checked, and since no code executed, these will all fail.

**Scope/Impact:** Test only change
**Risk:** Low, test only
**Testing:** Verified the tests
**Reviewed by:** @ktoso (I reviewed, this is @al45tair's patch)

**Original PR:** https://github.com/swiftlang/swift/pull/80720
**Radar:** rdar://148986812