### PR TITLE
[ClangImporter] Import constant values for 'const' globals

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4593,10 +4593,23 @@ namespace {
 
       ValueDecl *result = nullptr;
 
+      bool initIsEvaluatable = false;
+      if (auto init = decl->getInit()) {
+        // Don't import values for partial specializations. TODO: Should we stop
+        // importing partially specialized variables completely?
+        bool partial = isa<clang::VarTemplatePartialSpecializationDecl>(decl);
+
+        // Don't import values when type-dependent or value-dependent.
+        bool typeDependent = decl->getType()->isDependentType();
+        bool valueDependent = init->isValueDependent();
+
+        initIsEvaluatable = !partial && !typeDependent && !valueDependent;
+      }
+
       // If the variable is const (we're importing it as a let), and has an
       // initializer, then ask Clang for its constant value and synthesize a
       // getter with that value.
-      if (introducer == VarDecl::Introducer::Let && decl->hasInit()) {
+      if (introducer == VarDecl::Introducer::Let && initIsEvaluatable) {
         auto val = decl->evaluateValue();
         // For now, only import integer and float constants. If in the future
         // SwiftDeclSynthesizer::createConstant becomes able to import more

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4620,13 +4620,21 @@ namespace {
               ImportDiagnosticAdder(Impl, decl, decl->getLocation()),
               isInSystemModule(dc), Bridgeability::None, ImportTypeAttrs());
 
-          auto convertKind = ConstantConvertKind::None;
-          if (decl->getType()->isEnumeralType())
-            convertKind = ConstantConvertKind::Construction;
+          // FIXME: Handle CGFloat too.
+          if (!type->isCGFloat()) {
+            auto convertKind = ConstantConvertKind::None;
+            // Request conversions on enums, and swift_wrapper((enum/struct))
+            // types
+            if (decl->getType()->isEnumeralType())
+              convertKind = ConstantConvertKind::Construction;
+            else if (findSwiftNewtype(decl, Impl.getClangSema(),
+                                      Impl.CurrentVersion))
+              convertKind = ConstantConvertKind::Construction;
 
-          result = synthesizer.createConstant(
-              name, dc, type, *val, convertKind, isStatic, decl,
-              importer::convertClangAccess(decl->getAccess()));
+            result = synthesizer.createConstant(
+                name, dc, type, *val, convertKind, isStatic, decl,
+                importer::convertClangAccess(decl->getAccess()));
+          }
         }
       }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4590,12 +4590,37 @@ namespace {
       auto introducer = Impl.shouldImportGlobalAsLet(decl->getType())
                         ? VarDecl::Introducer::Let
                         : VarDecl::Introducer::Var;
-      auto result = Impl.createDeclWithClangNode<VarDecl>(
-          decl, importer::convertClangAccess(decl->getAccess()),
-          /*IsStatic*/ isStatic, introducer,
-          Impl.importSourceLoc(decl->getLocation()), name, dc);
-      result->setIsObjC(false);
-      result->setIsDynamic(false);
+
+      ValueDecl *result = nullptr;
+
+      // If the variable is const (we're importing it as a let), and has an
+      // initializer, then ask Clang for its constant value and synthesize a
+      // getter with that value.
+      if (introducer == VarDecl::Introducer::Let && decl->hasInit()) {
+        auto val = decl->evaluateValue();
+        // For now, only import integer and float constants. If in the future
+        // SwiftDeclSynthesizer::createConstant becomes able to import more
+        // types, we can lift this restriction.
+        if (val && (val->isFloat() || val->isInt())) {
+          auto type = Impl.importTypeIgnoreIUO(
+              decl->getType(), ImportTypeKind::Value,
+              ImportDiagnosticAdder(Impl, decl, decl->getLocation()),
+              isInSystemModule(dc), Bridgeability::None, ImportTypeAttrs());
+          result = synthesizer.createConstant(
+              name, dc, type, *val, ConstantConvertKind::None, isStatic, decl,
+              importer::convertClangAccess(decl->getAccess()));
+        }
+      }
+
+      // Otherwise, import as an external declaration
+      if (!result) {
+        result = Impl.createDeclWithClangNode<VarDecl>(
+            decl, importer::convertClangAccess(decl->getAccess()),
+            /*IsStatic*/ isStatic, introducer,
+            Impl.importSourceLoc(decl->getLocation()), name, dc);
+        result->setIsObjC(false);
+        result->setIsDynamic(false);
+      }
 
       // If imported as member, the member should be final.
       if (dc->getSelfClassDecl())

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4583,7 +4583,7 @@ namespace {
       if (dc->isTypeContext())
         isStatic = true;
 
-      // For now we don't import static constexpr
+      // For now we don't import static constexpr. TODO: Lift this restriction.
       if (isStatic && decl->isConstexpr())
         return nullptr;
 
@@ -4606,8 +4606,13 @@ namespace {
               decl->getType(), ImportTypeKind::Value,
               ImportDiagnosticAdder(Impl, decl, decl->getLocation()),
               isInSystemModule(dc), Bridgeability::None, ImportTypeAttrs());
+
+          auto convertKind = ConstantConvertKind::None;
+          if (decl->getType()->isEnumeralType())
+            convertKind = ConstantConvertKind::Construction;
+
           result = synthesizer.createConstant(
-              name, dc, type, *val, ConstantConvertKind::None, isStatic, decl,
+              name, dc, type, *val, convertKind, isStatic, decl,
               importer::convertClangAccess(decl->getAccess()));
         }
       }

--- a/test/ClangImporter/const_values.swift
+++ b/test/ClangImporter/const_values.swift
@@ -1,0 +1,95 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-bridging-header %t/src/test.h \
+// RUN:   -module-name main -I %t -emit-sil | %FileCheck %s
+
+//--- test.h
+#include <stdbool.h>
+
+#define MACRO_INT 42
+
+const int const_int = 42;
+static int static_int = 42;
+static const int static_const_int = 42;
+
+static const bool static_const_bool = true;
+static const char static_const_char = 42;
+static const long static_const_long = 42;
+static const float static_const_float = 42.0;
+static const double static_const_double = 42.0;
+
+//--- main.swift
+func foo() {
+  print(MACRO_INT)
+
+  print(const_int)
+  print(static_int)
+  print(static_const_int)
+
+  print(static_const_bool)
+  print(static_const_char)
+  print(static_const_long)
+  print(static_const_float)
+  print(static_const_double)
+}
+
+// Only 'static' cannot get the getter imported, because it's not guaranteed to be constant.
+// CHECK: sil_global public_external @static_int : $Int32
+
+// CHECK:      sil shared [transparent] @$sSC9MACRO_INTs5Int32Vvg : $@convention(thin) () -> Int32 {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   %1 = struct $Int32 (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo9const_ints5Int32Vvg : $@convention(thin) () -> Int32 {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   %1 = struct $Int32 (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo16static_const_ints5Int32Vvg : $@convention(thin) () -> Int32 {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   %1 = struct $Int32 (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo17static_const_boolSbvg : $@convention(thin) () -> Bool {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:   %1 = struct $Bool (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo17static_const_chars4Int8Vvg : $@convention(thin) () -> Int8 {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int8, 42
+// CHECK-NEXT:   %1 = struct $Int8 (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo17static_const_longSivg : $@convention(thin) () -> Int {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int64, 42
+// CHECK-NEXT:   %1 = struct $Int (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo18static_const_floatSfvg : $@convention(thin) () -> Float {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = float_literal $Builtin.FPIEEE32, 0x42280000 // 42
+// CHECK-NEXT:   %1 = struct $Float (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo19static_const_doubleSdvg : $@convention(thin) () -> Double {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = float_literal $Builtin.FPIEEE64, 0x4045000000000000 // 42
+// CHECK-NEXT:   %1 = struct $Double (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }

--- a/test/ClangImporter/const_values.swift
+++ b/test/ClangImporter/const_values.swift
@@ -40,6 +40,11 @@ struct MyStruct {
 __attribute__((swift_name("MyStruct.static_const_int_as_a_member")))
 static const int static_const_int_as_a_member = 42;
 
+typedef int ImportAsStruct __attribute__((swift_wrapper(struct)));
+static const ImportAsStruct ImportAsStructFoo = 123;
+typedef int ImportAsEnum __attribute__((swift_wrapper(enum)));
+static const ImportAsEnum ImportAsEnumFoo = 123;
+
 //--- main.swift
 func foo() {
   print(MACRO_INT)
@@ -64,6 +69,9 @@ func foo() {
   print(static_const_enum)
 
   print(MyStruct.static_const_int_as_a_member)
+
+  print(ImportAsStruct.foo)
+  print(ImportAsEnum.foo)
 }
 
 // Globals that don't get their value imported stay as public_external:

--- a/test/ClangImporter/const_values.swift
+++ b/test/ClangImporter/const_values.swift
@@ -128,10 +128,10 @@ func foo() {
 // CHECK-NEXT:   return %1
 // CHECK-NEXT: }
 
-// CHECK:      sil shared [transparent] @$sSo17static_const_longSivg : $@convention(thin) () -> Int {
+// CHECK:      sil shared [transparent] @$sSo17static_const_long{{.*}} : $@convention(thin) () -> {{.*}} {
 // CHECK-NEXT: bb0:
-// CHECK-NEXT:   %0 = integer_literal $Builtin.Int64, 42
-// CHECK-NEXT:   %1 = struct $Int (%0)
+// CHECK-NEXT:   %0 = integer_literal {{.*}}, 42
+// CHECK-NEXT:   %1 = struct {{.*}} (%0)
 // CHECK-NEXT:   return %1
 // CHECK-NEXT: }
 

--- a/test/ClangImporter/const_values.swift
+++ b/test/ClangImporter/const_values.swift
@@ -20,6 +20,15 @@ static const long static_const_long = 42;
 static const float static_const_float = 42.0;
 static const double static_const_double = 42.0;
 
+static const char static_const_char_array[4] = {1, 2, 3, 4};
+static const char *static_const_pointer = 0;
+
+typedef enum MyEnum: char {
+  MyEnumCase0 = 0, MyEnumCase1, MyEnumCase2
+} MyEnum;
+static const MyEnum static_const_enum = MyEnumCase1;
+
+
 //--- main.swift
 func foo() {
   print(MACRO_INT)
@@ -33,10 +42,17 @@ func foo() {
   print(static_const_long)
   print(static_const_float)
   print(static_const_double)
+
+  print(static_const_char_array)
+  print(static_const_pointer)
+
+  print(static_const_enum)
 }
 
-// Only 'static' cannot get the getter imported, because it's not guaranteed to be constant.
+// Globals that don't get their value imported stay as public_external:
 // CHECK: sil_global public_external @static_int : $Int32
+// CHECK: sil_global public_external [let] @static_const_char_array : $(Int8, Int8, Int8, Int8)
+// CHECK: sil_global public_external @static_const_pointer : $Optional<UnsafePointer<Int8>>
 
 // CHECK:      sil shared [transparent] @$sSC9MACRO_INTs5Int32Vvg : $@convention(thin) () -> Int32 {
 // CHECK-NEXT: bb0:
@@ -93,3 +109,5 @@ func foo() {
 // CHECK-NEXT:   %1 = struct $Double (%0)
 // CHECK-NEXT:   return %1
 // CHECK-NEXT: }
+
+// TODO: Add static_const_enum

--- a/test/ClangImporter/const_values.swift
+++ b/test/ClangImporter/const_values.swift
@@ -28,7 +28,6 @@ typedef enum MyEnum: char {
 } MyEnum;
 static const MyEnum static_const_enum = MyEnumCase1;
 
-
 //--- main.swift
 func foo() {
   print(MACRO_INT)
@@ -110,4 +109,10 @@ func foo() {
 // CHECK-NEXT:   return %1
 // CHECK-NEXT: }
 
-// TODO: Add static_const_enum
+// CHECK:      sil shared [transparent] @$sSo17static_const_enumSo6MyEnumVvg : $@convention(thin) () -> MyEnum {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int8, 1
+// CHECK-NEXT:   %1 = struct $Int8 (%0)
+// CHECK-NEXT:   %2 = struct $MyEnum (%1)
+// CHECK-NEXT:   return %2
+// CHECK-NEXT: }

--- a/test/ClangImporter/const_values_cxx.swift
+++ b/test/ClangImporter/const_values_cxx.swift
@@ -33,6 +33,12 @@ class OtherClass {
   static constexpr int class_static_constexpr_int = 42;
 };
 
+template <int N, int M>
+inline const int template_gcd = template_gcd<M, N % M>;
+
+template <int N>
+inline const int template_gcd<N, 0> = N;
+
 
 //--- main.swift
 func foo() {
@@ -49,6 +55,9 @@ func foo() {
 
   print(MyClass().class_const_int)
   print(MyClass.class_static_const_int)
+
+  // TODO: This seems to be incorrectly imported, this test here is just to check that the compiler doesn't crash.
+  print(template_gcd)
 }
 
 // Only imported as external declarations:

--- a/test/ClangImporter/const_values_cxx.swift
+++ b/test/ClangImporter/const_values_cxx.swift
@@ -1,0 +1,94 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swiftxx-frontend %t/src/main.swift \
+// RUN:   -import-bridging-header %t/src/test.h \
+// RUN:   -module-name main -I %t -emit-sil | %FileCheck %s
+
+//--- test.h
+
+const int const_int = 42;
+namespace Namespace {
+  const int namespaced_const_int = 42;
+}
+
+static inline int foo() { return 42; }
+const int not_really_constant = foo();
+
+constexpr int constexpr_func() { return 42; }
+constexpr int constexpr_int = constexpr_func();
+static constexpr int static_constexpr_int = constexpr_func();
+
+class MyClass {
+public:
+  const int class_const_int = 42; // member field, don't expect to import as a global, no CHECKs for this
+  static const int class_static_const_int = 42;
+};
+
+namespace OtherNamespace {
+  constexpr int namespaced_constexpr_int = constexpr_func();
+  static constexpr int namespaced_static_constexpr_int = constexpr_func();
+}
+class OtherClass {
+  static constexpr int class_static_constexpr_int = 42;
+};
+
+
+//--- main.swift
+func foo() {
+  print(const_int)
+  print(Namespace.namespaced_const_int)
+  print(not_really_constant)
+  print(constexpr_int)
+  print(static_constexpr_int)
+
+  // TODO: Non-top-level constexpr variables currently are not imported at all (would be imported as static members)
+  //print(OtherNamespace.namespaced_constexpr_int)
+  //print(OtherNamespace.namespaced_static_constexpr_int)
+  //print(MyClass.class_static_constexpr_int)
+
+  print(MyClass().class_const_int)
+  print(MyClass.class_static_const_int)
+}
+
+// Only imported as external declarations:
+// CHECK: sil_global public_external [let] @not_really_constant : $Int32
+
+// CHECK:      sil shared [transparent] @$sSo9const_ints5Int32Vvg : $@convention(thin) () -> Int32 {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   %1 = struct $Int32 (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo9NamespaceO20namespaced_const_ints5Int32VvgZ : $@convention(method) (@thin Namespace.Type) -> Int32 {
+// CHECK-NEXT: // %0 "self"
+// CHECK-NEXT: bb0(%0 : $@thin Namespace.Type):
+// CHECK-NEXT:   debug_value %0, let, name "self", argno 1
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   %3 = struct $Int32 (%2)
+// CHECK-NEXT:   return %3
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo13constexpr_ints5Int32Vvg : $@convention(thin) () -> Int32 {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   %1 = struct $Int32 (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo20static_constexpr_ints5Int32Vvg : $@convention(thin) () -> Int32 {
+// CHECK-NEXT: bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   %1 = struct $Int32 (%0)
+// CHECK-NEXT:   return %1
+// CHECK-NEXT: }
+
+// CHECK:      sil shared [transparent] @$sSo7MyClassV22class_static_const_ints5Int32VvgZ : $@convention(method) (@thin MyClass.Type) -> Int32 {
+// CHECK-NEXT: // %0 "self"
+// CHECK-NEXT: bb0(%0 : $@thin MyClass.Type):
+// CHECK-NEXT:   debug_value %0, let, name "self", argno 1
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int32, 42
+// CHECK-NEXT:   %3 = struct $Int32 (%2)
+// CHECK-NEXT:   return %3
+// CHECK-NEXT: }

--- a/test/ClangImporter/const_values_fail.swift
+++ b/test/ClangImporter/const_values_fail.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/src/main.swift \
+// RUN:   -import-bridging-header %t/src/test.h \
+// RUN:   -module-name main -I %t -emit-sil -serialize-diagnostics -serialize-diagnostics-path %t/test.diag
+
+// RUN: c-index-test -read-diagnostics %t/test.diag 2>&1 | %FileCheck --check-prefix CHECK-DIAG %t/src/test.h
+
+//--- test.h
+static char other = 42;
+static const char static_const_char_that_is_not_const = 1 + other;
+// CHECK-DIAG: [[@LINE-1]]:{{.*}}: error: initializer element is not a compile-time constant
+// CHECK-DIAG: error: failed to import bridging header
+
+//--- main.swift
+func foo() {
+  print(static_const_char_that_is_not_const)
+}

--- a/test/Interop/Cxx/class/access/access-inversion-module-interface.swift
+++ b/test/Interop/Cxx/class/access/access-inversion-module-interface.swift
@@ -9,7 +9,7 @@
 // CHECK:     public init()
 // CHECK:     private init()
 // CHECK:     public func privateRecMethod()
-// CHECK:     public static let PRIVATE_REC_CONST: Bool
+// CHECK:     public static var PRIVATE_REC_CONST: Bool { get }
 // CHECK:   }
 
 // CHECK:   private struct PrivateEnum : Hashable, Equatable, RawRepresentable {
@@ -26,7 +26,7 @@
 // CHECK:     case privateEnumClassMember
 // CHECK:   }
 
-// CHECK:   private static let PRIVATE_CONST: Bool
+// CHECK:   private static var PRIVATE_CONST: Bool { get }
 
 // CHECK:   private static var privateAliasVal: Leaky.PrivateAlias
 // CHECK:   private static var privateRecVal: Leaky.PrivateRec

--- a/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
@@ -12,7 +12,7 @@
 // CHECK-NEXT:     init(fwd: NS1.ForwardDeclared<CInt>)
 // CHECK-NEXT:     typealias MyInt = Int32
 // CHECK-NEXT:     var fwd: NS1.ForwardDeclared<CInt>
-// CHECK-NEXT:     static let intValue: NS1.Decl<CInt>.MyInt
+// CHECK-NEXT:     static var intValue: NS1.Decl<CInt>.MyInt { get }
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct Decl<T> {

--- a/test/Interop/Cxx/static/static-member-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-irgen.swift
@@ -45,8 +45,8 @@ public func readDefinedConstMember() -> CInt {
 }
 
 // CHECK: define {{(protected |dllexport )?}}swiftcc i32 @"$s4main22readDefinedConstMembers5Int32VyF"() #0
-// CHECK: [[VALUE:%.*]] = load i32, ptr @{{_ZN21WithConstStaticMember7definedE|"\?defined@WithConstStaticMember@@2HB"}}, align 4
-// CHECK: ret i32 [[VALUE]]
+// CHECK: ret i32 48
+
 public func readDefinedOutOfLineConstMember() -> CInt {
   return WithConstStaticMember.definedOutOfLine
 }

--- a/test/Interop/Cxx/static/static-member-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-member-var-silgen.swift
@@ -56,9 +56,10 @@ func readDefinedConstMember() -> CInt {
 }
 
 // CHECK: sil hidden @$s4main22readDefinedConstMembers5Int32VyF : $@convention(thin) () -> Int32
-// CHECK: [[ADDR:%.*]] = global_addr @{{_ZN21WithConstStaticMember7definedE|\?defined@WithConstStaticMember@@2HB}} : $*Int32
-// CHECK: [[VALUE:%.*]] = load [[ADDR]] : $*Int32
-// CHECK: return [[VALUE]] : $Int32
+// CHECK: [[VALUE:%.*]] = integer_literal $Builtin.Int32, 48
+// CHECK: [[STRUCT:%.*]] = struct $Int32 ([[VALUE]] : $Builtin.Int32)
+// CHECK: return [[STRUCT]] : $Int32
+
 func readDefinedOutOfLineConstMember() -> CInt {
   return WithConstStaticMember.definedOutOfLine
 }

--- a/test/Interop/Cxx/static/static-var-irgen.swift
+++ b/test/Interop/Cxx/static/static-var-irgen.swift
@@ -10,7 +10,6 @@ public func initStaticVars() -> CInt {
 // CHECK: @{{_ZL9staticVar|staticVar}} = internal global i32 2, align 4
 // CHECK: @{{_ZL13staticVarInit|staticVarInit}} = internal global i32 0, align 4
 // CHECK: @{{_ZL19staticVarInlineInit|staticVarInlineInit}} = internal global i32 0, align 4
-// CHECK: @{{_ZL11staticConst|staticConst}} = internal constant i32 4, align 4
 // CHECK: @{{_ZL15staticConstInit|staticConstInit}} = internal global i32 0, align 4
 // CHECK: @{{_ZL21staticConstInlineInit|staticConstInlineInit}} = internal global i32 0, align 4
 // CHECK: @{{_ZL16staticNonTrivial|staticNonTrivial}} = internal global %class.NonTrivial zeroinitializer, align 4

--- a/test/Interop/Cxx/static/static-var-silgen.swift
+++ b/test/Interop/Cxx/static/static-var-silgen.swift
@@ -13,8 +13,6 @@ func initStaticVars() -> CInt {
 // CHECK: sil_global public_external @staticVarInit : $Int32
 // CHECK: // clang name: staticVarInlineInit
 // CHECK: sil_global public_external @staticVarInlineInit : $Int32
-// CHECK: // clang name: staticConst
-// CHECK: sil_global public_external [let] @staticConst : $Int32
 // CHECK: // clang name: staticConstInit
 // CHECK: sil_global public_external [let] @staticConstInit : $Int32
 // CHECK: // clang name: staticConstInlineInit
@@ -23,6 +21,14 @@ func initStaticVars() -> CInt {
 // CHECK: sil_global public_external @staticNonTrivial : $NonTrivial
 // CHECK: // clang name: staticConstNonTrivial
 // CHECK: sil_global public_external [let] @staticConstNonTrivial : $NonTrivial
+
+// CHECK: // staticConst.getter
+// CHECK: sil shared [transparent] @$sSo11staticConsts5Int32Vvg : $@convention(thin) () -> Int32 {
+// CHECK: bb0:
+// CHECK:   %0 = integer_literal $Builtin.Int32, 4
+// CHECK:   %1 = struct $Int32 (%0 : $Builtin.Int32)
+// CHECK:   return %1 : $Int32
+// CHECK: }
 
 func readStaticVar() -> CInt {
   return staticVar

--- a/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
+++ b/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
@@ -5,5 +5,5 @@
 // CHECK: }
 
 // CHECK: struct HasEmptySpecializationAndStaticDateMember<CChar> {
-// CHECK:   static let value: Bool
+// CHECK:   static var value: Bool { get }
 // CHECK: }

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -618,11 +618,15 @@ func testShims() -> UInt32 {
 }
 // CHECK-LABEL: sil hidden [ossa] @$s20access_marker_verify9testShimss6UInt32VyF : $@convention(thin) () -> UInt32 {
 // CHECK: bb0:
-// CHECK:   [[GA:%.*]] = global_addr @_SwiftKeyPathBufferHeader_SizeMask : $*UInt32
-// CHECK-NOT: begin_access
-// CHECK:   load [trivial] [[GA]] : $*UInt32
-// CHECK:   return
+// CHECK:   [[FR:%.*]] = function_ref @$sSo34_SwiftKeyPathBufferHeader_SizeMasks6UInt32Vvg : $@convention(thin) () -> UInt32
+// CHECK:   [[AP:%.*]] = apply [[FR]]() : $@convention(thin) () -> UInt32
+// CHECK:   return [[AP]]
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify9testShimss6UInt32VyF'
+// CHECK: sil shared [transparent] [serialized] [ossa] @$sSo34_SwiftKeyPathBufferHeader_SizeMasks6UInt32Vvg : $@convention(thin) () -> UInt32 {
+// CHECK: bb0:
+// CHECK:   integer_literal $Builtin.IntLiteral, 16777215
+// CHECK: } // end sil function '$sSo34_SwiftKeyPathBufferHeader_SizeMasks6UInt32Vvg'
+
 
 // --- global variable initialization.
 var globalString1 = "⓪" // start non-empty


### PR DESCRIPTION
Macro-defined constants in C (`#define FOO 42`) get the concrete value imported (as a synthesized getter) into Swift. For global variables with initializer values (in bridging headers and in .h files in modules), we today only import them as external declarations. This PR starts importing the *values* of constant integer and floating-point global variables. Motivation is two-fold:

- (1) Ongoing work on `@const` and constant-value evaluation (see <https://github.com/swiftlang/swift/pull/79753>, <https://github.com/swiftlang/swift/pull/79290> and <https://forums.swift.org/t/pitch-3-swift-compile-time-values/77434>), where it would be very useful to be able to use imported constants from C in Swift constant expressions.
- (2) Enabling more SIL-level optimizations, specifically constant folding values that depend on imported constants from C.

TODOs in this PR:
- [x] test case where val is null (initializer cannot constant fold)
- [x] test case where val is neither isFloat or isInit
- [x] test case that uses `__attribute__((swift_name))` to import as a member
- [x] test case for type and literal not matching (e.g. `ull` suffix)
- [x] test case for literal being too large
- [x] test case for expression that uses other constant variables
- [x] test case for expression that uses other variable that cannot be evaluated
- [x] C++: constexpr globals
- [x] C++: constant in a namespace
- [x] C++: constant in a class scope (static + non-static)

TODOs leaving as follow-up:
- [ ] Start importing constexpr as members (i.e. if a constexpr global is inside a namespace or a class)
- [ ] Fix support for CGFloat