### PR TITLE
[CSStep] Overload pruning should skip previously disabled choices

### DIFF
--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -708,6 +708,9 @@ private:
       // Disable all of the overload choices which are different from
       // the one which is currently picked for representative.
       for (auto *constraint : disjunction->getNestedConstraints()) {
+        if (constraint->isDisabled())
+          continue;
+
         auto choice = constraint->getOverloadChoice();
         if (!choice.isDecl() || choice.getDecl() == representative.getDecl())
           continue;


### PR DESCRIPTION
This should be a no-op for operators today expect that we found a case were C++ imported operator that had a label for the second argument which disabled the overload choice early and attempted to disable it again here which breaks CSTrail because pruned choices are re-enabled once disjunction checking is complete.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
