### PR TITLE
[6.2][Caching][Macro] Make macro plugin options cacheable

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1262,6 +1262,10 @@ REMARK(macro_loaded,none,
        "compiler plugin server '%2' with shared library '%3'}1",
        (Identifier, unsigned, StringRef, StringRef))
 
+ERROR(resolved_macro_changed,none,
+      "resolved macro library '%0' failed verification: %1",
+      (StringRef, StringRef))
+
 REMARK(transitive_dependency_behavior,none,
        "%1 has %select{a required|an optional|an ignored}2 "
        "transitive dependency on '%0'",

--- a/include/swift/AST/PluginLoader.h
+++ b/include/swift/AST/PluginLoader.h
@@ -52,10 +52,17 @@ private:
   /// Get or lazily create and populate 'PluginMap'.
   llvm::DenseMap<swift::Identifier, PluginEntry> &getPluginMap();
 
+  /// Resolved plugin path remappings.
+  std::vector<std::string> PathRemap;
+
 public:
   PluginLoader(ASTContext &Ctx, DependencyTracker *DepTracker,
+               std::optional<std::vector<std::string>> Remap = std::nullopt,
                bool disableSandbox = false)
-      : Ctx(Ctx), DepTracker(DepTracker), disableSandbox(disableSandbox) {}
+      : Ctx(Ctx), DepTracker(DepTracker), disableSandbox(disableSandbox) {
+    if (Remap)
+      PathRemap = std::move(*Remap);
+  }
 
   void setRegistry(PluginRegistry *newValue);
   PluginRegistry *getRegistry();

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -510,6 +510,9 @@ public:
   /// Scanner Prefix Mapper.
   std::vector<std::string> ScannerPrefixMapper;
 
+  /// Verify resolved plugin is not changed.
+  bool ResolvedPluginVerification = false;
+
   /// When set, don't validate module system dependencies.
   ///
   /// If a system header is modified and this is not set, the compiler will

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2263,6 +2263,10 @@ def load_resolved_plugin:
            "and exectuable path can be empty if not used">,
   MetaVarName<"<library-path>#<executable-path>#<module-names>">;
 
+def resolved_plugin_verification : Flag<["-"], "resolved-plugin-verification">,
+                                   Flags<[FrontendOption, NoDriverOption]>,
+                                   HelpText<"verify resolved plugins">;
+
 def in_process_plugin_server_path : Separate<["-"], "in-process-plugin-server-path">,
   Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Path to dynamic library plugin server">;

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -13,11 +13,12 @@
 #include "swift/AST/PluginLoader.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
-#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/AST/DiagnosticsSema.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Parse/Lexer.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
 using namespace swift;
@@ -96,8 +97,44 @@ PluginLoader::getPluginMap() {
     map[moduleNameIdentifier] = {libPath, execPath};
   };
 
+  std::optional<llvm::PrefixMapper> mapper;
+  if (!PathRemap.empty()) {
+    SmallVector<llvm::MappedPrefix, 4> prefixes;
+    llvm::MappedPrefix::transformJoinedIfValid(PathRemap, prefixes);
+    mapper.emplace();
+    mapper->addRange(prefixes);
+    mapper->sort();
+  }
+  auto remapPath = [&mapper](StringRef path) {
+    if (!mapper)
+      return path.str();
+    return mapper->mapToString(path);
+  };
+
   auto fs = getPluginLoadingFS(Ctx);
   std::error_code ec;
+
+  auto validateLibrary = [&](StringRef path) -> llvm::Expected<std::string> {
+    auto remappedPath = remapPath(path);
+    if (!Ctx.SearchPathOpts.ResolvedPluginVerification || path.empty())
+      return remappedPath;
+
+    auto currentStat = fs->status(remappedPath);
+    if (!currentStat)
+      return llvm::createFileError(remappedPath, currentStat.getError());
+
+    auto goldStat = Ctx.SourceMgr.getFileSystem()->status(path);
+    if (!goldStat)
+      return llvm::createStringError(
+          "cannot open gold reference library to compare");
+
+    // Compare the size for difference for now.
+    if (currentStat->getSize() != goldStat->getSize())
+      return llvm::createStringError(
+          "plugin has changed since dependency scanning");
+
+    return remappedPath;
+  };
 
   for (auto &entry : Ctx.SearchPathOpts.PluginSearchOpts) {
     switch (entry.getKind()) {
@@ -156,9 +193,17 @@ PluginLoader::getPluginMap() {
       // Respect resolved plugin config above other search path, and it can
       // overwrite plugins found by other options or previous resolved
       // configuration.
-      for (auto &moduleName : val.ModuleNames)
-        try_emplace(moduleName, val.LibraryPath, val.ExecutablePath,
+      for (auto &moduleName : val.ModuleNames) {
+        auto libPath = validateLibrary(val.LibraryPath);
+        if (!libPath) {
+          Ctx.Diags.diagnose(SourceLoc(), diag::resolved_macro_changed,
+                             remapPath(val.LibraryPath),
+                             toString(libPath.takeError()));
+          continue;
+        }
+        try_emplace(moduleName, *libPath, remapPath(val.ExecutablePath),
                     /*overwrite*/ true);
+      }
       continue;
     }
     }

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -201,6 +201,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
                       ScanASTContext.SourceMgr, Diagnostics));
   auto loader = std::make_unique<PluginLoader>(
       *workerASTContext, /*DepTracker=*/nullptr,
+      workerCompilerInvocation->getFrontendOptions().CacheReplayPrefixMap,
       workerCompilerInvocation->getFrontendOptions().DisableSandbox);
   workerASTContext->setPluginLoader(std::move(loader));
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2417,6 +2417,9 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts, ArgList &Args,
     Opts.ScannerPrefixMapper.push_back(Opt.str());
   }
 
+  Opts.ResolvedPluginVerification |=
+      Args.hasArg(OPT_resolved_plugin_verification);
+
   // rdar://132340493 disable scanner-side validation for non-caching builds
   Opts.ScannerModuleValidation |= Args.hasFlag(OPT_scanner_module_validation,
                                                OPT_no_scanner_module_validation,

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -878,6 +878,7 @@ bool CompilerInstance::setUpPluginLoader() {
   /// FIXME: If Invocation has 'PluginRegistry', we can set it. But should we?
   auto loader = std::make_unique<PluginLoader>(
       *Context, getDependencyTracker(),
+      Invocation.getFrontendOptions().CacheReplayPrefixMap,
       Invocation.getFrontendOptions().DisableSandbox);
   Context->setPluginLoader(std::move(loader));
   return false;

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1932,6 +1932,8 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // Load plugin libraries for macro expression as default arguments
   genericSubInvocation.getSearchPathOptions().PluginSearchOpts =
       searchPathOpts.PluginSearchOpts;
+  genericSubInvocation.getSearchPathOptions().ResolvedPluginVerification =
+      searchPathOpts.ResolvedPluginVerification;
 
   // Get module loading behavior options.
   genericSubInvocation.getSearchPathOptions().ScannerModuleValidation = searchPathOpts.ScannerModuleValidation;

--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -43,10 +43,77 @@
 // RUN: %target-swift-frontend \
 // RUN:   -typecheck -verify -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
-// RUN:   -external-plugin-path %t/plugins/#%swift-plugin-server \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %t/macro.swift @%t/MyApp.cmd
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/macro.swift -o %t/deps2.json -swift-version 5 -cache-compile-job -cas-path %t/cas -external-plugin-path %t/plugins#%swift-plugin-server \
+// RUN:   -scanner-prefix-map %t=/^test -scanner-prefix-map %swift-bin-dir=/^bin -resolved-plugin-verification
+
+// RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps2.json MyApp casFSRootID > %t/fs.casid
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS-REMAP -DLIB=%target-library-name(MacroDefinition)
+
+/// CASFS is remapped.
+// FS-REMAP: /^test/plugins/[[LIB]]
+
+// RUN: %S/Inputs/BuildCommandExtractor.py %t/deps2.json clang:SwiftShims > %t/SwiftShims2.cmd
+// RUN: %swift_frontend_plain @%t/SwiftShims2.cmd
+
+// RUN: %S/Inputs/BuildCommandExtractor.py %t/deps2.json MyApp > %t/MyApp2.cmd
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps2.json > %t/map2.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map2.json > %t/map2.casid
+
+/// Command-line is remapped.
+// RUN: %FileCheck %s --check-prefix=CMD-REMAP --input-file=%t/MyApp2.cmd -DLIB=%target-library-name(MacroDefinition)
+
+// CMD-REMAP: -resolved-plugin-verification
+// CMD-REMAP-NEXT: -load-resolved-plugin
+// CMD-REMAP-NEXT: /^test/plugins/[[LIB]]#/^bin/swift-plugin-server#MacroDefinition
+
+// RUN: %target-swift-frontend \
+// RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map2.casid -Rmacro-loading -Rcache-compile-job \
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test=%t -cache-replay-prefix-map /^bin=%swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=REMARK
+// REMAKR: remark: cache miss
+// REMARK: remark: loaded macro implementation module 'MacroDefinition' from compiler plugin server
+
+/// Encoded PLUGIN_SEARCH_OPTION is remapped.
+// RUN: llvm-bcanalyzer -dump %t/Macro.swiftmodule | %FileCheck %s --check-prefix=MOD -DLIB=%target-library-name(MacroDefinition)
+
+// MOD: <PLUGIN_SEARCH_OPTION abbrevid=7 op0=4/> blob data = '/^test/plugins/[[LIB]]#/^bin/swift-plugin-server#MacroDefinition'
+
+/// Cache hit has no macro-loading remarks because no macro is actually loaded and the path might not be correct due to different mapping.
+// RUN: %target-swift-frontend \
+// RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map2.casid -Rmacro-loading -Rcache-compile-job \
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test=%t -cache-replay-prefix-map /^bin=%swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=NO-REMARK
+// NO-REMARK: remark: replay output file
+// NO-REMARK-NOT: remark: loaded macro implementation module 'MacroDefinition' from compiler plugin server
+
+/// Update timestamp, the build should still work.
+// RUN: touch %t/plugins/%target-library-name(MacroDefinition)
+// RUN: %target-swift-frontend \
+// RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map2.casid -Rmacro-loading -Rcache-compile-job -cache-disable-replay \
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test=%t -cache-replay-prefix-map /^bin=%swift-bin-dir
+
+/// Change the dylib content, this will fail the build.
+// RUN: echo " " >> %t/plugins/%target-library-name(MacroDefinition)
+// RUN: not %target-swift-frontend \
+// RUN:   -emit-module -o %t/Macro.swiftmodule -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map2.casid -Rmacro-loading -Rcache-compile-job -cache-disable-replay \
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test=%t -cache-replay-prefix-map /^bin=%swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=FAILED
+// FAILED: plugin has changed since dependency scanning
 
 //--- nomacro.swift
 func test() {}


### PR DESCRIPTION
  - **Explanation**: Make macro plugin options cacheable by applying prefix mapping to all of them.
    <!--
    A description of the changes. This can be brief, but it should be clear.
    -->
  - **Scope**: Allows swift caching to get more cache hits when the identical macro dylibs are relocated.
    <!--
    An assessment of the impact and importance of the changes. For example, can
    the changes break existing code?
    -->
  - **Issues**: rdar://148465899
    <!--
    References to issues the changes resolve, if any.
    -->
  - **Original PRs**: https://github.com/swiftlang/swift/pull/80474
    <!--
    Links to mainline branch pull requests in which the changes originated.
    -->
  - **Risk**: Low. Swift caching only.
    <!--
    The (specific) risk to the release for taking the changes.
    -->
  - **Testing**: Unit Test
    <!--
    The specific testing that has been done or needs to be done to further
    validate any impact of the changes.
    -->
  - **Reviewers**: @benlangmuir 
    <!--
    The code owners that GitHub-approved the original changes in the mainline
    branch pull requests. If an original change has not been GitHub-approved by
    a respective code owner, provide a reason. Technical review can be delegated
    by a code owner or otherwise requested as deemed appropriate or useful.
    -->

