### PR TITLE
NFC: fix comment in `WasmImpl.swift`

### DIFF
--- a/stdlib/public/Synchronization/Mutex/WasmImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WasmImpl.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Note: All atomic accesses on WASM are sequentially consistent regardless of
+// Note: All atomic accesses on Wasm are sequentially consistent regardless of
 // what ordering we tell LLVM to use.
 
 @_extern(c, "llvm.wasm.memory.atomic.wait32")


### PR DESCRIPTION
Wasm is not an acronym, thus it's not uppercased [per the spec](https://webassembly.github.io/spec/core/intro/introduction.html#wasm).

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
