### PR TITLE
[DCE] Don't delete instructions which consume escaping values.

### DIFF
--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -43,18 +43,18 @@ public:
   enum HandleTrivialVariable_t { IgnoreTrivialVariable, ExtendTrivialVariable };
 
 private:
-  // If domInfo is nullptr, then InteriorLiveness never assumes dominance. As a
-  // result it may report extra unenclosedPhis. In that case, any attempt to
-  // create a new phi would result in an immediately redundant phi.
+  /// If domInfo is nullptr, then InteriorLiveness never assumes dominance. As a
+  /// result it may report extra unenclosedPhis. In that case, any attempt to
+  /// create a new phi would result in an immediately redundant phi.
   const DominanceInfo *domInfo = nullptr;
 
   DeadEndBlocks &deadEndBlocks;
 
-  // Cache intructions already handled by the recursive algorithm to avoid
-  // recomputing their lifetimes.
+  /// Cache intructions already handled by the recursive algorithm to avoid
+  /// recomputing their lifetimes.
   ValueSet completedValues;
 
-  // Extend trivial variables for lifetime diagnostics (only in SILGenCleanup).
+  /// Extend trivial variables for lifetime diagnostics (only in SILGenCleanup).
   HandleTrivialVariable_t handleTrivialVariable;
 
 public:
@@ -64,13 +64,13 @@ public:
       : domInfo(domInfo), deadEndBlocks(deadEndBlocks),
         completedValues(function), handleTrivialVariable(handleTrivialVariable) {}
 
-  // The kind of boundary at which to complete the lifetime.
-  //
-  // Liveness: "As early as possible."  Consume the value after the last
-  //           non-consuming uses.
-  // Availability: "As late as possible."  Consume the value in the last blocks
-  //               beyond the non-consuming uses in which the value has been
-  //               consumed on no incoming paths.
+  /// The kind of boundary at which to complete the lifetime.
+  ///
+  /// Liveness: "As early as possible."  Consume the value after the last
+  ///           non-consuming uses.
+  /// Availability: "As late as possible."  Consume the value in the last blocks
+  ///               beyond the non-consuming uses in which the value has been
+  ///               consumed on no incoming paths.
   struct Boundary {
     enum Value : uint8_t {
       Liveness,

--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -57,12 +57,20 @@ private:
   /// Extend trivial variables for lifetime diagnostics (only in SILGenCleanup).
   HandleTrivialVariable_t handleTrivialVariable;
 
+  /// Whether verification of the computed liveness should be run even when the
+  /// global setting is off.
+  /// TODO: Remove this option.
+  bool ForceLivenessVerification;
+
 public:
-  OSSALifetimeCompletion(SILFunction *function, const DominanceInfo *domInfo,
-                         DeadEndBlocks &deadEndBlocks,
-                         HandleTrivialVariable_t handleTrivialVariable = IgnoreTrivialVariable)
+  OSSALifetimeCompletion(
+      SILFunction *function, const DominanceInfo *domInfo,
+      DeadEndBlocks &deadEndBlocks,
+      HandleTrivialVariable_t handleTrivialVariable = IgnoreTrivialVariable,
+      bool forceLivenessVerification = false)
       : domInfo(domInfo), deadEndBlocks(deadEndBlocks),
-        completedValues(function), handleTrivialVariable(handleTrivialVariable) {}
+        completedValues(function), handleTrivialVariable(handleTrivialVariable),
+        ForceLivenessVerification(forceLivenessVerification) {}
 
   /// The kind of boundary at which to complete the lifetime.
   ///

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -501,8 +501,9 @@ bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(
   };
   Walker walker(*this, scopedAddress, boundary, liveness);
   AddressUseKind result = walker.walk(scopedAddress.value);
-  if (VerifyLifetimeCompletion && boundary != Boundary::Availability
-      && result != AddressUseKind::NonEscaping) {
+  if ((VerifyLifetimeCompletion || ForceLivenessVerification) &&
+      boundary != Boundary::Availability &&
+      result != AddressUseKind::NonEscaping) {
     llvm::errs() << "Incomplete liveness for:\n" << scopedAddress.value;
     if (auto *escapingUse = walker.getEscapingUse()) {
       llvm::errs() << "  escapes at:\n";

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -835,7 +835,9 @@ bool DCE::removeDead() {
     }
   }
 
-  OSSALifetimeCompletion completion(F, DT, *deadEndBlocks);
+  OSSALifetimeCompletion completion(
+      F, DT, *deadEndBlocks, OSSALifetimeCompletion::IgnoreTrivialVariable,
+      /*forceLivenessVerification=*/true);
   for (auto value : valuesToComplete) {
     if (!value.has_value())
       continue;

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -15,10 +15,16 @@ class C {}
 
 sil @getC : $@convention(thin) () -> @owned C
 sil @barrier : $@convention(thin) () -> ()
+sil @initC : $@convention(thin) (Builtin.Word) -> (@owned C, Builtin.RawPointer)
+sil [readnone] @finalC : $@convention(thin) (@owned C) -> @owned C
 
 struct CAndBit {
     var c: C
     var bit: Int1
+}
+
+struct Bool {
+  var _value: Builtin.Int1
 }
 
 struct MO: ~Copyable {
@@ -507,3 +513,28 @@ bb0(%0 : @owned $Outer):
   return %6 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dont_remove_lifetime_end_of_escaping_value
+// CHECK:         [[FINALIZE:%[^,]+]] = function_ref @finalC
+// CHECK:         apply [[FINALIZE]]
+// CHECK-LABEL: } // end sil function 'dont_remove_lifetime_end_of_escaping_value'
+sil [ossa] @dont_remove_lifetime_end_of_escaping_value : $@convention(thin) (Bool) -> () {
+bb0(%0 : $Bool):
+  %1 = integer_literal $Builtin.Word, 1
+  %2 = function_ref @initC : $@convention(thin) (Builtin.Word) -> (@owned C, Builtin.RawPointer)
+  %3 = apply %2(%1) : $@convention(thin) (Builtin.Word) -> (@owned C, Builtin.RawPointer)
+  (%4, %5) = destructure_tuple %3
+  %6 = mark_dependence %5 on %4
+  %7 = pointer_to_address %6 to [strict] $*Bool
+  store %0 to [trivial] %7
+  br bb1
+
+bb1:
+  %13 = function_ref @finalC : $@convention(thin) (@owned C) -> @owned C
+  %14 = apply %13(%4) : $@convention(thin) (@owned C) -> @owned C
+  destroy_value %14
+  br bb2
+
+bb2:
+  %17 = tuple ()
+  return %17
+}


### PR DESCRIPTION
When DCE deletes instructions as dead, if the instruction ends one of its operands lifetimes, it must insert a compensating lifetime end. When the def block of the value and the parent block of the instruction are different, it uses lifetime completion.  Lifetime completion relies on complete liveness, which doesn't and can't exist for values with pointer escapes.  The result is ending lifetimes too early.

Avoid this scenario by marking such instructions live.

In the fullness of time, it may be possible to track the deleted instruction's "location" even in the face of deletions of adjacent instructions and parent blocks and to insert the lifetime end at that location.

rdar://149007151
