### PR TITLE
SILGen: Emit `copy x` on a trivial value as a trivial copy.

### DIFF
--- a/test/SILGen/copy_expr.swift
+++ b/test/SILGen/copy_expr.swift
@@ -439,3 +439,9 @@ func testCallMethodOnAddressOnlyInOutCopy<T : P>(_ x: inout T) {
   _ = (copy x).computedK
   _ = (copy x).consumingComputedK
 }
+
+struct Trivial: BitwiseCopyable { var x: Int }
+
+func copyTrivial(x: inout Trivial) -> Trivial {
+    return copy x
+}


### PR DESCRIPTION
Avoids an assertion failure emitting an `explicit_copy_value` on the trivial value, which is unsupported. This allows `copy x` to compile, albeit with no effect (which is not ideal, but also not a regression, since no-implicit-copy controls still don't fully work on trivial values). Fixes #80573 and rdar://148712387.