### PR TITLE
[6.2] SILGen: Emit `copy x` on a trivial value as a trivial copy.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -7179,6 +7179,14 @@ RValue RValueEmitter::visitCopyExpr(CopyExpr *E, SGFContext C) {
     auto address = SGF.emitAddressOfLValue(subExpr, std::move(lv));
 
     if (subType.isLoadable(SGF.F)) {
+      // Trivial types don't undergo any lifetime analysis, so simply load
+      // the value.
+      if (subType.isTrivial(SGF.F)
+          && !address.getType().isMoveOnlyWrapped()) {
+        return RValue(SGF, {SGF.B.createLoadCopy(E, address)},
+                      subType.getASTType());
+      }
+
       // Use a formal access load borrow so this closes in the writeback scope
       // above.
       ManagedValue value = SGF.B.createFormalAccessLoadBorrow(E, address);

--- a/test/SILGen/copy_expr.swift
+++ b/test/SILGen/copy_expr.swift
@@ -439,3 +439,9 @@ func testCallMethodOnAddressOnlyInOutCopy<T : P>(_ x: inout T) {
   _ = (copy x).computedK
   _ = (copy x).consumingComputedK
 }
+
+struct Trivial: BitwiseCopyable { var x: Int }
+
+func copyTrivial(x: inout Trivial) -> Trivial {
+    return copy x
+}


### PR DESCRIPTION
Avoids an assertion failure emitting an `explicit_copy_value` on the trivial value, which is unsupported. This allows `copy x` to compile, albeit with no effect (which is not ideal, but also not a regression, since no-implicit-copy controls still don't fully work on trivial values). Fixes #80573 and rdar://148712387.

PR for main: #80773

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
