### PR TITLE
utils: avoid redirection and use pipes for output redirection

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -765,13 +765,13 @@ function Invoke-Program() {
     if ($OutNull) {
       & $Executable @ExecutableArgs | Out-Null
     } elseif ($Silent) {
-      & $Executable @ExecutableArgs *> $null
+      & $Executable @ExecutableArgs | Out-Null 2>&1| Out-Null
     } elseif ($OutFile -and $ErrorFile) {
-      & $Executable @ExecutableArgs > $OutFile 2> $ErrorFile
+      & $Executable @ExecutableArgs | Out-File -FilePath $OutFile -Encoding UTF8 2>&1| Out-File -FilePath $ErrorFile -Encoding UTF8
     } elseif ($OutFile) {
-      & $Executable @ExecutableArgs > $OutFile
+      & $Executable @ExecutableArgs | Out-File -FilePath $OutFile -Encoding UTF8
     } elseif ($ErrorFile) {
-      & $Executable @ExecutableArgs 2> $ErrorFile
+      & $Executable @ExecutableArgs 2>&1| Out-File -FilePath $ErrorFile -Encoding UTF8
     } else {
       & $Executable @ExecutableArgs
     }


### PR DESCRIPTION
When the output is directly redirected, the output is re-encoded. This is particularly important as `Write-PList` uses `Invoke-Program` to invoke `python.exe` to write the plist. However, because it is writing to a file, while the output from Python is in UTF-8, the redirection re-encodes the output to UTF16LE (BOM). Adjust the invocation to use PS7+ `2|` and pipe both stdout and stderr as appropriate into files with UTF-8 encoding restoring the encoding for the file.