### PR TITLE
🌸 [ClangImporter] Fix import of aliased enum cases

### DIFF
--- a/test/ClangImporter/enum.swift
+++ b/test/ClangImporter/enum.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -compiler-assertions
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -compiler-assertions 2>&1 | %FileCheck %s
 // -- Check that we can successfully round-trip.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -D IRGEN -emit-ir -primary-file %s | %FileCheck -check-prefix=CHECK-IR %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -D IRGEN -emit-ir -primary-file %s -compiler-assertions | %FileCheck -check-prefix=CHECK-IR %s
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
* Explanation: Corrects a bug that could cause a C enum case with aliases to be imported incorrectly, resulting in a subtly malformed AST that could sometimes crash SILOptimizer's `ComputeSideEffects` pass.
* Issue: rdar://148213237
* Risk: Low. In theory this could cause `switch` statement exhaustivity to (correctly) diagnose a new error, but because C enums are usually non-frozen and are rarely switched over, we didn't see any failures in compatibility tests.
* Testing: Added assertions which are exercised by many existing tests.
* Original PR: #80557
* Reviewers: @Xazax-hun, @nkcsgexi 

Cherry-pick of #80557: 

> When a C enum has multiple constants with the same value, ClangImporter selects one of them to import as an `EnumElementDecl` and imports the others as `VarDecl` “aliases” of that one. This helps preserve the invariant that each case of an enum has a unique raw value and is distinct for exhaustiveness checking.
> 
> However, a bug in that logic could sometimes cause the canonical case to be imported *twice*—once as an `EnumElementDecl` and again as a `VarDecl` alias. In this situation, the `EnumElementDecl` was not added to the enum’s member list, resulting in a malformed AST. This bug has apparently been present since early 2017 (!), but it seems to have been harmless until recently, when the `ComputeSideEffects` SIL pass recently became sensitive to it (probably because of either #79872 or #80263).
> 
> Correct this problem by modifying the memoization logic to retrieve the canonical case’s clang-side constant so the subsequent check will succeed. Additionally change a variable name and add comments to help clarify this code for future maintainers.
> 
> In lieu of adding new unit tests, this commit adds a (slightly expensive) conditional assertion to catch this kind of AST malformation. There are actually about twenty tests that will fail with just the assertion and not the fix, but I’ve updated one of them to enable the assertion even in release mode.
> 
> Fixes rdar://148213237. Followup to #80487, which added related assertions to the SIL layer.