### PR TITLE
6.2: [DCE] Don't delete instructions which consume escaping values.

### DIFF
--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -43,18 +43,18 @@ public:
   enum HandleTrivialVariable_t { IgnoreTrivialVariable, ExtendTrivialVariable };
 
 private:
-  // If domInfo is nullptr, then InteriorLiveness never assumes dominance. As a
-  // result it may report extra unenclosedPhis. In that case, any attempt to
-  // create a new phi would result in an immediately redundant phi.
+  /// If domInfo is nullptr, then InteriorLiveness never assumes dominance. As a
+  /// result it may report extra unenclosedPhis. In that case, any attempt to
+  /// create a new phi would result in an immediately redundant phi.
   const DominanceInfo *domInfo = nullptr;
 
   DeadEndBlocks &deadEndBlocks;
 
-  // Cache intructions already handled by the recursive algorithm to avoid
-  // recomputing their lifetimes.
+  /// Cache intructions already handled by the recursive algorithm to avoid
+  /// recomputing their lifetimes.
   ValueSet completedValues;
 
-  // Extend trivial variables for lifetime diagnostics (only in SILGenCleanup).
+  /// Extend trivial variables for lifetime diagnostics (only in SILGenCleanup).
   HandleTrivialVariable_t handleTrivialVariable;
 
 public:
@@ -64,13 +64,13 @@ public:
       : domInfo(domInfo), deadEndBlocks(deadEndBlocks),
         completedValues(function), handleTrivialVariable(handleTrivialVariable) {}
 
-  // The kind of boundary at which to complete the lifetime.
-  //
-  // Liveness: "As early as possible."  Consume the value after the last
-  //           non-consuming uses.
-  // Availability: "As late as possible."  Consume the value in the last blocks
-  //               beyond the non-consuming uses in which the value has been
-  //               consumed on no incoming paths.
+  /// The kind of boundary at which to complete the lifetime.
+  ///
+  /// Liveness: "As early as possible."  Consume the value after the last
+  ///           non-consuming uses.
+  /// Availability: "As late as possible."  Consume the value in the last blocks
+  ///               beyond the non-consuming uses in which the value has been
+  ///               consumed on no incoming paths.
   struct Boundary {
     enum Value : uint8_t {
       Liveness,

--- a/include/swift/SIL/OSSALifetimeCompletion.h
+++ b/include/swift/SIL/OSSALifetimeCompletion.h
@@ -57,12 +57,20 @@ private:
   /// Extend trivial variables for lifetime diagnostics (only in SILGenCleanup).
   HandleTrivialVariable_t handleTrivialVariable;
 
+  /// Whether verification of the computed liveness should be run even when the
+  /// global setting is off.
+  /// TODO: Remove this option.
+  bool ForceLivenessVerification;
+
 public:
-  OSSALifetimeCompletion(SILFunction *function, const DominanceInfo *domInfo,
-                         DeadEndBlocks &deadEndBlocks,
-                         HandleTrivialVariable_t handleTrivialVariable = IgnoreTrivialVariable)
+  OSSALifetimeCompletion(
+      SILFunction *function, const DominanceInfo *domInfo,
+      DeadEndBlocks &deadEndBlocks,
+      HandleTrivialVariable_t handleTrivialVariable = IgnoreTrivialVariable,
+      bool forceLivenessVerification = false)
       : domInfo(domInfo), deadEndBlocks(deadEndBlocks),
-        completedValues(function), handleTrivialVariable(handleTrivialVariable) {}
+        completedValues(function), handleTrivialVariable(handleTrivialVariable),
+        ForceLivenessVerification(forceLivenessVerification) {}
 
   /// The kind of boundary at which to complete the lifetime.
   ///

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -501,8 +501,9 @@ bool OSSALifetimeCompletion::analyzeAndUpdateLifetime(
   };
   Walker walker(*this, scopedAddress, boundary, liveness);
   AddressUseKind result = walker.walk(scopedAddress.value);
-  if (VerifyLifetimeCompletion && boundary != Boundary::Availability
-      && result != AddressUseKind::NonEscaping) {
+  if ((VerifyLifetimeCompletion || ForceLivenessVerification) &&
+      boundary != Boundary::Availability &&
+      result != AddressUseKind::NonEscaping) {
     llvm::errs() << "Incomplete liveness for:\n" << scopedAddress.value;
     if (auto *escapingUse = walker.getEscapingUse()) {
       llvm::errs() << "  escapes at:\n";

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -835,7 +835,9 @@ bool DCE::removeDead() {
     }
   }
 
-  OSSALifetimeCompletion completion(F, DT, *deadEndBlocks);
+  OSSALifetimeCompletion completion(
+      F, DT, *deadEndBlocks, OSSALifetimeCompletion::IgnoreTrivialVariable,
+      /*forceLivenessVerification=*/true);
   for (auto value : valuesToComplete) {
     if (!value.has_value())
       continue;

--- a/test/SILOptimizer/dead_code_elimination_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_ossa.sil
@@ -15,10 +15,16 @@ class C {}
 
 sil @getC : $@convention(thin) () -> @owned C
 sil @barrier : $@convention(thin) () -> ()
+sil @initC : $@convention(thin) (Builtin.Word) -> (@owned C, Builtin.RawPointer)
+sil [readnone] @finalC : $@convention(thin) (@owned C) -> @owned C
 
 struct CAndBit {
     var c: C
     var bit: Int1
+}
+
+struct Bool {
+  var _value: Builtin.Int1
 }
 
 struct MO: ~Copyable {
@@ -507,3 +513,28 @@ bb0(%0 : @owned $Outer):
   return %6 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @dont_remove_lifetime_end_of_escaping_value
+// CHECK:         [[FINALIZE:%[^,]+]] = function_ref @finalC
+// CHECK:         apply [[FINALIZE]]
+// CHECK-LABEL: } // end sil function 'dont_remove_lifetime_end_of_escaping_value'
+sil [ossa] @dont_remove_lifetime_end_of_escaping_value : $@convention(thin) (Bool) -> () {
+bb0(%0 : $Bool):
+  %1 = integer_literal $Builtin.Word, 1
+  %2 = function_ref @initC : $@convention(thin) (Builtin.Word) -> (@owned C, Builtin.RawPointer)
+  %3 = apply %2(%1) : $@convention(thin) (Builtin.Word) -> (@owned C, Builtin.RawPointer)
+  (%4, %5) = destructure_tuple %3
+  %6 = mark_dependence %5 on %4
+  %7 = pointer_to_address %6 to [strict] $*Bool
+  store %0 to [trivial] %7
+  br bb1
+
+bb1:
+  %13 = function_ref @finalC : $@convention(thin) (@owned C) -> @owned C
+  %14 = apply %13(%4) : $@convention(thin) (@owned C) -> @owned C
+  destroy_value %14
+  br bb2
+
+bb2:
+  %17 = tuple ()
+  return %17
+}


### PR DESCRIPTION
**Explanation**: Fix a lifetime-shortening miscompile in DCE.

Dead code elimination deletes instructions.  Some of those instructions consume their operands.  When such an instruction is deleted, a compensating lifetime-ending instruction (e.g. `destroy_value`) must be inserted.  In simple cases, the pass has its own logic to determine where to insert the compensating lifetime-ending instruction.  For more complex cases, it depends on the lifetime completion utility, inserting compensating lifetime ends at the liveness boundary.  The utility requires (and can't be made not to) complete _liveness_ of the value that it's called on: it is not permitted to complete the lifetime at the liveness boundary of a value which does not have complete liveness.  Why?  The boundary isn't known.  In particular, it is not permitted if the value has a pointer escape.

Previously, however, DCE used the utility even in such cases.  This could result in inserting a compensating lifetime-ending instruction just after the value escapes to a pointer.  Code which then used that pointer would be using a dangling pointer.

Here, the pass is fixed to check whether an instruction consumes a value which escapes to a pointer.  If it does, it marks the instruction live, preventing it from being deleted.
**Scope**: Affects optimized code.
**Issue**: rdar://149007151
**Original PR**: https://github.com/swiftlang/swift/pull/80766
**Risk**: Low, the fix is to prevent the pass from making a change occasionally.
**Testing**: Added test.
**Reviewer**: Andrew Trick ( @atrick )
