### PR TITLE
[cxx-interop] Fix a crash with [[no_unique_address]]

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -16,6 +16,7 @@
 
 #include "GenStruct.h"
 
+#include "IRGen.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Decl.h"
@@ -42,6 +43,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
+#include "llvm/Support/Error.h"
 #include <iterator>
 
 #include "GenDecl.h"
@@ -1459,6 +1461,14 @@ private:
     unsigned fieldOffset = layout.getFieldOffset(clangField->getFieldIndex());
     assert(!clangField->isBitField());
     Size offset( SubobjectAdjustment.getValue() + fieldOffset / 8);
+    std::optional<Size> dataSize;
+    if (clangField->hasAttr<clang::NoUniqueAddressAttr>()) {
+      if (const auto *rd = clangField->getType()->getAsRecordDecl()) {
+        // Clang can store the next field in the padding of this one.
+        const auto &fieldLayout = ClangContext.getASTRecordLayout(rd);
+        dataSize = Size(fieldLayout.getDataSize().getQuantity());
+      }
+    }
 
     // If we have a Swift import of this type, use our lowered information.
     if (swiftField) {
@@ -1471,7 +1481,8 @@ private:
 
     // Otherwise, add it as an opaque blob.
     auto fieldSize = isZeroSized ? clang::CharUnits::Zero() : ClangContext.getTypeSizeInChars(clangField->getType());
-    return addOpaqueField(offset, Size(fieldSize.getQuantity()));
+    return addOpaqueField(offset,
+                          dataSize.value_or(Size(fieldSize.getQuantity())));
   }
 
   /// Add opaque storage for bitfields spanning the given range of bits.

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -1,6 +1,9 @@
 #ifndef TEST_INTEROP_CXX_CLASS_INPUTS_MEMBER_VARIABLES_H
 #define TEST_INTEROP_CXX_CLASS_INPUTS_MEMBER_VARIABLES_H
 
+#include <cstddef>
+#include <optional>
+
 class MyClass {
 public:
   const int const_member = 23;
@@ -23,6 +26,26 @@ struct HasZeroSizedField {
   short get_c() const { return c; }
   void set_c(short c) { this->c = c; }
 };
+
+struct ReuseFieldPadding {
+  [[no_unique_address]] std::optional<int> a = {2};
+  char c;
+  char get_c() const { return c; }
+  void set_c(char c) { this->c = c; }
+  int offset() const { return offsetof(ReuseFieldPadding, c); }
+  std::optional<int> getOptional() { return a; }
+};
+
+using OptInt = std::optional<int>;
+
+struct ReuseFieldPaddingWithTypedef {
+  [[no_unique_address]] OptInt a;
+  char c;
+  char get_c() const { return c; }
+  void set_c(char c) { this->c = c; }
+  int offset() const { return offsetof(ReuseFieldPadding, c); }
+};
+
 
 inline int takesZeroSizedInCpp(HasZeroSizedField x) {
   return x.a;

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -15,13 +15,43 @@ FieldsTestSuite.test("Zero sized field") {
   s.set_c(7)
   takeTypeWithZeroSizedMember(s)
   let s2 = s
-  let myInt : Empty.type = 6
+  let _ : Empty.type = 6
   expectEqual(s.a, 5)
   expectEqual(s.a, s.get_a())
   expectEqual(s2.c, 7)
   expectEqual(s2.c, s2.get_c())
   expectEqual(takesZeroSizedInCpp(s2), 5)
   expectEqual(s.b.getNum(), 42)
+}
+
+FieldsTestSuite.test("Field padding reused") {
+  var s = ReuseFieldPadding()
+  let opt = s.getOptional()
+  expectEqual(Int(opt.pointee), 2)
+  s.c = 5
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseFieldPadding>.offset(of: \.c)!)
+  expectEqual(s.c, 5)
+  expectEqual(s.get_c(), 5)
+  s.set_c(6)
+  expectEqual(s.c, 6)
+  expectEqual(s.get_c(), 6)
+  let s2 = s
+  expectEqual(s2.c, 6)
+  expectEqual(s2.get_c(), 6)
+}
+
+FieldsTestSuite.test("Typedef'd field padding reused") {
+  var s = ReuseFieldPaddingWithTypedef()
+  s.c = 5
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseFieldPadding>.offset(of: \.c)!)
+  expectEqual(s.c, 5)
+  expectEqual(s.get_c(), 5)
+  s.set_c(6)
+  expectEqual(s.c, 6)
+  expectEqual(s.get_c(), 6)
+  let s2 = s
+  expectEqual(s2.c, 6)
+  expectEqual(s2.get_c(), 6)
 }
 
 runAllTests()


### PR DESCRIPTION
Swift does not support storing fields in the padding of the previous fields just yet, so let's not import fields like that from C++. Represent them as opaque blobs instead.

Fixes #80764

rdar://149072458