### PR TITLE
[Concurrency] Avoid unused variable warning

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1800,8 +1800,7 @@ static void swift_task_removeCancellationHandlerImpl(
   auto task = swift_task_getCurrent();
   assert(task->_private()._status().load(std::memory_order_relaxed).getInnermostRecord() == record &&
     "We expect that the popped record will be exactly first as well as that it is of the expected type");
-  if (auto poppedRecord =
-      popStatusRecordOfType<CancellationNotificationStatusRecord>(task)) {
+  if (popStatusRecordOfType<CancellationNotificationStatusRecord>(task)) {
     swift_task_dealloc(record);
   }
 }


### PR DESCRIPTION
Minor cleanup, avoids warning:


```
warning: variable 'poppedRecord' set but not used [-Wunused-but-set-variable]
 1803 |   if (auto poppedRecord =
```

We already assert before the if, so no need for the `poppedRecord` anymore