### PR TITLE
[Concurrency] Remove -executor-factory option and replace with magic type.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1136,12 +1136,9 @@ NOTE(rbi_add_generic_parameter_sendable_conformance,none,
 
 // Concurrency related diagnostics
 ERROR(cannot_find_executor_factory_type, none,
-      "the specified executor factory '%0' could not be found", (StringRef))
+      "the DefaultExecutorFactory type could not be found", ())
 ERROR(executor_factory_must_conform, none,
-      "the executor factory '%0' does not conform to 'ExecutorFactory'",
-      (StringRef))
-ERROR(executor_factory_not_supported, none,
-      "deployment target too low for executor factory specification", ())
+      "the DefaultExecutorFactory does not conform to 'ExecutorFactory'", ())
 
 //===----------------------------------------------------------------------===//
 //                           MARK: Misc Diagnostics

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -409,10 +409,6 @@ namespace swift {
     /// Specifies how strict concurrency checking will be.
     StrictConcurrency StrictConcurrencyLevel = StrictConcurrency::Minimal;
 
-    /// Specifies the name of the executor factory to use to create the
-    /// default executors for Swift Concurrency.
-    std::optional<std::string> ExecutorFactory;
-
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -998,16 +998,6 @@ def default_isolation_EQ :  Joined<["-"], "default-isolation=">,
   Flags<[FrontendOption]>,
   Alias<default_isolation>;
 
-def executor_factory : JoinedOrSeparate<["-"], "executor-factory">,
-  Flags<[FrontendOption]>,
-  HelpText<"Specify the factory to use to create the default executors for "
-           "Swift Concurrency.  This must be a type conforming to the "
-           "'ExecutorFactory' protocol.">,
-  MetaVarName<"<factory-type>">;
-def executor_factory_EQ : Joined<["-"], "executor-factory=">,
-  Flags<[FrontendOption]>,
-  Alias<executor_factory>;
-
 def enable_experimental_feature :
   Separate<["-"], "enable-experimental-feature">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -379,10 +379,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     arguments.push_back(inputArgs.MakeArgString(globalRemapping));
   }
 
-  if (inputArgs.hasArg(options::OPT_executor_factory)) {
-    inputArgs.AddLastArg(arguments, options::OPT_executor_factory);
-  }
-
   // Pass through the values passed to -Xfrontend.
   inputArgs.AddAllArgValues(arguments, options::OPT_Xfrontend);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1364,12 +1364,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.enableFeature(Feature::RegionBasedIsolation);
   }
 
-  // Get the executor factory name
-  if (const Arg *A = Args.getLastArg(OPT_executor_factory)) {
-    printf("Got executor-factory option\n");
-    Opts.ExecutorFactory = A->getValue();
-  }
-
   Opts.WarnImplicitOverrides =
     Args.hasArg(OPT_warn_implicit_overrides);
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -514,25 +514,14 @@ FuncDecl *SILGenModule::getExit() {
 Type SILGenModule::getConfiguredExecutorFactory() {
   auto &ctx = getASTContext();
 
-  ModuleDecl *module;
+  // Look in the main module for a typealias
+  Type factory = ctx.getNamedSwiftType(ctx.MainModule, "DefaultExecutorFactory");
 
-  // Parse the executor factory name
-  StringRef qualifiedName = *ctx.LangOpts.ExecutorFactory;
-  StringRef typeName;
+  // If we don't find it, fall back to _Concurrency.PlatformExecutorFactory
+  if (!factory)
+    factory = getDefaultExecutorFactory();
 
-  auto parts = qualifiedName.split('.');
-
-  if (parts.second.empty()) {
-    // This was an unqualified name; assume it's relative to the main module
-    module = ctx.MainModule;
-    typeName = qualifiedName;
-  } else {
-    Identifier moduleName = ctx.getIdentifier(parts.first);
-    module = ctx.getModuleByIdentifier(moduleName);
-    typeName = parts.second;
-  }
-
-  return ctx.getNamedSwiftType(module, typeName);
+  return factory;
 }
 
 Type SILGenModule::getDefaultExecutorFactory() {

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -535,6 +535,9 @@ public protocol ExecutorFactory {
 }
 
 @available(SwiftStdlib 6.2, *)
+typealias DefaultExecutorFactory = PlatformExecutorFactory
+
+@available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_createExecutors")
 public func _createExecutors<F: ExecutorFactory>(factory: F.Type) {
   #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
@@ -556,7 +559,7 @@ extension MainActor {
   @available(SwiftStdlib 6.2, *)
   public static var executor: any MainExecutor {
     if _executor == nil {
-      _executor = PlatformExecutorFactory.mainExecutor
+      _executor = DefaultExecutorFactory.mainExecutor
     }
     return _executor!
   }
@@ -575,7 +578,7 @@ extension Task where Success == Never, Failure == Never {
   @available(SwiftStdlib 6.2, *)
   public static var defaultExecutor: any TaskExecutor {
     if _defaultExecutor == nil {
-      _defaultExecutor = PlatformExecutorFactory.defaultExecutor
+      _defaultExecutor = DefaultExecutorFactory.defaultExecutor
     }
     return _defaultExecutor!
   }

--- a/test/Concurrency/Runtime/custom_main_executor.swift
+++ b/test/Concurrency/Runtime/custom_main_executor.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -g %import-libdispatch -parse-as-library -executor-factory SimpleExecutorFactory) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -g %import-libdispatch -parse-as-library) | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: executable_test
@@ -12,6 +12,8 @@
 
 import StdlibUnittest
 import Synchronization
+
+typealias DefaultExecutorFactory = SimpleExecutorFactory
 
 struct SimpleExecutorFactory: ExecutorFactory {
   public static var mainExecutor: any MainExecutor {


### PR DESCRIPTION
We decided that using a magic typealias to set the executor factory was better than using a compiler option. Remove the `-executor-factory` option, and replace by looking up the `DefaultExecutorFactory` type, first in the main module, and then if that fails in Concurrency.

rdar://149058236
