### PR TITLE
[Concurrency] Fix size of AsyncTask::PrivateStorage.

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -316,9 +316,10 @@ public:
 #endif
 
     // Private storage is currently 6 pointers, 16 bytes of non-pointer data,
-    // the ActiveTaskStatus, and a RecursiveMutex.
+    // 8 bytes of padding, the ActiveTaskStatus, and a RecursiveMutex.
     static constexpr size_t PrivateStorageSize =
-        6 * sizeof(void *) + 16 + ActiveTaskStatusSize + sizeof(RecursiveMutex);
+      6 * sizeof(void *) + 16 + 8 + ActiveTaskStatusSize
+      + sizeof(RecursiveMutex);
 
     char Storage[PrivateStorageSize];
 

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -766,8 +766,10 @@ struct AsyncTask::PrivateStorage {
   alignas(ActiveTaskStatus) char StatusStorage[sizeof(ActiveTaskStatus)];
 
   /// The allocator for the task stack.
-  /// Currently 2 words + 8 bytes.
+  /// Currently 2 words + 4 bytes.
   TaskAllocator Allocator;
+
+  // Four bytes of padding here (on 64-bit)
 
   /// Storage for task-local values.
   /// Currently one word.
@@ -775,6 +777,8 @@ struct AsyncTask::PrivateStorage {
 
   /// The top 32 bits of the task ID. The bottom 32 bits are in Job::Id.
   uint32_t Id;
+
+  // Another four bytes of padding here too (on 64-bit)
 
   /// Base priority of Task - set only at creation time of task.
   /// Current max priority of task is ActiveTaskStatus.


### PR DESCRIPTION
Because `TaskAllocator` is not a round multiple of the machine word size on 64-bit platforms, I think we end up with padding before the `TaskLocal::Storage` following it, which makes the `PrivateStorage` structure larger than the calculation in `ABI/Task.h`.

rdar://149067144
