### PR TITLE
🍒[cxx-interop] Do not import arithmetic operators with rvalue reference parameters

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1967,6 +1967,14 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     case clang::OverloadedOperatorKind::OO_GreaterEqual:
     case clang::OverloadedOperatorKind::OO_AmpAmp:
     case clang::OverloadedOperatorKind::OO_PipePipe: {
+      // If the operator has a parameter that is an rvalue reference, it would
+      // cause name lookup collision with an overload that has lvalue reference
+      // parameter, if it exists.
+      for (auto paramDecl : functionDecl->parameters()) {
+        if (paramDecl->getType()->isRValueReferenceType())
+          return ImportedName();
+      }
+
       auto operatorName =
           isa<clang::CXXMethodDecl>(functionDecl)
               ? getOperatorName(swiftCtx, op)

--- a/test/Interop/Cxx/operators/Inputs/non-member-inline.h
+++ b/test/Interop/Cxx/operators/Inputs/non-member-inline.h
@@ -94,6 +94,29 @@ inline bool operator==(const ClassWithOperatorEqualsParamUnnamed &,
   return false;
 }
 
+struct RValueArithmetic {
+  int value;
+};
+
+RValueArithmetic operator+(const RValueArithmetic &lhs,
+                           RValueArithmetic &&rhs) {
+  return {lhs.value + rhs.value};
+}
+
+struct LValueAndRValueArithmetic {
+  int value;
+};
+
+LValueAndRValueArithmetic operator+(const LValueAndRValueArithmetic &lhs,
+                                    const LValueAndRValueArithmetic &rhs) {
+  return {lhs.value + rhs.value};
+}
+
+LValueAndRValueArithmetic operator+(const LValueAndRValueArithmetic &lhs,
+                                    LValueAndRValueArithmetic &&rhs) {
+  return {lhs.value + rhs.value};
+}
+
 // Make sure that we don't crash on templated operators
 template<typename T> struct S {};
 template<typename T> S<T> operator+(S<T> lhs, S<T> rhs);

--- a/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-module-interface.swift
@@ -19,3 +19,7 @@
 
 // CHECK:      func && (lhs: LoadableBoolWrapper, rhs: LoadableBoolWrapper) -> LoadableBoolWrapper
 // CHECK-NEXT: func || (lhs: LoadableBoolWrapper, rhs: LoadableBoolWrapper) -> LoadableBoolWrapper
+
+// CHECK-NOT:  func + (lhs: RValueArithmetic
+
+// CHECK:      func + (lhs: LValueAndRValueArithmetic, rhs: LValueAndRValueArithmetic) -> LValueAndRValueArithmetic

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -37,3 +37,11 @@ var rhsBool = LoadableBoolWrapper(value: false)
 
 let resultAmpAmp = lhsBool && rhsBool
 let resultPipePipe = lhsBool && rhsBool
+
+let lhsRValue = RValueArithmetic(value: 123)
+let rhsRValue = RValueArithmetic(value: 146)
+let resultRValue = lhsRValue + rhsRValue // expected-error {{binary operator '+' cannot be applied to two 'RValueArithmetic' operands}}
+
+let lhsLRValue = LValueAndRValueArithmetic(value: 123)
+let rhsLRValue = LValueAndRValueArithmetic(value: 146)
+let resultLRValue = lhsLRValue + rhsLRValue

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -193,4 +193,11 @@ OperatorsTestSuite.test("UnnamedParameterInOperator.equal") {
   expectFalse(lhs == rhs)
 }
 
+OperatorsTestSuite.test("LValueAndRValueArithmetic.+") {
+  let lhs = LValueAndRValueArithmetic(value: 123)
+  let rhs = LValueAndRValueArithmetic(value: 146)
+
+  expectEqual(269, (lhs + rhs).value)
+}
+
 runAllTests()


### PR DESCRIPTION
**Explanation**:  Before this change, Swift 6.2 tried importing rvalue parameters of overloaded operators by adding the `consuming:` label to the parameter. This isn't valid in Swift and it was causing an assertion failure.
**Scope**: This changes the way C++ overloaded operators are imported.
**Risk**: Low, this only affects C++ operators with rvalue reference parameters.
**Testing**: Added a compiler test.
**Issue**: rdar://149020099
**Reviewer**: @Xazax-hun @j-hui

Original PR: https://github.com/swiftlang/swift/pull/80763