### PR TITLE
[6.2 cherry-pick] [embedded] Fix linux-rng-support.c compiling in C++ mode, make it C instead

### DIFF
--- a/test/embedded/Inputs/linux-rng-support.c
+++ b/test/embedded/Inputs/linux-rng-support.c
@@ -5,14 +5,8 @@
 
 #ifdef __linux__ 
 
-#ifdef __cplusplus
-extern "C"
-#endif
 ssize_t getrandom(void *buf, size_t len, unsigned int flags);
 
-#ifdef __cplusplus
-extern "C"
-#endif
 void arc4random_buf(void *buf, size_t nbytes);
 
 void arc4random_buf(void *buf, size_t nbytes) {

--- a/test/embedded/linkage-mergeable4.swift
+++ b/test/embedded/linkage-mergeable4.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %linux_rng_support_c_if_needed %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
+// RUN: %target-embedded-link %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -4,6 +4,7 @@ config.substitutions = list(config.substitutions)
 # A handful of test setup tweaks that we want for *all* Embedded Swift tests (i.e. all tests in this directory):
 
 # (1) When targeting macOS, raise the deployment target to macOS 14.0 (from the default 13.0)
+config.target_clang = config.target_clang.replace("-apple-macosx13.0", "-apple-macos14")
 if config.target_sdk_name == 'macosx':
   def do_fixup(key, value):
     if isinstance(value, str):
@@ -31,6 +32,6 @@ if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.envi
 
 # (5) Provide some useful substitutions to simplify writing tests that work across platforms (macOS, Linux, etc.)
 if "OS=linux-gnu" in config.available_features:
-  config.substitutions.append(("%linux_rng_support_c_if_needed", "-x c %S/Inputs/linux-rng-support.c"))
+  config.substitutions.append(("%target-embedded-link", config.target_clang + " -x c %S/Inputs/linux-rng-support.c -x none"))
 else:
-  config.substitutions.append(("%linux_rng_support_c_if_needed", ""))
+  config.substitutions.append(("%target-embedded-link", config.target_clang))

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -31,6 +31,6 @@ if 'SWIFT_AVOID_WARNING_USING_OLD_DRIVER' in config.environment: del config.envi
 
 # (5) Provide some useful substitutions to simplify writing tests that work across platforms (macOS, Linux, etc.)
 if "OS=linux-gnu" in config.available_features:
-  config.substitutions.append(("%linux_rng_support_c_if_needed", "%S/Inputs/linux-rng-support.c"))
+  config.substitutions.append(("%linux_rng_support_c_if_needed", "-x c %S/Inputs/linux-rng-support.c"))
 else:
   config.substitutions.append(("%linux_rng_support_c_if_needed", ""))


### PR DESCRIPTION
Cherry-pick of <https://github.com/swiftlang/swift/pull/80617>, fixes this CI job: https://ci.swift.org/job/oss-swift-6.2-package-debian-12/7/

rdar://148944649
