### PR TITLE
test: tweak `verify-swift-feature-testing`

### DIFF
--- a/test/Misc/verify-swift-feature-testing.test-sh
+++ b/test/Misc/verify-swift-feature-testing.test-sh
@@ -98,6 +98,7 @@ def find_matches(swift_src_root):
     # `-enable-upcoming-feature` in the test directories.
     output = subprocess.check_output(
         [
+            "git",
             "grep",
             "--extended-regexp",
             "--recursive",


### PR DESCRIPTION
Attempt to use `git grep` instead of `grep`. This might help reduce the cost of this test. Currently, on Windows, this test takes ~350s, placing it 2nd in the slowest tests on Windows.