### PR TITLE
Tests: Re-enable async_sequence_existential.swift on Windows

### DIFF
--- a/test/Concurrency/async_sequence_existential.swift
+++ b/test/Concurrency/async_sequence_existential.swift
@@ -5,9 +5,6 @@
 
 // REQUIRES: concurrency
 
-// https://github.com/swiftlang/swift/issues/80582
-// UNSUPPORTED: OS=windows-msvc
-
 extension Error {
   func printMe() { }
 }


### PR DESCRIPTION
The fix in https://github.com/swiftlang/swift/pull/80685 (using `-o` to write the output to a file, instead of relying on stdout/stderr redirection) seems to have addressed this issue on other bots.

Resolves https://github.com/swiftlang/swift/issues/80582.
