### PR TITLE
Revert "tests: run `Misc/stats_dir_profiler.swift` only on macos and linux"

### DIFF
--- a/test/Misc/stats_dir_profiler.swift
+++ b/test/Misc/stats_dir_profiler.swift
@@ -2,12 +2,12 @@
 // RUN: %empty-directory(%t/stats-events)
 // RUN: %empty-directory(%t/stats-entities)
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-events %s -profile-stats-events -Xfrontend -fine-grained-timers
-// RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-entities %s -profile-stats-entities -Xfrontend -fine-grained-timers
+// %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-entities %s -profile-stats-entities -Xfrontend -fine-grained-timers
 
 // Need to use %long-tmp because in Windows the * may expand to a path longer
 // than 260 characters.
 // RUN: %FileCheck -check-prefix=EVENTS -input-file %long-tmp/stats-events/*.dir/Time.User.events %s
-// RUN: %FileCheck -check-prefix=ENTITIES -input-file %long-tmp/stats-entities/*.dir/Time.User.entities %s
+// %FileCheck -check-prefix=ENTITIES -input-file %long-tmp/stats-entities/*.dir/Time.User.entities %s
 
 // EVENTS: {{perform-sema;.*;typecheck-decl.* [0-9]+}}
 // ENTITIES: {{perform-sema;.*;TypeCheckFunctionBodyRequest bar\(\);typecheck-stmt.* [0-9]+}}

--- a/test/Misc/stats_dir_profiler.swift
+++ b/test/Misc/stats_dir_profiler.swift
@@ -4,13 +4,10 @@
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-events %s -profile-stats-events -Xfrontend -fine-grained-timers
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-entities %s -profile-stats-entities -Xfrontend -fine-grained-timers
 
+// Need to use %long-tmp because in Windows the * may expand to a path longer
+// than 260 characters.
 // RUN: %FileCheck -check-prefix=EVENTS -input-file %long-tmp/stats-events/*.dir/Time.User.events %s
 // RUN: %FileCheck -check-prefix=ENTITIES -input-file %long-tmp/stats-entities/*.dir/Time.User.entities %s
-
-// It's good enough to run the test on macOS and linux.
-// It takes very long on Windows because the * may expand to a path longer than 260 characters.
-
-// REQUIRES: OS=macosx || OS=linux-gnu
 
 // EVENTS: {{perform-sema;.*;typecheck-decl.* [0-9]+}}
 // ENTITIES: {{perform-sema;.*;TypeCheckFunctionBodyRequest bar\(\);typecheck-stmt.* [0-9]+}}


### PR DESCRIPTION
Reverts swiftlang/swift#80816 - the justification doesn't explain the issue (simply disabling any long running tests reduces test coverage but doesn't ensure functionality). This is a particularly important thing for things related to paths as those are particularly different across platforms.