### PR TITLE
Revert "[CS] Make sure macro arguments go through `coerceCallArguments`"

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5577,18 +5577,6 @@ namespace {
       E->setMacroRef(macroRef);
       E->setType(expandedType);
 
-      auto fnType =
-          simplifyType(overload.adjustedOpenedType)->castTo<FunctionType>();
-
-      auto newArgs = coerceCallArguments(
-          E->getArgs(), fnType, macroRef, /*applyExpr=*/nullptr,
-          cs.getConstraintLocator(E, ConstraintLocator::ApplyArgument),
-          solution.getAppliedPropertyWrappers(E));
-      if (!newArgs)
-        return nullptr;
-
-      E->setArgs(newArgs);
-
       // FIXME: Expansion should be lazy.
       // i.e. 'ExpandMacroExpansionExprRequest' should be sinked into
       // 'getRewritten()', and performed on-demand. Unfortunately that requires

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -667,28 +667,6 @@ func testLocalAccessorMacroWithAutoclosure() {
   takesAutoclosure(1)
 }
 
-@propertyWrapper
-struct SomePropertyWrapper<T> {
-  var wrappedValue: T
-  init(wrappedValue: T) {
-    self.wrappedValue = wrappedValue
-  }
-  init(projectedValue: Self) {
-    self = projectedValue
-  }
-  var projectedValue: Self { self }
-}
-
-// Property wrappers on macros probably aren't all that useful, but make sure
-// we don't crash.
-@freestanding(expression)
-macro hasPropertyWrapperParam(@SomePropertyWrapper x: Int) = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
-
-func testPropertyWrapperMacro() {
-  #hasPropertyWrapperParam(x: 0)
-  #hasPropertyWrapperParam($x: .init(wrappedValue: 0))
-}
-
 #if TEST_DIAGNOSTICS
 @freestanding(expression)
 macro missingMacro() = #externalMacro(module: "MacroDefinition", type: "BluhBlah")

--- a/test/Macros/macro_misc_diags.swift
+++ b/test/Macros/macro_misc_diags.swift
@@ -36,32 +36,6 @@ public struct TrailingClosureMacro: ExpressionMacro {
   }
 }
 
-public struct CallClosureMacro: ExpressionMacro {
-  public static func expansion(
-    of macro: some FreestandingMacroExpansionSyntax,
-    in context: some MacroExpansionContext
-  ) -> ExprSyntax {
-    guard let argument = macro.trailingClosure else {
-      fatalError()
-    }
-    return "\(argument)()"
-  }
-}
-
-public struct AddFunctionThatCallsClosureMacro: PeerMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    providingPeersOf declaration: some DeclSyntaxProtocol,
-    in context: some MacroExpansionContext
-  ) throws -> [DeclSyntax] {
-    guard case .argumentList(let args) = node.arguments else {
-      fatalError()
-    }
-    let arg = args.first!
-    return ["func qux() { \(arg)() }"]
-  }
-}
-
 public struct MakeBinding : DeclarationMacro {
   static public func expansion(
     of node: some FreestandingMacroExpansionSyntax,
@@ -89,12 +63,6 @@ macro identity<T>(_ x: T) -> T = #externalMacro(module: "MacroPlugin", type: "Id
 
 @freestanding(expression)
 macro trailingClosure<T>(_ x: T) -> T = #externalMacro(module: "MacroPlugin", type: "TrailingClosureMacro")
-
-@freestanding(expression)
-macro takesNonEscapingClosure(_ x: () -> Void) = #externalMacro(module: "MacroPlugin", type: "CallClosureMacro")
-
-@attached(peer, names: named(qux))
-macro AddFunctionThatCallsClosure<T>(_ fn: () -> T) = #externalMacro(module: "MacroPlugin", type: "AddFunctionThatCallsClosureMacro")
 
 @freestanding(declaration, names: named(x))
 macro makeBinding<T>(_ x: T) = #externalMacro(module: "MacroPlugin", type: "MakeBinding")
@@ -190,31 +158,5 @@ class rdar138997009_Class {
       #makeFunc(foo())
       // CHECK-DIAG: Client.swift:[[@LINE-1]]:17: warning: call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit; this will be an error in a future Swift language mode
     }
-  }
-}
-
-// https://github.com/swiftlang/swift/issues/80561
-class TestNonEscaping {
-  func foo() {}
-  func bar() {
-    _ = #takesNonEscapingClosure {
-      foo()
-    }
-    _ = {
-      _ = #takesNonEscapingClosure {
-        foo()
-        // CHECK-DIAG: @__swiftmacro_6Client0017Clientswift_yEEFcfMX[[@LINE-3]]{{.*}}takesNonEscapingClosurefMf_.swift:2:9: error: call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit
-        // CHECK-DIAG: Client.swift:[[@LINE-2]]:9: warning: call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit; this will be an error in a future Swift language mode
-      }
-    }
-
-    @AddFunctionThatCallsClosure({ foo() })
-    func baz() {}
-  }
-  func qux() {
-    @AddFunctionThatCallsClosure({ _ = { foo() } })
-    func baz() {}
-    // CHECK-DIAG: Client.swift:[[@LINE-2]]:42: warning: call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit; this will be an error in a future Swift language mode
-    // CHECK-DIAG: @__swiftmacro_6Client15TestNonEscapingC3quxyyF7baz_$l{{.*}}AddFunctionThatCallsClosurefMp_.swift:4:13: error: call to method 'foo' in closure requires explicit use of 'self' to make capture semantics explicit
   }
 }


### PR DESCRIPTION
Reverts swiftlang/swift#80583, this caused breakage for swift-testing: https://ci.swift.org/view/Swift%20Packages/job/swift-testing-main-swift-main-macos/518/console