### PR TITLE
[LifetimeDependenceMutableAccessors] defensive feature flag

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -419,6 +419,7 @@ EXPERIMENTAL_FEATURE(LifetimeDependence, true)
 
 /// Enable inout lifetime dependence - @lifetime(&arg)
 EXPERIMENTAL_FEATURE(InoutLifetimeDependence, true)
+EXPERIMENTAL_FEATURE(LifetimeDependenceMutableAccessors, true)
 
 /// Enable the `@_staticExclusiveOnly` attribute.
 EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -293,6 +293,23 @@ static bool usesFeatureInoutLifetimeDependence(Decl *decl) {
   }
 }
 
+static bool usesFeatureLifetimeDependenceMutableAccessors(Decl *decl) {
+  if (!isa<VarDecl>(decl)) {
+    return false;
+  }
+  auto var = cast<VarDecl>(decl);
+  if (!var->isGetterMutating()) {
+    return false;
+  }
+  if (auto dc = var->getDeclContext()) {
+    if (auto nominal = dc->getSelfNominalTypeDecl()) {
+      auto sig = nominal->getGenericSignature();
+      return !var->getInterfaceType()->isEscapable(sig);
+    }
+  }
+  return false;
+}
+
 UNINTERESTING_FEATURE(DynamicActorIsolation)
 UNINTERESTING_FEATURE(NonfrozenEnumExhaustivity)
 UNINTERESTING_FEATURE(ClosureIsolation)

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -636,6 +636,7 @@ function(_compile_swift_files
   list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")
   list(APPEND swift_flags "-enable-experimental-feature" "LifetimeDependence")
   list(APPEND swift_flags "-enable-experimental-feature" "InoutLifetimeDependence")
+  list(APPEND swift_flags "-enable-experimental-feature" "LifetimeDependenceMutableAccessors")
 
   list(APPEND swift_flags "-enable-upcoming-feature" "MemberImportVisibility")
 


### PR DESCRIPTION
Adds a feature flag for mutable getters that return non-escapable results.

The feature flag introduced here is intended to guard mutating accessors that return non-escapable types, because this combination crashes an older version of the compiler as it parses the swiftinterface file.

Addresses rdar://149227278