### PR TITLE
[Frontend] Add a way to print features supported by the compiler

### DIFF
--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -78,8 +78,8 @@ TYPE("fine-module-trace",   FineModuleTrace,           "",                "")
 // Complete dependency information for the given Swift files as JSON.
 TYPE("json-dependencies",   JSONDependencies,          "dependencies.json",      "")
 
-// Complete feature information for the given Swift compiler.
-TYPE("json-features",       JSONFeatures,              "features.json",   "")
+// Complete supported argument information for the given Swift compiler.
+TYPE("json-arguments",      JSONArguments,            "arguments.json",   "")
 
 // Gathered compile-time-known value information for the given Swift input file as JSON.
 TYPE("const-values",       ConstValues,              "swiftconstvalues",   "")

--- a/include/swift/Basic/SupportedFeatures.h
+++ b/include/swift/Basic/SupportedFeatures.h
@@ -1,0 +1,28 @@
+//===--- SupportedFeatures.h - Supported Features Output --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides a high-level API for supported features info
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SUPPORTEDFEATURES_H
+#define SWIFT_SUPPORTEDFEATURES_H
+
+#include "swift/Basic/LLVM.h"
+
+namespace swift {
+namespace features {
+void printSupportedFeatures(llvm::raw_ostream &out);
+} // namespace features
+} // namespace swift
+
+#endif

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -201,7 +201,7 @@ public:
 
     ScanDependencies, ///< Scan dependencies of Swift source files
     PrintVersion,     ///< Print version information.
-    PrintFeature,     ///< Print supported feature of this compiler
+    PrintArguments,   ///< Print supported arguments of this compiler
   };
 
   /// Indicates the action the user requested that the frontend perform.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -314,6 +314,10 @@ public:
   /// exit.
   bool PrintTargetInfo = false;
 
+  /// Indicates that the frontend should print the supported features and then
+  /// exit.
+  bool PrintSupportedFeatures = false;
+
   /// See the \ref SILOptions.EmitVerboseSIL flag.
   bool EmitVerboseSIL = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1534,6 +1534,10 @@ def print_target_info : Flag<["-"], "print-target-info">,
     Flags<[FrontendOption]>,
     HelpText<"Print target information for the given target <triple>, such as x86_64-apple-macos10.9">, MetaVarName<"<triple>">;
 
+def print_supported_features : Flag<["-"], "print-supported-features">,
+    Flags<[FrontendOption]>,
+    HelpText<"Print information about features supported by the compiler">;
+
 def target_cpu : Separate<["-"], "target-cpu">, Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Generate code for a particular CPU variant">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1654,9 +1654,13 @@ def scan_dependencies : Flag<["-"], "scan-dependencies">,
   HelpText<"Scan dependencies of the given Swift sources">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
-def emit_supported_features : Flag<["-"], "emit-supported-features">,
-  HelpText<"Emit a JSON file including all supported compiler features">, ModeOpt,
+def emit_supported_arguments : Flag<["-"], "emit-supported-arguments">,
+  HelpText<"Emit a JSON file including all supported compiler arguments">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def emit_supported_features : Flag<["-"], "emit-supported-features">,
+  HelpText<"This is a compatibility alias for '-emit-supported-arguments'">, ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild, HelpHidden]>,
+  Alias<emit_supported_arguments>;
 
 def enable_incremental_imports :
   Flag<["-"], "enable-incremental-imports">,

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -75,6 +75,7 @@ add_swift_host_library(swiftBasic STATIC
   StableHasher.cpp
   Statistic.cpp
   StringExtras.cpp
+  SupportedFeatures.cpp
   TargetInfo.cpp
   TaskQueue.cpp
   ThreadSafeRefCounted.cpp

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -112,7 +112,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_PackageSwiftModuleInterfaceFile:
   case file_types::TY_SwiftOverlayFile:
   case file_types::TY_JSONDependencies:
-  case file_types::TY_JSONFeatures:
+  case file_types::TY_JSONArguments:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:
   case file_types::TY_ConstValues:
@@ -195,7 +195,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_PrivateSwiftModuleInterfaceFile:
   case file_types::TY_PackageSwiftModuleInterfaceFile:
   case file_types::TY_JSONDependencies:
-  case file_types::TY_JSONFeatures:
+  case file_types::TY_JSONArguments:
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:
@@ -257,7 +257,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:
-  case file_types::TY_JSONFeatures:
+  case file_types::TY_JSONArguments:
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:
@@ -321,7 +321,7 @@ bool file_types::isProducedFromDiagnostics(ID Id) {
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:
-  case file_types::TY_JSONFeatures:
+  case file_types::TY_JSONArguments:
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:

--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -1,0 +1,74 @@
+//===--- SupportedFeatures.cpp - Supported features printing --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <array>
+#include <vector>
+
+#include "swift/Basic/Feature.h"
+#include "swift/Frontend/Frontend.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+namespace swift {
+namespace features {
+/// Print information about what features upcoming/experimental are
+/// supported by the compiler.
+/// The information includes whether a feature is adoptable and for
+/// upcoming features - what is the first mode it's introduced.
+void printSupportedFeatures(llvm::raw_ostream &out) {
+  std::array upcoming{
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
+#define UPCOMING_FEATURE(FeatureName, SENumber, Version) Feature::FeatureName,
+#include "swift/Basic/Features.def"
+  };
+
+  std::vector<swift::Feature> experimental{{
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
+#define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd) Feature::FeatureName,
+#include "swift/Basic/Features.def"
+  }};
+
+  // Include only experimental features that are available in production.
+  llvm::erase_if(experimental, [](auto &feature) {
+    return feature.isAvailableInProduction();
+  });
+
+  out << "{\n";
+  auto printFeature = [&out](const Feature &feature) {
+    out << "      ";
+    out << "{ \"name\": \"" << feature.getName() << "\"";
+    if (feature.isAdoptable()) {
+      out << ", \"migratable\": true";
+    }
+    if (auto version = feature.getLanguageVersion()) {
+      out << ", \"enabled_in\": " << *version;
+    }
+    out << " }";
+  };
+
+  out << "  \"features\": {\n";
+  out << "    \"upcoming\": [\n";
+  llvm::interleave(upcoming, printFeature, [&out] { out << ",\n"; });
+  out << "\n    ],\n";
+
+  out << "    \"experimental\": [\n";
+  llvm::interleave(experimental, printFeature, [&out] { out << ",\n"; });
+  out << "\n    ]\n";
+
+  out << "  }\n";
+  out << "}\n";
+}
+
+} // end namespace features
+} // end namespace swift

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2049,6 +2049,28 @@ bool Driver::handleImmediateArgs(const ArgList &Args, const ToolChain &TC) {
     return false;
   }
 
+  if (Args.hasArg(options::OPT_print_supported_features)) {
+    SmallVector<const char *, 5> commandLine;
+    commandLine.push_back("-frontend");
+    commandLine.push_back("-print-supported-features");
+
+    std::string executable = getSwiftProgramPath();
+
+    // FIXME(https://github.com/apple/swift/issues/54554): This bypasses
+    // mechanisms like -v and -###.
+    sys::TaskQueue queue;
+    queue.addTask(executable.c_str(), commandLine);
+    queue.execute(nullptr,
+                  [](sys::ProcessId PID, int returnCode, StringRef output,
+                     StringRef errors, sys::TaskProcessInformation ProcInfo,
+                     void *unused) -> sys::TaskFinishedResponse {
+                    llvm::outs() << output;
+                    llvm::errs() << errors;
+                    return sys::TaskFinishedResponse::ContinueExecution;
+                  });
+    return false;
+  }
+
   return true;
 }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1708,7 +1708,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_SwiftCrossImportDir:
       case file_types::TY_SwiftOverlayFile:
       case file_types::TY_JSONDependencies:
-      case file_types::TY_JSONFeatures:
+      case file_types::TY_JSONArguments:
       case file_types::TY_SwiftABIDescriptor:
       case file_types::TY_SwiftAPIDescriptor:
       case file_types::TY_ConstValues:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -754,8 +754,8 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
     return "-emit-imported-modules";
   case file_types::TY_JSONDependencies:
     return "-scan-dependencies";
-  case file_types::TY_JSONFeatures:
-    return "-emit-supported-features";
+  case file_types::TY_JSONArguments:
+    return "-emit-supported-arguments";
   case file_types::TY_IndexData:
     return "-typecheck";
   case file_types::TY_Remapping:
@@ -1041,7 +1041,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_ClangModuleFile:
     case file_types::TY_IndexData:
     case file_types::TY_JSONDependencies:
-    case file_types::TY_JSONFeatures:
+    case file_types::TY_JSONArguments:
       llvm_unreachable("Cannot be output from backend job");
     case file_types::TY_Swift:
     case file_types::TY_dSYM:

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -682,8 +682,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::CompileModuleFromInterface;
   if (Opt.matches(OPT_typecheck_module_from_interface))
     return FrontendOptions::ActionType::TypecheckModuleFromInterface;
-  if (Opt.matches(OPT_emit_supported_features))
-    return FrontendOptions::ActionType::PrintFeature;
+  if (Opt.matches(OPT_emit_supported_arguments))
+    return FrontendOptions::ActionType::PrintArguments;
   llvm_unreachable("Unhandled mode option");
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -206,6 +206,10 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.PrintTargetInfo = true;
   }
 
+  if (Args.hasArg(OPT_print_supported_features)) {
+    Opts.PrintSupportedFeatures = true;
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_verify_generic_signatures)) {
     Opts.VerifyGenericSignaturesInModule = A->getValue();
   }

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -451,7 +451,7 @@ static bool shouldEmitFineModuleTrace(FrontendOptions::ActionType action) {
   case swift::FrontendOptions::ActionType::DumpPCM:
   case swift::FrontendOptions::ActionType::ScanDependencies:
   case swift::FrontendOptions::ActionType::PrintVersion:
-  case swift::FrontendOptions::ActionType::PrintFeature:
+  case swift::FrontendOptions::ActionType::PrintArguments:
     return false;
   }
 }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -58,7 +58,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::EmitAssembly:
   case ActionType::EmitIRGen:
@@ -82,7 +82,7 @@ bool FrontendOptions::shouldActionOnlyParse(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return true;
   default:
     return false;
@@ -103,7 +103,7 @@ bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -138,7 +138,7 @@ bool FrontendOptions::doesActionRequireInputs(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::REPL:
   case ActionType::Parse:
@@ -181,7 +181,7 @@ bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
   case ActionType::EmitPCH:
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
@@ -226,7 +226,7 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
   case ActionType::DumpPCM:
   case ActionType::REPL:
   case ActionType::Parse:
@@ -362,8 +362,8 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
 
   case ActionType::ScanDependencies:
     return TY_JSONDependencies;
-  case ActionType::PrintFeature:
-    return TY_JSONFeatures;
+  case ActionType::PrintArguments:
+    return TY_JSONArguments;
   }
   llvm_unreachable("unhandled action");
 }
@@ -386,7 +386,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::REPL:
   case ActionType::DumpPCM:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -432,7 +432,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -482,7 +482,7 @@ bool FrontendOptions::canActionEmitModuleSummary(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -519,7 +519,7 @@ bool FrontendOptions::canActionEmitClangHeader(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -560,7 +560,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -610,7 +610,7 @@ bool FrontendOptions::canActionEmitModuleSemanticInfo(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
   case ActionType::EmitSIBGen:
@@ -653,7 +653,7 @@ bool FrontendOptions::canActionEmitConstValues(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -698,7 +698,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -744,7 +744,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -787,7 +787,7 @@ bool FrontendOptions::canActionEmitAPIDescriptor(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -838,7 +838,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return true;
 
   case ActionType::TypecheckModuleFromInterface:
@@ -889,7 +889,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return true;
   }
   llvm_unreachable("unhandled action");
@@ -916,7 +916,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
@@ -967,7 +967,7 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::Immediate:
   case ActionType::REPL:
@@ -1011,7 +1011,7 @@ bool FrontendOptions::doesActionBuildModuleFromInterface(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitIRGen:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -46,6 +46,7 @@
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/Basic/SupportedFeatures.h"
 #include "swift/Basic/TargetInfo.h"
 #include "swift/Basic/UUID.h"
 #include "swift/Basic/Version.h"
@@ -2060,6 +2061,11 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   if (Invocation.getFrontendOptions().PrintTargetInfo) {
     swift::targetinfo::printTargetInfo(Invocation, llvm::outs());
+    return finishDiagProcessing(0, /*verifierEnabled*/ false);
+  }
+
+  if (Invocation.getFrontendOptions().PrintSupportedFeatures) {
+    swift::features::printSupportedFeatures(llvm::outs());
     return finishDiagProcessing(0, /*verifierEnabled*/ false);
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1131,7 +1131,7 @@ static void printSingleFrontendOpt(llvm::opt::OptTable &table, options::ID id,
   }
 }
 
-static bool printSwiftFeature(CompilerInstance &instance) {
+static bool printSwiftArguments(CompilerInstance &instance) {
   ASTContext &context = instance.getASTContext();
   const CompilerInvocation &invocation = instance.getInvocation();
   const FrontendOptions &opts = invocation.getFrontendOptions();
@@ -1227,8 +1227,8 @@ static bool performAction(CompilerInstance &Instance,
     return Instance.getASTContext().hadError();
   case FrontendOptions::ActionType::PrintVersion:
     return printSwiftVersion(Instance.getInvocation());
-  case FrontendOptions::ActionType::PrintFeature:
-    return printSwiftFeature(Instance);
+  case FrontendOptions::ActionType::PrintArguments:
+    return printSwiftArguments(Instance);
   case FrontendOptions::ActionType::REPL:
     llvm::report_fatal_error("Compiler-internal integrated REPL has been "
                              "removed; use the LLDB-enhanced REPL instead.");

--- a/test/Frontend/emit-supported-features.swift
+++ b/test/Frontend/emit-supported-features.swift
@@ -1,8 +1,0 @@
-// RUN: %target-swift-frontend -emit-supported-features %s | %FileCheck %s
-
-// CHECK: "SupportedArguments"
-// CHECK: "abi"
-// CHECK: "emit-module"
-// CHECK: "LastOption"
-// CHECK: "SupportedFeatures"
-// CHECK: "LastFeature"

--- a/test/Frontend/print-supported-features.swift
+++ b/test/Frontend/print-supported-features.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -print-supported-features | %FileCheck %s
+
+// CHECK: "features": {
+// CHECK-NEXT:   "upcoming": [
+// CHECK:     { "name": "{{.*}}"{{, "migratable": true}}, "enabled_in": {{[0-9]+}} }
+// CHECK:   ],
+// CHECK-NEXT:   "experimental": [
+// CHECK:     { "name": "{{.*}}"{{, "migratable": true}} }
+// CHECK:   ]
+// CHECK: }


### PR DESCRIPTION
- Replace `-emit-supported-features` with `-emit-supported-arguments` mode because "features" part was never implemented.
- Introduce `-print-supported-features` option that prints supported upcoming/experimental features and their metadata.

Resolves: rdar://148124973
<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
