### PR TITLE
[swift-snapshot-tool] Two small fixes

### DIFF
--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/bisect_toolchains.swift
@@ -95,7 +95,7 @@ struct BisectToolchains: AsyncParsableCommand {
     // just say 50 toolchains ago. To get a few weeks worth. This is easier than
     // writing dates a lot.
     let oldDateAsDate = self.oldDateAsDate
-    guard let goodTagIndex = tags.firstIndex(where: { $0.tag.date(branch: self.branch) < oldDateAsDate }) else {
+    guard let goodTagIndex = tags.firstIndex(where: { $0.tag.date(branch: self.branch) <= oldDateAsDate }) else {
       log("Failed to find tag with date: \(oldDateAsDate)")
       fatalError()
     }

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
@@ -80,7 +80,7 @@ struct RunToolchains: AsyncParsableCommand {
     let tags = try! await getTagsFromSwiftRepo(branch: branch)
 
     let date = self.dateAsDate
-    guard var tagIndex = tags.firstIndex(where: { $0.tag.date(branch: self.branch) < date }) else {
+    guard var tagIndex = tags.firstIndex(where: { $0.tag.date(branch: self.branch) <= date }) else {
       log("Failed to find tag with date: \(date)")
       fatalError()
     }

--- a/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
+++ b/utils/swift_snapshot_tool/Sources/swift_snapshot_tool/run_toolchain.swift
@@ -39,8 +39,18 @@ struct RunToolchains: AsyncParsableCommand {
       """)
   var script: String
 
-  @Option(help: "Snapshot tag to run the test for")
-  var tag: String
+  @Option(help: "Date. We use the first snapshot produced before the given date")
+  var date: String
+
+  var dateAsDate: Date {
+    let d = DateFormatter()
+    d.dateFormat = "yyyy-MM-dd"
+    guard let result = d.date(from: date) else {
+      log("Improperly formatted date: \(date)! Expected format: yyyy_MM_dd.")
+      fatalError()
+    }
+    return result
+  }
 
   @Flag(help: "Invert the test so that we assume the newest succeeds")
   var invert = false
@@ -69,8 +79,9 @@ struct RunToolchains: AsyncParsableCommand {
     // Load our tags from swift's github repo
     let tags = try! await getTagsFromSwiftRepo(branch: branch)
 
-    guard var tagIndex = tags.firstIndex(where: { $0.tag.name == self.tag }) else {
-      log("Failed to find tag: \(self.tag)")
+    let date = self.dateAsDate
+    guard var tagIndex = tags.firstIndex(where: { $0.tag.date(branch: self.branch) < date }) else {
+      log("Failed to find tag with date: \(date)")
       fatalError()
     }
 


### PR DESCRIPTION
Just fixed this while using the tool to bisect some already fixed issues:

1. I changed it so that run doesn't take a full tag name and instead just takes a date like bisect does. Normalizing to just use the date makes sense since one shouldn't have to type swift-DEVELOPMENT-SNAPSHOT-YYYY-MM-DD-a instead of YYYY-MM-DD.
2. I noticed that when comparing dates to determine the tag to use, I was using < instead of <=. This meant that when one knew the exact tag to start bisecting at or running at, we always chose the one before it.