### PR TITLE
[Runtime] Handle relative witness tables in _getIsolationCheckingOptionsFromExecutorWitnessTable

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -506,7 +506,13 @@ extern "C" SWIFT_CC(swift) void _swift_task_enqueueOnExecutor(
 static swift_task_is_current_executor_flag
 _getIsolationCheckingOptionsFromExecutorWitnessTable(const SerialExecutorWitnessTable *_wtable) {
   const WitnessTable* wtable = reinterpret_cast<const WitnessTable*>(_wtable);
+#if SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES
+  auto description = lookThroughOptionalConditionalWitnessTable(
+    reinterpret_cast<const RelativeWitnessTable*>(wtable))
+    ->getDescription();
+#else
   auto description = wtable->getDescription();
+#endif
   if (!description) {
     return swift_task_is_current_executor_flag::None;
   }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -444,7 +444,7 @@ static bool _checkWitnessTableIsolation(
   llvm::ArrayRef<const void *> conditionalArgs,
   ConformanceExecutionContext &context
 ) {
-#if SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES && SWIFT_PTRAUTH
+#if SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES
   auto description = lookThroughOptionalConditionalWitnessTable(
                          reinterpret_cast<const RelativeWitnessTable *>(wtable))
                          ->getDescription();


### PR DESCRIPTION
Part of rdar://148687148.
