### PR TITLE
MoveOnlyChecker: Treat trivial stores as reinitializations rather than initializations.

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -1562,6 +1562,8 @@ void FieldSensitiveMultiDefPrunedLiveRange::findBoundariesInBlock(
                          return getBlockLiveness(predBlock, bitNo) ==
                                 FieldSensitivePrunedLiveBlocks::IsLive::LiveOut;
                        })) {
+        PRUNED_LIVENESS_LOG(llvm::dbgs() << "Marking ourself as boundary edge: bb"
+                                << block->getDebugID() << '\n');
         boundary.getBoundaryEdgeBits(block).set(bitNo);
       }
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -341,7 +341,9 @@ static void convertMemoryReinitToInitForm(SILInstruction *memInst,
   }
   case SILInstructionKind::StoreInst: {
     auto *si = cast<StoreInst>(memInst);
-    si->setOwnershipQualifier(StoreOwnershipQualifier::Init);
+    if (si->getOwnershipQualifier() != StoreOwnershipQualifier::Trivial) {
+      si->setOwnershipQualifier(StoreOwnershipQualifier::Init);
+    }
     dest = si->getDest();
     break;
   }
@@ -365,7 +367,8 @@ static bool isReinitToInitConvertibleInst(SILInstruction *memInst) {
   }
   case SILInstructionKind::StoreInst: {
     auto *si = cast<StoreInst>(memInst);
-    return si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign;
+    return si->getOwnershipQualifier() == StoreOwnershipQualifier::Assign
+        || si->getOwnershipQualifier() == StoreOwnershipQualifier::Trivial;
   }
   }
 }
@@ -2158,7 +2161,7 @@ bool GatherUsesVisitor::visitUse(Operand *op) {
     }
     return true;
   }
-
+  
   // Then handle destroy_addr specially. We want to as part of our dataflow to
   // ignore destroy_addr, so we need to track it separately from other uses.
   if (auto *dvi = dyn_cast<DestroyAddrInst>(user)) {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -213,8 +213,7 @@ bool noncopyable::memInstMustInitialize(Operand *memOper) {
   }
   case SILInstructionKind::StoreInst: {
     auto qual = cast<StoreInst>(memInst)->getOwnershipQualifier();
-    return qual == StoreOwnershipQualifier::Init ||
-           qual == StoreOwnershipQualifier::Trivial;
+    return qual == StoreOwnershipQualifier::Init;
   }
   case SILInstructionKind::BuiltinInst: {
     auto bi = cast<BuiltinInst>(memInst);
@@ -264,7 +263,9 @@ bool noncopyable::memInstMustReinitialize(Operand *memOper) {
   }
   case SILInstructionKind::StoreInst:
     return cast<StoreInst>(memInst)->getOwnershipQualifier() ==
-           StoreOwnershipQualifier::Assign;
+           StoreOwnershipQualifier::Assign
+        || cast<StoreInst>(memInst)->getOwnershipQualifier() ==
+           StoreOwnershipQualifier::Trivial;
 
 #define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \
   case SILInstructionKind::Store##Name##Inst:                                  \
@@ -506,6 +507,13 @@ struct SimpleTemporaryAllocStackElimVisitor
       // that if we have multiple projections on the final allocation, we can
       // tell these projections apart from projections from earlier allocations.
       return state.setFinalUser(op);
+    }
+    
+    if (auto *si = dyn_cast<StoreInst>(user);
+        si && si->getOwnershipQualifier() == StoreOwnershipQualifier::Trivial) {
+      // Bail on trivial stores.
+      LLVM_DEBUG(llvm::dbgs() << "Found trivial store: " << *user);
+      return false;
     }
 
     if (auto *cai = dyn_cast<CopyAddrInst>(user)) {

--- a/test/SILGen/inlinearray_reabstraction.swift
+++ b/test/SILGen/inlinearray_reabstraction.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+
+
+let a: InlineArray<_, (Int)->Int> = [{$0*2}]
+print(a[0](3))

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -367,9 +367,9 @@ bb0(%0 : @owned $Klass, %1 : @owned $Klass):
 // CHECK: bb0([[ARG0:%.*]] : ${{.*}}, [[ARG1:%.*]] :
 // CHECK:   debug_value [[ARG0]]
 // CHECK:   debug_value [[ARG1]]
-// CHECK:   destroy_addr [[ARG1]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[ARG1]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   destroy_addr [[ARG1]]
 // CHECK:   store [[ARG0]] to [trivial] [[GEP]]
 // CHECK:   end_access [[ACCESS]]
 // CHECK: } // end sil function 'myBufferViewSetter'

--- a/test/SILOptimizer/moveonly_addresschecker_trivial_member_assign.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_trivial_member_assign.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+final class Bar {
+	func update() {
+		foo?.baz = Foo2(baz: 5)
+	}
+	var foo: Foo? = Foo()
+}
+
+struct Foo: ~Copyable {
+	var baz: Foo2 = Foo2(baz: 0)
+}
+
+struct Foo2: ~Copyable {
+	var baz: Int = 0
+}
+


### PR DESCRIPTION
A trivial store is allowed to occur on an existing live value, and should not trigger an attempt to destroy the original value completely. Fixes rdar://147791932.