### PR TITLE
[6.2][rbi] Teach RBI how to handle non-Sendable bases of Sendable values

### DIFF
--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -303,26 +303,18 @@ private:
   struct UnderlyingTrackedValueInfo {
     SILValue value;
 
-    /// Only used for addresses.
-    std::optional<ActorIsolation> actorIsolation;
-
     explicit UnderlyingTrackedValueInfo(SILValue value) : value(value) {}
 
-    UnderlyingTrackedValueInfo() : value(), actorIsolation() {}
+    UnderlyingTrackedValueInfo() : value() {}
 
     UnderlyingTrackedValueInfo(const UnderlyingTrackedValueInfo &newVal)
-        : value(newVal.value), actorIsolation(newVal.actorIsolation) {}
+        : value(newVal.value) {}
 
     UnderlyingTrackedValueInfo &
     operator=(const UnderlyingTrackedValueInfo &newVal) {
       value = newVal.value;
-      actorIsolation = newVal.actorIsolation;
       return *this;
     }
-
-    UnderlyingTrackedValueInfo(SILValue value,
-                               std::optional<ActorIsolation> actorIsolation)
-        : value(value), actorIsolation(actorIsolation) {}
 
     operator bool() const { return value; }
   };

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -368,6 +368,12 @@ private:
     }
 
     operator bool() const { return value; }
+
+    void print(llvm::raw_ostream &os) const;
+    SWIFT_DEBUG_DUMP {
+      print(llvm::dbgs());
+      llvm::dbgs() << '\n';
+    }
   };
 
   /// A map from a SILValue to its equivalence class representative.

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -108,6 +108,7 @@ private:
 
 class TrackableValue;
 class TrackableValueState;
+struct TrackableValueLookupResult;
 
 enum class TrackableValueFlag {
   /// Base value that says a value is uniquely represented and is
@@ -272,6 +273,25 @@ public:
   }
 };
 
+/// A class that contains both a lookup value as well as extra metadata about
+/// properties of the original value that we looked up up from that we
+/// discovered as we searched for the lookup value.
+struct regionanalysisimpl::TrackableValueLookupResult {
+  /// The actual value that we are tracking.
+  ///
+  /// If we are tracking a Sendable address that has a non-Sendable base, this
+  /// will be an empty TrackableValue.
+  TrackableValue value;
+
+  /// If we are tracking an address, this is the base trackable value that is
+  /// being tracked. If the base is a Sendable value, then this will be an empty
+  /// TrackableValue.
+  std::optional<TrackableValue> base;
+
+  void print(llvm::raw_ostream &os) const;
+  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+};
+
 class RegionAnalysis;
 
 class RegionAnalysisValueMap {
@@ -282,6 +302,8 @@ public:
   using Region = PartitionPrimitives::Region;
   using TrackableValue = regionanalysisimpl::TrackableValue;
   using TrackableValueState = regionanalysisimpl::TrackableValueState;
+  using TrackableValueLookupResult =
+      regionanalysisimpl::TrackableValueLookupResult;
 
 private:
   /// A map from the representative of an equivalence class of values to their
@@ -301,18 +323,47 @@ private:
 
   /// State that the value -> representative computation yields to us.
   struct UnderlyingTrackedValueInfo {
+    /// The equivalence class value that we found that should be merged into
+    /// regions.
+    ///
+    /// Always set to a real value.
     SILValue value;
 
-    explicit UnderlyingTrackedValueInfo(SILValue value) : value(value) {}
+    /// The actual base value that we found if we were looking for an address
+    /// equivilance class and had a non-Sendable base. If we have an object or
+    /// we do not have a separate base, this is SILValue().
+    SILValue base;
 
-    UnderlyingTrackedValueInfo() : value() {}
+    /// Constructor for use if we only have either an object or an address
+    /// equivalence class that involves a complete non-Sendable path.
+    explicit UnderlyingTrackedValueInfo(SILValue value) : value(value), base() {
+      assert(value);
+    }
+
+    /// Constructor for use with addresses only where we have either:
+    ///
+    /// 1. A sendable address that is used but that has a non-Sendable base that
+    /// we have to insert requires for.
+    ///
+    /// 2. A non-Sendable address that is used but that has a separate
+    /// non-Sendable base due to an access path chain that has a split in
+    /// between the two due to the non-Sendable address being projected out of
+    /// an intervening sendable struct. The struct can be Sendable due to things
+    /// like being global actor isolated or by being marked @unchecked Sendable.
+    explicit UnderlyingTrackedValueInfo(SILValue value, SILValue base)
+        : value(value), base(base) {
+      assert(value);
+      assert(base);
+    }
+    UnderlyingTrackedValueInfo() : value(), base() {}
 
     UnderlyingTrackedValueInfo(const UnderlyingTrackedValueInfo &newVal)
-        : value(newVal.value) {}
+        : value(newVal.value), base(newVal.base) {}
 
     UnderlyingTrackedValueInfo &
     operator=(const UnderlyingTrackedValueInfo &newVal) {
       value = newVal.value;
+      base = newVal.base;
       return *this;
     }
 
@@ -355,10 +406,16 @@ public:
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 
-  TrackableValue
+  TrackableValueLookupResult
   getTrackableValue(SILValue value,
                     bool isAddressCapturedByPartialApply = false) const;
 
+private:
+  TrackableValue
+  getTrackableValueHelper(SILValue value,
+                          bool isAddressCapturedByPartialApply = false) const;
+
+public:
   /// An actor introducing inst is an instruction that doesn't have any
   /// non-Sendable parameters and produces a new value that has to be actor
   /// isolated.
@@ -370,7 +427,8 @@ public:
 
 private:
   std::optional<TrackableValue> getValueForId(Element id) const;
-  std::optional<TrackableValue> tryToTrackValue(SILValue value) const;
+  std::optional<TrackableValueLookupResult>
+  tryToTrackValue(SILValue value) const;
   TrackableValue
   getActorIntroducingRepresentative(SILInstruction *introducingInst,
                                     SILIsolationInfo isolation) const;
@@ -391,6 +449,15 @@ private:
   /// call this directly! Only call it from getUnderlyingTrackedValue.
   UnderlyingTrackedValueInfo
   getUnderlyingTrackedValueHelper(SILValue value) const;
+
+  /// A helper function that performs the actual getUnderlyingTrackedValue
+  /// computation that is cached in getUnderlyingTrackedValue(). Please never
+  /// call this directly! Only call it from getUnderlyingTrackedValue.
+  UnderlyingTrackedValueInfo
+  getUnderlyingTrackedValueHelperObject(SILValue value) const;
+
+  UnderlyingTrackedValueInfo
+  getUnderlyingTrackedValueHelperAddress(SILValue value) const;
 
   UnderlyingTrackedValueInfo getUnderlyingTrackedValue(SILValue value) const {
     // Use try_emplace so we only construct underlying tracked value info on

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -434,6 +434,16 @@ enum class PartitionOpKind : uint8_t {
   /// tryToTrackValue and SILIsolationInfo::get().
   AssignFresh,
 
+  /// Assign one value to a fresh region and then assign it to another value
+  /// that was also just assign fresh. Takes two parameters. The first is the
+  /// element to assign fresh and the second is the element to assign to.
+  ///
+  /// Used in combination with AssignFresh to initialize a chain of
+  /// values. Different from Assign since Assign allows for errors to
+  /// occur. This does not allow for any errors to be emitted since we are just
+  /// initializing a chain of values.
+  AssignFreshAssign,
+
   /// Merge the regions of two values, takes two args, both must be from
   /// non-sent regions.
   Merge,
@@ -483,39 +493,43 @@ enum class PartitionOpKind : uint8_t {
 class PartitionOp {
   using Element = PartitionPrimitives::Element;
 
-private:
-  PartitionOpKind opKind;
-  llvm::SmallVector<Element, 2> opArgs;
+public:
+  enum class Flag : uint8_t {
+    None,
 
+    /// This is a require of a non-Sendable base that we have a Sendable use
+    /// from. If the region was sent but at the sent point did not have any
+    /// element of the region that was captured by reference in a closure, we
+    /// can ignore the use.
+    RequireOfMutableBaseOfSendableValue,
+  };
+  using Options = OptionSet<Flag>;
+
+private:
   /// Record the SILInstruction that this PartitionOp was generated from, if
   /// generated during compilation from a SILBasicBlock
   PointerUnion<SILInstruction *, Operand *> source;
 
+  std::optional<Element> opArg1;
+  std::optional<Element> opArg2;
+
+  PartitionOpKind opKind;
+
+  Options options;
+
   // TODO: can the following declarations be merged?
   PartitionOp(PartitionOpKind opKind, Element arg1,
-              SILInstruction *sourceInst = nullptr)
-      : opKind(opKind), opArgs({arg1}), source(sourceInst) {
+              SILInstruction *sourceInst = nullptr, Options options = {})
+      : source(sourceInst), opArg1(arg1), opKind(opKind), options(options) {
     assert(((opKind != PartitionOpKind::Send &&
              opKind != PartitionOpKind::UndoSend) ||
             sourceInst) &&
            "Send needs a sourceInst");
   }
 
-  template <typename T>
-  PartitionOp(PartitionOpKind opKind, T collectionOfIndices,
-              SILInstruction *sourceInst = nullptr)
-      : opKind(opKind), opArgs(), source(sourceInst) {
-    assert(((opKind != PartitionOpKind::Send &&
-             opKind != PartitionOpKind::UndoSend) ||
-            sourceInst) &&
-           "Send needs a sourceInst");
-    for (Element elt : collectionOfIndices) {
-      opArgs.push_back(elt);
-    }
-  }
-
-  PartitionOp(PartitionOpKind opKind, Element arg1, Operand *sourceOperand)
-      : opKind(opKind), opArgs({arg1}), source(sourceOperand) {
+  PartitionOp(PartitionOpKind opKind, Element arg1, Operand *sourceOperand,
+              Options options = {})
+      : source(sourceOperand), opArg1(arg1), opKind(opKind), options(options) {
     assert(((opKind != PartitionOpKind::Send &&
              opKind != PartitionOpKind::UndoSend) ||
             bool(sourceOperand)) &&
@@ -523,8 +537,9 @@ private:
   }
 
   PartitionOp(PartitionOpKind opKind, Element arg1, Element arg2,
-              SILInstruction *sourceInst = nullptr)
-      : opKind(opKind), opArgs({arg1, arg2}), source(sourceInst) {
+              SILInstruction *sourceInst = nullptr, Options options = {})
+      : source(sourceInst), opArg1(arg1), opArg2(arg2), opKind(opKind),
+        options(options) {
     assert(((opKind != PartitionOpKind::Send &&
              opKind != PartitionOpKind::UndoSend) ||
             sourceInst) &&
@@ -532,15 +547,17 @@ private:
   }
 
   PartitionOp(PartitionOpKind opKind, Element arg1, Element arg2,
-              Operand *sourceOp = nullptr)
-      : opKind(opKind), opArgs({arg1, arg2}), source(sourceOp) {
+              Operand *sourceOp = nullptr, Options options = {})
+      : source(sourceOp), opArg1(arg1), opArg2(arg2), opKind(opKind),
+        options(options) {
     assert((opKind == PartitionOpKind::Assign ||
             opKind == PartitionOpKind::Merge) &&
            "Only supported for assign and merge");
   }
 
-  PartitionOp(PartitionOpKind opKind, SILInstruction *sourceInst)
-      : opKind(opKind), opArgs(), source(sourceInst) {}
+  PartitionOp(PartitionOpKind opKind, SILInstruction *sourceInst,
+              Options options = {})
+      : source(sourceInst), opKind(opKind), options(options) {}
 
   friend class Partition;
 
@@ -550,10 +567,19 @@ public:
     return PartitionOp(PartitionOpKind::Assign, destElt, srcElt, srcOperand);
   }
 
-  template <typename T>
-  static PartitionOp AssignFresh(T collection,
+  static PartitionOp AssignFresh(Element elt,
                                  SILInstruction *sourceInst = nullptr) {
-    return PartitionOp(PartitionOpKind::AssignFresh, collection, sourceInst);
+    return PartitionOp(PartitionOpKind::AssignFresh, elt, sourceInst);
+  }
+
+  /// Assign fresh \p elt and then assign it to \p srcElt.
+  ///
+  /// Used as part of emitting a sequence of AssignFresh that join the same
+  /// element.
+  static PartitionOp AssignFreshAssign(Element elt, Element srcElt,
+                                       SILInstruction *sourceInst = nullptr) {
+    return PartitionOp(PartitionOpKind::AssignFreshAssign, elt, srcElt,
+                       sourceInst);
   }
 
   static PartitionOp Send(Element tgt, Operand *sendingOp) {
@@ -570,9 +596,9 @@ public:
                        sourceOperand);
   }
 
-  static PartitionOp Require(Element tgt,
-                             SILInstruction *sourceInst = nullptr) {
-    return PartitionOp(PartitionOpKind::Require, tgt, sourceInst);
+  static PartitionOp Require(Element tgt, SILInstruction *sourceInst = nullptr,
+                             Options options = {}) {
+    return PartitionOp(PartitionOpKind::Require, tgt, sourceInst, options);
   }
 
   static PartitionOp UnknownPatternError(Element elt,
@@ -593,21 +619,50 @@ public:
   }
 
   bool operator==(const PartitionOp &other) const {
-    return opKind == other.opKind && opArgs == other.opArgs &&
-           source == other.source;
+    return opKind == other.opKind && opArg1 == other.opArg1 &&
+           opArg2 == other.opArg2 && source == other.source;
   };
 
   bool operator<(const PartitionOp &other) const {
     if (opKind != other.opKind)
       return opKind < other.opKind;
-    if (opArgs != other.opArgs)
-      return opArgs < other.opArgs;
+
+    if (opArg1 != other.opArg1) {
+      // null < non-null always.
+      if (!opArg1.has_value() && other.opArg1.has_value())
+        return true;
+      // non-null >= null always.
+      if (opArg1.has_value() && !other.opArg1.has_value())
+        return false;
+      return *opArg1 < other.opArg1.has_value();
+    }
+
+    if (opArg2 != other.opArg2) {
+      // null < non-null always.
+      if (!opArg2.has_value() && other.opArg2.has_value())
+        return true;
+      // non-null >= null always.
+      if (opArg2.has_value() && !other.opArg2.has_value())
+        return false;
+      return *opArg2 < other.opArg2.has_value();
+    }
+
     return source < other.source;
   }
 
   PartitionOpKind getKind() const { return opKind; }
 
-  ArrayRef<Element> getOpArgs() const { return opArgs; }
+  Element getOpArg1() const { return opArg1.value(); }
+  Element getOpArg2() const { return opArg2.value(); }
+
+  Options getOptions() const { return options; }
+
+  void getOpArgs(SmallVectorImpl<Element> &args) const {
+    if (opArg1.has_value())
+      args.push_back(*opArg1);
+    if (opArg2.has_value())
+      args.push_back(*opArg2);
+  }
 
   SILInstruction *getSourceInst() const {
     if (source.is<Operand *>())
@@ -1226,8 +1281,9 @@ public:
             isolationRegionInfo->merge(getIsolationRegionInfo(pair.first));
         if (!isolationRegionInfo)
           return {};
-        if (sourceOp)
+        if (sourceOp) {
           isClosureCapturedElt |= isClosureCaptured(pair.first, sourceOp);
+        }
       }
     }
 
@@ -1311,30 +1367,28 @@ public:
 
     switch (op.getKind()) {
     case PartitionOpKind::Assign: {
-      assert(op.getOpArgs().size() == 2 &&
-             "Assign PartitionOp should be passed 2 arguments");
-      assert(p.isTrackingElement(op.getOpArgs()[1]) &&
+      assert(p.isTrackingElement(op.getOpArg2()) &&
              "Assign PartitionOp's source argument should be already tracked");
 
       // See if we are assigning an a non-disconnected value into a 'out
       // sending' parameter. In such a case, we emit a diagnostic.
       if (doesParentFunctionHaveSendingResult(op)) {
-        if (auto instance = getRepresentativeValue(op.getOpArgs()[0])) {
+        if (auto instance = getRepresentativeValue(op.getOpArg1())) {
           if (auto value = instance.maybeGetValue()) {
             if (auto *fArg = dyn_cast<SILFunctionArgument>(value)) {
               if (fArg->getArgumentConvention().isIndirectOutParameter()) {
                 auto staticRegionIsolation =
-                    getIsolationRegionInfo(op.getOpArgs()[1]);
-                Region srcRegion = p.getRegion(op.getOpArgs()[1]);
+                    getIsolationRegionInfo(op.getOpArg2());
+                Region srcRegion = p.getRegion(op.getOpArg2());
                 auto dynamicRegionIsolation = getIsolationRegionInfo(srcRegion);
 
                 // We can unconditionally getValue here since we can never
                 // assign an actor introducing inst.
-                auto rep = getRepresentativeValue(op.getOpArgs()[1]).getValue();
+                auto rep = getRepresentativeValue(op.getOpArg2()).getValue();
                 if (!dynamicRegionIsolation.isDisconnected() &&
                     !staticRegionIsolation.isUnsafeNonIsolated()) {
                   handleError(AssignNeverSendableIntoSendingResultError(
-                      op, op.getOpArgs()[0], fArg, op.getOpArgs()[1], rep,
+                      op, op.getOpArg1(), fArg, op.getOpArg2(), rep,
                       dynamicRegionIsolation));
                 }
               }
@@ -1343,19 +1397,11 @@ public:
         }
       }
 
-      p.assignElement(op.getOpArgs()[0], op.getOpArgs()[1]);
+      p.assignElement(op.getOpArg1(), op.getOpArg2());
       return;
     }
     case PartitionOpKind::AssignFresh: {
-      auto arrayRef = op.getOpArgs();
-
-      Element front = arrayRef.front();
-      p.trackNewElement(front);
-      arrayRef = arrayRef.drop_front();
-      for (auto x : arrayRef) {
-        p.trackNewElement(x);
-        p.assignElement(x, front);
-      }
+      p.trackNewElement(op.getOpArg1());
       return;
     }
     case PartitionOpKind::Send: {
@@ -1364,14 +1410,12 @@ public:
       // ensures that if we pass the same argument multiple times to the same
       // sending function as weakly sent arguments, we do not get an
       // error.
-      assert(op.getOpArgs().size() == 1 &&
-             "Send PartitionOp should be passed 1 argument");
-      assert(p.isTrackingElement(op.getOpArgs()[0]) &&
+      assert(p.isTrackingElement(op.getOpArg1()) &&
              "Send PartitionOp's argument should already be tracked");
 
       // Before we do any further work, see if we have a nonisolated(unsafe)
       // element. In such a case, this is also not a real send point.
-      Element sentElement = op.getOpArgs()[0];
+      Element sentElement = op.getOpArg1();
       if (getIsolationRegionInfo(sentElement).isUnsafeNonIsolated()) {
         return;
       }
@@ -1380,7 +1424,7 @@ public:
       // isolation region info of everything else in our region. This is the
       // dynamic isolation region info found by the dataflow.
       Region sentRegion = p.getRegion(sentElement);
-      bool isClosureCapturedElt = false;
+      bool regionHasClosureCapturedElt = false;
       SILDynamicMergedIsolationInfo sentRegionIsolation;
 
       // TODO: Today we only return the first element in our region that has
@@ -1392,7 +1436,7 @@ public:
       if (!pairOpt) {
         return handleError(UnknownCodePatternError(op));
       }
-      std::tie(sentRegionIsolation, isClosureCapturedElt) = *pairOpt;
+      std::tie(sentRegionIsolation, regionHasClosureCapturedElt) = *pairOpt;
 
       // If we merged anything, we need to handle an attempt to send a
       // never-sent value unless our value has the same isolation info as our
@@ -1401,7 +1445,7 @@ public:
       if (!(calleeIsolationInfo &&
             sentRegionIsolation.hasSameIsolation(calleeIsolationInfo)) &&
           !sentRegionIsolation.isDisconnected()) {
-        return handleSendNeverSentHelper(op, op.getOpArgs()[0],
+        return handleSendNeverSentHelper(op, op.getOpArg1(),
                                          sentRegionIsolation);
       }
 
@@ -1417,9 +1461,16 @@ public:
           return;
       }
 
-      // Mark op.getOpArgs()[0] as sent.
+      // If this is a require of a mutable base of a Sendable value and we were
+      // not closure captured, we can bail.
+      if (op.getOptions().containsOnly(PartitionOp::Flag::RequireOfMutableBaseOfSendableValue) &&
+          regionHasClosureCapturedElt) {
+        return;
+      }
+
+      // Mark op.getOpArg1() as sent.
       SendingOperandState &state = operandToStateMap.get(op.getSourceOp());
-      state.isClosureCaptured |= isClosureCapturedElt;
+      state.isClosureCaptured |= regionHasClosureCapturedElt;
       if (auto newInfo = state.isolationInfo.merge(sentRegionIsolation)) {
         state.isolationInfo = *newInfo;
       } else {
@@ -1428,44 +1479,40 @@ public:
       assert(state.isolationInfo && "Cannot have unknown");
       state.isolationHistory.pushCFGHistoryJoin(p.getIsolationHistory());
       auto *ptrSet = ptrSetFactory.get(op.getSourceOp());
-      p.markSent(op.getOpArgs()[0], ptrSet);
+      p.markSent(op.getOpArg1(), ptrSet);
       return;
     }
     case PartitionOpKind::UndoSend: {
-      assert(op.getOpArgs().size() == 1 &&
-             "UndoSend PartitionOp should be passed 1 argument");
-      assert(p.isTrackingElement(op.getOpArgs()[0]) &&
+      assert(p.isTrackingElement(op.getOpArg1()) &&
              "UndoSend PartitionOp's argument should already be tracked");
 
-      // Mark op.getOpArgs()[0] as not sent.
-      p.undoSend(op.getOpArgs()[0]);
+      // Mark op.getOpArg1() as not sent.
+      p.undoSend(op.getOpArg1());
       return;
     }
     case PartitionOpKind::Merge: {
-      assert(op.getOpArgs().size() == 2 &&
-             "Merge PartitionOp should be passed 2 arguments");
-      assert(p.isTrackingElement(op.getOpArgs()[0]) &&
-             p.isTrackingElement(op.getOpArgs()[1]) &&
+      assert(p.isTrackingElement(op.getOpArg1()) &&
+             p.isTrackingElement(op.getOpArg2()) &&
              "Merge PartitionOp's arguments should already be tracked");
 
       // See if we are assigning an a non-disconnected value into a 'out
       // sending' parameter. In such a case, we emit a diagnostic.
       if (doesParentFunctionHaveSendingResult(op)) {
-        if (auto instance = getRepresentativeValue(op.getOpArgs()[0])) {
+        if (auto instance = getRepresentativeValue(op.getOpArg1())) {
           if (auto value = instance.maybeGetValue()) {
             if (auto *fArg = dyn_cast<SILFunctionArgument>(value)) {
               if (fArg->getArgumentConvention().isIndirectOutParameter()) {
                 auto staticRegionIsolation =
-                    getIsolationRegionInfo(op.getOpArgs()[1]);
-                Region srcRegion = p.getRegion(op.getOpArgs()[1]);
+                    getIsolationRegionInfo(op.getOpArg2());
+                Region srcRegion = p.getRegion(op.getOpArg2());
                 auto dynamicRegionIsolation = getIsolationRegionInfo(srcRegion);
                 // We can unconditionally getValue here since we can never
                 // assign an actor introducing inst.
-                auto rep = getRepresentativeValue(op.getOpArgs()[1]).getValue();
+                auto rep = getRepresentativeValue(op.getOpArg2()).getValue();
                 if (!dynamicRegionIsolation.isDisconnected() &&
                     !staticRegionIsolation.isUnsafeNonIsolated()) {
                   handleError(AssignNeverSendableIntoSendingResultError(
-                      op, op.getOpArgs()[0], fArg, op.getOpArgs()[1], rep,
+                      op, op.getOpArg1(), fArg, op.getOpArg2(), rep,
                       dynamicRegionIsolation));
                 }
               }
@@ -1474,39 +1521,35 @@ public:
         }
       }
 
-      p.merge(op.getOpArgs()[0], op.getOpArgs()[1]);
+      p.merge(op.getOpArg1(), op.getOpArg2());
       return;
     }
     case PartitionOpKind::Require:
-      assert(op.getOpArgs().size() == 1 &&
-             "Require PartitionOp should be passed 1 argument");
-      assert(p.isTrackingElement(op.getOpArgs()[0]) &&
+      assert(p.isTrackingElement(op.getOpArg1()) &&
              "Require PartitionOp's argument should already be tracked");
-      if (auto *sentOperandSet = p.getSentOperandSet(op.getOpArgs()[0])) {
+      if (auto *sentOperandSet = p.getSentOperandSet(op.getOpArg1())) {
         for (auto sentOperand : sentOperandSet->data()) {
-          handleLocalUseAfterSendHelper(op, op.getOpArgs()[0], sentOperand);
+          handleLocalUseAfterSendHelper(op, op.getOpArg1(), sentOperand);
         }
       }
       return;
     case PartitionOpKind::InOutSendingAtFunctionExit: {
-      assert(op.getOpArgs().size() == 1 &&
-             "Require PartitionOp should be passed 1 argument");
-      assert(p.isTrackingElement(op.getOpArgs()[0]) &&
+      assert(p.isTrackingElement(op.getOpArg1()) &&
              "Require PartitionOp's argument should already be tracked");
 
       // First check if the region of our 'inout sending' element has been
       // sent. In that case, we emit a special use after free error.
-      if (auto *sentOperandSet = p.getSentOperandSet(op.getOpArgs()[0])) {
+      if (auto *sentOperandSet = p.getSentOperandSet(op.getOpArg1())) {
         for (auto sentOperand : sentOperandSet->data()) {
-          handleError(InOutSendingNotInitializedAtExitError(
-              op, op.getOpArgs()[0], sentOperand));
+          handleError(InOutSendingNotInitializedAtExitError(op, op.getOpArg1(),
+                                                            sentOperand));
         }
         return;
       }
 
       // If we were not sent, check if our region is actor isolated. If so,
       // error since we need a disconnected value in the inout parameter.
-      Region inoutSendingRegion = p.getRegion(op.getOpArgs()[0]);
+      Region inoutSendingRegion = p.getRegion(op.getOpArg1());
       auto dynamicRegionIsolation = getIsolationRegionInfo(inoutSendingRegion);
 
       // If we failed to merge emit an unknown pattern error so we fail.
@@ -1519,24 +1562,31 @@ public:
       // disconnected.
       if (!dynamicRegionIsolation.isDisconnected()) {
         handleError(InOutSendingNotDisconnectedAtExitError(
-            op, op.getOpArgs()[0], dynamicRegionIsolation));
+            op, op.getOpArg1(), dynamicRegionIsolation));
       }
       return;
     }
     case PartitionOpKind::UnknownPatternError:
       // Begin tracking the specified element in case we have a later use.
-      p.trackNewElement(op.getOpArgs()[0]);
+      p.trackNewElement(op.getOpArg1());
 
       // Then emit an unknown code pattern error.
       return handleError(UnknownCodePatternError(op));
-    case PartitionOpKind::NonSendableIsolationCrossingResult:
+    case PartitionOpKind::NonSendableIsolationCrossingResult: {
       // Grab the dynamic dataflow isolation information for our element's
       // region.
-      Region region = p.getRegion(op.getOpArgs()[0]);
+      Region region = p.getRegion(op.getOpArg1());
 
       // Then emit the error.
       return handleError(
-          NonSendableIsolationCrossingResultError(op, op.getOpArgs()[0]));
+          NonSendableIsolationCrossingResultError(op, op.getOpArg1()));
+    }
+    case PartitionOpKind::AssignFreshAssign:
+      assert(p.isTrackingElement(op.getOpArg2()) &&
+             "Source argument should be already tracked");
+      p.trackNewElement(op.getOpArg1());
+      p.assignElement(op.getOpArg1(), op.getOpArg2());
+      return;
     }
     llvm_unreachable("Covered switch isn't covered?!");
   }

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1461,13 +1461,6 @@ public:
           return;
       }
 
-      // If this is a require of a mutable base of a Sendable value and we were
-      // not closure captured, we can bail.
-      if (op.getOptions().containsOnly(PartitionOp::Flag::RequireOfMutableBaseOfSendableValue) &&
-          regionHasClosureCapturedElt) {
-        return;
-      }
-
       // Mark op.getOpArg1() as sent.
       SendingOperandState &state = operandToStateMap.get(op.getSourceOp());
       state.isClosureCaptured |= regionHasClosureCapturedElt;

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -442,8 +442,16 @@ public:
   /// TODO: Fix the type checker.
   static bool isNonSendableType(SILType type, SILFunction *fn);
 
+  static bool isSendableType(SILType type, SILFunction *fn) {
+    return !isNonSendableType(type, fn);
+  }
+
   static bool isNonSendableType(SILValue value) {
     return isNonSendableType(value->getType(), value->getFunction());
+  }
+
+  static bool isSendableType(SILValue value) {
+    return !isNonSendableType(value);
   }
 
   bool hasSameIsolation(ActorIsolation actorIsolation) const;

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -874,11 +874,13 @@ RegionAnalysisValueMap::getUnderlyingTrackedValueHelper(SILValue value) const {
 
   // If we have an object base...
   if (base->getType().isObject()) {
-    // ... we purposely recurse into the cached version of our computation
-    // rather than recurse into getUnderlyingTrackedObjectValueHelper. This is
-    // safe since we know that value was previously an address so if our base is
-    // an object, it cannot be the same object.
-    return UnderlyingTrackedValueInfo(getUnderlyingTrackedValue(base).value);
+    // Recurse.
+    //
+    // NOTE: We purposely recurse into getUnderlyingTrackedValueHelper instead
+    // of getUnderlyingTrackedValue since we could cause an invalidation to
+    // occur in the underlying DenseMap that backs getUnderlyingTrackedValue()
+    // if we insert another entry into the DenseMap.
+    return UnderlyingTrackedValueInfo(getUnderlyingTrackedValueHelper(base));
   }
 
   // Otherwise, we return the actorIsolation that our visitor found.

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2539,11 +2539,16 @@ public:
     auto trackableDest = tryToTrackValue(dest);
     if (!trackableDest)
       return;
+
+    if (requireOperands)
+      builder.addRequire(trackableDest->getRepresentative().getValue());
+
     for (Operand *op : srcCollection) {
+      // If we have a trackable src, we need to require both if asked to and
+      // then merge the dest/src.
       if (auto trackableSrc = tryToTrackValue(op->get())) {
         if (requireOperands) {
           builder.addRequire(trackableSrc->getRepresentative().getValue());
-          builder.addRequire(trackableDest->getRepresentative().getValue());
         }
         builder.addMerge(trackableDest->getRepresentative().getValue(), op);
       }
@@ -2565,11 +2570,14 @@ public:
     auto trackableDest = tryToTrackValue(array.front().get());
     if (!trackableDest)
       return;
+
+    if (requireOperands)
+      builder.addRequire(trackableDest->getRepresentative().getValue());
+
     for (Operand &op : array.drop_front()) {
       if (auto trackableSrc = tryToTrackValue(op.get())) {
         if (requireOperands) {
           builder.addRequire(trackableSrc->getRepresentative().getValue());
-          builder.addRequire(trackableDest->getRepresentative().getValue());
         }
         builder.addMerge(trackableDest->getRepresentative().getValue(), &op);
       }

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3887,3 +3887,24 @@ void RegionAnalysis::initialize(SILPassManager *pm) {
 SILAnalysis *swift::createRegionAnalysis(SILModule *) {
   return new RegionAnalysis();
 }
+
+//===----------------------------------------------------------------------===//
+//                                MARK: Tests
+//===----------------------------------------------------------------------===//
+
+namespace swift::test {
+
+// Arguments:
+// - SILValue: value to look up isolation for.
+// Dumps:
+// - The inferred isolation.
+static FunctionTest
+    UnderlyingTrackedValue("sil_regionanalysis_underlying_tracked_value",
+                            [](auto &function, auto &arguments, auto &test) {
+                              RegionAnalysisValueMap valueMap(&function);
+                              auto value = arguments.takeValue();
+                              auto trackableValue = valueMap.getTrackableValue(value);
+                              trackableValue.print(llvm::outs());
+                            });
+
+} // namespace swift::test

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -2701,24 +2701,6 @@ struct DiagnosticEvaluator final
 
   void handleLocalUseAfterSend(LocalUseAfterSendError error) const {
     const auto &partitionOp = *error.op;
-
-    auto &operandState = operandToStateMap.get(error.sendingOp);
-
-    // Ignore this if we have a gep like instruction that is returning a
-    // sendable type and sendingOp was not set with closure
-    // capture.
-    if (auto *svi =
-            dyn_cast<SingleValueInstruction>(partitionOp.getSourceInst())) {
-      if (isa<TupleElementAddrInst, StructElementAddrInst>(svi) &&
-          !SILIsolationInfo::isNonSendableType(svi->getType(),
-                                               svi->getFunction())) {
-        bool isCapture = operandState.isClosureCaptured;
-        if (!isCapture) {
-          return;
-        }
-      }
-    }
-
     REGIONBASEDISOLATION_LOG(error.print(llvm::dbgs(), info->getValueMap()));
     sendingOpToRequireInstMultiMap.insert(
         error.sendingOp, RequireInst::forUseAfterSend(partitionOp.getSourceInst()));

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -142,6 +142,9 @@ void PartitionOp::print(llvm::raw_ostream &os, bool extraSpace) const {
   }
   case PartitionOpKind::Require: {
     os << "require ";
+    if (getOptions().containsOnly(
+            PartitionOp::Flag::RequireOfMutableBaseOfSendableValue))
+      os << "[mutable_base_of_sendable_val] ";
     if (extraSpace)
       os << extraSpaceLiteral;
     os << "%%" << getOpArg1();

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -113,55 +113,61 @@ void PartitionOp::print(llvm::raw_ostream &os, bool extraSpace) const {
     os << "assign ";
     if (extraSpace)
       os << extraSpaceLiteral;
-    os << "%%" << opArgs[0] << " = %%" << opArgs[1];
+    os << "%%" << getOpArg1() << " = %%" << getOpArg2();
     break;
   }
   case PartitionOpKind::AssignFresh:
-    os << "assign_fresh %%" << opArgs[0];
+    os << "assign_fresh %%" << getOpArg1();
     break;
   case PartitionOpKind::Send: {
     os << "send ";
     if (extraSpace)
       os << extraSpaceLiteral;
-    os << "%%" << opArgs[0];
+    os << "%%" << getOpArg1();
     break;
   }
   case PartitionOpKind::UndoSend: {
     os << "undo_send ";
     if (extraSpace)
       os << extraSpaceLiteral;
-    os << "%%" << opArgs[0];
+    os << "%%" << getOpArg1();
     break;
   }
   case PartitionOpKind::Merge: {
     os << "merge ";
     if (extraSpace)
       os << extraSpaceLiteral;
-    os << "%%" << opArgs[0] << " with %%" << opArgs[1];
+    os << "%%" << getOpArg1() << " with %%" << getOpArg2();
     break;
   }
   case PartitionOpKind::Require: {
     os << "require ";
     if (extraSpace)
       os << extraSpaceLiteral;
-    os << "%%" << opArgs[0];
+    os << "%%" << getOpArg1();
     break;
   }
   case PartitionOpKind::UnknownPatternError:
     os << "unknown pattern error ";
-    os << "%%" << opArgs[0];
+    os << "%%" << getOpArg1();
     break;
   case PartitionOpKind::InOutSendingAtFunctionExit:
     os << "inout_sending_at_function_exit ";
     if (extraSpace)
       os << extraSpaceLiteral;
-    os << "%%" << opArgs[0];
+    os << "%%" << getOpArg1();
     break;
   case PartitionOpKind::NonSendableIsolationCrossingResult:
     os << "nonsendable_isolationcrossing_result ";
     if (extraSpace)
       os << extraSpaceLiteral;
-    os << "%%" << opArgs[0];
+    os << "%%" << getOpArg1();
+    break;
+  case PartitionOpKind::AssignFreshAssign:
+    os << "assign_fresh_assign ";
+    if (extraSpace)
+      os << extraSpaceLiteral;
+    os << "%%" << getOpArg1() << " = %%" << getOpArg2();
     break;
   }
   os << ": " << *getSourceInst();

--- a/test/Concurrency/regionanalysis_trackable_value.sil
+++ b/test/Concurrency/regionanalysis_trackable_value.sil
@@ -1,0 +1,499 @@
+// RUN: %target-sil-opt -module-name infer --test-runner %s 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// PLEASE READ THIS!
+//
+// This test is specifically meant to test how we look through underlying
+// objects for region analysis.
+
+sil_stage raw
+
+import Swift
+import Builtin
+import _Concurrency
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {
+}
+
+class SendableKlass : @unchecked Sendable {
+}
+
+struct Struct2 {
+  let nsLet: NonSendableKlass
+  let sLet: SendableKlass
+  var nsVar: NonSendableKlass
+  var sVar: SendableKlass
+}
+
+struct Struct {
+  let nsLet: NonSendableKlass
+  let sLet: SendableKlass
+  var nsVar: NonSendableKlass
+  var sVar: SendableKlass
+
+  let struct2Let: Struct2
+  var struct2Var: Struct2
+
+  let sStruct: SendableStruct
+}
+
+struct SendableStruct : @unchecked Sendable {
+  let nsLet: NonSendableKlass
+}
+
+class NonSendableKlassWithState {
+  let sLet: Struct
+  var sVar: Struct
+  let recurseLet: NonSendableKlassWithState?
+  var recurseVar: NonSendableKlassWithState?
+}
+
+sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+sil @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+sil @constructStruct : $@convention(thin) () -> @owned Struct
+sil @constructSendableStruct : $@convention(thin) () -> @owned SendableStruct
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_direct_access: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var NonSendableKlass }
+// CHECK: end running test 1 of 1 on allocbox_direct_access: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_direct_access : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %c = apply %f() : $@convention(thin) () -> @owned NonSendableKlass
+  %a = alloc_box ${ var NonSendableKlass }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*NonSendableKlass
+
+  debug_value [trace] %p
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_nonsendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_nonsendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_nonsendable_let : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %nsLet = struct_element_addr %p : $*Struct, #Struct.nsLet
+  debug_value [trace] %nsLet
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_nonsendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_nonsendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_nonsendable_var : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %nsVar = struct_element_addr %p : $*Struct, #Struct.nsVar
+  debug_value [trace] %nsVar
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %6 = struct_element_addr %4 : $*Struct, #Struct.sLet
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_sendable_let : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %addr = struct_element_addr %p : $*Struct, #Struct.sLet
+  debug_value [trace] %addr
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %6 = struct_element_addr %4 : $*Struct, #Struct.sVar
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_sendable_var : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %addr = struct_element_addr %p : $*Struct, #Struct.sVar
+  debug_value [trace] %addr
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_let_grandfield_nonsendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_let_grandfield_nonsendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_let_grandfield_nonsendable_let : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %s2 = struct_element_addr %p : $*Struct, #Struct.struct2Let
+  %nsLet = struct_element_addr %s2 : $*Struct2, #Struct2.nsLet
+
+  debug_value [trace] %nsLet
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_let_grandfield_nonsendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_let_grandfield_nonsendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_let_grandfield_nonsendable_var : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p
+
+  %s2 = struct_element_addr %p : $*Struct, #Struct.struct2Let
+  %nsVar = struct_element_addr %s2 : $*Struct2, #Struct2.nsVar
+  debug_value [trace] %nsVar
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_let_grandfield_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %7 = struct_element_addr %6 : $*Struct2, #Struct2.sLet
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_let_grandfield_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_let_grandfield_sendable_let : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %s2 = struct_element_addr %p : $*Struct, #Struct.struct2Let
+  %addr = struct_element_addr %s2 : $*Struct2, #Struct2.sLet
+  debug_value [trace] %addr
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_let_grandfield_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   {{%.*}} = struct_element_addr %6 : $*Struct2, #Struct2.sVar
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_let_grandfield_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_let_grandfield_sendable_var : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %s2 = struct_element_addr %p : $*Struct, #Struct.struct2Let
+  %addr = struct_element_addr %s2 : $*Struct2, #Struct2.sVar
+  debug_value [trace] %addr
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_var_grandfield_nonsendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_var_grandfield_nonsendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_var_grandfield_nonsendable_let : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %s2 = struct_element_addr %p : $*Struct, #Struct.struct2Var
+  %nsLet = struct_element_addr %s2 : $*Struct2, #Struct2.nsLet
+
+  debug_value [trace] %nsLet
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_var_grandfield_nonsendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_var_grandfield_nonsendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_var_grandfield_nonsendable_var : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p
+
+  %s2 = struct_element_addr %p : $*Struct, #Struct.struct2Var
+  %nsVar = struct_element_addr %s2 : $*Struct2, #Struct2.nsVar
+  debug_value [trace] %nsVar
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_var_grandfield_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %7 = struct_element_addr %6 : $*Struct2, #Struct2.sLet
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_var_grandfield_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_var_grandfield_sendable_let : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %s2 = struct_element_addr %p : $*Struct, #Struct.struct2Var
+  %addr = struct_element_addr %s2 : $*Struct2, #Struct2.sLet
+  debug_value [trace] %addr
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_var_grandfield_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   {{%.*}} = struct_element_addr %6 : $*Struct2, #Struct2.sVar
+// CHECK: end running test 1 of 1 on allocbox_access_struct_field_var_grandfield_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_struct_field_var_grandfield_sendable_var : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructStruct : $@convention(thin) () -> @owned Struct
+  %c = apply %f() : $@convention(thin) () -> @owned Struct
+  %a = alloc_box ${ var Struct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p : $*Struct
+
+  %s2 = struct_element_addr %p : $*Struct, #Struct.struct2Var
+  %addr = struct_element_addr %s2 : $*Struct2, #Struct2.sVar
+  debug_value [trace] %addr
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_sendable_struct_field_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %6 = struct_element_addr %4 : $*SendableStruct, #SendableStruct.nsLet
+// CHECK: end running test 1 of 1 on allocbox_access_sendable_struct_field_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_sendable_struct_field_let : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructSendableStruct : $@convention(thin) () -> @owned SendableStruct
+  %c = apply %f() : $@convention(thin) () -> @owned SendableStruct
+  %a = alloc_box ${ var SendableStruct }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %c to [init] %p
+
+  %s2 = struct_element_addr %p : $*SendableStruct, #SendableStruct.nsLet
+  debug_value [trace] %s2
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on allocbox_access_sendable_struct_field_let_2: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %4 = struct_element_addr %2 : $*SendableStruct, #SendableStruct.nsLet
+// CHECK: end running test 1 of 1 on allocbox_access_sendable_struct_field_let_2: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allocbox_access_sendable_struct_field_let_2 : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %f = function_ref @constructSendableStruct : $@convention(thin) () -> @owned SendableStruct
+  %c = apply %f() : $@convention(thin) () -> @owned SendableStruct
+  %a = alloc_stack $SendableStruct
+  store %c to [init] %a
+
+  %s2 = struct_element_addr %a : $*SendableStruct, #SendableStruct.nsLet
+  debug_value [trace] %s2
+
+  destroy_addr %a
+  dealloc_stack %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on class_lookthrough_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %6 = ref_element_addr %5 : $NonSendableKlassWithState, #NonSendableKlassWithState.sLet
+// CHECK: end running test 1 of 1 on class_lookthrough_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @class_lookthrough_test : $@convention(thin) (@owned NonSendableKlassWithState) -> () {
+bb0(%0 : @owned $NonSendableKlassWithState):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %a = alloc_box ${ var NonSendableKlassWithState }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %0 to [init] %p : $*NonSendableKlassWithState
+
+  %p2 = load_borrow %p
+  %s = ref_element_addr %p2 : $NonSendableKlassWithState, #NonSendableKlassWithState.sLet
+  debug_value [trace] %s
+  end_borrow %p2
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// We model unchecked_enum_data as an assign, so we do not look through it. The
+// result of this is that we consider it a separate value (even though we could
+// cheat potentially).
+//
+// CHECK-LABEL: begin running test 1 of 1 on class_lookthrough_test_2: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:   Rep Value:   %8 = unchecked_enum_data %7 : $Optional<NonSendableKlassWithState>, #Optional.some!enumelt
+// CHECK: end running test 1 of 1 on class_lookthrough_test_2: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @class_lookthrough_test_2 : $@convention(thin) (@owned NonSendableKlassWithState) -> () {
+bb0(%0 : @owned $NonSendableKlassWithState):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %a = alloc_box ${ var NonSendableKlassWithState }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %0 to [init] %p : $*NonSendableKlassWithState
+
+  %p2 = load_borrow %p
+  %s = ref_element_addr %p2 : $NonSendableKlassWithState, #NonSendableKlassWithState.recurseLet
+  %s2 = load_borrow %s
+  %s3 = unchecked_enum_data %s2 : $Optional<NonSendableKlassWithState>, #Optional.some!enumelt
+  debug_value [trace] %s3
+  end_borrow %s2
+  end_borrow %p2
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// We always stop at ref_element_addr since it is a base of a value.
+//
+// CHECK-LABEL: begin running test 1 of 1 on class_lookthrough_test_3: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:   Rep Value:   %9 = ref_element_addr %8 : $NonSendableKlassWithState, #NonSendableKlassWithState.sLet
+// CHECK: end running test 1 of 1 on class_lookthrough_test_3: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @class_lookthrough_test_3 : $@convention(thin) (@owned NonSendableKlassWithState) -> () {
+bb0(%0 : @owned $NonSendableKlassWithState):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %a = alloc_box ${ var NonSendableKlassWithState }
+  %ab = begin_borrow %a
+  %p = project_box %ab, 0
+  store %0 to [init] %p : $*NonSendableKlassWithState
+
+  %p2 = load_borrow %p
+  %s = ref_element_addr %p2 : $NonSendableKlassWithState, #NonSendableKlassWithState.recurseLet
+  %s2 = load_borrow %s
+  %s3 = unchecked_enum_data %s2 : $Optional<NonSendableKlassWithState>, #Optional.some!enumelt
+  %s4 = ref_element_addr %s3 : $NonSendableKlassWithState, #NonSendableKlassWithState.sLet
+  debug_value [trace] %s4
+  end_borrow %s2
+  end_borrow %p2
+
+  end_borrow %ab
+  destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/Concurrency/regionanalysis_trackable_value.sil
+++ b/test/Concurrency/regionanalysis_trackable_value.sil
@@ -54,11 +54,15 @@ class NonSendableKlassWithState {
   var recurseVar: NonSendableKlassWithState?
 }
 
+actor Custom {}
+
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
 sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
 sil @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
 sil @constructStruct : $@convention(thin) () -> @owned Struct
 sil @constructSendableStruct : $@convention(thin) () -> @owned SendableStruct
+
+sil @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 
 /////////////////
 // MARK: Tests //
@@ -477,7 +481,7 @@ bb0(%0 : @owned $NonSendableKlassWithState):
 //
 // CHECK-LABEL: begin running test 1 of 1 on class_lookthrough_test_2: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
-// CHECK:   Rep Value:   %8 = unchecked_enum_data %7 : $Optional<NonSendableKlassWithState>, #Optional.some!enumelt
+// CHECK:    Rep Value:   %6 = ref_element_addr %5 : $NonSendableKlassWithState, #NonSendableKlassWithState.recurseLet
 // CHECK: end running test 1 of 1 on class_lookthrough_test_2: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @class_lookthrough_test_2 : $@convention(thin) (@owned NonSendableKlassWithState) -> () {
 bb0(%0 : @owned $NonSendableKlassWithState):
@@ -526,6 +530,113 @@ bb0(%0 : @owned $NonSendableKlassWithState):
 
   end_borrow %ab
   destroy_value %a
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on actor_deinit_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = unchecked_ref_cast %0 : $Custom to $Builtin.NativeObject
+// CHECK: end running test 1 of 1 on actor_deinit_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @actor_deinit_test : $@convention(thin) (@guaranteed Custom) -> @owned Builtin.NativeObject {
+bb0(%0 : @guaranteed $Custom):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %2 = builtin "destroyDefaultActor"(%0) : $()
+  %3 = unchecked_ref_cast %0 to $Builtin.NativeObject
+  %4 = unchecked_ownership_conversion %3, @guaranteed to @owned
+  debug_value [trace] %3
+  return %4
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on project_box_loadable_test_case: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK:    Rep Value: %0 = argument of bb0 : $*{ var NonSendableKlass }
+// CHECK: end running test 1 of 1 on project_box_loadable_test_case: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @project_box_loadable_test_case : $@convention(thin) @async (@in { var NonSendableKlass }) -> () {
+bb0(%0 : $*{ var NonSendableKlass }):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %1 = load [take] %0
+  %2 = project_box %1, 0
+  // function_ref transferIndirect
+  %3 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %4 = apply [callee_isolation=nonisolated] [caller_isolation=global_actor] %3<NonSendableKlass>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  debug_value [trace] %2
+  destroy_value %1
+  %6 = tuple ()
+  return %6
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on deep_value_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK:     Rep Value: %0 = argument of bb0 : $*{ var { var NonSendableKlass } }
+// CHECK: end running test 1 of 1 on deep_value_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @deep_value_test : $@convention(thin) @async (@in_guaranteed { var { var NonSendableKlass }  }) -> () {
+bb0(%0 : $*{ var { var NonSendableKlass } }):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %1 = load_borrow %0
+  %2 = project_box %1, 0
+  %3 = load_borrow %2
+  %4 = project_box %3, 0
+  // function_ref transferIndirect
+  %func = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply [callee_isolation=nonisolated] [caller_isolation=global_actor] %func<NonSendableKlass>(%4) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  debug_value [trace] %4
+  end_borrow %3
+  end_borrow %1
+  %6 = tuple ()
+  return %6
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on deep_base_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %5 = struct_element_addr %4 : $*Struct2, #Struct2.sLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: task-isolated].
+// CHECK:     Rep Value: %0 = argument of bb0 : $*{ var { var Struct2 } }
+// CHECK: end running test 1 of 1 on deep_base_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @deep_base_test : $@convention(thin) @async (@in_guaranteed { var { var Struct2 }  }) -> () {
+bb0(%0 : $*{ var { var Struct2 } }):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %1 = load_borrow %0
+  %2 = project_box %1, 0
+  %3 = load_borrow %2
+  %4 = project_box %3, 0
+  %5 = struct_element_addr %4 : $*Struct2, #Struct2.sLet
+  // function_ref transferIndirect
+  %func = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply [callee_isolation=nonisolated] [caller_isolation=global_actor] %func<SendableKlass>(%5) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  debug_value [trace] %5
+  end_borrow %3
+  end_borrow %1
+  %6 = tuple ()
+  return %6
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on alloc_stack_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %3 = struct_element_addr %1 : $*Struct2, #Struct2.sLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %1 = alloc_stack $Struct2
+// CHECK: end running test 1 of 1 on alloc_stack_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @alloc_stack_test : $@convention(thin) @async (@owned Struct2) -> () {
+bb0(%0 : @owned $Struct2):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %1 = alloc_stack $Struct2, let
+  store %0 to [init] %1
+
+  %5 = struct_element_addr %1 : $*Struct2, #Struct2.sLet
+  %func = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply [callee_isolation=nonisolated] [caller_isolation=global_actor] %func<SendableKlass>(%5) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  debug_value [trace] %5
+
+  destroy_addr %1
+  dealloc_stack %1
   %9999 = tuple ()
   return %9999 : $()
 }

--- a/test/Concurrency/regionanalysis_trackable_value.sil
+++ b/test/Concurrency/regionanalysis_trackable_value.sil
@@ -133,8 +133,12 @@ bb0:
 }
 
 // CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK:     Rep Value:   %6 = struct_element_addr %4 : $*Struct, #Struct.sLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
 // CHECK: end running test 1 of 1 on allocbox_access_struct_field_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @allocbox_access_struct_field_sendable_let : $@convention(thin) () -> () {
 bb0:
@@ -156,8 +160,12 @@ bb0:
 }
 
 // CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK:     Rep Value:   %6 = struct_element_addr %4 : $*Struct, #Struct.sVar
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
 // CHECK: end running test 1 of 1 on allocbox_access_struct_field_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @allocbox_access_struct_field_sendable_var : $@convention(thin) () -> () {
 bb0:
@@ -228,8 +236,12 @@ bb0:
 }
 
 // CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_let_grandfield_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK:     Rep Value:   %7 = struct_element_addr %6 : $*Struct2, #Struct2.sLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
 // CHECK: end running test 1 of 1 on allocbox_access_struct_field_let_grandfield_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @allocbox_access_struct_field_let_grandfield_sendable_let : $@convention(thin) () -> () {
 bb0:
@@ -252,8 +264,12 @@ bb0:
 }
 
 // CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_let_grandfield_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
-// CHECK:     Rep Value:   {{%.*}} = struct_element_addr %6 : $*Struct2, #Struct2.sVar
+// CHECK:     Rep Value:   %7 = struct_element_addr %6 : $*Struct2, #Struct2.sVar
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
 // CHECK: end running test 1 of 1 on allocbox_access_struct_field_let_grandfield_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @allocbox_access_struct_field_let_grandfield_sendable_var : $@convention(thin) () -> () {
 bb0:
@@ -325,8 +341,12 @@ bb0:
 }
 
 // CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_var_grandfield_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
 // CHECK:     Rep Value:   %7 = struct_element_addr %6 : $*Struct2, #Struct2.sLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
 // CHECK: end running test 1 of 1 on allocbox_access_struct_field_var_grandfield_sendable_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @allocbox_access_struct_field_var_grandfield_sendable_let : $@convention(thin) () -> () {
 bb0:
@@ -349,8 +369,12 @@ bb0:
 }
 
 // CHECK-LABEL: begin running test 1 of 1 on allocbox_access_struct_field_var_grandfield_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
-// CHECK:     Rep Value:   {{%.*}} = struct_element_addr %6 : $*Struct2, #Struct2.sVar
+// CHECK:     Rep Value:   %7 = struct_element_addr %6 : $*Struct2, #Struct2.sVar
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var Struct }
 // CHECK: end running test 1 of 1 on allocbox_access_struct_field_var_grandfield_sendable_var: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @allocbox_access_struct_field_var_grandfield_sendable_var : $@convention(thin) () -> () {
 bb0:
@@ -373,8 +397,12 @@ bb0:
 }
 
 // CHECK-LABEL: begin running test 1 of 1 on allocbox_access_sendable_struct_field_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK:     Rep Value:   %6 = struct_element_addr %4 : $*SendableStruct, #SendableStruct.nsLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_box ${ var SendableStruct }
 // CHECK: end running test 1 of 1 on allocbox_access_sendable_struct_field_let: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @allocbox_access_sendable_struct_field_let : $@convention(thin) () -> () {
 bb0:
@@ -396,8 +424,12 @@ bb0:
 }
 
 // CHECK-LABEL: begin running test 1 of 1 on allocbox_access_sendable_struct_field_let_2: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: Value:
 // CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
 // CHECK:     Rep Value:   %4 = struct_element_addr %2 : $*SendableStruct, #SendableStruct.nsLet
+// CHECK: Base:
+// CHECK: TrackableValue. State: TrackableValueState[id: 1][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value:   %2 = alloc_stack $SendableStruct
 // CHECK: end running test 1 of 1 on allocbox_access_sendable_struct_field_let_2: sil_regionanalysis_underlying_tracked_value with: @trace[0]
 sil [ossa] @allocbox_access_sendable_struct_field_let_2 : $@convention(thin) () -> () {
 bb0:

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1968,3 +1968,32 @@ extension NonIsolatedFinalKlass {
     // expected-tns-note @-1 {{sending task-isolated 'self.ns' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and task-isolated uses}}
   }
 }
+
+func mutableLocalCaptureDataRace() async {
+  var x = 0
+  x = 0
+  _ = x
+
+  Task.detached { x = 1 } // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+  // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(priority:operation:)' risks causing races in between local and caller code}}
+
+  x = 2 // expected-tns-note {{access can happen concurrently}}
+}
+
+func mutableLocalCaptureDataRace2() async {
+  var x = 0
+  x = 0
+
+  Task.detached { x = 1 } // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+  // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(priority:operation:)' risks causing races in between local and caller code}}
+
+  print(x) // expected-tns-note {{access can happen concurrently}}
+}
+
+func localCaptureDataRace3() async {
+  let x = 0
+
+  Task.detached { print(x) }
+
+  print(x)
+}


### PR DESCRIPTION
Explanation: This involves fixing a serious bug that was reported on the swift forums: https://forums.swift.org/t/lets-debug-missing-rbi-data-race-diagnostics/78910/6. At a high level the problem is that previously when we saw a use of a Sendable value, we just ignored the use. This becomes an issue if we are extracting the Sendable value from a non-Sendable value using static fields. Often times this would reduce the access to the Sendable value to loads and projections which are look through instructions and do not act as actual uses of the underlying non-Sendable value. If we had already sent the non-Sendable value to another isolation domain by reference this would result in a race:

```swift
func mutableLocalCaptureDataRace() async {
  var x = 0

  Task.detached { x = 1 }

  x = 2
}
```

In words, the above example shows a non-Sendable box containing an Integer value. We send that non-Sendable value into a detached Task by reference so we can update its value to 1. In the mean time, we attempt to update x to 2 in the original Task resulting in a race.

NOTE: If we extracted the Sendable value from the non-Sendable value using a computed property, we would in the above case recognize the computed property use as a use of the non-Sendable base and emit an error. This only occurs if we project out using static properties.

To fix this, I had to make some changes to the RBI "machine", namely making it so that when we compute the equivalence class that a specific value belongs to, we also return potentially a base value. From the perspective of RBI, I hid that we are doing this by making it so that we no longer manipulate underlying values directly. Instead, we always work with them in pairs and in PartitionOpBuilder itself, we handle the pair's elements as appropriate. The truth is we only use the base in one way: when we require, we also require the base if it is non-Sendable. The rest of the methods on PartitionOpBuilder just ignores the base.

There are two potential cases where we get a base:

1. If we have a non-Sendable value type that is extracted from a non-Sendable value type with an unchecked Sendable or a type that is Sendable b/c of global actor isolation that separates the two.
2. If we have a Sendable type extracted out from a non-Sendable type. (The example above).

Scope: Affects how we find underlying equivalence class values in RBI and makes it so we also track the base. Changes RBI so that the change does not impact the flow of how we translate instructions by having the builder struct that creates partition ops be the place that we reason about bases. Also adds the ability to test the map from value -> equivalence class directly.

Issue: rdar://149019222

Original PR: https://github.com/swiftlang/swift/commit/23b6937cbcc61ca5c9f29b203bc8f0115eb3f633

Risk: Medium/Low. This change does do a big of surgery to RBI inherently increasing the risk of unintentional bugs. But we think that fixing this concurrency hole is important enough and the additional testing provided by the direct testing of the changed functionality mitigates that issue.

Testing: Added tests to the test suite that test out the specific test cases that broke. Validated that we did not have to change any already passing tests (that is with all current tests this doesn't change compiler output). I also added new tests where the compiler directly dumps out the value/base that it discovers. This allows for this behavior change to be tested directly without relying on other parts of the compiler working correctly.
Reviewer: @hborla 