### PR TITLE
[Runtime] Don't use the low bit of a WitnessTable pointer in the conformance cache

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -586,7 +586,10 @@ namespace {
       if (auto proto = ProtoOrStorage.dyn_cast<const ProtocolDescriptor *>())
         return proto;
 
-      return ProtoOrStorage.get<const ExtendedStorage *>()->Proto;
+      if (auto storage = ProtoOrStorage.dyn_cast<const ExtendedStorage *>())
+        return storage->Proto;
+
+      return nullptr;
     }
 
     /// Get the conformance cache key.

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -537,47 +537,77 @@ namespace {
 
   struct ConformanceCacheEntry {
   private:
-    ConformanceCacheKey Key;
+    /// Storage used when we have global actor isolation on the conformance.
+    struct ExtendedStorage {
+      /// The protocol to which the type conforms.
+      const ProtocolDescriptor *Proto;
 
-    /// The witness table or along with a bit that indicates whether the
-    /// conformance is isolated to a global actor.
-    llvm::PointerUnion<const WitnessTable *, const ConformanceLookupResult *>
-        WitnessTableOrLookupResult;
+      /// The global actor to which this conformance is isolated, or NULL for
+      /// a nonisolated conformances.
+      const Metadata *globalActorIsolationType = nullptr;
+
+      /// When the conformance is global-actor-isolated, this is the conformance
+      /// of globalActorIsolationType to GlobalActor.
+      const WitnessTable *globalActorIsolationWitnessTable = nullptr;
+    };
+
+    const Metadata *Type;
+    llvm::PointerUnion<const ProtocolDescriptor *, const ExtendedStorage *>
+        ProtoOrStorage;
+
+    /// The witness table.
+    const WitnessTable *Witness;
 
   public:
     ConformanceCacheEntry(ConformanceCacheKey key,
                           ConformanceLookupResult result)
-        : Key(key) {
+      : Type(key.Type), Witness(result.witnessTable)
+    {
       if (result.globalActorIsolationType) {
-        WitnessTableOrLookupResult = new ConformanceLookupResult(result);
+        ProtoOrStorage = new ExtendedStorage{
+          key.Proto, result.globalActorIsolationType,
+          result.globalActorIsolationWitnessTable
+        };
       } else {
-        WitnessTableOrLookupResult = result.witnessTable;
+        ProtoOrStorage = key.Proto;
       }
     }
 
     bool matchesKey(const ConformanceCacheKey &key) const {
-      return Key.Type == key.Type && Key.Proto == key.Proto;
+      return Type == key.Type && getProtocol() == key.Proto;
     }
 
     friend llvm::hash_code hash_value(const ConformanceCacheEntry &entry) {
-      return hash_value(entry.Key);
+      return hash_value(entry.getKey());
+    }
+
+    /// Get the protocol.
+    const ProtocolDescriptor *getProtocol() const {
+      if (auto proto = ProtoOrStorage.dyn_cast<const ProtocolDescriptor *>())
+        return proto;
+
+      return ProtoOrStorage.get<const ExtendedStorage *>()->Proto;
+    }
+
+    /// Get the conformance cache key.
+    ConformanceCacheKey getKey() const {
+      return ConformanceCacheKey(Type, getProtocol());
     }
 
     /// Get the cached witness table, or null if we cached failure.
     const WitnessTable *getWitnessTable() const {
-      if (auto witnessTable = WitnessTableOrLookupResult.dyn_cast<const WitnessTable *>())
-        return witnessTable;
-
-      return WitnessTableOrLookupResult.get<const ConformanceLookupResult *>()
-          ->witnessTable;
+      return Witness;
     }
 
     ConformanceLookupResult getResult() const {
-      if (auto witnessTable = WitnessTableOrLookupResult.dyn_cast<const WitnessTable *>())
-        return ConformanceLookupResult { witnessTable, nullptr, nullptr };
+      if (ProtoOrStorage.is<const ProtocolDescriptor *>())
+        return ConformanceLookupResult { Witness, nullptr, nullptr };
 
-      if (auto lookupResult = WitnessTableOrLookupResult.dyn_cast<const ConformanceLookupResult *>())
-        return *lookupResult;
+      if (auto storage = ProtoOrStorage.dyn_cast<const ExtendedStorage *>()) {
+        return ConformanceLookupResult(
+            Witness, storage->globalActorIsolationType,
+            storage->globalActorIsolationWitnessTable);
+      }
 
       return nullptr;
     }


### PR DESCRIPTION
With relative witness tables, the low bit of a witness table pointer is an indicator that we need to load from the given pointer. We were also using the low bit of the witness table pointer in the conformance cache entry as part of a pointer union. Hilarity ensures [*].

Switch to another low bit by exploding the conformance cache key into separate fields and taking the low bit of one of those pointers that isn't reserved.

Fixes the remainder of rdar://149326058, I hope.

[*] No, I am not laughing.
