### PR TITLE
[6.2] Relative witness table fixes

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -506,7 +506,13 @@ extern "C" SWIFT_CC(swift) void _swift_task_enqueueOnExecutor(
 static swift_task_is_current_executor_flag
 _getIsolationCheckingOptionsFromExecutorWitnessTable(const SerialExecutorWitnessTable *_wtable) {
   const WitnessTable* wtable = reinterpret_cast<const WitnessTable*>(_wtable);
+#if SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES
+  auto description = lookThroughOptionalConditionalWitnessTable(
+    reinterpret_cast<const RelativeWitnessTable*>(wtable))
+    ->getDescription();
+#else
   auto description = wtable->getDescription();
+#endif
   if (!description) {
     return swift_task_is_current_executor_flag::None;
   }

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -586,7 +586,10 @@ namespace {
       if (auto proto = ProtoOrStorage.dyn_cast<const ProtocolDescriptor *>())
         return proto;
 
-      return ProtoOrStorage.get<const ExtendedStorage *>()->Proto;
+      if (auto storage = ProtoOrStorage.dyn_cast<const ExtendedStorage *>())
+        return storage->Proto;
+
+      return nullptr;
     }
 
     /// Get the conformance cache key.

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -444,7 +444,7 @@ static bool _checkWitnessTableIsolation(
   llvm::ArrayRef<const void *> conditionalArgs,
   ConformanceExecutionContext &context
 ) {
-#if SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES && SWIFT_PTRAUTH
+#if SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES
   auto description = lookThroughOptionalConditionalWitnessTable(
                          reinterpret_cast<const RelativeWitnessTable *>(wtable))
                          ->getDescription();

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -537,47 +537,77 @@ namespace {
 
   struct ConformanceCacheEntry {
   private:
-    ConformanceCacheKey Key;
+    /// Storage used when we have global actor isolation on the conformance.
+    struct ExtendedStorage {
+      /// The protocol to which the type conforms.
+      const ProtocolDescriptor *Proto;
 
-    /// The witness table or along with a bit that indicates whether the
-    /// conformance is isolated to a global actor.
-    llvm::PointerUnion<const WitnessTable *, const ConformanceLookupResult *>
-        WitnessTableOrLookupResult;
+      /// The global actor to which this conformance is isolated, or NULL for
+      /// a nonisolated conformances.
+      const Metadata *globalActorIsolationType = nullptr;
+
+      /// When the conformance is global-actor-isolated, this is the conformance
+      /// of globalActorIsolationType to GlobalActor.
+      const WitnessTable *globalActorIsolationWitnessTable = nullptr;
+    };
+
+    const Metadata *Type;
+    llvm::PointerUnion<const ProtocolDescriptor *, const ExtendedStorage *>
+        ProtoOrStorage;
+
+    /// The witness table.
+    const WitnessTable *Witness;
 
   public:
     ConformanceCacheEntry(ConformanceCacheKey key,
                           ConformanceLookupResult result)
-        : Key(key) {
+      : Type(key.Type), Witness(result.witnessTable)
+    {
       if (result.globalActorIsolationType) {
-        WitnessTableOrLookupResult = new ConformanceLookupResult(result);
+        ProtoOrStorage = new ExtendedStorage{
+          key.Proto, result.globalActorIsolationType,
+          result.globalActorIsolationWitnessTable
+        };
       } else {
-        WitnessTableOrLookupResult = result.witnessTable;
+        ProtoOrStorage = key.Proto;
       }
     }
 
     bool matchesKey(const ConformanceCacheKey &key) const {
-      return Key.Type == key.Type && Key.Proto == key.Proto;
+      return Type == key.Type && getProtocol() == key.Proto;
     }
 
     friend llvm::hash_code hash_value(const ConformanceCacheEntry &entry) {
-      return hash_value(entry.Key);
+      return hash_value(entry.getKey());
+    }
+
+    /// Get the protocol.
+    const ProtocolDescriptor *getProtocol() const {
+      if (auto proto = ProtoOrStorage.dyn_cast<const ProtocolDescriptor *>())
+        return proto;
+
+      return ProtoOrStorage.get<const ExtendedStorage *>()->Proto;
+    }
+
+    /// Get the conformance cache key.
+    ConformanceCacheKey getKey() const {
+      return ConformanceCacheKey(Type, getProtocol());
     }
 
     /// Get the cached witness table, or null if we cached failure.
     const WitnessTable *getWitnessTable() const {
-      if (auto witnessTable = WitnessTableOrLookupResult.dyn_cast<const WitnessTable *>())
-        return witnessTable;
-
-      return WitnessTableOrLookupResult.get<const ConformanceLookupResult *>()
-          ->witnessTable;
+      return Witness;
     }
 
     ConformanceLookupResult getResult() const {
-      if (auto witnessTable = WitnessTableOrLookupResult.dyn_cast<const WitnessTable *>())
-        return ConformanceLookupResult { witnessTable, nullptr, nullptr };
+      if (ProtoOrStorage.is<const ProtocolDescriptor *>())
+        return ConformanceLookupResult { Witness, nullptr, nullptr };
 
-      if (auto lookupResult = WitnessTableOrLookupResult.dyn_cast<const ConformanceLookupResult *>())
-        return *lookupResult;
+      if (auto storage = ProtoOrStorage.dyn_cast<const ExtendedStorage *>()) {
+        return ConformanceLookupResult(
+            Witness, storage->globalActorIsolationType,
+            storage->globalActorIsolationWitnessTable);
+      }
 
       return nullptr;
     }


### PR DESCRIPTION
  - **Explanation**: The introduction of isolated conformance checking and improved current-isolation checking in the runtime caused runtime crashes when using relative witness tables. 
  - **Scope**: Only affects the runtime in a fairly narrow place (conformance caching), and only meaningfully impacts environments that use relative witness tables.
  - **Issues**: rdar://149326058
  - **Original PRs**: https://github.com/swiftlang/swift/pull/80838 & https://github.com/swiftlang/swift/pull/80844
  - **Risk**: Low. The changes themselves are straightforward and with either explode spectacularly everywhere, or be fine.
  - **Testing**: CI.
  - **Reviewers**: @al45tair 
