### PR TITLE
[Sema] Downgrade `noasync` diagnostic to warning for closure macro args

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -390,6 +390,17 @@ namespace swift {
       return limitBehaviorUntilSwiftVersion(limit, languageMode);
     }
 
+    /// Limit the diagnostic behavior to warning until the next future
+    /// language mode.
+    ///
+    /// This should be preferred over passing the next major version to
+    /// `warnUntilSwiftVersion` to make it easier to find and update clients
+    /// when a new language mode is introduced.
+    ///
+    /// This helps stage in fixes for stricter diagnostics as warnings
+    /// until the next major language version.
+    InFlightDiagnostic &warnUntilFutureSwiftVersion();
+
     /// Limit the diagnostic behavior to warning until the specified version.
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -267,7 +267,7 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
@@ -295,7 +295,12 @@ protected:
     /// isolation checks when it either specifies or inherits isolation
     /// and was passed as an argument to a function that is not fully 
     /// concurrency checked.
-    RequiresDynamicIsolationChecking : 1
+    RequiresDynamicIsolationChecking : 1,
+
+    /// Whether this closure was type-checked as an argument to a macro. This
+    /// is only populated after type-checking, and only exists for diagnostic
+    /// logic. Do not add more uses of this.
+    IsMacroArgument : 1
   );
 
   SWIFT_INLINE_BITFIELD_FULL(BindOptionalExpr, Expr, 16,
@@ -4316,6 +4321,7 @@ public:
     Bits.ClosureExpr.IsPassedToSendingParameter = false;
     Bits.ClosureExpr.NoGlobalActorAttribute = false;
     Bits.ClosureExpr.RequiresDynamicIsolationChecking = false;
+    Bits.ClosureExpr.IsMacroArgument = false;
   }
 
   SourceRange getSourceRange() const;
@@ -4392,6 +4398,17 @@ public:
 
   void setRequiresDynamicIsolationChecking(bool value = true) {
     Bits.ClosureExpr.RequiresDynamicIsolationChecking = value;
+  }
+
+  /// Whether this closure was type-checked as an argument to a macro. This
+  /// is only populated after type-checking, and only exists for diagnostic
+  /// logic. Do not add more uses of this.
+  bool isMacroArgument() const {
+    return Bits.ClosureExpr.IsMacroArgument;
+  }
+
+  void setIsMacroArgument(bool value = true) {
+    Bits.ClosureExpr.IsMacroArgument = value;
   }
 
   /// Determine whether this closure expression has an

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -131,6 +131,13 @@ public:
   /// SWIFT_VERSION_MINOR.
   static Version getCurrentLanguageVersion();
 
+  /// Returns a major version to represent the next future language mode. This
+  /// exists to make it easier to find and update clients when a new language
+  /// mode is added.
+  static constexpr unsigned getFutureMajorLanguageVersion() {
+    return 7;
+  }
+
   // List of backward-compatibility versions that we permit passing as
   // -swift-version <vers>
   static std::array<StringRef, 4> getValidEffectiveVersions() {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -452,7 +452,7 @@ InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
     // version. We do this before limiting the behavior, because
     // wrapIn will result in the behavior of the wrapping diagnostic.
     if (limit >= DiagnosticBehavior::Warning) {
-      if (majorVersion > 6) {
+      if (majorVersion >= version::Version::getFutureMajorLanguageVersion()) {
         wrapIn(diag::error_in_a_future_swift_lang_mode);
       } else {
         wrapIn(diag::error_in_swift_lang_mode, majorVersion);
@@ -470,6 +470,11 @@ InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
   }
 
   return *this;
+}
+
+InFlightDiagnostic &InFlightDiagnostic::warnUntilFutureSwiftVersion() {
+  using namespace version;
+  return warnUntilSwiftVersion(Version::getFutureMajorLanguageVersion());
 }
 
 InFlightDiagnostic &

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -181,16 +181,19 @@ std::optional<Version> Version::getEffectiveLanguageVersion() const {
     static_assert(SWIFT_VERSION_MAJOR == 6,
                   "getCurrentLanguageVersion is no longer correct here");
     return Version::getCurrentLanguageVersion();
-  case 7:
-    // Allow version '7' in asserts compilers *only* so that we can start
-    // testing changes planned for after Swift 6. Note that it's still not
-    // listed in `Version::getValidEffectiveVersions()`.
-    // FIXME: When Swift 7 becomes real, remove 'REQUIRES: swift7' from tests
-    //        using '-swift-version 7'.
+
+  // FIXME: When Swift 7 becomes real, remove 'REQUIRES: swift7' from tests
+  //        using '-swift-version 7'.
+
+  case Version::getFutureMajorLanguageVersion():
+    // Allow the future language mode version in asserts compilers *only* so
+    // that we can start testing changes planned for after the current latest
+    // language mode. Note that it'll not be listed in
+    // `Version::getValidEffectiveVersions()`.
 #ifdef NDEBUG
     LLVM_FALLTHROUGH;
 #else
-    return Version{7};
+    return Version{Version::getFutureMajorLanguageVersion()};
 #endif
   default:
     return std::nullopt;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5612,6 +5612,18 @@ namespace {
       E->setMacroRef(macroRef);
       E->setType(expandedType);
 
+      auto fnType =
+          simplifyType(overload.adjustedOpenedType)->castTo<FunctionType>();
+
+      auto newArgs = coerceCallArguments(
+          E->getArgs(), fnType, macroRef, /*applyExpr=*/nullptr,
+          cs.getConstraintLocator(E, ConstraintLocator::ApplyArgument),
+          solution.getAppliedPropertyWrappers(E));
+      if (!newArgs)
+        return nullptr;
+
+      E->setArgs(newArgs);
+
       // FIXME: Expansion should be lazy.
       // i.e. 'ExpandMacroExpansionExprRequest' should be sinked into
       // 'getRewritten()', and performed on-demand. Unfortunately that requires

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6085,13 +6085,15 @@ static bool hasCurriedSelf(ConstraintSystem &cs, ConcreteDeclRef callee,
 static void applyContextualClosureFlags(Expr *expr, bool implicitSelfCapture,
                                         bool inheritActorContext,
                                         bool isPassedToSendingParameter,
-                                        bool requiresDynamicIsolationChecking) {
+                                        bool requiresDynamicIsolationChecking,
+                                        bool isMacroArg) {
   if (auto closure = dyn_cast<ClosureExpr>(expr)) {
     closure->setAllowsImplicitSelfCapture(implicitSelfCapture);
     closure->setInheritsActorContext(inheritActorContext);
     closure->setIsPassedToSendingParameter(isPassedToSendingParameter);
     closure->setRequiresDynamicIsolationChecking(
         requiresDynamicIsolationChecking);
+    closure->setIsMacroArgument(isMacroArg);
     return;
   }
 
@@ -6099,14 +6101,16 @@ static void applyContextualClosureFlags(Expr *expr, bool implicitSelfCapture,
     applyContextualClosureFlags(captureList->getClosureBody(),
                                 implicitSelfCapture, inheritActorContext,
                                 isPassedToSendingParameter,
-                                requiresDynamicIsolationChecking);
+                                requiresDynamicIsolationChecking,
+                                isMacroArg);
   }
 
   if (auto identity = dyn_cast<IdentityExpr>(expr)) {
     applyContextualClosureFlags(identity->getSubExpr(), implicitSelfCapture,
                                 inheritActorContext,
                                 isPassedToSendingParameter,
-                                requiresDynamicIsolationChecking);
+                                requiresDynamicIsolationChecking,
+                                isMacroArg);
   }
 }
 
@@ -6231,7 +6235,8 @@ ArgumentList *ExprRewriter::coerceCallArguments(
   }();
 
   auto applyFlagsToArgument = [&paramInfo,
-                               &closuresRequireDynamicIsolationChecking](
+                               &closuresRequireDynamicIsolationChecking,
+                               &locator](
                                   unsigned paramIdx, Expr *argument) {
     if (!isClosureLiteralExpr(argument))
       return;
@@ -6239,11 +6244,13 @@ ArgumentList *ExprRewriter::coerceCallArguments(
     bool isImplicitSelfCapture = paramInfo.isImplicitSelfCapture(paramIdx);
     bool inheritsActorContext = paramInfo.inheritsActorContext(paramIdx);
     bool isPassedToSendingParameter = paramInfo.isSendingParameter(paramIdx);
+    bool isMacroArg = isExpr<MacroExpansionExpr>(locator.getAnchor());
 
     applyContextualClosureFlags(argument, isImplicitSelfCapture,
                                 inheritsActorContext,
                                 isPassedToSendingParameter,
-                                closuresRequireDynamicIsolationChecking);
+                                closuresRequireDynamicIsolationChecking,
+                                isMacroArg);
   };
 
   // Quickly test if any further fix-ups for the argument types are necessary.

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2240,11 +2240,12 @@ public:
         invalidImplicitSelfShouldOnlyWarn510(base, closure)) {
       warnUntilVersion.emplace(6);
     }
-    // Prior to Swift 7, downgrade to a warning if we're in a macro to preserve
-    // compatibility with the Swift 6 diagnostic behavior where we previously
-    // skipped diagnosing.
-    if (!Ctx.isSwiftVersionAtLeast(7) && isInMacro())
-      warnUntilVersion.emplace(7);
+    // Prior to the next language mode, downgrade to a warning if we're in a
+    // macro to preserve compatibility with the Swift 6 diagnostic behavior
+    // where we previously skipped diagnosing.
+    auto futureVersion = version::Version::getFutureMajorLanguageVersion();
+    if (!Ctx.isSwiftVersionAtLeast(futureVersion) && isInMacro())
+      warnUntilVersion.emplace(futureVersion);
 
     auto diag = Ctx.Diags.diagnose(loc, ID, std::move(Args)...);
     if (warnUntilVersion)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1260,7 +1260,7 @@ void AttributeChecker::visitAccessControlAttr(AccessControlAttr *attr) {
             diagnose(attr->getLocation(),
                      diag::access_control_non_objc_open_member, VD)
                 .fixItReplace(attr->getRange(), "public")
-                .warnUntilSwiftVersion(7);
+                .warnUntilFutureSwiftVersion();
           }
         }
       }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2675,7 +2675,7 @@ namespace {
                     fromType, toType);
 
                 if (downgradeToWarning)
-                  diag.warnUntilSwiftVersion(7);
+                  diag.warnUntilFutureSwiftVersion();
               }
 
               for (auto type : nonSendableTypes) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5185,7 +5185,8 @@ static bool diagnoseTypeWitnessAvailability(
     return false;
 
   // In Swift 6 and earlier type witness availability diagnostics are warnings.
-  const unsigned warnBeforeVersion = 7;
+  using namespace version;
+  const unsigned warnBeforeVersion = Version::getFutureMajorLanguageVersion();
   bool shouldError =
       ctx.LangOpts.EffectiveLanguageVersion.isVersionAtLeast(warnBeforeVersion);
 

--- a/test/Macros/issue-80835.swift
+++ b/test/Macros/issue-80835.swift
@@ -1,0 +1,84 @@
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
+
+// RUN: %target-typecheck-verify-swift -swift-version 6 -load-plugin-library %t/%target-library-name(MacroDefinition) -verify-additional-prefix swift6-
+// RUN: %target-typecheck-verify-swift -swift-version 7 -load-plugin-library %t/%target-library-name(MacroDefinition) -verify-additional-prefix swift7-
+
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift7
+
+// https://github.com/swiftlang/swift/issues/80835
+
+@available(*, noasync)
+func noasyncFn() {}
+
+@_unavailableFromAsync
+func unavailableFromAsyncFn() {} // expected-note {{'unavailableFromAsyncFn()' declared here}}
+
+@freestanding(expression)
+macro asyncMacro(_ fn: () async -> Void) = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+
+@freestanding(declaration)
+macro asyncMacroDecl(_ fn: () async -> Void) = #externalMacro(module: "MacroDefinition", type: "EmptyDeclarationMacro")
+
+@attached(peer)
+macro AsyncMacro(_ fn: () async -> Void) = #externalMacro(module: "MacroDefinition", type: "WrapperMacro")
+
+func takesAsyncFn(_ fn: () async -> Void) {}
+
+#asyncMacro {
+  defer {
+    noasyncFn()
+    // expected-swift7-error@-1 {{global function 'noasyncFn' is unavailable from asynchronous contexts}}
+    // expected-swift6-warning@-2 {{global function 'noasyncFn' is unavailable from asynchronous contexts; this will be an error in a future Swift language mode}}
+  }
+  noasyncFn()
+  // expected-swift7-error@-1 {{global function 'noasyncFn' is unavailable from asynchronous contexts}}
+  // expected-swift6-warning@-2 {{global function 'noasyncFn' is unavailable from asynchronous contexts; this will be an error in a future Swift language mode}}
+
+  unavailableFromAsyncFn()
+  // expected-swift7-error@-1 {{global function 'unavailableFromAsyncFn' is unavailable from asynchronous contexts}}
+  // expected-swift6-warning@-2 {{global function 'unavailableFromAsyncFn' is unavailable from asynchronous contexts; this will be an error in a future Swift language mode}}
+
+  // This was always an error.
+  let _: () async -> Void = {
+    noasyncFn()
+    // expected-error@-1 {{global function 'noasyncFn' is unavailable from asynchronous contexts}}
+  }
+}
+
+// This was always an error.
+takesAsyncFn {
+  noasyncFn()
+  // expected-error@-1 {{global function 'noasyncFn' is unavailable from asynchronous contexts}}
+}
+
+#asyncMacroDecl {
+  noasyncFn()
+  // expected-swift7-error@-1 {{global function 'noasyncFn' is unavailable from asynchronous contexts}}
+  // expected-swift6-warning@-2 {{global function 'noasyncFn' is unavailable from asynchronous contexts; this will be an error in a future Swift language mode}}
+}
+
+typealias Magic<T> = T
+
+// expected-swift7-error@+2 {{global function 'noasyncFn' is unavailable from asynchronous contexts}}
+// expected-swift6-warning@+1 {{global function 'noasyncFn' is unavailable from asynchronous contexts; this will be an error in a future Swift language mode}}
+@AsyncMacro({ noasyncFn() })
+func foo() {
+  #asyncMacro(({
+    noasyncFn()
+    // expected-swift7-error@-1 {{global function 'noasyncFn' is unavailable from asynchronous contexts}}
+    // expected-swift6-warning@-2 {{global function 'noasyncFn' is unavailable from asynchronous contexts; this will be an error in a future Swift language mode}}
+  }))
+
+  #asyncMacroDecl(({
+    noasyncFn()
+    // expected-swift7-error@-1 {{global function 'noasyncFn' is unavailable from asynchronous contexts}}
+    // expected-swift6-warning@-2 {{global function 'noasyncFn' is unavailable from asynchronous contexts; this will be an error in a future Swift language mode}}
+  }))
+
+  // This was never treated as async.
+  #asyncMacro({
+    noasyncFn()
+  } as Magic)
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -667,6 +667,28 @@ func testLocalAccessorMacroWithAutoclosure() {
   takesAutoclosure(1)
 }
 
+@propertyWrapper
+struct SomePropertyWrapper<T> {
+  var wrappedValue: T
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+  init(projectedValue: Self) {
+    self = projectedValue
+  }
+  var projectedValue: Self { self }
+}
+
+// Property wrappers on macros probably aren't all that useful, but make sure
+// we don't crash.
+@freestanding(expression)
+macro hasPropertyWrapperParam(@SomePropertyWrapper x: Int) = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+
+func testPropertyWrapperMacro() {
+  #hasPropertyWrapperParam(x: 0)
+  #hasPropertyWrapperParam($x: .init(wrappedValue: 0))
+}
+
 #if TEST_DIAGNOSTICS
 @freestanding(expression)
 macro missingMacro() = #externalMacro(module: "MacroDefinition", type: "BluhBlah")


### PR DESCRIPTION
Downgrade to a warning until the next language mode. This is necessary since we previously missed coercing macro arguments to parameter types, resulting in cases where closure arguments weren't being treated as `async` when they should have been. This then allows us to reapply #80583.

rdar://149328745
Resolves #80835