### PR TITLE
[6.2] [NameLookup] Allow value generics to show up as static members

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -310,6 +310,9 @@ struct OverloadSignature {
   /// Whether this is a macro.
   unsigned IsMacro : 1;
 
+  /// Whether this is a generic argument.
+  unsigned IsGenericArg : 1;
+
   /// Whether this signature is part of a protocol extension.
   unsigned InProtocolExtension : 1;
 
@@ -323,8 +326,10 @@ struct OverloadSignature {
   OverloadSignature()
       : UnaryOperator(UnaryOperatorKind::None), IsInstanceMember(false),
         IsVariable(false), IsFunction(false), IsAsyncFunction(false),
-        IsDistributed(false), InProtocolExtension(false),
-        InExtensionOfGenericType(false), HasOpaqueReturnType(false) { }
+        IsDistributed(false), IsEnumElement(false), IsNominal(false),
+        IsTypeAlias(false), IsMacro(false), IsGenericArg(false),
+        InProtocolExtension(false), InExtensionOfGenericType(false),
+        HasOpaqueReturnType(false) { }
 };
 
 /// Determine whether two overload signatures conflict.

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1454,23 +1454,25 @@ public:
 };
 
 class TypeValueExpr : public Expr {
-  GenericTypeParamDecl *paramDecl;
-  DeclNameLoc loc;
+  TypeRepr *repr;
   Type paramType;
 
-  /// Create a \c TypeValueExpr from a given generic value param decl.
-  TypeValueExpr(DeclNameLoc loc, GenericTypeParamDecl *paramDecl) :
-      Expr(ExprKind::TypeValue, /*implicit*/ false), paramDecl(paramDecl),
-      loc(loc), paramType(nullptr) {}
+  /// Create a \c TypeValueExpr from a given type representation.
+  TypeValueExpr(TypeRepr *repr) :
+      Expr(ExprKind::TypeValue, /*implicit*/ false), repr(repr),
+      paramType(nullptr) {}
 
 public:
-  /// Create a \c TypeValueExpr for a given \c GenericTypeParamDecl.
+  /// Create a \c TypeValueExpr for a given \c TypeDecl.
   ///
   /// The given location must be valid.
-  static TypeValueExpr *createForDecl(DeclNameLoc Loc, GenericTypeParamDecl *D);
+  static TypeValueExpr *createForDecl(DeclNameLoc loc, TypeDecl *d,
+                                      DeclContext *dc);
 
-  GenericTypeParamDecl *getParamDecl() const {
-    return paramDecl;
+  GenericTypeParamDecl *getParamDecl() const;
+
+  TypeRepr *getRepr() const {
+    return repr;
   }
 
   /// Retrieves the corresponding parameter type of the value referenced by this
@@ -1485,9 +1487,7 @@ public:
     this->paramType = paramType;
   }
 
-  SourceRange getSourceRange() const {
-    return loc.getSourceRange();
-  }
+  SourceRange getSourceRange() const;
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::TypeValue;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -257,6 +257,7 @@ LANGUAGE_FEATURE(SendableCompletionHandlers, 463, "Objective-C completion handle
 LANGUAGE_FEATURE(IsolatedConformances, 470, "Global-actor isolated conformances")
 LANGUAGE_FEATURE(AsyncExecutionBehaviorAttributes, 0, "@concurrent and nonisolated(nonsending)")
 LANGUAGE_FEATURE(GeneralizedIsSameMetaTypeBuiltin, 465, "Builtin.is_same_metatype with support for noncopyable/nonescapable types")
+LANGUAGE_FEATURE(ValueGenericsNameLookup, 452, "Value generics appearing as static members for namelookup")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3856,6 +3856,13 @@ bool swift::conflicting(ASTContext &ctx,
   if (sig1.IsFunction != sig2.IsFunction)
     return true;
 
+  // Gracefully handle the case where value generic arguments were introduced
+  // as a conflicting value with static variables of the same name.
+  if (sig1.IsGenericArg != sig2.IsGenericArg) {
+    *wouldConflictInSwift5 = true;
+    return true;
+  }
+
   // Variables always conflict with non-variables with the same signature.
   // (e.g variables with zero argument functions, variables with type
   //  declarations)
@@ -4034,6 +4041,7 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
   signature.IsNominal = isa<NominalTypeDecl>(this);
   signature.IsTypeAlias = isa<TypeAliasDecl>(this);
   signature.IsMacro = isa<MacroDecl>(this);
+  signature.IsGenericArg = isa<GenericTypeParamDecl>(this);
   signature.HasOpaqueReturnType =
                        !signature.IsVariable && (bool)getOpaqueResultTypeDecl();
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2441,11 +2441,22 @@ bool Expr::isSelfExprOf(const AbstractFunctionDecl *AFD, bool sameBase) const {
   return false;
 }
 
-TypeValueExpr *TypeValueExpr::createForDecl(DeclNameLoc loc, 
-                                            GenericTypeParamDecl *paramDecl) {
-  auto &ctx = paramDecl->getASTContext();
+TypeValueExpr *TypeValueExpr::createForDecl(DeclNameLoc loc, TypeDecl *decl,
+                                            DeclContext *dc) {
+  auto &ctx = decl->getASTContext();
   ASSERT(loc.isValid());
-  return new (ctx) TypeValueExpr(loc, paramDecl);
+  auto repr = UnqualifiedIdentTypeRepr::create(ctx, loc, decl->createNameRef());
+  repr->setValue(decl, dc);
+  return new (ctx) TypeValueExpr(repr);
+}
+
+GenericTypeParamDecl *TypeValueExpr::getParamDecl() const {
+  auto declRefRepr = cast<DeclRefTypeRepr>(getRepr());
+  return cast<GenericTypeParamDecl>(declRefRepr->getBoundDecl());
+}
+
+SourceRange TypeValueExpr::getSourceRange() const {
+  return getRepr()->getSourceRange();
 }
 
 ExistentialArchetypeType *OpenExistentialExpr::getOpenedArchetype() const {

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -12,6 +12,7 @@
 
 #include "FeatureSet.h"
 
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericParamList.h"
@@ -487,6 +488,54 @@ static bool usesFeatureValueGenerics(Decl *decl) {
   }
 
   return false;
+}
+
+class UsesTypeValueExpr : public ASTWalker {
+public:
+  bool used = false;
+
+  PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
+    if (isa<TypeValueExpr>(expr)) {
+      used = true;
+      return Action::Stop();
+    }
+
+    return Action::Continue(expr);
+  }
+};
+
+static bool usesFeatureValueGenericsNameLookup(Decl *decl) {
+  // Be conservative and mark any function that has a TypeValueExpr in its body
+  // as having used this feature. It's a little difficult to fine grain this
+  // check because the following:
+  //
+  // func a() -> Int {
+  //   A<123>.n
+  // }
+  //
+  // Would appear to have the same expression as something like:
+  //
+  // extension A where n == 123 {
+  //   func b() -> Int {
+  //     n
+  //   }
+  // }
+
+  auto fn = dyn_cast<AbstractFunctionDecl>(decl);
+
+  if (!fn)
+    return false;
+
+  auto body = fn->getMacroExpandedBody();
+
+  if (!body)
+    return false;
+
+  UsesTypeValueExpr utve;
+
+  body->walk(utve);
+
+  return utve.used;
 }
 
 static bool usesFeatureCoroutineAccessors(Decl *decl) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2732,6 +2732,18 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
       }
     }
 
+    // Qualified name lookup can find generic value parameters.
+    auto gpList = current->getGenericParams();
+
+    // .. But not in type contexts (yet)
+    if (!(options & NL_OnlyTypes) && gpList && !member.isSpecial()) {
+      auto gp = gpList->lookUpGenericParam(member.getBaseIdentifier());
+
+      if (gp && gp->isValue()) {
+        decls.push_back(gp);
+      }
+    }
+
     // If we're not looking at a protocol and we're not supposed to
     // visit the protocols that this type conforms to, skip the next
     // step.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1631,6 +1631,29 @@ namespace {
       // Build a member reference.
       auto memberRef = resolveConcreteDeclRef(member, memberLocator);
 
+      // If our member reference is a value generic, then the resulting
+      // expression is the type value one to access the underlying parameter's
+      // value.
+      //
+      // This can occur in code that does something like: 'type(of: x).a' where
+      // 'a' is the static value generic member.
+      if (auto gp = dyn_cast<GenericTypeParamDecl>(member)) {
+        if (gp->isValue()) {
+          auto refType = adjustedOpenedType;
+          auto ref = TypeValueExpr::createForDecl(memberLoc, gp, dc);
+          cs.setType(ref, refType);
+
+          auto gpTy = gp->getDeclaredInterfaceType();
+          auto subs = baseTy->getContextSubstitutionMap();
+          ref->setParamType(gpTy.subst(subs));
+
+          auto result = new (ctx) DotSyntaxBaseIgnoredExpr(base, dotLoc, ref,
+                                                           refType);
+          cs.setType(result, refType);
+          return result;
+        }
+      }
+
       // If we're referring to a member type, it's just a type
       // reference.
       if (auto *TD = dyn_cast<TypeDecl>(member)) {
@@ -3223,8 +3246,20 @@ namespace {
 
     Expr *visitTypeValueExpr(TypeValueExpr *expr) {
       auto toType = simplifyType(cs.getType(expr));
-      assert(toType->isEqual(expr->getParamDecl()->getValueType()));
+      ASSERT(toType->isEqual(expr->getParamDecl()->getValueType()));
       cs.setType(expr, toType);
+
+      auto declRefRepr = cast<DeclRefTypeRepr>(expr->getRepr());
+      auto resolvedTy =
+          TypeResolution::resolveContextualType(declRefRepr, cs.DC,
+                                             TypeResolverContext::InExpression,
+                                                nullptr, nullptr, nullptr);
+
+      if (!resolvedTy || resolvedTy->hasError())
+        return nullptr;
+
+      expr->setParamType(resolvedTy);
+
       return expr;
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1723,9 +1723,6 @@ namespace {
     }
 
     Type visitTypeValueExpr(TypeValueExpr *E) {
-      auto ty = E->getParamDecl()->getDeclaredInterfaceType();
-      auto paramType = CS.DC->mapTypeIntoContext(ty);
-      E->setParamType(paramType);
       return E->getParamDecl()->getValueType();
     }
 

--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -817,8 +817,7 @@ Expr *TypeChecker::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE,
                    : D->getInterfaceType());
     } else {
       if (makeTypeValue) {
-        return TypeValueExpr::createForDecl(UDRE->getNameLoc(),
-                                            cast<GenericTypeParamDecl>(D));
+        return TypeValueExpr::createForDecl(UDRE->getNameLoc(), D, LookupDC);
       } else {
         return TypeExpr::createForDecl(UDRE->getNameLoc(), D, LookupDC);
       }
@@ -1853,7 +1852,7 @@ TypeExpr *PreCheckTarget::simplifyUnresolvedSpecializeExpr(
     UnresolvedSpecializeExpr *us) {
   // If this is a reference type a specialized type, form a TypeExpr.
   // The base should be a TypeExpr that we already resolved.
-  if (auto *te = dyn_cast<TypeExpr>(us->getSubExpr())) {
+  if (auto *te = dyn_cast_or_null<TypeExpr>(us->getSubExpr())) {
     if (auto *declRefTR =
             dyn_cast_or_null<DeclRefTypeRepr>(te->getTypeRepr())) {
       return TypeExpr::createForSpecializedDecl(

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -728,6 +728,20 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
       auto found = nominal->lookupDirect(current->getBaseName(), SourceLoc(),
                                          flags);
       otherDefinitions.append(found.begin(), found.end());
+
+      // Look into the generics of the type. Value generic parameters can appear
+      // as static members of the type.
+      if (auto genericDC = static_cast<Decl *>(nominal)->getAsGenericContext()) {
+        auto gpList = genericDC->getGenericParams();
+
+        if (gpList && !current->getBaseName().isSpecial()) {
+          auto gp = gpList->lookUpGenericParam(current->getBaseIdentifier());
+
+          if (gp && gp->isValue()) {
+            otherDefinitions.push_back(gp);
+          }
+        }
+      }
     }
   } else if (currentDC->isLocalContext()) {
     if (!current->isImplicit()) {
@@ -1136,6 +1150,7 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
       break;
     }
   }
+
   return std::make_tuple<>();
 }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6341,6 +6341,18 @@ Type TypeChecker::substMemberTypeWithBase(TypeDecl *member,
     resultType = TypeAliasType::get(aliasDecl, sugaredBaseTy, {}, resultType);
   }
 
+  // However, if overload resolution finds a value generic decl from name
+  // lookup, replace the returned member type to be the underlying value type
+  // of the generic.
+  //
+  // This can occur in code that does something like: 'type(of: x).a' where
+  // 'a' is the static value generic member.
+  if (auto gp = dyn_cast<GenericTypeParamDecl>(member)) {
+    if (gp->isValue()) {
+      resultType = gp->getValueType();
+    }
+  }
+
   return resultType;
 }
 

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1557,6 +1557,13 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
     // Wrap it in a metatype.
     memberTy = MetatypeType::get(memberTy);
 
+    // If this is a value generic, undo the wrapping. 'substMemberTypeWithBase'
+    // returns the underlying value type of the value generic (e.g. 'Int').
+    if (isa<GenericTypeParamDecl>(value) &&
+        cast<GenericTypeParamDecl>(value)->isValue()) {
+      memberTy = memberTy->castTo<MetatypeType>()->getInstanceType();
+    }
+
     auto openedType = FunctionType::get({baseObjParam}, memberTy);
     return { openedType, openedType, memberTy, memberTy, Type() };
   }

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -247,11 +247,15 @@ extension InlineArray where Element: Copyable {
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init(repeating value: Element) {
+#if $ValueGenericsNameLookup
     self = Builtin.emplace {
       let buffer = unsafe Self._initializationBuffer(start: $0)
 
       unsafe buffer.initialize(repeating: value)
     }
+#else
+    fatalError()
+#endif
   }
 }
 

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -273,14 +273,6 @@ extension InlineArray where Element: ~Copyable {
   @available(SwiftStdlib 6.2, *)
   public typealias Index = Int
 
-  // FIXME: Remove when SE-0452 "Integer Generic Parameters" is implemented.
-  @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
-  @_transparent
-  public static var count: Int {
-    count
-  }
-
   /// The number of elements in the array.
   ///
   /// - Complexity: O(1)

--- a/test/ModuleInterface/value_generics.swift
+++ b/test/ModuleInterface/value_generics.swift
@@ -14,6 +14,8 @@ public struct Slab<Element, let N: Int> {
   public var count: Int {
     N
   }
+
+  public init() {}
 }
 
 // CHECK: public func usesGenericSlab<let N : Swift.Int>(_: ValueGeneric.Slab<Swift.Int, N>)
@@ -24,3 +26,27 @@ public func usesConcreteSlab(_: Slab<Int, 2>) {}
 
 // CHECK: public func usesNegativeSlab(_: ValueGeneric.Slab<Swift.String, -10>)
 public func usesNegativeSlab(_: Slab<String, -10>) {}
+
+// CHECK: $ValueGenericsNameLookup
+@inlinable
+public func test() -> Int {
+  // CHECK: Slab<Int, 123>.N
+  Slab<Int, 123>.N
+}
+
+// CHECK: $ValueGenericsNameLookup
+@inlinable
+public func test2() -> Int {
+  // CHECK: type(of: Slab<Int, 123>()).N
+  type(of: Slab<Int, 123>()).N
+}
+
+// CHECK: $ValueGenericsNameLookup
+@inlinable
+public func test3() {
+  {
+    print(123)
+    print(123)
+    print(Slab<Int, 123>.N)
+  }()
+}

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -123,7 +123,7 @@ func testC4<let T: Int>(with c: C<T, T>) {
 struct D<let N: Int & P> {} // expected-error {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
 
 struct E<A, let b: Int> { // expected-note {{'b' previously declared here}}
-  static var b: Int { // expected-error {{invalid redeclaration of 'b'}}
+  static var b: Int { // expected-warning {{redeclaration of 'b' is deprecated and will be an error in Swift 5}}
                       // expected-note@-1 {{'b' declared here}}
     123
   }
@@ -185,7 +185,7 @@ func testTypeOf2<let c: Int>(_: E<Int, c>.Type) -> Int {
 }
 
 struct H<let I: Int> { // expected-note {{'I' previously declared here}}
-  struct I {} // expected-error {{invalid redeclaration of 'I'}}
+  struct I {} // expected-warning {{redeclaration of 'I' is deprecated and will be an error in Swift 5}}
 }
 
 typealias J = E<Int, 123>.b // expected-error {{static property 'b' is not a member type of 'E<Int, 123>'}}

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -121,3 +121,71 @@ func testC4<let T: Int>(with c: C<T, T>) {
 }
 
 struct D<let N: Int & P> {} // expected-error {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
+
+struct E<A, let b: Int> { // expected-note {{'b' previously declared here}}
+  static var b: Int { // expected-error {{invalid redeclaration of 'b'}}
+                      // expected-note@-1 {{'b' declared here}}
+    123
+  }
+
+  let b: String // expected-note {{'b' previously declared here}}
+                // expected-note@-1 {{'b' declared here}}
+
+  func b() {} // expected-error {{invalid redeclaration of 'b()'}}
+              // expected-note@-1 {{'b' declared here}}
+
+  func dumb() -> Int {
+    Self.b // OK
+  }
+
+  static func dumb2() -> Int {
+    Self.b // OK
+  }
+}
+
+func testE1() -> Int {
+  E<Int, 123>.b // OK
+}
+
+func testE2() -> Int {
+  E<Int, 123>.A // expected-error {{type 'E<Int, 123>' has no member 'A'}}
+}
+
+func testE3<let c: Int>(_: E<Int, c>.Type) -> Int {
+  E<Int, c>.b // OK
+}
+
+func testShadowing<let a: Int>(_: A<a>) {
+  var a: String {
+    "123"
+  }
+
+  let x: String = a // OK
+  let y: Int = a // expected-error {{cannot convert value of type 'String' to specified type 'Int'}}
+
+  print(a) // OK
+  print(a.self) // OK
+}
+
+class F<let n: Int> {}
+class G: F<3> {}
+
+func hello() -> Int {
+  G.n // OK
+}
+
+func testTypeOf() -> Int {
+  let x = E<Int, 123>(b: "")
+  return type(of: x).b // OK
+}
+
+func testTypeOf2<let c: Int>(_: E<Int, c>.Type) -> Int {
+  let x = E<Int, c>(b: "")
+  return type(of: x).b // OK
+}
+
+struct H<let I: Int> { // expected-note {{'I' previously declared here}}
+  struct I {} // expected-error {{invalid redeclaration of 'I'}}
+}
+
+typealias J = E<Int, 123>.b // expected-error {{static property 'b' is not a member type of 'E<Int, 123>'}}

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1015,9 +1015,6 @@ Added: _$ss11InlineArrayVMa
 // InlineArray nominal type descriptor
 Added: _$ss11InlineArrayVMn
 
-// InlineArray.count property descriptor
-Added: _$ss11InlineArrayVsRi__rlE5countSivpZMV
-
 // InlineArray._storage _read accessor
 Added: _$ss11InlineArrayVsRi__rlE8_storagexq_BVvr
 

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1016,9 +1016,6 @@ Added: _$ss11InlineArrayVMa
 // InlineArray nominal type descriptor
 Added: _$ss11InlineArrayVMn
 
-// InlineArray.count property descriptor
-Added: _$ss11InlineArrayVsRi__rlE5countSivpZMV
-
 // InlineArray._storage _read accessor
 Added: _$ss11InlineArrayVsRi__rlE8_storagexq_BVvr
 


### PR DESCRIPTION
* **Explanation**: This patch adds value generics to appear as static members in name lookup as described in: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0452-integer-generic-parameters.md

* **Risk**: Medium, because this changes how name lookup works with respects to value generic types. Early adopters could potentially have source breakage with this change because of redeclarations.

* **Testing**: Tested by lit tests.

* **Issue**: N/A

* **Reviewer**: @slavapestov @xedin 

* **Main** **branch** **PR**: https://github.com/swiftlang/swift/pull/78248 & https://github.com/swiftlang/swift/pull/81169 & https://github.com/swiftlang/swift/pull/81104