### PR TITLE
6.2: [CoroutineAccessors] Only reference when available

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6242,10 +6242,11 @@ public:
                               bool forConformance=false) const;
 
   /// Determine how this storage declaration should actually be accessed.
-  AccessStrategy getAccessStrategy(AccessSemantics semantics,
-                                   AccessKind accessKind, ModuleDecl *module,
-                                   ResilienceExpansion expansion,
-                                   bool useOldABI) const;
+  AccessStrategy getAccessStrategy(
+      AccessSemantics semantics, AccessKind accessKind, ModuleDecl *module,
+      ResilienceExpansion expansion,
+      std::optional<std::pair<SourceRange, const DeclContext *>> location,
+      bool useOldABI) const;
 
   /// Whether access is via physical storage.
   bool isAccessedViaPhysicalStorage(AccessSemantics semantics,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6247,6 +6247,11 @@ public:
                                    ResilienceExpansion expansion,
                                    bool useOldABI) const;
 
+  /// Whether access is via physical storage.
+  bool isAccessedViaPhysicalStorage(AccessSemantics semantics,
+                                    AccessKind accessKind, ModuleDecl *module,
+                                    ResilienceExpansion expansion) const;
+
   /// Do we need to use resilient access patterns outside of this
   /// property's resilience domain?
   bool isResilient() const;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1,4 +1,3 @@
-
 //===--- Decl.cpp - Swift Language Decl ASTs ------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -15,7 +14,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Strings.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
@@ -24,6 +22,7 @@
 #include "swift/AST/AccessRequests.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/AvailabilityContext.h"
 #include "swift/AST/AvailabilityInference.h"
 #include "swift/AST/CaptureInfo.h"
 #include "swift/AST/ConformanceLookup.h"
@@ -64,6 +63,7 @@
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Parse/Lexer.h" // FIXME: Bad dependency
+#include "swift/Strings.h"
 #include "clang/Lex/MacroInfo.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -3022,9 +3022,11 @@ getDirectWriteAccessStrategy(const AbstractStorageDecl *storage) {
   llvm_unreachable("bad impl kind");
 }
 
-static AccessStrategy
-getOpaqueReadAccessStrategy(const AbstractStorageDecl *storage, bool dispatch,
-                            bool useOldABI);
+static AccessStrategy getOpaqueReadAccessStrategy(
+    const AbstractStorageDecl *storage, bool dispatch, ModuleDecl *module,
+    ResilienceExpansion expansion,
+    std::optional<std::pair<SourceRange, const DeclContext *>> location,
+    bool useOldABI);
 static AccessStrategy
 getOpaqueWriteAccessStrategy(const AbstractStorageDecl *storage, bool dispatch);
 
@@ -3039,7 +3041,9 @@ getDirectReadWriteAccessStrategy(const AbstractStorageDecl *storage) {
     // If the storage isDynamic (and not @objc) use the accessors.
     if (storage->shouldUseNativeDynamicDispatch())
       return AccessStrategy::getMaterializeToTemporary(
-          getOpaqueReadAccessStrategy(storage, false, false),
+          getOpaqueReadAccessStrategy(storage, false, nullptr,
+                                      ResilienceExpansion::Minimal,
+                                      std::nullopt, false),
           getOpaqueWriteAccessStrategy(storage, false));
     return AccessStrategy::getStorage();
   }
@@ -3076,15 +3080,61 @@ getDirectReadWriteAccessStrategy(const AbstractStorageDecl *storage) {
   llvm_unreachable("bad impl kind");
 }
 
-static AccessStrategy
-getOpaqueReadAccessStrategy(const AbstractStorageDecl *storage, bool dispatch,
-                            bool useOldABI) {
+static bool mayReferenceUseCoroutineAccessorOnStorage(
+    ModuleDecl *module, ResilienceExpansion expansion,
+    std::optional<std::pair<SourceRange, const DeclContext *>> reference,
+    const AbstractStorageDecl *storage) {
+  assert(storage);
+  ASTContext &ctx = storage->getASTContext();
+  assert(ctx.LangOpts.hasFeature(Feature::CoroutineAccessors));
+
+  // For triples without platforms, coroutine accessors are always available.
+  auto domain = ctx.getTargetAvailabilityDomain();
+  if (domain.isUniversal())
+    return true;
+
+  // A non-resilient access to storage can always use the coroutine accessor,
+  // provided it exists.  Such an access is compiled with the version of the
+  // module that includes the accessor.
+  bool resilient = [&] {
+    if (module)
+      return storage->isResilient(module, expansion);
+    else
+      return storage->isResilient();
+  }();
+  if (!resilient)
+    return true;
+
+  // Without knowing where the storage is referenced, it can't be known that
+  // a coroutine accessor is available.
+  if (!reference) {
+    return false;
+  }
+
+  // A resilient access to storage may only use a coroutine accessor if the
+  // storage became available no earlier than the feature.
+  auto referenceAvailability = AvailabilityContext::forLocation(
+                                   reference->first.Start, reference->second)
+                                   .getPlatformRange();
+  auto featureAvailability =
+      storage->getASTContext().getCoroutineAccessorsAvailability();
+
+  return referenceAvailability.isContainedIn(featureAvailability);
+}
+
+static AccessStrategy getOpaqueReadAccessStrategy(
+    const AbstractStorageDecl *storage, bool dispatch, ModuleDecl *module,
+    ResilienceExpansion expansion,
+    std::optional<std::pair<SourceRange, const DeclContext *>> location,
+    bool useOldABI) {
   if (useOldABI) {
     assert(storage->requiresOpaqueRead2Coroutine());
     assert(storage->requiresOpaqueReadCoroutine());
     return AccessStrategy::getAccessor(AccessorKind::Read, dispatch);
   }
-  if (storage->requiresOpaqueRead2Coroutine())
+  if (storage->requiresOpaqueRead2Coroutine() &&
+      mayReferenceUseCoroutineAccessorOnStorage(module, expansion, location,
+                                                storage))
     return AccessStrategy::getAccessor(AccessorKind::Read2, dispatch);
   if (storage->requiresOpaqueReadCoroutine())
     return AccessStrategy::getAccessor(AccessorKind::Read, dispatch);
@@ -3098,41 +3148,53 @@ getOpaqueWriteAccessStrategy(const AbstractStorageDecl *storage, bool dispatch) 
   return AccessStrategy::getAccessor(AccessorKind::Set, dispatch);
 }
 
-static AccessStrategy
-getOpaqueReadWriteAccessStrategy(const AbstractStorageDecl *storage,
-                                 bool dispatch, bool useOldABI) {
+static AccessStrategy getOpaqueReadWriteAccessStrategy(
+    const AbstractStorageDecl *storage, bool dispatch, ModuleDecl *module,
+    ResilienceExpansion expansion,
+    std::optional<std::pair<SourceRange, const DeclContext *>> location,
+    bool useOldABI) {
   if (useOldABI) {
     assert(storage->requiresOpaqueModify2Coroutine());
     assert(storage->requiresOpaqueModifyCoroutine());
     return AccessStrategy::getAccessor(AccessorKind::Modify, dispatch);
   }
-  if (storage->requiresOpaqueModify2Coroutine())
+  if (storage->requiresOpaqueModify2Coroutine() &&
+      mayReferenceUseCoroutineAccessorOnStorage(module, expansion, location,
+                                                storage))
     return AccessStrategy::getAccessor(AccessorKind::Modify2, dispatch);
   if (storage->requiresOpaqueModifyCoroutine())
     return AccessStrategy::getAccessor(AccessorKind::Modify, dispatch);
   return AccessStrategy::getMaterializeToTemporary(
-      getOpaqueReadAccessStrategy(storage, dispatch, false),
+      getOpaqueReadAccessStrategy(storage, dispatch, nullptr,
+                                  ResilienceExpansion::Minimal, location,
+                                  false),
       getOpaqueWriteAccessStrategy(storage, dispatch));
 }
 
-static AccessStrategy
-getOpaqueAccessStrategy(const AbstractStorageDecl *storage,
-                        AccessKind accessKind, bool dispatch, bool useOldABI) {
+static AccessStrategy getOpaqueAccessStrategy(
+    const AbstractStorageDecl *storage, AccessKind accessKind, bool dispatch,
+    ModuleDecl *module, ResilienceExpansion expansion,
+    std::optional<std::pair<SourceRange, const DeclContext *>> location,
+    bool useOldABI) {
   switch (accessKind) {
   case AccessKind::Read:
-    return getOpaqueReadAccessStrategy(storage, dispatch, useOldABI);
+    return getOpaqueReadAccessStrategy(storage, dispatch, module, expansion,
+                                       location, useOldABI);
   case AccessKind::Write:
     assert(!useOldABI);
     return getOpaqueWriteAccessStrategy(storage, dispatch);
   case AccessKind::ReadWrite:
-    return getOpaqueReadWriteAccessStrategy(storage, dispatch, useOldABI);
+    return getOpaqueReadWriteAccessStrategy(storage, dispatch, module,
+                                            expansion, location, useOldABI);
   }
   llvm_unreachable("bad access kind");
 }
 
 AccessStrategy AbstractStorageDecl::getAccessStrategy(
     AccessSemantics semantics, AccessKind accessKind, ModuleDecl *module,
-    ResilienceExpansion expansion, bool useOldABI) const {
+    ResilienceExpansion expansion,
+    std::optional<std::pair<SourceRange, const DeclContext *>> location,
+    bool useOldABI) const {
   switch (semantics) {
   case AccessSemantics::DirectToStorage:
     assert(hasStorage() || getASTContext().Diags.hadAnyError());
@@ -3149,11 +3211,11 @@ AccessStrategy AbstractStorageDecl::getAccessStrategy(
       // accessors are dynamically dispatched, and we cannot do direct access.
       if (isPolymorphic(this))
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ true,
-                                       useOldABI);
+                                       module, expansion, location, useOldABI);
 
       if (shouldUseNativeDynamicDispatch())
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false,
-                                       useOldABI);
+                                       module, expansion, location, useOldABI);
 
       // If the storage is resilient from the given module and resilience
       // expansion, we cannot use direct access.
@@ -3176,7 +3238,7 @@ AccessStrategy AbstractStorageDecl::getAccessStrategy(
 
       if (resilient)
         return getOpaqueAccessStrategy(this, accessKind, /*dispatch*/ false,
-                                       useOldABI);
+                                       module, expansion, location, useOldABI);
     }
 
     LLVM_FALLTHROUGH;
@@ -3200,6 +3262,7 @@ bool AbstractStorageDecl::isAccessedViaPhysicalStorage(
     AccessSemantics semantics, AccessKind accessKind, ModuleDecl *module,
     ResilienceExpansion expansion) const {
   return getAccessStrategy(semantics, accessKind, module, expansion,
+                           /*location=*/std::nullopt,
                            /*useOldABI=*/false)
              .getKind() == AccessStrategy::Kind::Storage;
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3196,6 +3196,14 @@ AccessStrategy AbstractStorageDecl::getAccessStrategy(
   llvm_unreachable("bad access semantics");
 }
 
+bool AbstractStorageDecl::isAccessedViaPhysicalStorage(
+    AccessSemantics semantics, AccessKind accessKind, ModuleDecl *module,
+    ResilienceExpansion expansion) const {
+  return getAccessStrategy(semantics, accessKind, module, expansion,
+                           /*useOldABI=*/false)
+             .getKind() == AccessStrategy::Kind::Storage;
+}
+
 bool AbstractStorageDecl::requiresOpaqueAccessors() const {
   // Subscripts always require opaque accessors, so don't even kick off
   // a request.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1974,7 +1974,7 @@ SILGenModule::canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
   auto strategy = decl->getAccessStrategy(
       AccessSemantics::Ordinary,
       decl->supportsMutation() ? AccessKind::ReadWrite : AccessKind::Read,
-      M.getSwiftModule(), expansion,
+      M.getSwiftModule(), expansion, std::nullopt,
       /*useOldABI=*/false);
   switch (strategy.getKind()) {
   case AccessStrategy::Storage: {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3335,12 +3335,15 @@ Expr *SILGenFunction::findStorageReferenceExprForMoveOnly(Expr *argExpr,
 
   if (!storage)
     return nullptr;
+
   // This should match the strategy computation used in
   // SILGenLValue::visit{DeclRef,Member}RefExpr.
-  auto strategy = storage->getAccessStrategy(accessSemantics,
-         AccessKind::Read, SGM.M.getSwiftModule(), F.getResilienceExpansion(),
-         /* old abi*/ false);
-  
+  auto strategy = storage->getAccessStrategy(
+      accessSemantics, AccessKind::Read, SGM.M.getSwiftModule(),
+      F.getResilienceExpansion(),
+      std::make_pair<>(argExpr->getSourceRange(), FunctionDC),
+      /* old abi*/ false);
+
   switch (strategy.getKind()) {
   case AccessStrategy::Storage:
     // Storage can benefit from direct borrowing/consumption.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3815,6 +3815,7 @@ static SILFunction *getOrCreateKeyPathSetter(
   auto semantics = AccessSemantics::Ordinary;
   auto strategy = property->getAccessStrategy(semantics, AccessKind::Write,
                                               SGM.M.getSwiftModule(), expansion,
+                                              std::nullopt,
                                               /*useOldABI=*/false);
 
   LValueOptions lvOptions;
@@ -4634,7 +4635,7 @@ KeyPathPatternComponent SILGenModule::emitKeyPathComponentForDecl(
     auto strategy = storage->getAccessStrategy(
         AccessSemantics::Ordinary,
         storage->supportsMutation() ? AccessKind::ReadWrite : AccessKind::Read,
-        M.getSwiftModule(), expansion,
+        M.getSwiftModule(), expansion, std::nullopt,
         /*useOldABI=*/false);
 
     AbstractStorageDecl *externalDecl = nullptr;

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -3323,11 +3323,13 @@ static bool isBorrowableSubject(SILGenFunction &SGF,
   if (!storage) {
     return false;
   }
-  
+
+  auto pair = std::make_pair<>(subjectExpr->getSourceRange(), SGF.FunctionDC);
+
   // Check the access strategy used to read the storage.
   auto strategy =
       storage->getAccessStrategy(access, AccessKind::Read, SGF.SGM.SwiftModule,
-                                 SGF.F.getResilienceExpansion(),
+                                 SGF.F.getResilienceExpansion(), pair,
                                  /*useOldABI=*/false);
 
   switch (strategy.getKind()) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4407,11 +4407,9 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
 
       // Check what access strategy is used for a read-write access. It must be
       // direct-to-storage in order for the conversion to be non-ephemeral.
-      auto access = asd->getAccessStrategy(
+      return asd->isAccessedViaPhysicalStorage(
           AccessSemantics::Ordinary, AccessKind::ReadWrite,
-          DC->getParentModule(), DC->getResilienceExpansion(),
-          /*useOldABI=*/false);
-      return access.getKind() == AccessStrategy::Storage;
+          DC->getParentModule(), DC->getResilienceExpansion());
     };
 
     SourceRange range;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1508,11 +1508,10 @@ DeferredDiags swift::findSyntacticErrorForConsume(
         break;
       }
       partial = true;
-      AccessStrategy strategy =
-          vd->getAccessStrategy(mre->getAccessSemantics(), AccessKind::Read,
-                                module, ResilienceExpansion::Minimal,
-                                /*useOldABI=*/false);
-      if (strategy.getKind() != AccessStrategy::Storage) {
+      auto isAccessedViaStorage = vd->isAccessedViaPhysicalStorage(
+          mre->getAccessSemantics(), AccessKind::Read, module,
+          ResilienceExpansion::Minimal);
+      if (!isAccessedViaStorage) {
         if (noncopyable) {
           result.emplace_back(loc, diag::consume_expression_non_storage);
           result.emplace_back(mre->getLoc(),

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -396,13 +396,11 @@ public:
     // If this is a direct reference to underlying storage, then this is a
     // capture of the storage address - not a capture of the getter/setter.
     if (auto var = dyn_cast<VarDecl>(D)) {
-      if (var->getAccessStrategy(DRE->getAccessSemantics(),
-                                 var->supportsMutation() ? AccessKind::ReadWrite
-                                                         : AccessKind::Read,
-                                 CurDC->getParentModule(),
-                                 CurDC->getResilienceExpansion(),
-                                 /*useOldABI=*/false)
-              .getKind() == AccessStrategy::Storage)
+      if (var->isAccessedViaPhysicalStorage(
+              DRE->getAccessSemantics(),
+              var->supportsMutation() ? AccessKind::ReadWrite
+                                      : AccessKind::Read,
+              CurDC->getParentModule(), CurDC->getResilienceExpansion()))
         Flags |= CapturedValue::IsDirect;
     }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2702,7 +2702,7 @@ bool AbstractStorageDecl::requiresCorrespondingUnderscoredCoroutineAccessor(
     return true;
 
   auto modifyAvailability = AvailabilityContext::forLocation({}, accessor);
-  auto featureAvailability = ctx.getCoroutineAccessorsRuntimeAvailability();
+  auto featureAvailability = ctx.getCoroutineAccessorsAvailability();
   // If accessor was introduced only after the feature was, there's no old ABI
   // to maintain.
   if (modifyAvailability.getPlatformRange().isContainedIn(featureAvailability))

--- a/test/IRGen/run-coroutine_accessors.swift
+++ b/test/IRGen/run-coroutine_accessors.swift
@@ -99,11 +99,14 @@
 
 //--- Library.swift
 
+// TODO: CoroutineAccessors: Change to X.Y
+@available(SwiftStdlib 9999, *)
 public protocol ResilientWrapping {
   associatedtype Wrapped
   var wrapped: Wrapped { read set }
   var wrapped2: Wrapped { read set }
 }
+@available(SwiftStdlib 9999, *)
 extension ResilientWrapping {
   public var wrapped2: Wrapped {
     read {
@@ -115,6 +118,7 @@ extension ResilientWrapping {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 public struct ResilientBoxtional<T> : ResilientWrapping {
   var storage: T?
   public init(_ t: T?) {
@@ -132,6 +136,7 @@ public struct ResilientBoxtional<T> : ResilientWrapping {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 open class ResilientWrappingClass<Wrapped> {
   public init() {}
   open var wrapped: Wrapped {
@@ -144,6 +149,7 @@ open class ResilientWrappingClass<Wrapped> {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 open class ResilientWrappingSubclass<X : ResilientWrapping> : ResilientWrappingClass<X.Wrapped> {
   public init(_ impl: X) { self.impl = impl }
   var impl: X
@@ -161,6 +167,7 @@ open class ResilientWrappingSubclass<X : ResilientWrapping> : ResilientWrappingC
 
 import Library
 
+@available(SwiftStdlib 9999, *)
 struct MaybePtrBox<T> {
   private var ptr: UnsafeMutablePointer<T>
 
@@ -216,6 +223,7 @@ struct MaybePtrBox<T> {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 struct Boxtional<T> : ResilientWrapping {
   var storage: T?
   init(_ t: T?) {
@@ -233,6 +241,7 @@ struct Boxtional<T> : ResilientWrapping {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 class NonresilientResilientWrappingSubclass<X : ResilientWrapping> : ResilientWrappingClass<X.Wrapped> {
   init(_ impl: X) { 
     self.impl = impl
@@ -249,10 +258,12 @@ class NonresilientResilientWrappingSubclass<X : ResilientWrapping> : ResilientWr
   }
 }
 
+@available(SwiftStdlib 9999, *)
 protocol AsyncMutatable {
   mutating func mutate() async
 }
 
+@available(SwiftStdlib 9999, *)
 struct Stringg : AsyncMutatable {
   var value: String
   mutating func mutate() async {
@@ -260,10 +271,12 @@ struct Stringg : AsyncMutatable {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 protocol Mutatable {
   mutating func mutate()
 }
 
+@available(SwiftStdlib 9999, *)
 struct Stringgg : Mutatable {
   var value: String
   mutating func mutate() {
@@ -271,11 +284,13 @@ struct Stringgg : Mutatable {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 protocol Wrapping {
   associatedtype Wrapped
   var wrapped: Wrapped { read set }
 }
 
+@available(SwiftStdlib 9999, *)
 extension MaybePtrBox : Wrapping {
   typealias Wrapped = T?
   var wrapped: T? {
@@ -287,8 +302,10 @@ extension MaybePtrBox : Wrapping {
     }
   }
 }
+@available(SwiftStdlib 9999, *)
 extension MaybePtrBox : ResilientWrapping {}
 
+@available(SwiftStdlib 9999, *)
 class WrappingClass<Wrapped> {
   var wrapped: Wrapped {
     read {
@@ -300,6 +317,7 @@ class WrappingClass<Wrapped> {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 class WrappingSubclass<X : Wrapping> : WrappingClass<X.Wrapped> {
   init(_ impl: X) { self.impl = impl }
   var impl: X
@@ -313,6 +331,7 @@ class WrappingSubclass<X : Wrapping> : WrappingClass<X.Wrapped> {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 extension Optional : Mutatable where Wrapped : Mutatable {
   mutating func mutate() {
     switch (self) {
@@ -325,6 +344,7 @@ extension Optional : Mutatable where Wrapped : Mutatable {
   }
 }
 
+@available(SwiftStdlib 9999, *)
 @main
 struct M {
   static func sync_mutate<T : Mutatable>(_ t: inout T?) {

--- a/test/SILGen/coroutine_accessors_availability.swift
+++ b/test/SILGen/coroutine_accessors_availability.swift
@@ -1,0 +1,350 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-silgen                           \
+// RUN:     %t/Library.swift                                \
+// RUN:     -enable-library-evolution                       \
+// RUN:     -module-name Library                            \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -I %t                                           \
+// RUN: | %FileCheck %t/Library.swift --check-prefixes=CHECK
+
+// RUN: %target-swift-frontend                              \
+// RUN:     %t/Library.swift                                \
+// RUN:     -emit-module                                    \
+// RUN:     -enable-library-evolution                       \
+// RUN:     -module-name Library                            \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-emit-silgen                           \
+// RUN:     %t/Downstream.swift                             \
+// RUN:     -target %target-swift-5.9-abi-triple            \
+// RUN:     -module-name main                               \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -lLibrary                                       \
+// RUN:     -I %t                                           \
+// RUN: | %FileCheck %t/Downstream.swift --check-prefixes=CHECK,CHECK-OLD
+
+// RUN: %target-swift-emit-silgen                           \
+// RUN:     %t/Downstream.swift                             \
+// TODO: CoroutineAccessors: Change to %target-swift-x.y-abi-triple
+// RUN:     -target %target-future-triple                   \
+// RUN:     -module-name main                               \
+// RUN:     -enable-experimental-feature CoroutineAccessors \
+// RUN:     -lLibrary                                       \
+// RUN:     -I %t                                           \
+// RUN: | %FileCheck %t/Downstream.swift --check-prefixes=CHECK,CHECK-NEW
+
+// REQUIRES: swift_stable_abi
+// REQUIRES: swift_feature_CoroutineAccessors
+
+//--- Library.swift
+
+extension Int {
+  public mutating func increment() {
+    self = self + 1
+  }
+}
+
+// TODO: CoroutineAccessors: Change to X.Y throughout file.
+@available(SwiftStdlib 9999, *)
+public struct StructNew {
+  var _i: Int
+  public var i: Int {
+    read {
+      yield _i
+    }
+    modify {
+      yield &_i
+    }
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+public func getNew() -> StructNew {
+  return StructNew(_i: 3)
+}
+
+@inlinable
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readNewInlinableNew")
+public func readNewInlinableNew(_ n: StructNew) -> Int {
+// CHECK-LABEL: sil {{.*}}@readNewInlinableNew : {{.*}} {
+                  // function_ref StructNew.i.read2
+// CHECK:         function_ref @$s7Library9StructNewV1iSivy
+// CHECK-LABEL: } // end sil function 'readNewInlinableNew'
+  return n.i
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readNewNoninlinableNew")
+public func readNewNoninlinableNew(_ n: StructNew) -> Int {
+// CHECK-LABEL: sil {{.*}}@readNewNoninlinableNew : {{.*}} {
+                  // function_ref StructNew.i.read2
+// CHECK:         function_ref @$s7Library9StructNewV1iSivy
+// CHECK-LABEL: } // end sil function 'readNewNoninlinableNew'
+  return n.i
+}
+
+@inlinable
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyNewInlinableNew")
+public func modifyNewInlinableNew(_ n: inout StructNew) {
+// CHECK-LABEL: sil {{.*}}@modifyNewInlinableNew : {{.*}} {
+                  // function_ref StructNew.i.modify2
+// CHECK:         function_ref @$s7Library9StructNewV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyNewInlinableNew'
+  n.i.increment()
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyNewNoninlinableNew")
+public func modifyNewNoninlinableNew(_ n: inout StructNew) {
+// CHECK-LABEL: sil {{.*}}@modifyNewNoninlinableNew : {{.*}} {
+                  // function_ref StructNew.i.modify2
+// CHECK:         function_ref @$s7Library9StructNewV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyNewNoninlinableNew'
+  n.i.increment()
+}
+
+public struct StructOld {
+  var _i: Int
+  public var i: Int {
+    read {
+      yield _i
+    }
+    modify {
+      yield &_i
+    }
+  }
+}
+
+public func getOld() -> StructOld {
+  return StructOld(_i: 3)
+}
+
+@inlinable
+@_silgen_name("readOldInlinableOld")
+public func readOldInlinableOld(_ n: StructOld) -> Int {
+// CHECK-LABEL: sil {{.*}}@readOldInlinableOld : {{.*}} {
+// Could be inlined into code that's running before CoroutineAccessors is
+// available--must use read.
+                  // function_ref StructOld.i.read
+// CHECK:         function_ref @$s7Library9StructOldV1iSivr
+// CHECK-LABEL: } // end sil function 'readOldInlinableOld'
+  return n.i
+}
+
+@_silgen_name("readOldNoninlinableOld")
+public func readOldNoninlinableOld(_ n: StructOld) -> Int {
+// CHECK-LABEL: sil {{.*}}@readOldNoninlinableOld : {{.*}} {
+// Opaque symbol never inlined.  Even though it was available before
+// CoroutineAccessors was, the implementation in this version of the module--can
+// use read2.
+                  // function_ref StructOld.i.read2
+// CHECK:         function_ref @$s7Library9StructOldV1iSivy
+// CHECK-LABEL: } // end sil function 'readOldNoninlinableOld'
+  return n.i
+}
+
+@inlinable
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readOldInlinableNew")
+public func readOldInlinableNew(_ n: StructOld) -> Int {
+// CHECK-LABEL: sil {{.*}}@readOldInlinableNew : {{.*}} {
+// Could be inlined, but only into code that's running at or after
+// CoroutineAccessors is available--can use read2.
+                  // function_ref StructOld.i.read2
+// CHECK:         function_ref @$s7Library9StructOldV1iSivy
+// CHECK-LABEL: } // end sil function 'readOldInlinableNew'
+  return n.i
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readOldNoninlinableNew")
+public func readOldNoninlinableNew(_ n: StructOld) -> Int {
+// CHECK-LABEL: sil {{.*}}@readOldNoninlinableNew : {{.*}} {
+// Neither inlinable nor available before CoroutineAccessors--can use read2.
+                  // function_ref StructOld.i.read2
+// CHECK:         function_ref @$s7Library9StructOldV1iSivy
+// CHECK-LABEL: } // end sil function 'readOldNoninlinableNew'
+  return n.i
+}
+
+@inlinable
+@_silgen_name("modifyOldInlinableOld")
+public func modifyOldInlinableOld(_ n: inout StructOld) {
+// CHECK-LABEL: sil {{.*}}@modifyOldInlinableOld : {{.*}} {
+// Could be inlined into code that's running before CoroutineAccessors is
+// available--must use modify.
+                  // function_ref StructOld.i.modify
+// CHECK:         function_ref @$s7Library9StructOldV1iSivM
+// CHECK-LABEL: } // end sil function 'modifyOldInlinableOld'
+  n.i.increment()
+}
+
+@_silgen_name("modifyOldNoninlinableOld")
+public func modifyOldNoninlinableOld(_ n: inout StructOld) {
+// CHECK-LABEL: sil {{.*}}@modifyOldNoninlinableOld : {{.*}} {
+// Opaque symbol never inlined.  Even though it was available before
+// CoroutineAccessors was, the implementation in this version of the module--can
+// use modify2.
+                  // function_ref StructOld.i.modify2
+// CHECK:         function_ref @$s7Library9StructOldV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyOldNoninlinableOld'
+  n.i.increment()
+}
+
+@inlinable
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyOldInlinableNew")
+public func modifyOldInlinableNew(_ n: inout StructOld) {
+// CHECK-LABEL: sil {{.*}}@modifyOldInlinableNew : {{.*}} {
+// Could be inlined, but only into code that's running at or after
+// CoroutineAccessors is available--can use modify2.
+                  // function_ref StructOld.i.modify2
+// CHECK:         function_ref @$s7Library9StructOldV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyOldInlinableNew'
+  n.i.increment()
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyOldNoninlinableNew")
+public func modifyOldNoninlinableNew(_ n: inout StructOld) {
+// CHECK-LABEL: sil {{.*}}@modifyOldNoninlinableNew : {{.*}} {
+// Neither inlinable nor available before CoroutineAccessors--can use modify2.
+                  // function_ref StructOld.i.modify2
+// CHECK:         function_ref @$s7Library9StructOldV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyOldNoninlinableNew'
+  n.i.increment()
+}
+
+public func takeInt(_ i: Int) {
+}
+
+//--- Downstream.swift
+
+import Library
+
+@_silgen_name("readNewOld")
+func readNewOld() {
+// CHECK-LABEL: sil {{.*}}@readNewOld : {{.*}} {
+// Neither inlinable nor available before CoroutineAccessors--can use read2.
+                  // function_ref StructNew.i.read2
+// CHECK:         function_ref @$s7Library9StructNewV1iSivy
+// CHECK-LABEL: } // end sil function 'readNewOld'
+  if #available(SwiftStdlib 9999, *) {
+    let n = getNew()
+
+    let i = n.i
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readNewNew")
+func readNewNew() {
+// CHECK-LABEL: sil {{.*}}@readNewNew : {{.*}} {
+// Neither inlinable nor available before CoroutineAccessors--can use read2.
+                  // function_ref StructNew.i.read2
+// CHECK:         function_ref @$s7Library9StructNewV1iSivy
+// CHECK-LABEL: } // end sil function 'readNewNew'
+  let n = getNew()
+
+  let i = n.i
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("readOldNew")
+func readOldNew() {
+// CHECK-LABEL: sil {{.*}}@readOldNew : {{.*}} {
+// Although this module could be back-deployed to before CoroutineAccessors were
+// available, it can only run in environments where the feature is available--
+// can use read2.
+                  // function_ref StructOld.i.read2
+// CHECK:         function_ref @$s7Library9StructOldV1iSivy
+// CHECK-LABEL: } // end sil function 'readOldNew'
+  let n = getOld()
+
+  let i = n.i
+}
+
+@_silgen_name("readOldOld")
+func readOldOld() {
+// CHECK-LABEL: sil {{.*}}@readOldOld : {{.*}} {
+// This module could be back-deployed to before CoroutineAccessors were
+// available, and nothing ensures the function is available only after the
+// feature is available--must use read.
+                  // function_ref StructOld.i.read
+// CHECK-OLD:     function_ref @$s7Library9StructOldV1iSivr
+// This module cannot be back-deployed (the deployment target is
+// available, and nothing ensures the function is available only after the
+// feature is available--must use read.
+                  // function_ref StructOld.i.read2
+// CHECK-NEW:     function_ref @$s7Library9StructOldV1iSivy
+// CHECK-LABEL: } // end sil function 'readOldOld'
+  let n = getOld()
+
+  let i = n.i
+}
+
+@_silgen_name("modifyNewOld")
+func modifyNewOld() {
+// CHECK-LABEL: sil {{.*}}@modifyNewOld : {{.*}} {
+// Neither inlinable nor available before CoroutineAccessors--can use modify2.
+                  // function_ref StructNew.i.modify2
+// CHECK:         function_ref @$s7Library9StructNewV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyNewOld'
+  if #available(SwiftStdlib 9999, *) {
+    var n = getNew()
+
+    n.i.increment()
+  }
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyNewNew")
+func modifyNewNew() {
+// CHECK-LABEL: sil {{.*}}@modifyNewNew : {{.*}} {
+// Neither inlinable nor available before CoroutineAccessors--can use modify2.
+                  // function_ref StructNew.i.modify2
+// CHECK:         function_ref @$s7Library9StructNewV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyNewNew'
+  var n = getNew()
+
+  n.i.increment()
+}
+
+@available(SwiftStdlib 9999, *)
+@_silgen_name("modifyOldNew")
+func modifyOldNew() {
+// CHECK-LABEL: sil {{.*}}@modifyOldNew : {{.*}} {
+// Although this module could be back-deployed to before CoroutineAccessors were
+// available, it can only run in environments where the feature is available--
+// can use modify2.
+                  // function_ref StructOld.i.modify2
+// CHECK:         function_ref @$s7Library9StructOldV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyOldNew'
+  var n = getOld()
+
+  n.i.increment()
+}
+
+@_silgen_name("modifyOldOld")
+func modifyOldOld() {
+// CHECK-LABEL: sil {{.*}}@modifyOldOld : {{.*}} {
+// This module could be back-deployed to before CoroutineAccessors were
+// available, and nothing ensures the function is available only after the
+// feature is available--must use modify.
+                  // function_ref StructOld.i.modify
+// CHECK-OLD:     function_ref @$s7Library9StructOldV1iSivM
+// This module cannot be back-deployed (the deployment target is
+// available, and nothing ensures the function is available only after the
+// feature is available--must use modify.
+                  // function_ref StructOld.i.modify2
+// CHECK-NEW:     function_ref @$s7Library9StructOldV1iSivx
+// CHECK-LABEL: } // end sil function 'modifyOldOld'
+  var n = getOld()
+
+  n.i.increment()
+}


### PR DESCRIPTION
**Explanation**: Emit calls to new coroutine accessors when they're contextually available.

When lowering a semantic storage access, a determination about how to access the storage is made.  Among other things, it must be determined whether to access storage via `_read` or `read` and modify it via `_modify` or `modify`.  It's more performant to use the latter, but doing so is not always possible.  For example, it's not possible to use the `read` accessor on storage which has always been available--such an accessor has not alway existed!  On the other hand, it is possible if the availability context of the caller is such that `read` is available within it.

When determining the strategy to use to access storage, pass in the relevant information to determine the caller's availability context, and use that availability context to determine which accessor to call.
**Scope**: Affects the coroutine accessors feature.
**Issue**: rdar://148783895
**Original PR**: https://github.com/swiftlang/swift/pull/80828
**Risk**: Low, only affects coroutine accessors.
**Testing**: Added tests.
**Reviewer**: Joe Groff ( @jckarter )