### PR TITLE
[stdlib] Remove _withUnsafeBufferPointer APIs on InlineArray

### DIFF
--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -523,7 +523,6 @@ extension InlineArray where Element: ~Copyable {
 @available(SwiftStdlib 6.2, *)
 extension InlineArray where Element: ~Copyable {
   @available(SwiftStdlib 6.2, *)
-  @_addressableSelf
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -145,7 +145,7 @@ extension InlineArray where Element: ~Copyable {
   @_transparent
   internal var _protectedMutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
-      unsafe UnsafeMutablePointer<Element>(Builtin.addressOf(&self))
+      unsafe UnsafeMutablePointer<Element>(Builtin.addressof(&self))
     }
   }
 

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -93,7 +93,11 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal var _protectedAddress: UnsafePointer<Element> {
+#if $AddressOfProperty
+    unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(_storage))
+#else
     unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(self))
+#endif
   }
 
   /// Returns a buffer pointer over the entire array while performing stack
@@ -145,7 +149,11 @@ extension InlineArray where Element: ~Copyable {
   @_transparent
   internal var _protectedMutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
+#if $AddressOfProperty
+      unsafe UnsafeMutablePointer<Element>(Builtin.addressof(&_storage))
+#else
       unsafe UnsafeMutablePointer<Element>(Builtin.addressof(&self))
+#endif
     }
   }
 
@@ -526,6 +534,7 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
+    @_transparent
     borrowing get {
       let span = unsafe Span(_unsafeStart: _protectedAddress, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
@@ -536,6 +545,7 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
+    @_transparent
     mutating get {
       let span = unsafe MutableSpan(
         _unsafeStart: _protectedMutableAddress,

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -84,6 +84,30 @@ extension InlineArray where Element: ~Copyable {
     unsafe UnsafeBufferPointer<Element>(start: _address, count: count)
   }
 
+  /// Returns a pointer to the first element in the array while performing stack
+  /// checking.
+  ///
+  /// Use this when the value of the pointer could potentially be directly used
+  /// by users (e.g. through the use of span or the unchecked subscript).
+  @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var _protectedAddress: UnsafePointer<Element> {
+    unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(self))
+  }
+
+  /// Returns a buffer pointer over the entire array while performing stack
+  /// checking.
+  ///
+  /// Use this when the value of the pointer could potentially be directly used
+  /// by users (e.g. through the use of span or the unchecked subscript).
+  @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var _protectedBuffer: UnsafeBufferPointer<Element> {
+    unsafe UnsafeBufferPointer<Element>(start: _protectedAddress, count: count)
+  }
+
   /// Returns a mutable pointer to the first element in the array.
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
@@ -106,6 +130,37 @@ extension InlineArray where Element: ~Copyable {
     mutating get {
       unsafe UnsafeMutableBufferPointer<Element>(
         start: _mutableAddress,
+        count: count
+      )
+    }
+  }
+
+  /// Returns a mutable pointer to the first element in the array while
+  /// performing stack checking.
+  ///
+  /// Use this when the value of the pointer could potentially be directly used
+  /// by users (e.g. through the use of span or the unchecked subscript).
+  @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var _protectedMutableAddress: UnsafeMutablePointer<Element> {
+    mutating get {
+      unsafe UnsafeMutablePointer<Element>(Builtin.addressOf(&self))
+    }
+  }
+
+  /// Returns a mutable buffer pointer over the entire array while performing
+  /// stack checking.
+  ///
+  /// Use this when the value of the pointer could potentially be directly used
+  /// by users (e.g. through the use of span or the unchecked subscript).
+  @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal var _protectedMutableBuffer: UnsafeMutableBufferPointer<Element> {
+    mutating get {
+      unsafe UnsafeMutableBufferPointer<Element>(
+        start: _protectedMutableAddress,
         count: count
       )
     }
@@ -415,12 +470,12 @@ extension InlineArray where Element: ~Copyable {
   public subscript(unchecked i: Index) -> Element {
     @_transparent
     unsafeAddress {
-      unsafe _address + i
+      unsafe _protectedAddress + i
     }
 
     @_transparent
     unsafeMutableAddress {
-      unsafe _mutableAddress + i
+      unsafe _protectedMutableAddress + i
     }
   }
 }
@@ -473,8 +528,7 @@ extension InlineArray where Element: ~Copyable {
     @lifetime(borrow self)
     @_alwaysEmitIntoClient
     borrowing get {
-      let pointer = unsafe _address
-      let span = unsafe Span(_unsafeStart: pointer, count: count)
+      let span = unsafe Span(_unsafeStart: _protectedAddress, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
@@ -484,36 +538,11 @@ extension InlineArray where Element: ~Copyable {
     @lifetime(&self)
     @_alwaysEmitIntoClient
     mutating get {
-      let pointer = unsafe _mutableAddress
-      let span = unsafe MutableSpan(_unsafeStart: pointer, count: count)
+      let span = unsafe MutableSpan(
+        _unsafeStart: _protectedMutableAddress,
+        count: count
+      )
       return unsafe _overrideLifetime(span, mutating: &self)
     }
-  }
-}
-
-//===----------------------------------------------------------------------===//
-// MARK: - Unsafe APIs
-//===----------------------------------------------------------------------===//
-
-@available(SwiftStdlib 6.2, *)
-extension InlineArray where Element: ~Copyable {
-  // FIXME: @available(*, deprecated, renamed: "span.withUnsafeBufferPointer(_:)")
-  @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
-  @_transparent
-  public borrowing func _withUnsafeBufferPointer<Result: ~Copyable, E: Error>(
-    _ body: (UnsafeBufferPointer<Element>) throws(E) -> Result
-  ) throws(E) -> Result {
-    try unsafe body(_buffer)
-  }
-
-  // FIXME: @available(*, deprecated, renamed: "mutableSpan.withUnsafeMutableBufferPointer(_:)")
-  @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
-  @_transparent
-  public mutating func _withUnsafeMutableBufferPointer<Result: ~Copyable, E: Error>(
-    _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> Result
-  ) throws(E) -> Result {
-    try unsafe body(_mutableBuffer)
   }
 }

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -522,11 +522,11 @@ extension InlineArray where Element: ~Copyable {
 
 @available(SwiftStdlib 6.2, *)
 extension InlineArray where Element: ~Copyable {
-
   @available(SwiftStdlib 6.2, *)
+  @_addressableSelf
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
     borrowing get {
       let span = unsafe Span(_unsafeStart: _protectedAddress, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
@@ -534,9 +534,9 @@ extension InlineArray where Element: ~Copyable {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       let span = unsafe MutableSpan(
         _unsafeStart: _protectedMutableAddress,

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -932,7 +932,6 @@ Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
 Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
-Added: _$ss11InlineArrayVsRi__rlE11mutableSpans07MutableD0Vyq_Gvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
 Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
 Added: _$sSw12mutableBytess14MutableRawSpanVvr
@@ -1090,3 +1089,8 @@ Added: _$ss8UTF8SpanV9_asciiBits6UInt64VvpZMV
 
 // printing foreign reference types requires a new displayStyle: .foreign
 Added: _$ss6MirrorV12DisplayStyleO16foreignReferenceyA2DmFWC
+
+// var InlineArray._protectedBuffer
+// var InlineArray._protectedAddress
+Added: _$ss11InlineArrayVsRi__rlE16_protectedBufferSRyq_GvpMV
+Added: _$ss11InlineArrayVsRi__rlE17_protectedAddressSPyq_GvpMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -933,7 +933,6 @@ Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
 Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
-Added: _$ss11InlineArrayVsRi__rlE11mutableSpans07MutableD0Vyq_Gvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
 Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
 Added: _$sSw12mutableBytess14MutableRawSpanVvr
@@ -1090,3 +1089,8 @@ Added: _$ss8UTF8SpanV9_asciiBits6UInt64VvpZMV
 
 // printing foreign reference types requires a new displayStyle: .foreign
 Added: _$ss6MirrorV12DisplayStyleO16foreignReferenceyA2DmFWC
+
+// var InlineArray._protectedBuffer
+// var InlineArray._protectedAddress
+Added: _$ss11InlineArrayVsRi__rlE16_protectedBufferSRyq_GvpMV
+Added: _$ss11InlineArrayVsRi__rlE17_protectedAddressSPyq_GvpMV


### PR DESCRIPTION
These are no longer needed because you can just access the API from the span getters. Also, add protected address and buffer variants for the span APIs and the unchecked subscript access so that we get stack checking enabled for those APIs.

Resolves: rdar://145487409