### PR TITLE
[stdlib] Allow metatype comparisons to work with outdated compilers

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -257,6 +257,7 @@ LANGUAGE_FEATURE(SendableCompletionHandlers, 463, "Objective-C completion handle
 LANGUAGE_FEATURE(AsyncExecutionBehaviorAttributes, 0, "@concurrent and nonisolated(nonsending)")
 LANGUAGE_FEATURE(IsolatedConformances, 407, "Global-actor isolated conformances")
 LANGUAGE_FEATURE(ValueGenericsNameLookup, 452, "Value generics appearing as static members for namelookup")
+LANGUAGE_FEATURE(GeneralizedIsSameMetaTypeBuiltin, 465, "Builtin.is_same_metatype with support for noncopyable/nonescapable types")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -538,6 +538,8 @@ static bool usesFeatureCoroutineAccessors(Decl *decl) {
   }
 }
 
+UNINTERESTING_FEATURE(GeneralizedIsSameMetaTypeBuiltin)
+
 static bool usesFeatureCustomAvailability(Decl *decl) {
   for (auto attr : decl->getSemanticAvailableAttrs()) {
     if (attr.getDomain().isCustom())

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -175,7 +175,15 @@ public func == (
   case (.none, .none):
     return true
   case let (.some(ty0), .some(ty1)):
+#if compiler(>=5.3) && $GeneralizedIsSameMetaTypeBuiltin
     return Bool(Builtin.is_same_metatype(ty0, ty1))
+#else
+    // FIXME: Remove this branch once all supported compilers understand the
+    // generalized is_same_metatype builtin
+    let p1 = unsafeBitCast(ty0, to: UnsafeRawPointer.self)
+    let p2 = unsafeBitCast(ty1, to: UnsafeRawPointer.self)
+    return p1 == p2
+#endif
   default:
     return false
   }


### PR DESCRIPTION
Add a new language feature to avoid the stdlib’s swiftinterface becoming unintelligible to older compilers due to the generalization of Builtin.is_same_metatype.

Restore the original version of the `==` operator so that metatypes can continue to be compared even if the generalized version ends up getting omitted.

rdar://149396721
