### PR TITLE
Embedded: fix arguments mismatch in `ResultTypeInfo`

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -240,7 +240,7 @@ struct ResultTypeInfo {
   void (*initializeWithCopy)(OpaqueValue *result, OpaqueValue *src) = nullptr;
   void (*storeEnumTagSinglePayload)(OpaqueValue *v, unsigned whichCase,
                                     unsigned emptyCases) = nullptr;
-  void (*destroy)(OpaqueValue *) = nullptr;
+  void (*destroy)(OpaqueValue *, void *) = nullptr;
 
   bool isNull() {
     return initializeWithCopy == nullptr;
@@ -259,7 +259,7 @@ struct ResultTypeInfo {
     storeEnumTagSinglePayload(v, whichCase, emptyCases);
   }
   void vw_destroy(OpaqueValue *v) {
-    destroy(v);
+    destroy(v, nullptr);
   }
 #endif
 };

--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -199,7 +199,7 @@ public:
   AsyncLet *getAsyncLet() const {
     return asyncLet;
   }
-  
+
   void *getResultBuffer() const {
     return resultBuffer;
   }
@@ -224,7 +224,7 @@ class ResultTypeInfoTaskOptionRecord : public TaskOptionRecord {
             storeEnumTagSinglePayload)(OpaqueValue *, unsigned, unsigned);
 
   void (*__ptrauth_swift_value_witness_function_pointer(
-      SpecialPointerAuthDiscriminators::Destroy) destroy)(OpaqueValue *);
+      SpecialPointerAuthDiscriminators::Destroy) destroy)(OpaqueValue *, void *);
 
   static bool classof(const TaskOptionRecord *record) {
     return record->getKind() == TaskOptionRecordKind::ResultTypeInfo;


### PR DESCRIPTION
Mismatched number of arguments between a call (including indirect calls) and declarations traps on Wasm. `destroy` is [declared with two arguments](https://github.com/swiftlang/swift/blob/9eebee8b7c3560a67013c33b729961d291666f18/include/swift/ABI/ValueWitness.def#L123), but was called with one argument in embedded concurrency runtime. Second argument of `destroy` in VW seems unused, so let's pass `nullptr` as a workaround.
