### PR TITLE
[6.2][stdlib] Allow metatype comparisons to work with outdated compilers

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -256,6 +256,7 @@ LANGUAGE_FEATURE(RawIdentifiers, 451, "Raw identifiers")
 LANGUAGE_FEATURE(SendableCompletionHandlers, 463, "Objective-C completion handler parameters are imported as @Sendable")
 LANGUAGE_FEATURE(IsolatedConformances, 470, "Global-actor isolated conformances")
 LANGUAGE_FEATURE(AsyncExecutionBehaviorAttributes, 0, "@concurrent and nonisolated(nonsending)")
+LANGUAGE_FEATURE(GeneralizedIsSameMetaTypeBuiltin, 465, "Builtin.is_same_metatype with support for noncopyable/nonescapable types")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -491,6 +491,8 @@ static bool usesFeatureCoroutineAccessors(Decl *decl) {
   }
 }
 
+UNINTERESTING_FEATURE(GeneralizedIsSameMetaTypeBuiltin)
+
 static bool usesFeatureCustomAvailability(Decl *decl) {
   for (auto attr : decl->getSemanticAvailableAttrs()) {
     if (attr.getDomain().isCustom())

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -175,7 +175,15 @@ public func == (
   case (.none, .none):
     return true
   case let (.some(ty0), .some(ty1)):
+#if compiler(>=5.3) && $GeneralizedIsSameMetaTypeBuiltin
     return Bool(Builtin.is_same_metatype(ty0, ty1))
+#else
+    // FIXME: Remove this branch once all supported compilers understand the
+    // generalized is_same_metatype builtin
+    let p1 = unsafeBitCast(ty0, to: UnsafeRawPointer.self)
+    let p2 = unsafeBitCast(ty1, to: UnsafeRawPointer.self)
+    return p1 == p2
+#endif
   default:
     return false
   }


### PR DESCRIPTION
This is cherry-picked from https://github.com/swiftlang/swift/pull/80859

Add a new language feature to avoid the stdlib’s swiftinterface becoming unintelligible to outdated compiler builds due to the generalization of Builtin.is_same_metatype.

rdar://149396721
