### PR TITLE
[CoroutineAccessors] Infer same lifetime dependencies for read as _read.

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1100,7 +1100,8 @@ protected:
     }
     switch (accessor->getAccessorKind()) {
     case AccessorKind::Read:
-      // An implicit _read accessor is generated when a mutating getter is
+    case AccessorKind::Read2:
+      // An implicit _read/read accessor is generated when a mutating getter is
       // declared. Emit the same lifetime dependencies as an implicit _modify.
     case AccessorKind::Modify:
     case AccessorKind::Modify2:

--- a/validation-test/Sema/rdar149385088.swift
+++ b/validation-test/Sema/rdar149385088.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature CoroutineAccessors
+
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_CoroutineAccessors
+
+struct NE<T : ~Copyable & ~Escapable> : ~Copyable & ~Escapable {
+  @lifetime(&t)
+  init(
+    t: inout T
+  )
+  {
+  }
+}
+
+struct S : ~Copyable & ~Escapable {
+  var mutableBytes: NE<S> {
+    @lifetime(&self)
+    mutating get {
+      return NE(t: &self)
+    }
+  }
+}


### PR DESCRIPTION
When the feature is enabled, a read2 accessor is generated when a mutating getter is declared.

rdar://149385088
