### PR TITLE
[stdlib][runtime] Establish Swift Stdlib/runtime version 6.3

### DIFF
--- a/include/swift/AST/RuntimeVersions.def
+++ b/include/swift/AST/RuntimeVersions.def
@@ -163,6 +163,11 @@ RUNTIME_VERSION(
   FUTURE
 )
 
+RUNTIME_VERSION(
+  (6, 3),
+  FUTURE
+)
+
 END_MAJOR_VERSION(6)
 
 // .......................................................................... //

--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -240,9 +240,11 @@ extension _SwiftStdlibVersion {
   public static var v6_1_0: Self { Self(_value: 0x060100) }
   @_alwaysEmitIntoClient
   public static var v6_2_0: Self { Self(_value: 0x060200) }
+  @_alwaysEmitIntoClient
+  public static var v6_3_0: Self { Self(_value: 0x060300) }
 
   @available(SwiftStdlib 5.7, *)
-  public static var current: Self { .v6_2_0 }
+  public static var current: Self { .v6_3_0 }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -770,6 +770,7 @@ Added: _$ss7UnicodeO5UTF16O27encodedReplacementCharacters11_UIntBufferVys6UInt16
 Added: _$ss7UnicodeO5UTF32O27encodedReplacementCharacters15CollectionOfOneVys6UInt32VGvpZMV
 Added: _$sSo19_SwiftStdlibVersionasE6v6_1_0ABvpZMV
 Added: _$sSo19_SwiftStdlibVersionasE6v6_2_0ABvpZMV
+Added: _$sSo19_SwiftStdlibVersionasE6v6_3_0ABvpZMV
 Added: _$sSBsE5radixSivpZMV
 Added: _$sSFsE8ulpOfOnexvpZMV
 Added: _$sSUsE8isSignedSbvpZMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -751,6 +751,7 @@ Added: _$ss8SIMDMaskVss6SIMD64Vys5Int32VGRszrlE7allTrueAByAGGvpZMV
 Added: _$ss8SIMDMaskVss6SIMD64Vys5Int64VGRszrlE7allTrueAByAGGvpZMV
 Added: _$sSo19_SwiftStdlibVersionasE6v6_1_0ABvpZMV
 Added: _$sSo19_SwiftStdlibVersionasE6v6_2_0ABvpZMV
+Added: _$sSo19_SwiftStdlibVersionasE6v6_3_0ABvpZMV
 Added: _$ss7Float80V12signalingNaNABvpZMV
 Added: _$ss7Float80V13_exponentBiasSuvpZMV
 Added: _$ss7Float80V13_quietNaNMasks6UInt64VvpZMV

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -38,6 +38,7 @@ SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1
 SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0
 SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4
 SwiftStdlib 6.2:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
+SwiftStdlib 6.3:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999
 
 # Like SwiftStdlib 5.0, but also the oldest visionOS from SwiftStdlib 5.10.
 SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1


### PR DESCRIPTION
- Bump the version number of the stdlib to 6.3. 
- Establish the `SwiftStdlib 6.3` availability macro to mark newly introduced API. This currently resolves to placeholder (9999) OS versions, as usual.
- Establish that there is a version 6.3 of the Swift runtime in AST/RuntimeVersions.def.