### PR TITLE
[TypeChecker] Allow closures to assume `nonisolated(nonsending)`

### DIFF
--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -206,8 +206,12 @@ void SILGenFunction::emitExpectedExecutorProlog() {
     switch (actorIsolation.getKind()) {
     case ActorIsolation::Unspecified:
     case ActorIsolation::Nonisolated:
-    case ActorIsolation::CallerIsolationInheriting:
     case ActorIsolation::NonisolatedUnsafe:
+      break;
+
+    case ActorIsolation::CallerIsolationInheriting:
+      assert(F.isAsync());
+      setExpectedExecutorForParameterIsolation(*this, actorIsolation);
       break;
 
     case ActorIsolation::Erased:

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4696,6 +4696,13 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
       }
     }
 
+    // `nonisolated(nonsending)` inferred from the context makes
+    // the closure caller isolated.
+    if (auto *closureTy = getType(closure)->getAs<FunctionType>()) {
+      if (closureTy->getIsolation().isNonIsolatedCaller())
+        return ActorIsolation::forCallerIsolationInheriting();
+    }
+
     // If a closure has an isolated parameter, it is isolated to that
     // parameter.
     for (auto param : *closure->getParameters()) {

--- a/test/Concurrency/Runtime/startSynchronously.swift
+++ b/test/Concurrency/Runtime/startSynchronously.swift
@@ -294,7 +294,7 @@ syncOnNonTaskThread(synchronousTask: behavior)
 // CHECK: after startSynchronously, outside; cancel (wakeup) the synchronous task!  [thread:[[CALLING_THREAD3]]]
 
 print("\n\n==== ------------------------------------------------------------------")
-print("callActorFromStartSynchronousTask()")
+print("callActorFromStartSynchronousTask() - not on specific queue")
 callActorFromStartSynchronousTask(recipient: .recipient(Recipient()))
 
 // CHECK: callActorFromStartSynchronousTask()
@@ -309,11 +309,6 @@ callActorFromStartSynchronousTask(recipient: .recipient(Recipient()))
 // CHECK: inside startSynchronously, call rec.sync() done
 
 // CHECK-NOT: ERROR!
-// CHECK: inside startSynchronously, call rec.async()
-// CHECK-NOT: ERROR!
-// CHECK: inside startSynchronously, call rec.async() done
-
-// CHECK-NOT: ERROR!
 // CHECK: inside startSynchronously, done
 
 /// Don't want to involve protocol calls to not confuse the test with additional details,
@@ -324,35 +319,20 @@ enum TargetActorToCall {
 }
 
 protocol RecipientProtocol where Self: Actor {
-  func sync(syncTaskThreadID: ThreadID) async
-  func async(syncTaskThreadID: ThreadID) async
+  func callAndSuspend(syncTaskThreadID: ThreadID) async
 }
 
 // default actor, must not declare an 'unownedExecutor'
-actor Recipient {
-  func sync(syncTaskThreadID: ThreadID) {
+actor Recipient: RecipientProtocol {
+  func callAndSuspend(syncTaskThreadID: ThreadID) async {
     self.preconditionIsolated()
 
     print("\(Recipient.self)/\(#function) Current actor thread id = \(getCurrentThreadID()) @ :\(#line)")
     if compareThreadIDs(syncTaskThreadID, .equal, getCurrentThreadID()) {
       print("NOTICE: Actor must not run on the synchronous task's thread :\(#line)")
     }
-  }
 
-  func async(syncTaskThreadID: ThreadID) async {
-    self.preconditionIsolated()
-
-    // Dispatch may end up reusing the thread used to service the queue so we
-    // cannot truly assert exact thread identity in such tests.
-    // Usually this will be on a different thread by now though.
-    print("\(Recipient.self)/\(#function) Current actor thread id = \(getCurrentThreadID()) @ :\(#line)")
-    if compareThreadIDs(syncTaskThreadID, .equal, getCurrentThreadID()) {
-      print("NOTICE: Actor must not run on the synchronous task's thread :\(#line)")
-    }
-
-    await Task {
-      self.preconditionIsolated()
-    }.value
+    try? await Task.sleep(for: .milliseconds(100))
   }
 }
 
@@ -379,29 +359,13 @@ func callActorFromStartSynchronousTask(recipient rec: TargetActorToCall) {
 
       print("inside startSynchronously, call rec.sync() [thread:\(getCurrentThreadID())] @ :\(#line)")
       switch rec {
-      case .recipient(let recipient): await recipient.sync(syncTaskThreadID: innerTID)
-      case .recipientOnQueue(let recipient): await recipient.sync(syncTaskThreadID: innerTID)
+      case .recipient(let recipient): await recipient.callAndSuspend(syncTaskThreadID: innerTID)
+      case .recipientOnQueue(let recipient): await recipient.callAndSuspend(syncTaskThreadID: innerTID)
       }
       print("inside startSynchronously, call rec.sync() done [thread:\(getCurrentThreadID())] @ :\(#line)")
 
       // after suspension we are supposed to hop off to the global pool,
       // thus the thread IDs cannot be the same anymore
-      print("Inner thread id = \(innerTID)")
-      print("Current thread id = \(getCurrentThreadID())")
-      // Dispatch may end up reusing the thread used to service the queue so we
-      // cannot truly assert exact thread identity in such tests.
-      // Usually this will be on a different thread by now though.
-      if compareThreadIDs(innerTID, .equal, getCurrentThreadID()) {
-        print("NOTICE: Task resumed on same thread as it entered the synchronous task!")
-      }
-
-      print("inside startSynchronously, call rec.async() [thread:\(getCurrentThreadID())] @ :\(#line)")
-      switch rec {
-      case .recipient(let recipient): await recipient.async(syncTaskThreadID: innerTID)
-      case .recipientOnQueue(let recipient): await recipient.async(syncTaskThreadID: innerTID)
-      }
-      print("inside startSynchronously, call rec.async() done [thread:\(getCurrentThreadID())] @ :\(#line)")
-
       print("Inner thread id = \(innerTID)")
       print("Current thread id = \(getCurrentThreadID())")
       // Dispatch may end up reusing the thread used to service the queue so we
@@ -428,6 +392,28 @@ print("callActorFromStartSynchronousTask() - actor in custom executor with its o
 let actorQueue = DispatchQueue(label: "recipient-actor-queue")
 callActorFromStartSynchronousTask(recipient: .recipientOnQueue(RecipientOnQueue(queue: actorQueue)))
 
+
+//            50: callActorFromStartSynchronousTask()
+//            51: before startSynchronously [thread:0x00007000054f5000] @ :366
+//            52: inside startSynchronously [thread:0x00007000054f5000] @ :372
+//            53: inside startSynchronously, call rec.sync() [thread:0x00007000054f5000] @ :380
+//            54: Recipient/sync(syncTaskThreadID:) Current actor thread id = 0x000070000567e000 @ :336
+//            55: inside startSynchronously, call rec.sync() done [thread:0x000070000567e000] @ :385
+//            56: Inner thread id = 0x00007000054f5000
+//            57: Current thread id = 0x000070000567e000
+//            60: after startSynchronously [thread:0x00007000054f5000] @ :418
+//            61: - async work on queue
+//            62: - async work on queue
+//            63: - async work on queue
+//            64: - async work on queue
+//            65: - async work on queue
+//            67: - async work on queue
+//            68: - async work on queue
+//            69: - async work on queue
+//            71: Inner thread id = 0x00007000054f5000
+//            72: Current thread id = 0x000070000567e000
+//            73: inside startSynchronously, done [thread:0x000070000567e000] @ :414
+
 // CHECK-LABEL: callActorFromStartSynchronousTask() - actor in custom executor with its own queue
 // No interleaving allowed between "before" and "inside":
 // CHECK: before startSynchronously [thread:[[CALLING_THREAD4:.*]]]
@@ -438,21 +424,14 @@ callActorFromStartSynchronousTask(recipient: .recipientOnQueue(RecipientOnQueue(
 // allowing the 'after startSynchronously' to run.
 //
 // CHECK-NEXT: inside startSynchronously, call rec.sync() [thread:[[CALLING_THREAD4]]]
-// CHECK: NaiveQueueExecutor(recipient-actor-queue) enqueue
 // CHECK: after startSynchronously
 // CHECK-NOT: ERROR!
 // CHECK: inside startSynchronously, call rec.sync() done
 
 // CHECK-NOT: ERROR!
-// CHECK: inside startSynchronously, call rec.async()
-// CHECK: NaiveQueueExecutor(recipient-actor-queue) enqueue
-// CHECK-NOT: ERROR!
-// CHECK: inside startSynchronously, call rec.async() done
-
-// CHECK-NOT: ERROR!
 // CHECK: inside startSynchronously, done
 
-actor RecipientOnQueue {
+actor RecipientOnQueue: RecipientProtocol {
   let executor: NaiveQueueExecutor
   nonisolated let unownedExecutor: UnownedSerialExecutor
 
@@ -461,7 +440,7 @@ actor RecipientOnQueue {
     self.unownedExecutor = executor.asUnownedSerialExecutor()
   }
 
-  func sync(syncTaskThreadID: ThreadID) {
+  func callAndSuspend(syncTaskThreadID: ThreadID) async {
     self.preconditionIsolated()
     dispatchPrecondition(condition: .onQueue(self.executor.queue))
 
@@ -469,22 +448,7 @@ actor RecipientOnQueue {
     if compareThreadIDs(syncTaskThreadID, .equal, getCurrentThreadID()) {
       print("NOTICE: Actor must not run on the synchronous task's thread :\(#line)")
     }
-  }
 
-  func async(syncTaskThreadID: ThreadID) async {
-    self.preconditionIsolated()
-    dispatchPrecondition(condition: .onQueue(self.executor.queue))
-
-    // Dispatch may end up reusing the thread used to service the queue so we
-    // cannot truly assert exact thread identity in such tests.
-    // Usually this will be on a different thread by now though.
-    print("\(Recipient.self)/\(#function) Current actor thread id = \(getCurrentThreadID()) @ :\(#line)")
-    if compareThreadIDs(syncTaskThreadID, .equal, getCurrentThreadID()) {
-      print("NOTICE: Actor must not run on the synchronous task's thread :\(#line)")
-    }
-
-    await Task {
-      self.preconditionIsolated()
-    }.value
+    try? await Task.sleep(for: .milliseconds(100))
   }
 }

--- a/test/Concurrency/attr_execution/conversions_silgen.swift
+++ b/test/Concurrency/attr_execution/conversions_silgen.swift
@@ -425,3 +425,24 @@ func conversionsFromSyncToAsync(_ x: @escaping @Sendable (NonSendableKlass) -> V
   let _: @concurrent (SendableKlass) async -> Void = y
   let _: @concurrent (NonSendableKlass) async -> Void = z
 }
+
+func testThatClosuresAssumeIsolation(fn: inout nonisolated(nonsending) (Int) async -> Void) {
+  // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFyyYaYCcfU_ : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
+  let _: nonisolated(nonsending) () async -> Void = {
+    42
+  }
+
+  func testParam(_: nonisolated(nonsending) () async throws -> Void) {}
+
+  // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFyyYaYCXEfU0_ : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> @error any Error
+  testParam { 42 }
+
+  // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFyyYaXEfU1_ : $@convention(thin) @async () -> ()
+  testParam { @concurrent in 42 }
+
+  // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFySiYaYCcfU2_ : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, Int) -> ()
+  fn = { _ in }
+
+  // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFySiYacfU3_ : $@convention(thin) @async (Int) -> ()
+  fn = { @concurrent _ in }
+}

--- a/test/Concurrency/attr_execution/conversions_silgen.swift
+++ b/test/Concurrency/attr_execution/conversions_silgen.swift
@@ -428,6 +428,8 @@ func conversionsFromSyncToAsync(_ x: @escaping @Sendable (NonSendableKlass) -> V
 
 func testThatClosuresAssumeIsolation(fn: inout nonisolated(nonsending) (Int) async -> Void) {
   // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFyyYaYCcfU_ : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
+  // CHECK: bb0([[EXECUTOR:%.*]] : @guaranteed $Optional<any Actor>):
+  // CHECK: hop_to_executor [[EXECUTOR]]
   let _: nonisolated(nonsending) () async -> Void = {
     42
   }
@@ -435,14 +437,22 @@ func testThatClosuresAssumeIsolation(fn: inout nonisolated(nonsending) (Int) asy
   func testParam(_: nonisolated(nonsending) () async throws -> Void) {}
 
   // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFyyYaYCXEfU0_ : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> @error any Error
+  // CHECK: bb0([[EXECUTOR:%.*]] : @guaranteed $Optional<any Actor>):
+  // CHECK: hop_to_executor [[EXECUTOR]]
   testParam { 42 }
 
   // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFyyYaXEfU1_ : $@convention(thin) @async () -> ()
+  // CHECK: [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+  // CHECK: hop_to_executor [[GENERIC_EXECUTOR]]
   testParam { @concurrent in 42 }
 
   // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFySiYaYCcfU2_ : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, Int) -> ()
+  // CHECK: bb0([[EXECUTOR:%.*]] : @guaranteed $Optional<any Actor>, %1 : $Int):
+  // CHECK: hop_to_executor [[EXECUTOR]]
   fn = { _ in }
 
   // CHECK-LABEL: sil private [ossa] @$s21attr_execution_silgen31testThatClosuresAssumeIsolation2fnyySiYaYCcz_tFySiYacfU3_ : $@convention(thin) @async (Int) -> ()
+  // CHECK: [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+  // CHECK: hop_to_executor [[GENERIC_EXECUTOR]]
   fn = { @concurrent _ in }
 }


### PR DESCRIPTION
Always infer `nonisolated(nonsending)` from context directly on a closure unless the closure is marked as `@concurrent`, otherwise the closure is not going to get correct isolation and going to hop to the wrong executor in its preamble.

Resolves: rdar://149107104

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
