### PR TITLE
Fix assertion failure when performing constant-evaluation through basic blocks with non-constant arguments

### DIFF
--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1785,8 +1785,8 @@ ConstExprFunctionState::evaluateInstructionAndGetNext(
     // Set up basic block arguments.
     for (unsigned i = 0, e = br->getNumArgs(); i != e; ++i) {
       auto argument = getConstantValue(br->getArg(i));
-      if (!argument.isConstant())
-        return {std::nullopt, argument};
+      // Do not fail if an argument is not constant because we still know enough to know what the next instruction will be.
+      // Failure may occur later, however, if/when this unknown argument value is used by an instruction in the target basic block.
       setValue(destBB->getArgument(i), argument);
     }
     // Set the instruction pointer to the first instruction of the block.


### PR DESCRIPTION
This fixes one of the issues exposed by #79707, which marked more integer initializers as `@_transparent`.

The constant evaluator was overly conservative in returning early when arguments to basic blocks were non-constant. This caused us to hit an assertion assuming that we would only fail to proceed past an unconditional branch if we are inside a loop.

Now, when encountering an unconditional branch, we always proceed to the destination basic block even if some of the arguments are non-constant. This lets us get as far as we can go in constant evaluation and avoids the assertion.