### PR TITLE
[Diagnostics] Use the swift-syntax formatting for invalid source locations, too

### DIFF
--- a/include/swift/AST/DiagnosticBridge.h
+++ b/include/swift/AST/DiagnosticBridge.h
@@ -46,6 +46,10 @@ public:
   void enqueueDiagnostic(SourceManager &SM, const DiagnosticInfo &Info,
                          unsigned innermostBufferID);
 
+  /// Emit a single diagnostic without location information.
+  void emitDiagnosticWithoutLocation(
+      const DiagnosticInfo &Info, llvm::raw_ostream &out, bool forceColors);
+
   /// Flush all enqueued diagnostics.
   void flush(llvm::raw_ostream &OS, bool includeTrailingBreak,
              bool forceColors);

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -35,6 +35,14 @@ void swift_ASTGen_addQueuedDiagnostic(
     const BridgedCharSourceRange *_Nullable highlightRanges,
     ptrdiff_t numHighlightRanges,
     BridgedArrayRef /*BridgedFixIt*/ fixIts);
+void swift_ASTGen_renderSingleDiagnostic(
+    void *_Nonnull state,
+    BridgedStringRef text,
+    BridgedDiagnosticSeverity severity,
+    BridgedStringRef categoryName,
+    BridgedStringRef documentationPath,
+    ssize_t colorize,
+    BridgedStringRef *_Nonnull renderedString);
 void swift_ASTGen_renderQueuedDiagnostics(
     void *_Nonnull queued, ssize_t contextSize, ssize_t colorize,
     BridgedStringRef *_Nonnull renderedString);

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -26,6 +26,22 @@
 using namespace swift;
 
 #if SWIFT_BUILD_SWIFT_SYNTAX
+static BridgedDiagnosticSeverity bridgeDiagnosticSeverity(DiagnosticKind kind) {
+  switch (kind) {
+  case DiagnosticKind::Error:
+    return BridgedDiagnosticSeverity::BridgedError;
+
+  case DiagnosticKind::Warning:
+    return BridgedDiagnosticSeverity::BridgedWarning;
+
+  case DiagnosticKind::Remark:
+    return BridgedDiagnosticSeverity::BridgedRemark;
+
+  case DiagnosticKind::Note:
+    return BridgedDiagnosticSeverity::BridgedNote;
+  }
+}
+
 /// Enqueue a diagnostic with ASTGen's diagnostic rendering.
 static void addQueueDiagnostic(void *queuedDiagnostics,
                                void *perFrontendState,
@@ -37,24 +53,7 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
                                            info.FormatArgs);
   }
 
-  BridgedDiagnosticSeverity severity;
-  switch (info.Kind) {
-  case DiagnosticKind::Error:
-    severity = BridgedDiagnosticSeverity::BridgedError;
-    break;
-
-  case DiagnosticKind::Warning:
-    severity = BridgedDiagnosticSeverity::BridgedWarning;
-    break;
-
-  case DiagnosticKind::Remark:
-    severity = BridgedDiagnosticSeverity::BridgedRemark;
-    break;
-
-  case DiagnosticKind::Note:
-    severity = BridgedDiagnosticSeverity::BridgedNote;
-    break;
-  }
+  BridgedDiagnosticSeverity severity = bridgeDiagnosticSeverity(info.Kind);
 
   // Map the highlight ranges.
   SmallVector<BridgedCharSourceRange, 2> highlightRanges;
@@ -84,6 +83,39 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
   // bridging of `Note` structure and new serialization.
   for (auto *childNote : info.ChildDiagnosticInfo) {
     addQueueDiagnostic(queuedDiagnostics, perFrontendState, *childNote, SM);
+  }
+}
+
+void DiagnosticBridge::emitDiagnosticWithoutLocation(
+    const DiagnosticInfo &info, llvm::raw_ostream &out, bool forceColors) {
+  ASSERT(queuedDiagnostics == nullptr);
+
+  // If we didn't have per-frontend state before, create it now.
+  if (!perFrontendState) {
+    perFrontendState = swift_ASTGen_createPerFrontendDiagnosticState();
+  }
+
+  llvm::SmallString<256> text;
+  {
+    llvm::raw_svector_ostream out(text);
+    DiagnosticEngine::formatDiagnosticText(out, info.FormatString,
+                                           info.FormatArgs);
+  }
+
+  BridgedDiagnosticSeverity severity = bridgeDiagnosticSeverity(info.Kind);
+
+  BridgedStringRef bridgedRenderedString{nullptr, 0};
+  swift_ASTGen_renderSingleDiagnostic(
+      perFrontendState, text.str(), severity, info.Category,
+      llvm::StringRef(info.CategoryDocumentationURL), forceColors ? 1 : 0,
+      &bridgedRenderedString);
+
+  auto renderedString = bridgedRenderedString.unbridged();
+  if (renderedString.data()) {
+    out << "<unknown>:0: ";
+    out.write(renderedString.data(), renderedString.size());
+    swift_ASTGen_freeBridgedString(renderedString);
+    out << "\n";
   }
 }
 


### PR DESCRIPTION
The diagnostics formatter from swift-syntax previously only handled
fully-formed diagnostics anchored at a particular syntax node.
Therefore, the compiler would fall back to the existing LLVM-based
diagnostic formatter for diagnostics that had no source location.

Adopt new API in the swift-syntax diagnostics formatter that renders a
diagnostic message without requiring source location information, so
that we consistently use the swift-syntax formatter when it is
selected (which is the default).