### PR TITLE
Fix bootstrap build again.

### DIFF
--- a/stdlib/public/core/UTF8EncodingError.swift
+++ b/stdlib/public/core/UTF8EncodingError.swift
@@ -256,6 +256,7 @@ extension UTF8 {
           errors.append(adjustedErr)
         }
       }
+      return errors
     }
   }
 }


### PR DESCRIPTION
Otherwise, a bootstrap build fails with `error: missing return in closure expected to return 'Array<UTF8.ValidationError>' (aka 'Array<Unicode.UTF8 .ValidationError>')`.