### PR TITLE
[embedded][Concurrency] Start building Concurrency.swiftmodule for armv6/armv6m

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -280,7 +280,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
         continue()
       endif()
     elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
-      if(NOT "${mod}" MATCHES "x86_64|arm64|arm64e|armv7|armv7m|armv7em")
+      if(NOT "${mod}" MATCHES "x86_64|arm64|arm64e|armv6|armv6m|armv7|armv7m|armv7em")
         continue()
       endif()
 


### PR DESCRIPTION
This is particularly relevant for the Pico (the MCU is RP2040, which is Cortex-M0+, which is ARMv6-M).