### PR TITLE
Add a platform executor module for OpenBSD.

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(swift_Concurrency
   PartialAsyncTask.swift
   PlatformExecutorDarwin.swift
   PlatformExecutorLinux.swift
+  PlatformExecutorOpenBSD.swift
   PlatformExecutorWindows.swift
   PriorityQueue.swift
   SourceCompatibilityShims.swift

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -164,6 +164,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
   PlatformExecutorDarwin.swift
   PlatformExecutorLinux.swift
   PlatformExecutorWindows.swift
+  PlatformExecutorOpenBSD.swift
 )
 
 set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_C_SOURCES

--- a/stdlib/public/Concurrency/PlatformExecutorOpenBSD.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorOpenBSD.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !$Embedded && os(OpenBSD)
+
+import Swift
+
+// The default executors for now are Dispatch-based
+@available(SwiftStdlib 6.2, *)
+public struct PlatformExecutorFactory: ExecutorFactory {
+  public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
+  public static let defaultExecutor: any TaskExecutor
+    = DispatchGlobalTaskExecutor()
+}
+
+#endif


### PR DESCRIPTION
This is basically the same as the one for Linux, but it would be somewhat awkward to add the platform conditional on a file named for Linux when OpenBSD is not Linux.

Important note: if Dispatch is disabled, then this will cause a compilation error (probably not just for OpenBSD either), because PlatformExecutorFactory is both defined in PlatformExecutorNone.swift and PlatformExecutor<...>.swift in this case.

Because this only bites OpenBSD bootstrap builds, and since OpenBSD support has been upstreamed to Dispatch, default to the Dispatch implementation for now to get this in, and we'll refactor in a different pr.