### PR TITLE
[6.2] LifetimeDependenceScopeFixup: _read accessor: extend temporaries

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/InstructionRange.swift
@@ -181,3 +181,122 @@ struct InstructionRange : CustomStringConvertible, NoReflectionChildren {
     blockRange.deinitialize()
   }
 }
+
+extension InstructionRange {
+  enum PathOverlap {
+    // range:  ---
+    //          |    pathBegin
+    //          |        |
+    //          |     pathEnd
+    //         ---
+    case containsPath
+
+    // range:  ---
+    //          |    pathBegin
+    //         ---       |
+    //                pathEnd
+    case containsBegin
+
+    //               pathBegin
+    // range:  ---       |
+    //          |     pathEnd
+    //         ---
+    case containsEnd
+
+    //               pathBegin
+    // range:  ---       |
+    //          |        |
+    //         ---       |
+    //                pathEnd
+    case overlappedByPath
+
+    // either:       pathBegin
+    //                   |
+    //                pathEnd
+    // range:  ---
+    //          |
+    //         ---
+    // or:           pathBegin
+    //                   |
+    //                pathEnd
+    case disjoint
+  }
+
+  /// Return true if any exclusive path from `begin` to `end` includes an instruction in this exclusive range.
+  ///
+  /// Returns .containsBegin, if this range has the same begin and end as the path.
+  ///
+  /// Precondition: `begin` dominates `end`.
+  func overlaps(pathBegin: Instruction, pathEnd: Instruction, _ context: some Context) -> PathOverlap {
+    assert(pathBegin != pathEnd, "expect an exclusive path")
+    if contains(pathBegin) {
+      // Note: pathEnd != self.begin here since self.contains(pathBegin)
+      if contains(pathEnd) { return .containsPath }
+      return .containsBegin
+    }
+    if contains(pathEnd) {
+      if let rangeBegin = self.begin, rangeBegin == pathEnd {
+        return .disjoint
+      }
+      return .containsEnd
+    }
+    // Neither end-point is contained. If a backward path walk encouters this range, then it must overlap this
+    // range. Otherwise, it is disjoint.
+    var backwardBlocks = BasicBlockWorklist(context)
+    defer { backwardBlocks.deinitialize() }
+    backwardBlocks.pushIfNotVisited(pathEnd.parentBlock)
+    while let block = backwardBlocks.pop() {
+      if blockRange.inclusiveRangeContains(block) {
+        // This range overlaps with this block, but there are still three possibilities:
+        // (1) range, pathBegin, pathEnd = disjoint         (range might not begin in this block)
+        // (2) pathBegin, pathEnd, range = disjoint         (pathBegin might not be in this block)
+        // (3) pathBegin, range, pathEnd = overlappedByPath (range or pathBegin might not be in this block)
+        //
+        // Walk backward from pathEnd to find either pathBegin or an instruction in this range.
+        // Both this range and the path may or may not begin in this block.
+        let endInBlock = block == pathEnd.parentBlock ? pathEnd : block.terminator
+        for inst in ReverseInstructionList(first: endInBlock) {
+          // Check pathBegin first because the range is exclusive.
+          if inst == pathBegin {
+            break
+          }
+          // Check inclusiveRangeContains() in case the range end is the first instruction in this block.
+          if inclusiveRangeContains(inst) {
+            return .overlappedByPath
+          }
+        }
+        // No instructions in this range occur between pathBegin and pathEnd.
+        return .disjoint
+      }
+      // No range blocks have been reached.
+      if block == pathBegin.parentBlock {
+        return .disjoint
+      }
+      backwardBlocks.pushIfNotVisited(contentsOf: block.predecessors)
+    }
+    fatalError("begin: \(pathBegin)\n  must dominate end: \(pathEnd)")
+  }
+}
+
+let rangeOverlapsPathTest = FunctionTest("range_overlaps_path") {
+  function, arguments, context in
+  let rangeValue = arguments.takeValue()
+  print("Range of: \(rangeValue)")
+  var range = computeLinearLiveness(for: rangeValue, context)
+  defer { range.deinitialize() }
+  let pathInst = arguments.takeInstruction()
+  print("Path begin: \(pathInst)")
+  if let pathBegin = pathInst as? ScopedInstruction {
+    for end in pathBegin.endInstructions {
+      print("Overlap kind:", range.overlaps(pathBegin: pathInst, pathEnd: end, context))
+    }
+    return
+  }
+  if let pathValue = pathInst as? SingleValueInstruction, pathValue.ownership == .owned {
+    for end in pathValue.uses.endingLifetime {
+      print("Overlap kind:", range.overlaps(pathBegin: pathInst, pathEnd: end.instruction, context))
+    }
+    return
+  }
+  print("Test specification error: not a scoped or owned instruction: \(pathInst)")
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -292,7 +292,7 @@ private struct LifetimeVariable {
       return .abortWalk
     }
     defer { useDefVisitor.deinitialize() }
-    _ = useDefVisitor.walkUp(valueOrAddress: value)
+    _ = useDefVisitor.walkUp(newLifetime: value)
     return introducer
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -116,8 +116,10 @@ let lifetimeDependenceScopeFixupPass = FunctionPass(
     // Redirect the dependence base to ignore irrelevant borrow scopes.
     let newLifetimeDep = markDep.rewriteSkippingBorrow(scope: innerLifetimeDep.scope, context)
 
-    // Recursively sink enclosing end_access, end_borrow, or end_apply.
-    let args = extendScopes(dependence: newLifetimeDep, localReachabilityCache, context)
+    // Recursively sink enclosing end_access, end_borrow, end_apply, and destroy_value. If the scope can be extended
+    // into the caller, return the function arguments that are the dependency sources.
+    var scopeExtension = ScopeExtension(localReachabilityCache, context)
+    let args = scopeExtension.extendScopes(dependence: newLifetimeDep)
 
     // Redirect the dependence base to the function arguments. This may create additional mark_dependence instructions.
     markDep.redirectFunctionReturn(to: args, context)
@@ -189,6 +191,31 @@ private extension MarkDependenceAddrInst {
   }
 }
 
+/// A scope extension is a set of nested scopes and their owners. The owner is a value that represents ownerhip of
+/// the outermost scopes, which cannot be extended; it limits how far the nested scopes can be extended.
+private struct ScopeExtension {
+  let context: FunctionPassContext
+  let localReachabilityCache: LocalVariableReachabilityCache
+
+  /// The ownership lifetime of the dependence base, which cannot be extended.
+  var owners = SingleInlineArray<Value>()
+
+  // Initialized after walking dependent uses. True if the scope can be extended into the caller.
+  var dependsOnCaller: Bool?
+
+  // Scopes listed in RPO over an upward walk. The outermost scope is first.
+  var scopes = SingleInlineArray<ExtendableScope>()
+
+  var innermostScope: ExtendableScope { get { scopes.last! } }
+
+  var visitedValues: ValueSet?
+
+  init(_ localReachabilityCache: LocalVariableReachabilityCache, _ context: FunctionPassContext) {
+    self.localReachabilityCache = localReachabilityCache
+    self.context = context
+  }
+}
+
 /// Transitively extend nested scopes that enclose the dependence base.
 ///
 /// If the parent function returns the dependent value, then this returns the function arguments that represent the
@@ -218,215 +245,240 @@ private extension MarkDependenceAddrInst {
 // access. This scope fixup pass must extend '%a1' to cover the `@useDependent` but must not extend the base of the
 // `mark_dependence` to the outer access `%0`. This ensures that exclusivity diagnostics correctly reports the
 // violation, and that subsequent optimizations do not shrink the inner access `%a1`.
-private func extendScopes(dependence: LifetimeDependence,
-                          _ localReachabilityCache: LocalVariableReachabilityCache,
-                          _ context: FunctionPassContext) -> SingleInlineArray<FunctionArgument> {
-  log("Scope fixup for lifetime dependent instructions: \(dependence)")
+extension ScopeExtension {
+  mutating func extendScopes(dependence: LifetimeDependence) -> SingleInlineArray<FunctionArgument> {
+    log("Scope fixup for lifetime dependent instructions: \(dependence)")
 
-  // Each scope extension is a set of nested scopes and an owner. The owner is a value that represents ownerhip of the
-  // outermost scope, which cannot be extended; it limits how far the nested scopes can be extended.
-  guard let scopeExtensions = dependence.scope.gatherExtensions(context) else {
-    return SingleInlineArray()
-  }
-  var dependsOnArgs = SingleInlineArray<FunctionArgument>()
-  for scopeExtension in scopeExtensions {
-    var scopeExtension = scopeExtension
-    guard var useRange = computeDependentUseRange(of: dependence, within: &scopeExtension, localReachabilityCache,
-                                                  context) else {
-      continue
-    }
+    gatherExtensions(dependence: dependence)
 
-    // deinitializes 'useRange'
-    guard scopeExtension.tryExtendScopes(over: &useRange, context) else {
-      continue
+    let noCallerScope = SingleInlineArray<FunctionArgument>()
+
+    // computeDependentUseRange initializes scopeExtension.dependsOnCaller.
+    guard var useRange = computeDependentUseRange(of: dependence) else {
+      return noCallerScope
     }
-    if scopeExtension.dependsOnCaller, let arg = scopeExtension.dependsOnArg {
-      dependsOnArgs.push(arg)
+    // tryExtendScopes deinitializes 'useRange'
+    var scopesToExtend = SingleInlineArray<ExtendableScope>()
+    guard canExtendScopes(over: &useRange, scopesToExtend: &scopesToExtend) else {
+      useRange.deinitialize()
+      return noCallerScope
     }
+    // extend(over:) must receive the original unmodified `useRange`, without intermediate scope ending instructions.
+    // This deinitializes `useRange` before erasing instructions.
+    extend(scopesToExtend: scopesToExtend, over: &useRange, context)
+
+    return dependsOnArgs
   }
-  return dependsOnArgs
 }
 
-/// All scopes nested within a single dependence base that require extension.
-private struct ScopeExtension {
-  /// The ownership lifetime of the dependence base, which cannot be extended.
-  let owner: Value
+// TODO: add parent and child indices to model a DAG of scopes. This will allow sibling scopes that do not follow a
+// stack discipline among them but still share the same parent and child scopes. This can occur with dependencies on
+// multiple call operands. Until then, scope extension may bail out unnecessarily while trying to extend over a sibling
+// scope.
+private struct ExtendableScope {
+  enum Introducer {
+    case scoped(ScopedInstruction)
+    case owned(Value)
+  }
 
-  /// The scopes nested under 'value' that may be extended, in inside-out order. There is always at
-  /// least one element, otherwise there is nothing to consider extending.
-  let nestedScopes: SingleInlineArray<LifetimeDependence.Scope>
+  let scope: LifetimeDependence.Scope
+  let introducer: Introducer
 
-  var innerScope: LifetimeDependence.Scope { get { nestedScopes.first! } }
+  var firstInstruction: Instruction {
+    switch introducer {
+    case let .scoped(scopedInst):
+      return scopedInst.instruction
+    case let .owned(value):
+      if let definingInst = value.definingInstructionOrTerminator {
+        return definingInst
+      }
+      return value.parentBlock.instructions.first!
+    }
+  }
+  var endInstructions: LazyMapSequence<LazyFilterSequence<UseList>, Instruction> {
+    switch introducer {
+    case let .scoped(scopedInst):
+      return scopedInst.endOperands.users
+    case let .owned(value):
+      return value.uses.endingLifetime.users
+    }
+  }
 
-  /// `dependsOnArg` is set to the function argument that represents the caller's dependency source.
-  ///
-  /// Note: for non-address owners, this is equivalent to: owner as? FunctionArg?
-  var dependsOnArg: FunctionArgument?
+  // Allow scope extension as long as `beginInst` is scoped instruction and does not define a variable scope.
+  init?(_ scope: LifetimeDependence.Scope, beginInst: Instruction?) {
+    self.scope = scope
+    guard let beginInst = beginInst, VariableScopeInstruction(beginInst) == nil else {
+      return nil
+    }
+    guard let scopedInst = beginInst as? ScopedInstruction else {
+      return nil
+    }
+    self.introducer = .scoped(scopedInst)
+  }
 
-  /// `dependsOnCaller` is true if the dependent value is returned by the function.
-  /// Initialized during computeDependentUseRange().
-  var dependsOnCaller = false
+  // Allow extension of owned temporaries that
+  // (a) are Escapable
+  // (b) do not define a variable scope
+  // (c) are only consumed by destroy_value
+  init?(_ scope: LifetimeDependence.Scope, owner: Value) {
+    self.scope = scope
+    // TODO: allow extension of lifetime dependent values by implementing a ScopeExtensionWalker that extends
+    // LifetimeDependenceUseDefWalker.
+    guard owner.type.isEscapable(in: owner.parentFunction),
+          VariableScopeInstruction(owner.definingInstruction) == nil,
+          owner.uses.endingLifetime.allSatisfy({ $0.instruction is DestroyValueInst }) else {
+      return nil
+    }
+    self.introducer = .owned(owner)
+  }
 }
 
-private extension LifetimeDependence.Scope {
-  /// The instruction that introduces an extendable scope. This returns a non-nil scope introducer for
-  /// each scope in ScopeExtension.nestedScopes.
-  var extendableBegin: ScopedInstruction? {
-    switch self {
+// Gather extendable scopes.
+extension ScopeExtension {
+  mutating func gatherExtensions(dependence: LifetimeDependence) {
+    visitedValues = ValueSet(context)
+    defer {
+      visitedValues!.deinitialize()
+      visitedValues = nil
+    }
+    gatherExtensions(scope: dependence.scope)
+  }
+
+  mutating func gatherExtensions(valueOrAddress: Value) {
+    if visitedValues!.insert(valueOrAddress) {
+      gatherExtensions(scope: LifetimeDependence.Scope(base: valueOrAddress, context))
+    }
+  }
+
+  mutating func nonExtendable(_ scope: LifetimeDependence.Scope) {
+    owners.push(scope.parentValue)
+  }
+
+  // If `scope` is extendable, find its owner or outer scopes first, then push for extension.
+  mutating func gatherExtensions(scope: LifetimeDependence.Scope) {
+    switch scope {
     case let .access(beginAccess):
-      return beginAccess
+      gatherAccessExtensions(beginAccess: beginAccess)
+      return
+
     case let .borrowed(beginBorrow):
-      return beginBorrow.value.definingInstruction as? ScopedInstruction
+      if let beginInst = beginBorrow.value.definingInstruction {
+        if let extScope = ExtendableScope(scope, beginInst: beginInst) {
+          gatherExtensions(valueOrAddress: beginBorrow.baseOperand!.value)
+          scopes.push(extScope)
+          return
+        }
+      }
+
     case let .yield(yieldedValue):
-      return yieldedValue.definingInstruction as? ScopedInstruction
+      let beginApply = yieldedValue.definingInstruction as! BeginApplyInst
+      gatherYieldExtension(beginApply)
+      scopes.push(ExtendableScope(scope, beginInst: beginApply)!)
+      return
+
     case let .initialized(initializer):
       switch initializer {
       case let .store(initializingStore: store, initialAddress: _):
         if let sb = store as? StoreBorrowInst {
-          return sb
+          // Follow the source for nested scopes.
+          gatherExtensions(valueOrAddress: sb.source)
+          scopes.push(ExtendableScope(scope, beginInst: sb)!)
+          return
         }
-        return nil
       case .argument, .yield:
         // TODO: extend indirectly yielded scopes.
-        return nil
+        break
+      }
+    case let .owned(value):
+      if let extScope = ExtendableScope(scope, owner: value) {
+        scopes.push(extScope)
+        return
+      }
+
+    case let .local(varInst):
+      switch varInst {
+      case let .beginBorrow(beginBorrow):
+        if let extScope = ExtendableScope(scope, beginInst: beginBorrow) {
+          gatherExtensions(valueOrAddress: beginBorrow.operand.value)
+          scopes.push(extScope)
+          return
+        }
+
+      case let .moveValue(moveValue):
+        if let extScope = ExtendableScope(scope, owner: moveValue) {
+          scopes.push(extScope)
+          return
+        }
       }
     default:
-      return nil
+      break
     }
+    nonExtendable(scope)
   }
 
-  /// Precondition: the 'self' scope encloses a dependent value. 'innerScopes' are the extendable scopes enclosed by
-  /// 'self' that also enclose the dependent value.
-  ///
-  /// Gather the list of ScopeExtensions. Each extension is a list of scopes, including 'innerScopes', 'self' and,
-  /// recursively, any of its enclosing scopes that are extendable. We may have multiple extensions because a scope
-  /// introducer may itself depend on multiple operands.
-  ///
-  /// Return 'nil' if 'self' is not extendable.
-  func gatherExtensions(innerScopes: SingleInlineArray<LifetimeDependence.Scope>? = nil, _ context: FunctionPassContext)
-    -> SingleInlineArray<ScopeExtension>? {
-
-    // Note: LifetimeDependence.Scope.extend() will assume that all inner scopes begin with a ScopedInstruction.
-    var innerScopes = innerScopes ?? SingleInlineArray()
-    switch self {
-    case let .access(beginAccess):
-      return gatherAccessExtension(beginAccess: beginAccess, innerScopes: &innerScopes, context)
-
-    case let .borrowed(beginBorrow):
-      // begin_borrow is extendable, so push this scope.
-      innerScopes.push(self)
-      return gatherBorrowExtension(borrowedValue: beginBorrow.baseOperand!.value, innerScopes: innerScopes, context)
-
-    case let .yield(yieldedValue):
-      // A yield is extendable, so push this scope.
-      innerScopes.push(self)
-      // Create a separate ScopeExtension for each operand that the yielded value depends on.
-      var extensions = SingleInlineArray<ScopeExtension>()
-      let applySite = yieldedValue.definingInstruction as! BeginApplyInst
-      for operand in applySite.parameterOperands {
-        guard let dep = applySite.resultDependence(on: operand), dep.isScoped else {
-          continue
-        }
-        // Pass a copy of innerScopes without modifying this one.
-        extensions.append(contentsOf: gatherOperandExtension(on: operand, innerScopes: innerScopes, context))
+  /// Unlike LifetimeDependenceInsertion, this does not stop at an argument's "variable introducer" and does not stop at
+  /// an addressable parameter. The purpose here is to extend any enclosing OSSA scopes as far as possible to achieve
+  /// the longest possible owner lifetime, rather than to find the source-level lvalue for a call argument.
+  mutating func gatherYieldExtension(_ beginApply: BeginApplyInst) {
+    // Create a separate ScopeExtension for each operand that the yielded value depends on.
+    for operand in beginApply.parameterOperands {
+      guard let dep = beginApply.resultDependence(on: operand), dep.isScoped else {
+        continue
       }
-      return extensions
-    case let .initialized(initializer):
-      switch initializer {
-      case let .store(initializingStore: store, initialAddress: _):
-        if let sb = store as? StoreBorrowInst {
-          innerScopes.push(self)
-          // Only follow the source of the store_borrow. The address is always an alloc_stack without any access scope.
-          return gatherBorrowExtension(borrowedValue: sb.source, innerScopes: innerScopes, context)
-        }
-        return nil
-      case .argument, .yield:
-        // TODO: extend indirectly yielded scopes.
-        return nil
-      }
-    default:
-      return nil
+      gatherExtensions(valueOrAddress: operand.value)
     }
   }
 
-  /// Unlike LifetimeDependenceInsertion this does not use gatherVariableIntroducers. The purpose here is to extend
-  /// any enclosing OSSA scopes as far as possible to achieve the longest possible owner lifetime, rather than to
-  /// find the "dependence root" for a call argument.
-  func gatherOperandExtension(on operand: Operand, innerScopes: SingleInlineArray<LifetimeDependence.Scope>,
-                              _ context: FunctionPassContext) -> SingleInlineArray<ScopeExtension> {
-    let enclosingScope = LifetimeDependence.Scope(base: operand.value, context)
-    if let extensions = enclosingScope.gatherExtensions(innerScopes: innerScopes, context) {
-      return extensions
-    }
-    // This is the outermost scope to be extended because gatherExtensions did not find an enclosing scope.
-    return SingleInlineArray(element: getOuterExtension(owner: operand.value, nestedScopes: innerScopes, context))
-  }
-
-  func getOuterExtension(owner: Value, nestedScopes: SingleInlineArray<LifetimeDependence.Scope>,
-                         _ context: FunctionPassContext) -> ScopeExtension {
-    let dependsOnArg = owner as? FunctionArgument
-    return ScopeExtension(owner: owner, nestedScopes: nestedScopes, dependsOnArg: dependsOnArg)
-  }
-
-  // Find the nested access scopes that may be extended as if they are the same access. This includes any combination of
-  // read/modify accesses, regardless of whether they may cause an exclusivity violation. The outer accesses will only
-  // be extended as far as required such that the innermost access coveres all dependent uses.
-  // Set ScopeExtension.dependsOnArg if the nested accesses are all compatible with the argument's convention. Then, if
-  // all nested accesses were extended to the return statement, it is valid to logically combine them into a single
-  // access for the purpose of diagnostinc lifetime dependence.
-  func gatherAccessExtension(beginAccess: BeginAccessInst,
-                             innerScopes: inout SingleInlineArray<LifetimeDependence.Scope>,
-                             _ context: FunctionPassContext) -> SingleInlineArray<ScopeExtension> {
-    // Finding the access base also finds all intermediate nested scopes; there is no need to recursively call
-    // gatherExtensions().
+  mutating func gatherAccessExtensions(beginAccess: BeginAccessInst) {
     let accessBaseAndScopes = beginAccess.accessBaseWithScopes
-    var isCompatibleAccess = true
-    for nestedScope in accessBaseAndScopes.scopes {
+    if let baseAddress = accessBaseAndScopes.base.address {
+      gatherExtensions(valueOrAddress: baseAddress)
+    }
+    for nestedScope in accessBaseAndScopes.scopes.reversed() {
       switch nestedScope {
       case let .access(nestedBeginAccess):
-        innerScopes.push(.access(nestedBeginAccess))
-        if nestedBeginAccess.accessKind != beginAccess.accessKind {
-          isCompatibleAccess = false
-        }
+        scopes.push(ExtendableScope(.access(nestedBeginAccess), beginInst: nestedBeginAccess)!)
       case .dependence, .base:
         // ignore recursive mark_dependence base for the purpose of extending scopes. This pass will extend the base
         // of that mark_dependence (if it is unresolved) later as a separate LifetimeDependence.Scope.
         break
       }
     }
-    guard case let .access(outerBeginAccess) = innerScopes.last else {
-      // beginAccess is included in accessBaseWithScopes; so at least one access was added to innerScopes.
-      fatalError("missing outer access")
+  }
+}
+
+extension ScopeExtension {
+  /// Return all scope owners as long as they are all function arguments and all nested accesses are compatible with
+  /// their argument convention. Then, if all nested accesses were extended to the return statement, it is valid to
+  /// logically combine them into a single access for the purpose of diagnostic lifetime dependence.
+  var dependsOnArgs: SingleInlineArray<FunctionArgument> {
+    let noCallerScope = SingleInlineArray<FunctionArgument>()
+    if !dependsOnCaller! {
+      return noCallerScope
     }
-    if case let .argument(arg) = accessBaseAndScopes.base {
-      if isCompatibleAccess && beginAccess.accessKind.isCompatible(with: arg.convention) {
-        let scopes = ScopeExtension(owner: outerBeginAccess.address, nestedScopes: innerScopes, dependsOnArg: arg)
-        return SingleInlineArray(element: scopes)
+    // All owners must be arguments to depend on the caller's scope.
+    var compatibleArgs = SingleInlineArray<FunctionArgument>()
+    for owner in owners {
+      guard let arg = owner as? FunctionArgument else {
+        return noCallerScope
+      }
+      compatibleArgs.push(arg)
+    }
+    // The only local scopes that are compatible with the caller's scope are access scopes that either read an
+    // immutable argument or modify a mutable argument.
+    for extScope in scopes {
+      switch extScope.scope {
+      case let .access(beginAccess):
+        for arg in compatibleArgs {
+          if !beginAccess.accessKind.isCompatible(with: arg.convention) {
+            return noCallerScope
+          }
+        }
+      default:
+        return noCallerScope
       }
     }
-    /// Recurse in case of indirect yields.
-    let enclosingScope = LifetimeDependence.Scope(base: outerBeginAccess.address, context)
-    if let extensions = enclosingScope.gatherExtensions(innerScopes: innerScopes, context) {
-      return extensions
-    }
-    // When the owner is an address, the owner's scope is considered the availability of its access base starting at the
-    // position of innerScopes.last.
-    let scopes = ScopeExtension(owner: outerBeginAccess.address, nestedScopes: innerScopes, dependsOnArg: nil)
-    return SingleInlineArray(element: scopes)
-  }
-
-  func gatherBorrowExtension(borrowedValue: Value,
-                             innerScopes: SingleInlineArray<LifetimeDependence.Scope>,
-                             _ context: FunctionPassContext)
-    -> SingleInlineArray<ScopeExtension> {
-
-    let enclosingScope = LifetimeDependence.Scope(base: borrowedValue, context)
-    if let extensions = enclosingScope.gatherExtensions(innerScopes: innerScopes, context) {
-      return extensions
-    }
-    // This is the outermost scope to be extended because gatherExtensions did not find an enclosing scope.
-    return SingleInlineArray(element: getOuterExtension(owner: enclosingScope.parentValue, nestedScopes: innerScopes,
-                                                        context))
+    return compatibleArgs
   }
 }
 
@@ -460,121 +512,172 @@ extension ScopeExtension {
         return range.deinitialize()
       }
     }
+
+    var description: String {
+      switch self {
+      case .fullRange:
+        return "full range"
+      case let .addressRange(range):
+        return range.description
+      case let .valueRange(range):
+        return range.description
+      }
+    }
   }
 
   /// Return nil if the scope's owner is valid across the function, such as a guaranteed function argument.
-  func computeRange(_ localReachabilityCache: LocalVariableReachabilityCache, _ context: FunctionPassContext) -> Range?
-  {
+  func computeSingleOwnerRange(owner: Value) -> Range? {
     if owner.type.isAddress {
       // Get the range of the accessBase lifetime at the point where the outermost extendable scope begins.
-      if let range = AddressOwnershipLiveRange.compute(for: owner, at: nestedScopes.last!.extendableBegin!.instruction,
+      if let range = AddressOwnershipLiveRange.compute(for: owner, at: scopes.first!.firstInstruction,
                                                        localReachabilityCache, context) {
         return .addressRange(range)
       }
       return nil
     }
-    if owner.ownership == .owned {
+    switch owner.ownership {
+    case .owned:
       return .valueRange(computeLinearLiveness(for: owner, context))
-    }
-    // Trivial or guaranted owner.
-    //
-    // TODO: limit extension to the begin_borrow [var_decl] scope
-    return .fullRange
-  }
-}
-
-/// Return an InstructionRange covering all the dependent uses of 'dependence'.
-private func computeDependentUseRange(of dependence: LifetimeDependence, within scopeExtension: inout ScopeExtension,
-                                      _ localReachabilityCache: LocalVariableReachabilityCache,
-                                      _ context: FunctionPassContext)
-  -> InstructionRange? {
-  let function = dependence.function
-  guard var ownershipRange = scopeExtension.computeRange(localReachabilityCache, context) else {
-    return nil
-  }
-  defer {ownershipRange.deinitialize()}
-
-  // The innermost scope that must be extended must dominate all uses.
-  var useRange = InstructionRange(begin: scopeExtension.innerScope.extendableBegin!.instruction, context)
-  var walker = LifetimeDependentUseWalker(function, localReachabilityCache, context) {
-    // Do not extend the useRange past the ownershipRange.
-    let dependentInst = $0.instruction
-    if ownershipRange.coversUse(dependentInst) {
-      useRange.insert(dependentInst)
-    }
-    return .continueWalk
-  }
-  defer {walker.deinitialize()}
-
-  _ = walker.walkDown(dependence: dependence)
-
-  log("Scope fixup for dependent uses:\n\(useRange)")
-
-  scopeExtension.dependsOnCaller = walker.dependsOnCaller
-
-  // Lifetime dependenent uses may not be dominated by the access. The dependent value may be used by a phi or stored
-  // into a memory location. The access may be conditional relative to such uses. If any use was not dominated, then
-  // `useRange` will include the function entry. There is not way to directly check
-  // useRange.isValid. useRange.blockRange.isValid is not a strong enough check because it will always succeed when
-  // useRange.begin == entryBlock even if a use if above useRange.begin.
-  let firstInst = function.entryBlock.instructions.first!
-  if firstInst != useRange.begin, useRange.contains(firstInst) {
-    useRange.deinitialize()
-    return nil
-  }
-  return useRange
-}
-
-// Extend nested scopes across a use-range within their owner's range.
-extension ScopeExtension {
-  // Prepare to extend each scope.
-  func tryExtendScopes(over useRange: inout InstructionRange, _ context: some MutatingContext) -> Bool {
-    var extendedUseRange = InstructionRange(begin: useRange.begin!, ends: useRange.ends, context)
-    // Insert the first instruction of the exit blocks to mimic 'useRange'. This is innacurate, but it produces the same
-    // result for canExtend() check below, which only checks reachability of end_apply.
-    extendedUseRange.insert(contentsOf: useRange.exits)
-    for innerScope in nestedScopes {
-      guard let beginInst = innerScope.extendableBegin else {
-        fatalError("all nested scopes must have a scoped begin instruction")
+    case .guaranteed:
+      if let bbv = BeginBorrowValue(owner) {
+        if case .functionArgument = bbv {
+          return .fullRange
+        }
+        return .valueRange(computeLinearLiveness(for: bbv.value, context))
       }
-      // Extend 'extendedUseRange' to to cover this scope's end instructions. The extended scope must at least cover the
-      // original scope because the original scope may protect other operations.
-      extendedUseRange.insert(contentsOf: beginInst.endInstructions)
-      if !innerScope.canExtend(over: &extendedUseRange, context) {
+      return nil
+    case .none:
+      return .fullRange
+    case .unowned:
+      return nil
+    }
+  }
+
+  /// Return an InstructionRange covering all the dependent uses of 'dependence'.
+  ///
+  /// Initialize dependsOnCaller.
+  mutating func computeDependentUseRange(of dependence: LifetimeDependence) -> InstructionRange? {
+    if scopes.isEmpty {
+      return nil
+    }
+    let function = dependence.function
+    var inRangeUses = [Instruction]()
+    do {
+      // The innermost scope that must be extended must dominate all uses.
+      var walker = LifetimeDependentUseWalker(function, localReachabilityCache, context) {
+        inRangeUses.append($0.instruction)
+        return .continueWalk
+      }
+      defer {walker.deinitialize()}
+      _ = walker.walkDown(dependence: dependence)
+      dependsOnCaller = walker.dependsOnCaller
+    }
+    for owner in owners {
+      guard var ownershipRange = computeSingleOwnerRange(owner: owner) else {
+        return nil
+      }
+      defer { ownershipRange.deinitialize() }
+
+      inRangeUses = inRangeUses.filter { ownershipRange.coversUse($0) }
+    }
+    var useRange = InstructionRange(begin: innermostScope.firstInstruction, context)
+    useRange.insert(contentsOf: inRangeUses)
+
+    log("Scope fixup for dependent uses:\n\(useRange)")
+
+    // Lifetime dependenent uses may not be dominated by `innermostScope`. The dependent value may be used by a phi or
+    // stored into a memory location. The access may be conditional relative to such uses. If any use was not dominated,
+    // then `useRange` will include the function entry. There is no way to directly check if `useRange` is
+    // valid. `useRange.blockRange.isValid` is not a strong enough check because it will always succeed when
+    // `useRange.begin == entryBlock` even if a use is above `useRange.begin`. Instead check if `useRange` contains the
+    // first instruction, and the first instruction does not itself start `innermostScope`.
+    let firstInst = function.entryBlock.instructions.first!
+    if firstInst != useRange.begin, useRange.contains(firstInst) {
+      useRange.deinitialize()
+      return nil
+    }
+    return useRange
+  }
+}
+
+extension ScopeExtension {
+  /// Return true if all nested scopes were extended across `useRange`. `useRange` has already been pruned to be a
+  /// subset of the ranges of the owners.
+  ///
+  /// Note: the scopes may not be strictly nested. Two adjacent scopes in the nested scopes array may have begin at the
+  /// same nesting level. Their begin instructions may occur in any order relative to the nested scopes array, but we
+  /// order the end instructions according to the arbitrary order that the scopes were inserted in the array. This is
+  /// conservative and could extend some scopes longer than strictly necessary. To improve this, `scopes` must be
+  /// represnted as a DAG by recording parent and child indices.
+  func canExtendScopes(over useRange: inout InstructionRange,
+                       scopesToExtend: inout SingleInlineArray<ExtendableScope>) -> Bool {
+    var extendedUseRange = InstructionRange(begin: useRange.begin!, ends: useRange.ends, context)
+
+    // Insert the first instruction of the exit blocks to mimic `useRange`. There is no way to directly copy
+    // `useRange`. Inserting the exit block instructions is innacurate, but for the purpose of canExtend() below, it has
+    // the same effect as a copy of `useRange`.
+    extendedUseRange.insert(contentsOf: useRange.exits)
+    defer { extendedUseRange.deinitialize() }
+
+    // Append each scope that needs extention to scopesToExtend from the inner to the outer scope.
+    for extScope in scopes.reversed() {
+      // An outer scope might not originally cover one of its inner scopes. Therefore, extend 'extendedUseRange' to to
+      // cover this scope's end instructions. The extended scope must at least cover the original scopes because the
+      // original scopes may protect other operations.
+      var mustExtend = false
+      for scopeEndInst in extScope.endInstructions {
+        switch extendedUseRange.overlaps(pathBegin: extScope.firstInstruction, pathEnd: scopeEndInst, context) {
+        case .containsPath, .containsEnd, .disjoint:
+          // containsPath can occur when the extendable scope has the same begin as the use range.
+          // disjoint is unexpected, but if it occurs then `extScope` must be before the useRange.
+          mustExtend = true
+          break
+        case .containsBegin, .overlappedByPath:
+          // containsBegin can occur when the extendable scope has the same begin as the use range.
+          extendedUseRange.insert(scopeEndInst)
+          break
+        }
+      }
+      if !mustExtend {
+        continue
+      }
+      scopesToExtend.push(extScope)
+      if !extScope.canExtend(over: &extendedUseRange, context) {
         // Scope ending instructions cannot be inserted at the 'range' boundary. Ignore all nested scopes.
         //
-        // Note: We could still extend previously prepared inner scopes up to this 'innerScope'. To do that, we would
-        // need to repeat the steps above: treat 'innerScope' as the new owner, and recompute 'useRange'. But this
+        // Note: We could still extend previously prepared inner scopes up to this scope. To do that, we would
+        // need to repeat the steps above: treat 'extScope' as the new owner, and recompute `useRange`. But this
         // scenario could only happen with nested coroutine, where the range boundary is reachable from the outer
         // coroutine's EndApply and AbortApply--it is vanishingly unlikely if not impossible.
         return false
       }
     }
-    extendedUseRange.deinitialize()
-    // extend(over:) must receive the original unmodified 'useRange'.
-    extend(over: &useRange, context)
     return true
   }
   
   // Extend the scopes that actually required extension.
   //
   // Consumes 'useRange'
-  private func extend(over useRange: inout InstructionRange, _ context: some MutatingContext) {
+  private func extend(scopesToExtend: SingleInlineArray<ExtendableScope>,
+                      over useRange: inout InstructionRange,
+                      _ context: some MutatingContext) {
     var deadInsts = [Instruction]()
-    for innerScope in nestedScopes {
-      guard let beginInst = innerScope.extendableBegin else {
-        fatalError("all nested scopes must have a scoped begin instruction")
-      }
-      let mustExtend = beginInst.endInstructions.contains(where: { useRange.contains($0) })
-
+    for extScope in scopesToExtend {
       // Extend 'useRange' to to cover this scope's end instructions. 'useRange' cannot be extended until the
       // inner scopes have been extended.
-      for endInst in beginInst.endInstructions {
-        useRange.insert(endInst)
-      }
-      if mustExtend {
-        deadInsts += innerScope.extend(over: &useRange, context)
-      }
+      useRange.insert(contentsOf: extScope.endInstructions)
+
+      // Note, we could Skip extension here if we have a fully overlapping scope. But that requires computing the scope
+      // of [beginInst : beginInst.endInstructions) because an outer scope may be disjoint from the inner scope but
+      // still requires extension:
+      //     %access = begin_access [read] %owner       // <=== outer scoope
+      //     %temp = load [copy] %access
+      //     end_access %access
+      //     (%dependent, %token) = begin_apply (%temp) // <=== inner scope
+      //     end_apply %token
+      //
+      deadInsts += extScope.extend(over: &useRange, context)
+
       // Continue checking enclosing scopes for extension even if 'mustExtend' is false. Multiple ScopeExtensions may
       // share the same inner scope, so this inner scope may already have been extended while handling a previous
       // ScopeExtension. Nonetheless, some enclosing scopes may still require extension. This only happens when a
@@ -582,6 +685,7 @@ extension ScopeExtension {
     }
     // 'useRange' is invalid as soon as instructions are deleted.
     useRange.deinitialize()
+
     // Delete original end instructions.
     for deadInst in deadInsts {
       context.erase(instruction: deadInst)
@@ -590,28 +694,20 @@ extension ScopeExtension {
 }
 
 // Extend a dependence scope to cover the dependent uses.
-private extension LifetimeDependence.Scope {
+extension ExtendableScope {
   /// Return true if new scope-ending instruction can be inserted at the range boundary.
   func canExtend(over range: inout InstructionRange, _ context: some Context) -> Bool {
-    switch self {
+    switch self.scope {
     case let .yield(yieldedValue):
-      let beginApply = yieldedValue.definingInstruction as! BeginApplyInst
-      let canEndAtBoundary = { (boundaryInst: Instruction) in
-        switch beginApply.endReaches(block: boundaryInst.parentBlock, context) {
-        case .abortReaches, .endReaches:
-          return true
-        case .none:
-          return false
-        }
-      }
-      for end in range.ends {
-        if (!canEndAtBoundary(end)) {
-          return false
-        }
-      }
-      for exit in range.exits {
-        if (!canEndAtBoundary(exit)) {
-          return false
+      return canExtend(beginApply: yieldedValue.definingInstruction as! BeginApplyInst, over: &range, context)
+    case let .initialized(initializer):
+      switch initializer {
+      case .argument, .yield:
+        // A yield is already considered nested within the coroutine.
+        break
+      case let .store(initializingStore, _):
+        if let sb = initializingStore as? StoreBorrowInst {
+          return canExtend(storeBorrow: sb, over: &range)
         }
       }
       return true
@@ -621,24 +717,49 @@ private extension LifetimeDependence.Scope {
     }
   }
 
-  /// Extend this scope over the 'range' boundary. Return the old scope ending instructions to be deleted.
-  func extend(over range: inout InstructionRange, _ context: some MutatingContext) -> [Instruction] {
-    guard let beginInst = extendableBegin else {
-      fatalError("all nested scoped must have a scoped begin instruction")
+  func canExtend(beginApply: BeginApplyInst, over range: inout InstructionRange, _ context: some Context) -> Bool {
+    let canEndAtBoundary = { (boundaryInst: Instruction) in
+      switch beginApply.endReaches(block: boundaryInst.parentBlock, context) {
+      case .abortReaches, .endReaches:
+        return true
+      case .none:
+        return false
+      }
     }
-    // Collect the original end instructions and extend the range to to cover them. The resulting access scope
-    // must cover the original scope because it may protect other memory operations.
-    var endInsts = [Instruction]()
-    for end in beginInst.endInstructions {
-      assert(range.inclusiveRangeContains(end))
-      endInsts.append(end)
+    for end in range.ends {
+      if (!canEndAtBoundary(end)) {
+        return false
+      }
     }
-    insertBoundaryEnds(range: &range, context)
-    return endInsts
+    for exit in range.exits {
+      if (!canEndAtBoundary(exit)) {
+        return false
+      }
+    }
+    return true
   }
 
-  /// Create new scope-ending instructions at the boundary of 'range'.
-  func insertBoundaryEnds(range: inout InstructionRange, _ context: some MutatingContext) {
+  /// A store borrow is considered to be nested within the scope of its stored values. It is, however, also
+  /// restricted to the range of its allocation.
+  ///
+  /// TODO: consider rewriting the dealloc_stack instructions if we ever find that SILGen emits them sooner that
+  /// we need for lifetime dependencies.
+  func canExtend(storeBorrow: StoreBorrowInst, over range: inout InstructionRange) -> Bool {
+    // store_borrow can be extended if all deallocations occur after the use range.
+    return storeBorrow.allocStack.deallocations.allSatisfy({ !range.contains($0) })
+  }
+
+  /// Extend this scope over the 'range' boundary. Return the old scope ending instructions to be deleted.
+  func extend(over range: inout InstructionRange, _ context: some MutatingContext) -> [Instruction] {
+    // Collect the original end instructions and extend the range to to cover them. The resulting access scope
+    // must cover the original scope because it may protect other memory operations.
+    let endsToErase = self.endInstructions
+    var unusedEnds = InstructionSet(context)
+    for end in endsToErase {
+      assert(range.inclusiveRangeContains(end))
+      unusedEnds.insert(end)
+    }
+    defer { unusedEnds.deinitialize() }
     for end in range.ends {
       let location = end.location.autoGenerated
       if end is ReturnInst {
@@ -647,6 +768,11 @@ private extension LifetimeDependence.Scope {
         let builder = Builder(before: end, location: location, context)
         // Insert newEnd so that this scope will be nested in any outer scopes.
         range.insert(createEndInstruction(builder, context))
+        continue
+      }
+      if unusedEnds.contains(end) {
+        unusedEnds.erase(end)
+        assert(!unusedEnds.contains(end))
         continue
       }
       Builder.insert(after: end, location: location, context) {
@@ -658,11 +784,12 @@ private extension LifetimeDependence.Scope {
       let builder = Builder(before: exitInst, location: location, context)
       range.insert(createEndInstruction(builder, context))
     }
+    return endsToErase.filter { unusedEnds.contains($0) }
   }
 
   /// Create a scope-ending instruction at 'builder's insertion point.
   func createEndInstruction(_ builder: Builder, _ context: some Context) -> Instruction {
-    switch self {
+    switch self.scope {
     case let .access(beginAccess):
       return builder.createEndAccess(beginAccess: beginAccess)
     case let .borrowed(beginBorrow):
@@ -675,12 +802,23 @@ private extension LifetimeDependence.Scope {
       switch initializer {
       case let .store(initializingStore: store, initialAddress: _):
         if let sb = store as? StoreBorrowInst {
+          // FIXME: we may need to rewrite the dealloc_stack.
           return builder.createEndBorrow(of: sb)
         }
         break
       case .argument, .yield:
         // TODO: extend indirectly yielded scopes.
         break
+      }
+    case let .owned(value):
+      return builder.createDestroyValue(operand: value)
+    case let .local(varInst):
+      switch varInst {
+      case let .beginBorrow(beginBorrow):
+        // FIXME: we may need to rewrite the dealloc_stack.
+        return builder.createEndBorrow(of: beginBorrow)
+      case let .moveValue(moveValue):
+        return builder.createDestroyValue(operand: moveValue)
       }
     default:
       break

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -501,6 +501,11 @@ enum AddressOwnershipLiveRange : CustomStringConvertible {
     }
   }
 
+  /// Return the live range of the addressable value that reaches 'begin', not including 'begin', which may itself be an
+  /// access of the address.
+  ///
+  /// The range ends at the destroy or reassignment of the addressable value.
+  ///
   /// Return nil if the live range is unknown.
   static func compute(for address: Value, at begin: Instruction,
                       _ localReachabilityCache: LocalVariableReachabilityCache,
@@ -624,7 +629,7 @@ extension AddressOwnershipLiveRange {
     var reachableUses = Stack<LocalVariableAccess>(context)
     defer { reachableUses.deinitialize() }
 
-    localReachability.gatherKnownReachableUses(from: assignment, in: &reachableUses)
+    localReachability.gatherKnownLifetimeUses(from: assignment, in: &reachableUses)
 
     let assignmentInst = assignment.instruction ?? allocation.parentFunction.entryBlock.instructions.first!
     var range = InstructionRange(begin: assignmentInst, context)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -425,7 +425,7 @@ enum BeginBorrowValue {
   var baseOperand: Operand? {
     switch self {
     case let .beginBorrow(beginBorrow):
-    return beginBorrow.operand
+      return beginBorrow.operand
     case let .loadBorrow(loadBorrow):
       return loadBorrow.operand
     case .beginApply, .functionArgument, .reborrow, .uncheckOwnershipConversion:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -930,8 +930,8 @@ extension LifetimeDependenceDefUseWalker {
       // of its forwarded address has were visited by LocalVariableAccessWalker and recorded as separate local accesses.
       return .continueWalk
     case .store:
-      let si = localAccess.operand!.instruction as! StoringInstruction
-      assert(si.sourceOperand == initialValue, "the only reachable store should be the current assignment")
+      // A store does not use the previous in-memory value.
+      return .continueWalk
     case .apply:
       return visitAppliedUse(of: localAccess.operand!, by: localAccess.instruction as! FullApplySite)
     case .escape:
@@ -946,7 +946,6 @@ extension LifetimeDependenceDefUseWalker {
     case .incomingArgument:
       fatalError("Incoming arguments are never reachable")
     }
-    return .continueWalk
   }
 
   private mutating func visitAppliedUse(of operand: Operand, by apply: FullApplySite) -> WalkResult {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -279,8 +279,10 @@ extension LifetimeDependence.Scope {
     case let .box(projectBox):
       // Note: the box may be in a borrow scope.
       self.init(base: projectBox.operand.value, context)
-    case .stack, .class, .tail, .pointer, .index, .unidentified:
+    case .stack, .class, .tail, .pointer, .index:
       self = .unknown(accessBase.address!)
+    case .unidentified:
+      self = .unknown(address)
     case .global:
       // TODO: When AccessBase directly stores GlobalAccessBase, we don't need a check here and don't need to pass
       // 'address' in to this function.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -929,7 +929,7 @@ extension LifetimeDependenceDefUseWalker {
       // Simply a marker that indicates the start of an in-memory dependent value. If this was a mark_dependence, uses
       // of its forwarded address has were visited by LocalVariableAccessWalker and recorded as separate local accesses.
       return .continueWalk
-    case .store:
+    case .store, .storeBorrow:
       // A store does not use the previous in-memory value.
       return .continueWalk
     case .apply:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -1064,6 +1064,276 @@ private struct LifetimeDependenceUsePrinter : LifetimeDependenceDefUseWalker {
   }
 }
 
+// =============================================================================
+// LifetimeDependenceUseDefWalker - upward walk
+// =============================================================================
+
+/// Walk up lifetime dependencies to the first value associated with a variable declaration.
+///
+/// To start walking:
+///     walkUp(newLifetime: Value) -> WalkResult
+///
+/// This utility finds a value or address that is the best-effort "root" of the chain of temporary lifetime-dependent
+/// values.
+///
+/// This "looks through" projections: a property that is either visible as a stored property or access via
+/// unsafe[Mutable]Address.
+///
+///     dependsOn(lvalue.field) // finds 'lvalue' when 'field' is a stored property
+///
+///     dependsOn(lvalue.computed) // finds the temporary value directly returned by a getter.
+///
+/// SILGen emits temporary copies that violate lifetime dependence semantcs. This utility looks through such temporary
+/// copies, stopping at a value that introduces an immutable variable: move_value [var_decl] or begin_borrow [var_decl],
+/// or at an access of a mutable variable: begin_access [read] or begin_access [modify].
+///
+/// In this example, the dependence "root" is copied, borrowed, and forwarded before being used as the base operand of
+/// `mark_dependence`. The dependence "root" is the parent of the outer-most dependence scope.
+///
+///     %root = apply                  // lifetime dependence root
+///     %copy = copy_value %root
+///     %parent = begin_borrow %copy   // lifetime dependence parent value
+///     %base = struct_extract %parent // lifetime dependence base value
+///     %dependent = mark_dependence [nonescaping] %value on %base
+///
+/// LifetimeDependenceUseDefWalker extends the ForwardingUseDefWalker to follow copies, moves, and
+/// borrows. ForwardingUseDefWalker treats these as forward-extended lifetime introducers. But they inherit a lifetime
+/// dependency from their operand because non-escapable values can be copied, moved, and borrowed. Nonetheless, all of
+/// their uses must remain within original dependence scope.
+///
+///   # owned lifetime dependence
+///   %parent = apply               // begin dependence scope -+
+///   ...                                                      |
+///   %1 = mark_dependence [nonescaping] %value on %parent     |
+///   ...                                                      |
+///   %2 = copy_value %1        -+                             |
+///   # forwarding instruction   |                             |
+///   %3 = struct $S (%2)        | forward-extended lifetime   |
+///                              |                             | OSSA Lifetime
+///   %4 = move_value %3        -+                             |
+///   ...                        | forward-extended lifetime   |
+///   %5 = begin_borrow %4       | -+                          |
+///   # dependent use of %1      |  | forward-extended lifetime|
+///   end_borrow %5              | -+                          |
+///   destroy_value %4          -+                             |
+///   ...                                                      |
+///   destroy_value %parent        // end dependence scope    -+
+///
+/// All of the dependent uses including `end_borrow %5` and `destroy_value %4` must be before the end of the dependence
+/// scope: `destroy_value %parent`. In this case, the dependence parent is an owned value, so the scope is simply the
+/// value's OSSA lifetime.
+///
+/// The ForwardingUseDefWalker's PathContext is the most recent lifetime owner (Value?). If we ever want to track the
+/// access path as well, then we can aggregate both the owner and access path in a single PathContext.
+protocol LifetimeDependenceUseDefValueWalker : ForwardingUseDefWalker where PathContext == Value? {
+  var context: Context { get }
+
+  // 'path' is the lifetime "owner": the "def" into which the current 'value' is eventually forwarded.
+  mutating func introducer(_ value: Value, _ path: PathContext) -> WalkResult
+
+  // Minimally, check a ValueSet. This walker may traverse chains of
+  // aggregation and destructuring along with phis.
+  //
+  // 'path' is the "owner" of the forwarded value.
+  mutating func needWalk(for value: Value, _ path: PathContext) -> Bool
+
+  // The 'newLifetime' value is not forwarded to its uses.
+  mutating func walkUp(newLifetime: Value) -> WalkResult
+
+  // 'owner' is the "def" into which the current 'value' is eventually forwarded.
+  mutating func walkUp(value: Value, _ owner: Value?) -> WalkResult
+}
+
+// Defaults
+extension LifetimeDependenceUseDefValueWalker {
+  mutating func walkUp(value: Value, _ owner: Value?) -> WalkResult {
+    walkUpDefault(value: value, owner)
+  }
+}
+
+// Helpers
+extension LifetimeDependenceUseDefValueWalker {
+  mutating func walkUpDefault(value: Value, _ owner: Value?) -> WalkResult {
+    switch value.definingInstruction {
+    case let transition as OwnershipTransitionInstruction:
+      return walkUp(newLifetime: transition.operand.value)
+    case let load as LoadInstruction:
+      return walkUp(newLifetime: load.address)
+    default:
+      break
+    }
+    // If the dependence chain has a phi, consider it a root. Dependence roots dominate all dependent values.
+    if Phi(value) != nil {
+      return introducer(value, owner)
+    }
+    // ForwardingUseDefWalker will callback to introducer() when it finds no forwarding instruction.
+    return walkUpDefault(forwarded: value, owner)
+  }
+}
+
+protocol LifetimeDependenceUseDefAddressWalker {
+  var context: Context { get }
+
+  // If the scoped value is trivial, then only the variable's lexical scope is relevant, and access scopes can be
+  // ignored.
+  var isTrivialScope: Bool { get }
+
+  mutating func addressIntroducer(_ address: Value, access: AccessBaseAndScopes) -> WalkResult
+
+  // The 'newLifetime' value is not forwarded to its uses. It may be a non-address or an address.
+  mutating func walkUp(newLifetime: Value) -> WalkResult
+
+  mutating func walkUp(address: Value, access: AccessBaseAndScopes) -> WalkResult
+}
+
+// Defaults
+extension LifetimeDependenceUseDefAddressWalker {
+  mutating func walkUp(address: Value, access: AccessBaseAndScopes) -> WalkResult {
+    walkUpDefault(address: address, access: access)
+  }
+}
+
+// Helpers
+extension LifetimeDependenceUseDefAddressWalker {
+  mutating func walkUp(address: Value) -> WalkResult {
+    walkUp(address: address, access: address.accessBaseWithScopes)
+  }
+
+  mutating func walkUpDefault(address: Value, access: AccessBaseAndScopes) -> WalkResult {
+    // Continue walking for some kinds of access base.
+    switch access.base {
+    case .box, .global, .class, .tail, .pointer, .index, .unidentified:
+      break
+    case let .stack(allocStack):
+      // Ignore stack locations. Their access scopes do not affect lifetime dependence.
+      return walkUp(stackInitializer: allocStack, at: address, access: access)
+    case let .argument(arg):
+      // Ignore access scopes for @in or @in_guaranteed arguments when all scopes are reads. Do not ignore a [read]
+      // access of an inout argument or outer [modify]. Mutation later with the outer scope could invalidate the
+      // borrowed state in this narrow scope. Do not ignore any mark_depedence on the address.
+      if arg.convention.isIndirectIn && access.isOnlyReadAccess {
+        return addressIntroducer(arg, access: access)
+      }
+      // @inout arguments may be singly initialized (when no modification exists in this function), but this is not
+      // relevant here because they require nested access scopes which can never be ignored.
+    case let .yield(yieldedAddress):
+      // Ignore access scopes for @in or @in_guaranteed yields when all scopes are reads.
+      let apply = yieldedAddress.definingInstruction as! FullApplySite
+      if apply.convention(of: yieldedAddress).isIndirectIn && access.isOnlyReadAccess {
+        return addressIntroducer(yieldedAddress, access: access)
+      }
+    case .storeBorrow(let sb):
+      // Walk up through a store into a temporary.
+      if access.scopes.isEmpty,
+         case .stack = sb.destinationOperand.value.accessBase {
+        return walkUp(newLifetime: sb.source)
+      }
+    }
+    // Skip the access scope for unsafe[Mutable]Address. Treat it like a projection of 'self' rather than a separate
+    // variable access.
+    if case let .access(innerAccess) = access.scopes.first,
+       let addressorSelf = innerAccess.unsafeAddressorSelf {
+      return walkUp(newLifetime: addressorSelf)
+    }
+    // Ignore the acces scope for trivial values regardless of whether it is singly-initialized. Trivial values do not
+    // need to be kept alive in memory and can be safely be overwritten in the same scope. Lifetime dependence only
+    // cares that the loaded value is within the lexical scope of the trivial value's variable declaration. Rather than
+    // skipping all access scopes, call 'walkUp' on each nested access in case one of them needs to redirect the walk,
+    // as required for 'access.unsafeAddressorSelf'.
+    if isTrivialScope {
+      switch access.scopes.first {
+      case .none, .base:
+        break
+      case let .access(beginAccess):
+        return walkUp(newLifetime: beginAccess.address)
+      case let .dependence(markDep):
+        return walkUp(newLifetime: markDep.value)
+      }
+    }
+    return addressIntroducer(access.enclosingAccess.address ?? address, access: access)
+  }
+
+  // Handle singly-initialized temporary stack locations.
+  mutating func walkUp(stackInitializer allocStack: AllocStackInst, at address: Value,
+                       access: AccessBaseAndScopes) -> WalkResult {
+    guard let initializer = allocStack.accessBase.findSingleInitializer(context) else {
+      return addressIntroducer(address, access: access)
+    }
+    if case let .store(store, _) = initializer {
+      switch store {
+      case let store as StoringInstruction:
+        return walkUp(newLifetime: store.source)
+      case let srcDestInst as SourceDestAddrInstruction:
+        return walkUp(newLifetime: srcDestInst.destination)
+      case let apply as FullApplySite:
+        if let f = apply.referencedFunction, f.isConvertPointerToPointerArgument {
+          return walkUp(newLifetime: apply.parameterOperands[0].value)
+        }
+      default:
+        break
+      }
+    }
+    return addressIntroducer(address, access: access)
+  }
+}
+
+/// Walk up through all new lifetimes to find the roots of a lifetime dependence chain.
+struct LifetimeDependenceRootWalker : LifetimeDependenceUseDefValueWalker, LifetimeDependenceUseDefAddressWalker {
+  // The ForwardingUseDefWalker's context is the most recent lifetime owner.
+  typealias PathContext = Value?
+
+  let context: Context
+
+  // If the scoped value is trivial, then only the variable's lexical scope is relevant, and access scopes can be
+  // ignored.
+  let isTrivialScope: Bool
+
+  // This visited set is only really needed for instructions with
+  // multiple results, including phis.
+  private var visitedValues: ValueSet
+
+  var roots: SingleInlineArray<Value> = SingleInlineArray<Value>()
+
+  init(_ context: Context, scopedValue: Value) {
+    self.context = context
+    self.isTrivialScope = scopedValue.type.isAddress
+      ? scopedValue.type.objectType.isTrivial(in: scopedValue.parentFunction)
+      : scopedValue.isTrivial(context)
+    self.visitedValues = ValueSet(context)
+  }
+
+  mutating func deinitialize() {
+    visitedValues.deinitialize()
+  }
+ 
+  mutating func introducer(_ value: Value, _ owner: Value?) -> WalkResult {
+    roots.push(value)
+    return .continueWalk
+  }
+
+  mutating func addressIntroducer(_ address: Value, access: AccessBaseAndScopes) -> WalkResult {
+    roots.push(address)
+    return .continueWalk
+  }
+
+  mutating func needWalk(for value: Value, _ owner: Value?) -> Bool {
+    visitedValues.insert(value)
+  }
+
+  mutating func walkUp(newLifetime: Value) -> WalkResult {
+    if newLifetime.type.isAddress {
+      return walkUp(address: newLifetime)
+    }
+    let newOwner = newLifetime.ownership == .owned ? newLifetime : nil
+    return walkUp(value: newLifetime, newOwner)
+  }
+}
+
+// =============================================================================
+// Unit tests
+// =============================================================================
+
+
 let lifetimeDependenceUseTest = FunctionTest("lifetime_dependence_use") {
     function, arguments, context in
   let value = arguments.takeValue()
@@ -1086,6 +1356,18 @@ let lifetimeDependenceUseTest = FunctionTest("lifetime_dependence_use") {
   _ = printer.walkDown(dependence: dependence)
 }
 
+let lifetimeDependenceRootTest = FunctionTest("lifetime_dependence_root") {
+    function, arguments, context in
+  let value = arguments.takeValue()
+  print("Lifetime dependence roots of: \(value)")
+  var walker = LifetimeDependenceRootWalker(context, scopedValue: value)
+  let result = walker.walkUp(newLifetime: value)
+  assert(result == .continueWalk)
+  for root in walker.roots {
+    print("root: \(root)")
+  }
+  walker.deinitialize()
+}
 
 // SIL Unit tests
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -638,7 +638,7 @@ extension LifetimeDependenceDefUseWalker {
          is DestroyNotEscapedClosureInst, is ClassMethodInst, is SuperMethodInst,
          is ClassifyBridgeObjectInst, is DebugValueInst,
          is ObjCMethodInst, is ObjCSuperMethodInst, is UnmanagedRetainValueInst,
-         is UnmanagedReleaseValueInst, is SelectEnumInst:
+         is UnmanagedReleaseValueInst, is SelectEnumInst, is IgnoredUseInst:
       // Catch .instantaneousUse operations that are dependence leaf uses.
       return leafUse(of: operand)
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -456,7 +456,7 @@ extension Instruction {
     }
   }
 
-  /// Returns true if `otherInst` is in the same block and dominated by this instruction.
+  /// Returns true if `otherInst` is in the same block and is strictly dominated by this instruction.
   /// To be used as simple dominance check if both instructions are most likely located in the same block
   /// and no DominatorTree is available (like in instruction simplification).
   func dominatesInSameBlock(_ otherInst: Instruction) -> Bool {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -160,6 +160,7 @@ public func registerOptimizerTests() {
     enclosingValuesTest,
     forwardingDefUseTest,
     forwardingUseDefTest,
+    gatherCallSitesTest,
     interiorLivenessTest,
     lifetimeDependenceScopeTest,
     lifetimeDependenceUseTest,
@@ -167,10 +168,10 @@ public func registerOptimizerTests() {
     localVariableReachableUsesTest,
     localVariableReachingAssignmentsTest,
     parseTestSpecificationTest,
-    variableIntroducerTest,
-    gatherCallSitesTest,
+    rangeOverlapsPathTest,
+    rewrittenCallerBodyTest,
     specializedFunctionSignatureAndBodyTest,
-    rewrittenCallerBodyTest
+    variableIntroducerTest
   )
 
   // Finally register the thunk they all call through.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -162,6 +162,7 @@ public func registerOptimizerTests() {
     forwardingUseDefTest,
     gatherCallSitesTest,
     interiorLivenessTest,
+    lifetimeDependenceRootTest,
     lifetimeDependenceScopeTest,
     lifetimeDependenceUseTest,
     linearLivenessTest,

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1474,7 +1474,7 @@ final public class LoadBorrowInst : SingleValueInstruction, LoadInstruction, Bor
 }
 
 final public class StoreBorrowInst : SingleValueInstruction, StoringInstruction, BorrowIntroducingInstruction {
-  var allocStack: AllocStackInst {
+  public var allocStack: AllocStackInst {
     var dest = destination
     if let mark = dest as? MarkUnresolvedNonCopyableValueInst {
       dest = mark.operand.value

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -149,7 +149,8 @@ public class Instruction : CustomStringConvertible, Hashable {
   /// their operand.
   public final var isIncidentalUse: Bool {
     switch self {
-    case is DebugValueInst, is FixLifetimeInst, is EndLifetimeInst:
+    case is DebugValueInst, is FixLifetimeInst, is EndLifetimeInst,
+         is IgnoredUseInst:
       return true
     default:
       return isEndOfScopeMarker

--- a/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
@@ -556,10 +556,6 @@ public struct AccessBaseAndScopes {
     self.scopes = scopes
   }
 
-  public var outerAddress: Value? {
-    base.address ?? scopes.last?.address
-  }
-
   public var enclosingAccess: EnclosingAccessScope {
     return scopes.first ?? .base(base)
   }

--- a/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
@@ -89,6 +89,8 @@ public enum AccessBase : CustomStringConvertible, Hashable {
 
   /// The access base is some SIL pattern which does not fit into any other case.
   /// This should be a very rare situation.
+  ///
+  /// TODO: unidentified should preserve its base address value, but AccessBase must be Hashable.
   case unidentified
 
   public init(baseAddress: Value) {

--- a/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/WalkUtils.swift
@@ -39,10 +39,11 @@ public enum WalkResult {
 }
 
 extension Sequence {
+  // Walk each element until the walk aborts.
   public func walk(
-    _ predicate: (Element) throws -> WalkResult
+    _ walker: (Element) throws -> WalkResult
   ) rethrows -> WalkResult {
-    return try contains { try predicate($0) == .abortWalk } ? .abortWalk : .continueWalk
+    return try contains { try walker($0) == .abortWalk } ? .abortWalk : .continueWalk
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_util.sil
@@ -6,7 +6,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
 
-sil_stage canonical
+sil_stage raw
 
 import Builtin
 
@@ -90,6 +90,34 @@ entry(%0 : @owned $C):
   destroy_value %move : $C
   %99 = tuple()
   return %99 : $()
+}
+
+sil hidden [ossa] @testRootForTemp : $@convention(thin) () -> () {
+bb0:
+  %varC = alloc_box ${ var C }, var, name "ne"
+  %borrowC = begin_borrow [lexical] [var_decl] %varC
+  %addrC = project_box %borrowC, 0
+
+  %finit = function_ref @getC : $@convention(thin) () -> @owned C
+  %newC = apply %finit() : $@convention(thin) () -> @owned C
+  store %newC to [init] %addrC
+
+  %accessC = begin_access [read] [unknown] %addrC
+  %tempC = load [copy] %accessC
+  end_access %accessC
+  specify_test "lifetime_dependence_root %tempC"
+// CHECK-LABEL: testRootForTemp: lifetime_dependence_root with: %tempC
+// CHECK: Lifetime dependence roots of: {{%.*}} = load [copy] %{{.*}} : $*C
+// CHECK: root: %{{.*}} = begin_access [read] [unknown] %{{.*}} : $*C
+// CHECK-LABEL: end running test 1 of 1 on testRootForTemp: lifetime_dependence_root with: %tempC
+
+  destroy_value %tempC
+
+  end_borrow %borrowC
+  destroy_value %varC
+
+  %99 = tuple ()
+  return %99
 }
 
 sil [ossa] @dependence_scope : $@convention(thin) (@owned C, @owned D, @guaranteed D, @in_guaranteed D, @inout D) -> () {

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -43,6 +43,10 @@ struct TrivialHolder {
   var pointer: UnsafeRawPointer
 }
 
+struct A {
+  init()
+}
+
 struct Holder {
   var object: AnyObject
 }
@@ -58,6 +62,9 @@ sil @useNE : $@convention(thin) (@guaranteed NE) -> ()
 sil [ossa] @Wrapper_init : $@convention(method) (@owned NE, @thin Wrapper.Type) -> @lifetime(copy 0) @owned Wrapper
 
 sil [ossa] @NCContainer_ne_read : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed NE
+
+sil @yieldRawSpan : $@yield_once @convention(method) (@in_guaranteed A) -> @lifetime(borrow address_for_deps 0) @yields @guaranteed RawSpan
+sil @useRawSpan : $@convention(thin) (@guaranteed RawSpan) -> ()
 
 // NCContainer.wrapper._read:
 //   var wrapper: Wrapper {
@@ -236,4 +243,36 @@ bb0(%0 : @guaranteed $Holder):
   destroy_value %nevar
   %99 = tuple ()
   return %99 : $()
+}
+
+// FIXME: extend temporary lifetimes for coroutine access.
+//
+// CHECK-LABEL: sil [ossa] @testYieldSpan : $@convention(thin) (@in A) -> () {
+// CHECK:   alloc_stack [lexical] [var_decl] $A
+// CHECK:   (%{{.*}}, %{{.*}}) = begin_apply %{{.*}}(%{{.*}}) : $@yield_once @convention(method) (@in_guaranteed A) -> @lifetime(borrow address_for_deps 0) @yields @guaranteed RawSpan
+// CHECK:   [[MD:%.*]] = mark_dependence [unresolved]
+// CHECK:   [[CP:%.*]] = copy_value [[MD]]
+// CHECK:   apply %{{.*}}([[CP]]) : $@convention(thin) (@guaranteed RawSpan) -> ()
+// CHECK:   destroy_value [[CP]]
+// CHECK:   end_apply
+// CHECK:   destroy_addr
+// CHECK-LABEL: } // end sil function 'testYieldSpan'
+sil [ossa] @testYieldSpan : $@convention(thin) (@in A) -> () {
+bb0(%0 : $*A):
+  %1 = alloc_stack [lexical] [var_decl] $A
+  copy_addr [take] %0 to [init] %1
+
+  %3 = function_ref @yieldRawSpan : $@yield_once @convention(method) (@in_guaranteed A) -> @lifetime(borrow address_for_deps 0) @yields @guaranteed RawSpan
+  (%4, %5) = begin_apply %3(%1) : $@yield_once @convention(method) (@in_guaranteed A) -> @lifetime(borrow address_for_deps 0) @yields @guaranteed RawSpan
+  %6 = mark_dependence [unresolved] %4 on %5
+  %7 = copy_value %6
+  %8 = end_apply %5 as $()
+
+  %9 = function_ref @useRawSpan : $@convention(thin) (@guaranteed RawSpan) -> ()
+  %10 = apply %9(%7) : $@convention(thin) (@guaranteed RawSpan) -> ()
+  destroy_value %7
+  destroy_addr %1
+  dealloc_stack %1
+  %14 = tuple ()
+  return %14
 }

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -47,12 +47,21 @@ struct A {
   init()
 }
 
+struct B: ~Copyable, ~Escapable {
+  let ne: NE
+
+  deinit
+}
+
 struct Holder {
   var object: AnyObject
 }
 
 @_addressableForDependencies
 struct AddressableForDeps {}
+
+sil @getNEPointerToA : $@convention(thin) (@guaranteed NE) -> UnsafePointer<A>
+sil @useA : $@convention(thin) (A) -> ()
 
 sil @getPtr : $@convention(thin) () -> @out UnsafeRawPointer
 sil @getSpan : $@convention(thin) (@in_guaranteed AnyObject) -> @lifetime(borrow 0) @out NE
@@ -379,4 +388,54 @@ bb0:
 
   %99 = tuple ()
   return %99
+}
+
+// =============================================================================
+// Reduced bugs
+// =============================================================================
+
+// rdar149226564 (Compiler crash with non-escapable storing another non-escapable and having a deinit)
+//
+// Test that initializing LifetimeDependence.Scope from an unidentified enclosing access scope does not
+// unwrap nil.
+//
+// TODO: the mark_dependence should redirect to the drop_deinit, not the struct_element_addr, but AccessBase does not
+// currently preserve the address of an unidentified base.
+//
+// CHECK-LABEL: sil hidden [ossa] @testUnidentified : $@convention(method) (@owned B) -> () {
+// CHECK: [[DD:%.*]] = drop_deinit
+// CHECK: [[SE:%.*]] = struct_element_addr [[DD]], #B.ne
+// CHECK: [[LB:%.*]] = load_borrow
+// CHECK: apply %{{.*}} : $@convention(thin) (@guaranteed NE) -> UnsafePointer<A>
+// CHECK: mark_dependence [unresolved] %{{.*}} on [[SE]]
+// CHECK-LABEL: } // end sil function 'testUnidentified'
+sil hidden [ossa] @testUnidentified : $@convention(method) (@owned B) -> () {
+bb0(%0 : @owned $B):
+  %1 = alloc_stack $B, let, name "self", argno 1
+  %2 = mark_unresolved_non_copyable_value [consumable_and_assignable] %1
+  store %0 to [init] %2
+  %4 = drop_deinit %2
+  debug_value %4, let, name "self", argno 1, expr op_deref
+  %6 = struct_element_addr %4, #B.ne
+  %7 = load_borrow %6
+
+  %8 = function_ref @getNEPointerToA : $@convention(thin) (@guaranteed NE) -> UnsafePointer<A>
+  %9 = apply %8(%7) : $@convention(thin) (@guaranteed NE) -> UnsafePointer<A>
+  %10 = struct_extract %9, #UnsafePointer._rawValue
+  %11 = pointer_to_address %10 to [strict] $*A
+  %12 = mark_dependence [unresolved] %11 on %7
+  %13 = begin_access [read] [unsafe] %12
+  %14 = load [trivial] %13
+  end_access %13
+
+  %16 = function_ref @useA : $@convention(thin) (A) -> ()
+  %17 = apply %16(%14) : $@convention(thin) (A) -> ()
+  end_borrow %7
+  %19 = struct_element_addr %4, #B.ne
+  %20 = begin_access [deinit] [static] %19
+  destroy_addr %20
+  end_access %20
+  dealloc_stack %1
+  %24 = tuple ()
+  return %24
 }

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -66,6 +66,9 @@ sil [ossa] @NCContainer_ne_read : $@yield_once @convention(method) (@guaranteed 
 sil @yieldRawSpan : $@yield_once @convention(method) (@in_guaranteed A) -> @lifetime(borrow address_for_deps 0) @yields @guaranteed RawSpan
 sil @useRawSpan : $@convention(thin) (@guaranteed RawSpan) -> ()
 
+sil @initHolder : $@convention(method) (@thin Holder.Type) -> @owned Holder
+sil @readAccess : $@yield_once @convention(method) (@guaranteed Holder) -> @lifetime(borrow 0) @yields @guaranteed NE
+
 // NCContainer.wrapper._read:
 //   var wrapper: Wrapper {
 //     _read {
@@ -198,6 +201,44 @@ bb0(%0 : @guaranteed $Holder):
   return %99 : $()
 }
 
+// Avoid extending a store_borrow with a small allocation range.
+//
+// CHECK-LABEL: sil hidden [ossa] @testSmallStoreBorrow : $@convention(thin) (@guaranteed Holder) -> () {
+// CHECK: bb0(%0 : @guaranteed $Holder):
+// CHECK: [[BORROWA:%.*]] = begin_borrow %0
+// CHECK: [[ALLOC:%.*]] = alloc_stack $Holder
+// CHECK: [[SB:%.*]] = store_borrow [[BORROWA]] to [[ALLOC]]
+// CHECK: [[APPLY:%.*]] = apply %{{.*}}([[SB]]) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
+// CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[APPLY]] on [[SB]]
+// CHECK: end_borrow [[SB]]
+// CHECK: dealloc_stack [[ALLOC]]
+// CHECK: end_borrow [[BORROWA]]
+// CHECK: [[MV:%.*]] = move_value [var_decl] [[MD]]
+// CHECK: apply %{{.*}}([[MV]]) : $@convention(thin) (@guaranteed NE) -> ()
+// CHECK: destroy_value [[MV]]
+// CHECK-LABEL: } // end sil function 'testSmallStoreBorrow'
+sil hidden [ossa] @testSmallStoreBorrow : $@convention(thin) (@guaranteed Holder) -> () {
+bb0(%0 : @guaranteed $Holder):
+  debug_value %0, let, name "arg", argno 1
+  %borrow0a = begin_borrow %0 : $Holder
+  // store-borrow
+  %sballoc = alloc_stack $Holder
+  %sb = store_borrow %borrow0a to %sballoc
+  %fdep = function_ref @addressableArg : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
+  %ne = apply %fdep(%sb) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address 0) @owned NE
+  %nedep = mark_dependence [unresolved] %ne on %sb
+  end_borrow %sb
+  dealloc_stack %sballoc
+  end_borrow %borrow0a : $Holder
+  %nevar = move_value [var_decl] %nedep
+  debug_value %nevar, let, name "ne"
+  %fuse = function_ref @useNE : $@convention(thin) (@guaranteed NE) -> ()
+  %user = apply %fuse(%nevar) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %nevar
+  %99 = tuple ()
+  return %99 : $()
+}
+
 // CHECK-LABEL: sil hidden [ossa] @testIndirectYield : $@convention(thin) (@guaranteed Holder) -> () {
 // CHECK: bb0(%0 : @guaranteed $Holder):
 // CHECK: [[BORROW0A:%.*]] = begin_borrow %0
@@ -275,4 +316,67 @@ bb0(%0 : $*A):
   dealloc_stack %1
   %14 = tuple ()
   return %14
+}
+
+// =============================================================================
+// Owned value extension
+// =============================================================================
+
+// Handle direct _read accessor. Extend the coroutine scope and extend the lifetime of the coroutine's guaranteed
+// argument.
+//
+// CHECK-LABEL: sil hidden [ossa] @testNestedCoro : $@convention(thin) () -> () {
+// CHECK: [[SPAN:%.*]] = alloc_box ${ var NE }, var, name "span"
+// CHECK: [[BORROW:%.*]] = begin_borrow [var_decl] [[SPAN]]
+// CHECK: [[A1:%.*]] = begin_access [read] [unknown] %2
+// CHECK: [[LD:%.*]] = load [copy] [[A1]]
+// CHECK: end_access [[A1]]
+// CHECK: (%{{.*}}, [[TOKEN:%.*]]) = begin_apply %13([[LD]]) : $@yield_once @convention(method) (@guaranteed Holder) -> @lifetime(borrow 0) @yields @guaranteed NE
+// CHECK: ignored_use [[DEP:%[0-9]+]]
+// CHECK: destroy_value [[DEP]]
+// CHECK: end_apply [[TOKEN]] as $()
+// CHECK: destroy_value [[LD]]
+// CHECK: end_borrow [[BORROW]]
+// CHECK-LABEL: } // end sil function 'testNestedCoro'
+sil hidden [ossa] @testNestedCoro : $@convention(thin) () -> () {
+bb0:
+  %varH = alloc_box ${ var Holder }, var, name "h"
+  %borrowH = begin_borrow [lexical] [var_decl] %varH
+  %addrH = project_box %borrowH, 0
+  %metaH = metatype $@thin Holder.Type
+
+  %finit = function_ref @initHolder : $@convention(method) (@thin Holder.Type) -> @owned Holder
+  %newH = apply %finit(%metaH) : $@convention(method) (@thin Holder.Type) -> @owned Holder
+  store %newH to [init] %addrH
+
+  %varSpan = alloc_box ${ var NE }, var, name "span"
+  %borrowSpan = begin_borrow [var_decl] %varSpan
+  %addrSpan = project_box %borrowSpan, 0
+
+  %accessH = begin_access [read] [unknown] %addrH
+  %tempH = load [copy] %accessH
+  end_access %accessH
+
+  %fread = function_ref @readAccess : $@yield_once @convention(method) (@guaranteed Holder) -> @lifetime(borrow 0) @yields @guaranteed NE
+  (%yieldSpan, %token) = begin_apply %fread(%tempH) : $@yield_once @convention(method) (@guaranteed Holder) -> @lifetime(borrow 0) @yields @guaranteed NE
+  %depSpan = mark_dependence [unresolved] %yieldSpan on %token
+  %copySpan = copy_value %depSpan
+  %endCoro = end_apply %token as $()
+  destroy_value %tempH
+
+  store %copySpan to [init] %addrSpan
+  %accessSpan = begin_access [read] [unknown] %addrSpan
+  %span = load [copy] %accessSpan
+  end_access %accessSpan
+  ignored_use %span
+  destroy_value %span
+
+  end_borrow %borrowSpan
+  destroy_value %varSpan
+
+  end_borrow %borrowH
+  destroy_value %varH
+
+  %99 = tuple ()
+  return %99
 }

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -512,9 +512,6 @@ func testExprExtendTrivialTemp(outer: Outer) {
 
 func testExprExtendObjectTemp(outer: Outer) {
   parse(outer.innerObjectTemp.span())
-  // expected-error @-1{{lifetime-dependent value escapes its scope}}
-  // expected-note  @-2{{it depends on the lifetime of this parent value}}
-  // expected-note  @-3{{this use of the lifetime-dependent value is out of scope}}
 }
 
 func testLocalExtendTrivialTemp(outer: Outer) {
@@ -524,9 +521,7 @@ func testLocalExtendTrivialTemp(outer: Outer) {
 
 func testLocalExtendObjectTemp(outer: Outer) {
   let span = outer.innerObjectTemp.span()
-  // expected-error @-1{{lifetime-dependent variable 'span' escapes its scope}}
-  // expected-note  @-2{{it depends on the lifetime of this parent value}}
-  parse(span) // expected-note {{this use of the lifetime-dependent value is out of scope}}
+  parse(span)
 }
 
 @lifetime(borrow outer)

--- a/test/SILOptimizer/range_unit.sil
+++ b/test/SILOptimizer/range_unit.sil
@@ -1,0 +1,420 @@
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+class C {}
+
+// CHECK-LABEL: testIdentity: range_overlaps_path
+// CHECK: Overlap kind: containsBegin
+sil [ossa] @testIdentity : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %range"
+  %range = begin_borrow %0
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsPath1: range_overlaps_path
+// CHECK: Overlap kind: containsPath
+sil [ossa] @testContainsPath1 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  %path = begin_borrow %0
+  end_borrow %path
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsPath2: range_overlaps_path
+// CHECK: Overlap kind: containsPath
+sil [ossa] @testContainsPath2 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  br bb1
+bb1:
+  %path = begin_borrow %0
+  end_borrow %path
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsPath3: range_overlaps_path
+// CHECK: Overlap kind: containsPath
+sil [ossa] @testContainsPath3 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  br bb1
+bb1:
+  %path = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %path
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsPath4: range_overlaps_path
+// CHECK: Overlap kind: containsPath
+sil [ossa] @testContainsPath4 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  br bb1
+bb1:
+  %path = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %path
+  br bb3
+bb3:
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsBegin1: range_overlaps_path
+// CHECK: Overlap kind: containsBegin
+sil [ossa] @testContainsBegin1 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  %path = begin_borrow %0
+  end_borrow %range
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsBegin2: range_overlaps_path
+// CHECK: Overlap kind: containsBegin
+sil [ossa] @testContainsBegin2 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  br bb1
+bb1:
+  %path = begin_borrow %0
+  end_borrow %range
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsBegin3: range_overlaps_path
+// CHECK: Overlap kind: containsBegin
+sil [ossa] @testContainsBegin3 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  br bb1
+bb1:
+  %path = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %range
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsBegin4: range_overlaps_path
+// CHECK: Overlap kind: containsBegin
+sil [ossa] @testContainsBegin4 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  br bb1
+bb1:
+  %path = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %range
+  br bb3
+bb3:
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsEnd1: range_overlaps_path
+// CHECK: Overlap kind: containsEnd
+sil [ossa] @testContainsEnd1 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  %range = begin_borrow %0
+  end_borrow %path
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsEnd2: range_overlaps_path
+// CHECK: Overlap kind: containsEnd
+sil [ossa] @testContainsEnd2 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  %range = begin_borrow %0
+  end_borrow %path
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsEnd3: range_overlaps_path
+// CHECK: Overlap kind: containsEnd
+sil [ossa] @testContainsEnd3 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  %range = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %path
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testContainsEnd4: range_overlaps_path
+// CHECK: Overlap kind: containsEnd
+sil [ossa] @testContainsEnd4 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  %range = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %path
+  br bb3
+bb3:
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testOverlappedByPath1: range_overlaps_path
+// CHECK: Overlap kind: overlappedByPath
+sil [ossa] @testOverlappedByPath1 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  %range = begin_borrow %0
+  end_borrow %range
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testOverlappedByPath2: range_overlaps_path
+// CHECK: Overlap kind: overlappedByPath
+sil [ossa] @testOverlappedByPath2 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  %range = begin_borrow %0
+  end_borrow %range
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testOverlappedByPath3: range_overlaps_path
+// CHECK: Overlap kind: overlappedByPath
+sil [ossa] @testOverlappedByPath3 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  %range = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %range
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testOverlappedByPath4: range_overlaps_path
+// CHECK: Overlap kind: overlappedByPath
+sil [ossa] @testOverlappedByPath4 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  %range = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %range
+  br bb3
+bb3:
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testOverlappedByPath5: range_overlaps_path
+// CHECK: Overlap kind: overlappedByPath
+sil [ossa] @testOverlappedByPath5 : $@convention(thin) (@owned C, @owned C) -> () {
+entry(%0 : @owned $C, %1 : @owned $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = move_value %0
+  %range = move_value %1
+  %tuple = tuple (%path, %range)
+  destroy_value %tuple
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint1: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint1 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  end_borrow %path
+  %range = begin_borrow %0
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint2: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint2 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  end_borrow %range
+  %path = begin_borrow %0
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint3: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint3 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  end_borrow %range
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint4: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint4 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  end_borrow %path
+  %range = begin_borrow %0
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint5: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint5 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = begin_borrow %0
+  br bb1
+bb1:
+  end_borrow %range
+  %path = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %path
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint6: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint6 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  end_borrow %path
+  %range = begin_borrow %0
+  br bb2
+bb2:
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint7: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint7 : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = begin_borrow %0
+  br bb1
+bb1:
+  end_borrow %path
+  br bb2
+bb2:
+  %range = begin_borrow %0
+  br bb3
+bb3:
+  end_borrow %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint8: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint8 : $@convention(thin) (@owned C) -> () {
+entry(%0 : @owned $C):
+  specify_test "range_overlaps_path %range %path"
+  %path = move_value %0
+  %range = move_value %path
+  destroy_value %range
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: testDisjoint9: range_overlaps_path
+// CHECK: Overlap kind: disjoint
+sil [ossa] @testDisjoint9 : $@convention(thin) (@owned C) -> () {
+entry(%0 : @owned $C):
+  specify_test "range_overlaps_path %range %path"
+  %range = move_value %0
+  %path = move_value %range
+  destroy_value %path
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Add support for extending owned temporary values in addition to access scopes and borrow scopes. Required for _read accessors in which the coroutine depends on an owned value.

Fix unidentified LifetimeDependence.Scope initialization.

Fixes rdar://148540048 (Assigning span value to _ results in an incorrect escape diagnostic)

Fixes rdar://149226564 (Compiler crash with non-escapable storing another
non-escapable and having a deinit)

main PR: https://github.com/swiftlang/swift/pull/80848