### PR TITLE
CMake: SwiftCore: Directory Swift Modules

### DIFF
--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -9,63 +9,74 @@ function(emit_swift_interface target)
   # Generate the target-variant binary swift module when performing zippered
   # build
   if(SwiftCore_VARIANT_MODULE_TRIPLE)
-    set(variant_module_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}")
-    file(MAKE_DIRECTORY "${variant_module_tmp_dir}")
+    # Clean this up once CMake has nested swiftmodules in the build directory:
+    # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10664
+
+    # We can't expand the Swift_MODULE_NAME target property in a generator
+    # expression or it will fail saying that the target doesn't exist.
+    get_target_property(module_name ${target} Swift_MODULE_NAME)
+    if(NOT module_name)
+      set(module_name ${target})
+    endif()
     target_compile_options(${target} PRIVATE
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${variant_module_tmp_dir}/${target}.swiftmodule>")
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule>"
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>")
+    add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
+      DEPENDS ${target})
+    target_sources(${target}
+      INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule>)
   endif()
 
   # Generate textual swift interfaces is library-evolution is enabled
   if(SwiftCore_ENABLE_LIBRARY_EVOLUTION)
+    # Emit catalyst swiftmodules and interfaces
+    if(SwiftCore_VARIANT_MODULE_TRIPLE)
+      target_compile_options(${target} PRIVATE
+        $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftinterface>
+        $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.private.swiftinterface>
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
+    else()
+      target_compile_options(${target} PRIVATE
+        $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface>
+        $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface>)
+    endif()
     target_compile_options(${target} PRIVATE
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface>
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface>
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>
       $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend$<SEMICOLON>-require-explicit-availability=ignore>)
-
-      # Emit catalyst swiftmodules and interfaces
-      if(SwiftCore_VARIANT_MODULE_TRIPLE)
-        target_compile_options(${target} PRIVATE
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${variant_module_tmp_dir}/${target}.swiftinterface>"
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${variant_module_tmp_dir}/${target}.private.swiftinterface>")
-      endif()
   endif()
 endfunction()
 
 # Install the generated swift interface file for the target if library evolution
 # is enabled.
 function(install_swift_interface target)
-  # Install binary swift modules
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-    RENAME "${SwiftCore_MODULE_TRIPLE}.swiftmodule"
-    DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-    COMPONENT SwiftCore_development)
   if(SwiftCore_VARIANT_MODULE_TRIPLE)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftmodule"
-      RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
-      DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT SwiftCore_development)
-  endif()
+    # Swiftmodules are already in the directory structure if we are doing a
+    # catalyst build. Just copy the entire directory.
+    get_target_property(module_name ${target} Swift_MODULE_NAME)
+    if(NOT module_name)
+      set(module_name ${target})
+    endif()
 
-  # Install Swift interfaces if library-evolution is enabled
-  if(SwiftCore_ENABLE_LIBRARY_EVOLUTION)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface"
-      RENAME "${SwiftCore_MODULE_TRIPLE}.swiftinterface"
-      DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+    install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
+      DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}"
       COMPONENT SwiftCore_development)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface"
-      RENAME "${SwiftCore_MODULE_TRIPLE}.private.swiftinterface"
+  else()
+    # Install binary swift modules
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+      RENAME "${SwiftCore_MODULE_TRIPLE}.swiftmodule"
       DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
       COMPONENT SwiftCore_development)
 
-    # Install catalyst interface files
-    if(SwiftCore_VARIANT_MODULE_TRIPLE)
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftinterface"
-        RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface"
+    # Install Swift interfaces if library-evolution is enabled
+    if(SwiftCore_ENABLE_LIBRARY_EVOLUTION)
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface"
+        RENAME "${SwiftCore_MODULE_TRIPLE}.swiftinterface"
         DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
         COMPONENT SwiftCore_development)
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.private.swiftinterface"
-        RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface"
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface"
+        RENAME "${SwiftCore_MODULE_TRIPLE}.private.swiftinterface"
         DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
         COMPONENT SwiftCore_development)
     endif()


### PR DESCRIPTION
The catalyst support in the driver requires that the swiftmodules for the catalyst slice live in the swiftmodule directory. CMake currently doesn't do this natively so this patch works around it by specifying the module path explicitly. The use of an empty custom command is used to hook up the dependency graph on the specific target swiftmodule files correctly.

This is only needed for catalyst builds that this time so limit the affect of this change to instances where we are building zippered catalyst binaries.

The nested structure also greatly simplifies the installation story. We simply need to copy the entire swiftmodule directory into the install location.

I'm not enabling this always since it's not clear to me that the dependency edge on the actual binary swiftmodule file is being created consistently. This is fine for clean builds since the swiftmodule directory and swiftmodule file are created in the same invocation, but might break dependency tracking in incremental builds.

This is a workaround until we can use [CMP0195](https://cmake.org/cmake/help/git-stage/policy/CMP0195.html) --https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10664