### PR TITLE
IRGen: fix a compiler warning

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -862,6 +862,40 @@ CanType irgen::getArgumentLoweringType(CanType type, SILParameterInfo paramInfo,
   llvm_unreachable("unhandled convention");
 }
 
+llvm::Constant *irgen::getCoroFrameAllocStubFn(IRGenModule &IGM) {
+  return IGM.getOrCreateHelperFunction(
+    "__swift_coroFrameAllocStub", IGM.Int8PtrTy,
+    {IGM.SizeTy, IGM.Int64Ty},
+    [&](IRGenFunction &IGF) {
+      auto parameters = IGF.collectParameters();
+      auto *size = parameters.claimNext();
+      auto coroAllocPtr = IGF.IGM.getCoroFrameAllocFn();
+      auto coroAllocFn = dyn_cast<llvm::Function>(coroAllocPtr);
+      coroAllocFn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
+      auto *coroFrameAllocFn = IGF.IGM.getOpaquePtr(coroAllocPtr);
+      auto *nullSwiftCoroFrameAlloc = IGF.Builder.CreateCmp(
+        llvm::CmpInst::Predicate::ICMP_NE, coroFrameAllocFn,
+        llvm::ConstantPointerNull::get(
+            cast<llvm::PointerType>(coroFrameAllocFn->getType())));
+      auto *coroFrameAllocReturn = IGF.createBasicBlock("return-coroFrameAlloc");
+      auto *mallocReturn = IGF.createBasicBlock("return-malloc");
+      IGF.Builder.CreateCondBr(nullSwiftCoroFrameAlloc, coroFrameAllocReturn, mallocReturn);
+
+      IGF.Builder.emitBlock(coroFrameAllocReturn);
+      auto *mallocTypeId = parameters.claimNext();
+      auto *coroFrameAllocCall = IGF.Builder.CreateCall(IGF.IGM.getCoroFrameAllocFunctionPointer(), {size, mallocTypeId});
+      IGF.Builder.CreateRet(coroFrameAllocCall);
+
+      IGF.Builder.emitBlock(mallocReturn);
+      auto *mallocCall = IGF.Builder.CreateCall(IGF.IGM.getMallocFunctionPointer(), {size});
+      IGF.Builder.CreateRet(mallocCall);
+    },
+    /*setIsNoInline=*/false,
+    /*forPrologue=*/false,
+    /*isPerformanceConstraint=*/false,
+    /*optionalLinkageOverride=*/nullptr, llvm::CallingConv::C);
+}
+
 static Size getOffsetOfOpaqueIsolationField(IRGenModule &IGM,
                                       const LoadableTypeInfo &isolationTI) {
   auto offset = IGM.RefCountedStructSize;

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -64,39 +64,7 @@ namespace irgen {
 
   /// Stub function that weakly links againt the swift_coroFrameAlloc
   /// function. This is required for back-deployment.
-  static llvm::Constant *getCoroFrameAllocStubFn(IRGenModule &IGM) {
-  return IGM.getOrCreateHelperFunction(
-    "__swift_coroFrameAllocStub", IGM.Int8PtrTy,
-    {IGM.SizeTy, IGM.Int64Ty},
-    [&](IRGenFunction &IGF) {
-      auto parameters = IGF.collectParameters();
-      auto *size = parameters.claimNext();
-      auto coroAllocPtr = IGF.IGM.getCoroFrameAllocFn();
-      auto coroAllocFn = dyn_cast<llvm::Function>(coroAllocPtr);
-      coroAllocFn->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
-      auto *coroFrameAllocFn = IGF.IGM.getOpaquePtr(coroAllocPtr);
-      auto *nullSwiftCoroFrameAlloc = IGF.Builder.CreateCmp(
-        llvm::CmpInst::Predicate::ICMP_NE, coroFrameAllocFn,
-        llvm::ConstantPointerNull::get(
-            cast<llvm::PointerType>(coroFrameAllocFn->getType())));
-      auto *coroFrameAllocReturn = IGF.createBasicBlock("return-coroFrameAlloc");
-      auto *mallocReturn = IGF.createBasicBlock("return-malloc");
-      IGF.Builder.CreateCondBr(nullSwiftCoroFrameAlloc, coroFrameAllocReturn, mallocReturn);
-
-      IGF.Builder.emitBlock(coroFrameAllocReturn);
-      auto *mallocTypeId = parameters.claimNext();
-      auto *coroFrameAllocCall = IGF.Builder.CreateCall(IGF.IGM.getCoroFrameAllocFunctionPointer(), {size, mallocTypeId});
-      IGF.Builder.CreateRet(coroFrameAllocCall);
-
-      IGF.Builder.emitBlock(mallocReturn);
-      auto *mallocCall = IGF.Builder.CreateCall(IGF.IGM.getMallocFunctionPointer(), {size});
-      IGF.Builder.CreateRet(mallocCall);
-    },
-    /*setIsNoInline=*/false,
-    /*forPrologue=*/false,
-    /*isPerformanceConstraint=*/false,
-    /*optionalLinkageOverride=*/nullptr, llvm::CallingConv::C);
-  }
+  llvm::Constant *getCoroFrameAllocStubFn(IRGenModule &IGM);
 } // end namespace irgen
 } // end namespace swift
 


### PR DESCRIPTION
Move a static inline function into the cpp file.
Fixes
```
warning: unused function 'getCoroFrameAllocStubFn'
```

NFC
