### PR TITLE
[6.2] [Runtime] Properly deallocate extended storage for conformance cache entries

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -563,14 +563,19 @@ namespace {
                           ConformanceLookupResult result)
       : Type(key.Type), Witness(result.witnessTable)
     {
-      if (result.globalActorIsolationType) {
-        ProtoOrStorage = new ExtendedStorage{
-          key.Proto, result.globalActorIsolationType,
-          result.globalActorIsolationWitnessTable
-        };
-      } else {
+      if (!result.globalActorIsolationType) {
         ProtoOrStorage = key.Proto;
+        return;
       }
+
+      // Allocate extended storage.
+      void *memory = malloc(sizeof(ExtendedStorage));
+      auto storage = new (memory) ExtendedStorage{
+        key.Proto, result.globalActorIsolationType,
+        result.globalActorIsolationWitnessTable
+      };
+
+      ProtoOrStorage = storage;
     }
 
     bool matchesKey(const ConformanceCacheKey &key) const {

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -536,7 +536,7 @@ namespace {
   };
 
   struct ConformanceCacheEntry {
-  private:
+  public:
     /// Storage used when we have global actor isolation on the conformance.
     struct ExtendedStorage {
       /// The protocol to which the type conforms.
@@ -549,10 +549,13 @@ namespace {
       /// When the conformance is global-actor-isolated, this is the conformance
       /// of globalActorIsolationType to GlobalActor.
       const WitnessTable *globalActorIsolationWitnessTable = nullptr;
+
+      /// The next pointer in the list of extended storage allocations.
+      ExtendedStorage *next = nullptr;
     };
 
     const Metadata *Type;
-    llvm::PointerUnion<const ProtocolDescriptor *, const ExtendedStorage *>
+    llvm::PointerUnion<const ProtocolDescriptor *, ExtendedStorage *>
         ProtoOrStorage;
 
     /// The witness table.
@@ -560,7 +563,8 @@ namespace {
 
   public:
     ConformanceCacheEntry(ConformanceCacheKey key,
-                          ConformanceLookupResult result)
+                          ConformanceLookupResult result,
+                          std::atomic<ExtendedStorage *> &storageHead)
       : Type(key.Type), Witness(result.witnessTable)
     {
       if (!result.globalActorIsolationType) {
@@ -576,6 +580,17 @@ namespace {
       };
 
       ProtoOrStorage = storage;
+
+      // Add the storage pointer to the list of extended storage allocations
+      // so that we can free them later.
+      auto head = storageHead.load(std::memory_order_relaxed);
+      while (true) {
+        storage->next = head;
+        if (storageHead.compare_exchange_weak(
+                head, storage, std::memory_order_release,
+                std::memory_order_relaxed))
+          break;
+      };
     }
 
     bool matchesKey(const ConformanceCacheKey &key) const {
@@ -591,7 +606,7 @@ namespace {
       if (auto proto = ProtoOrStorage.dyn_cast<const ProtocolDescriptor *>())
         return proto;
 
-      if (auto storage = ProtoOrStorage.dyn_cast<const ExtendedStorage *>())
+      if (auto storage = ProtoOrStorage.dyn_cast<ExtendedStorage *>())
         return storage->Proto;
 
       return nullptr;
@@ -611,7 +626,7 @@ namespace {
       if (ProtoOrStorage.is<const ProtocolDescriptor *>())
         return ConformanceLookupResult { Witness, nullptr, nullptr };
 
-      if (auto storage = ProtoOrStorage.dyn_cast<const ExtendedStorage *>()) {
+      if (auto storage = ProtoOrStorage.dyn_cast<ExtendedStorage *>()) {
         return ConformanceLookupResult(
             Witness, storage->globalActorIsolationType,
             storage->globalActorIsolationWitnessTable);
@@ -626,6 +641,11 @@ namespace {
 struct ConformanceState {
   ConcurrentReadableHashMap<ConformanceCacheEntry> Cache;
   ConcurrentReadableArray<ConformanceSection> SectionsToScan;
+
+  /// The head of an intrusive linked list that keeps track of all of the
+  /// conformance cache entries that require extended storage.
+  std::atomic<ConformanceCacheEntry::ExtendedStorage *> ExtendedStorageHead{nullptr};
+
   bool scanSectionsBackwards;
 
 #if USE_DYLD_SHARED_CACHE_CONFORMANCE_TABLES
@@ -714,7 +734,8 @@ struct ConformanceState {
                           return false; // abandon the new entry
 
                         ::new (entry) ConformanceCacheEntry(
-                            ConformanceCacheKey(type, proto), result);
+                            ConformanceCacheKey(type, proto), result,
+                            ExtendedStorageHead);
                         return true; // keep the new entry
                       });
   }
@@ -748,7 +769,20 @@ static void _registerProtocolConformances(ConformanceState &C,
 
   // Blow away the conformances cache to get rid of any negative entries that
   // may now be obsolete.
-  C.Cache.clear();
+  C.Cache.clear([&](ConcurrentFreeListNode *&freeListHead) {
+    // The extended storage for conformance entries will need to be freed
+    // eventually. Put it on the concurrent free list so the cache will do so.
+    auto storageHead = C.ExtendedStorageHead.load(std::memory_order_relaxed);
+    while (storageHead) {
+      auto current = storageHead;
+      auto newHead = current->next;
+      if (C.ExtendedStorageHead.compare_exchange_weak(
+              storageHead, newHead, std::memory_order_release,
+              std::memory_order_relaxed)) {
+        ConcurrentFreeListNode::add(&freeListHead, current);
+      }
+    }
+  });
 }
 
 void swift::addImageProtocolConformanceBlockCallbackUnsafe(


### PR DESCRIPTION
  - **Explanation**: When the conformance cache has to allocate an "extended" cache entry, which includes information about global actor isolation for the conformance, that memory was not being freed when the conformance cache is cleared, for example when a new shared library is loaded via `dlopen` or similar. Keep track of these allocations in a list, and move them over to the concurrent free list in the conformance cache when clearing the cache, so they will eventually be deallocated.
  - **Scope**: Limited to the conformance cache in the runtime, and only has an effect when using isolated conformances.
  - **Issues**: Noticed as part of rdar://149326058.
  - **Original PRs**: https://github.com/swiftlang/swift/pull/80865
  - **Risk**: Relatively low. It's some lock-free freelist handling in the runtime on top of an existing freelist mechanism, but in a very narrow place and fairly straightforward.
  - **Testing**: CI.
  - **Reviewers**: @al45tair 
