### PR TITLE
LargeTypesReg2Mem: Add unchecked_bitwise_cast to the projections we need to propagate largeness from destination to source operand

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3574,6 +3574,7 @@ void LargeLoadableHeuristic::propagate(PostOrderFunctionInfo &po) {
   for (auto *BB : po.getPostOrder()) {
     for (auto &I : llvm::reverse(*BB)) {
       switch (I.getKind()) {
+      case SILInstructionKind::UncheckedBitwiseCastInst:
       case SILInstructionKind::TupleExtractInst:
       case SILInstructionKind::StructExtractInst: {
         auto &proj = cast<SingleValueInstruction>(I);

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -425,3 +425,23 @@ bb0(%0 : $member_id_t):
   %13 = tuple ()
   return %13 : $()
 }
+
+struct Z {
+  var r: String
+  var p: X
+}
+
+// CHECK: sil @test17 : $@convention(thin) (@owned String) -> () {
+// CHECK: bb0(%0 : $String):
+// CHECK:   [[T0:%.*]] = alloc_stack $String
+// CHECK:   store %0 to [[T0]] : $*String
+// CHECK:   [[T1:%.*]] = unchecked_addr_cast [[T0]] : $*String to $*Z
+// CHECK:   release_value_addr [[T1]] : $*Z
+
+sil @test17: $@convention(thin) (@owned String) -> () {
+bb0(%0 : $String):
+  %1 = unchecked_bitwise_cast %0 : $String to $Z
+  release_value %1 : $Z
+  %13 = tuple ()
+  return %13 : $()
+}


### PR DESCRIPTION

rdar://148545382
