### PR TITLE
[6.2][AST] ASTPrinter: Improvements to specifier and attribute printing

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6911,6 +6911,9 @@ class ParamDecl : public VarDecl {
 
     /// Whether or not this parameter is 'sending'.
     IsSending = 1 << 4,
+
+    /// Whether or not this parameter is isolated to a caller.
+    IsCallerIsolated = 1 << 5,
   };
 
   /// The type repr and 3 bits used for flags.
@@ -7197,6 +7200,18 @@ public:
       addFlag(Flag::IsSending);
     else
       removeFlag(Flag::IsSending);
+  }
+
+  /// Whether or not this parameter is marked with 'nonisolated(nonsending)'.
+  bool isCallerIsolated() const {
+    return getOptions().contains(Flag::IsCallerIsolated);
+  }
+
+  void setCallerIsolated(bool value = true) {
+    if (value)
+      addFlag(Flag::IsCallerIsolated);
+    else
+      removeFlag(Flag::IsCallerIsolated);
   }
 
   /// Whether or not this parameter is marked with '@_addressable'.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3855,13 +3855,6 @@ static void printParameterFlags(ASTPrinter &printer,
     printer.printKeyword("nonisolated(nonsending)", options, " ");
   }
 
-  if (!options.excludeAttrKind(TypeAttrKind::Autoclosure) &&
-      flags.isAutoClosure())
-    printer.printAttrName("@autoclosure ");
-  if (!options.excludeAttrKind(TypeAttrKind::NoDerivative) &&
-      flags.isNoDerivative())
-    printer.printAttrName("@noDerivative ");
-
   switch (flags.getOwnershipSpecifier()) {
   case ParamSpecifier::Default:
     /*nothing*/
@@ -3907,15 +3900,22 @@ static void printParameterFlags(ASTPrinter &printer,
       printer.printKeyword("isolated", options, " ");
   }
 
+  if (flags.isCompileTimeLiteral())
+    printer.printKeyword("_const", options, " ");
+
+  if (!options.excludeAttrKind(TypeAttrKind::Autoclosure) &&
+      flags.isAutoClosure())
+    printer.printAttrName("@autoclosure ");
+  if (!options.excludeAttrKind(TypeAttrKind::NoDerivative) &&
+      flags.isNoDerivative())
+    printer.printAttrName("@noDerivative ");
+
   // `inout` implies `@escaping`
   if (flags.getOwnershipSpecifier() != ParamSpecifier::InOut) {
     if (!options.excludeAttrKind(TypeAttrKind::Escaping) && escaping)
       printer.printAttrName("@escaping ");
   }
 
-  if (flags.isCompileTimeLiteral())
-    printer.printKeyword("_const", options, " ");
-  
   if (flags.isConstValue())
     printer.printAttrName("@const ");
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3847,7 +3847,14 @@ static void printParameterFlags(ASTPrinter &printer,
                                 const PrintOptions &options,
                                 const ParamDecl *param,
                                 ParameterTypeFlags flags,
-                                bool escaping) {
+                                bool escaping,
+                                bool isIsolatedToCaller = false) {
+  // Always print `nonisolated(nonsending)` specifier on a parameter
+  // first, to avoid any issues with ordering.
+  if (isIsolatedToCaller) {
+    printer.printKeyword("nonisolated(nonsending)", options, " ");
+  }
+
   if (!options.excludeAttrKind(TypeAttrKind::Autoclosure) &&
       flags.isAutoClosure())
     printer.printAttrName("@autoclosure ");
@@ -4016,11 +4023,24 @@ void PrintAST::printOneParameter(const ParamDecl *param,
 
   printArgName();
 
+  auto interfaceTy = param->getInterfaceType();
+
+  // If type of this parameter is isolated to a caller, let's
+  // strip the isolation from the type to avoid printing it as
+  // part of the function type because that would break ordering
+  // between specifiers and attributes.
+  if (param->isCallerIsolated()) {
+    if (auto *funcTy = dyn_cast<AnyFunctionType>(interfaceTy.getPointer())) {
+      interfaceTy =
+          funcTy->withIsolation(FunctionTypeIsolation::forNonIsolated());
+    }
+  }
+
   TypeLoc TheTypeLoc;
   if (auto *repr = param->getTypeRepr()) {
-    TheTypeLoc = TypeLoc(repr, param->getInterfaceType());
+    TheTypeLoc = TypeLoc(repr, interfaceTy);
   } else {
-    TheTypeLoc = TypeLoc::withoutLoc(param->getInterfaceType());
+    TheTypeLoc = TypeLoc::withoutLoc(interfaceTy);
   }
 
   {
@@ -4032,7 +4052,8 @@ void PrintAST::printOneParameter(const ParamDecl *param,
         !willUseTypeReprPrinting(TheTypeLoc, CurrentType, Options)) {
       auto type = TheTypeLoc.getType();
       printParameterFlags(Printer, Options, param, paramFlags,
-                          isEscaping(type));
+                          isEscaping(type),
+                          param->isCallerIsolated());
     }
 
     printTypeLocForImplicitlyUnwrappedOptional(

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3907,8 +3907,11 @@ static void printParameterFlags(ASTPrinter &printer,
       printer.printKeyword("isolated", options, " ");
   }
 
-  if (!options.excludeAttrKind(TypeAttrKind::Escaping) && escaping)
-    printer.printKeyword("@escaping", options, " ");
+  // `inout` implies `@escaping`
+  if (flags.getOwnershipSpecifier() != ParamSpecifier::InOut) {
+    if (!options.excludeAttrKind(TypeAttrKind::Escaping) && escaping)
+      printer.printKeyword("@escaping", options, " ");
+  }
 
   if (flags.isCompileTimeLiteral())
     printer.printKeyword("_const", options, " ");

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3889,7 +3889,7 @@ static void printParameterFlags(ASTPrinter &printer,
 
   if (flags.isSending()) {
     if (!options.SuppressSendingArgsAndResults) {
-      printer.printAttrName("sending ");
+      printer.printKeyword("sending", options, " ");
     } else if (flags.getOwnershipSpecifier() ==
                ParamSpecifier::ImplicitlyCopyableConsuming) {
       // Ok. We are suppressing sending. If our ownership specifier was
@@ -3910,14 +3910,14 @@ static void printParameterFlags(ASTPrinter &printer,
   // `inout` implies `@escaping`
   if (flags.getOwnershipSpecifier() != ParamSpecifier::InOut) {
     if (!options.excludeAttrKind(TypeAttrKind::Escaping) && escaping)
-      printer.printKeyword("@escaping", options, " ");
+      printer.printAttrName("@escaping ");
   }
 
   if (flags.isCompileTimeLiteral())
     printer.printKeyword("_const", options, " ");
   
   if (flags.isConstValue())
-    printer.printKeyword("@const", options, " ");
+    printer.printAttrName("@const ");
 }
 
 void PrintAST::visitVarDecl(VarDecl *decl) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9010,6 +9010,12 @@ void ParamDecl::setTypeRepr(TypeRepr *repr) {
         continue;
       }
 
+      if (auto *callerIsolated =
+              dyn_cast<CallerIsolatedTypeRepr>(unwrappedType)) {
+        setCallerIsolated(true);
+        unwrappedType = callerIsolated->getBase();
+      }
+
       break;
     }
   }
@@ -11094,6 +11100,9 @@ AccessorDecl *AccessorDecl::createParsed(
 
       if (subscriptParam->isSending())
         param->setSending();
+
+      if (subscriptParam->isCallerIsolated())
+        param->setCallerIsolated();
 
       newParams.push_back(param);
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4117,6 +4117,7 @@ public:
     bool isIsolated;
     bool isCompileTimeLiteral, isConstValue;
     bool isSending;
+    bool isCallerIsolated;
     uint8_t rawDefaultArg;
     TypeID defaultExprType;
     uint8_t rawDefaultArgIsolation;
@@ -4129,6 +4130,7 @@ public:
                                          isCompileTimeLiteral,
                                          isConstValue,
                                          isSending,
+                                         isCallerIsolated,
                                          rawDefaultArg,
                                          defaultExprType,
                                          rawDefaultArgIsolation,
@@ -4174,6 +4176,7 @@ public:
     param->setCompileTimeLiteral(isCompileTimeLiteral);
     param->setConstValue(isConstValue);
     param->setSending(isSending);
+    param->setCallerIsolated(isCallerIsolated);
 
     // Decode the default argument kind.
     // FIXME: Default argument expression, if available.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 937; // remove @execution attr
+const uint16_t SWIFTMODULE_VERSION_MINOR = 938; // `isCallerIsolated` parameter flag
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1733,6 +1733,7 @@ namespace decls_block {
     BCFixed<1>,              // isCompileTimeLiteral?
     BCFixed<1>,              // isConst?
     BCFixed<1>,              // isSending?
+    BCFixed<1>,              // isCallerIsolated?
     DefaultArgumentField,    // default argument kind
     TypeIDField,             // default argument type
     ActorIsolationField,     // default argument isolation

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4750,6 +4750,7 @@ public:
         param->isCompileTimeLiteral(),
         param->isConstVal(),
         param->isSending(),
+        param->isCallerIsolated(),
         getRawStableDefaultArgumentKind(argKind),
         S.addTypeRef(defaultExprType),
         getRawStableActorIsolationKind(isolation.getKind()),

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1127,7 +1127,7 @@ func rdar17170728() {
   }
 
   let _ = [i, j, k].reduce(0 as Int?) { // expected-error {{missing argument label 'into:' in call}}
-    // expected-error@-1 {{cannot convert value of type 'Int?' to expected argument type '(inout @escaping (Bool, Bool) -> Bool?, Int?) throws -> ()'}}
+    // expected-error@-1 {{cannot convert value of type 'Int?' to expected argument type '(inout (Bool, Bool) -> Bool?, Int?) throws -> ()'}}
     $0 && $1 ? $0 + $1 : ($0 ? $0 : ($1 ? $1 : nil))
     // expected-error@-1 {{binary operator '+' cannot be applied to two 'Bool' operands}}
   }

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -92,3 +92,12 @@ public func testExecutionConcurrent() async {}
 nonisolated(nonsending)
 public func testExecutionCaller() async {}
 // CHECK: nonisolated(nonsending) public func testExecutionCaller() async
+
+public struct TestPlacementOfAttrsAndSpecifiers {
+  // CHECK: public func test1<T>(_: sending @autoclosure () -> T)
+  public func test1<T>(_: sending @autoclosure () -> T) {}
+  // CHECK: public func test2<T>(_: borrowing @autoclosure () -> T)
+  public func test2<T>(_: borrowing @autoclosure () -> T) {}
+  // CHECK: public func test3<T>(_: inout () async -> T)
+  public func test3<T>(_: inout () async -> T) {}
+}

--- a/test/ModuleInterface/execution_behavior_attrs.swift
+++ b/test/ModuleInterface/execution_behavior_attrs.swift
@@ -10,6 +10,11 @@ public struct TestWithAttrs {
   // CHECK-NEXT: public func test(_: nonisolated(nonsending) @escaping () async -> Swift.Void)
   // CHECK-NEXT: #endif
   public func test(_: nonisolated(nonsending) @escaping () async -> Void) {}
+
+  // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
+  // CHECK-NEXT: public func withInOut(fn: nonisolated(nonsending) inout () async -> Swift.Void)
+  // CHECK-NEXT: #endif
+  public func withInOut(fn: nonisolated(nonsending) inout () async -> Void) {}
 }
 
 public struct Test {

--- a/test/ModuleInterface/execution_behavior_attrs.swift
+++ b/test/ModuleInterface/execution_behavior_attrs.swift
@@ -5,6 +5,13 @@
 
 // REQUIRES: concurrency
 
+public struct TestWithAttrs {
+  // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
+  // CHECK-NEXT: public func test(_: nonisolated(nonsending) @escaping () async -> Swift.Void)
+  // CHECK-NEXT: #endif
+  public func test(_: nonisolated(nonsending) @escaping () async -> Void) {}
+}
+
 public struct Test {
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
   // CHECK-NEXT: nonisolated(nonsending) public init() async

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Function.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/Function.swift
@@ -39,12 +39,12 @@ public func foo<S>(f: @escaping () -> (), ext int: Int = 2, s: S) where S: Seque
 // CHECK-NEXT:          "spelling": ": "
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
-// CHECK-NEXT:          "kind": "keyword",
-// CHECK-NEXT:          "spelling": "@escaping"
+// CHECK-NEXT:          "kind": "attribute",
+// CHECK-NEXT:          "spelling": "@escaping "
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "kind": "text",
-// CHECK-NEXT:          "spelling": " () -> (), "
+// CHECK-NEXT:          "spelling": "() -> (), "
 // CHECK-NEXT:        },
 // CHECK-NEXT:        {
 // CHECK-NEXT:          "kind": "externalParam",


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/80843

---

- Explanation:

  Fixes positioning of `nonisolated(nonsending)` and other specifiers when printed in swift interfaces. Makes sure that specifiers are always printed before attributes (how parser expects the order to be) and that attributes are printed as attributes.

  - Make sure that specifiers are always printed before attributes
  - Don't print `@escaping` if parameter is `inout`
  - Always print `nonisolated(nonsending)` as a first specifier
  - Make sure that attributes are consistently printed as attributes and specifiers as keywords

- Main Branch PR: https://github.com/swiftlang/swift/pull/80843

- Risk: Low (The change to `nonsisolated(nonsending)` printing has to source compatibility impact because no existing swift interfaces have that attribute printed yet. When it comes to the rest - mixing of specifiers and attribute would have caused failures already and there could be no existing interface files that could regress due to this change).

- Reviewed By: @xymus @ktoso 

- Testing: Added new tests to the test suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
