### PR TITLE
Unconditionally add -z,origin on OpenBSD.

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -439,6 +439,8 @@ macro(configure_sdk_unix name architectures)
 
         set(SWIFT_SDK_OPENBSD_ARCH_${arch}_TRIPLE "${arch}-unknown-openbsd${openbsd_system_version}")
 
+        add_link_options("LINKER:-z,origin")
+
         if(CMAKE_SYSROOT)
           set(SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH}" CACHE INTERNAL "sysroot path" FORCE)
         endif()


### PR DESCRIPTION
This is a little less than ideal, since as I understand it, it only makes sense to add -z,origin when $ORIGIN expansion is required, but doing this surgically per target is rather cumbersome. I don't believe there are any significant drawbacks to doing it unconditionally like this, however.