### PR TITLE
Update-Checkout Tests: Disable commit singing

### DIFF
--- a/utils/update_checkout/tests/scheme_mock.py
+++ b/utils/update_checkout/tests/scheme_mock.py
@@ -118,9 +118,11 @@ def setup_mock_remote(base_dir, base_config):
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=remote_repo_path)
         call_quietly(['git', 'clone', '-l', remote_repo_path, local_repo_path])
-        call_quietly(['git', 'config', 'user.name', 'swift_test'],
+        call_quietly(['git', 'config', '--local', 'user.name', 'swift_test'],
                      cwd=local_repo_path)
-        call_quietly(['git', 'config', 'user.email', 'no-reply@swift.org'],
+        call_quietly(['git', 'config', '--local', 'user.email', 'no-reply@swift.org'],
+                     cwd=local_repo_path)
+        call_quietly(['git', 'config', '--local', 'commit.gpgsign', 'false'],
                      cwd=local_repo_path)
         call_quietly(['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
                      cwd=local_repo_path)


### PR DESCRIPTION
Disabling commit signing on the local mock repo so that signing tools don't cause the tests to fail when the signing identity doesn't match the identity of the committer.

Also marking the config changes as local to ensure that they don't affect the user's global config accidentally. Technically this isn't required since local is the default, but this ensures that it is clear and that we aren't making assumptions about the user's global git config.