### PR TITLE
[SymbolGraphGen] fix AvailabilityFilter test to be resilient against path names

### DIFF
--- a/test/SymbolGraph/Symbols/Mixins/Availability/AvailabilityFilter.swift
+++ b/test/SymbolGraph/Symbols/Mixins/Availability/AvailabilityFilter.swift
@@ -42,22 +42,22 @@ public struct S {}
 @available(*, deprecated)
 public class C {}
 
-// DEFAULT-DAG: macOS
-// DEFAULT-DAG: iOS
-// DEFAULT-DAG: watchOS
+// DEFAULT-DAG: "domain":{{ ?}}"macOS"
+// DEFAULT-DAG: "domain":{{ ?}}"iOS"
+// DEFAULT-DAG: "domain":{{ ?}}"watchOS"
 // DEFAULT-DAG: "isUnconditionallyDeprecated":{{ ?}}true
 
-// ALLOWLIST-NOT: watchOS
-// ALLOWLIST-DAG: macOS
-// ALLOWLIST-DAG: iOS
+// ALLOWLIST-NOT: "domain":{{ ?}}"watchOS"
+// ALLOWLIST-DAG: "domain":{{ ?}}"macOS"
+// ALLOWLIST-DAG: "domain":{{ ?}}"iOS"
 // ALLOWLIST-DAG: "isUnconditionallyDeprecated":{{ ?}}true
 
-// BLOCKLIST-NOT: macOS
-// BLOCKLIST-NOT: iOS
-// BLOCKLIST-DAG: watchOS
+// BLOCKLIST-NOT: "domain":{{ ?}}"macOS"
+// BLOCKLIST-NOT: "domain":{{ ?}}"iOS"
+// BLOCKLIST-DAG: "domain":{{ ?}}"watchOS"
 // BLOCKLIST-DAG: "isUnconditionallyDeprecated":{{ ?}}true
 
-// EMPTY-NOT: macOS
-// EMPTY-NOT: iOS
-// EMPTY-NOT: watchOS
+// EMPTY-NOT: "domain":{{ ?}}"macOS"
+// EMPTY-NOT: "domain":{{ ?}}"iOS"
+// EMPTY-NOT: "domain":{{ ?}}"watchOS"
 // EMPTY-DAG: "isUnconditionallyDeprecated":{{ ?}}true


### PR DESCRIPTION
The test added in https://github.com/swiftlang/swift/pull/80778 checked the symbol graph to make sure it didn't include certain platforms' availability information when it was being screened out. However, it accomplished this by checking against the string `macOS`, which seems to have broken tests for swift-syntax since that string is also present in file paths. This PR updates the test to specifically check for `"domain": "[os]"` instead so that it avoids hitting the file path as a false positive.