### PR TITLE
[6.2][rbi] When checking for partial apply reachability of a value at a user, include the user itself in case the user is the actual partial apply

### DIFF
--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1997,3 +1997,13 @@ func localCaptureDataRace3() async {
 
   print(x)
 }
+
+nonisolated func localCaptureDataRace4() {
+  var x = 0
+  _ = x
+
+  Task.detached { @MainActor in x = 1 } // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+
+  x = 2 // expected-tns-note {{access can happen concurrently}}
+}

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -329,3 +329,14 @@ struct Clock {
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
+
+@MainActor
+func localCaptureDataRace5() {
+  var x = 0
+  _ = x
+
+  Task.detached { @CustomActor in x = 1 } // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-note @-1 {{'x' is captured by a global actor 'CustomActor'-isolated closure. global actor 'CustomActor'-isolated uses in closure may race against later main actor-isolated uses}}
+
+  x = 2 // expected-tns-note {{access can happen concurrently}}
+}


### PR DESCRIPTION
- Explanation:
  In RBI, we need to be more conservative around later uses of sent boxes that are also escaped by reference before the send point. To do this, we perform an earlier forward dataflow that determines partial applies that boxes escape to and then propagate reachability forward. Then when we send the box later, we mark the box as having already escaped at the sending point by using the reachability analysis. If the reachability analysis determines that the sending instruction is in a block where reachability starts, we walk the block to determine if the send is before or after the partial apply instruction. Sadly during this walk, we included all instructions up to the send instruction and not the send instruction itself. The result of this is that if the escaping partial apply and the send instruction were the same, we would say that the partial apply was not escaped and would say in cases like the following that the more conservative behavior did not need to be applied:

  ```swift
  nonisolated func localCaptureDataRace4() {
    var x = 0
    _ = x

    Task.detached { @MainActor in x = 1 } // expected-tns-warning {{sending 'x' risks causing data races}}
    // expected-tns-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}

    x = 2 // expected-tns-note {{access can happen concurrently}}
  }
  ```

  The result of this less conservative behavior is that we would think that no error needed to be emitted here since we would assume that `x` is never passed by reference so we do not need to consider concurrent writes to `x` when we see the use of `x = 2`. Since no concurrent writes could occur to the `x` box and `x` contains a `Sendable` value, the box containing `x` is `Sendable` in a flow sensitive manner at that point.

- Scope: Just tweaks a little bit of logic so that we include the partial apply "gen" instruction that we are searching for as the user that sends the value.
- Resolves: rdar://149414471
- Main PR: https://github.com/swiftlang/swift/pull/80863
- Risk: Low. This just tweaks an instruction walk slightly.
- Testing: Added tests that show that the concurrency hole is eliminated.
- Reviewer: @xedin