### PR TITLE
[6.2] LargeTypesReg2Mem: Add unchecked_bitwise_cast to the projections we need to propagate largeness from destination to source operand

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3574,6 +3574,7 @@ void LargeLoadableHeuristic::propagate(PostOrderFunctionInfo &po) {
   for (auto *BB : po.getPostOrder()) {
     for (auto &I : llvm::reverse(*BB)) {
       switch (I.getKind()) {
+      case SILInstructionKind::UncheckedBitwiseCastInst:
       case SILInstructionKind::TupleExtractInst:
       case SILInstructionKind::StructExtractInst: {
         auto &proj = cast<SingleValueInstruction>(I);

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -425,3 +425,23 @@ bb0(%0 : $member_id_t):
   %13 = tuple ()
   return %13 : $()
 }
+
+struct Z {
+  var r: String
+  var p: X
+}
+
+// CHECK: sil @test17 : $@convention(thin) (@owned String) -> () {
+// CHECK: bb0(%0 : $String):
+// CHECK:   [[T0:%.*]] = alloc_stack $String
+// CHECK:   store %0 to [[T0]] : $*String
+// CHECK:   [[T1:%.*]] = unchecked_addr_cast [[T0]] : $*String to $*Z
+// CHECK:   release_value_addr [[T1]] : $*Z
+
+sil @test17: $@convention(thin) (@owned String) -> () {
+bb0(%0 : $String):
+  %1 = unchecked_bitwise_cast %0 : $String to $Z
+  release_value %1 : $Z
+  %13 = tuple ()
+  return %13 : $()
+}


### PR DESCRIPTION

Scope: Fixes a compiler crash in some version of swift-collections Issue: An instruction whose result type address'ness needs to be propagated to its operand was not handled.
Risk: Low, this case would have crashed without the change. Testing: Unit test added. The compiler successfully compiled the project after this change.
Original PR: https://github.com/swiftlang/swift/pull/80888

rdar://148545382
(cherry picked from commit 370b7e82193b9d252533af442cdfa2340e24db9b)