### PR TITLE
[SILGen]Check if baseType is DynamicSelfType

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3399,10 +3399,10 @@ static ManagedValue emitKeyPathRValueBase(SILGenFunction &subSGF,
   
   // Upcast a class instance to the property's declared type if necessary.
   if (auto propertyClass = storage->getDeclContext()->getSelfClassDecl()) {
+    if (auto selfType = baseType->getAs<DynamicSelfType>())
+      baseType = selfType->getSelfType()->getCanonicalType();
     auto baseClass = baseType->getClassOrBoundGenericClass();
-    if (auto dynamicSelfType = baseType->getAs<DynamicSelfType>()) {
-      baseClass = dynamicSelfType->getSelfType()->getClassOrBoundGenericClass();
-    }
+
     if (baseClass != propertyClass) {
       baseType = baseType->getSuperclassForDecl(propertyClass)
         ->getCanonicalType();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3399,7 +3399,11 @@ static ManagedValue emitKeyPathRValueBase(SILGenFunction &subSGF,
   
   // Upcast a class instance to the property's declared type if necessary.
   if (auto propertyClass = storage->getDeclContext()->getSelfClassDecl()) {
-    if (baseType->getClassOrBoundGenericClass() != propertyClass) {
+    auto baseClass = baseType->getClassOrBoundGenericClass();
+    if (auto dynamicSelfType = baseType->getAs<DynamicSelfType>()) {
+      baseClass = dynamicSelfType->getSelfType()->getClassOrBoundGenericClass();
+    }
+    if (baseClass != propertyClass) {
       baseType = baseType->getSuperclassForDecl(propertyClass)
         ->getCanonicalType();
       paramSubstValue = subSGF.B.createUpcast(loc, paramSubstValue,

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -805,3 +805,24 @@ protocol HasAlias {
 func testHasAlias() {
   _ = \HasAlias.id
 }
+
+// https://github.com/swiftlang/swift/issues/80669
+func type<Root, Value>(at keyPath: KeyPath<Root, Value>) -> Value.Type {
+  return Value.self
+}
+
+class DynamicSelfTypeTestClass {
+  var other = DynamicSelfTypeTestClass()
+
+  static func staticFunc() {
+    type(at: \Self.other).bar()
+  }
+
+  static func bar() {
+    print("Hello")
+  }
+}
+
+func testDynamicSelfType() {
+  DynamicSelfTypeTestClass.staticFunc()
+}


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/80669
I think the issue mentioned above has been resolved by this, but it’s unrelated. I will create a separate one for it.  

The compiler crashed when compiling the following code:

```swift
func type<Root, Value>(at keyPath: KeyPath<Root, Value>) -> Value.Type {
    return Value.self
}

class Foo {
    var other = Foo()

    static func staticFunc() {
        type(at: \Self.other).bar()
    }

    static func bar() {
        print("Hello")
    }
}
```

The crash log was as follows:

```
SIL verification failed: can't upcast to same type: UI->getType() != UI->getOperand()->getType()
Verifying instruction:
     %4 = load [take] %2 : $*Foo                  // user: %5
->   %5 = upcast %4 : $Foo to $Foo                // users: %11, %6
     %6 = begin_borrow %5 : $Foo                  // users: %9, %8, %7
     destroy_value %5 : $Foo                      // id: %11
In function:
// key path getter for Foo.other : Self
sil shared [thunk] [ossa] @$s4main3FooC5otherACvpACXDTK : $@convention(keypath_accessor_getter) (@in_guaranteed Foo) -> @out Foo {
// %0                                             // user: %10
// %1                                             // user: %3
bb0(%0 : $*Foo, %1 : $*Foo):
  %2 = alloc_stack $Foo                           // users: %12, %4, %3
  copy_addr %1 to [init] %2                       // id: %3
  %4 = load [take] %2                             // user: %5
  %5 = upcast %4 to $Foo                          // users: %11, %6
  %6 = begin_borrow %5                            // users: %9, %8, %7
  %7 = class_method %6, #Foo.other!getter : (Foo) -> () -> Foo, $@convention(method) (@guaranteed Foo) -> @owned Foo // user: %8
  %8 = apply %7(%6) : $@convention(method) (@guaranteed Foo) -> @owned Foo // user: %10
  end_borrow %6                                   // id: %9
  store %8 to [init] %0                           // id: %10
  destroy_value %5                                // id: %11
  dealloc_stack %2                                // id: %12
  %13 = tuple ()                                  // user: %14
  return %13                                      // id: %14
} // end sil function '$s4main3FooC5otherACvpACXDTK'
Stack dump:
0.      Program arguments: /usr/bin/swift-frontend -frontend -interpret - -disable-objc-interop -color-diagnostics -enable-bare-slash-regex -empty-abi-descriptor -resource-dir /usr/lib/swift -no-auto-bridging-header-chaining -module-name main -in-process-plugin-server-path /usr/lib/swift/host/libSwiftInProcPluginServer.so -plugin-path /usr/lib/swift/host/plugins -plugin-path /usr/local/lib/swift/host/plugins
1.      Swift version 6.2-dev (LLVM a3e32cdaae72f3d, Swift fa8609703528715)
2.      Compiling with effective version 5.10
3.      While evaluating request ASTLoweringRequest(Lowering AST to SIL for module main)
4.      While verifying SIL function "@$s4main3FooC5otherACvpACXDTK".
 for <<debugloc at "<compiler-generated>":0:0>>
...
```

The cause appears to be that when using `\Self` in a key path, the `baseType` is `DynamicSelfType`. This prevents retrieving the `baseClass` using `getClassOrBoundGenericClass`, as seen here:
https://github.com/swiftlang/swift/blob/main/lib/SILGen/SILGenExpr.cpp#L3402

Therefore, a check was added to determine if `baseType` is `DynamicSelfType`.