### PR TITLE
PrintAsClang: Print a C block in the compatibility header for `@cdecl` functions

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -3006,6 +3006,14 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
       return false;
   }
 
+  // In C output mode print only @cdecls and skip them in other modes.
+  bool isCDeclForC = false;
+  auto *FD = dyn_cast<AbstractFunctionDecl>(VD);
+  if (FD)
+    isCDeclForC = FD->getCDeclKind() == ForeignLanguage::C;
+  if (isCDeclForC != (outputLang == OutputLanguageMode::C))
+    return false;
+
   if (VD->getAttrs().hasAttribute<ImplementationOnlyAttr>())
     return false;
 

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -3006,13 +3006,21 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
       return false;
   }
 
-  // In C output mode print only @cdecls and skip them in other modes.
-  bool isCDeclForC = false;
-  auto *FD = dyn_cast<AbstractFunctionDecl>(VD);
-  if (FD)
-    isCDeclForC = FD->getCDeclKind() == ForeignLanguage::C;
-  if (isCDeclForC != (outputLang == OutputLanguageMode::C))
+  // In C output mode print only the C variant `@cdecl` (no `@_cdecl`),
+  // while in other modes print only `@_cdecl`.
+  std::optional<ForeignLanguage> cdeclKind = std::nullopt;
+  if (auto *FD = dyn_cast<AbstractFunctionDecl>(VD))
+    cdeclKind = FD->getCDeclKind();
+  if (cdeclKind &&
+      (*cdeclKind == ForeignLanguage::C) !=
+       (outputLang == OutputLanguageMode::C))
     return false;
+
+  // C output mode only accepts @cdecl functions.
+  if (outputLang == OutputLanguageMode::C &&
+      !cdeclKind) {
+    return false;
+  }
 
   if (VD->getAttrs().hasAttribute<ImplementationOnlyAttr>())
     return false;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2289,6 +2289,14 @@ private:
     return false;
   }
 
+  std::optional<PrimitiveTypeMapping::ClangTypeInfo>
+  getKnownType(const TypeDecl *typeDecl) {
+    if (outputLang == OutputLanguageMode::C)
+      return owningPrinter.typeMapping.getKnownCTypeInfo(typeDecl);
+
+    return owningPrinter.typeMapping.getKnownObjCTypeInfo(typeDecl);
+  }
+
   /// If \p typeDecl is one of the standard library types used to map in Clang
   /// primitives and basic types, print out the appropriate spelling and
   /// return true.
@@ -2297,8 +2305,7 @@ private:
   /// for interfacing with C and Objective-C.
   bool printIfKnownSimpleType(const TypeDecl *typeDecl,
                               std::optional<OptionalTypeKind> optionalKind) {
-    auto knownTypeInfo =
-        owningPrinter.typeMapping.getKnownObjCTypeInfo(typeDecl);
+    auto knownTypeInfo = getKnownType(typeDecl);
     if (!knownTypeInfo)
       return false;
     os << knownTypeInfo->name;

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -1118,6 +1118,17 @@ void swift::printModuleContentsAsObjC(
       .write();
 }
 
+void swift::printModuleContentsAsC(
+    raw_ostream &os, llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
+    ModuleDecl &M, SwiftToClangInteropContext &interopContext) {
+  llvm::raw_null_ostream prologueOS;
+  llvm::StringSet<> exposedModules;
+  ModuleWriter(os, prologueOS, imports, M, interopContext, getRequiredAccess(M),
+               /*requiresExposedAttribute=*/false, exposedModules,
+               OutputLanguageMode::C)
+      .write();
+}
+
 EmittedClangHeaderDependencyInfo swift::printModuleContentsAsCxx(
     raw_ostream &os, ModuleDecl &M, SwiftToClangInteropContext &interopContext,
     bool requiresExposedAttribute, llvm::StringSet<> &exposedModules) {

--- a/lib/PrintAsClang/ModuleContentsWriter.h
+++ b/lib/PrintAsClang/ModuleContentsWriter.h
@@ -37,6 +37,11 @@ void printModuleContentsAsObjC(raw_ostream &os,
                                ModuleDecl &M,
                                SwiftToClangInteropContext &interopContext);
 
+void printModuleContentsAsC(raw_ostream &os,
+                            llvm::SmallPtrSetImpl<ImportModuleTy> &imports,
+                            ModuleDecl &M,
+                            SwiftToClangInteropContext &interopContext);
+
 struct EmittedClangHeaderDependencyInfo {
     /// The set of imported modules used by this module.
     SmallPtrSet<ImportModuleTy, 8> imports;

--- a/lib/PrintAsClang/OutputLanguageMode.h
+++ b/lib/PrintAsClang/OutputLanguageMode.h
@@ -15,7 +15,7 @@
 
 namespace swift {
 
-enum class OutputLanguageMode { ObjC, Cxx };
+enum class OutputLanguageMode { ObjC, Cxx, C };
 
 } // end namespace swift
 

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -58,6 +58,17 @@ static void emitObjCConditional(raw_ostream &out,
   out << "#endif\n";
 }
 
+static void emitExternC(raw_ostream &out,
+                        llvm::function_ref<void()> cCase) {
+  emitCxxConditional(out, [&] {
+    out << "extern \"C\" {\n";
+  });
+  cCase();
+  emitCxxConditional(out, [&] {
+    out << "} // extern \"C\"\n";
+  });
+}
+
 static void writePtrauthPrologue(raw_ostream &os, ASTContext &ctx) {
   emitCxxConditional(os, [&]() {
     ClangSyntaxPrinter(ctx, os).printIgnoredDiagnosticBlock(
@@ -577,12 +588,21 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
   llvm::PrettyStackTraceString trace("While generating Clang header");
 
   SwiftToClangInteropContext interopContext(*M, irGenOpts);
+  writePrologue(os, M->getASTContext(), computeMacroGuard(M));
 
+  // C content (@cdecl)
+  if (M->getASTContext().LangOpts.hasFeature(Feature::CDecl)) {
+    SmallPtrSet<ImportModuleTy, 8> imports;
+    emitExternC(os, [&] {
+      printModuleContentsAsC(os, imports, *M, interopContext);
+    });
+  }
+
+  // Objective-C content
   SmallPtrSet<ImportModuleTy, 8> imports;
   std::string objcModuleContentsBuf;
   llvm::raw_string_ostream objcModuleContents{objcModuleContentsBuf};
   printModuleContentsAsObjC(objcModuleContents, imports, *M, interopContext);
-  writePrologue(os, M->getASTContext(), computeMacroGuard(M));
   emitObjCConditional(os, [&] {
     llvm::StringMap<StringRef> exposedModuleHeaderNames;
     writeImports(os, imports, *M, bridgingHeader, frontendOpts,
@@ -591,6 +611,8 @@ bool swift::printAsClangHeader(raw_ostream &os, ModuleDecl *M,
   writePostImportPrologue(os, *M);
   emitObjCConditional(os, [&] { os << "\n" << objcModuleContents.str(); });
   writeObjCEpilogue(os);
+
+  // C++ content
   emitCxxConditional(os, [&] {
     // FIXME: Expose Swift with @expose by default.
     bool enableCxx = frontendOpts.ClangHeaderExposedDecls.has_value() ||

--- a/lib/PrintAsClang/PrintAsClang.cpp
+++ b/lib/PrintAsClang/PrintAsClang.cpp
@@ -218,6 +218,21 @@ static void writePrologue(raw_ostream &out, ASTContext &ctx,
 
   static_assert(SWIFT_MAX_IMPORTED_SIMD_ELEMENTS == 4,
               "need to add SIMD typedefs here if max elements is increased");
+
+  if (ctx.LangOpts.hasFeature(Feature::CDecl)) {
+    // For C compilers which don’t support nullability attributes, ignore them;
+    // for ones which do, suppress warnings about them being an extension.
+    out << "#if !__has_feature(nullability)\n"
+           "# define _Nonnull\n"
+           "# define _Nullable\n"
+           "# define _Null_unspecified\n"
+           "#elif !defined(__OBJC__)\n"
+           "# pragma clang diagnostic ignored \"-Wnullability-extension\"\n"
+           "#endif\n"
+           "#if !__has_feature(nullability_nullable_result)\n"
+           "# define _Nullable_result _Nullable\n"
+           "#endif\n";
+  }
 }
 
 static int compareImportModulesByName(const ImportModuleTy *left,

--- a/test/PrintAsObjC/cdecl-imports.swift
+++ b/test/PrintAsObjC/cdecl-imports.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -parse-as-library -typecheck -verify -emit-objc-header-path %t/swift.h
 // RUN: %FileCheck %s < %t/swift.h
 // RUN: %check-in-clang %t/swift.h
+// RUN: %check-in-clang-c %t/swift.h
 // RUN: %check-in-clang-cxx %t/swift.h
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/cdecl-official-for-objc-clients.swift
+++ b/test/PrintAsObjC/cdecl-official-for-objc-clients.swift
@@ -1,0 +1,23 @@
+/// Similar test to cdecl-official but gated to objc-interop compatibility
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %S/cdecl-official.swift %t --leading-lines
+
+/// Generate cdecl.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %t/Lib.swift -emit-module -verify -o %t -emit-module-doc \
+// RUN:   -emit-clang-header-path %t/cdecl.h \
+// RUN:   -enable-experimental-feature CDecl
+
+/// Check cdecl.h directly
+// RUN: %check-in-clang %t/cdecl.h
+// RUN: %check-in-clang-cxx %t/cdecl.h
+
+/// Build an Objective-C client against cdecl.h
+// RUN: %clang -c %t/Client.c -fmodules -I %t \
+// RUN:   -F %S/../Inputs/clang-importer-sdk-path/frameworks \
+// RUN:   -I %clang-include-dir -Werror \
+// RUN:   -isysroot %S/../Inputs/clang-importer-sdk
+
+// REQUIRES: swift_feature_CDecl
+// REQUIRES: objc_interop

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -4,14 +4,12 @@
 /// Generate cdecl.h
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
 // RUN:   %t/Lib.swift -emit-module -verify -o %t -emit-module-doc \
-// RUN:   -emit-objc-header-path %t/cdecl.h \
+// RUN:   -emit-clang-header-path %t/cdecl.h \
 // RUN:   -enable-experimental-feature CDecl
 
 /// Check cdecl.h directly
 // RUN: %FileCheck %s --input-file %t/cdecl.h
-// RUN: %check-in-clang %t/cdecl.h
 // RUN: %check-in-clang-c %t/cdecl.h -Wnullable-to-nonnull-conversion
-// RUN: %check-in-clang-cxx %t/cdecl.h
 
 /// Build a client against cdecl.h
 // RUN: %clang -c %t/Client.c -fmodules -I %t \

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -21,6 +21,8 @@
 
 //--- Lib.swift
 
+// CHECK-NOT: assume_nonnull
+
 // CHECK: #if defined(__cplusplus)
 // CHECK: extern "C" {
 // CHECK: #endif
@@ -42,6 +44,23 @@ func c_keywordArgNames(auto: Int, union: Int) {}
 @cdecl("return_never")
 func d_returnNever() -> Never { fatalError() }
 // CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NOEXCEPT SWIFT_NORETURN;
+
+/// Pointer types
+// CHECK: /// Pointer types
+
+@cdecl("pointers")
+func f_pointers(_ x: UnsafeMutablePointer<Int>,
+                  y: UnsafePointer<Int>,
+                  z: UnsafeMutableRawPointer,
+                  w: UnsafeRawPointer,
+                  u: OpaquePointer) {}
+// CHECK: SWIFT_EXTERN void pointers(ptrdiff_t * _Nonnull x, ptrdiff_t const * _Nonnull y, void * _Nonnull z, void const * _Nonnull w, void * _Nonnull u) SWIFT_NOEXCEPT;
+
+@cdecl("nullable_pointers")
+func g_nullablePointers(_ x: UnsafeMutableRawPointer,
+                          y: UnsafeMutableRawPointer?,
+                          z: UnsafeMutableRawPointer!) {}
+// CHECK: SWIFT_EXTERN void nullable_pointers(void * _Nonnull x, void * _Nullable y, void * _Null_unspecified z) SWIFT_NOEXCEPT;
 
 // CHECK:      #if defined(__cplusplus)
 // CHECK-NEXT: }

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -43,30 +43,6 @@ func c_keywordArgNames(auto: Int, union: Int) {}
 func d_returnNever() -> Never { fatalError() }
 // CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NOEXCEPT SWIFT_NORETURN;
 
-@cdecl("block_nightmare")
-public func s_block_nightmare(x: @convention(block) (Int) -> Float)
-  -> @convention(block) (CChar) -> Double { return { _ in 0 } }
-// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(ptrdiff_t)))(char) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
-
-@cdecl("block_recurring_nightmare")
-public func t_block_recurring_nightmare(x: @escaping @convention(block) (@convention(block) (Double) -> Int) -> Float)
-  -> @convention(block) (_ asdfasdf: @convention(block) (CUnsignedChar) -> CChar) -> Double {
-  fatalError()
-}
-// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE ptrdiff_t (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
-
-@cdecl("function_pointer_nightmare")
-func u_function_pointer_nightmare(x: @convention(c) (Int) -> Float)
-  -> @convention(c) (CChar) -> Double { return { _ in 0 } }
-// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_nightmare(float (* _Nonnull x)(ptrdiff_t)))(char) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
-
-@cdecl("function_pointer_recurring_nightmare")
-public func v_function_pointer_recurring_nightmare(x: @escaping @convention(c) (@convention(c) (Double) -> Int) -> Float)
-  -> @convention(c) (@convention(c) (CUnsignedChar) -> CChar) -> Double {
-  fatalError()
-}
-// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(ptrdiff_t (* _Nonnull)(double))))(char (* _Nonnull)(unsigned char)) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
-
 // CHECK:      #if defined(__cplusplus)
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -14,7 +14,7 @@
 // RUN: %check-in-clang-cxx %t/cdecl.h
 
 /// Build a client against cdecl.h
-// RUN: %clang -c %t/Client.c -fobjc-arc -fmodules -I %t \
+// RUN: %clang -c %t/Client.c -fmodules -I %t \
 // RUN:   -F %S/../Inputs/clang-importer-sdk-path/frameworks \
 // RUN:   -I %clang-include-dir -Werror \
 // RUN:   -isysroot %S/../Inputs/clang-importer-sdk

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -1,0 +1,85 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+/// Generate cdecl.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %t/Lib.swift -emit-module -verify -o %t -emit-module-doc \
+// RUN:   -emit-objc-header-path %t/cdecl.h \
+// RUN:   -enable-experimental-feature CDecl
+
+/// Check cdecl.h directly
+// RUN: %FileCheck %s --input-file %t/cdecl.h
+// RUN: %check-in-clang %t/cdecl.h
+// RUN: %check-in-clang-c %t/cdecl.h -Wnullable-to-nonnull-conversion
+// RUN: %check-in-clang-cxx %t/cdecl.h
+
+/// Build a client against cdecl.h
+// RUN: %clang -c %t/Client.c -fobjc-arc -fmodules -I %t \
+// RUN:   -F %S/../Inputs/clang-importer-sdk-path/frameworks \
+// RUN:   -I %clang-include-dir -Werror \
+// RUN:   -isysroot %S/../Inputs/clang-importer-sdk
+
+// REQUIRES: swift_feature_CDecl
+
+//--- Lib.swift
+
+// CHECK: #if defined(__cplusplus)
+// CHECK: extern "C" {
+// CHECK: #endif
+
+/// My documentation
+@cdecl("simple")
+func a_simple(x: Int, bar y: Int) -> Int { return x }
+// CHECK-LABEL: // My documentation
+// CHECK-LABEL: SWIFT_EXTERN ptrdiff_t simple(ptrdiff_t x, ptrdiff_t y) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+@cdecl("primitiveTypes")
+public func b_primitiveTypes(i: Int, ci: CInt, l: CLong, c: CChar, f: Float, d: Double, b: Bool) {}
+// CHECK-LABEL: SWIFT_EXTERN void primitiveTypes(ptrdiff_t i, int ci, long l, char c, float f, double d, bool b) SWIFT_NOEXCEPT;
+
+@cdecl("has_keyword_arg_names")
+func c_keywordArgNames(auto: Int, union: Int) {}
+// CHECK-LABEL: SWIFT_EXTERN void has_keyword_arg_names(ptrdiff_t auto_, ptrdiff_t union_) SWIFT_NOEXCEPT;
+
+@cdecl("return_never")
+func d_returnNever() -> Never { fatalError() }
+// CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NOEXCEPT SWIFT_NORETURN;
+
+@cdecl("block_nightmare")
+public func s_block_nightmare(x: @convention(block) (Int) -> Float)
+  -> @convention(block) (CChar) -> Double { return { _ in 0 } }
+// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_nightmare(SWIFT_NOESCAPE float (^ _Nonnull x)(ptrdiff_t)))(char) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+@cdecl("block_recurring_nightmare")
+public func t_block_recurring_nightmare(x: @escaping @convention(block) (@convention(block) (Double) -> Int) -> Float)
+  -> @convention(block) (_ asdfasdf: @convention(block) (CUnsignedChar) -> CChar) -> Double {
+  fatalError()
+}
+// CHECK-LABEL: SWIFT_EXTERN double (^ _Nonnull block_recurring_nightmare(float (^ _Nonnull x)(SWIFT_NOESCAPE ptrdiff_t (^ _Nonnull)(double))))(SWIFT_NOESCAPE char (^ _Nonnull)(unsigned char)) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+@cdecl("function_pointer_nightmare")
+func u_function_pointer_nightmare(x: @convention(c) (Int) -> Float)
+  -> @convention(c) (CChar) -> Double { return { _ in 0 } }
+// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_nightmare(float (* _Nonnull x)(ptrdiff_t)))(char) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+@cdecl("function_pointer_recurring_nightmare")
+public func v_function_pointer_recurring_nightmare(x: @escaping @convention(c) (@convention(c) (Double) -> Int) -> Float)
+  -> @convention(c) (@convention(c) (CUnsignedChar) -> CChar) -> Double {
+  fatalError()
+}
+// CHECK-LABEL: SWIFT_EXTERN double (* _Nonnull function_pointer_recurring_nightmare(float (* _Nonnull x)(ptrdiff_t (* _Nonnull)(double))))(char (* _Nonnull)(unsigned char)) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+// CHECK:      #if defined(__cplusplus)
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+
+//--- Client.c
+
+#include "cdecl.h"
+
+int main() {
+    ptrdiff_t x = simple(42, 43);
+    primitiveTypes(1, 2, 3, 'a', 1.0f, 2.0, true);
+    has_keyword_arg_names(1, 2);
+    return_never();
+}

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -12,7 +12,7 @@
 // RUN: %check-in-clang-c %t/cdecl.h -Wnullable-to-nonnull-conversion
 
 /// Build a client against cdecl.h
-// RUN: %clang -c %t/Client.c -fmodules -I %t \
+// RUN: %clang-no-modules -c %t/Client.c -I %t \
 // RUN:   -F %S/../Inputs/clang-importer-sdk-path/frameworks \
 // RUN:   -I %clang-include-dir -Werror \
 // RUN:   -isysroot %S/../Inputs/clang-importer-sdk

--- a/test/PrintAsObjC/cdecl-with-objc.swift
+++ b/test/PrintAsObjC/cdecl-with-objc.swift
@@ -1,0 +1,33 @@
+/// Ensure we print @cdecl and @_cdecl only once.
+
+// RUN: %empty-directory(%t)
+
+/// Generate cdecl.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %s -emit-module -verify -o %t -emit-module-doc \
+// RUN:   -emit-objc-header-path %t/cdecl.h \
+// RUN:   -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CDecl
+
+/// Check cdecl.h directly
+// RUN: %FileCheck %s --input-file %t/cdecl.h
+// RUN: %check-in-clang %t/cdecl.h
+// RUN: %check-in-clang-c %t/cdecl.h -Wnullable-to-nonnull-conversion
+// RUN: %check-in-clang-cxx %t/cdecl.h
+
+// REQUIRES: swift_feature_CDecl
+// REQUIRES: objc_interop
+
+@cdecl("cFunc")
+func cFunc() { }
+// CHECK: cFunc
+// CHECK-NOT: cFunc
+
+/// The class would break C parsing if printed in wrong block
+@objc
+class ObjCClass {}
+
+@_cdecl("objcFunc")
+func objcFunc() -> ObjCClass! { return ObjCClass() }
+// CHECK: objcFunc
+// CHECK-NOT: objcFunc

--- a/test/PrintAsObjC/cdecl.swift
+++ b/test/PrintAsObjC/cdecl.swift
@@ -4,6 +4,7 @@
 // RUN: %FileCheck %s < %t/cdecl.h
 // RUN: %check-in-clang %t/cdecl.h
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/cdecl.h -include ctypes.h -include CoreFoundation.h
+// RUN: %check-in-clang-c -fno-modules -Qunused-arguments %t/cdecl.h -include ctypes.h -include CoreFoundation.h
 // RUN: %check-in-clang-cxx -fno-modules -Qunused-arguments %t/cdecl.h -include ctypes.h -include CoreFoundation.h
 
 // REQUIRES: objc_interop

--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -11,7 +11,7 @@ config.substitutions.insert(0, ('%check-in-clang',
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )
 
 config.substitutions.insert(0, ('%check-in-clang-c',
-  '%%clang -fsyntax-only -x c-header -std=c99 -fobjc-arc -fmodules '
+  '%%clang -fsyntax-only -x c-header -std=c99 -fmodules '
   '-fmodules-validate-system-headers '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
   '-Wno-auto-import '

--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -10,6 +10,15 @@ config.substitutions.insert(0, ('%check-in-clang',
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )
 
+config.substitutions.insert(0, ('%check-in-clang-c',
+  '%%clang -fsyntax-only -x c-header -std=c99 -fobjc-arc -fmodules '
+  '-fmodules-validate-system-headers '
+  '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
+  '-Wno-auto-import '
+  '-F %%clang-importer-sdk-path/frameworks '
+  '-I %%clang-include-dir '
+  '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )
+
 config.substitutions.insert(0, ('%check-in-clang-cxx',
   '%%clang -fsyntax-only -x objective-c++-header -std=c++17 '
   '-fobjc-arc -fmodules -fmodules-validate-system-headers '

--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -11,8 +11,7 @@ config.substitutions.insert(0, ('%check-in-clang',
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )
 
 config.substitutions.insert(0, ('%check-in-clang-c',
-  '%%clang -fsyntax-only -x c-header -std=c99 -fmodules '
-  '-fmodules-validate-system-headers '
+  '%%clang-no-modules -fsyntax-only -x c-header -std=c99 '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
   '-Wno-auto-import -Wno-poison-system-directories '
   '-F %%clang-importer-sdk-path/frameworks '

--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -14,7 +14,7 @@ config.substitutions.insert(0, ('%check-in-clang-c',
   '%%clang -fsyntax-only -x c-header -std=c99 -fmodules '
   '-fmodules-validate-system-headers '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
-  '-Wno-auto-import '
+  '-Wno-auto-import -Wno-poison-system-directories '
   '-F %%clang-importer-sdk-path/frameworks '
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -55,3 +55,19 @@ class Foo {
 
 @cdecl("throwing") // expected-error{{raising errors from @cdecl functions is not supported}}
 func throwing() throws { }
+
+@cdecl("acceptedPointers")
+func acceptedPointers(_ x: UnsafeMutablePointer<Int>,
+                        y: UnsafePointer<Int>,
+                        z: UnsafeMutableRawPointer,
+                        w: UnsafeRawPointer,
+                        u: OpaquePointer) {}
+
+@cdecl("rejectedPointers")
+func rejectedPointers( // expected-error 6 {{global function cannot be marked '@cdecl' because the type of the parameter}}
+    x: UnsafePointer<String>, // expected-note {{Swift structs cannot be represented in Objective-C}} // FIXME: Should reference C.
+    y: CVaListPointer, // expected-note {{Swift structs cannot be represented in Objective-C}}
+    z: UnsafeBufferPointer<Int>, // expected-note {{Swift structs cannot be represented in Objective-C}}
+    u: UnsafeMutableBufferPointer<Int>, // expected-note {{Swift structs cannot be represented in Objective-C}}
+    v: UnsafeRawBufferPointer, // expected-note {{Swift structs cannot be represented in Objective-C}}
+    t: UnsafeMutableRawBufferPointer) {} // expected-note {{Swift structs cannot be represented in Objective-C}}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -789,6 +789,11 @@ config.substitutions.append( ('%clangxx',
                               "%r %s" %
                                 (config.clangxx, clang_mcp_opt)) )
 
+# Alternative to %clang that doesn't require -fmodules.
+config.substitutions.append( ('%clang-no-modules',
+                              "%r" %
+                                (config.clang)) )
+
 # This must come after all substitutions containing "%clang".
 # Note: %clang is the locally-built clang.
 # To get Xcode's clang, use %target-clang.


### PR DESCRIPTION
Add a block for C clients in the compatibility header. This block contains only the C representation of the `@cdecl` functions that are printed using only C types.

This C block is printed above the Objective-C and C++ blocks as if we add support for `@cdecl` types other languages should be able to reference them in function signatures. Other languages block don't duplicate printing the `@cdecl` functions either as they are already accessible to them.

Nullability attributes may still be printed so we simply ignore them for C clients.