### PR TITLE
Use LLVM-default spellings for amd64 on OpenBSD.

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -291,6 +291,13 @@ StringRef swift::getMajorArchitectureName(const llvm::Triple &Triple) {
       break;
     }
   }
+
+  if (Triple.isOSOpenBSD()) {
+    if (Triple.getArchName() == "amd64") {
+      return "x86_64";
+    }
+  }
+
   return Triple.getArchName();
 }
 
@@ -420,6 +427,11 @@ llvm::Triple swift::getTargetSpecificModuleTriple(const llvm::Triple &triple) {
 
   if (triple.isOSFreeBSD()) {
     return swift::getUnversionedTriple(triple);
+  }
+
+  if (triple.isOSOpenBSD()) {
+    StringRef arch = swift::getMajorArchitectureName(triple);
+    return llvm::Triple(arch, triple.getVendorName(), triple.getOSName());
   }
 
   // Other platforms get no normalization.


### PR DESCRIPTION
OpenBSD spells the common 64-bit x86 architecture as amd64, while LLVM defaults it to x86_64. A while back we tried to stick with the amd64 spelling, but this was difficult to make the change properly and consistently. A while back we decided to just stick with LLVM spellings, but there are a few minor cases missing.

This change is necessary for properly finding swiftrt.o.