### PR TITLE
[6.2][Concurrency] Downgrade non-Sendable type captures to warnings if clo…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2931,8 +2931,10 @@ namespace {
       auto *explicitClosure = dyn_cast_or_null<ClosureExpr>(closure);
 
       bool preconcurrency = false;
-      if (explicitClosure) {
-        preconcurrency = explicitClosure->isIsolatedByPreconcurrency();
+      if (closure) {
+        preconcurrency =
+            getActorIsolationOfContext(closure, getClosureActorIsolation)
+                .preconcurrency();
       }
 
       for (const auto &capture : localFunc.getCaptureInfo().getCaptures()) {

--- a/test/Concurrency/sendable_checking_captures_swift6.swift
+++ b/test/Concurrency/sendable_checking_captures_swift6.swift
@@ -50,3 +50,31 @@ do {
     }
   }
 }
+
+func use(_ closure: @autoclosure () -> Any) {
+}
+
+do {
+  class C {
+    @preconcurrency static func f(_: @escaping @Sendable () -> Void) {}
+  }
+
+  class SelfCapture { // expected-note 5 {{class 'SelfCapture' does not conform to the 'Sendable' protocol}}
+    func fooDirect() {
+      C.f {
+        use(self)
+        // expected-warning@-1 {{capture of 'self' with non-sendable type 'SelfCapture' in a '@Sendable' closure}}
+        // expected-warning@-2 {{implicit capture of 'self' requires that 'SelfCapture' conforms to 'Sendable'}}
+      }
+    }
+
+    func fooThroughClosure() {
+      C.f {
+        { use(self) }()
+        // expected-warning@-1 {{capture of 'self' with non-sendable type 'SelfCapture' in a '@Sendable' closure}}
+        // expected-warning@-2 {{capture of 'self' with non-sendable type 'SelfCapture' in an isolated closure}}
+        // expected-warning@-3 {{implicit capture of 'self' requires that 'SelfCapture' conforms to 'Sendable'}}
+      }
+    }
+  }
+}

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -86,6 +86,10 @@ void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^blo
 -(void) testWithCompletion: (void (^)(void)) completion;
 @end
 
+@interface TestSelfCapture : NSObject
++ (void)doWithCompletion:(void(^)(void)) completion;
+@end
+
 #pragma clang assume_nonnull end
 
 //--- main.swift
@@ -218,4 +222,26 @@ extension DataHandler : CompletionWithoutSendable {
 extension TestDR {
   @_dynamicReplacement(for: test(completion:))
   func __replaceObjCFunc(_: @escaping () -> Void) {} // Ok
+}
+
+class SelfCapture { // expected-note 5 {{class 'SelfCapture' does not conform to the 'Sendable' protocol}}
+  static func use(_ closure: @autoclosure () -> Any) {
+  }
+  
+  func testDirect() {
+    TestSelfCapture.do {
+      Self.use(self)
+      // expected-warning@-1 {{capture of 'self' with non-sendable type 'SelfCapture' in a '@Sendable' closure}}
+      // expected-warning@-2 {{implicit capture of 'self' requires that 'SelfCapture' conforms to 'Sendable'}}
+    }
+  }
+
+  func testThroughClosure() {
+    TestSelfCapture.do {
+      let _ = { Self.use(self) }()
+      // expected-warning@-1 {{capture of 'self' with non-sendable type 'SelfCapture' in a '@Sendable' closure}}
+      // expected-warning@-2 {{capture of 'self' with non-sendable type 'SelfCapture' in an isolated closure}}
+      // expected-warning@-3 {{implicit capture of 'self' requires that 'SelfCapture' conforms to 'Sendable'}}
+    }
+  }
 }


### PR DESCRIPTION
…sure is in @preconcurrency context

Cherry-pick of https://github.com/swiftlang/swift/pull/80737

--- 

- Explanation:

  Downgrades an error to a warning when closure captures something non-Sendable in pre-concurrency context.

  The original check examined only the immediate closure, but it's possible that the closure happens to be in a preconcurrency context which also requires a downgrade.

- Main Branch PR: https://github.com/swiftlang/swift/pull/80737

- Risk: Low (Downgrades an error to a warning in a narrow set of circumstances that should not have any other side-effects and allow more code to type-check successfully).

- Reviewed By: @hborla 

- Testing: Added new tests to the test suite.

- Resolves: rdar://148996589


(cherry picked from commit cad2df3d5c2bffcaecdee10d92675a0ce603c247)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
