### PR TITLE
[ClangImporter] Handle nullptr from importTypeIgnoreIUO() in constant values importing logic

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4621,7 +4621,7 @@ namespace {
               isInSystemModule(dc), Bridgeability::None, ImportTypeAttrs());
 
           // FIXME: Handle CGFloat too.
-          if (!type->isCGFloat()) {
+          if (type && !type->isCGFloat()) {
             auto convertKind = ConstantConvertKind::None;
             // Request conversions on enums, and swift_wrapper((enum/struct))
             // types


### PR DESCRIPTION
Attempting to fix this CI failure: https://ci.swift.org/job/oss-swift-RA-linux-ubuntu-22_04/9031/console