### PR TITLE
[Parser] Fix String interpolation accepts invalid argument label syntax without expression

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1924,11 +1924,6 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   default:
   UnknownCharacter:
     checkForInputIncomplete();
-    // Enable trailing comma in string literal interpolation
-    // Note that 'Tok.is(tok::r_paren)' is not used because the text is ")\"\n" but the kind is actualy 'eof'
-    if (Tok.is(tok::eof) && Tok.getText() == ")") {
-      return nullptr;
-    }
     // FIXME: offer a fixit: 'Self' -> 'self'
     diagnose(Tok, ID);
     return nullptr;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1057,11 +1057,18 @@ Parser::parseListItem(ParserStatus &Status, tok RightK, SourceLoc LeftLoc,
       return ParseListItemResult::Finished;
   }
   if (consumeIf(tok::comma)) {
-    if (Tok.isNot(RightK))
+    if (Tok.isNot(RightK) && !tokIsStringInterpolationEOF(Tok, RightK))
       return ParseListItemResult::Continue;
     if (!AllowSepAfterLast) {
       diagnose(Tok, diag::unexpected_separator, ",").fixItRemove(PreviousLoc);
     }
+    
+    // Enable trailing comma in string literal interpolation
+    if (tokIsStringInterpolationEOF(Tok, RightK)) {
+      RightLoc = Tok.getLoc();
+      return ParseListItemResult::FinishedInStringInterpolation;
+    }
+    
     return ParseListItemResult::Finished;
   }
   // If we're in a comma-separated list, the next token is at the

--- a/test/Parse/trailing-comma.swift
+++ b/test/Parse/trailing-comma.swift
@@ -60,6 +60,7 @@ struct S {
 // String Literal Interpolation
 
 "\(1,)"
+"\(1, f:)" // expected-error {{expected expression in list of expressions}}
 
 // Availability Spec List
 


### PR DESCRIPTION
# Description

resolves: https://github.com/swiftlang/swift/issues/80927

The interpolated string "(1, f:)" compiles without error, despite f: being an argument label with no following expression.

```swift
print("\(10,f:)") // 10
```

It seems to be regression of [SE-0439 Allow trailing comma in comma-separated lists](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0439-trailing-comma-lists.md). https://github.com/swiftlang/swift/pull/74522.

# Approach

In this PR, I fixed the bug by aligning the approach for trailing comma in StringInterpolation with the approach in other contexts.

When we think about valid case: `"\(10,)"`, In https://github.com/swiftlang/swift/pull/74522, `parseListItem` returns `ParseListItemResult::Continue` when parser found right paren with trailing comma `,)` in StringInterpolation then `parseExprPrimary` (triggered by the next iteration of `parseListItem`) will parse `)` next to `"\(10,`.  Therefore, [we wrote the specific logic for trailing comma in String Interpolation at `parseExprPrimary`](https://github.com/swiftlang/swift/blob/f31c89a73e3f14e8f5e7ad1b92dd434ef12654b1/lib/Parse/ParseExpr.cpp#L1911-L1915) in order to enable trailing comma in String Interpolation.

```swift
// Enable trailing comma in string literal interpolation
// Note that 'Tok.is(tok::r_paren)' is not used because the text is ")\"\n" but the kind is actualy 'eof'
if (Tok.is(tok::eof) && Tok.getText() == ")") {
  return nullptr;
}
```

However, this logic has problem that incorrectly allow the pattern invalid argument label syntax without expression: `\(10, f:)` (since tokens `f:` are consumed as optional before we call `parseExprPrimary`.)

Regarding the approach for trailing comma in other than String Interpolation such as function call,[`parseListItem` returns `ParseListItemResult::Finished` when parser found right paren with trailing comma `,)`.](https://github.com/swiftlang/swift/blob/f31c89a73e3f14e8f5e7ad1b92dd434ef12654b1/lib/Parse/Parser.cpp#L1059-L1066). in this case we don't have to write additional logic in `parseExprPrimary` and correctly emit error on the pattern: `\(1, f:)` as well. (`parseExprPrimary` originally correctly emit error on that pattern without the specific logic for trailing comma in String Interpolation)

```swift
if (Tok.isNot(RightK))
      return ParseListItemResult::Continue;

..omitted

return ParseListItemResult::Finished;
```

I this PR, to align the approach for trailing comma,  `parseListItem` returns `ParseListItemResult::FinishedInStringInterpolation` when parser found right paren with trailing comma `,)` in String Interpolation. 

# Alternative Considered

Add additional validation after calling `parseExpr` (and subsequent `parseExprPrimary`).

https://github.com/swiftlang/swift/blob/f31c89a73e3f14e8f5e7ad1b92dd434ef12654b1/lib/Parse/ParseExpr.cpp#L3249-L3253

```swift
else {
    auto ParsedSubExpr = parseExpr(diag::expected_expr_in_expr_list);
    SubExpr = ParsedSubExpr.getPtrOrNull();
    Status = ParsedSubExpr;
    
    // added. if we have a label `f:`and its expression is empty, emit diagnosis.
    if ((Tok.is(tok::eof) && Tok.getText() == ")") && !SubExpr && FieldName.nonempty()) {
      diagnose(Tok, diag::expected_expr_in_expr_list);
    }
  }
```

It's a good thing that the change is purely additive, but in the first place, writing StringInterpolation-specific logic directly in `parseExpr` may harm scalability, considering the possibility of future grammar changes and modifications to `parseExpr`. Ensuring scalability in the long term requires aligning the approach for StringInterpolation with that of other contexts such as function calls..