### PR TITLE
Fix Bootstrap: UTF8EncoddingError

### DIFF
--- a/stdlib/public/core/UTF8EncodingError.swift
+++ b/stdlib/public/core/UTF8EncodingError.swift
@@ -256,6 +256,7 @@ extension UTF8 {
           errors.append(adjustedErr)
         }
       }
+      fatalError()
     }
   }
 }


### PR DESCRIPTION
The pass that annotated control-flow positions unreachable after an infinite loop was migrated to pure Swift in PR 79186 (https://github.com/swiftlang/swift/pull/79186). As a result, the C++-only bootstrap compiler is unable to determine that the code-location is unreachable. Placing a fatalError after the infinite while loop.

Fixes: rdar://149631113