### PR TITLE
[🍒: 6.2] Fix Bootstrap: UTF8EncoddingError

### DIFF
--- a/stdlib/public/core/UTF8EncodingError.swift
+++ b/stdlib/public/core/UTF8EncodingError.swift
@@ -256,6 +256,7 @@ extension UTF8 {
           errors.append(adjustedErr)
         }
       }
+      fatalError()
     }
   }
 }


### PR DESCRIPTION
🍒https://github.com/swiftlang/swift/pull/80934

The pass that annotated control-flow positions unreachable after an infinite loop was migrated to pure Swift in PR 79186 (https://github.com/swiftlang/swift/pull/79186). As a result, the C++-only bootstrap compiler is unable to determine that the code-location is unreachable. Placing a fatalError after the infinite while loop.

Fixes: rdar://149568740
(cherry picked from commit 783c969e103a3cb424eb660faa3d5222568c1abc)

**Explanation:**

Fixes a regression caught by the bootstrap job. The pass that identifies unreachable code locations using the control-flow-graph was moved to Swift-only, so any code that is required in the bootstrap must explicitly annotate those locations or the code will fail to compile when compiled with the bootstrap compiler.

Risk: Low, the full compiler places an unreachable instruction here at the SIL level under normal circumstances. The bootstrap compiler doesn't have that capability, so we must add one explicitly.

Reviewed By: @xedin 

Testing: Locally verified that the bootstrap works after this PR. Standard PR testing passes with this PR. The bootstrapping bot caught the regression.