### PR TITLE
[ClangImporter] Don't import accessors of constants as 'open' if they're static

### DIFF
--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -426,8 +426,6 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
       /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
       params, type, dc);
   func->setStatic(isStatic);
-  func->setAccess(isStatic ? AccessLevel::Public
-                           : getOverridableAccessLevel(dc));
   func->setIsObjC(false);
   func->setIsDynamic(false);
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -426,7 +426,8 @@ ValueDecl *SwiftDeclSynthesizer::createConstant(Identifier name,
       /*ThrowsLoc=*/SourceLoc(), /*ThrownType=*/TypeLoc(),
       params, type, dc);
   func->setStatic(isStatic);
-  func->setAccess(getOverridableAccessLevel(dc));
+  func->setAccess(isStatic ? AccessLevel::Public
+                           : getOverridableAccessLevel(dc));
   func->setIsObjC(false);
   func->setIsDynamic(false);
 

--- a/test/ClangImporter/const_values_objc.swift
+++ b/test/ClangImporter/const_values_objc.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/src/main.swift \
+// RUN:   -import-bridging-header %t/src/test.h \
+// RUN:   -module-name main -I %t -emit-sil | %FileCheck %s
+
+//--- test.h
+#include <objc/objc.h>
+
+@interface MyClass : NSObject
+@end
+
+__attribute__((swift_name("MyClass.value")))
+static const int MyClassValue = -1;
+
+//--- main.swift
+func foo() {
+  print(MyClass.value)
+}
+
+// CHECK:      sil shared [transparent] @$sSo7MyClassC5values5Int32VvgZ : $@convention(method) (@thick MyClass.Type) -> Int32 {
+// CHECK-NEXT: // %0 "self"
+// CHECK-NEXT: bb0(%0 : $@thick MyClass.Type):
+// CHECK-NEXT:   debug_value %0, let, name "self", argno 1
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Int32, -1
+// CHECK-NEXT:   %3 = struct $Int32 (%2)
+// CHECK-NEXT:   return %3
+// CHECK-NEXT: }

--- a/test/ClangImporter/const_values_objc.swift
+++ b/test/ClangImporter/const_values_objc.swift
@@ -5,6 +5,8 @@
 // RUN:   -import-bridging-header %t/src/test.h \
 // RUN:   -module-name main -I %t -emit-sil | %FileCheck %s
 
+// REQUIRES: objc_interop
+
 //--- test.h
 #include <objc/objc.h>
 


### PR DESCRIPTION
This is a fixup for <https://github.com/swiftlang/swift/pull/80749>, which has caused a regression in the Source Compatibility test suite. Concretely, the Alamofire and Kommander projects, see <https://ci.swift.org/job/swift-main-source-compat-suite-debug/1090/>. The failure is a compiler crash when processing OperationQueue.defaultMaxConcurrentOperationCount (which comes from NSOperationQueueDefaultMaxConcurrentOperationCount constant in a header, with an apinote to put it onto NSOperationQueue/OperationQueue). The crash is:

```
decl cannot be 'open'
(accessor_decl decl_context=0x7ff76fa04418 <anonymous @ 0x7ff76faea430> interface_type="(OperationQueue.Type) -> () -> Int" access=open final static get for="defaultMaxConcurrentOperationCount"
  (final_attr implicit)
  (transparent_attr implicit)
  (parameter "self" decl_context=0x7ff76faea428 interface_type="OperationQueue.Type") result="Int" thrown_type="<null>"
  (parameter_list)
  (brace_stmt implicit
    (return_stmt implicit
      (integer_literal_expr implicit type="Int" negative value="1" builtin_initializer="Swift.(file).Int.init(_builtinIntegerLiteral:)" initializer="**NULL**"))))
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: /Users/ec2-user/jenkins/workspace-private/swift-main-source-compat-suite-debug/build/compat_macos/install/toolchain/usr/bin/swift-frontend -frontend -c /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/Source/KommandCancelledError.swift /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/Source/Kommander.swift /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/Source/CurrentDispatcher.swift /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/Source/Kommand.swift -primary-file /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/Source/Dispatcher.swift /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/Source/MainDispatcher.swift -emit-dependencies-path "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Objects-normal/arm64/Dispatcher.d" -emit-const-values-path "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Objects-normal/arm64/Dispatcher.swiftconstvalues" -emit-reference-dependencies-path "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Objects-normal/arm64/Dispatcher.swiftdeps" -serialize-diagnostics-path "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Objects-normal/arm64/Dispatcher.dia" -target arm64-apple-macos10.13 -Xllvm -aarch64-use-tbi -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk -I /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Products/Debug -F /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Products/Debug -no-color-diagnostics -application-extension -enable-testing -g -debug-info-format=dwarf -dwarf-version=4 -import-underlying-module -module-cache-path /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/ModuleCache.noindex -profile-generate -profile-coverage-mapping -swift-version 5 -enforce-exclusivity=checked -Onone -D DEBUG -serialize-debugging-options -const-gather-protocols-file "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Objects-normal/arm64/Kommander macOS_const_extract_protocols.json" -enable-experimental-feature DebugDescriptionMacro -enable-experimental-feature OpaqueTypeErasure -enable-bare-slash-regex -empty-abi-descriptor -validate-clang-modules-once -clang-build-session-file /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/ModuleCache.noindex/Session.modulevalidation -Xcc -working-directory -Xcc /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander -resource-dir /Users/ec2-user/jenkins/workspace-private/swift-main-source-compat-suite-debug/build/compat_macos/install/toolchain/usr/lib/swift -enable-anonymous-context-mangled-names -file-compilation-dir /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -Xcc "-I/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/swift-overrides.hmap" -Xcc -iquote -Xcc "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Kommander-generated-files.hmap" -Xcc "-I/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Kommander-own-target-headers.hmap" -Xcc "-I/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Kommander-all-non-framework-target-headers.hmap" -Xcc -ivfsoverlay -Xcc /Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander-bc07c704b869f412934bcabb7b72d48c-VFS/all-product-headers.yaml -Xcc -iquote -Xcc "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Kommander-project-headers.hmap" -Xcc -I/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Products/Debug/include -Xcc "-I/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/DerivedSources-normal/arm64" -Xcc "-I/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/DerivedSources/arm64" -Xcc "-I/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/DerivedSources" -Xcc -DDEBUG=1 -Xcc -ivfsoverlay -Xcc "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/unextended-module-overlay.yaml" -module-name Kommander -frontend-parseable-output -disable-clang-spi -plugin-path /Users/ec2-user/jenkins/workspace-private/swift-main-source-compat-suite-debug/build/compat_macos/install/toolchain/usr/lib/swift/host/plugins -plugin-path /Users/ec2-user/jenkins/workspace-private/swift-main-source-compat-suite-debug/build/compat_macos/install/toolchain/usr/local/lib/swift/host/plugins -target-sdk-version 15.2 -target-sdk-name macosx15.2 -external-plugin-path /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins#/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin/swift-plugin-server -external-plugin-path /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/local/lib/swift/host/plugins#/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/bin/swift-plugin-server -o "/Users/ec2-user/jenkins/workspace/swift-main-source-compat-suite-debug/swift-source-compat-suite/project_cache/kommander/build/Build/Intermediates.noindex/Kommander.build/Debug/Kommander macOS.build/Objects-normal/arm64/Dispatcher.o" -index-unit-output-path "/Kommander.build/Debug/Kommander macOS.build/Objects-normal/arm64/Dispatcher.o"
1.	Apple Swift version 6.2-dev (LLVM 0c697cbccafd2de, Swift 54e4400e920c615)
2.	Compiling with effective version 5.10
3.	While verifying AccessorDecl getter for defaultMaxConcurrentOperationCount (in module 'Foundation')
4.	While verifying FuncDecl getter for defaultMaxConcurrentOperationCount (in module 'Foundation')
5.	While verifying AbstractFunctionDecl getter for defaultMaxConcurrentOperationCount (in module 'Foundation')
```

The error message is pretty clear: The accessor cannot be "open" because it's static. This PR fixes the general `createConstant` to avoid creating "open" accessors if they're static.
