### PR TITLE
[SE-0489] Better `debugDescription` for `EncodingError` and  `DecodingError`

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -95,23 +95,23 @@ extension CodingKey {
   /// to form a path when printing debug information.
   /// - parameter isFirst: Whether this is the first key in a coding path, in
   ///   which case we will omit the prepended '.' delimiter from string keys.
-  func errorPresentationDescription(isFirstInCodingPath isFirst: Bool = true) -> String {
+  fileprivate func _errorPresentationDescription(isFirstInCodingPath isFirst: Bool = true) -> String {
     if let intValue {
       return "[\(intValue)]"
     } else {
       let delimiter = isFirst ? "" : "."
-      return "\(delimiter)\(stringValue.escapedForCodingKeyErrorPresentationDescription)"
+      return "\(delimiter)\(stringValue._escapedForCodingKeyErrorPresentationDescription)"
     }
   }
 }
 
-private extension [any CodingKey] {
+extension [any CodingKey] {
   /// Concatenates the elements of an array of coding keys and joins them with
   /// "/" separators to make them read like a path.
-  func errorPresentationDescription() -> String {
+  fileprivate func _errorPresentationDescription() -> String {
     return (
-      self.prefix(1).map { $0.errorPresentationDescription(isFirstInCodingPath: true) }
-      + self.dropFirst(1).map { $0.errorPresentationDescription(isFirstInCodingPath: false) }
+      self.prefix(1).map { $0._errorPresentationDescription(isFirstInCodingPath: true) }
+      + self.dropFirst(1).map { $0._errorPresentationDescription(isFirstInCodingPath: false) }
     ).joined(separator: "")
   }
 }
@@ -121,7 +121,7 @@ extension String {
   /// the key contains a period, escape it with backticks so that it can be
   /// distinguished from the delimiter. Also escape backslashes and backticks
   /// (but *not* periods) to avoid confusion with delimiters.
-  var escapedForCodingKeyErrorPresentationDescription: String {
+  internal var _escapedForCodingKeyErrorPresentationDescription: String {
     let charactersThatNeedBackticks: Set<Character> = [".", "`", "\\"]
     let charactersThatNeedEscaping: Set<Character> = ["`", "\\"]
     assert(
@@ -3797,7 +3797,7 @@ extension EncodingError: CustomDebugStringConvertible {
     let contextDebugDescription = context.debugDescription
 
     if !context.codingPath.isEmpty {
-      output.append(". Path: \(context.codingPath.errorPresentationDescription())")
+      output.append(". Path: \(context.codingPath._errorPresentationDescription())")
     }
 
     if !contextDebugDescription.isEmpty {
@@ -3826,7 +3826,7 @@ extension DecodingError: CustomDebugStringConvertible {
       case .valueNotFound(let expectedType, let context):
         ("DecodingError.valueNotFound: Expected value of type \(expectedType) but found null instead", context)
       case .keyNotFound(let expectedKey, let context):
-        ("DecodingError.keyNotFound: Key '\(expectedKey.errorPresentationDescription())' not found in keyed decoding container", context)
+        ("DecodingError.keyNotFound: Key '\(expectedKey._errorPresentationDescription())' not found in keyed decoding container", context)
       case .dataCorrupted(let context):
         ("DecodingError.dataCorrupted: Data was corrupted", context)
     }
@@ -3834,7 +3834,7 @@ extension DecodingError: CustomDebugStringConvertible {
     var output = message
 
     if !context.codingPath.isEmpty {
-      output.append(". Path: \(context.codingPath.errorPresentationDescription())")
+      output.append(". Path: \(context.codingPath._errorPresentationDescription())")
     }
 
     let contextDebugDescription = context.debugDescription

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3778,6 +3778,10 @@ public enum DecodingError: Error {
 
 @available(SwiftStdlib 6.3, *)
 extension EncodingError: CustomDebugStringConvertible {
+  /// A textual representation of this encoding error, intended for debugging.
+  ///
+  /// - Important: The contents of the returned string are not guaranteed to
+  ///    remain stable: they may arbitrarily change in any Swift release.
   @available(SwiftStdlib 6.3, *)
   public var debugDescription: String {
     let (message, context) = switch self {
@@ -3810,6 +3814,10 @@ extension EncodingError: CustomDebugStringConvertible {
 
 @available(SwiftStdlib 6.3, *)
 extension DecodingError: CustomDebugStringConvertible {
+  /// A textual representation of this decoding error, intended for debugging.
+  ///
+  /// - Important: The contents of the returned string are not guaranteed to
+  ///    remain stable: they may arbitrarily change in any Swift release.
   @available(SwiftStdlib 6.3, *)
   public var debugDescription: String {
     let (message, context) = switch self {

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3751,21 +3751,25 @@ extension EncodingError: CustomDebugStringConvertible {
     let (message, context) = switch self {
       case .invalidValue(let value, let context):
         (
-          "Invalid value: \(String(reflecting: value)) (\(type(of: value)))",
+          "EncodingError.invalidValue: \(String(reflecting: value)) (\(type(of: value)))",
           context
         )
     }
 
-    var output = """
-      \(message)
-      \(context.debugDescription)
-      """
+    var output = message
+
+    let contextDebugDescription = context.debugDescription
+
+    if !context.codingPath.isEmpty {
+      output.append(". Path: \(context.codingPath.errorPresentationDescription)")
+    }
+
+    if !contextDebugDescription.isEmpty {
+      output.append(". Debug description: \(context.debugDescription)")
+    }
 
     if let underlyingError = context.underlyingError {
-      output.append("\nUnderlying error: \(underlyingError)")
-    }
-    if !context.codingPath.isEmpty {
-      output.append("\nPath: \(context.codingPath.errorPresentationDescription)")
+      output.append(". Underlying error: \(underlyingError)")
     }
 
     return output
@@ -3778,26 +3782,28 @@ extension DecodingError: CustomDebugStringConvertible {
   public var debugDescription: String {
     let (message, context) = switch self {
       case .typeMismatch(let expectedType, let context):
-        ("Type mismatch: expected value of type \(expectedType).", context)
+        ("DecodingError.typeMismatch: expected value of type \(expectedType)", context)
       case .valueNotFound(let expectedType, let context):
-        ("Expected value of type \(expectedType) but found null instead.", context)
+        ("DecodingError.valueNotFound: Expected value of type \(expectedType) but found null instead", context)
       case .keyNotFound(let expectedKey, let context):
-        ("Key '\(expectedKey.errorPresentationDescription)' not found in keyed decoding container.", context)
+        ("DecodingError.keyNotFound: Key '\(expectedKey.errorPresentationDescription)' not found in keyed decoding container", context)
       case .dataCorrupted(let context):
-        ("Data was corrupted.", context)
+        ("DecodingError.dataCorrupted: Data was corrupted", context)
     }
 
     var output = message
 
-    if !context.debugDescription.isEmpty {
-      output.append("\nDebug description: \(context.debugDescription)")
+    if !context.codingPath.isEmpty {
+      output.append(". Path: \(context.codingPath.errorPresentationDescription)")
+    }
+
+    let contextDebugDescription = context.debugDescription
+    if !contextDebugDescription.isEmpty {
+      output.append(". Debug description: \(contextDebugDescription)")
     }
 
     if let underlyingError = context.underlyingError {
-      output.append("\nUnderlying error: \(underlyingError)")
-    }
-    if !context.codingPath.isEmpty {
-      output.append("\nPath: \(context.codingPath.errorPresentationDescription)")
+      output.append(". Underlying error: \(underlyingError)")
     }
 
     return output

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -37,7 +37,7 @@ func test() {
   // FIXME: -module-abi-name ABI name is leaking.
 
   let _: String = #fooMacro(1)
-  // expected-error @-1 {{typeMismatch(_CompilerSwiftCompilerPluginMessageHandling.PluginToHostMessage}}
+  // expected-error @-1 {{typeMismatch}}
   let _: String = #fooMacro(2)
   // expected-error @-1 {{failed to receive result from plugin (from macro 'fooMacro')}}
   let _: String = #fooMacro(3)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1151,3 +1151,13 @@ Added: _swift_retain_preservemost
 
 // New debug environment variable for the concurrency runtime.
 Added: _concurrencyEnableTaskSlabAllocator
+
+// SE-0489 Better debugDescription for EncodingError and DecodingError
+Added: _$ss13DecodingErrorO16debugDescriptionSSvg
+Added: _$ss13DecodingErrorO16debugDescriptionSSvpMV
+Added: _$ss13DecodingErrorOs28CustomDebugStringConvertiblesMc
+Added: _$ss13DecodingErrorOs28CustomDebugStringConvertiblesWP
+Added: _$ss13EncodingErrorO16debugDescriptionSSvg
+Added: _$ss13EncodingErrorO16debugDescriptionSSvpMV
+Added: _$ss13EncodingErrorOs28CustomDebugStringConvertiblesMc
+Added: _$ss13EncodingErrorOs28CustomDebugStringConvertiblesWP

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1146,3 +1146,13 @@ Added: __swift_debug_metadataAllocatorPageSize
 
 // New debug environment variable for the concurrency runtime.
 Added: _concurrencyEnableTaskSlabAllocator
+
+// SE-0489 Better debugDescription for EncodingError and DecodingError
+Added: _$ss13DecodingErrorO16debugDescriptionSSvg
+Added: _$ss13DecodingErrorO16debugDescriptionSSvpMV
+Added: _$ss13DecodingErrorOs28CustomDebugStringConvertiblesMc
+Added: _$ss13DecodingErrorOs28CustomDebugStringConvertiblesWP
+Added: _$ss13EncodingErrorO16debugDescriptionSSvg
+Added: _$ss13EncodingErrorO16debugDescriptionSSvpMV
+Added: _$ss13EncodingErrorOs28CustomDebugStringConvertiblesMc
+Added: _$ss13EncodingErrorOs28CustomDebugStringConvertiblesWP

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -879,4 +879,8 @@ Func _float64ToStringImpl(_:_:_:_:) is a new API without '@available'
 Func _int64ToStringImpl(_:_:_:_:_:) is a new API without '@available'
 Func _uint64ToStringImpl(_:_:_:_:_:) is a new API without '@available'
 
+// New conformances from SE-0489: Better debugDescription for EncodingError and DecodingError
+Enum DecodingError has added a conformance to an existing protocol CustomDebugStringConvertible
+Enum EncodingError has added a conformance to an existing protocol CustomDebugStringConvertible
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -1113,7 +1113,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_typeMismatch_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.typeMismatch: expected value of type String. Path: [0]/address/city/birds/[1]/name. Debug description: This is where the debug description goes
+            DecodingError.typeMismatch: expected value of type String. Path: [0].address.city.birds[1].name. Debug description: This is where the debug description goes
             """#,
             fromDecodingError: DecodingError.typeMismatch(
                 String.self,
@@ -1128,7 +1128,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_typeMismatch_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.typeMismatch: expected value of type String. Path: [0]/address/[1]/street. Debug description: Some debug description. Underlying error: GenericError(name: "some generic error goes here")
+            DecodingError.typeMismatch: expected value of type String. Path: [0].address[1].street. Debug description: Some debug description. Underlying error: GenericError(name: "some generic error goes here")
             """#,
             fromDecodingError: DecodingError.typeMismatch(
                 String.self,
@@ -1144,7 +1144,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_valueNotFound_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.valueNotFound: Expected value of type String but found null instead. Path: [0]/firstName. Debug description: Description for debugging purposes
+            DecodingError.valueNotFound: Expected value of type String but found null instead. Path: [0].firstName. Debug description: Description for debugging purposes
             """#,
             fromDecodingError: DecodingError.valueNotFound(
                 String.self,
@@ -1159,7 +1159,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_valueNotFound_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.valueNotFound: Expected value of type Int but found null instead. Path: [0]/population. Debug description: Here is the debug description for value-not-found. Underlying error: GenericError(name: "these aren\'t the droids you\'re looking for")
+            DecodingError.valueNotFound: Expected value of type Int but found null instead. Path: [0].population. Debug description: Here is the debug description for value-not-found. Underlying error: GenericError(name: "these aren\'t the droids you\'re looking for")
             """#,
             fromDecodingError: DecodingError.valueNotFound(
                 Int.self,
@@ -1175,7 +1175,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_keyNotFound_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.keyNotFound: Key 'name' not found in keyed decoding container. Path: [0]/address/city. Debug description: How would you describe your relationship with your debugger?
+            DecodingError.keyNotFound: Key 'name' not found in keyed decoding container. Path: [0].address.city. Debug description: How would you describe your relationship with your debugger?
             """#,
             fromDecodingError: DecodingError.keyNotFound(
                 GenericCodingKey(stringValue: "name"),
@@ -1190,7 +1190,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_keyNotFound_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            DecodingError.keyNotFound: Key 'name' not found in keyed decoding container. Path: [0]/address/city. Debug description: Just some info to help you out. Underlying error: GenericError(name: "hey, who turned out the lights?")
+            DecodingError.keyNotFound: Key 'name' not found in keyed decoding container. Path: [0].address.city. Debug description: Just some info to help you out. Underlying error: GenericError(name: "hey, who turned out the lights?")
             """#,
             fromDecodingError: DecodingError.keyNotFound(
                 GenericCodingKey(stringValue: "name"),
@@ -1221,7 +1221,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_dataCorrupted_nonEmptyCodingPath() {
         expectErrorDescription(
             #"""
-            DecodingError.dataCorrupted: Data was corrupted. Path: first/second/[2]. Debug description: There was apparently some data corruption!. Underlying error: GenericError(name: "This data corruption is getting out of hand")
+            DecodingError.dataCorrupted: Data was corrupted. Path: first.second[2]. Debug description: There was apparently some data corruption!. Underlying error: GenericError(name: "This data corruption is getting out of hand")
             """#,
             fromDecodingError: DecodingError.dataCorrupted(
                 DecodingError.Context(
@@ -1260,7 +1260,7 @@ class TestCodable : TestCodableSuper {
     func test_encodingError_invalidValue_nonEmptyCodingPath_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            EncodingError.invalidValue: 234 (Int). Path: first/second/[2]. Debug description: You cannot do that!
+            EncodingError.invalidValue: 234 (Int). Path: first.second[2]. Debug description: You cannot do that!
             """#,
             fromEncodingError: EncodingError.invalidValue(
                 234 as Int,
@@ -1291,7 +1291,7 @@ class TestCodable : TestCodableSuper {
     func test_encodingError_invalidValue_nonEmptyCodingPath_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            EncodingError.invalidValue: 456 (Int). Path: first/second/[2]. Debug description: You cannot do that!. Underlying error: GenericError(name: "You really cannot do that")
+            EncodingError.invalidValue: 456 (Int). Path: first.second[2]. Debug description: You cannot do that!. Underlying error: GenericError(name: "You really cannot do that")
             """#,
             fromEncodingError: EncodingError.invalidValue(
                 456 as Int,

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -1303,6 +1303,45 @@ class TestCodable : TestCodableSuper {
             )
         )
     }
+
+    func test_encodingError_pathEscaping() {
+        func expectCodingPathDescription(
+            _ expectedErrorDescription: String,
+            fromCodingPath path: [GenericCodingKey],
+            lineNumber: UInt = #line
+        ) {
+            let error = EncodingError.invalidValue(234 as Int, EncodingError.Context(codingPath: path, debugDescription: ""))
+            expectEqual(String(describing: error), expectedErrorDescription, "Unexpectedly wrong error for path \(path): \(error)", line: lineNumber)
+        }
+
+        expectCodingPathDescription(
+            #"""
+            EncodingError.invalidValue: 234 (Int). Path: `first.second`[3]
+            """#,
+            fromCodingPath: ["first.second", 3]
+        )
+
+        expectCodingPathDescription(
+            #"""
+            EncodingError.invalidValue: 234 (Int). Path: [1].`second\`third`
+            """#,
+            fromCodingPath: [1, "second`third"]
+        )
+
+        expectCodingPathDescription(
+            #"""
+            EncodingError.invalidValue: 234 (Int). Path: [1].`second\\third`
+            """#,
+            fromCodingPath: [1, "second\\third"]
+        )
+
+        expectCodingPathDescription(
+            #"""
+            EncodingError.invalidValue: 234 (Int). Path: [1].`two.three\\four\`five.six..seven\`\`\`eight`[9][10]
+            """#,
+            fromCodingPath: [1, "two.three\\four`five.six..seven```eight", 9, 10]
+        )
+    }
 }
 
 // MARK: - Helper Types
@@ -1414,6 +1453,7 @@ var tests = [
     "test_encodingError_invalidValue_nonEmptyCodingPath_nilUnderlyingError": TestCodable.test_encodingError_invalidValue_nonEmptyCodingPath_nilUnderlyingError,
     "test_encodingError_invalidValue_emptyCodingPath_nonNilUnderlyingError": TestCodable.test_encodingError_invalidValue_emptyCodingPath_nonNilUnderlyingError,
     "test_encodingError_invalidValue_nonEmptyCodingPath_nonNilUnderlyingError": TestCodable.test_encodingError_invalidValue_nonEmptyCodingPath_nonNilUnderlyingError,
+    "test_encodingError_pathEscaping": TestCodable.test_encodingError_pathEscaping,
 ]
 
 #if os(macOS)

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -1113,9 +1113,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_typeMismatch_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Type mismatch: expected value of type String.
-            Debug description: This is where the debug description goes
-            Path: [0]/address/city/birds/[1]/name
+            DecodingError.typeMismatch: expected value of type String. Path: [0]/address/city/birds/[1]/name. Debug description: This is where the debug description goes
             """#,
             fromDecodingError: DecodingError.typeMismatch(
                 String.self,
@@ -1130,10 +1128,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_typeMismatch_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Type mismatch: expected value of type String.
-            Debug description: Some debug description
-            Underlying error: GenericError(name: "some generic error goes here")
-            Path: [0]/address/[1]/street
+            DecodingError.typeMismatch: expected value of type String. Path: [0]/address/[1]/street. Debug description: Some debug description. Underlying error: GenericError(name: "some generic error goes here")
             """#,
             fromDecodingError: DecodingError.typeMismatch(
                 String.self,
@@ -1149,9 +1144,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_valueNotFound_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Expected value of type String but found null instead.
-            Debug description: Description for debugging purposes
-            Path: [0]/firstName
+            DecodingError.valueNotFound: Expected value of type String but found null instead. Path: [0]/firstName. Debug description: Description for debugging purposes
             """#,
             fromDecodingError: DecodingError.valueNotFound(
                 String.self,
@@ -1166,10 +1159,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_valueNotFound_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Expected value of type Int but found null instead.
-            Debug description: Here is the debug description for value-not-found
-            Underlying error: GenericError(name: "these aren\'t the droids you\'re looking for")
-            Path: [0]/population
+            DecodingError.valueNotFound: Expected value of type Int but found null instead. Path: [0]/population. Debug description: Here is the debug description for value-not-found. Underlying error: GenericError(name: "these aren\'t the droids you\'re looking for")
             """#,
             fromDecodingError: DecodingError.valueNotFound(
                 Int.self,
@@ -1185,9 +1175,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_keyNotFound_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Key 'name' not found in keyed decoding container.
-            Debug description: How would you describe your relationship with your debugger?
-            Path: [0]/address/city
+            DecodingError.keyNotFound: Key 'name' not found in keyed decoding container. Path: [0]/address/city. Debug description: How would you describe your relationship with your debugger?
             """#,
             fromDecodingError: DecodingError.keyNotFound(
                 GenericCodingKey(stringValue: "name"),
@@ -1202,10 +1190,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_keyNotFound_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Key 'name' not found in keyed decoding container.
-            Debug description: Just some info to help you out
-            Underlying error: GenericError(name: "hey, who turned out the lights?")
-            Path: [0]/address/city
+            DecodingError.keyNotFound: Key 'name' not found in keyed decoding container. Path: [0]/address/city. Debug description: Just some info to help you out. Underlying error: GenericError(name: "hey, who turned out the lights?")
             """#,
             fromDecodingError: DecodingError.keyNotFound(
                 GenericCodingKey(stringValue: "name"),
@@ -1221,9 +1206,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_dataCorrupted_emptyCodingPath() {
         expectErrorDescription(
             #"""
-            Data was corrupted.
-            Debug description: The given data was not valid JSON
-            Underlying error: GenericError(name: "just some data corruption")
+            DecodingError.dataCorrupted: Data was corrupted. Debug description: The given data was not valid JSON. Underlying error: GenericError(name: "just some data corruption")
             """#,
             fromDecodingError: DecodingError.dataCorrupted(
                 DecodingError.Context(
@@ -1238,10 +1221,7 @@ class TestCodable : TestCodableSuper {
     func test_decodingError_dataCorrupted_nonEmptyCodingPath() {
         expectErrorDescription(
             #"""
-            Data was corrupted.
-            Debug description: There was apparently some data corruption!
-            Underlying error: GenericError(name: "This data corruption is getting out of hand")
-            Path: first/second/[2]
+            DecodingError.dataCorrupted: Data was corrupted. Path: first/second/[2]. Debug description: There was apparently some data corruption!. Underlying error: GenericError(name: "This data corruption is getting out of hand")
             """#,
             fromDecodingError: DecodingError.dataCorrupted(
                 DecodingError.Context(
@@ -1265,8 +1245,7 @@ class TestCodable : TestCodableSuper {
     func test_encodingError_invalidValue_emptyCodingPath_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Invalid value: 123 (Int)
-            You cannot do that!
+            EncodingError.invalidValue: 123 (Int). Debug description: You cannot do that!
             """#,
             fromEncodingError: EncodingError.invalidValue(
                 123 as Int,
@@ -1281,9 +1260,7 @@ class TestCodable : TestCodableSuper {
     func test_encodingError_invalidValue_nonEmptyCodingPath_nilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Invalid value: 234 (Int)
-            You cannot do that!
-            Path: first/second/[2]
+            EncodingError.invalidValue: 234 (Int). Path: first/second/[2]. Debug description: You cannot do that!
             """#,
             fromEncodingError: EncodingError.invalidValue(
                 234 as Int,
@@ -1298,9 +1275,7 @@ class TestCodable : TestCodableSuper {
     func test_encodingError_invalidValue_emptyCodingPath_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Invalid value: 345 (Int)
-            You cannot do that!
-            Underlying error: GenericError(name: "You really cannot do that")
+            EncodingError.invalidValue: 345 (Int). Debug description: You cannot do that!. Underlying error: GenericError(name: "You really cannot do that")
             """#,
             fromEncodingError: EncodingError.invalidValue(
                 345 as Int,
@@ -1316,10 +1291,7 @@ class TestCodable : TestCodableSuper {
     func test_encodingError_invalidValue_nonEmptyCodingPath_nonNilUnderlyingError() {
         expectErrorDescription(
             #"""
-            Invalid value: 456 (Int)
-            You cannot do that!
-            Underlying error: GenericError(name: "You really cannot do that")
-            Path: first/second/[2]
+            EncodingError.invalidValue: 456 (Int). Path: first/second/[2]. Debug description: You cannot do that!. Underlying error: GenericError(name: "You really cannot do that")
             """#,
             fromEncodingError: EncodingError.invalidValue(
                 456 as Int,

--- a/test/stdlib/CodableTests.swift
+++ b/test/stdlib/CodableTests.swift
@@ -1100,6 +1100,237 @@ class TestCodable : TestCodableSuper {
             expectRoundTripEqualityThroughPlist(for: UUIDCodingWrapper(uuid), lineNumber: testLine)
         }
     }
+
+    // MARK: - DecodingError
+    func expectErrorDescription(
+        _ expectedErrorDescription: String,
+        fromDecodingError error: DecodingError,
+        lineNumber: UInt = #line
+    ) {
+        expectEqual(String(describing: error), expectedErrorDescription, "Unexpectedly wrong error: \(error)", line: lineNumber)
+    }
+
+    func test_decodingError_typeMismatch_nilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Type mismatch: expected value of type String.
+            Debug description: This is where the debug description goes
+            Path: [0]/address/city/birds/[1]/name
+            """#,
+            fromDecodingError: DecodingError.typeMismatch(
+                String.self,
+                DecodingError.Context(
+                    codingPath: [0, "address", "city", "birds", 1, "name"] as [GenericCodingKey],
+                    debugDescription: "This is where the debug description goes"
+                )
+            )
+        )
+    }
+
+    func test_decodingError_typeMismatch_nonNilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Type mismatch: expected value of type String.
+            Debug description: Some debug description
+            Underlying error: GenericError(name: "some generic error goes here")
+            Path: [0]/address/[1]/street
+            """#,
+            fromDecodingError: DecodingError.typeMismatch(
+                String.self,
+                DecodingError.Context(
+                    codingPath: [0, "address", 1, "street"] as [GenericCodingKey],
+                    debugDescription: "Some debug description",
+                    underlyingError: GenericError(name: "some generic error goes here")
+                )
+            )
+        )
+    }
+
+    func test_decodingError_valueNotFound_nilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Expected value of type String but found null instead.
+            Debug description: Description for debugging purposes
+            Path: [0]/firstName
+            """#,
+            fromDecodingError: DecodingError.valueNotFound(
+                String.self,
+                DecodingError.Context(
+                    codingPath: [0, "firstName"] as [GenericCodingKey],
+                    debugDescription: "Description for debugging purposes"
+                )
+            )
+        )
+    }
+
+    func test_decodingError_valueNotFound_nonNilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Expected value of type Int but found null instead.
+            Debug description: Here is the debug description for value-not-found
+            Underlying error: GenericError(name: "these aren\'t the droids you\'re looking for")
+            Path: [0]/population
+            """#,
+            fromDecodingError: DecodingError.valueNotFound(
+                Int.self,
+                DecodingError.Context(
+                    codingPath: [0, "population"] as [GenericCodingKey],
+                    debugDescription: "Here is the debug description for value-not-found",
+                    underlyingError: GenericError(name: "these aren't the droids you're looking for")
+                )
+            )
+        )
+    }
+
+    func test_decodingError_keyNotFound_nilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Key 'name' not found in keyed decoding container.
+            Debug description: How would you describe your relationship with your debugger?
+            Path: [0]/address/city
+            """#,
+            fromDecodingError: DecodingError.keyNotFound(
+                GenericCodingKey(stringValue: "name"),
+                DecodingError.Context(
+                    codingPath: [0, "address", "city"] as [GenericCodingKey],
+                    debugDescription: "How would you describe your relationship with your debugger?"
+                )
+            )
+        )
+    }
+
+    func test_decodingError_keyNotFound_nonNilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Key 'name' not found in keyed decoding container.
+            Debug description: Just some info to help you out
+            Underlying error: GenericError(name: "hey, who turned out the lights?")
+            Path: [0]/address/city
+            """#,
+            fromDecodingError: DecodingError.keyNotFound(
+                GenericCodingKey(stringValue: "name"),
+                DecodingError.Context(
+                    codingPath: [0, "address", "city"] as [GenericCodingKey],
+                    debugDescription: "Just some info to help you out",
+                    underlyingError: GenericError(name: "hey, who turned out the lights?")
+                )
+            )
+        )
+    }
+
+    func test_decodingError_dataCorrupted_emptyCodingPath() {
+        expectErrorDescription(
+            #"""
+            Data was corrupted.
+            Debug description: The given data was not valid JSON
+            Underlying error: GenericError(name: "just some data corruption")
+            """#,
+            fromDecodingError: DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [] as [GenericCodingKey], // sometimes empty when generated by JSONDecoder
+                    debugDescription: "The given data was not valid JSON",
+                    underlyingError: GenericError(name: "just some data corruption")
+                )
+            )
+        )
+    }
+
+    func test_decodingError_dataCorrupted_nonEmptyCodingPath() {
+        expectErrorDescription(
+            #"""
+            Data was corrupted.
+            Debug description: There was apparently some data corruption!
+            Underlying error: GenericError(name: "This data corruption is getting out of hand")
+            Path: first/second/[2]
+            """#,
+            fromDecodingError: DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: ["first", "second", 2] as [GenericCodingKey],
+                    debugDescription: "There was apparently some data corruption!",
+                    underlyingError: GenericError(name: "This data corruption is getting out of hand")
+                )
+            )
+        )
+    }
+
+    // MARK: - EncodingError
+    func expectErrorDescription(
+        _ expectedErrorDescription: String,
+        fromEncodingError error: EncodingError,
+        lineNumber: UInt = #line
+    ) {
+        expectEqual(String(describing: error), expectedErrorDescription, "Unexpectedly wrong error: \(error)", line: lineNumber)
+    }
+
+    func test_encodingError_invalidValue_emptyCodingPath_nilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Invalid value: 123 (Int)
+            You cannot do that!
+            """#,
+            fromEncodingError: EncodingError.invalidValue(
+                123 as Int,
+                EncodingError.Context(
+                    codingPath: [] as [GenericCodingKey],
+                    debugDescription: "You cannot do that!"
+                )
+            )
+        )
+    }
+
+    func test_encodingError_invalidValue_nonEmptyCodingPath_nilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Invalid value: 234 (Int)
+            You cannot do that!
+            Path: first/second/[2]
+            """#,
+            fromEncodingError: EncodingError.invalidValue(
+                234 as Int,
+                EncodingError.Context(
+                    codingPath: ["first", "second", 2] as [GenericCodingKey],
+                    debugDescription: "You cannot do that!"
+                )
+            )
+        )
+    }
+
+    func test_encodingError_invalidValue_emptyCodingPath_nonNilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Invalid value: 345 (Int)
+            You cannot do that!
+            Underlying error: GenericError(name: "You really cannot do that")
+            """#,
+            fromEncodingError: EncodingError.invalidValue(
+                345 as Int,
+                EncodingError.Context(
+                    codingPath: [] as [GenericCodingKey],
+                    debugDescription: "You cannot do that!",
+                    underlyingError: GenericError(name: "You really cannot do that")
+                )
+            )
+        )
+    }
+
+    func test_encodingError_invalidValue_nonEmptyCodingPath_nonNilUnderlyingError() {
+        expectErrorDescription(
+            #"""
+            Invalid value: 456 (Int)
+            You cannot do that!
+            Underlying error: GenericError(name: "You really cannot do that")
+            Path: first/second/[2]
+            """#,
+            fromEncodingError: EncodingError.invalidValue(
+                456 as Int,
+                EncodingError.Context(
+                    codingPath: ["first", "second", 2] as [GenericCodingKey],
+                    debugDescription: "You cannot do that!",
+                    underlyingError: GenericError(name: "You really cannot do that")
+                )
+            )
+        )
+    }
 }
 
 // MARK: - Helper Types
@@ -1118,6 +1349,18 @@ struct GenericCodingKey: CodingKey {
     }
 }
 
+extension GenericCodingKey: ExpressibleByStringLiteral {
+    init(stringLiteral: String) {
+        self.init(stringValue: stringLiteral)
+    }
+}
+
+extension GenericCodingKey: ExpressibleByIntegerLiteral {
+    init(integerLiteral: Int) {
+        self.init(intValue: integerLiteral)
+    }
+}
+
 struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable {
     let value: T
 
@@ -1128,6 +1371,10 @@ struct TopLevelWrapper<T> : Codable, Equatable where T : Codable, T : Equatable 
     static func ==(_ lhs: TopLevelWrapper<T>, _ rhs: TopLevelWrapper<T>) -> Bool {
         return lhs.value == rhs.value
     }
+}
+
+struct GenericError: Error {
+    let name: String
 }
 
 // MARK: - Tests
@@ -1183,6 +1430,18 @@ var tests = [
     "test_URL_Plist" : TestCodable.test_URL_Plist,
     "test_UUID_JSON" : TestCodable.test_UUID_JSON,
     "test_UUID_Plist" : TestCodable.test_UUID_Plist,
+    "test_decodingError_typeMismatch_nilUnderlyingError" : TestCodable.test_decodingError_typeMismatch_nilUnderlyingError,
+    "test_decodingError_typeMismatch_nonNilUnderlyingError" : TestCodable.test_decodingError_typeMismatch_nonNilUnderlyingError,
+    "test_decodingError_valueNotFound_nilUnderlyingError" : TestCodable.test_decodingError_valueNotFound_nilUnderlyingError,
+    "test_decodingError_valueNotFound_nonNilUnderlyingError" : TestCodable.test_decodingError_valueNotFound_nonNilUnderlyingError,
+    "test_decodingError_keyNotFound_nilUnderlyingError" : TestCodable.test_decodingError_keyNotFound_nilUnderlyingError,
+    "test_decodingError_keyNotFound_nonNilUnderlyingError" : TestCodable.test_decodingError_keyNotFound_nonNilUnderlyingError,
+    "test_decodingError_dataCorrupted_emptyCodingPath" : TestCodable.test_decodingError_dataCorrupted_emptyCodingPath,
+    "test_decodingError_dataCorrupted_nonEmptyCodingPath" : TestCodable.test_decodingError_dataCorrupted_nonEmptyCodingPath,
+    "test_encodingError_invalidValue_emptyCodingPath_nilUnderlyingError": TestCodable.test_encodingError_invalidValue_emptyCodingPath_nilUnderlyingError,
+    "test_encodingError_invalidValue_nonEmptyCodingPath_nilUnderlyingError": TestCodable.test_encodingError_invalidValue_nonEmptyCodingPath_nilUnderlyingError,
+    "test_encodingError_invalidValue_emptyCodingPath_nonNilUnderlyingError": TestCodable.test_encodingError_invalidValue_emptyCodingPath_nonNilUnderlyingError,
+    "test_encodingError_invalidValue_nonEmptyCodingPath_nonNilUnderlyingError": TestCodable.test_encodingError_invalidValue_nonEmptyCodingPath_nonNilUnderlyingError,
 ]
 
 #if os(macOS)


### PR DESCRIPTION
Now accepted as [SE-0489](https://github.com/ZevEisenberg/swift-evolution/blob/main/proposals/0489-codable-error-printing.md).

# To Do

- [x] confirm which version of Swift to use for the availability annotations. Probably 6.3 at time of writing.

# Context

Re: [Swift forum post](https://forums.swift.org/t/the-future-of-serialization-deserialization-apis/78585/77), where a discussion about future serialization tools in Swift prompted Kevin Perry to suggest that some proposed changes could actually be made in today's stdlib.

# Summary of Changes

Conforms `EncodingError` and `DecodingError` to `CustomDebugStringConvertible` and adds a more-readable `debugDescription`.

# Future Directions

This is a pared-down version of some experiments I did in [UsefulDecode](https://github.com/ZevEisenberg/UsefulDecode). The changes in this PR are the best I could do without changing the public interface of `DecodingError` and `EncodingError`, and without modifying the way the `JSON`/`PropertyList` `Encoder`/`Decoder` in Foundation generate their errors' debug descriptions.

In the above-linked [UsefulDecode](https://github.com/ZevEisenberg/UsefulDecode) repo, when JSON decoding fails, I go back and re-decode the JSON using `JSONSerialization` in order to provide more context about what failed, and why. I didn't attempt to make such a change here, but I'd like to discuss what may be possible.

# Examples

To illustrate the effect of the changes in this PR, I removed my changes to stdlib/public/core/Codable.swift and ran my new test cases again. Here are the resulting diffs.

## `test_encodingError_invalidValue_nonEmptyCodingPath_nilUnderlyingError`

### Before
`invalidValue(234, Swift.EncodingError.Context(codingPath: [GenericCodingKey(stringValue: "first", intValue: nil), GenericCodingKey(stringValue: "second", intValue: nil), GenericCodingKey(stringValue: "2", intValue: 2)], debugDescription: "You cannot do that!", underlyingError: nil))`

### After
`EncodingError.invalidValue: 234 (Int). Path: first.second[2]. Debug description: You cannot do that!`

## `test_decodingError_valueNotFound_nilUnderlyingError`

### Before
`valueNotFound(Swift.String, Swift.DecodingError.Context(codingPath: [GenericCodingKey(stringValue: "0", intValue: 0), GenericCodingKey(stringValue: "firstName", intValue: nil)], debugDescription: "Description for debugging purposes", underlyingError: nil))`

### After
`DecodingError.valueNotFound: Expected value of type String but found null instead. Path: [0].firstName. Debug description: Description for debugging purposes`

## `test_decodingError_keyNotFound_nonNilUnderlyingError`

### Before
`keyNotFound(GenericCodingKey(stringValue: "name", intValue: nil), Swift.DecodingError.Context(codingPath: [GenericCodingKey(stringValue: "0", intValue: 0), GenericCodingKey(stringValue: "address", intValue: nil), GenericCodingKey(stringValue: "city", intValue: nil)], debugDescription: "Just some info to help you out", underlyingError: Optional(main.GenericError(name: "hey, who turned out the lights?"))))`

### After
`DecodingError.keyNotFound: Key \'name\' not found in keyed decoding container. Path: [0].address.city. Debug description: Just some info to help you out. Underlying error: GenericError(name: "hey, who turned out the lights?")`

## `test_decodingError_typeMismatch_nilUnderlyingError`

### Before
`typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [GenericCodingKey(stringValue: "0", intValue: 0), GenericCodingKey(stringValue: "address", intValue: nil), GenericCodingKey(stringValue: "city", intValue: nil), GenericCodingKey(stringValue: "birds", intValue: nil), GenericCodingKey(stringValue: "1", intValue: 1), GenericCodingKey(stringValue: "name", intValue: nil)], debugDescription: "This is where the debug description goes", underlyingError: nil))`

### After
`DecodingError.typeMismatch: expected value of type String. Path: [0].address.city.birds[1].name. Debug description: This is where the debug description goes`

## `test_decodingError_dataCorrupted_nonEmptyCodingPath`

### Before
`dataCorrupted(Swift.DecodingError.Context(codingPath: [GenericCodingKey(stringValue: "first", intValue: nil), GenericCodingKey(stringValue: "second", intValue: nil), GenericCodingKey(stringValue: "2", intValue: 2)], debugDescription: "There was apparently some data corruption!", underlyingError: Optional(main.GenericError(name: "This data corruption is getting out of hand"))))`

### After
`DecodingError.dataCorrupted: Data was corrupted. Path: first.second[2]. Debug description: There was apparently some data corruption!. Underlying error: GenericError(name: "This data corruption is getting out of hand")`

## `test_decodingError_valueNotFound_nonNilUnderlyingError`

### Before
`valueNotFound(Swift.Int, Swift.DecodingError.Context(codingPath: [GenericCodingKey(stringValue: "0", intValue: 0), GenericCodingKey(stringValue: "population", intValue: nil)], debugDescription: "Here is the debug description for value-not-found", underlyingError: Optional(main.GenericError(name: "these aren\\\'t the droids you\\\'re looking for"))))`

### After
`DecodingError.valueNotFound: Expected value of type Int but found null instead. Path: [0].population. Debug description: Here is the debug description for value-not-found. Underlying error: GenericError(name: "these aren\\\'t the droids you\\\'re looking for")`

## `test_encodingError_invalidValue_emptyCodingPath_nonNilUnderlyingError`

### Before
`invalidValue(345, Swift.EncodingError.Context(codingPath: [], debugDescription: "You cannot do that!", underlyingError: Optional(main.GenericError(name: "You really cannot do that"))))`

### After
`EncodingError.invalidValue: 345 (Int). Debug description: You cannot do that!. Underlying error: GenericError(name: "You really cannot do that")`

## `test_decodingError_typeMismatch_nonNilUnderlyingError`

### Before
`typeMismatch(Swift.String, Swift.DecodingError.Context(codingPath: [GenericCodingKey(stringValue: "0", intValue: 0), GenericCodingKey(stringValue: "address", intValue: nil), GenericCodingKey(stringValue: "1", intValue: 1), GenericCodingKey(stringValue: "street", intValue: nil)], debugDescription: "Some debug description", underlyingError: Optional(main.GenericError(name: "some generic error goes here"))))`

### After
`DecodingError.typeMismatch: expected value of type String. Path: [0].address[1].street. Debug description: Some debug description. Underlying error: GenericError(name: "some generic error goes here")`

## `test_encodingError_invalidValue_emptyCodingPath_nilUnderlyingError`

### Before
`invalidValue(123, Swift.EncodingError.Context(codingPath: [], debugDescription: "You cannot do that!", underlyingError: nil))`

### After
`EncodingError.invalidValue: 123 (Int). Debug description: You cannot do that!`

## `test_decodingError_keyNotFound_nilUnderlyingError`

### Before
`keyNotFound(GenericCodingKey(stringValue: "name", intValue: nil), Swift.DecodingError.Context(codingPath: [GenericCodingKey(stringValue: "0", intValue: 0), GenericCodingKey(stringValue: "address", intValue: nil), GenericCodingKey(stringValue: "city", intValue: nil)], debugDescription: "How would you describe your relationship with your debugger?", underlyingError: nil))`

### After
`DecodingError.keyNotFound: Key \'name\' not found in keyed decoding container. Path: [0]address.city. Debug description: How would you describe your relationship with your debugger?`

## `test_decodingError_dataCorrupted_emptyCodingPath`

### Before
`dataCorrupted(Swift.DecodingError.Context(codingPath: [], debugDescription: "The given data was not valid JSON", underlyingError: Optional(main.GenericError(name: "just some data corruption"))))`

### After
`DecodingError.dataCorrupted: Data was corrupted. Debug description: The given data was not valid JSON. Underlying error: GenericError(name: "just some data corruption")`

## `test_encodingError_invalidValue_nonEmptyCodingPath_nonNilUnderlyingError`

### Before
`invalidValue(456, Swift.EncodingError.Context(codingPath: [GenericCodingKey(stringValue: "first", intValue: nil), GenericCodingKey(stringValue: "second", intValue: nil), GenericCodingKey(stringValue: "2", intValue: 2)], debugDescription: "You cannot do that!", underlyingError: Optional(main.GenericError(name: "You really cannot do that"))))`

### After
`EncodingError.invalidValue: 456 (Int). Path: first.second[2]. Debug description: You cannot do that!. Underlying error: GenericError(name: "You really cannot do that")`
