### PR TITLE
[6.2][Distributed] Distributed actor usage through protocol with lib-evolution

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1001,8 +1001,7 @@ namespace {
 
       // Emit the dispatch thunk.
       auto shouldEmitDispatchThunk =
-          (Resilient || IGM.getOptions().WitnessMethodElimination) &&
-          (!func.isDistributed() || !func.isDistributedThunk());
+          (Resilient || IGM.getOptions().WitnessMethodElimination);
       if (shouldEmitDispatchThunk) {
         IGM.emitDispatchThunk(func);
       }
@@ -1083,14 +1082,10 @@ namespace {
             // Define the method descriptor.
             SILDeclRef func(entry.getFunction());
 
-            /// Distributed thunks don't need method descriptors
-            if (!func.isDistributedThunk()) {
-              auto *descriptor =
-                B.getAddrOfCurrentPosition(
-                  IGM.ProtocolRequirementStructTy);
-              IGM.defineMethodDescriptor(func, Proto, descriptor,
-                                         IGM.ProtocolRequirementStructTy);
-            }
+            auto *descriptor =
+                B.getAddrOfCurrentPosition(IGM.ProtocolRequirementStructTy);
+            IGM.defineMethodDescriptor(func, Proto, descriptor,
+                                       IGM.ProtocolRequirementStructTy);
           }
         }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2368,12 +2368,6 @@ namespace {
               LinkEntity::forBaseConformanceDescriptor(requirement));
           B.addRelativeAddress(baseConformanceDescriptor);
         } else if (entry.getKind() == SILWitnessTable::Method) {
-          // distributed thunks don't need resilience
-          if (entry.getMethodWitness().Requirement.isDistributedThunk()) {
-            witnesses = witnesses.drop_back();
-            continue;
-          }
-
           // Method descriptor.
           auto declRef = entry.getMethodWitness().Requirement;
           auto requirement =

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -157,14 +157,6 @@ public:
   }
 
   void addMethodDescriptor(SILDeclRef declRef) override {
-    if (declRef.isDistributedThunk()) {
-      auto afd = declRef.getAbstractFunctionDecl();
-      auto DC = afd->getDeclContext();
-      if (isa<ProtocolDecl>(DC)) {
-        return;
-      }
-    }
-
     addLinkEntity(LinkEntity::forMethodDescriptor(declRef));
   }
 

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -835,7 +835,6 @@ public:
                   V.Ctx.getOpts().WitnessMethodElimination} {}
 
         void addMethod(SILDeclRef declRef) {
-          // TODO: alternatively maybe prevent adding distributed thunk here rather than inside those?
           if (Resilient || WitnessMethodElimination) {
             Visitor.addDispatchThunk(declRef);
             Visitor.addMethodDescriptor(declRef);

--- a/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
+++ b/test/Distributed/Runtime/distributed_actor_library_evolution_da_protocol_use.swift
@@ -1,0 +1,54 @@
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// UNSUPPORTED: use_os_stdlib
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -enable-library-evolution -target %target-cpu-apple-macosx13.0 -parse-as-library -emit-library -emit-module-path %t/Library.swiftmodule -module-name Library %t/library.swift -o %t/%target-library-name(Library)
+// RUN: %target-build-swift -Xfrontend -validate-tbd-against-ir=all -target %target-cpu-apple-macosx13.0 -parse-as-library -lLibrary -module-name main -I %t -L %t %t/main.swift -o %t/a.out
+
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+//--- library.swift
+import Distributed
+
+public protocol SimpleProtocol: DistributedActor
+    where ActorSystem == LocalTestingDistributedActorSystem {
+
+  // nonisolated override var id: ID { get } // comes from DistributedActor
+
+  // Has to have a distributed method to fail
+  distributed func test() -> Int
+}
+
+//--- main.swift
+import Distributed
+import Library
+
+public distributed actor SimpleActor: SimpleProtocol {
+  public distributed func test() -> Int {
+    print("SimpleActor.test")
+    return 1
+  }
+}
+
+public func makeFromFail<Act: SimpleProtocol>(_ act: Act) async {
+  print(act.id)
+  try! await print("act.test() = \(act.test())")
+  // CHECK: SimpleActor.test
+  // CHECK: act.test() = 1
+}
+
+@main
+struct TestSwiftFrameworkTests {
+  static func main() async {
+    let system = LocalTestingDistributedActorSystem()
+
+    let simpleActor = SimpleActor(actorSystem: system)
+    await makeFromFail(simpleActor)
+  }
+}


### PR DESCRIPTION
**Description**: This corrects how we were dealing with dispatch thunks -- mostly be
removing a lot of special casing we did but doesn't seem necessary and
instead we correct and emit all the necessary information int TBD.

This builds on https://github.com/swiftlang/swift/pull/74935 by further refining how we fixed that issue, and adds more regression tests. It also removes a load of special casing of distributed thunks in library evolution mode, which is great.

**Scope/Impact**: Resolves how we deal with dispatch thunks in library evolution mode. We previously wrongly assumed we can just not do dispatch thunks in some situations, this together with other partial fixes worked however was only a partial fix. Instead, this patch resolves all these issues, by removing all the piled up special cases.

**Risk:** Low, resolves library evolution issues in distributed @resolvable protocols specifically. Other code would not be affected, not would be code outside of library evoltion.
**Testing**: CI testing, added test covering this situation
**Reviewed by**: @xedin 

**Original PR:**  https://github.com/swiftlang/swift/pull/80588
**Radar:** rdar://145292018