### PR TITLE
[6.2] Run only Swift subset of LLDB tests for Linux Smoketest preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1094,6 +1094,7 @@ install-swiftformat
 reconfigure
 test-optimized
 skip-test-swiftdocc
+lldb-test-swift-only
 
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
 # Use the clang that we install in the path for macros


### PR DESCRIPTION
Addresses rdar://149562580

(cherry picked from commit 60150e7da08fc69facad352362d2bda3f53e13ad)

  - **Explanation**:
    Update the  Linux Smoketest preset to only run the LLDB tests that apply to Swift.
  - **Scope**:
    `buildbot_linux,smoketest` preset
  - **Issues**:
    rdar://149562580
  - **Original PRs**:
    https://github.com/swiftlang/swift/pull/80916
  - **Risk**:
    Low -- this flag is already used by other presets used in CI, and in the worst case we will keep running too many tests but not failing
  - **Testing**:
    Linux PR testing in the original PR and manual inspection of the resulting log to ensure we indeed run less LLDB tests.
  - **Reviewers**:
    @adrian-prantl 