### PR TITLE
[🍒 6.2] Fix String interpolation accepts invalid argument label syntax without expression 

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1908,11 +1908,6 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   default:
   UnknownCharacter:
     checkForInputIncomplete();
-    // Enable trailing comma in string literal interpolation
-    // Note that 'Tok.is(tok::r_paren)' is not used because the text is ")\"\n" but the kind is actualy 'eof'
-    if (Tok.is(tok::eof) && Tok.getText() == ")") {
-      return nullptr;
-    }
     // FIXME: offer a fixit: 'Self' -> 'self'
     diagnose(Tok, ID);
     return nullptr;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1057,11 +1057,18 @@ Parser::parseListItem(ParserStatus &Status, tok RightK, SourceLoc LeftLoc,
       return ParseListItemResult::Finished;
   }
   if (consumeIf(tok::comma)) {
-    if (Tok.isNot(RightK))
+    if (Tok.isNot(RightK) && !tokIsStringInterpolationEOF(Tok, RightK))
       return ParseListItemResult::Continue;
     if (!AllowSepAfterLast) {
       diagnose(Tok, diag::unexpected_separator, ",").fixItRemove(PreviousLoc);
     }
+    
+    // Enable trailing comma in string literal interpolation
+    if (tokIsStringInterpolationEOF(Tok, RightK)) {
+      RightLoc = Tok.getLoc();
+      return ParseListItemResult::FinishedInStringInterpolation;
+    }
+    
     return ParseListItemResult::Finished;
   }
   // If we're in a comma-separated list, the next token is at the

--- a/test/Parse/trailing-comma.swift
+++ b/test/Parse/trailing-comma.swift
@@ -60,6 +60,7 @@ struct S {
 // String Literal Interpolation
 
 "\(1,)"
+"\(1, f:)" // expected-error {{expected expression in list of expressions}}
 
 // Availability Spec List
 


### PR DESCRIPTION
🍒 #80928 

**Explanation:** The patch from #80928 fixes false-negative on invalid syntax related to String Interpolation with trailing comma:  #80927.

```swift
"\(1, diag:)" // should be compile error.
```

**Scope**: Parser/syntax, related to String Interpolation with trailing comma. won't break existing code that has valid syntax.

**Issues**: #80927

**Testing:** Added test to test suite

**Risk**: Low. the compiler only fixes false-negative on invalid syntax.

**Original PRs**: #80928 

**Reviewers**: @rintaro 
