### PR TITLE
[silgen] Fix a small typo bug I found on inspection.

### DIFF
--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -81,7 +81,7 @@ public:
     assert(box && "buffer never emitted before activating cleanup?!");
     auto theBox = box;
     if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
-      if (auto *bbi = cast<BeginBorrowInst>(theBox)) {
+      if (auto *bbi = dyn_cast<BeginBorrowInst>(theBox)) {
         SGF.B.createEndBorrow(loc, bbi);
         theBox = bbi->getOperand();
       }


### PR DESCRIPTION
We are performing a cast instead of a dyn_cast in an if statement. This will assert on failure rather than fall through. It seems to be an obvious typo. I checked in the actual commit in question that introduced it and the intention was to be a dyn_cast.

rdar://149698148
