### PR TITLE
🍒 [6.1][cxx-interop] Fix a CI failure in ptrauth test

### DIFF
--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
@@ -16,7 +16,7 @@
 // CHECK-NEXT: void **vtable_ = *selfPtr_;
 // CHECK-NEXT: #endif
 // CHECK-NEXT: struct FTypeAddress {
-// CHECK-NEXT: decltype(_impl::$s5Class04BaseA0C13virtualMethodyyF) * __ptrauth_swift_class_method_pointer([[#AUTH:]]) func;
+// CHECK-NEXT: decltype(Class::_impl::$s5Class04BaseA0C13virtualMethodyyF) * __ptrauth_swift_class_method_pointer([[#AUTH:]]) func;
 // CHECK-NEXT: };
 // CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1:]] / sizeof(void *));
 // CHECK-NEXT:   (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));


### PR DESCRIPTION
Explanation: #80495 was merged to `main` to fix an issue, and was followed up by #80638 to fix a platform-specific test case. #80495 was cherry-picked to `release/6.1` in #80587; this PR cherry-picks the test case fix from #80638. Fixes the CI failure [here](https://ci.swift.org/job/oss-swift-6.1_tools-RA_stdlib-DA_test-device-non_executable/334/).
Issue: rdar://149683618
Risk: Low, the only change is targeted a platform-specific regression test.
Testing: Fixes a test
Original PR: https://github.com/swiftlang/swift/pull/80638
Reviewer: @j-hui (myself)

I'm cherry-picking this on behalf of @Xazax-hun (author of the original PR) because UK folks are on holiday.