### PR TITLE
[6.2][Sema/SILGen] Import ObjC async functions as nonisolated(nonsending) by default

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1706,8 +1706,12 @@ private:
 
     // If we are an async function that is unspecified or nonisolated, insert an
     // isolated parameter if AsyncCallerExecution is enabled.
+    //
+    // NOTE: The parameter is not inserted for async functions imported
+    // from ObjC because they are handled in a special way that doesn't
+    // require it.
     if (IsolationInfo && IsolationInfo->isCallerIsolationInheriting() &&
-        extInfoBuilder.isAsync()) {
+        extInfoBuilder.isAsync() && !Foreign.async) {
       auto actorProtocol = TC.Context.getProtocol(KnownProtocolKind::Actor);
       auto actorType =
           ExistentialType::get(actorProtocol->getDeclaredInterfaceType());

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5852,6 +5852,18 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
                         // isolation for this decl.
   }
 
+  // Asynchronous variants for functions imported from ObjC are
+  // `nonisolated(nonsending)` by default.
+  if (value->hasClangNode()) {
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(value)) {
+      if (!isa<ProtocolDecl>(AFD->getDeclContext()) &&
+          AFD->getForeignAsyncConvention()) {
+        return {
+            {ActorIsolation::forCallerIsolationInheriting(), {}}, nullptr, {}};
+      }
+    }
+  }
+
   // We did not find anything special, return unspecified.
   return {{ActorIsolation::forUnspecified(), {}}, nullptr, {}};
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5845,6 +5845,22 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
     // Use the overridden decl's isolation as the default isolation for this
     // decl.
     auto isolation = getOverriddenIsolationFor(value);
+
+    // If this is an override of an async completion handler, mark
+    // it `@concurrent` instead of inferring `nonisolated(nonsending)`
+    // to preserve pre-SE-0461 behavior.
+    if (isolation.isCallerIsolationInheriting() &&
+        overriddenValue->hasClangNode()) {
+      if (auto *AFD = dyn_cast<AbstractFunctionDecl>(overriddenValue)) {
+        if (AFD->getForeignAsyncConvention()) {
+          return {{ActorIsolation::forNonisolated(/*unsafe=*/false),
+                   IsolationSource(overriddenValue, IsolationSource::Override)},
+                  overriddenValue,
+                  isolation};
+        }
+      }
+    }
+
     return {{isolation,
              IsolationSource(overriddenValue, IsolationSource::Override)},
             overriddenValue,

--- a/test/Concurrency/attr_execution_objc.swift
+++ b/test/Concurrency/attr_execution_objc.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -swift-version 6 \
+// RUN:   -module-name main -I %t -verify
+
+// REQUIRES: objc_interop
+
+//--- Test.h
+#define MAIN_ACTOR __attribute__((__swift_attr__("@MainActor")))
+
+#pragma clang assume_nonnull begin
+
+@import Foundation;
+
+@interface Test : NSObject
+- (void)loadWithCompletionHandler:(void (^)(void)) completionHandler;
+@end
+
+MAIN_ACTOR
+@interface TestIsolated : NSObject
+- (void)loadWithCompletionHandler:(void (^)(void)) completionHandler;
+@end
+
+#pragma clang assume_nonnull end
+
+//--- main.swift
+
+func test(t: Test, i: TestIsolated) async throws {
+  let fn = t.load // nonisolated(nonsending) () async -> Void
+
+  let _: @isolated(any) () async -> Void = fn
+  // expected-error@-1 {{cannot convert value of type 'nonisolated(nonsending) () async -> Void' to specified type '@isolated(any) () async -> Void'}}
+
+  let isolatedFn = i.load
+  let _: () -> Void = isolatedFn
+  // expected-error@-1 {{invalid conversion from 'async' function of type '@MainActor @Sendable () async -> Void' to synchronous function type '() -> Void'}}
+}

--- a/test/Concurrency/nonisolated_nonsending_objc_async_by_default.swift
+++ b/test/Concurrency/nonisolated_nonsending_objc_async_by_default.swift
@@ -29,6 +29,14 @@ MAIN_ACTOR
 
 //--- main.swift
 
+class OverrideTest1 : Test {
+  override func load() async {}
+}
+
+class OverrideTest2 : TestIsolated {
+  override func load() async {}
+}
+
 func test(t: Test, i: TestIsolated) async throws {
   let fn = t.load // nonisolated(nonsending) () async -> Void
 
@@ -38,4 +46,11 @@ func test(t: Test, i: TestIsolated) async throws {
   let isolatedFn = i.load
   let _: () -> Void = isolatedFn
   // expected-error@-1 {{invalid conversion from 'async' function of type '@MainActor @Sendable () async -> Void' to synchronous function type '() -> Void'}}
+}
+
+func testOverrides(o1: OverrideTest1, o2: OverrideTest2) {
+  let _: () -> Void = o1.load
+  // expected-error@-1 {{invalid conversion from 'async' function of type '() async -> ()' to synchronous function type '() -> Void'}}
+  let _: () -> Void = o2.load
+  // expected-error@-1 {{invalid conversion from 'async' function of type '@MainActor @Sendable () async -> ()' to synchronous function type '() -> Void'}}
 }

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -108,17 +108,19 @@ extension SlowServer: NativelySlowServing {}
 class SlowServerlet: SlowServer {
     // Native Function
     //
-    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> Int {
-    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaF : $@convention(method) @async (@guaranteed String, @guaranteed SlowServerlet) -> Int
+    // CHECK-NOT: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
     // CHECK:   hop_to_executor [[ACTOR]]
     // CHECK:   // end sil function '$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaF'
 
     // @objc thunk closure
     //
     // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaFyyYacfU_To : $@convention(thin) @Sendable @async (NSString, Optional<@convention(block) @Sendable (Int) -> ()>, SlowServerlet) -> () {
-    // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
-    // CHECK: [[FUNC:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> Int
-    // CHECK: apply [[FUNC]]([[ACTOR]],
+    // CHECK: [[STR_ARG:%.*]] = begin_borrow {{.*}} : $String
+    // CHECK: [[SELF:%.*]] = begin_borrow {{.*}} : $SlowServerlet
+    // CHECK: [[FUNC:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaF : $@convention(method) @async (@guaranteed String, @guaranteed SlowServerlet) -> Int
+    // CHECK: apply [[FUNC]]([[STR_ARG]], [[SELF]])
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaFyyYacfU_To'
     override func doSomethingSlowNullably(_: String) async -> Int {
         return 0
@@ -126,16 +128,18 @@ class SlowServerlet: SlowServer {
 
     // Native function.
     //
-    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> @owned String {
-    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
-    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaF : $@convention(method) @async (@guaranteed String, @guaranteed SlowServerlet) -> @owned String
+    // CHECK-NOT: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+    // CHECK-NEXT: hop_to_executor [[ACTOR]]
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaF'
 
     // @objc closure thunk
     // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaFyyYacfU_To : $@convention(thin) @Sendable @async (NSString, Optional<@convention(block) @Sendable (NSString) -> ()>, SlowServerlet) -> () {
-    // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
-    // CHECK: [[FUNC:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> @owned String
-    // CHECK: apply [[FUNC]]([[ACTOR]],
+    // CHECK: [[STR_ARG:%.*]] = begin_borrow {{.*}} : $String
+    // CHECK: [[SELF:%.*]] = begin_borrow {{.*}} : $SlowServerlet
+    // CHECK: [[FUNC:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaF : $@convention(method) @async (@guaranteed String, @guaranteed SlowServerlet) -> @owned String
+    // CHECK: apply [[FUNC]]([[STR_ARG]], [[SELF]])
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaFyyYacfU_To'
     override func findAnswerNullably(_ x: String) async -> String {
         return x
@@ -143,17 +147,19 @@ class SlowServerlet: SlowServer {
 
     // Native
     //
-    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> (@owned String, @error any Error) {
-    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
-    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKF : $@convention(method) @async (@guaranteed String, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK-NOT: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+    // CHECK-NEXT: hop_to_executor [[ACTOR]]
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKF'
 
     // @objc thunk closure
     //
     // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKFyyYacfU_To : $@convention(thin) @Sendable @async (NSString, Optional<@convention(block) @Sendable (Optional<NSString>, Optional<NSError>) -> ()>, SlowServerlet) -> () {
-    // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
-    // CHECK: [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
-    // CHECK: apply [[NATIVE]]([[ACTOR]],
+    // CHECK: [[STR_ARG:%.*]] = begin_borrow {{.*}} : $String
+    // CHECK: [[SELF:%.*]] = begin_borrow {{.*}} : $SlowServerlet
+    // CHECK: [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKF : $@convention(method) @async (@guaranteed String, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK: apply [[NATIVE]]([[STR_ARG]], [[SELF]])
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKFyyYacfU_To'
     override func doSomethingDangerousNullably(_ x: String) async throws -> String {
         return x
@@ -161,16 +167,17 @@ class SlowServerlet: SlowServer {
 
     // Native
     //
-    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error) {
-    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
-    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKF : $@convention(method) @async (@guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK-NOT: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+    // CHECK-NEXT: hop_to_executor [[ACTOR]]
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKF'
 
     // @objc closure thunk
     // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (Optional<@convention(block) @Sendable (Optional<NSString>, Optional<NSError>) -> ()>, SlowServerlet) -> () {
-    // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
-    // CHECK: [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
-    // CHECK: apply [[NATIVE]]([[ACTOR]],
+    // CHECK: [[SELF:%.*]] = begin_borrow {{.*}} : $SlowServerlet
+    // CHECK: [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKF : $@convention(method) @async (@guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK: apply [[NATIVE]]([[SELF]])
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKFyyYacfU_To'
     override func doSomethingUnspecifiedNullably() async throws -> String {
       fatalError()
@@ -178,15 +185,16 @@ class SlowServerlet: SlowServer {
 
     // Native
     //
-    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error) {
-    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
-    // CHECK:   hop_to_executor [[ACTOR]]
-    //
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKF : $@convention(method) @async (@guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK-NOT: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+    // CHECK-NEXT: hop_to_executor [[ACTOR]]
+
     // @objc thunk closure
-    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Bool, Optional<NSString>, Optional<NSError>) -> (), SlowServerlet) -> () {
-    // CHECK:   [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
-    // CHECK:   [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
-    // CHECK:   try_apply [[NATIVE]]([[ACTOR]], {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable ({{.*}}, Optional<NSString>, Optional<NSError>) -> (), SlowServerlet) -> () {
+    // CHECK: [[SELF:%.*]] = begin_borrow {{.*}} : $SlowServerlet
+    // CHECK:   [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKF : $@convention(method) @async (@guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK:   try_apply [[NATIVE]]([[SELF]]) : {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
     // CHECK: [[NORMAL_BB]]({{.*}}):
     // CHECK:   integer_literal {{.*}}0
     // CHECK: [[ERROR_BB]]({{.*}}):
@@ -198,16 +206,17 @@ class SlowServerlet: SlowServer {
 
     // Native
     //
-    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error) {
-    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
-    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKF : $@convention(method) @async (@guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK-NOT: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+    // CHECK-NEXT: hop_to_executor [[ACTOR]]
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKF'
     //
     // @objc thunk closure
-    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Optional<NSString>, Bool, Optional<NSError>) -> (), SlowServerlet) -> () {
-    // CHECK:    [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
-    // CHECK:    [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
-    // CHECK:    try_apply [[NATIVE]]([[ACTOR]], {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Optional<NSString>, {{.*}}, Optional<NSError>) -> (), SlowServerlet) -> () {
+    // CHECK: [[SELF:%.*]] = begin_borrow {{.*}} : $SlowServerlet
+    // CHECK:    [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKF : $@convention(method) @async (@guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK:    try_apply [[NATIVE]]([[SELF]]) : {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
     // CHECK:  [[NORMAL_BB]]({{.*}}):
     // CHECK:    integer_literal {{.*}}1
     // CHECK:  [[ERROR_BB]]({{.*}}):
@@ -218,15 +227,16 @@ class SlowServerlet: SlowServer {
 
     // Native
     //
-    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @owned String, @error any Error) {
-    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
-    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKF : $@convention(method) @async (@guaranteed SlowServerlet) -> (@owned String, @owned String, @error any Error)
+    // CHECK-NOT: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+    // CHECK-NEXT: hop_to_executor [[ACTOR]]
     // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKF'
     //
-    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Bool, Optional<NSString>, Optional<NSError>, Optional<NSString>) -> (), SlowServerlet) -> () {
-    // CHECK:   [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
-    // CHECK:   [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @owned String, @error any Error)
-    // CHECK:   try_apply [[NATIVE]]([[ACTOR]], {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable ({{.*}}, Optional<NSString>, Optional<NSError>, Optional<NSString>) -> (), SlowServerlet) -> () {
+    // CHECK: [[SELF:%.*]] = begin_borrow {{.*}} : $SlowServerlet
+    // CHECK:   [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKF : $@convention(method) @async (@guaranteed SlowServerlet) -> (@owned String, @owned String, @error any Error)
+    // CHECK:   try_apply [[NATIVE]]([[SELF]]) : {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
     // CHECK: [[NORMAL_BB]]({{.*}}):
     // CHECK:   integer_literal {{.*}}1
     // CHECK: [[ERROR_BB]]({{.*}}):

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -106,69 +106,132 @@ protocol NativelySlowServing {
 extension SlowServer: NativelySlowServing {}
 
 class SlowServerlet: SlowServer {
-    // CHECK-LABEL: sil{{.*}}13SlowServerlet{{.*}}011doSomethingE8Nullably{{.*}}
-    // CHECK:         [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
-    // CHECK:         hop_to_executor [[GENERIC_EXECUTOR]] :
+    // Native Function
+    //
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> Int {
+    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>
+    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK:   // end sil function '$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaF'
+
+    // @objc thunk closure
+    //
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaFyyYacfU_To : $@convention(thin) @Sendable @async (NSString, Optional<@convention(block) @Sendable (Int) -> ()>, SlowServerlet) -> () {
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+    // CHECK: [[FUNC:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> Int
+    // CHECK: apply [[FUNC]]([[ACTOR]],
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC011doSomethingE8NullablyySiSSYaFyyYacfU_To'
     override func doSomethingSlowNullably(_: String) async -> Int {
         return 0
     }
 
-    // CHECK-LABEL: sil{{.*}}13SlowServerlet{{.*}}18findAnswerNullably{{.*}}
-    // CHECK:         [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
-    // CHECK:         hop_to_executor [[GENERIC_EXECUTOR]] :
+    // Native function.
+    //
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> @owned String {
+    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaF'
+
+    // @objc closure thunk
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaFyyYacfU_To : $@convention(thin) @Sendable @async (NSString, Optional<@convention(block) @Sendable (NSString) -> ()>, SlowServerlet) -> () {
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+    // CHECK: [[FUNC:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> @owned String
+    // CHECK: apply [[FUNC]]([[ACTOR]],
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC18findAnswerNullablyyS2SYaFyyYacfU_To'
     override func findAnswerNullably(_ x: String) async -> String {
         return x
     }
 
-    // CHECK-LABEL: sil{{.*}}13SlowServerlet{{.*}}28doSomethingDangerousNullably{{.*}} :
-    // CHECK:         [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
-    // CHECK:         hop_to_executor [[GENERIC_EXECUTOR]] :
+    // Native
+    //
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> (@owned String, @error any Error) {
+    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKF'
+
+    // @objc thunk closure
+    //
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKFyyYacfU_To : $@convention(thin) @Sendable @async (NSString, Optional<@convention(block) @Sendable (Optional<NSString>, Optional<NSError>) -> ()>, SlowServerlet) -> () {
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+    // CHECK: [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed String, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK: apply [[NATIVE]]([[ACTOR]],
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC28doSomethingDangerousNullablyyS2SYaKFyyYacfU_To'
     override func doSomethingDangerousNullably(_ x: String) async throws -> String {
         return x
     }
 
-    // CHECK-LABEL: sil{{.*}}13SlowServerlet{{.*}}30doSomethingUnspecifiedNullably{{.*}} :
-    // CHECK:         [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
-    // CHECK:         hop_to_executor [[GENERIC_EXECUTOR]] :
+    // Native
+    //
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error) {
+    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKF'
+
+    // @objc closure thunk
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (Optional<@convention(block) @Sendable (Optional<NSString>, Optional<NSError>) -> ()>, SlowServerlet) -> () {
+    // CHECK: [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+    // CHECK: [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK: apply [[NATIVE]]([[ACTOR]],
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC30doSomethingUnspecifiedNullablySSyYaKFyyYacfU_To'
     override func doSomethingUnspecifiedNullably() async throws -> String {
       fatalError()
     }
 
-    // CHECK-LABEL: sil{{.*}}13SlowServerlet{{.*}}17doSomethingFlaggy{{.*}} :
-    // CHECK:         [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
-    // CHECK:         hop_to_executor [[GENERIC_EXECUTOR]] :
-    // CHECK-LABEL: sil private{{.*}}13SlowServerlet{{.*}}17doSomethingFlaggy{{.*}}To :
-    // CHECK:         try_apply{{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-    // CHECK:       [[NORMAL_BB]]({{.*}}):
-    // CHECK:         integer_literal {{.*}}0 
-    // CHECK:       [[ERROR_BB]]({{.*}}):
-    // CHECK:         integer_literal {{.*}}1 
+    // Native
+    //
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error) {
+    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK:   hop_to_executor [[ACTOR]]
+    //
+    // @objc thunk closure
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Bool, Optional<NSString>, Optional<NSError>) -> (), SlowServerlet) -> () {
+    // CHECK:   [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+    // CHECK:   [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK:   try_apply [[NATIVE]]([[ACTOR]], {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    // CHECK: [[NORMAL_BB]]({{.*}}):
+    // CHECK:   integer_literal {{.*}}0
+    // CHECK: [[ERROR_BB]]({{.*}}):
+    // CHECK:   integer_literal {{.*}}1
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC17doSomethingFlaggySSyYaKFyyYacfU_To'
     override func doSomethingFlaggy() async throws -> String {
         return ""
     }
 
-    // CHECK-LABEL: sil{{.*}}13SlowServerlet{{.*}}21doSomethingZeroFlaggy{{.*}} :
-    // CHECK:         [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
-    // CHECK:         hop_to_executor [[GENERIC_EXECUTOR]] :
-    // CHECK-LABEL: sil private{{.*}}13SlowServerlet{{.*}}21doSomethingZeroFlaggy{{.*}}To :
-    // CHECK:         try_apply{{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-    // CHECK:       [[NORMAL_BB]]({{.*}}):
-    // CHECK:         integer_literal {{.*}}1 
-    // CHECK:       [[ERROR_BB]]({{.*}}):
-    // CHECK:         integer_literal {{.*}}0 
+    // Native
+    //
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error) {
+    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKF'
+    //
+    // @objc thunk closure
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Optional<NSString>, Bool, Optional<NSError>) -> (), SlowServerlet) -> () {
+    // CHECK:    [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+    // CHECK:    [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC21doSomethingZeroFlaggySSyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @error any Error)
+    // CHECK:    try_apply [[NATIVE]]([[ACTOR]], {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    // CHECK:  [[NORMAL_BB]]({{.*}}):
+    // CHECK:    integer_literal {{.*}}1
+    // CHECK:  [[ERROR_BB]]({{.*}}):
+    // CHECK:    integer_literal {{.*}}0
     override func doSomethingZeroFlaggy() async throws -> String {
         return ""
     }
 
-    // CHECK-LABEL: sil{{.*}}13SlowServerlet{{.*}}28doSomethingMultiResultFlaggy{{.*}} :
-    // CHECK:         [[GENERIC_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
-    // CHECK:         hop_to_executor [[GENERIC_EXECUTOR]] :
-    // CHECK-LABEL: sil private{{.*}}13SlowServerlet{{.*}}28doSomethingMultiResultFlaggy{{.*}}To :
-    // CHECK:         try_apply{{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
-    // CHECK:       [[NORMAL_BB]]({{.*}}):
-    // CHECK:         integer_literal {{.*}}1 
-    // CHECK:       [[ERROR_BB]]({{.*}}):
-    // CHECK:         integer_literal {{.*}}0 
+    // Native
+    //
+    // CHECK-LABEL: sil hidden [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @owned String, @error any Error) {
+    // CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>,
+    // CHECK:   hop_to_executor [[ACTOR]]
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKF'
+    //
+    // CHECK-LABEL: sil shared [thunk] [ossa] @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKFyyYacfU_To : $@convention(thin) @Sendable @async (@convention(block) @Sendable (Bool, Optional<NSString>, Optional<NSError>, Optional<NSString>) -> (), SlowServerlet) -> () {
+    // CHECK:   [[ACTOR:%.*]] = enum $Optional<any Actor>, #Optional.none!enumelt
+    // CHECK:   [[NATIVE:%.*]] = function_ref @$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKF : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, @guaranteed SlowServerlet) -> (@owned String, @owned String, @error any Error)
+    // CHECK:   try_apply [[NATIVE]]([[ACTOR]], {{.*}}, normal [[NORMAL_BB:bb[0-9]+]], error [[ERROR_BB:bb[0-9]+]]
+    // CHECK: [[NORMAL_BB]]({{.*}}):
+    // CHECK:   integer_literal {{.*}}1
+    // CHECK: [[ERROR_BB]]({{.*}}):
+    // CHECK:   integer_literal {{.*}}0
+    // CHECK: } // end sil function '$s21objc_async_from_swift13SlowServerletC28doSomethingMultiResultFlaggySS_SStyYaKFyyYacfU_To'
     override func doSomethingMultiResultFlaggy() async throws -> (String, String) {
         return ("", "")
     }


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/79717

---

- Explanation:
 
   This was discussed as part of SE-0461 proposal. These functions already have special code generation that keeps them in the caller's isolation context, so there is no behavior change here.

- Main Branch PR: https://github.com/swiftlang/swift/pull/79717

- Risk: Low (The change affects only default isolation of the async ObjC declarations, code generation stays the same as do overrides, it should be transparent from the use perspective as `nonisolated(nonsending)` has a very flexible conversion scheme).

- Reviewed By: @gottesmm 

- Resolves: rdar://145672343

- Testing: Added new tests to the test suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
