### PR TITLE
Clarify _implementationOnly documentation

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -544,7 +544,8 @@ property is stored or computed to correctly perform type layout.
 Used to mark an imported module as an implementation detail.
 This prevents types from that module being exposed in API
 (types of public functions, constraints in public extension etc.)
-and ABI (usage in `@inlinable` code).
+and ABI (usage in `@inlinable` code). In Swift 6 and later, an
+[access level modifier](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md) of `internal` or lower should generally be used instead.
 
 ## `@_spiOnly`
 


### PR DESCRIPTION
According to [SE-0409](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md#_implementationonly-import), an access control modifier should almost always be used instead of @_implementationOnly. This commit adds a reference to that documentation to make it clear to readers of this document
