### PR TITLE
Fix crash in OSLogOptimization

### DIFF
--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -163,9 +163,9 @@ public:
 
     this->stringInitIntrinsic = callee;
 
-    MetatypeInst *stringMetatypeInst =
-        dyn_cast<MetatypeInst>(inst->getOperand(4)->getDefiningInstruction());
-    this->stringMetatype = stringMetatypeInst->getType();
+    auto stringMetatype = inst->getOperand(4)->getType();
+    assert(stringMetatype.isMetatype());
+    this->stringMetatype = stringMetatype;
   }
 
   bool isInitialized() { return stringInitIntrinsic != nullptr; }

--- a/test/SILOptimizer/OSLogMandatoryOptTest.sil
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.sil
@@ -66,6 +66,34 @@ bb0:
   return %13 : $()
 }
 
+// CHECK-LABEL: @testConstantFoldingOfStructExtractMetatypeArg :
+// CHECK-DAG: [[STRINGUSE:%[0-9]+]] = function_ref @useFormatString
+// CHECK-DAG: {{%.*}} = apply [[STRINGUSE]]([[BORROW:%[0-9]+]])
+// CHECK-DAG: [[BORROW]] = begin_borrow [[STRINGCONST:%[0-9]+]]
+// CHECK-DAG: [[STRINGCONST]] = apply [[STRINGINIT:%[0-9]+]]([[LIT:%[0-9]+]], {{%.*}}, {{%.*}}, {{%.*}})
+// CHECK-DAG: [[STRINGINIT]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+// CHECK-DAG: [[LIT]] = string_literal oslog "test message: %lld"
+// CHECK-DAG: destroy_value [[STRINGCONST]] : $String
+sil [ossa] @testConstantFoldingOfStructExtractMetatypeArg : $@convention(thin) (@thin String.Type) -> () {
+bb0(%0 : $@thin String.Type):
+  %1 = string_literal utf8 "test message: %lld"
+  %2 = integer_literal $Builtin.Word, 18
+  %3 = integer_literal $Builtin.Int1, -1
+  %4 = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %5 = apply %4(%1, %2, %3, %0) : $@convention(method) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, @thin String.Type) -> @owned String
+  %6 = function_ref @oslogMessageInit : $@convention(thin) (@owned String) -> @owned OSLogMessageStub
+  %7 = apply %6(%5) : $@convention(thin) (@owned String) -> @owned OSLogMessageStub
+  %8 = begin_borrow %7
+  %9 = struct_extract %8, #OSLogMessageStub.interpolation
+  %10 = struct_extract %9, #OSLogInterpolationStub.formatString
+  %11 = function_ref @useFormatString : $@convention(thin) (@guaranteed String) -> ()
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed String) -> ()
+  end_borrow %8
+  destroy_value %7
+  %15 = tuple ()
+  return %15
+}
+
 /// A function that models the use of a string in some arbitrary way.
 sil @useFormatStringIndirect: $@convention(thin) (@in_guaranteed String) -> ()
 


### PR DESCRIPTION
A metatype need not always come from a metatype instruction. It can come from a SILArgument. Fix the invalid cast operation in OSLogOptimization.

Fixes rdar://146160325

Fixes https://github.com/swiftlang/swift/issues/72733

