### PR TITLE
Sema: Fix case where witness thrown error type is a subtype of a type parameter

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -912,8 +912,7 @@ RequirementMatch swift::matchWitness(
 
     case ThrownErrorSubtyping::Subtype:
       // If there were no type parameters, we're done.
-      if (!reqThrownError->hasTypeVariable() &&
-          !reqThrownError->hasTypeParameter())
+      if (!reqThrownError->hasTypeParameter())
         break;
 
       LLVM_FALLTHROUGH;

--- a/test/decl/protocol/conforms/typed_throws.swift
+++ b/test/decl/protocol/conforms/typed_throws.swift
@@ -77,3 +77,17 @@ public protocol HasRethrowingMap: Sequence {
 }
 
 extension Array: HasRethrowingMap {}
+
+// rdar://149438520 -- incorrect handling of subtype relation between type parameter and Never
+protocol DependentThrowing {
+  associatedtype E: Error
+  func f() throws(E)
+}
+
+extension DependentThrowing {
+  func f() {}
+}
+
+struct DefaultDependentThrowing: DependentThrowing {
+  typealias E = Error
+}


### PR DESCRIPTION
In b30006837e31689c4eb96d27a00c583024b1b0ea, I changed the `if` condition here to check for the absence of type variables as well as type parameters. The correct condition is to actually not check for anything at all.

Fixes rdar://149438520.