### PR TITLE
[6.2] Sema: Fix case where witness thrown error type is a subtype of a type parameter

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -912,8 +912,7 @@ RequirementMatch swift::matchWitness(
 
     case ThrownErrorSubtyping::Subtype:
       // If there were no type parameters, we're done.
-      if (!reqThrownError->hasTypeVariable() &&
-          !reqThrownError->hasTypeParameter())
+      if (!reqThrownError->hasTypeParameter())
         break;
 
       LLVM_FALLTHROUGH;

--- a/test/decl/protocol/conforms/typed_throws.swift
+++ b/test/decl/protocol/conforms/typed_throws.swift
@@ -77,3 +77,17 @@ public protocol HasRethrowingMap: Sequence {
 }
 
 extension Array: HasRethrowingMap {}
+
+// rdar://149438520 -- incorrect handling of subtype relation between type parameter and Never
+protocol DependentThrowing {
+  associatedtype E: Error
+  func f() throws(E)
+}
+
+extension DependentThrowing {
+  func f() {}
+}
+
+struct DefaultDependentThrowing: DependentThrowing {
+  typealias E = Error
+}


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/80963

* **Description:** Allow a non-throwing witness to match a protocol requirement that throws an associated type, because Never is conceptually a subtype of every type, even a type parameter.

* **Origination:** This used to work but was untested. It regressed in https://github.com/swiftlang/swift/pull/80445.

* **Tested:** New test added.

* **Radar:** rdar://149438520

* **Reviewed by:** @DougGregor 