### PR TITLE
parse symbol availability allow/block-list args together

### DIFF
--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -203,23 +203,15 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
             .Default(AccessLevel::Public);
   }
 
-  if (auto *A = ParsedArgs.getLastArg(OPT_allow_availability_platforms)) {
+  if (auto *A = ParsedArgs.getLastArg(OPT_allow_availability_platforms,
+        OPT_block_availability_platforms)) {
     llvm::SmallVector<StringRef> AvailabilityPlatforms;
     StringRef(A->getValue())
         .split(AvailabilityPlatforms, ',', /*MaxSplits*/ -1,
                /*KeepEmpty*/ false);
     Options.AvailabilityPlatforms = llvm::DenseSet<StringRef>(
         AvailabilityPlatforms.begin(), AvailabilityPlatforms.end());
-    Options.AvailabilityIsBlockList = false;
-  } else if (auto *A =
-                 ParsedArgs.getLastArg(OPT_block_availability_platforms)) {
-    llvm::SmallVector<StringRef> AvailabilityPlatforms;
-    StringRef(A->getValue())
-        .split(AvailabilityPlatforms, ',', /*MaxSplits*/ -1,
-               /*KeepEmpty*/ false);
-    Options.AvailabilityPlatforms = llvm::DenseSet<StringRef>(
-        AvailabilityPlatforms.begin(), AvailabilityPlatforms.end());
-    Options.AvailabilityIsBlockList = true;
+    Options.AvailabilityIsBlockList = A->getOption().matches(OPT_block_availability_platforms);
   }
 
   Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2213,23 +2213,15 @@ static void ParseSymbolGraphArgs(symbolgraphgen::SymbolGraphOptions &Opts,
     Opts.MinimumAccessLevel = AccessLevel::Public;
   }
 
-  if (auto *A = Args.getLastArg(OPT_symbol_graph_allow_availability_platforms)) {
+  if (auto *A = Args.getLastArg(OPT_symbol_graph_allow_availability_platforms,
+        OPT_symbol_graph_block_availability_platforms)) {
     llvm::SmallVector<StringRef> AvailabilityPlatforms;
     StringRef(A->getValue())
         .split(AvailabilityPlatforms, ',', /*MaxSplits*/ -1,
                /*KeepEmpty*/ false);
     Opts.AvailabilityPlatforms = llvm::DenseSet<StringRef>(
         AvailabilityPlatforms.begin(), AvailabilityPlatforms.end());
-    Opts.AvailabilityIsBlockList = false;
-  } else if (auto *A = Args.getLastArg(
-                 OPT_symbol_graph_block_availability_platforms)) {
-    llvm::SmallVector<StringRef> AvailabilityPlatforms;
-    StringRef(A->getValue())
-        .split(AvailabilityPlatforms, ',', /*MaxSplits*/ -1,
-               /*KeepEmpty*/ false);
-    Opts.AvailabilityPlatforms = llvm::DenseSet<StringRef>(
-        AvailabilityPlatforms.begin(), AvailabilityPlatforms.end());
-    Opts.AvailabilityIsBlockList = true;
+    Opts.AvailabilityIsBlockList = A->getOption().matches(OPT_symbol_graph_block_availability_platforms);
   }
 
   // default values for generating symbol graphs during a build


### PR DESCRIPTION
This PR forward-ports a review comment from https://github.com/swiftlang/swift/pull/80806 back to the main branch.

The way i originally wrote the argument handling for `[-symbol-graph]-{allow,block}-availability-platforms` left in a surprising behavior if both arguments were present, where it would favor the presence of the allowlist argument over the blocklist argument, even if the blocklist was written later in the command-line. This PR updates the argument handling to look for both arguments at the same time and favor whichever is last in the argument list.