### PR TITLE
[Frontend] Promote `AsyncCallerExecution` to an upcoming feature

### DIFF
--- a/include/swift/AST/DiagnosticGroups.def
+++ b/include/swift/AST/DiagnosticGroups.def
@@ -41,7 +41,7 @@
 GROUP(no_group, "")
 
 GROUP(ActorIsolatedCall, "actor-isolated-call")
-GROUP(AsyncCallerExecution, "async-caller-execution")
+GROUP(NonisolatedNonsendingByDefault, "nonisolated-nonsending-by-default")
 GROUP(ConformanceIsolation, "conformance-isolation")
 GROUP(DeprecatedDeclaration, "deprecated-declaration")
 GROUP(DynamicCallable, "dynamic-callable-requirements")

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8643,7 +8643,7 @@ NOTE(type_does_not_conform_to_Sendable,none,
      "type %0 does not conform to 'Sendable' protocol", (Type))
 
 GROUPED_WARNING(
-    attr_execution_nonisolated_behavior_will_change_decl, AsyncCallerExecution,
+    attr_execution_nonisolated_behavior_will_change_decl, NonisolatedNonsendingByDefault,
     none,
     "feature '%0' will cause nonisolated async %kindbase1 to run on the "
     "caller's actor; use %2 to preserve behavior",
@@ -8651,14 +8651,14 @@ GROUPED_WARNING(
 
 GROUPED_WARNING(
     attr_execution_nonisolated_behavior_will_change_closure,
-    AsyncCallerExecution, none,
+    NonisolatedNonsendingByDefault, none,
     "feature '%0' will cause nonisolated async closure to run on the caller's "
     "actor; use %1 to preserve behavior",
     (StringRef, DeclAttribute))
 
 GROUPED_WARNING(
     attr_execution_nonisolated_behavior_will_change_typerepr,
-    AsyncCallerExecution, none,
+    NonisolatedNonsendingByDefault, none,
     "feature '%0' will cause nonisolated async function type to be treated as "
     "specified to run on the caller's actor; use %1 to preserve "
     "behavior",

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -280,6 +280,7 @@ ADOPTABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
 UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
 UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
+ADOPTABLE_UPCOMING_FEATURE(AsyncCallerExecution, 461, 7)
 
 // Optional language features / modes
 
@@ -488,10 +489,6 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AddressableTypes, true)
 
 /// Allow the @abi attribute.
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ABIAttribute, true)
-
-/// Functions with nonisolated isolation inherit their isolation from the
-/// calling context.
-ADOPTABLE_EXPERIMENTAL_FEATURE(AsyncCallerExecution, false)
 
 /// Allow custom availability domains to be defined and referenced.
 EXPERIMENTAL_FEATURE(CustomAvailability, true)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -280,7 +280,7 @@ ADOPTABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
 UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
 UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
-ADOPTABLE_UPCOMING_FEATURE(AsyncCallerExecution, 461, 7)
+ADOPTABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
 
 // Optional language features / modes
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -124,7 +124,7 @@ UNINTERESTING_FEATURE(Volatile)
 UNINTERESTING_FEATURE(SuppressedAssociatedTypes)
 UNINTERESTING_FEATURE(StructLetDestructuring)
 UNINTERESTING_FEATURE(MacrosOnImports)
-UNINTERESTING_FEATURE(AsyncCallerExecution)
+UNINTERESTING_FEATURE(NonisolatedNonsendingByDefault)
 UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
 
 static bool usesFeatureNonescapableTypes(Decl *decl) {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1705,7 +1705,7 @@ private:
     }
 
     // If we are an async function that is unspecified or nonisolated, insert an
-    // isolated parameter if AsyncCallerExecution is enabled.
+    // isolated parameter if NonisolatedNonsendingByDefault is enabled.
     //
     // NOTE: The parameter is not inserted for async functions imported
     // from ObjC because they are handled in a special way that doesn't

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_swift_host_library(swiftSema STATIC
   AssociatedTypeInference.cpp
-  AsyncCallerExecutionMigration.cpp
+  NonisolatedNonsendingByDefaultMigration.cpp
   BuilderTransform.cpp
   Comment.cpp
   CSApply.cpp

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -1,4 +1,4 @@
-//===-- Sema/AsyncCallerExecutionMigration.cpp ------------------*- C++ -*-===//
+//===-- Sema/NonisolatedNonsendingByDefaultMigration.cpp --------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -11,12 +11,12 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file implements code migration support for the `AsyncCallerExecution`
-/// feature.
+/// This file implements code migration support for the
+/// `NonisolatedNonsendingByDefault` feature.
 ///
 //===----------------------------------------------------------------------===//
 
-#include "AsyncCallerExecutionMigration.h"
+#include "NonisolatedNonsendingByDefaultMigration.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
@@ -30,34 +30,34 @@
 using namespace swift;
 
 namespace {
-class AsyncCallerExecutionMigrationTarget {
+class NonisolatedNonsendingByDefaultMigrationTarget {
   ASTContext &ctx;
   PointerUnion<ValueDecl *, AbstractClosureExpr *, FunctionTypeRepr *> node;
   TaggedUnion<ActorIsolation, FunctionTypeIsolation> isolation;
 
 public:
-  AsyncCallerExecutionMigrationTarget(ASTContext &ctx, ValueDecl *decl,
+  NonisolatedNonsendingByDefaultMigrationTarget(ASTContext &ctx, ValueDecl *decl,
                                       ActorIsolation isolation)
       : ctx(ctx), node(decl), isolation(isolation) {}
 
-  AsyncCallerExecutionMigrationTarget(ASTContext &ctx,
+  NonisolatedNonsendingByDefaultMigrationTarget(ASTContext &ctx,
                                       AbstractClosureExpr *closure,
                                       ActorIsolation isolation)
       : ctx(ctx), node(closure), isolation(isolation) {}
 
-  AsyncCallerExecutionMigrationTarget(ASTContext &ctx, FunctionTypeRepr *repr,
+  NonisolatedNonsendingByDefaultMigrationTarget(ASTContext &ctx, FunctionTypeRepr *repr,
                                       FunctionTypeIsolation isolation)
       : ctx(ctx), node(repr), isolation(isolation) {}
 
   /// Warns that the behavior of nonisolated async functions will change under
-  /// `AsyncCallerExecution` and suggests `@concurrent` to preserve the current
+  /// `NonisolatedNonsendingByDefault` and suggests `@concurrent` to preserve the current
   /// behavior.
   void diagnose() const;
 };
 } // end anonymous namespace
 
-void AsyncCallerExecutionMigrationTarget::diagnose() const {
-  const auto feature = Feature::AsyncCallerExecution;
+void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
+  const auto feature = Feature::NonisolatedNonsendingByDefault;
 
   ASSERT(node);
   ASSERT(ctx.LangOpts.getFeatureState(feature).isEnabledForAdoption());
@@ -189,15 +189,15 @@ void AsyncCallerExecutionMigrationTarget::diagnose() const {
 
 void swift::warnAboutNewNonisolatedAsyncExecutionBehavior(
     ASTContext &ctx, FunctionTypeRepr *repr, FunctionTypeIsolation isolation) {
-  AsyncCallerExecutionMigrationTarget(ctx, repr, isolation).diagnose();
+  NonisolatedNonsendingByDefaultMigrationTarget(ctx, repr, isolation).diagnose();
 }
 
 void swift::warnAboutNewNonisolatedAsyncExecutionBehavior(
     ASTContext &ctx, ValueDecl *decl, ActorIsolation isolation) {
-  AsyncCallerExecutionMigrationTarget(ctx, decl, isolation).diagnose();
+  NonisolatedNonsendingByDefaultMigrationTarget(ctx, decl, isolation).diagnose();
 }
 
 void swift::warnAboutNewNonisolatedAsyncExecutionBehavior(
     ASTContext &ctx, AbstractClosureExpr *closure, ActorIsolation isolation) {
-  AsyncCallerExecutionMigrationTarget(ctx, closure, isolation).diagnose();
+  NonisolatedNonsendingByDefaultMigrationTarget(ctx, closure, isolation).diagnose();
 }

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.h
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.h
@@ -1,4 +1,4 @@
-//===-- Sema/AsyncCallerExecutionMigration.h --------------------*- C++ -*-===//
+//===-- Sema/NonisolatedNonsendingByDefaultMigration.h ----------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -11,13 +11,13 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file provides code migration support for the `AsyncCallerExecution`
-/// feature.
+/// This file provides code migration support for the
+/// `NonisolatedNonsendingByDefault` feature.
 ///
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SEMA_ASYNCCALLEREXECUTIONMIGRATION_H
-#define SWIFT_SEMA_ASYNCCALLEREXECUTIONMIGRATION_H
+#ifndef SWIFT_SEMA_NONISOLATEDNONSENDINGBYDEFAULTMIGRATION_H
+#define SWIFT_SEMA_NONISOLATEDNONSENDINGBYDEFAULTMIGRATION_H
 
 #include "swift/AST/ActorIsolation.h"
 #include "swift/AST/ExtInfo.h"
@@ -29,20 +29,20 @@ class ValueDecl;
 class AbstractClosureExpr;
 
 /// Warns that the behavior of nonisolated async functions will change under
-/// `AsyncCallerExecution` and suggests `@concurrent` to preserve the current
+/// `NonisolatedNonsendingByDefault` and suggests `@concurrent` to preserve the current
 /// behavior.
 void warnAboutNewNonisolatedAsyncExecutionBehavior(
     ASTContext &ctx, FunctionTypeRepr *node, FunctionTypeIsolation isolation);
 
 /// Warns that the behavior of nonisolated async functions will change under
-/// `AsyncCallerExecution` and suggests `@concurrent` to preserve the current
+/// `NonisolatedNonsendingByDefault` and suggests `@concurrent` to preserve the current
 /// behavior.
 void warnAboutNewNonisolatedAsyncExecutionBehavior(ASTContext &ctx,
                                                    ValueDecl *node,
                                                    ActorIsolation isolation);
 
 /// Warns that the behavior of nonisolated async functions will change under
-/// `AsyncCallerExecution` and suggests `@concurrent` to preserve the current
+/// `NonisolatedNonsendingByDefault` and suggests `@concurrent` to preserve the current
 /// behavior.
 void warnAboutNewNonisolatedAsyncExecutionBehavior(ASTContext &ctx,
                                                    AbstractClosureExpr *node,
@@ -50,4 +50,4 @@ void warnAboutNewNonisolatedAsyncExecutionBehavior(ASTContext &ctx,
 
 } // end namespace swift
 
-#endif /* SWIFT_SEMA_ASYNCCALLEREXECUTIONMIGRATION_H */
+#endif /* SWIFT_SEMA_NONISOLATEDNONSENDINGBYDEFAULTMIGRATION_H */

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -16,7 +16,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "TypeCheckType.h"
-#include "AsyncCallerExecutionMigration.h"
+#include "NonisolatedNonsendingByDefaultMigration.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckInvertible.h"
@@ -4245,7 +4245,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     if (!repr->isInvalid())
       isolation = FunctionTypeIsolation::forNonIsolated();
   } else {
-    if (ctx.LangOpts.getFeatureState(Feature::AsyncCallerExecution)
+    if (ctx.LangOpts.getFeatureState(Feature::NonisolatedNonsendingByDefault)
             .isEnabledForAdoption()) {
       // Diagnose only in the interface stage, which is run once.
       if (inStage(TypeResolutionStage::Interface)) {

--- a/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -swift-version 6 -g %import-libdispatch -import-objc-header %S/Inputs/RunOnMainActor.h -enable-experimental-feature AsyncCallerExecution )
+// RUN: %target-run-simple-swift( -swift-version 6 -g %import-libdispatch -import-objc-header %S/Inputs/RunOnMainActor.h -enable-upcoming-feature AsyncCallerExecution )
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/Runtime/nonisolated_inherits_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift( -swift-version 6 -g %import-libdispatch -import-objc-header %S/Inputs/RunOnMainActor.h -enable-upcoming-feature AsyncCallerExecution )
+// RUN: %target-run-simple-swift( -swift-version 6 -g %import-libdispatch -import-objc-header %S/Inputs/RunOnMainActor.h -enable-upcoming-feature NonisolatedNonsendingByDefault )
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -6,7 +6,7 @@
 // REQUIRES: libdispatch
 // REQUIRES: asserts
 
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // UNSUPPORTED: freestanding
 

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -enable-experimental-feature AsyncCallerExecution:adoption
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -enable-experimental-feature AsyncCallerExecution:adoption
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -enable-upcoming-feature AsyncCallerExecution:adoption
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature AsyncCallerExecution:adoption
 
 // REQUIRES: swift_feature_AsyncCallerExecution
 

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -enable-upcoming-feature AsyncCallerExecution:adoption
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature AsyncCallerExecution:adoption
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -enable-upcoming-feature NonisolatedNonsendingByDefault:adoption
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault:adoption
 
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 struct G<T> {
   init(_: T) {}
@@ -19,20 +19,20 @@ do {
     isolation: isolated (any Actor)? = #isolation
   ) async {}
 
-  // expected-warning@+1:20 {{feature 'AsyncCallerExecution' will cause nonisolated async local function 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:20 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async local function 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
   nonisolated func asyncF() async {}
 
   struct S {
     init(sync: ()) {}
     @concurrent init(executionAsync: ()) async {}
     @MainActor init(mainActorAsync: ()) async {}
-    // expected-warning@+1:5 {{feature 'AsyncCallerExecution' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
     init(async: ()) async {}
 
     func syncF() {}
     @concurrent func executionAsyncF() async {}
     @MainActor func mainActorAsyncF() async {}
-    // expected-warning@+2:17 {{feature 'AsyncCallerExecution' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:17 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     nonisolated
     public func asyncF() async {}
   }
@@ -41,13 +41,13 @@ do {
     init(sync: ())
     @concurrent init(executionAsync: ()) async
     @MainActor init(mainActorAsync: ()) async
-    // expected-warning@+1:5 {{feature 'AsyncCallerExecution' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
     init(async: ()) async
 
     func syncF()
     @concurrent func executionAsyncF() async
     @MainActor func mainActorAsyncF() async
-    // expected-warning@+1:10 {{feature 'AsyncCallerExecution' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
     func asyncF() async
   }
 }
@@ -56,13 +56,13 @@ extension Functions {
   init(sync: ()) {}
   @concurrent init(executionAsync: ()) async {}
   @MainActor init(mainActorAsync: ()) async {}
-  // expected-warning@+1:3 {{feature 'AsyncCallerExecution' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:3 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
   init(async: ()) async {}
 
   func syncF() {}
   @concurrent func executionAsyncF() async {}
   @MainActor func mainActorAsyncF() async {}
-  // expected-warning@+1:8 {{feature 'AsyncCallerExecution' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:8 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
   func asyncF() async {}
 }
 
@@ -81,11 +81,11 @@ do {
     @MainActor var mainActorAsyncS: Int { get async {} }
     @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async {} }
 
-    // expected-warning@+2:7 {{feature 'AsyncCallerExecution' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     var asyncS: Int {
       get async {}
     }
-    // expected-warning@+2:7 {{feature 'AsyncCallerExecution' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     subscript(asyncS _: Int) -> Int {
       get async throws {}
     }
@@ -101,9 +101,9 @@ do {
     @MainActor var mainActorAsyncS: Int { get async }
     @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async }
 
-    // expected-warning@+1:23 {{feature 'AsyncCallerExecution' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:23 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
     var asyncS: Int { get async }
-    // expected-warning@+1:39 {{feature 'AsyncCallerExecution' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:39 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
     subscript(asyncS _: Int) -> Int { get async }
   }
 }
@@ -118,11 +118,11 @@ extension Storage {
   @MainActor var mainActorAsyncS: Int { get async {} }
   @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async {} }
 
-  // expected-warning@+2:5 {{feature 'AsyncCallerExecution' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
+  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
   var asyncS: Int {
     get async {}
   }
-  // expected-warning@+2:5 {{feature 'AsyncCallerExecution' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
+  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
   subscript(asyncS _: Int) -> Int {
     get async throws {}
   }
@@ -136,9 +136,9 @@ do {
       sync: () -> Void,
       executionAsync: @concurrent () async -> Void,
       mainActorAsync: @MainActor () async -> Void,
-      // expected-warning@+1:14 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
       async: () async -> Void,
-      // expected-warning@+1:26 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
       structuralAsync: G<() async -> Void>
     )
   }
@@ -148,9 +148,9 @@ do {
       sync: () -> Void,
       executionAsync: @concurrent () async -> Void,
       mainActorAsync: @MainActor () async -> Void,
-      // expected-warning@+1:14 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
       async: () async -> Void,
-      // expected-warning@+1:26 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
       structuralAsync: G<() async -> Void>
     ) -> Int {
       0
@@ -161,9 +161,9 @@ do {
     sync: () -> Void,
     executionAsync: @concurrent () async -> Void,
     mainActorAsync: @MainActor () async -> Void,
-    // expected-warning@+1:12 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
     async: () async -> Void,
-    // expected-warning@+1:24 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
     structuralAsync: G<() async -> Void>
   ) {}
 
@@ -171,9 +171,9 @@ do {
     sync: () -> Void,
     executionAsync: @concurrent () async -> Void,
     mainActorAsync: @MainActor () async -> Void,
-    // expected-warning@+1:12 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
     async: () async -> Void,
-    // expected-warning@+1:24 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
     structuralAsync: G<() async -> Void>
   ) in
   }
@@ -185,9 +185,9 @@ do {
     struct Sync where T == () -> Void {}
     struct ExecutionAsync where T == @concurrent () async -> Void {}
     struct MainActorAsync where T == @MainActor () async -> Void {}
-    // expected-warning@+1:29 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{29-29=@concurrent }}{{none}}
+    // expected-warning@+1:29 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{29-29=@concurrent }}{{none}}
     struct Async where T == () async -> Void {}
-    // expected-warning@+1:41 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{41-41=@concurrent }}{{none}}
+    // expected-warning@+1:41 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{41-41=@concurrent }}{{none}}
     struct StructuralAsync where T == G<() async -> Void> {}
   }
 }
@@ -197,9 +197,9 @@ do {
   let _: () -> Void
   let _: @concurrent () async -> Void
   let _: @MainActor () async -> Void
-  // expected-warning@+1:10 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{10-10=@concurrent }}{{none}}
+  // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{10-10=@concurrent }}{{none}}
   let _: () async -> Void
-  // expected-warning@+1:12 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+  // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
   let _: G<() async -> Void>
 }
 
@@ -210,9 +210,9 @@ do {
   let _ = anything as? () -> Void
   let _ = anything as? @concurrent () async -> Void
   let _ = anything as? @MainActor () async -> Void
-  // expected-warning@+1:24 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+  // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
   let _ = anything as? () async -> Void
-  // expected-warning@+1:26 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+  // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
   let _ = anything as? G<() async -> Void>
 }
 
@@ -225,37 +225,37 @@ do {
     let _ = { @concurrent () async -> Void in }
     let _ = { @MainActor () async -> Void in }
 
-    // expected-warning@+1:13 {{feature 'AsyncCallerExecution' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{15-15=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{15-15=@concurrent }}{{none}}
     let _ = { () async -> Void in }
 
     func takesInts(_: Int...) {}
 
-    // expected-warning@+1:13 {{feature 'AsyncCallerExecution' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {await globalAsyncF()}
-    // expected-warning@+1:13 {{feature 'AsyncCallerExecution' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {
       await globalAsyncF()
     }
-    // expected-warning@+1:13 {{feature 'AsyncCallerExecution' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {
       await globalAsyncF()
       takesInts($0, $1, $2)
     }
-    // expected-warning@+1:13 {{feature 'AsyncCallerExecution' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{25-25=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{25-25=@concurrent }}{{none}}
     let _ = { @Sendable in
       await globalAsyncF()
     }
-    // expected-warning@+2:18 {{feature 'AsyncCallerExecution' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{18-18=@concurrent }}{{none}}
-    // expected-warning@+1:45 {{feature 'AsyncCallerExecution' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{47-47=@concurrent }}{{none}}
+    // expected-warning@+2:18 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{18-18=@concurrent }}{{none}}
+    // expected-warning@+1:45 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{47-47=@concurrent }}{{none}}
     var closure: (Int, Int) async -> Void = { a, b in
       await globalAsyncF()
     }
-    // expected-warning@+1:15 {{feature 'AsyncCallerExecution' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
     closure = {
       a, b async in
       await globalAsyncF()
     }
-    // expected-warning@+1:15 {{feature 'AsyncCallerExecution' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
     closure = { (a, b) in
       await globalAsyncF()
     }

--- a/test/Concurrency/attr_execution/attr_execution.swift
+++ b/test/Concurrency/attr_execution/attr_execution.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature AsyncCallerExecution %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-upcoming-feature AsyncCallerExecution %s | %FileCheck %s
 
 // REQUIRES: swift_feature_AsyncCallerExecution
 

--- a/test/Concurrency/attr_execution/attr_execution.swift
+++ b/test/Concurrency/attr_execution/attr_execution.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-emit-silgen -enable-upcoming-feature AsyncCallerExecution %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-upcoming-feature NonisolatedNonsendingByDefault %s | %FileCheck %s
 
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 
 // CHECK-LABEL: // concurrentTest()

--- a/test/Concurrency/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -swift-version 6 -verify -verify-additional-prefix disabled- -c
-// RUN: %target-swift-frontend %s -swift-version 6 -verify -enable-experimental-feature AsyncCallerExecution -verify-additional-prefix enable- -c -verify-additional-prefix enabled-
+// RUN: %target-swift-frontend %s -swift-version 6 -verify -enable-upcoming-feature AsyncCallerExecution -verify-additional-prefix enable- -c -verify-additional-prefix enabled-
 
 // REQUIRES: asserts
 // REQUIRES: concurrency

--- a/test/Concurrency/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-frontend %s -swift-version 6 -verify -verify-additional-prefix disabled- -c
-// RUN: %target-swift-frontend %s -swift-version 6 -verify -enable-upcoming-feature AsyncCallerExecution -verify-additional-prefix enable- -c -verify-additional-prefix enabled-
+// RUN: %target-swift-frontend %s -swift-version 6 -verify -enable-upcoming-feature NonisolatedNonsendingByDefault -verify-additional-prefix enable- -c -verify-additional-prefix enabled-
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // This test checks and validates that when AsyncCallerExecution is enabled, we emit the
 // appropriate diagnostics. It also runs with the mode off so we can validate

--- a/test/Concurrency/nonisolated_inherits_isolation_sema.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation_sema.swift
@@ -1,8 +1,8 @@
-// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-upcoming-feature AsyncCallerExecution -parse-as-library
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault -parse-as-library
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 class NonSendable {} // expected-note {{}}
 

--- a/test/Concurrency/nonisolated_inherits_isolation_sema.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation_sema.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-experimental-feature AsyncCallerExecution -parse-as-library
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-upcoming-feature AsyncCallerExecution -parse-as-library
 
 // REQUIRES: asserts
 // REQUIRES: concurrency

--- a/test/Frontend/print-supported-features.swift
+++ b/test/Frontend/print-supported-features.swift
@@ -5,6 +5,6 @@
 // CHECK:     { "name": "{{.*}}"{{, "migratable": true}}, "enabled_in": {{[0-9]+}} }
 // CHECK:   ],
 // CHECK-NEXT:   "experimental": [
-// CHECK:     { "name": "{{.*}}"{{, "migratable": true}} }
+// CHECK:     { "name": "{{.*}}" }
 // CHECK:   ]
 // CHECK: }

--- a/test/SILGen/execution_attr.swift
+++ b/test/SILGen/execution_attr.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-emit-silgen %s  | %FileCheck -check-prefix CHECK -check-prefix DISABLED %s
-// RUN: %target-swift-emit-silgen %s -enable-upcoming-feature AsyncCallerExecution | %FileCheck -check-prefix CHECK -check-prefix ENABLED %s
+// RUN: %target-swift-emit-silgen %s -enable-upcoming-feature NonisolatedNonsendingByDefault | %FileCheck -check-prefix CHECK -check-prefix ENABLED %s
 
 // REQUIRES: concurrency
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // Validate that both with and without the experimental flag we properly codegen
 // execution(caller) and execution(concurrent).

--- a/test/SILGen/execution_attr.swift
+++ b/test/SILGen/execution_attr.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-silgen %s  | %FileCheck -check-prefix CHECK -check-prefix DISABLED %s
-// RUN: %target-swift-emit-silgen %s -enable-experimental-feature AsyncCallerExecution | %FileCheck -check-prefix CHECK -check-prefix ENABLED %s
+// RUN: %target-swift-emit-silgen %s -enable-upcoming-feature AsyncCallerExecution | %FileCheck -check-prefix CHECK -check-prefix ENABLED %s
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_AsyncCallerExecution

--- a/test/SILGen/nonisolated_inherits_isolation.swift
+++ b/test/SILGen/nonisolated_inherits_isolation.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-emit-silgen -swift-version 6 -enable-upcoming-feature AsyncCallerExecution %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault %s | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 //===----------------------------------------------------------------------===//
 //                             MARK: Declarations

--- a/test/SILGen/nonisolated_inherits_isolation.swift
+++ b/test/SILGen/nonisolated_inherits_isolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -swift-version 6 -enable-experimental-feature AsyncCallerExecution %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -swift-version 6 -enable-upcoming-feature AsyncCallerExecution %s | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Serialization/caller_isolation_inherit.swift
+++ b/test/Serialization/caller_isolation_inherit.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-experimental-feature AsyncCallerExecution -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
+// RUN: %target-swift-frontend -enable-upcoming-feature AsyncCallerExecution -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
 // RUN: %target-swift-frontend -emit-module-path %t/WithoutFeature.swiftmodule -module-name WithoutFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
 
 // RUN: %target-swift-frontend -module-name main -I %t %s -emit-sil -o - | %FileCheck %s
 
-// RUN: %target-swift-frontend -enable-experimental-feature AsyncCallerExecution -module-name main -I %t %s -emit-sil -verify -swift-version 6
+// RUN: %target-swift-frontend -enable-upcoming-feature AsyncCallerExecution -module-name main -I %t %s -emit-sil -verify -swift-version 6
 
 // REQUIRES: asserts
 // REQUIRES: swift_feature_AsyncCallerExecution

--- a/test/Serialization/caller_isolation_inherit.swift
+++ b/test/Serialization/caller_isolation_inherit.swift
@@ -1,13 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -enable-upcoming-feature AsyncCallerExecution -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
+// RUN: %target-swift-frontend -enable-upcoming-feature NonisolatedNonsendingByDefault -emit-module-path %t/WithFeature.swiftmodule -module-name WithFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
 // RUN: %target-swift-frontend -emit-module-path %t/WithoutFeature.swiftmodule -module-name WithoutFeature %S/Inputs/caller_inheriting_isolation.swift -swift-version 6
 
 // RUN: %target-swift-frontend -module-name main -I %t %s -emit-sil -o - | %FileCheck %s
 
-// RUN: %target-swift-frontend -enable-upcoming-feature AsyncCallerExecution -module-name main -I %t %s -emit-sil -verify -swift-version 6
+// RUN: %target-swift-frontend -enable-upcoming-feature NonisolatedNonsendingByDefault -module-name main -I %t %s -emit-sil -verify -swift-version 6
 
 // REQUIRES: asserts
-// REQUIRES: swift_feature_AsyncCallerExecution
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 import WithFeature
 import WithoutFeature


### PR DESCRIPTION
- Promote the feature to upcoming in Swift 7 (tentatively)
- Rename it to `NonisolatedNonsendingByDefault` to better match the established naming convention

Resolves: rdar://145776322

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
