### PR TITLE
[6.2][silgen] Fix a small typo bug I found on inspection.

### DIFF
--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -81,7 +81,7 @@ public:
     assert(box && "buffer never emitted before activating cleanup?!");
     auto theBox = box;
     if (SGF.getASTContext().SILOpts.supportsLexicalLifetimes(SGF.getModule())) {
-      if (auto *bbi = cast<BeginBorrowInst>(theBox)) {
+      if (auto *bbi = dyn_cast<BeginBorrowInst>(theBox)) {
         SGF.B.createEndBorrow(loc, bbi);
         theBox = bbi->getOperand();
       }


### PR DESCRIPTION
Explanation: While looking at making some changes in ResultPlan.cpp, I noticed
that we were performing:

```c++
if (auto *b = cast<BeginBorrowInst>(inst)) {
```

which is very suspicious since cast<> fails on failure rather than failing like
a dyn_cast would. After reviewing the git history, I discovered that this was
clearly a thinko where dyn_cast was actually meant to be used:

```c++
if (auto *b = dyn_cast<BeginBorrowInst>(inst)) {
```

Scope: Just converts a cast that was meant to be a dyn_cast to actually be a
dyn_cast.

Resolves: rdar://149698148

Main PR: https://github.com/swiftlang/swift/pull/80952

Risk: Low.

Testing: N/A. Correct on sight.

Reviewer: @nate-chandler 