### PR TITLE
[embedded] Make -mergeable-symbols the default for Embedded Swift

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -783,6 +783,10 @@ def mergeable_symbols : Flag<["-"], "mergeable-symbols">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Emit symbol definitions as mergeable (linkonce_odr)">;
 
+def no_mergeable_symbols : Flag<["-"], "no-mergeable-symbols">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Disable symbol definitions as mergeable (linkonce_odr)">;
+
 def disable_preallocated_instantiation_caches : Flag<["-"], "disable-preallocated-instantiation-caches">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Avoid preallocating metadata instantiation caches in globals">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3718,9 +3718,9 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   Opts.InternalizeSymbols = FrontendOpts.Static;
 
-  if (Args.hasArg(OPT_mergeable_symbols)) {
-    Opts.MergeableSymbols = true;
-  }
+  Opts.MergeableSymbols =
+      Args.hasFlag(OPT_mergeable_symbols, OPT_no_mergeable_symbols,
+                   LangOpts.hasFeature(Feature::Embedded));
 
   if (Args.hasArg(OPT_disable_preallocated_instantiation_caches)) {
     Opts.NoPreallocatedInstantiationCaches = true;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2276,7 +2276,7 @@ getIRLinkage(StringRef name, const UniversalLinkageInfo &info,
   case SILLinkage::Package: {
     auto linkage = llvm::GlobalValue::ExternalLinkage;
 
-    if (info.MergeableSymbols)
+    if (info.MergeableSymbols && isDefinition)
       linkage = llvm::GlobalValue::WeakODRLinkage;
 
     return {linkage, PublicDefinitionVisibility,
@@ -2294,7 +2294,7 @@ getIRLinkage(StringRef name, const UniversalLinkageInfo &info,
                         : RESULT(External, Hidden, Default);
 
   case SILLinkage::Hidden:
-    if (info.MergeableSymbols)
+    if (info.MergeableSymbols && isDefinition)
       return RESULT(WeakODR, Hidden, Default);
 
     return RESULT(External, Hidden, Default);

--- a/test/embedded/concurrency-deleted-method.swift
+++ b/test/embedded/concurrency-deleted-method.swift
@@ -31,7 +31,7 @@ actor MyActor {
 }
 
 // CHECK-IR:      @swift_deletedAsyncMethodErrorTu =
-// CHECK-IR:      @"$e4main7MyActorCN" = global <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{ 
+// CHECK-IR:      @"$e4main7MyActorCN" = {{.*}}global <{ ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr, ptr }> <{
 // CHECK-IR-SAME:   ptr null,
 // CHECK-IR-SAME:   ptr @"$e4main7MyActorCfD",
 // CHECK-IR-SAME:   ptr null,
@@ -45,6 +45,6 @@ actor MyActor {
 
 // CHECK-IR-NOT:  $e4main7MyActorC12thisIsUnusedyyYaF
 
-// CHECK-IR: define swifttailcc void @swift_deletedAsyncMethodError(ptr swiftasync %0)
+// CHECK-IR: define {{.*}}swifttailcc void @swift_deletedAsyncMethodError(ptr swiftasync %0)
 
 // CHECK: value: 42

--- a/test/embedded/ptrauth-none-macho.swift
+++ b/test/embedded/ptrauth-none-macho.swift
@@ -16,7 +16,7 @@ public func foo() {
   callback3?(true, true)
 }
 
-// CHECK-LABEL: define swiftcc void @"$e4main3fooyyF"()
+// CHECK-LABEL: define {{.*}}swiftcc void @"$e4main3fooyyF"()
 
 // CHECK:       [[P1:%.*]] = load ptr, ptr @"$e4main8callbackyycSgvp"
 // CHECK:       call swiftcc void [[P1:%.*]](ptr swiftself {{.*}}) [ "ptrauth"(i32 0, i64 3848) ]

--- a/test/embedded/static-object.swift
+++ b/test/embedded/static-object.swift
@@ -16,8 +16,8 @@
 // CHECK-DAG: @"$e4test10storeArrayyyFTv_r" = {{.*}} constant {{.*}} @"$es20__StaticArrayStorageCN", {{.*}} -1
 // CHECK-DAG: @"$e4test3StrV9staticLet_WZTv_r" = {{.*}} constant {{.*}} @"$es20__StaticArrayStorageCN", {{.*}} -1
 // CHECK-DAG: @"$e4test3StrV9staticVar_WZTv_r" = {{.*}} constant {{.*}} @"$es20__StaticArrayStorageCN", {{.*}} -1
-// CHECK-DAG: @"$e4test3StrV9staticVarSaySiGvpZ" = global {{.*}} ptr @"$e4test3StrV9staticVar_WZTv_r"
-// CHECK-DAG: @"$e4test3StrV14twoDimensionalSaySaySiGGvpZ" = global {{.*}} ptr @"$e4test3StrV14twoDimensional_WZTv{{[0-9]*}}_r"
+// CHECK-DAG: @"$e4test3StrV9staticVarSaySiGvpZ" = {{.*}}global {{.*}} ptr @"$e4test3StrV9staticVar_WZTv_r"
+// CHECK-DAG: @"$e4test3StrV14twoDimensionalSaySaySiGGvpZ" = {{.*}}global {{.*}} ptr @"$e4test3StrV14twoDimensional_WZTv{{[0-9]*}}_r"
 
 // Currently, constant static arrays only work on Darwin platforms.
 // REQUIRES: VENDOR=apple

--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s                             | %FileCheck %s --check-prefix=CHECK-MESSAGE
-// RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -O                          | %FileCheck %s --check-prefix=CHECK-NOMESSAGE
-// RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -Osize                      | %FileCheck %s --check-prefix=CHECK-NOMESSAGE
-// RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -O     -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
-// RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -Osize -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
+// RUN: %target-swift-emit-ir -disable-llvm-merge-functions-pass -enable-experimental-feature Embedded -wmo %s                             | %FileCheck %s --check-prefix=CHECK-MESSAGE
+// RUN: %target-swift-emit-ir -disable-llvm-merge-functions-pass -enable-experimental-feature Embedded -wmo %s -O                          | %FileCheck %s --check-prefix=CHECK-NOMESSAGE
+// RUN: %target-swift-emit-ir -disable-llvm-merge-functions-pass -enable-experimental-feature Embedded -wmo %s -Osize                      | %FileCheck %s --check-prefix=CHECK-NOMESSAGE
+// RUN: %target-swift-emit-ir -disable-llvm-merge-functions-pass -enable-experimental-feature Embedded -wmo %s -O     -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
+// RUN: %target-swift-emit-ir -disable-llvm-merge-functions-pass -enable-experimental-feature Embedded -wmo %s -Osize -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/traps-multiple-preconditions-ir.swift
+++ b/test/embedded/traps-multiple-preconditions-ir.swift
@@ -36,16 +36,16 @@ public func test(i: Int) {
 
 // "Production builds" - We expect 4 separate trap blocks in the IR.
 // CHECK-NOMESSAGE: define {{.*}}void @"$e4main4test1iySi_tF"(i64 %0) {{.*}}{
-// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 0) #3
+// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 0)
 // CHECK-NOMESSAGE:   tail call void @llvm.trap()
 // CHECK-NOMESSAGE:   unreachable
-// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 1) #3
+// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 1)
 // CHECK-NOMESSAGE:   tail call void @llvm.trap()
 // CHECK-NOMESSAGE:   unreachable
-// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 2) #3
+// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 2)
 // CHECK-NOMESSAGE:   tail call void @llvm.trap()
 // CHECK-NOMESSAGE:   unreachable
-// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 3) #3
+// CHECK-NOMESSAGE:   tail call void asm sideeffect "", "n"(i32 3)
 // CHECK-NOMESSAGE:   tail call void @llvm.trap()
 // CHECK-NOMESSAGE:   unreachable
 // CHECK-NOMESSAGE: }


### PR DESCRIPTION
I have experimented with -mergeable-symbols on some larger projects, and it seems like it does retain dead-stripping as desired, and it seems like the easiest path forward that allows some level of separate compilations (separate .o/.a builds for libraries) in Embedded Swift. Let's make it enabled by default.
