### PR TITLE
[6.2] LoadableByAddress: Fix shouldTransformYields to use (properly) substituted types

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -375,12 +375,14 @@ static bool modResultType(SILFunction *F, irgen::IRGenModule &Mod,
 static bool shouldTransformYields(GenericEnvironment *genEnv,
                                   CanSILFunctionType loweredTy,
                                   irgen::IRGenModule &Mod,
-                                  LargeSILTypeMapper &Mapper) {
+                                  LargeSILTypeMapper &Mapper,
+                                  TypeExpansionContext expansion) {
   if (!modifiableFunction(loweredTy)) {
     return false;
   }
   for (auto &yield : loweredTy->getYields()) {
-    auto yieldStorageType = yield.getSILStorageInterfaceType();
+    auto yieldStorageType = yield.getSILStorageType(Mod.getSILModule(),
+                                                    loweredTy, expansion);
     auto newYieldStorageType =
         Mapper.getNewSILType(genEnv, yieldStorageType, Mod);
     if (yieldStorageType != newYieldStorageType)
@@ -394,7 +396,8 @@ static bool modYieldType(SILFunction *F, irgen::IRGenModule &Mod,
   GenericEnvironment *genEnv = getSubstGenericEnvironment(F);
   auto loweredTy = F->getLoweredFunctionType();
 
-  return shouldTransformYields(genEnv, loweredTy, Mod, Mapper);
+  return shouldTransformYields(genEnv, loweredTy, Mod, Mapper,
+                               F->getTypeExpansionContext());
 }
 
 SILParameterInfo LargeSILTypeMapper::getNewParameter(GenericEnvironment *env,

--- a/test/IRGen/loadable_by_address.swift
+++ b/test/IRGen/loadable_by_address.swift
@@ -30,3 +30,30 @@ public class Test {
     }
   }
 }
+
+// So did this test case.
+enum E {
+  case a
+}
+
+protocol P {
+  associatedtype A
+  typealias S = C<A>.S
+
+  var v: E { get set }
+
+  var v2: (t: Int, i: S)? { get set }
+}
+
+class C<A> {
+  struct S { }
+
+  init(_: ClosedRange<Double>) { }
+}
+
+class C2<T>: P {
+  typealias A = T
+  var v: E = .a
+
+  var v2: (t: Int, i: S)?
+}


### PR DESCRIPTION
Scope: The LoadableByAddress pass fails on some Swift source because it ignores pattern substitutions.

Risk: Low. Many source patterns where this difference matters should have crashed.

Fix: Don't ignore pattern substitutions.

Testing: The project that crashed no longer does. Unit test added.

`main` PR: https://github.com/swiftlang/swift/pull/80966

rdar://149281263
issues/80818