### PR TITLE
[6.2 cherry-pick] [embedded] Annotate concurrency-modules.swift with REQUIRES: optimized_stdlib

### DIFF
--- a/test/embedded/concurrency-modules.swift
+++ b/test/embedded/concurrency-modules.swift
@@ -8,6 +8,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
 // REQUIRES: swift_feature_Embedded
 


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/80689/. To fix a CI failure on this bot: <https://ci.swift.org/job/oss-swift-6.2_tools-RA_stdlib-DA_test-simulators/50/console>.

rdar://148633239