### PR TITLE
[Test Only] Restrict '@const' test to optimized-stdlib builds

### DIFF
--- a/test/ConstValues/IntegerExpressions.swift
+++ b/test/ConstValues/IntegerExpressions.swift
@@ -1,5 +1,6 @@
 // Constant globals on integer expressions
 // REQUIRES: swift_feature_CompileTimeValues
+// REQUIRES: optimized_stdlib
 // RUN: %target-swift-frontend -emit-ir -primary-file %s -parse-as-library -enable-experimental-feature CompileTimeValues -verify
 
 @const let constGlobal1: Int = (42 + 42 + 42) / 3


### PR DESCRIPTION
This should fix this CI job: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-DA_test-simulators/6014/console