### PR TITLE
Disable C++ interop benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -210,10 +210,10 @@ set(SWIFT_BENCH_MODULES
     single-source/WordCount
     single-source/XorLoop
     cxx-source/CreateObjects
-    cxx-source/CxxSetToCollection
-    cxx-source/CxxSpanTests
-    cxx-source/CxxStringConversion
-    cxx-source/CxxVectorSum
+#    cxx-source/CxxSetToCollection
+#    cxx-source/CxxSpanTests
+#    cxx-source/CxxStringConversion
+#    cxx-source/CxxVectorSum
     # TODO: rdar://92120528
     # cxx-source/ReadAccessor
 )

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -57,8 +57,8 @@ import CountAlgo
 import CreateObjects
 // rdar://128520766
 // import CxxSetToCollection
-import CxxSpanTests
-import CxxStringConversion
+// import CxxSpanTests
+// import CxxStringConversion
 // rdar://128520766
 // import CxxVectorSum
 import DataBenchmarks
@@ -257,8 +257,8 @@ register(ClassArrayGetter.benchmarks)
 register(CreateObjects.benchmarks)
 // rdar://128520766
 // register(CxxSetToCollection.benchmarks)
-register(CxxSpanTests.benchmarks)
-register(CxxStringConversion.benchmarks)
+// register(CxxSpanTests.benchmarks)
+// register(CxxStringConversion.benchmarks)
 // rdar://128520766
 // register(CxxVectorSum.benchmarks)
 register(DataBenchmarks.benchmarks)


### PR DESCRIPTION
Microbenchmarks on swift CI have been broken for over 2 weeks. Bisecting points to c++ interop benchmarks interacting badly with https://github.com/swiftlang/swift/commit/43da773685e1fc93718af6b45cc4e25a2224ef63. 

Disabling them here until their underlying issues are resolved.

rdar://149402670