### PR TITLE
[Runtimes][CMake] Set up supplemental super-build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1665,13 +1665,14 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
 
       ExternalProject_Get_Property("${stdlib_target}-core" INSTALL_DIR)
 
-      ExternalProject_Add("${stdlib_target}-StringProcessing"
-        SOURCE_DIR
-          "${CMAKE_CURRENT_SOURCE_DIR}/Runtimes/Supplemental/StringProcessing"
+      ExternalProject_Add("${stdlib_target}-Supplemental"
+        SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Runtimes/Supplemental"
         DEPENDS "${stdlib_target}-core"
         INSTALL_DIR "${INSTALL_DIR}"
-        INSTALL_COMMAND "" # No install story set up yet
+        INSTALL_COMMAND ""
+        LIST_SEPARATOR "|"
         CMAKE_ARGS
+          -DSwift_ENABLE_RUNTIMES=StringProcessing
           -DBUILD_SHARED_LIBS=YES
           -DCMAKE_Swift_COMPILER_WORKS:BOOLEAN=YES
           -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/Runtimes/Supplemental/CMakeLists.txt
+++ b/Runtimes/Supplemental/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.29)
+
+project(SwiftRuntime LANGUAGES Swift C CXX)
+
+include(ExternalProject)
+
+set(SwiftRuntime_SWIFTC_SOURCE_DIR "${PROJECT_SOURCE_DIR}/../../")
+
+foreach(lib ${Swift_ENABLE_RUNTIMES})
+  string(TOLOWER ${lib} name)
+  set(SwiftRuntime_ENABLE_${name} YES)
+endforeach()
+
+if(SwiftCore_DIR)
+  set(SwiftCore_DIR_FLAG "-DSwiftCore_DIR=${SwiftCore_DIR}")
+endif()
+
+if(CMAKE_MAKE_PROGRAM)
+  set(MAKE_PROGRAM_FLAG "-DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}")
+endif()
+
+set(COMMON_OPTIONS
+  -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
+  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+  -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+  -DCMAKE_COLOR_DIAGNOSTICS=${CMAKE_COLOR_DIAGNOSTICS}
+  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+  -DCMAKE_Swift_COMPILER=${CMAKE_Swift_COMPILER}
+  -DCMAKE_C_COMPILER_TARGET=${CMAKE_C_COMPILER_TARGET}
+  -DCMAKE_CXX_COMPILER_TARGET=${CMAKE_CXX_COMPILER_TARGET}
+  -DCMAKE_Swift_COMPILER_TARGET=${CMAKE_Swift_COMPILER_TARGET}
+  ${SwiftCore_DIR_FLAG}
+  ${MAKE_PROGRAM_FLAG})
+
+# StringProcessing
+if(SwiftRuntime_ENABLE_stringprocessing)
+  ExternalProject_Add(StringProcessing
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/StringProcessing"
+    INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
+    INSTALL_COMMAND ""
+    CMAKE_ARGS
+      ${COMMON_OPTIONS})
+endif()

--- a/Runtimes/Supplemental/Readme.md
+++ b/Runtimes/Supplemental/Readme.md
@@ -1,0 +1,52 @@
+# Swift Supplemental Libraries
+
+The supplemental libraries are all libraries that are not one of the Core or
+overlay libraries. Each supplemental library builds as an independent project.
+
+The supplemental libraries are:
+ - CxxInterop
+ - Differentiation
+ - Distributed
+ - Observation
+ - StringProcessing
+ - SwiftRuntime
+ - Synchronization
+
+The top-level Supplemental CMakeLists supplies a super-build pattern for
+configuring and compiling each of the supplemental library projects through a
+single CMake invocation. The `Swift_ENABLE_RUNTIMES` CMake option enables the
+specified supplemental libraries. All libraries configured this way are built
+with the same compilers, against the same sysroot, with the same target triple
+and installed into the same location.
+
+## Super-Build
+
+Configuring each project independently is tedious. The Supplemental directory
+contains a Super-Build CMakeLists that invokes the build of each of the
+supplemental libraries in the appropriate order, simplifying the process of
+building each library.
+
+Important configuration variables:
+ - `Swift_ENABLE_RUNTIMES`: Used to configure which runtime libraries are built.
+
+The super-build forwards the following variables to each sub-project
+unconditionally:
+ - `BUILD_SHARED_LIBS`
+ - `CMAKE_BUILD_TYPE`
+ - `CMAKE_INSTALL_PREFIX`
+ - `CMAKE_COLOR_DIAGNOSTICS`
+ - `CMAKE_C_COMPILER`
+ - `CMAKE_C_COMPILER_TARGET`
+ - `CMAKE_CXX_COMPILER`
+ - `CMAKE_CXX_COMPILER_TARGET`
+ - `CMAKE_Swift_COMPILER`
+ - `CMAKE_Swift_COMPILER_TARGET`
+
+If set, the super-build forwards the following values to each sub-project:
+
+ - `SwiftCore_DIR`: Path to the SwiftCore build directory
+ - `CMAKE_MAKE_PROGRAM`: Path to `ninja`
+
+The super-build is for convenience. If more fine-grained control is desired for
+configuring a specific runtime library, you may configure that library
+independently.


### PR DESCRIPTION
As we add libraries, it will become more tedious to manage building all of them independently. When built together, they should mostly take the same arguments specifying where they are installed, what compilers to use, and what configuration to use when building them. The super-build pattern is useful for this purpose. For certain distributions, it is useful to configure libraries with specific flags, but for most purposes, that is unnecessary.

This moves the StringProcessing library to use the supplemental super build in CI.

This is splitting out the super-build pattern form the Differentiation PR: https://github.com/swiftlang/swift/pull/80513/