### PR TITLE
utils: correct the logging for `Get-Dependencies`

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -868,7 +868,7 @@ function Invoke-VsDevShell([Hashtable] $Platform) {
 }
 
 function Get-Dependencies {
-  Write-Host "[$([DateTime]::Now.ToString("yyyy-MM-dd HH:mm:ss"))] Fetch-Dependencies ..." -ForegroundColor Cyan
+  Write-Host "[$([DateTime]::Now.ToString("yyyy-MM-dd HH:mm:ss"))] Get-Dependencies ..." -ForegroundColor Cyan
   $ProgressPreference = "SilentlyContinue"
 
   $WebClient = New-Object Net.WebClient


### PR DESCRIPTION
`Fetch-Dependencies` was renamed but we did not fully rename the references. Update the straggling instance of the old name which was used in logging.