### PR TITLE
6.2: [OSSACanOwned] Don't dead-end extend if consumed.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -469,6 +469,12 @@ private:
     return explicitLifetimeEnds.size() > 0;
   }
 
+  bool respectsDeadEnds() const {
+    // TODO: OSSALifetimeCompletion: Once lifetimes are always complete, delete
+    //                               this method.
+    return !endingLifetimeAtExplicitEnds();
+  }
+
   bool respectsDeinitBarriers() const {
     if (!currentDef->isLexical())
       return false;

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -261,7 +261,7 @@ private:
   SILValue currentDef;
 
   /// Instructions beyond which liveness is not extended by destroy uses.
-  ArrayRef<SILInstruction *> currentLexicalLifetimeEnds;
+  ArrayRef<SILInstruction *> explicitLifetimeEnds;
 
   /// Original points in the CFG where the current value's lifetime is consumed
   /// or destroyed.  Each block either contains a consuming instruction (e.g.
@@ -368,7 +368,7 @@ public:
     clear();
 
     currentDef = def;
-    currentLexicalLifetimeEnds = lexicalLifetimeEnds;
+    explicitLifetimeEnds = lexicalLifetimeEnds;
 
     liveness->initializeDiscoveredBlocks(&discoveredBlocks);
     liveness->initializeDef(getCurrentDef());

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -465,6 +465,10 @@ public:
   UserRange getUsers() const { return liveness->getAllUsers(); }
 
 private:
+  bool endingLifetimeAtExplicitEnds() const {
+    return explicitLifetimeEnds.size() > 0;
+  }
+
   bool respectsDeinitBarriers() const {
     if (!currentDef->isLexical())
       return false;

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -1406,10 +1406,12 @@ bool CanonicalizeOSSALifetime::computeLiveness() {
     clear();
     return false;
   }
-  if (respectsDeinitBarriers()) {
-    extendLexicalLivenessToDeadEnds();
+  if (respectsDeadEnds()) {
+    if (respectsDeinitBarriers()) {
+      extendLexicalLivenessToDeadEnds();
+    }
+    extendLivenessToDeadEnds();
   }
-  extendLivenessToDeadEnds();
   if (respectsDeinitBarriers()) {
     extendLivenessToDeinitBarriers();
   }

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -387,9 +387,9 @@ void CanonicalizeOSSALifetime::extendLivenessToDeadEnds() {
 
 void CanonicalizeOSSALifetime::extendLivenessToDeinitBarriers() {
   SmallVector<SILInstruction *, 8> ends;
-  if (currentLexicalLifetimeEnds.size() > 0) {
+  if (explicitLifetimeEnds.size() > 0) {
     visitExtendedUnconsumedBoundary(
-        currentLexicalLifetimeEnds,
+        explicitLifetimeEnds,
         [&ends](auto *instruction, auto lifetimeEnding) {
           instruction->visitSubsequentInstructions([&](auto *next) {
             ends.push_back(next);

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -387,7 +387,7 @@ void CanonicalizeOSSALifetime::extendLivenessToDeadEnds() {
 
 void CanonicalizeOSSALifetime::extendLivenessToDeinitBarriers() {
   SmallVector<SILInstruction *, 8> ends;
-  if (explicitLifetimeEnds.size() > 0) {
+  if (endingLifetimeAtExplicitEnds()) {
     visitExtendedUnconsumedBoundary(
         explicitLifetimeEnds,
         [&ends](auto *instruction, auto lifetimeEnding) {

--- a/test/Interpreter/consume_operator_kills_copyable_values.swift.gyb
+++ b/test/Interpreter/consume_operator_kills_copyable_values.swift.gyb
@@ -176,6 +176,20 @@ func testNested2_${introducer}(_ c1: Bool, _ c2: Bool) {
   end([c1, c2])
 }
 
+// CHECK-LABEL: begin testDeadEnd_{{let|var}}(_:)(true)
+// CHECK:       hi
+// CHECK:       adios
+// CHECK:       barrier
+// CHECK-LABEL: end testDeadEnd_{{let|var}}(_:)(true)
+func testDeadEnd_${introducer}(_ condition: Bool) {
+  begin([condition])
+  ${introducer} x = X(0)
+  _ = consume x
+  guard condition else { fatalError() }
+  barrier()
+  end([condition])
+}
+
 func main_${introducer}() {
   simple_${introducer}()
   testLeft_${introducer}(true)
@@ -188,6 +202,7 @@ func main_${introducer}() {
   testNested2_${introducer}(false, true)
   testNested2_${introducer}(true, false)
   testNested2_${introducer}(true, true)
+  testDeadEnd_${introducer}(true)
 }
 
 % end


### PR DESCRIPTION
**Explanation**: If a value is `consume`'d in Swift source, don't force its lifetime to extend to dead-ends.

The lack of complete lifetimes in SIL has forced the OSSA lifetime canonicalization utility to explicitly add dead-ends to a value's lifetime.  When the utility is used by the `consume` checker, however, doing so isn't correct.  The value's lifetime may end before such dead-ends if the `consume` occurs between the value's definition and the dead-end.

Here, this is fixed by not extending lifetimes into dead-ends when the utility is used by the `consume` checker.
**Scope**: Affects lifetimes of values which are `consume`'d in functions with dead-ends.
**Issue**: rdar://147586673
**Original PR**: https://github.com/swiftlang/swift/pull/80990
**Risk**: Low, only affects `consume` checking of copyable values.
**Testing**: Added test.
**Reviewer**: Andrew Trick ( @atrick )
