### PR TITLE
[MoveOnly] Fix consumption of opened existentials.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7821,6 +7821,7 @@ public:
   }
 
   OpenedExistentialAccess getAccessKind() const { return ForAccess; }
+  void setAccessKind(OpenedExistentialAccess kind) { ForAccess = kind; }
 
   CanExistentialArchetypeType getDefinedOpenedArchetype() const {
     const auto archetype = getOpenedArchetypeOf(getType().getASTType());

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -3430,6 +3430,10 @@ void MoveOnlyAddressCheckerPImpl::rewriteUses(
       auto accessPath = AccessPathWithBase::computeInScope(copy->getSrc());
       if (auto *access = dyn_cast_or_null<BeginAccessInst>(accessPath.base))
         access->setAccessKind(SILAccessKind::Modify);
+      if (auto *oeai =
+              dyn_cast_or_null<OpenExistentialAddrInst>(copy->getSrc())) {
+        oeai->setAccessKind(OpenedExistentialAccess::Mutable);
+      }
       copy->setIsTakeOfSrc(IsTake);
       continue;
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1898,7 +1898,7 @@ shouldEmitPartialMutationError(UseState &useState, PartialMutation::Kind kind,
     // Otherwise, walk one level towards our child type. We unconditionally
     // unwrap since we should never fail here due to earlier checking.
     std::tie(iterPair, iterType) =
-        *pair.walkOneLevelTowardsChild(iterPair, iterType, fn);
+        *pair.walkOneLevelTowardsChild(iterPair, iterType, targetType, fn);
   }
 
   return {};

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -1390,8 +1390,8 @@ update_operand:
 
           // Then walk one level towards our target type.
           std::tie(iterOffsetSize, iterType) =
-              *useOffsetSize.walkOneLevelTowardsChild(parentOffsetSize,
-                                                      iterType, fn);
+              *useOffsetSize.walkOneLevelTowardsChild(
+                  parentOffsetSize, iterType, unwrappedOperandType, fn);
 
           unsigned start = parentOffsetSize.startOffset;
           consumeBuilder.emitDestructureValueOperation(

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -877,7 +877,6 @@ AvailableValues &Implementation::computeAvailableValues(SILBasicBlock *block) {
       llvm::dbgs()
       << "    Destructuring available values in preds to smallest size for bb"
       << block->getDebugID() << '\n');
-  auto *fn = block->getFunction();
   IntervalMapAllocator::Map typeSpanToValue(getAllocator());
   for (auto *predBlock : predsSkippingBackEdges) {
     SWIFT_DEFER { typeSpanToValue.clear(); };
@@ -930,20 +929,10 @@ AvailableValues &Implementation::computeAvailableValues(SILBasicBlock *block) {
       // smallest offset size could result in further destructuring that an
       // earlier value required. Instead, we do a final loop afterwards using
       // the interval map to update each available value.
-      auto iterType = iterValue->getType();
       auto loc = getSafeLoc(predBlock->getTerminator());
       SILBuilderWithScope builder(predBlock->getTerminator());
 
       while (smallestOffsetSize->first.size < iterOffsetSize.size) {
-        TypeOffsetSizePair childOffsetSize;
-        SILType childType;
-
-        // We are returned an optional here and should never fail... so use a
-        // force unwrap.
-        std::tie(childOffsetSize, childType) =
-            *iterOffsetSize.walkOneLevelTowardsChild(iterOffsetSize, iterType,
-                                                     fn);
-
         // Before we destructure ourselves, erase our entire value from the
         // map. We do not need to consider the possibility of there being holes
         // in our range since we always store values whole to their entire

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.cpp
@@ -127,6 +127,16 @@ TypeOffsetSizePair::walkOneLevelTowardsChild(
     llvm_unreachable("Not a child of this enum?!");
   }
 
+  if (ancestorType.isExistentialType()) {
+    assert(childType);
+    auto childArchetypeType =
+        childType.getASTType()->getAs<ExistentialArchetypeType>();
+    assert(childArchetypeType);
+    assert(childArchetypeType->getExistentialType()->getCanonicalType() ==
+           ancestorType.getASTType());
+    return {{ancestorOffsetSize, childType}};
+  }
+
   llvm_unreachable("Hit a leaf type?! Should have handled it earlier");
 }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.cpp
@@ -26,7 +26,7 @@ static StructDecl *getFullyReferenceableStruct(SILType ktypeTy) {
 std::optional<std::pair<TypeOffsetSizePair, SILType>>
 TypeOffsetSizePair::walkOneLevelTowardsChild(
     TypeOffsetSizePair ancestorOffsetSize, SILType ancestorType,
-    SILFunction *fn) const {
+    SILType childType, SILFunction *fn) const {
   assert(ancestorOffsetSize.size >= size &&
          "Too large to be a child of ancestorType");
   assert((ancestorOffsetSize.startOffset <= startOffset &&

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.h
@@ -64,7 +64,8 @@ struct TypeOffsetSizePair {
   /// be a child type of \p ancestorType.
   std::optional<std::pair<TypeOffsetSizePair, SILType>>
   walkOneLevelTowardsChild(TypeOffsetSizePair ancestorOffsetSize,
-                           SILType ancestorType, SILFunction *fn) const;
+                           SILType ancestorType, SILType childType,
+                           SILFunction *fn) const;
 
   /// Given an ancestor offset \p ancestorOffset and a type called \p
   /// ancestorType, walk one level towards this current type inserting on value,

--- a/validation-test/SILOptimizer/rdar141279635.swift
+++ b/validation-test/SILOptimizer/rdar141279635.swift
@@ -1,0 +1,21 @@
+// RUN: %target-build-swift %s
+
+protocol P: ~Copyable {
+    var property: Bool { get }
+    consuming func function()
+}
+
+struct S: P, ~Copyable {
+    var property: Bool { false }
+    consuming func function() {}
+}
+
+func g(s: consuming any P & ~Copyable) {
+    let s = s
+    s.function()
+}
+
+func f() {
+    let s = S()
+    g(s: s)
+}


### PR DESCRIPTION
Enable walking into `TypeOffsetSizePair`s from an existential into an archetype.  And set the access kind on `open_existential_addr` instructions which are the sources of rewritten `copy_addr`s to mutable.

rdar://141279635
