### PR TITLE
[cxx-interop] Allow C++ function templates to be instantiated with Swift closures

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6576,13 +6576,16 @@ const clang::Type *
 ASTContext::getClangFunctionType(ArrayRef<AnyFunctionType::Param> params,
                                  Type resultTy,
                                  FunctionTypeRepresentation trueRep) {
-  return getClangTypeConverter().getFunctionType(params, resultTy, trueRep);
+  return getClangTypeConverter().getFunctionType(params, resultTy, trueRep,
+                                                 /*templateArgument=*/false);
 }
 
 const clang::Type *ASTContext::getCanonicalClangFunctionType(
     ArrayRef<SILParameterInfo> params, std::optional<SILResultInfo> result,
     SILFunctionType::Representation trueRep) {
-  auto *ty = getClangTypeConverter().getFunctionType(params, result, trueRep);
+  auto *ty =
+      getClangTypeConverter().getFunctionType(params, result, trueRep,
+                                              /*templateArgument=*/false);
   return ty ? ty->getCanonicalTypeInternal().getTypePtr() : nullptr;
 }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6576,16 +6576,16 @@ const clang::Type *
 ASTContext::getClangFunctionType(ArrayRef<AnyFunctionType::Param> params,
                                  Type resultTy,
                                  FunctionTypeRepresentation trueRep) {
-  return getClangTypeConverter().getFunctionType(params, resultTy, trueRep,
-                                                 /*templateArgument=*/false);
+  return getClangTypeConverter().getFunctionType</*templateArgument=*/false>(
+      params, resultTy, trueRep);
 }
 
 const clang::Type *ASTContext::getCanonicalClangFunctionType(
     ArrayRef<SILParameterInfo> params, std::optional<SILResultInfo> result,
     SILFunctionType::Representation trueRep) {
   auto *ty =
-      getClangTypeConverter().getFunctionType(params, result, trueRep,
-                                              /*templateArgument=*/false);
+      getClangTypeConverter().getFunctionType</*templateArgument=*/false>(
+          params, result, trueRep);
   return ty ? ty->getCanonicalTypeInternal().getTypePtr() : nullptr;
 }
 

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -70,14 +70,16 @@ public:
   /// \returns The appropriate clang type on success, nullptr on failure.
   ///
   /// Precondition: The representation argument must be C-compatible.
-  const clang::Type *getFunctionType(
-    ArrayRef<AnyFunctionType::Param> params, Type resultTy,
-    AnyFunctionType::Representation repr);
+  const clang::Type *getFunctionType(ArrayRef<AnyFunctionType::Param> params,
+                                     Type resultTy,
+                                     AnyFunctionType::Representation repr,
+                                     bool templateArgument);
 
   /// Compute the C function type for a SIL function type.
   const clang::Type *getFunctionType(ArrayRef<SILParameterInfo> params,
                                      std::optional<SILResultInfo> result,
-                                     SILFunctionType::Representation repr);
+                                     SILFunctionType::Representation repr,
+                                     bool templateArgument);
 
   /// Check whether the given Clang declaration is an export of a Swift
   /// declaration introduced by this converter, and if so, return the original
@@ -148,7 +150,8 @@ private:
   clang::QualType visitBoundGenericClassType(BoundGenericClassType *type);
   clang::QualType visitBoundGenericType(BoundGenericType *type);
   clang::QualType visitEnumType(EnumType *type);
-  clang::QualType visitFunctionType(FunctionType *type);
+  clang::QualType visitFunctionType(FunctionType *type,
+                                    bool templateArgument = false);
   clang::QualType visitProtocolCompositionType(ProtocolCompositionType *type);
   clang::QualType visitExistentialType(ExistentialType *type);
   clang::QualType visitBuiltinRawPointerType(BuiltinRawPointerType *type);
@@ -156,7 +159,8 @@ private:
   clang::QualType visitBuiltinFloatType(BuiltinFloatType *type);
   clang::QualType visitArchetypeType(ArchetypeType *type);
   clang::QualType visitDependentMemberType(DependentMemberType *type);
-  clang::QualType visitSILFunctionType(SILFunctionType *type);
+  clang::QualType visitSILFunctionType(SILFunctionType *type,
+                                       bool templateArgument = false);
   clang::QualType visitGenericTypeParamType(GenericTypeParamType *type);
   clang::QualType visitDynamicSelfType(DynamicSelfType *type);
   clang::QualType visitSILBlockStorageType(SILBlockStorageType *type);

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -70,16 +70,16 @@ public:
   /// \returns The appropriate clang type on success, nullptr on failure.
   ///
   /// Precondition: The representation argument must be C-compatible.
+  template <bool templateArgument>
   const clang::Type *getFunctionType(ArrayRef<AnyFunctionType::Param> params,
                                      Type resultTy,
-                                     AnyFunctionType::Representation repr,
-                                     bool templateArgument);
+                                     AnyFunctionType::Representation repr);
 
   /// Compute the C function type for a SIL function type.
+  template <bool templateArgument>
   const clang::Type *getFunctionType(ArrayRef<SILParameterInfo> params,
                                      std::optional<SILResultInfo> result,
-                                     SILFunctionType::Representation repr,
-                                     bool templateArgument);
+                                     SILFunctionType::Representation repr);
 
   /// Check whether the given Clang declaration is an export of a Swift
   /// declaration introduced by this converter, and if so, return the original
@@ -127,11 +127,11 @@ private:
 
   clang::QualType convertClangDecl(Type type, const clang::Decl *decl);
 
-  clang::QualType convertSIMDType(CanType scalarType, unsigned width,
-                                  bool templateArgument);
+  template <bool templateArgument>
+  clang::QualType convertSIMDType(CanType scalarType, unsigned width);
 
-  clang::QualType convertPointerType(CanType pointeeType, PointerKind kind,
-                                     bool templateArgument);
+  template <bool templateArgument>
+  clang::QualType convertPointerType(CanType pointeeType, PointerKind kind);
 
   void registerExportedClangDecl(Decl *swiftDecl,
                                  const clang::Decl *clangDecl);
@@ -150,8 +150,8 @@ private:
   clang::QualType visitBoundGenericClassType(BoundGenericClassType *type);
   clang::QualType visitBoundGenericType(BoundGenericType *type);
   clang::QualType visitEnumType(EnumType *type);
-  clang::QualType visitFunctionType(FunctionType *type,
-                                    bool templateArgument = false);
+  template <bool templateArgument = false>
+  clang::QualType visitFunctionType(FunctionType *type);
   clang::QualType visitProtocolCompositionType(ProtocolCompositionType *type);
   clang::QualType visitExistentialType(ExistentialType *type);
   clang::QualType visitBuiltinRawPointerType(BuiltinRawPointerType *type);
@@ -159,8 +159,8 @@ private:
   clang::QualType visitBuiltinFloatType(BuiltinFloatType *type);
   clang::QualType visitArchetypeType(ArchetypeType *type);
   clang::QualType visitDependentMemberType(DependentMemberType *type);
-  clang::QualType visitSILFunctionType(SILFunctionType *type,
-                                       bool templateArgument = false);
+  template <bool templateArgument = false>
+  clang::QualType visitSILFunctionType(SILFunctionType *type);
   clang::QualType visitGenericTypeParamType(GenericTypeParamType *type);
   clang::QualType visitDynamicSelfType(DynamicSelfType *type);
   clang::QualType visitSILBlockStorageType(SILBlockStorageType *type);

--- a/test/Interop/Cxx/templates/Inputs/function-templates.h
+++ b/test/Interop/Cxx/templates/Inputs/function-templates.h
@@ -15,8 +15,27 @@ template <class T> void expectsConstCharPtr(T str) { takesString(str); }
 template <long x> void hasNonTypeTemplateParameter() {}
 template <long x = 0> void hasDefaultedNonTypeTemplateParameter() {}
 
+// NOTE: these will cause multi-def linker errors if used in more than one compilation unit
 int *intPtr;
-int (*functionPtr)(void);
+
+int get42(void) { return 42; }
+int (*functionPtrGet42)(void) = &get42;
+int (*_Nonnull nonNullFunctionPtrGet42)(void) = &get42;
+
+int tripleInt(int x) { return x * 3; }
+int (*functionPtrTripleInt)(int) = &tripleInt;
+int (*_Nonnull nonNullFunctionPtrTripleInt)(int) = &tripleInt;
+
+int (^blockReturns111)(void) = ^{ return 111; };
+int (^_Nonnull nonNullBlockReturns222)(void) = ^{ return 222; };
+
+int (^blockTripleInt)(int) = ^(int x) { return x * 3; };
+int (^_Nonnull nonNullBlockTripleInt)(int) = ^(int x) { return x * 3; };
+
+// These functions construct block literals that capture a local variable, and
+// then feed those blocks back to Swift via the given Swift closure (cb).
+void getConstantIntBlock(int returnValue, void (^_Nonnull cb)(int (^_Nonnull)(void))) { cb(^{ return returnValue; }); }
+int getMultiplyIntBlock(int multiplier, int (^_Nonnull cb)(int (^_Nonnull)(int))) { return cb(^(int x) { return x * multiplier; }); }
 
 // We cannot yet use this in Swift but, make sure we don't crash when parsing
 // it.
@@ -59,6 +78,7 @@ struct PlainStruct {
 struct CxxClass {
   int x;
   void method() {}
+  int getX() const { return x; }
 };
 
 struct __attribute__((swift_attr("import_reference")))
@@ -101,6 +121,21 @@ template <class T> bool constLvalueReferenceToBool(const T &t) { return t; }
 template <class T> void forwardingReference(T &&) {}
 
 template <class T> void PointerTemplateParameter(T*){}
+
+template <typename F> void callFunction(F f) { f(); }
+template <typename F, typename T> void callFunctionWithParam(F f, T t) { f(t); }
+template <typename F, typename T> T callFunctionWithReturn(F f) { return f(); }
+template <typename F, typename T> T callFunctionWithPassthrough(F f, T t) { return f(t); }
+
+static inline void callBlock(void (^_Nonnull callback)(void)) { callback(); }
+template <typename F> void indirectlyCallFunction(F f) { callBlock(f); }
+template <typename F> void indirectlyCallFunctionTemplate(F f) { callFunction(f); }
+
+static inline void callBlockWith42(void (^_Nonnull callback)(int)) { callback(42); }
+template <typename F> void indirectlyCallFunctionWith42(F f) { callBlockWith42(f); }
+
+static inline void callBlockWithCxxClass24(void (^_Nonnull cb)(CxxClass)) { CxxClass c = {24}; cb(c); }
+template <typename F> void indirectlyCallFunctionWithCxxClass24(F f) { callBlockWithCxxClass24(f); }
 
 namespace Orbiters {
 

--- a/test/Interop/Cxx/templates/function-template-closures.swift
+++ b/test/Interop/Cxx/templates/function-template-closures.swift
@@ -1,0 +1,146 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=default)
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import FunctionTemplates
+import StdlibUnittest
+
+var FunctionTemplateClosuresTestSuite = TestSuite("Function Templates with Closures")
+
+FunctionTemplateClosuresTestSuite.test("callFunction<F> where F == () -> ()") {
+  var value = false
+  callFunction({() in value = true})
+  expectTrue(value)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunction<F> where F == () -> Bool") {
+  var value = false
+  callFunction({() in value = true; return true})
+  expectTrue(value)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithParam<F, T> where F == (Int) -> (), T == Int") {
+  var value = 42
+  callFunctionWithParam({(x: Int) in value = x}, 24)
+  expectEqual(value, 24)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithParam<F, T> where F == (Int) -> Bool, T == Int") {
+  var value = 42
+  callFunctionWithParam({(x: Int) in value = x; return true}, 24)
+  expectEqual(value, 24)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithParam<F, T> where F == (CxxClass) -> (), T == CxxClass") {
+  var value: CInt = 42
+
+  // Read x via direct field access
+  callFunctionWithParam({(c: CxxClass) in value = c.x}, CxxClass(x: 24))
+  expectEqual(value, 24)
+
+  // Read x via getter method
+  callFunctionWithParam({(c: CxxClass) in value = c.getX()}, CxxClass(x: 22))
+  expectEqual(value, 22)
+}
+
+// TODO: this likely needs more design work
+// FunctionTemplateClosuresTestSuite.test("callFunctionWithParam<F, T> where F == (()) -> (), T == ()") {
+//   var value = 42
+//   // None of these are quite right:
+//   // callFunctionWithParam({(_: ()) in value = 24}, ())
+//   // callFunctionWithParam({(_: Void) in value = 24}, ())
+//   // callFunctionWithParam({() in value = 24}, ())
+//   expectEqual(value, 24)
+// }
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithReturn<F, T> where F == () -> Int, T == Int") {
+  let val1: Int = callFunctionWithReturn({() in 111})
+  expectEqual(val1, 111)
+  let val2: Int = callFunctionWithReturn({() -> Int in 222})
+  expectEqual(val2, 222)
+  // Cannot infer return type without val3 explicitly annotated as Int
+  // let val3 = callFunctionWithReturn({() -> Int in 333})
+  // expectEqual(val3, 333)
+
+  // This works:
+  expectEqual(callFunctionWithReturn({() in 444}), 444)
+  // This too:
+  expectEqual(callFunctionWithReturn({() in true}), true)
+  // But this does not (probably a quirk of expectTrue())
+  // expectTrue(callFunctionWithReturn({() in true}))
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithReturn<F, T> where F == () -> CxxClass, T == CxxClass") {
+  let c: CxxClass = callFunctionWithReturn({() in CxxClass(x: 42)})
+  expectEqual(c.x, 42)
+
+  let d: CxxClass = callFunctionWithReturn({() in c})
+  expectEqual(d.x, 42)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithPassthrough<F, T> where F == (T) -> T, T == Int") {
+  expectEqual(callFunctionWithPassthrough({(x: Int) in x}, 42), 42)
+  expectEqual(callFunctionWithPassthrough({(x: Int) in 24}, 42), 24)
+  expectEqual(callFunctionWithPassthrough({(x: Int) in x + 42}, 42), 84)
+}
+
+FunctionTemplateClosuresTestSuite.test("indirectlyCallFunction<T> where T == () -> ()") {
+  var value = 42
+
+  indirectlyCallFunction({() in value = 111});
+  expectEqual(value, 111)
+
+  indirectlyCallFunctionTemplate({() in value = 222});
+  expectEqual(value, 222)
+}
+
+FunctionTemplateClosuresTestSuite.test("indirectlyCallFunction<T> where T == () -> ()") {
+  var value: CInt = 0
+
+  indirectlyCallFunctionWith42({(x: CInt) in value = x});
+  expectEqual(value, 42)
+
+  indirectlyCallFunctionWithCxxClass24({(c: CxxClass) in value = c.x});
+  expectEqual(value, 24)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithReturn<F, T> where F == void (^)(int), T == CInt") {
+  var value: CInt = 0
+
+  value = callFunctionWithReturn(blockReturns111!)
+  expectEqual(value, 111)
+
+  value = callFunctionWithReturn(nonNullBlockReturns222)
+  expectEqual(value, 222)
+
+  getConstantIntBlock(333, {cb in value = callFunctionWithReturn(cb) })
+  expectEqual(value, 333)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithPassthrough<F, T> where F == int (^)(int), T == CInt") {
+  expectEqual(callFunctionWithPassthrough(blockTripleInt!, 7), 21)
+  expectEqual(callFunctionWithPassthrough(nonNullBlockTripleInt, 8), 24)
+  expectEqual(getMultiplyIntBlock(9, {cb in callFunctionWithPassthrough(cb, 3)}), 27)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithReturn<T, B> where T == C function ptr, B == CInt") {
+  var value: CInt = 0
+
+  value = callFunctionWithReturn(get42)
+  expectEqual(value, 42)
+
+  value = callFunctionWithReturn(functionPtrGet42!)
+  expectEqual(value, 42)
+
+  value = callFunctionWithReturn(nonNullFunctionPtrGet42)
+  expectEqual(value, 42)
+}
+
+FunctionTemplateClosuresTestSuite.test("callFunctionWithPassthrough<F, T> where C function ptr, T == CInt") {
+  expectEqual(callFunctionWithPassthrough(tripleInt, 4), 12)
+  expectEqual(callFunctionWithPassthrough(functionPtrTripleInt!, 5), 15)
+  expectEqual(callFunctionWithPassthrough(nonNullFunctionPtrTripleInt, 6), 18)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/templates/template-instantiation-irgen.swift
+++ b/test/Interop/Cxx/templates/template-instantiation-irgen.swift
@@ -1,4 +1,18 @@
+// This regression test was originally written because the Swift compiler would
+// crash when it tried to instantiate C++ function templates with various types.
+// In particular, instantiating them with Swift types was problematic.
+//
+// Aside from validating that we can successfully instantiate function templates
+// with basic primitive types (e.g., Bool, Int32) and imported C/ObjC/C++ types,
+// this regression test aims to document the current status of C++ function
+// template instantiation.
+//
+// With the following, we check the happy path, that we _can_ successfully emit
+// SIL for certain template instantiations:
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -cxx-interoperability-mode=default -disable-availability-checking | %FileCheck %s
+//
+// Some instantiations still cause Swift compiler crashes. These are documented
+// with "FIXME" comments.
 
 import FunctionTemplates
 
@@ -32,7 +46,7 @@ func takesPtrToStruct(x: UnsafePointer<PlainStruct>) { takesValue(x) }
 func takesPtrToClass(x: UnsafePointer<CxxClass>) { takesValue(x) }
 // CHECK: define {{.*}} void @{{.*}}takesPtrToClass{{.*}}
 
-// TODO: this does not work because this round-trips to UnsafePointer<FRT?>
+// FIXME: this crashes because this round-trips to UnsafePointer<FRT?>
 // func takesPtrToFRT(x: UnsafePointer<FRT>) { takesValue(x) }
 
 func takesMutPtrToStruct(x: UnsafeMutablePointer<PlainStruct>) { takesValue(x) }
@@ -41,12 +55,46 @@ func takesMutPtrToStruct(x: UnsafeMutablePointer<PlainStruct>) { takesValue(x) }
 func takesMutPtrToClass(x: UnsafeMutablePointer<CxxClass>) { takesValue(x) }
 // CHECK: define {{.*}} void @{{.*}}takesMutPtrToClass{{.*}}
 
-// TODO: this does not work because this round-trips to UnsafeMutablePointer<FRT?>
+// FIXME: this crashes because this round-trips to UnsafeMutablePointer<FRT?>
 // func takesMutPtrToFRT(x: UnsafeMutablePointer<FRT>) { takesValue(x) }
 
-// TODO: optional pointers are not yet supported but they should be
-// func takesCPtr() { takesValue(intPtr) }
-func takesCPtr() { let swiftPtr = intPtr!; takesValue(swiftPtr) }
+func takesCPtr() {
+  // FIXME: optional pointers are not yet supported but they should be; this crashes
+  // takesValue(intPtr)
 
-// TODO: function pointers are not yet supported but they should be
-// func takesCFnPtr() { takesValue(functionPtr) }
+  // It's fine if we dereference it, though
+  takesValue(intPtr!)
+}
+
+func takesCFnPtr() {
+  takesValue(get42) // function symbol
+  // FIXME: optional pointers are not yet supported but they should be; this crashes
+  // takesValue(functionPtrGet42)
+  takesValue(functionPtrGet42!) // dereferenced nullable function pointer
+  takesValue(nonNullFunctionPtrGet42) // non-null function symbol
+}
+
+func takesRecursively() { takesValue(takesRecursively) }
+func takesRecursiveClosure() { takesValue({() in takesRecursiveClosure()}) }
+func takesSwiftClosure() { takesValue({() in ()}) }
+func takesTakesTrue() { takesValue(takesTrue) }
+
+func takesSwiftClosureReturningBool() { takesValue({() -> Bool in true}) }
+func takesSwiftClosureTakingBool() { takesValue({(x: Bool) in ()}) }
+func takesTakesBool() { takesValue(takesBool) }
+
+func takesSwiftClosureReturningPlainStruct() { takesValue({() -> PlainStruct in PlainStruct(x: 42)}) }
+func takesSwiftClosureTakingPlainStruct() { takesValue({(x: PlainStruct) in takesValue(x)}) }
+func takesTakesPlainStruct() { takesValue(takesPlainStruct) }
+
+func takesSwiftClosureReturningCxxClass() { takesValue({() -> CxxClass in CxxClass(x: 42)}) }
+func takesSwiftClosureTakingCxxClass() { takesValue({(x: CxxClass) in takesValue(x)}) }
+func takesTakesCxxClass() { takesValue(takesCxxClass) }
+
+func takesSwiftClosureReturningFRT() { takesValue({() -> FRT in FRT()}) }
+
+// FIXME: this crashes due to pointer round-tripping
+// func takesSwiftClosureTakingFRT() { takesValue({(x: FRT) in takesValue(x)}) }
+
+// FIXME: this crashes due to pointer round-tripping
+// func takesTakesFRT() { takesValue(takesFRT) }


### PR DESCRIPTION
Swift started to explicitly forbid the instantiation of C++ function templates with arbitrary types in #77430, because many types cause the Swift compiler to crash. However, those checks prevented them from being instantiated with Swift closures (which were previously fine), causing a regression.

This patch relaxes the convertTemplateArgument() function to also allow converting Swift function types, and adds some tests to make sure doing so is fine. This patch also does some cleanup of an existing test checking the instantiation of various types.

rdar://148124104