### PR TITLE
[6.2] Fix LifetimeDependenceDiagnostics: handle drop_deinit unsafeAddress

### DIFF
--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -33,6 +33,15 @@ public struct Holder {
   var c: C
 }
 
+struct A {}
+
+struct NCWrapper : ~Copyable, ~Escapable {
+  @_hasStorage let a: NE { get }
+  deinit
+}
+
+sil @getNEPointer : $@convention(thin) (@guaranteed NE) -> Builtin.RawPointer
+sil @useA : $@convention(thin) (A) -> ()
 sil @makeNE : $@convention(thin) () -> @lifetime(immortal) @owned NE
 sil @makeNEObject : $@convention(thin) () -> @lifetime(immortal) @owned NEObject
 sil @useNE : $@convention(thin) (NE) -> ()
@@ -79,4 +88,30 @@ bb0(%0 : @owned $Holder):
   destroy_value %val
   %99 = tuple ()
   return %99
+}
+
+// Test that local variable analysis can handle an address-type mark_dependence on an address base. The drop_deinit
+// also creates an an unknown address scope, preventing diagnostics from promoting the mark_dependence to noescape.
+sil [ossa] @testMarkDepAddressProjection : $@convention(thin) (@owned NCWrapper) -> () {
+bb0(%0 : @owned $NCWrapper):
+  %1 = alloc_stack $NCWrapper, let, name "self", argno 1
+  store %0 to [init] %1
+  %3 = drop_deinit %1
+  %4 = struct_element_addr %3, #NCWrapper.a
+  %5 = load_borrow %4
+
+  %6 = function_ref @getNEPointer : $@convention(thin) (@guaranteed NE) -> Builtin.RawPointer
+  %7 = apply %6(%5) : $@convention(thin) (@guaranteed NE) -> Builtin.RawPointer
+  %8 = pointer_to_address %7 to [strict] $*A
+  %9 = mark_dependence [unresolved] %8 on %4
+  %10 = begin_access [read] [unsafe] %9
+  %11 = load [trivial] %10
+  end_access %10
+
+  %13 = function_ref @useA : $@convention(thin) (A) -> ()
+  %14 = apply %13(%11) : $@convention(thin) (A) -> ()
+  end_borrow %5
+  dealloc_stack %1
+  %17 = tuple ()
+  return %17
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -2,15 +2,39 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
+// RUN:   -enable-builtin-module \
 // RUN:   -module-name test \
 // RUN:   -define-availability "Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999" \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature AddressableParameters
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_AddressableParameters
 
 // Test diagnostic output for interesting corner cases. Similar to semantics.swift, but this tests corner cases in the
 // implementation as opposed to basic language rules.
+
+import Builtin
+
+struct Borrow<T: ~Copyable>: Copyable, ~Escapable {
+  let pointer: UnsafePointer<T>
+
+  @lifetime(borrow value)
+  init(_ value: borrowing @_addressable T) {
+    pointer = UnsafePointer(Builtin.unprotectedAddressOfBorrow(value))
+  }
+
+  subscript() -> T {
+    unsafeAddress {
+      pointer
+    }
+  }
+}
+
+struct A {}
+
+func useA(_:A){}
 
 // Test that conditionally returning an Optional succeeds.
 //
@@ -34,4 +58,12 @@ extension Array {
 @lifetime(&array)
 func getImmutableSpan(_ array: inout [Int]) -> Span<Int> {
  return array.span
+}
+
+struct TestDeinitCallsAddressor: ~Copyable, ~Escapable {
+  let a: Borrow<A>
+
+  deinit {
+    useA(a[])
+  }
 }


### PR DESCRIPTION
This adds support to handle unsafe addressors, which generate mark_dependence
instructions with an address base. This case does not arise with lifetime
dependencies. Nonetheless, the lifetime dependence diagnostics kick in to
attempt to promote the unsafe addressor's mark_dependence to noescape, so we
need to handle it.

rdar://149784450 (Compiler crash with non-escapable deinit dereferencing)
(cherry picked from commit 3b08592ed21210a451c2e82a3f8ef38b011ae7b9)

main PR: https://github.com/swiftlang/swift/pull/81018
