### PR TITLE
Fixed no copying IsIsolated flag when cloning subscript params

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6993,6 +6993,10 @@ public:
   /// Create a an identical copy of this ParamDecl.
   static ParamDecl *clone(const ASTContext &Ctx, ParamDecl *PD);
 
+  static ParamDecl *cloneAccessor(const ASTContext &Ctx,
+                                  ParamDecl const *subscriptParam,
+                                  DeclContext *Parent);
+
   static ParamDecl *
   createImplicit(ASTContext &Context, SourceLoc specifierLoc,
                  SourceLoc argumentNameLoc, Identifier argumentName,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11113,16 +11113,16 @@ AccessorDecl *AccessorDecl::createParsed(
           subscriptParam->getArgumentNameLoc(),
           subscriptParam->getArgumentName(), subscriptParam->getNameLoc(),
           subscriptParam->getName(), /*declContext*/ accessor);
-      param->setAutoClosure(subscriptParam->isAutoClosure());
 
       // The cloned parameter is implicit.
       param->setImplicit();
 
-      if (subscriptParam->isSending())
-        param->setSending();
-
-      if (subscriptParam->isCallerIsolated())
-        param->setCallerIsolated();
+      // TODO: Check why IsVariadic is not copied.
+      param->setAutoClosure(subscriptParam->isAutoClosure());
+      param->setIsolated(subscriptParam->isIsolated());
+      // TODO: Check why IsAddressable is not copied.
+      param->setSending(subscriptParam->isSending());
+      param->setCallerIsolated(subscriptParam->isCallerIsolated());
 
       newParams.push_back(param);
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8888,6 +8888,21 @@ ParamDecl *ParamDecl::clone(const ASTContext &Ctx, ParamDecl *PD) {
   return Clone;
 }
 
+ParamDecl *ParamDecl::cloneAccessor(const ASTContext &Ctx,
+                                    ParamDecl const *subscriptParam,
+                                    DeclContext *Parent) {
+  auto *param = new (Ctx) ParamDecl(
+      subscriptParam->getSpecifierLoc(), subscriptParam->getArgumentNameLoc(),
+      subscriptParam->getArgumentName(), subscriptParam->getNameLoc(),
+      subscriptParam->getName(), /*declContext*/ Parent);
+  param->setOptions(subscriptParam->getOptions());
+
+  // The cloned parameter is implicit.
+  param->setImplicit();
+
+  return param;
+}
+
 ParamDecl *
 ParamDecl::createImplicit(ASTContext &Context, SourceLoc specifierLoc,
                           SourceLoc argumentNameLoc, Identifier argumentName,
@@ -11107,23 +11122,7 @@ AccessorDecl *AccessorDecl::createParsed(
       paramsEnd = indices->getEndLoc();
     }
     for (auto *subscriptParam : *indices) {
-      // Clone the parameter.
-      auto *param = new (ctx) ParamDecl(
-          subscriptParam->getSpecifierLoc(),
-          subscriptParam->getArgumentNameLoc(),
-          subscriptParam->getArgumentName(), subscriptParam->getNameLoc(),
-          subscriptParam->getName(), /*declContext*/ accessor);
-
-      // The cloned parameter is implicit.
-      param->setImplicit();
-
-      // TODO: Check why IsVariadic is not copied.
-      param->setAutoClosure(subscriptParam->isAutoClosure());
-      param->setIsolated(subscriptParam->isIsolated());
-      // TODO: Check why IsAddressable is not copied.
-      param->setSending(subscriptParam->isSending());
-      param->setCallerIsolated(subscriptParam->isCallerIsolated());
-
+      auto param = ParamDecl::cloneAccessor(ctx, subscriptParam, accessor);
       newParams.push_back(param);
     }
 


### PR DESCRIPTION
Fixes https://github.com/swiftlang/swift/issues/80992

Should `IsVariadic` and `IsAddressable` be copied as well? I suspect `param->setOptions(subscriptParam->getOptions());` would be better than copying flags one by one.