### PR TITLE
[cxx-interop] Reenable C++ benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -210,10 +210,10 @@ set(SWIFT_BENCH_MODULES
     single-source/WordCount
     single-source/XorLoop
     cxx-source/CreateObjects
-#    cxx-source/CxxSetToCollection
-#    cxx-source/CxxSpanTests
-#    cxx-source/CxxStringConversion
-#    cxx-source/CxxVectorSum
+    cxx-source/CxxSetToCollection
+    cxx-source/CxxSpanTests
+    cxx-source/CxxStringConversion
+    cxx-source/CxxVectorSum
     # TODO: rdar://92120528
     # cxx-source/ReadAccessor
 )

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -57,8 +57,8 @@ import CountAlgo
 import CreateObjects
 // rdar://128520766
 // import CxxSetToCollection
-// import CxxSpanTests
-// import CxxStringConversion
+import CxxSpanTests
+import CxxStringConversion
 // rdar://128520766
 // import CxxVectorSum
 import DataBenchmarks
@@ -257,8 +257,8 @@ register(ClassArrayGetter.benchmarks)
 register(CreateObjects.benchmarks)
 // rdar://128520766
 // register(CxxSetToCollection.benchmarks)
-// register(CxxSpanTests.benchmarks)
-// register(CxxStringConversion.benchmarks)
+register(CxxSpanTests.benchmarks)
+register(CxxStringConversion.benchmarks)
 // rdar://128520766
 // register(CxxVectorSum.benchmarks)
 register(DataBenchmarks.benchmarks)

--- a/stdlib/public/Cxx/CxxVector.swift
+++ b/stdlib/public/Cxx/CxxVector.swift
@@ -50,7 +50,7 @@ extension CxxVector {
   }
 }
 
-@available(SwiftStdlib 6.2, *)
+@available(SwiftCompatibilitySpan 5.0, *)
 extension CxxVector {
   public var span: Span<Element> {
     @lifetime(borrow self)


### PR DESCRIPTION
The underlying issue was fixed in #82309

rdar://149402670
