### PR TITLE
[Sema] Add missing null check for Type

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4700,9 +4700,11 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
 
     // `nonisolated(nonsending)` inferred from the context makes
     // the closure caller isolated.
-    if (auto *closureTy = getType(closure)->getAs<FunctionType>()) {
-      if (closureTy->getIsolation().isNonIsolatedCaller())
-        return ActorIsolation::forCallerIsolationInheriting();
+    if (auto closureTy = getType(closure)) {
+      if (auto *closureFnTy = closureTy->getAs<FunctionType>()) {
+        if (closureFnTy->getIsolation().isNonIsolatedCaller())
+          return ActorIsolation::forCallerIsolationInheriting();
+      }
     }
 
     // If a closure has an isolated parameter, it is isolated to that

--- a/test/SourceKit/CodeComplete/issue-80985.swift
+++ b/test/SourceKit/CodeComplete/issue-80985.swift
@@ -1,0 +1,13 @@
+// https://github.com/swiftlang/swift/issues/80985
+struct S<T> {
+  func foo<U>(_ fn: (T) -> U) -> S<U> { fatalError() }
+}
+
+func foo(xs: S<(Int, Int)>) {
+  _ = {
+    let y = xs
+      .foo{ $1 }
+      .foo{ $0 }
+    // RUN: %sourcekitd-test -req=complete -pos=%(line-1):11 %s -- %s
+  }
+}


### PR DESCRIPTION
`getType` here can return a null type if the queried expression isn't part of the solution, which can currently happen for code completion. I'm working on a more principled fix for this, but until then this is a low-risk fix that will unblock the stress tester and can be cherry-picked to 6.2.

rdar://149759542
Resolves #80985