### PR TITLE
[SIL][MoveOnlyChecker] Omit creation of `destroy_addr` instruction for `UncheckedTakeEnumDataAddrInst` preventing use after destroy for `~Copyable` structs in special cases

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -3091,6 +3091,10 @@ static void insertDestroyBeforeInstruction(UseState &addressUseState,
     return;
   }
 
+  if (isa<UncheckedTakeEnumDataAddrInst>(nextInstruction)) {
+    return;
+  }
+
   // If we need all bits...
   if (bv.all()) {
     // And our next instruction is a destroy_addr on the base address, just


### PR DESCRIPTION
Resolves #80261

When assigning properties for non-copyable structs globally or in final class, a destroy instruction is incorrectly placed in the basic block causing compiler crash.