### PR TITLE
[ASTPrinter] Add missing null check in `isNonSendableExtension`

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2235,8 +2235,11 @@ bool isNonSendableExtension(const Decl *D) {
   if (!ED || !ED->isUnavailable())
     return false;
 
-  auto nonSendable =
-      ED->getExtendedNominal()->getAttrs().getEffectiveSendableAttr();
+  auto *NTD = ED->getExtendedNominal();
+  if (!NTD)
+    return false;
+
+  auto nonSendable = NTD->getAttrs().getEffectiveSendableAttr();
   if (!isa_and_nonnull<NonSendableAttr>(nonSendable))
     return false;
 

--- a/validation-test/IDE/issues_fixed/rdar149032713.swift
+++ b/validation-test/IDE/issues_fixed/rdar149032713.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -print-swift-file-interface -source-filename %s
+
+@available(*, unavailable)
+extension Foo {}


### PR DESCRIPTION
The extended nominal may not be present for an invalid extension.

rdar://149032713