### PR TITLE
[cxx-interop] Work around crash in codegen when initializing C++ span

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4110,6 +4110,15 @@ namespace {
         if (ctordecl->isCopyConstructor() || ctordecl->isMoveConstructor())
           return nullptr;
 
+        // Don't import the generic ctors of std::span, rely on the ctors that
+        // we instantiate when conforming to the overlay. These generic ctors
+        // can cause crashes in codegen.
+        // FIXME: figure out why.
+        const auto *parent = ctordecl->getParent();
+        if (funcTemplate && parent->isInStdNamespace() &&
+            parent->getIdentifier() && parent->getName() == "span")
+          return nullptr;
+
         DeclName ctorName(Impl.SwiftContext, DeclBaseName::createConstructor(),
                           bodyParams);
         result = Impl.createDeclWithClangNode<ConstructorDecl>(

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -11,3 +11,11 @@ arr.withUnsafeBufferPointer { ubpointer in
     let _ = ConstSpanOfInt(ubpointer.baseAddress!, ubpointer.count) 
     // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
+
+arr.withUnsafeBufferPointer { ubpointer in 
+    // FIXME: this crashes the compiler once we import span's templated ctors as Swift generics.
+    let _ = ConstSpanOfInt(ubpointer.baseAddress, ubpointer.count)
+    // expected-error@-1 {{value of optional type 'UnsafePointer<Int32>?' must be unwrapped to a value of type 'UnsafePointer<Int32>'}}
+    // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}


### PR DESCRIPTION
When initializing span with an UnsafePointer<Element>? we call into the generic initializer that we imported from the C++ templated constructor instead of the concrete initializer we have in the overlay that takes an UnsafePointer<Element> (non-optional). We cannot properly codegen for this generic initializer at the moment, so let's stop importing them since the user probably wanted to call the initializer from the overlay.

We should come back later and fix the root cause.

rdar://148961349
