### PR TITLE
[6.2][cxx-interop] Properly import annotations from functions in namespace scope

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4190,7 +4190,8 @@ namespace {
         return;
 
       // FIXME: support C functions imported as members.
-      if (result->getImportAsMemberStatus().isImportAsMember() &&
+      if (!isClangNamespace(result->getDeclContext()) &&
+          result->getImportAsMemberStatus().isImportAsMember() &&
           !isa<clang::CXXMethodDecl, clang::ObjCMethodDecl>(decl))
         return;
 

--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -109,6 +109,12 @@ struct SWIFT_NONESCAPABLE AggregateView {
     const int *member;
 };
 
+namespace NS {
+    View getView(const Owner& owner [[clang::lifetimebound]]) {
+        return View(&owner.data);
+    }
+}
+
 // CHECK: sil [clang makeOwner] {{.*}}: $@convention(c) () -> Owner
 // CHECK: sil [clang getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @owned View
 // CHECK: sil [clang getViewFromFirst] {{.*}} : $@convention(c) (@in_guaranteed Owner, @in_guaranteed Owner) -> @lifetime(borrow 0) @owned View
@@ -123,6 +129,7 @@ struct SWIFT_NONESCAPABLE AggregateView {
 // CHECK: sil [clang getCaptureView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @owned CaptureView
 // CHECK: sil [clang CaptureView.captureView] {{.*}} : $@convention(cxx_method) (View, @lifetime(copy 0) @inout CaptureView) -> ()
 // CHECK: sil [clang CaptureView.handOut] {{.*}} : $@convention(cxx_method) (@lifetime(copy 1) @inout View, @in_guaranteed CaptureView) -> ()
+// CHECK: sil [clang NS.getView] {{.*}} : $@convention(c) (@in_guaranteed Owner) -> @lifetime(borrow 0) @owned View
 
 //--- test.swift
 
@@ -144,6 +151,7 @@ public func test() {
     var cv = getCaptureView(o)
     cv.captureView(v1)
     cv.handOut(&v1)
+    var _ = NS.getView(o)
 }
 
 public func test2(_ x: AggregateView) {


### PR DESCRIPTION
Explanation: C++ namespaces imported as Swift enums. This was not accounted for in a condition and that resulted in not importing lifetime annotations for functions that are in namespace scope. This PR fixes that condition.
Issue: rdar://149756644
Risk: Low, the fix is very targeted.
Testing: Regression test added.
Original PR: #80986
Reviewer: @j-hui