### PR TITLE
Runtimes: manually adjust the library prefix for core,Concurrency

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -130,6 +130,10 @@ target_link_libraries(swift_Concurrency PRIVATE
 set_target_properties(swift_Concurrency PROPERTIES
   Swift_MODULE_NAME _Concurrency
   LINKER_LANGUAGE CXX)
+if(NOT BUILD_SHARED_LIBS AND CMAKE_STATIC_LIBRARY_PREFIX_Swift)
+  set_target_properties(swift_Concurrency PROPERTIES
+    PREFIX ${CMAKE_STATIC_LIBRARY_PREFIX_Swift})
+endif()
 
 install(TARGETS swift_Concurrency
   EXPORT SwiftCoreTargets

--- a/Runtimes/Core/core/CMakeLists.txt
+++ b/Runtimes/Core/core/CMakeLists.txt
@@ -281,6 +281,10 @@ endif()
 set_target_properties(swiftCore PROPERTIES
   Swift_MODULE_NAME Swift
   LINKER_LANGUAGE CXX)
+if(NOT BUILD_SHARED_LIBS AND CMAKE_STATIC_LIBRARY_PREFIX_Swift)
+  set_target_properties(swiftCore PROPERTIES
+    PREFIX ${CMAKE_STATIC_LIBRARY_PREFIX_Swift})
+endif()
 
 target_compile_definitions(swiftCore
   PRIVATE


### PR DESCRIPTION
These libraries use C++ as the linker language which will prevent `CMAKE_STATIC_LIBRARY_PREFIX_Swift` from impacting them. Wire this property to the target manually so that it takes effect. This is primarily meant to support Windows, where we use a non-standard library prefix for static libraries mirroring the behaviour of the language runtimes (i.e. ucrt, vcruntime, msvcrt).