### PR TITLE
[Runtime] Change the unowned reference fatal error to "was already destroyed."

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -506,11 +506,11 @@ void swift::swift_abortRetainUnowned(const void *object) {
   if (object) {
     swift::fatalError(FatalErrorFlags::ReportBacktrace,
                       "Fatal error: Attempted to read an unowned reference but "
-                      "object %p was already deallocated\n", object);
+                      "object %p was already destroyed\n", object);
   } else {
     swift::fatalError(FatalErrorFlags::ReportBacktrace,
                       "Fatal error: Attempted to read an unowned reference but "
-                      "the object was already deallocated\n");
+                      "the object was already destroyed\n");
   }
 }
 


### PR DESCRIPTION
The "was already deallocated" message is incorrect, since the target of an unowned reference stays allocated even after being deinitialized. We could say "was already deinitialized" but that's a bit of a niche term. "Was already destroyed" conveys what happened without the reader needing to worry about deinitialization versus deallocation.

rdar://149237704