### PR TITLE
[6.2] [ASTPrinter] Add missing null check in `isNonSendableExtension`

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2234,8 +2234,11 @@ bool isNonSendableExtension(const Decl *D) {
   if (!ED || !ED->isUnavailable())
     return false;
 
-  auto nonSendable =
-      ED->getExtendedNominal()->getAttrs().getEffectiveSendableAttr();
+  auto *NTD = ED->getExtendedNominal();
+  if (!NTD)
+    return false;
+
+  auto nonSendable = NTD->getAttrs().getEffectiveSendableAttr();
   if (!isa_and_nonnull<NonSendableAttr>(nonSendable))
     return false;
 

--- a/validation-test/IDE/issues_fixed/rdar149032713.swift
+++ b/validation-test/IDE/issues_fixed/rdar149032713.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -print-swift-file-interface -source-filename %s
+
+@available(*, unavailable)
+extension Foo {}


### PR DESCRIPTION
*6.2 cherry-pick of #81029*

- Explanation: Fixes a crash that could occur when generating an interface for a file with an invalid extension
- Scope: Affects generated interfaces
- Issue: rdar://149032713
- Risk: Low, adds a null check
- Testing: Added tests to test suite
- Reviewer: Allan Shortlidge