### PR TITLE
[6.2][cxx-interop] Work around crash in codegen when initializing C++ span

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4102,6 +4102,15 @@ namespace {
         if (ctordecl->isCopyConstructor() || ctordecl->isMoveConstructor())
           return nullptr;
 
+        // Don't import the generic ctors of std::span, rely on the ctors that
+        // we instantiate when conforming to the overlay. These generic ctors
+        // can cause crashes in codegen.
+        // FIXME: figure out why.
+        const auto *parent = ctordecl->getParent();
+        if (funcTemplate && parent->isInStdNamespace() &&
+            parent->getIdentifier() && parent->getName() == "span")
+          return nullptr;
+
         DeclName ctorName(Impl.SwiftContext, DeclBaseName::createConstructor(),
                           bodyParams);
         result = Impl.createDeclWithClangNode<ConstructorDecl>(

--- a/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span-typechecker.swift
@@ -11,3 +11,11 @@ arr.withUnsafeBufferPointer { ubpointer in
     let _ = ConstSpanOfInt(ubpointer.baseAddress!, ubpointer.count) 
     // expected-warning@-1 {{'init(_:_:)' is deprecated: use 'init(_:)' instead.}}
 }
+
+arr.withUnsafeBufferPointer { ubpointer in 
+    // FIXME: this crashes the compiler once we import span's templated ctors as Swift generics.
+    let _ = ConstSpanOfInt(ubpointer.baseAddress, ubpointer.count)
+    // expected-error@-1 {{value of optional type 'UnsafePointer<Int32>?' must be unwrapped to a value of type 'UnsafePointer<Int32>'}}
+    // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+    // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+}


### PR DESCRIPTION
Explanation: C++ templates are imported as Swift generics. Unfortunately, the codegen for some of the instantiations will crash codegen due to a confusion in how Swift pointer types are mapped back to their native counterparts. As a result, when a user is passing an UnsafePointer<Element>? to a C++ span constructor we got a crash. The user should never need the generic version of the initializer as we already have an initializer taking an UnsafePointer<Element> in the C++ overlay. This PR avoids importing the templated span constructors to work around this issue.
Issue: rdar://148961349
Risk: Low, the fix is very targeted.
Testing: Regression test added.
Original PR: #81030
Reviewer: @j-hui
