### PR TITLE
[6.2][Sema] ConstnessChecker: Look through function conversions while chec…

### DIFF
--- a/lib/Sema/ConstantnessSemaDiagnostics.cpp
+++ b/lib/Sema/ConstantnessSemaDiagnostics.cpp
@@ -175,7 +175,8 @@ static Expr *checkConstantness(Expr *expr) {
       return expr;
 
     ApplyExpr *apply = cast<ApplyExpr>(expr);
-    ValueDecl *calledValue = apply->getCalledValue();
+    ValueDecl *calledValue =
+        apply->getCalledValue(/*skipFunctionConversions=*/true);
     if (!calledValue)
       return expr;
 
@@ -300,7 +301,8 @@ static void diagnoseConstantArgumentRequirementOfCall(const CallExpr *callExpr,
                                                       const ASTContext &ctx) {
   assert(callExpr && callExpr->getType() &&
          "callExpr should have a valid type");
-  ValueDecl *calledDecl = callExpr->getCalledValue();
+  ValueDecl *calledDecl =
+      callExpr->getCalledValue(/*skipFunctionConversions=*/true);
   if (!calledDecl || !isa<AbstractFunctionDecl>(calledDecl))
     return;
   AbstractFunctionDecl *callee = cast<AbstractFunctionDecl>(calledDecl);

--- a/test/Sema/diag_constantness_check_os_log_swift6.swift
+++ b/test/Sema/diag_constantness_check_os_log_swift6.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -swift-version 6
+
+// REQUIRES: VENDOR=apple
+// REQUIRES: concurrency
+
+import OSLogTestHelper
+
+class Log {
+  @_semantics("oslog.requires_constant_arguments")
+  func debug(_: OSLogMessage) {}
+}
+
+@_semantics("constant_evaluable")
+@_transparent
+public func __outputFormatter(_ key: String, fallback: OSLogMessage) -> OSLogMessage {
+    fallback
+}
+
+@MainActor
+@_semantics("constant_evaluable")
+@_transparent
+public func __isolatedOutputFormatter(_ key: String, fallback: OSLogMessage) -> OSLogMessage {
+    fallback
+}
+
+func test(log: Log) {
+  log.debug(__outputFormatter("1", fallback: "msg")) // Ok
+}
+
+@MainActor
+func isolatedTest(log: Log) {
+  log.debug(__isolatedOutputFormatter("1", fallback: "msg")) // Ok
+}


### PR DESCRIPTION
…king arguments

Cherry-pick of https://github.com/swiftlang/swift/pull/81049

---

- Explanation:

  Avoid false-positive diagnostics about non-constant arguments in some APIs.

  In strict concurrency mode some calls could reference a declaration that is  wrapped in one or more function conversion expressions to apply concurrency related attributes or erase them (such as `@Sendable` or `@MainActor`). This shouldn't impact constness checking and the checker should look through such conversions.

- Main Branch PR: https://github.com/swiftlang/swift/pull/81049

- Risk: Low (This change should be no-op because no swift interfaces are expected to be using the names yet).

- Reviewed By: @slavapestov

- Resolves: rdar://148168219

- Testing: Added new tests to the Sema test suite.

(cherry picked from commit b484e9645dd5549287cacfd3257dfdcc4502e06c)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
