### PR TITLE
[6.2] Workaround for performance regression with opaque archetypes

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -329,7 +329,7 @@ public:
   std::optional<Type> transformLocalArchetypeType(LocalArchetypeType *local,
                                                   TypePosition pos);
 
-  SubstitutionMap transformSubstitutionMap(SubstitutionMap subs);
+  // SubstitutionMap transformSubstitutionMap(SubstitutionMap subs);
 
   CanType transformSILField(CanType fieldTy, TypePosition pos);
 };
@@ -446,10 +446,13 @@ Type TypeSubstituter::transformDependentMemberType(DependentMemberType *dependen
   return conformance.getTypeWitness(substBase, assocType, IFS.getOptions());
 }
 
+// FIXME: This exposes a scalability issue; see test/SILGen/opaque_result_type_slow.swift.
+/*
 SubstitutionMap TypeSubstituter::transformSubstitutionMap(SubstitutionMap subs) {
   // FIXME: Take level into account? Move level down into IFS?
   return subs.subst(IFS);
 }
+*/
 
 CanType TypeSubstituter::transformSILField(CanType fieldTy, TypePosition pos) {
   // Type substitution does not walk into the SILBoxType's field types, because

--- a/test/SILGen/Inputs/opaque_result_type_slow_other.swift
+++ b/test/SILGen/Inputs/opaque_result_type_slow_other.swift
@@ -1,0 +1,8 @@
+public protocol P {}
+public protocol Q {}
+
+public func wrap<T: P & Q>(_ t: T) -> some P & Q {
+  return t
+}
+
+

--- a/test/SILGen/opaque_result_type_slow.swift
+++ b/test/SILGen/opaque_result_type_slow.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/opaque_result_type_slow_other.swift -emit-module -emit-module-path %t/opaque_result_type_slow_other.swiftmodule -enable-library-evolution
+// RUN: %target-swift-emit-silgen %s -I %t
+
+import opaque_result_type_slow_other
+
+struct G<T: P & Q>: P & Q {}
+
+public func myWrap<T: P & Q>(_ t: T) -> some P & Q {
+  return G<T>()
+}
+
+public func wrapWrap<T: P & Q>(_ t: T) -> some P & Q {
+  return wrap(wrap(myWrap(t)))
+}
+
+public struct S: P, Q {}
+
+// We generate a series of substitution maps where each one contains an opaque archetype,
+// and an abstract conformance of this opaque archetype to a protocol. Each opaque archetype
+// then has a substitution map of the same form, and so on.
+//
+// Transforming each substitution map then visits each opaque archetype twice: once as part
+// of the replacement type, and again as part of the conformance.
+//
+// What saves us is that we would skip the conformance substitution in some cases, and perform
+// a lookup instead. This lookup is now load bearing, because changing it into a substitution
+// makes this program intractably slow.
+//
+// The correct fix is to probably cache substituted opaque GenericEnvironments, or
+// substituted SubstitutionMaps, inside of the InFlightSubstitution.
+let x = wrapWrap(wrapWrap(wrapWrap(wrapWrap(wrapWrap(wrapWrap(wrapWrap(wrapWrap(wrapWrap(S())))))))))


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/81052

* **Description:** Fix a recent performance regression from https://github.com/swiftlang/swift/pull/80327 that could result in exponential running time when unwrapping opaque archetypes.

* **Risk:** Low. This returns to the status quo from a few weeks ago (the TypeSubstituter::transformSubstitutionMap() customization point was never called, which happens to avoid the slowdown).

* **Radar:** rdar://149315905

* **Tested:** Added a test case that will take a very long time to run if this regresses again.

* **Reviewed by:** @xedin 