### PR TITLE
[SILGen] Make eagerMove class init's self lexical.

### DIFF
--- a/test/Interpreter/rdar149782365.swift
+++ b/test/Interpreter/rdar149782365.swift
@@ -1,0 +1,31 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+
+@_silgen_name("start")
+func start() {
+  print("init C")
+}
+@_silgen_name("barrier")
+func barrier() {
+	print("nothing uses C anymore")
+}
+@_silgen_name("end")
+func end() {
+  print("deinit C")
+}
+
+@_eagerMove class C {
+	init() { start() }
+	deinit { end() }
+}
+
+@_silgen_name("doit")
+public func main() {
+	C()
+  barrier()
+}
+
+main()
+
+// CHECK: init C
+// CHECK: deinit C
+// CHECK: nothing uses C anymore


### PR DESCRIPTION
Change the representation for eagerMove classes so that the body of their deinit runs after the body of their init.

rdar://149782365
