### PR TITLE
6.2: Revert "[DCE] Verify liveness of completed lifetimes."

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -835,9 +835,7 @@ bool DCE::removeDead() {
     }
   }
 
-  OSSALifetimeCompletion completion(
-      F, DT, *deadEndBlocks, OSSALifetimeCompletion::IgnoreTrivialVariable,
-      /*forceLivenessVerification=*/true);
+  OSSALifetimeCompletion completion(F, DT, *deadEndBlocks);
   for (auto value : valuesToComplete) {
     if (!value.has_value())
       continue;


### PR DESCRIPTION
**Explanation**: Disable additional verification that was recently added.
**Scope**: Affects additional verification done during DCE.
**Issue**: rdar://149896608
**Original PR**: https://github.com/swiftlang/swift/pull/81059
**Risk**: None, the only effect is to disable additional verification.
**Testing**: CI.
**Reviewer**: Andrew Trick ( @atrick )
