### PR TITLE
[Concurrency] Offer way to get SerialExecutor from Actor

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -93,6 +93,31 @@ public protocol SchedulableExecutor: Executor {
 
 }
 
+extension Actor {
+
+  /// Perform an operation with the actor's ``SerialExecutor``.
+  ///
+  /// This converts the actor's ``Actor/unownedExecutor`` to a ``SerialExecutor`` while
+  /// retaining the actor for the duration of the operation. This is to ensure the lifetime
+  /// of the executor while performing the operation.
+  @_alwaysEmitIntoClient
+  @available(SwiftStdlib 5.1, *)
+  public nonisolated func withSerialExecutor<T>(_ operation: (any SerialExecutor) throws -> T) rethrows -> T {
+    try operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
+  }
+
+  /// Perform an operation with the actor's ``SerialExecutor``.
+  ///
+  /// This converts the actor's ``Actor/unownedExecutor`` to a ``SerialExecutor`` while
+  /// retaining the actor for the duration of the operation. This is to ensure the lifetime
+  /// of the executor while performing the operation.
+  @_alwaysEmitIntoClient
+  @available(SwiftStdlib 5.1, *)
+  public nonisolated func withSerialExecutor<T>(_ operation: (any SerialExecutor) async throws -> T) async rethrows -> T {
+    try await operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
+  }
+}
+
 extension Executor {
   /// Return this executable as a SchedulableExecutor, or nil if that is
   /// unsupported.

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -113,7 +113,7 @@ extension Actor {
   /// of the executor while performing the operation.
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 5.1, *)
-  public nonisolated func withSerialExecutor<T: ~Copyable, E: Error>(_ operation: (any SerialExecutor) async throws(E) -> T) async throws(E) -> T {
+  public nonisolated func withSerialExecutor<T: ~Copyable, E: Error>(_ operation: nonisolated(nonsending) (any SerialExecutor) async throws(E) -> T) async throws(E) -> T {
     try await operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
   }
 }

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -102,7 +102,7 @@ extension Actor {
   /// of the executor while performing the operation.
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 5.1, *)
-  public nonisolated func withSerialExecutor<T, E: Error>(_ operation: (any SerialExecutor) throws(E) -> T) throws(E) -> T {
+  public nonisolated func withSerialExecutor<T: ~Copyable, E: Error>(_ operation: (any SerialExecutor) throws(E) -> T) throws(E) -> T {
     try operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
   }
 
@@ -113,7 +113,7 @@ extension Actor {
   /// of the executor while performing the operation.
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 5.1, *)
-  public nonisolated func withSerialExecutor<T, E: Error>(_ operation: (any SerialExecutor) async throws(E) -> T) async throws(E) -> T {
+  public nonisolated func withSerialExecutor<T: ~Copyable, E: Error>(_ operation: (any SerialExecutor) async throws(E) -> T) async throws(E) -> T {
     try await operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
   }
 }

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -102,7 +102,7 @@ extension Actor {
   /// of the executor while performing the operation.
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 5.1, *)
-  public nonisolated func withSerialExecutor<T>(_ operation: (any SerialExecutor) throws -> T) rethrows -> T {
+  public nonisolated func withSerialExecutor<T, E: Error>(_ operation: (any SerialExecutor) throws(E) -> T) throws(E) -> T {
     try operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
   }
 
@@ -113,7 +113,7 @@ extension Actor {
   /// of the executor while performing the operation.
   @_alwaysEmitIntoClient
   @available(SwiftStdlib 5.1, *)
-  public nonisolated func withSerialExecutor<T>(_ operation: (any SerialExecutor) async throws -> T) async rethrows -> T {
+  public nonisolated func withSerialExecutor<T, E: Error>(_ operation: (any SerialExecutor) async throws(E) -> T) async throws(E) -> T {
     try await operation(unsafe unsafeBitCast(self.unownedExecutor, to: (any SerialExecutor).self))
   }
 }

--- a/test/Concurrency/Runtime/actor_isIsolatingCurrentContext.swift
+++ b/test/Concurrency/Runtime/actor_isIsolatingCurrentContext.swift
@@ -1,0 +1,103 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %import-libdispatch -Xfrontend -disable-availability-checking -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// REQUIRES: libdispatch
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+@available(SwiftStdlib 6.2, *)
+final class IsIsolatingExecutor: SerialExecutor {
+  init() {}
+
+  func enqueue(_ job: consuming ExecutorJob) {
+    job.runSynchronously(on: self.asUnownedSerialExecutor())
+  }
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+
+  func checkIsolated() {
+    print("called: checkIsolated")
+  }
+
+  func isIsolatingCurrentContext() -> Bool {
+    print("called: isIsolatingCurrentContext")
+    return true
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+final class NoChecksImplementedExecutor: SerialExecutor {
+  init() {}
+
+  func enqueue(_ job: consuming ExecutorJob) {
+    job.runSynchronously(on: self.asUnownedSerialExecutor())
+  }
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+final class JustCheckIsolatedExecutor: SerialExecutor {
+  init() {}
+
+  func enqueue(_ job: consuming ExecutorJob) {
+    job.runSynchronously(on: self.asUnownedSerialExecutor())
+  }
+
+  func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+
+  func checkIsolated() {
+    print("called: checkIsolated")
+  }
+}
+
+@available(SwiftStdlib 6.2, *)
+actor ActorOnIsCheckImplementingExecutor<Ex: SerialExecutor> {
+  let executor: Ex
+
+  init(on executor: Ex) {
+    self.executor = executor
+  }
+
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    self.executor.asUnownedSerialExecutor()
+  }
+
+  func checkIsIsolatingCurrentContext() async -> Bool {
+    executor.isIsolatingCurrentContext()
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    let hasIsIsolatingCurrentContextExecutor = IsIsolatingExecutor()
+    let hasIsCheckActor = ActorOnIsCheckImplementingExecutor(on: hasIsIsolatingCurrentContextExecutor)
+
+    let anyActor: any Actor = hasIsCheckActor
+
+    anyActor.withSerialExecutor { se in
+      let outside = se.isIsolatingCurrentContext()
+      assert(outside == true) // This is just a mock executor impl that always returns "true" (it is lying)
+      // CHECK: called: isIsolatingCurrentContext
+    }
+
+    let inside = await hasIsCheckActor.checkIsIsolatingCurrentContext()
+    assert(inside == true)
+    // CHECK: called: isIsolatingCurrentContext
+  }
+}

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -37,8 +37,8 @@ func testSyncMember(obj: MyActor) -> Int {
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
-// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) throws -> T##(any SerialExecutor) throws -> T#})[' rethrows'][#T#]; name=withSerialExecutor(:)
-// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) async throws -> T##(any SerialExecutor) async throws -> T#})[' async'][' rethrows'][#T#]; name=withSerialExecutor(:)
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) throws(Error) -> ~Copyable##(any SerialExecutor) throws(Error) -> ~Copyable#})[' throws'][#~Copyable#]; name=withSerialExecutor(:)
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) async throws(Error) -> ~Copyable##(any SerialExecutor) async throws(Error) -> ~Copyable#})[' async'][' throws'][#~Copyable#]; name=withSerialExecutor(:)
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated()[#Void#]; name=preconditionIsolated()
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()
@@ -53,8 +53,8 @@ func testSyncMember(obj: MyActor) async -> Int {
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
-// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) throws -> T##(any SerialExecutor) throws -> T#})[' rethrows'][#T#]; name=withSerialExecutor(:)
-// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) async throws -> T##(any SerialExecutor) async throws -> T#})[' async'][' rethrows'][#T#]; name=withSerialExecutor(:)
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) throws(Error) -> ~Copyable##(any SerialExecutor) throws(Error) -> ~Copyable#})[' throws'][#~Copyable#]; name=withSerialExecutor(:)
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) async throws(Error) -> ~Copyable##(any SerialExecutor) async throws(Error) -> ~Copyable#})[' async'][' throws'][#~Copyable#]; name=withSerialExecutor(:)
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated()[#Void#]; name=preconditionIsolated()
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -32,11 +32,13 @@ func testAsync() async -> Int {
 }
 func testSyncMember(obj: MyActor) -> Int {
     obj.#^MEMBER_IN_SYNC^#
-// MEMBER_IN_SYNC: Begin completions, 9 items
+// MEMBER_IN_SYNC: Begin completions, 11 items
 // MEMBER_IN_SYNC-DAG: Keyword[self]/CurrNominal:          self[#MyActor#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_SYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) throws -> T##(any SerialExecutor) throws -> T#})[' rethrows'][#T#]; name=withSerialExecutor(:)
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) async throws -> T##(any SerialExecutor) async throws -> T#})[' async'][' rethrows'][#T#]; name=withSerialExecutor(:)
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated()[#Void#]; name=preconditionIsolated()
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()
@@ -46,11 +48,13 @@ func testSyncMember(obj: MyActor) -> Int {
 
 func testSyncMember(obj: MyActor) async -> Int {
     obj.#^MEMBER_IN_ASYNC^#
-// MEMBER_IN_ASYNC: Begin completions, 9 items
+// MEMBER_IN_ASYNC: Begin completions, 11 items
 // MEMBER_IN_ASYNC-DAG: Keyword[self]/CurrNominal:          self[#MyActor#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: actorMethod()[' async'][#Int#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/CurrNominal/NotRecommended: deprecatedMethod()[' async'][#Void#];
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceVar]/CurrNominal:      unownedExecutor[#UnownedSerialExecutor#];
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) throws -> T##(any SerialExecutor) throws -> T#})[' rethrows'][#T#]; name=withSerialExecutor(:)
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: withSerialExecutor({#(operation): (any SerialExecutor) async throws -> T##(any SerialExecutor) async throws -> T#})[' async'][' rethrows'][#T#]; name=withSerialExecutor(:)
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated()[#Void#]; name=preconditionIsolated()
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()


### PR DESCRIPTION
This allows to access the `isIsolatingCurrentContext` when all we have in hand is an `Actor`.

SE proposal update is over here: https://github.com/swiftlang/swift-evolution/pull/2801