### PR TITLE
[Frontend] Add `ExtensibleAttribute` to guard use of `@extensible` at…

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -880,6 +880,7 @@ SIMPLE_DECL_ATTR(extensible, Extensible,
   OnEnum,
   ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove | ForbiddenInABIAttr,
   169)
+DECL_ATTR_FEATURE_REQUIREMENT(Extensible, ExtensibleAttribute)
 
 SIMPLE_DECL_ATTR(concurrent, Concurrent,
   OnFunc | OnConstructor | OnSubscript | OnVar,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -514,6 +514,9 @@ EXPERIMENTAL_FEATURE(AllowRuntimeSymbolDeclarations, true)
 /// Allow use of `@cdecl`
 EXPERIMENTAL_FEATURE(CDecl, false)
 
+/// Allow use of `@extensible` on public enums
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ExtensibleAttribute, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -402,7 +402,6 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
       DeclAttrKind::RestatedObjCConformance,
       DeclAttrKind::NonSendable,
       DeclAttrKind::AllowFeatureSuppression,
-      DeclAttrKind::Extensible,
   };
 
   return result;
@@ -3299,6 +3298,13 @@ suppressingFeatureAddressableTypes(PrintOptions &options,
                                    llvm::function_ref<void()> action) {
   ExcludeAttrRAII scope(options.ExcludeAttrList,
                         DeclAttrKind::AddressableForDependencies);
+  action();
+}
+
+static void
+suppressingFeatureExtensibleAttribute(PrintOptions &options,
+                                      llvm::function_ref<void()> action) {
+  ExcludeAttrRAII scope(options.ExcludeAttrList, DeclAttrKind::Extensible);
   action();
 }
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -624,6 +624,10 @@ static bool usesFeatureAsyncExecutionBehaviorAttributes(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureExtensibleAttribute(Decl *decl) {
+  return decl->getAttrs().hasAttribute<ExtensibleAttr>();
+}
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -330,7 +330,6 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       freestanding[#Declaration Attribute#]; name=freestanding
 // ON_MEMBER_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // ON_MEMBER_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
-// ON_MEMBER_LAST-DAG: Keyword/None:                       extensible[#Declaration Attribute#]; name=extensible
 // ON_MEMBER_LAST-DAG: Keyword/None:                       concurrent[#Declaration Attribute#]; name=concurrent
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
@@ -404,7 +403,6 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // KEYWORD_LAST-DAG: Keyword/None:                       storageRestrictions[#Declaration Attribute#]; name=storageRestrictions
 // KEYWORD_LAST-DAG: Keyword/None:                       lifetime[#Declaration Attribute#]; name=lifetime
-// KEYWORD_LAST-DAG: Keyword/None:                       extensible[#Declaration Attribute#]; name=extensible
 // KEYWORD_LAST-DAG: Keyword/None:                       concurrent[#Declaration Attribute#]; name=concurrent
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct

--- a/test/IDE/complete_decl_attribute_feature_requirement.swift
+++ b/test/IDE/complete_decl_attribute_feature_requirement.swift
@@ -7,7 +7,8 @@
 
 // RUN: %batch-code-completion -filecheck-additional-suffix _DISABLED
 // RUN: %batch-code-completion -filecheck-additional-suffix _ENABLED \
-// RUN:        -enable-experimental-feature ABIAttribute
+// RUN:        -enable-experimental-feature ABIAttribute \
+// RUN:        -enable-experimental-feature ExtensibleAttribute
 
 // NOTE: Please do not include the ", N items" after "Begin completions". The
 // item count creates needless merge conflicts given that an "End completions"
@@ -34,6 +35,8 @@
 // KEYWORD4:              Begin completions
 // KEYWORD4_ENABLED-NOT:  Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
 // KEYWORD4_DISABLED-NOT: Keyword/None:              abi[#{{.*}} Attribute#]; name=abi
+// KEYWORD4_ENABLED-DAG:  Keyword/None:              extensible[#{{.*}} Attribute#]; name=extensible
+// KEYWORD4_DISABLED-NOT: Keyword/None:              extensible[#{{.*}} Attribute#]; name=extensible
 // KEYWORD4:              End completions
 
 @#^KEYWORD5^# struct S{}

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -107,14 +107,6 @@ nonisolated(nonsending)
 public func testExecutionCaller() async {}
 // CHECK: nonisolated(nonsending) public func testExecutionCaller() async
 
-// CHECK-NOT: @extensible
-// CHECK: public enum TestExtensible
-@extensible
-public enum TestExtensible {
-  case a
-  case b
-}
-
 public struct TestPlacementOfAttrsAndSpecifiers {
   // CHECK: public func test1<T>(_: sending @autoclosure () -> T)
   public func test1<T>(_: sending @autoclosure () -> T) {}

--- a/test/ModuleInterface/extensible_attr.swift
+++ b/test/ModuleInterface/extensible_attr.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -enable-experimental-feature ExtensibleAttribute -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -enable-experimental-feature ExtensibleAttribute -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// REQUIRES: swift_feature_ExtensibleAttribute
+
+// CHECK: #if compiler(>=5.3) && $ExtensibleAttribute
+// CHECK-NEXT: @extensible public enum E {
+// CHECK-NEXT: }
+// CHECK-NEXT: #else
+// CHECK-NEXT: public enum E {
+// CHECK-NEXT: }
+// CHECK-NEXT: #endif
+@extensible
+public enum E {
+}

--- a/test/ModuleInterface/extensible_enums.swift
+++ b/test/ModuleInterface/extensible_enums.swift
@@ -5,7 +5,8 @@
 /// Build the library
 // RUN: %target-swift-frontend -emit-module %t/src/Lib.swift \
 // RUN:   -module-name Lib \
-// RUN:   -emit-module-path %t/Lib.swiftmodule
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -enable-experimental-feature ExtensibleAttribute
 
 // Check that the errors are produced when using enums from module with `ExtensibleEnums` feature enabled.
 // RUN: %target-swift-frontend -typecheck %t/src/TestChecking.swift \
@@ -18,13 +19,17 @@
 // RUN: %target-swift-frontend -emit-module %t/src/Lib.swift \
 // RUN:   -module-name Lib \
 // RUN:   -package-name Test \
-// RUN:   -emit-module-path %t/Lib.swiftmodule
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -enable-experimental-feature ExtensibleAttribute
+
 
 // Different module but the same package
 // RUN: %target-swift-frontend -typecheck %t/src/TestSamePackage.swift \
 // RUN:   -swift-version 5 -module-name Client -I %t \
 // RUN:   -package-name Test \
 // RUN:   -verify
+
+// REQUIRES: swift_feature_ExtensibleAttribute
 
 //--- Lib.swift
 

--- a/test/attr/attr_extensible.swift
+++ b/test/attr/attr_extensible.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ExtensibleAttribute
+
+// REQUIRES: swift_feature_ExtensibleAttribute
 
 @extensible
 public enum E1 { // Ok

--- a/test/attr/feature_requirement.swift
+++ b/test/attr/feature_requirement.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library -disable-experimental-parser-round-trip -verify-additional-prefix disabled-
-// RUN: %target-typecheck-verify-swift -parse-as-library -verify-additional-prefix enabled- -enable-experimental-feature ABIAttribute
+// RUN: %target-typecheck-verify-swift -parse-as-library -verify-additional-prefix enabled- -enable-experimental-feature ABIAttribute -enable-experimental-feature ExtensibleAttribute
 
 // REQUIRES: asserts
 
@@ -14,3 +14,13 @@ func fn() {}  // expected-disabled-error@-1 {{'abi' attribute is only valid when
 #else
   #error("doesn't have @abi")  // expected-disabled-error {{doesn't have @abi}}
 #endif
+
+@extensible
+public enum E {}  // expected-disabled-error@-1 {{'extensible' attribute is only valid when experimental feature ExtensibleAttribute is enabled}}
+
+#if hasAttribute(extensible)
+  #error("does have @extensible")  // expected-enabled-error {{does have @extensible}}
+#else
+  #error("doesn't have @extensible")  // expected-disabled-error {{doesn't have @extensible}}
+#endif
+


### PR DESCRIPTION
…tribute

Guard against condfails when older compilers get a swift interface that uses `@extensible` attribute. The attribute itself doesn't have any effect in swift interfaces yet since all of the public enums are already resilient in that mode.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
