### PR TITLE
[RemoteMirror] Only look through Task wait adapters when there's a dependency record.

### DIFF
--- a/include/swift/RemoteInspection/RuntimeInternals.h
+++ b/include/swift/RemoteInspection/RuntimeInternals.h
@@ -82,8 +82,7 @@ template <typename Runtime>
 struct StackAllocator {
   typename Runtime::StoredPointer LastAllocation;
   typename Runtime::StoredPointer FirstSlab;
-  int32_t NumAllocatedSlabs;
-  bool FirstSlabIsPreallocated;
+  int32_t NumAllocatedSlabsAndFirstSlabIsPreallocated;
 
   struct Slab {
     typename Runtime::StoredPointer Metadata;
@@ -123,7 +122,8 @@ struct AsyncTaskPrivateStorage {
   StackAllocator<Runtime> Allocator;
   typename Runtime::StoredPointer Local;
   uint32_t Id;
-  uint32_t BasePriority;
+  typename Runtime::StoredSize BasePriority;
+  typename Runtime::StoredPointer DependencyRecord;
 };
 
 template <typename Runtime, typename ActiveTaskStatus>


### PR DESCRIPTION
When the RunJob pointer is set to adapters, we try to get the "real" run pointer from the context. However, there are cases where the context can be a dangling pointer, when the task has finished with it but hasn't reset the pointer to anything else. For cases where that can happen, the context is legitimate only when there's a dependency record. Check for a dependency record before trying to read the context in those cases.

In most uses this will fail gracefully or return a garbage run pointer, but swift-reflection-test uses an in-process memory reader which can crash when trying to chase this pointer, resulting in test failures.

rdar://149252404