### PR TITLE
6.2: [FSPL] Look through unchecked addr casts.

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -148,6 +148,12 @@ SubElementOffset::computeForAddress(SILValue projectionDerivedFromRoot,
       continue;
     }
 
+    if (auto *uaci =
+            dyn_cast<UncheckedAddrCastInst>(projectionDerivedFromRoot)) {
+      projectionDerivedFromRoot = uaci->getOperand();
+      continue;
+    }
+
     if (auto *sbi = dyn_cast<StoreBorrowInst>(projectionDerivedFromRoot)) {
       projectionDerivedFromRoot = sbi->getDest();
       continue;

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -2,21 +2,26 @@
 // RUN: -enable-experimental-feature NoImplicitCopy \
 // RUN: -enable-experimental-feature MoveOnlyClasses \
 // RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature BuiltinModule \
 // RUN: -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
 
 // RUN: %target-swift-emit-sil -O -sil-verify-all -verify \
 // RUN: -enable-experimental-feature NoImplicitCopy \
 // RUN: -enable-experimental-feature MoveOnlyClasses \
 // RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature BuiltinModule \
 // RUN: %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
 // REQUIRES: swift_feature_NoImplicitCopy
 // REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_BuiltinModule
 
 // This file contains tests that used to crash due to verifier errors. It must
 // be separate from moveonly_addresschecker_diagnostics since when we fail on
 // the diagnostics in that file, we do not actually run the verifier.
+
+import Builtin
 
 struct TestTrivialReturnValue : ~Copyable {
     var i: Int = 5
@@ -75,4 +80,11 @@ struct TestCoroAccessorOfCoroAccessor<T : ~Escapable> : ~Copyable & ~Escapable {
       yield inner
     }
   }
+}
+
+@usableFromInline
+internal func unsafeBitCast<T: ~Escapable & ~Copyable, U>(
+   _ x: consuming T, to type: U.Type
+) -> U {
+   Builtin.reinterpretCast(x)
 }


### PR DESCRIPTION
**Explanation**: Enable unsafeBitwiseCast of values of non-copyable type.

Add a missing instruction to the utility used by the move-only address checker.
**Scope**: Affects move-checking.
**Issue**: rdar://149850921
**Original PR**: https://github.com/swiftlang/swift/pull/81065
**Risk**: Low.
**Testing**: Added test.
**Reviewer**: Gábor Horváth ( @Xazax-hun )