### PR TITLE
tests: add missing stdlib requirements in `SILOptimizer/static_init_globals.swift`

### DIFF
--- a/test/SILOptimizer/static_init_globals.swift
+++ b/test/SILOptimizer/static_init_globals.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend %s -module-name=test -emit-sil | %FileCheck %s
 
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
 public struct MyStruct {
   // CHECK-LABEL: sil_global [let] @$s4test8MyStructV1rSnySiGvpZ : $Range<Int> = {
   // CHECK-NEXT:    %0 = integer_literal $Builtin.Int{{[0-9]+}}, 1


### PR DESCRIPTION
rdar://149908059