### PR TITLE
SIL: Use SubstitutionMap::mapIntoTypeExpansionContext() in SILTypeSubstituter

### DIFF
--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -68,19 +68,7 @@ public:
     if (!typeExpansionContext.shouldLookThroughOpaqueTypeArchetypes())
       return subs;
 
-    return subs.subst([&](SubstitutableType *s) -> Type {
-        return substOpaqueTypesWithUnderlyingTypes(s->getCanonicalType(),
-                                                   typeExpansionContext);
-      }, [&](CanType dependentType,
-             Type conformingReplacementType,
-             ProtocolDecl *conformedProtocol) -> ProtocolConformanceRef {
-        return substOpaqueTypesWithUnderlyingTypes(
-               ProtocolConformanceRef::forAbstract(conformingReplacementType,
-                                                   conformedProtocol),
-               typeExpansionContext);
-      },
-      SubstFlags::SubstituteOpaqueArchetypes |
-      SubstFlags::PreservePackExpansionLevel);
+    return subs.mapIntoTypeExpansionContext(typeExpansionContext);
   }
 
   // Substitute a function type.

--- a/test/SILGen/subst_function_type_opaque.swift
+++ b/test/SILGen/subst_function_type_opaque.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-silgen %s
+
+public protocol P {}
+
+extension P {
+}
+
+public struct S: P {
+  public func callAsFunction<V>(_: () -> V) { }
+}
+
+public func f() -> some P {
+  S()
+}
+
+public struct G<T: P>: P {
+  public init(_: () -> T) {}
+}
+
+S() {
+  return G { return f() }
+}
+


### PR DESCRIPTION
I made a mistake in 47156e006bf0029c59edfd072392ae17045db73d. There was a call to call to forAbstract() in SILTypeSubstituter that passed in the wrong subject type.

This call was inside SILTypeSubstituter's own implementation of replacing opaque types with underlying types in a substitution map. This duplicates an existing utility method in SubstitutionMap anyway, so let's just use that instead.

Fixes rdar://149353285.