### PR TITLE
[6.2] SIL: Use SubstitutionMap::mapIntoTypeExpansionContext() in SILTypeSubstituter

### DIFF
--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -68,20 +68,7 @@ public:
     if (!typeExpansionContext.shouldLookThroughOpaqueTypeArchetypes())
       return subs;
 
-    return subs.subst([&](SubstitutableType *s) -> Type {
-        return substOpaqueTypesWithUnderlyingTypes(s->getCanonicalType(),
-                                                   typeExpansionContext);
-      }, [&](CanType dependentType,
-             Type conformingReplacementType,
-             ProtocolDecl *conformedProtocol) -> ProtocolConformanceRef {
-        return substOpaqueTypesWithUnderlyingTypes(
-               ProtocolConformanceRef::forAbstract(conformingReplacementType,
-                                                   conformedProtocol),
-               conformingReplacementType->getCanonicalType(),
-               typeExpansionContext);
-      },
-      SubstFlags::SubstituteOpaqueArchetypes |
-      SubstFlags::PreservePackExpansionLevel);
+    return subs.mapIntoTypeExpansionContext(typeExpansionContext);
   }
 
   // Substitute a function type.

--- a/test/SILGen/subst_function_type_opaque.swift
+++ b/test/SILGen/subst_function_type_opaque.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-silgen %s
+
+public protocol P {}
+
+extension P {
+}
+
+public struct S: P {
+  public func callAsFunction<V>(_: () -> V) { }
+}
+
+public func f() -> some P {
+  S()
+}
+
+public struct G<T: P>: P {
+  public init(_: () -> T) {}
+}
+
+S() {
+  return G { return f() }
+}
+


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/81079.

* **Description:** Replace some incorrect duplicated code with a call to the right utility method. The old implementation was wrong in the provided test case.

* **Scope of the issue:** The assertion failure was introduced by https://github.com/swiftlang/swift/pull/80304, although the actual problem is a bit older.

* **Radar:** rdar://149353285.

* **Reviewed by:** @DougGregor