### PR TITLE
[6.2] [Sema] Add missing null check for Type

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4703,9 +4703,11 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
 
     // `nonisolated(nonsending)` inferred from the context makes
     // the closure caller isolated.
-    if (auto *closureTy = getType(closure)->getAs<FunctionType>()) {
-      if (closureTy->getIsolation().isNonIsolatedCaller())
-        return ActorIsolation::forCallerIsolationInheriting();
+    if (auto closureTy = getType(closure)) {
+      if (auto *closureFnTy = closureTy->getAs<FunctionType>()) {
+        if (closureFnTy->getIsolation().isNonIsolatedCaller())
+          return ActorIsolation::forCallerIsolationInheriting();
+      }
     }
 
     // If a closure has an isolated parameter, it is isolated to that

--- a/test/SourceKit/CodeComplete/issue-80985.swift
+++ b/test/SourceKit/CodeComplete/issue-80985.swift
@@ -1,0 +1,13 @@
+// https://github.com/swiftlang/swift/issues/80985
+struct S<T> {
+  func foo<U>(_ fn: (T) -> U) -> S<U> { fatalError() }
+}
+
+func foo(xs: S<(Int, Int)>) {
+  _ = {
+    let y = xs
+      .foo{ $1 }
+      .foo{ $0 }
+    // RUN: %sourcekitd-test -req=complete -pos=%(line-1):11 %s -- %s
+  }
+}


### PR DESCRIPTION
*6.2 cherry-pick of #81025*

- Explanation: Fixes a crash that could occur when performing code completion
- Scope: Affects code completion
- Issue: rdar://149759542
- Risk: Low, adds a null check
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich