### PR TITLE
[APIGen] Don't record declarations from clang header files

### DIFF
--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -775,9 +775,9 @@ private:
   }
 
   bool shouldRecordDecl(const Decl *decl) const {
-    // In Swift, we cannot reason about API access for Clang declarations from
-    // header files as Swift doesn't know the header group. API records for
-    // header declarations should be deferred to Clang tools.
+    // We cannot reason about API access for Clang declarations from header
+    // files as we don't know the header group. API records for header
+    // declarations should be deferred to Clang tools.
     if (getAPILocForDecl(decl).getFilename().ends_with_insensitive(".h"))
       return false;
     return true;

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -708,6 +708,9 @@ public:
     apigen::APIAvailability availability;
     auto access = apigen::APIAccess::Public;
     if (decl) {
+      if (!shouldRecordDecl(decl))
+        return;
+
       availability = getAvailability(decl);
       if (isSPI(decl))
         access = apigen::APIAccess::Private;
@@ -733,6 +736,9 @@ public:
     auto access = apigen::APIAccess::Public;
     auto decl = method.hasDecl() ? method.getDecl() : nullptr;
     if (decl) {
+      if (!shouldRecordDecl(decl))
+        return;
+
       availability = getAvailability(decl);
       if (decl->getDescriptiveKind() == DescriptiveDeclKind::ClassMethod)
         isInstanceMethod = false;
@@ -752,7 +758,7 @@ public:
   }
 
 private:
-  apigen::APILoc getAPILocForDecl(const Decl *decl) {
+  apigen::APILoc getAPILocForDecl(const Decl *decl) const {
     if (!decl)
       return defaultLoc;
 
@@ -766,6 +772,15 @@ private:
     auto displayName = SM.getDisplayNameForLoc(loc);
 
     return apigen::APILoc(std::string(displayName), line, col);
+  }
+
+  bool shouldRecordDecl(const Decl *decl) const {
+    // In Swift, we cannot reason about API access for Clang declarations from
+    // header files as Swift doesn't know the header group. API records for
+    // header declarations should be deferred to Clang tools.
+    if (getAPILocForDecl(decl).getFilename().ends_with_insensitive(".h"))
+      return false;
+    return true;
   }
 
   /// Follow the naming schema that IRGen uses for Categories (see
@@ -809,6 +824,9 @@ private:
   }
 
   apigen::ObjCInterfaceRecord *addOrGetObjCInterface(const ClassDecl *decl) {
+    if (!shouldRecordDecl(decl))
+      return nullptr;
+
     auto entry = classMap.find(decl);
     if (entry != classMap.end())
       return entry->second;
@@ -847,6 +865,9 @@ private:
   }
 
   apigen::ObjCCategoryRecord *addOrGetObjCCategory(const ExtensionDecl *decl) {
+    if (!shouldRecordDecl(decl))
+      return nullptr;
+
     auto entry = categoryMap.find(decl);
     if (entry != categoryMap.end())
       return entry->second;

--- a/test/APIJSON/objc-implement.swift
+++ b/test/APIJSON/objc-implement.swift
@@ -1,0 +1,65 @@
+// REQUIRES: objc_interop, OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) %t/objc-implement.swift -typecheck -parse-as-library -emit-module-interface-path %t/ObjcImplement.swiftinterface -enable-library-evolution -module-name ObjcImplement -import-underlying-module -swift-version 5 -emit-api-descriptor-path %t/api.json
+// RUN: %validate-json %t/api.json | %FileCheck %s
+
+//--- objc-implement.swift
+import Foundation
+
+// API record for ObjCClass shouldn't be emitted from swift.
+@objc @implementation
+extension ObjCClass {
+  init?(char: CChar) {}
+}
+
+// API record for ObjCClass and ObjCCategory shouldn't be emitted from swift.
+@objc(ObjCCategory) @implementation
+extension ObjCClass {
+  convenience init?(int: Int32) {}
+}
+
+// This is an actual class declaration that should be included in the API
+// descriptor.
+@objc
+public class SwiftObjCClass: NSObject {}
+
+//--- ObjcImplement.h
+@interface Root
+@end
+
+@interface ObjCClass : Root
+- (instancetype) initWithChar:(char)c;
+@end
+
+@interface ObjCClass (ObjCCategory)
+- (instancetype) initWithInt:(int)i;
+@end
+
+//--- module.modulemap
+module ObjcImplement {
+  header "ObjcImplement.h"
+  export *
+}
+
+
+// CHECK:      "interfaces": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "name": "_TtC13ObjcImplement14SwiftObjCClass",
+// CHECK-NEXT:      "access": "public",
+// CHECK-NEXT:      "file": "{{.*}}/objc-implement.swift",
+// CHECK-NEXT:      "linkage": "exported",
+// CHECK-NEXT:      "super": "NSObject",
+// CHECK-NEXT:      "instanceMethods": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "name": "init",
+// CHECK-NEXT:          "access": "public",
+// CHECK-NEXT:          "file": "{{.*}}/objc-implement.swift"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],
+// CHECK-NEXT:      "classMethods": []
+// CHECK-NEXT:    }
+// CHECK-NEXT: ],
+// CHECK-NEXT: "categories": [],
+// CHECK-NEXT: "version": "1.0"

--- a/test/APIJSON/objc-implement.swift
+++ b/test/APIJSON/objc-implement.swift
@@ -44,6 +44,8 @@ module ObjcImplement {
 }
 
 
+// CHECK-NOT: "file": "{{.*}}.h"
+
 // CHECK:      "interfaces": [
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "name": "_TtC13ObjcImplement14SwiftObjCClass",


### PR DESCRIPTION
When Swift visits an `ExtensionDecl` from an `@objc @implementation` extension, it fetches the implemented Objective-C interface declaration from the header file and adds to the visitor.
We don't want these API records from `APIGenRecorder` for Swift API descriptor, because we cannot correctly reason about their API access as they depend on the header group which Swift doesn't know about.

Resolves rdar://148943382

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
