### PR TITLE
[6.2][cxx-interop] Fix runtime crash passing FRTs as const FRT*

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1520,10 +1520,8 @@ static bool isClangTypeMoreIndirectThanSubstType(TypeConverter &TC,
       return false;
 
     if (clangTy->getPointeeType()->getAs<clang::RecordType>()) {
-      // CF type as foreign class
-      if (substTy->getClassOrBoundGenericClass() &&
-          substTy->getClassOrBoundGenericClass()->getForeignClassKind() ==
-            ClassDecl::ForeignKind::CFType) {
+      // Foreign reference types
+      if (substTy->getClassOrBoundGenericClass()) {
         return false;
       }
     }

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -45,4 +45,34 @@ void cfuncARCWeak(ARCWeak) noexcept;
 void (* _Nonnull getFnPtr() noexcept)(NonTrivial) noexcept;
 void (* _Nonnull getFnPtr2() noexcept)(ARCWeak) noexcept;
 
+class SharedRef {
+public:
+  static SharedRef *_Nonnull makeSharedRef() { return new SharedRef(); }
+  int _refCount = 1;
+
+private:
+  SharedRef() = default;
+
+  SharedRef(const SharedRef &other) = delete;
+  SharedRef &operator=(const SharedRef &other) = delete;
+  SharedRef(SharedRef &&other) = delete;
+  SharedRef &operator=(SharedRef &&other) = delete;
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retainSharedRef")))
+__attribute__((swift_attr("release:releaseSharedRef")));
+
+inline void
+cppGo(void (*_Nonnull takeConstSharedRef)(const SharedRef *_Nonnull x)) {
+  SharedRef *ref = SharedRef::makeSharedRef();
+  takeConstSharedRef(ref);
+}
+
+inline void retainSharedRef(SharedRef *_Nonnull x) { x->_refCount += 1; }
+inline void releaseSharedRef(SharedRef *_Nonnull x) {
+  x->_refCount -= 1;
+  if (x->_refCount == 0) {
+    delete x;
+  }
+}
+
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-executable.swift
+++ b/test/Interop/Cxx/class/closure-thunk-executable.swift
@@ -11,4 +11,8 @@ ClosureTestSuite.test("ConvertToFunctionPointer") {
   cfunc2({N in})
 }
 
+ClosureTestSuite.test("Pass FRT to function pointer") {
+  cppGo({N in })
+}
+
 runAllTests()

--- a/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
@@ -6,14 +6,11 @@ import MoveOnly
 // CHECK-LABEL: define {{.*}}swiftcc void @"$s4main4testyyF"
 
 // CHECK: [[X:%.*]] = alloca ptr
-// CHECK: [[TMP:%.*]] = alloca ptr
 
 // CHECK: [[CREATED:%.*]] = call ptr @{{_ZN8MoveOnly6createEv|"\?create\@MoveOnly\@\@SAPEAU1\@XZ"}}()
 // CHECK: store ptr [[CREATED]], ptr [[X]]
-// CHECK: store ptr [[CREATED]], ptr [[TMP]]
 
-// CHECK: [[TMP_LOAD:%.*]] = load ptr, ptr [[TMP]]
-// CHECK: call i32 @{{_ZNK8MoveOnly4testEv|"\?test\@MoveOnly\@\@QEBAHXZ"}}(ptr [[TMP_LOAD]])
+// CHECK: call i32 @{{_ZNK8MoveOnly4testEv|"\?test\@MoveOnly\@\@QEBAHXZ"}}(ptr [[CREATED]])
 
 // CHECK: ret void
 

--- a/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-silgen.swift
@@ -15,11 +15,8 @@ import MoveOnly
 // CHECK: [[ACCESS_1:%.*]] = begin_access [read] [unknown] [[BOX]] : $*MoveOnly
 // CHECK: [[X_1:%.*]] = load [trivial] [[ACCESS_1]] : $*MoveOnly
 
-// CHECK: [[TMP:%.*]] = alloc_stack $MoveOnly
-// CHECK: store [[X_1]] to [trivial] [[TMP]]
-
-// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK8MoveOnly4testEv|\?test\@MoveOnly\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed MoveOnly) -> Int32
-// CHECK: apply [[TEST_FN]]([[TMP]]) : $@convention(cxx_method) (@in_guaranteed MoveOnly) -> Int32
+// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK8MoveOnly4testEv|\?test\@MoveOnly\@\@QEBAHXZ}} : $@convention(cxx_method) (MoveOnly) -> Int32
+// CHECK: apply [[TEST_FN]]([[X_1]]) : $@convention(cxx_method) (MoveOnly) -> Int32
 
 // CHECK: return
 // CHECK-LABEL: end sil function '$s4main4testyyF'
@@ -30,4 +27,4 @@ public func test() {
 
 // CHECK-LABEL: sil{{ \[available .*\] | }}[clang MoveOnly.create] @{{_ZN8MoveOnly6createEv|\?create\@MoveOnly\@\@SAPEAU1\@XZ}} : $@convention(c) () -> MoveOnly
 
-// CHECK-LABEL: sil{{ \[available .*\] | }}[clang MoveOnly.test] @{{_ZNK8MoveOnly4testEv|\?test\@MoveOnly\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed MoveOnly) -> Int32
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang MoveOnly.test] @{{_ZNK8MoveOnly4testEv|\?test\@MoveOnly\@\@QEBAHXZ}} : $@convention(cxx_method) (MoveOnly) -> Int32

--- a/test/Interop/Cxx/foreign-reference/pod-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-irgen.swift
@@ -9,7 +9,6 @@ import POD
 // CHECK-LABEL: define {{.*}}swiftcc void @"$s4main4testyyF"
 
 // CHECK: [[X:%.*]] = alloca ptr
-// CHECK: [[TMP:%.*]] = alloca ptr
 
 // CHECK: [[CREATED:%.*]] = call ptr @{{_ZN7IntPair6createEv|"\?create\@IntPair\@\@SAPEAU1\@XZ"}}()
 // CHECK: store ptr [[CREATED]], ptr [[X]]
@@ -18,9 +17,7 @@ import POD
 // CHECK: [[INT_VALUE:%.*]] = getelementptr inbounds %Ts5Int32V, ptr [[B_FIELD]], i32 0, i32 0
 // CHECK: store i32 42, ptr [[INT_VALUE]], align 4
 
-// CHECK: store ptr [[CREATED]], ptr [[TMP]]
-// CHECK: [[TMP_LOAD:%.*]] = load ptr, ptr [[TMP]]
-// CHECK: call i32 @{{_ZNK7IntPair4testEv|"\?test\@IntPair\@\@QEBAHXZ"}}(ptr [[TMP_LOAD]])
+// CHECK: call i32 @{{_ZNK7IntPair4testEv|"\?test\@IntPair\@\@QEBAHXZ"}}(ptr [[CREATED]])
 
 // CHECK: ret void
 

--- a/test/Interop/Cxx/foreign-reference/pod-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-silgen.swift
@@ -21,10 +21,8 @@ import POD
 
 // CHECK: [[ACCESS_3:%.*]] = begin_access [read] [unknown] [[BOX]] : $*IntPair
 // CHECK: [[X_2:%.*]] = load [trivial] [[ACCESS_3]] : $*IntPair
-// CHECK: [[TMP:%.*]] = alloc_stack $IntPair
-// CHECK: store [[X_2]] to [trivial] [[TMP]]
-// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK7IntPair4testEv|\?test\@IntPair\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed IntPair) -> Int32
-// CHECK: apply [[TEST_FN]]([[TMP]]) : $@convention(cxx_method) (@in_guaranteed IntPair) -> Int32
+// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK7IntPair4testEv|\?test\@IntPair\@\@QEBAHXZ}} : $@convention(cxx_method) (IntPair) -> Int32
+// CHECK: apply [[TEST_FN]]([[X_2]]) : $@convention(cxx_method) (IntPair) -> Int32
 
 // CHECK: return
 // CHECK-LABEL: end sil function '$s4main4testyyF'
@@ -36,4 +34,4 @@ public func test() {
 
 // CHECK-LABEL: sil{{ \[available .*\] | }}[clang IntPair.create] @{{_ZN7IntPair6createEv|\?create\@IntPair\@\@SAPEAU1\@XZ}} : $@convention(c) () -> IntPair
 
-// CHECK-LABEL: sil{{ \[available .*\] | }}[clang IntPair.test] @{{_ZNK7IntPair4testEv|\?test\@IntPair\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed IntPair) -> Int32
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang IntPair.test] @{{_ZNK7IntPair4testEv|\?test\@IntPair\@\@QEBAHXZ}} : $@convention(cxx_method) (IntPair) -> Int32

--- a/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
@@ -7,14 +7,11 @@ import Singleton
 // CHECK-LABEL: define {{.*}}swiftcc void @"$s4main4testyyF"
 
 // CHECK: [[X:%.*]] = alloca ptr
-// CHECK: [[TMP:%.*]] = alloca ptr
 
 // CHECK: [[CREATED:%.*]] = call ptr @{{_ZN21DeletedSpecialMembers6createEv|"\?create\@DeletedSpecialMembers\@\@SAPEAU1\@XZ"}}()
 // CHECK: store ptr [[CREATED]], ptr [[X]]
-// CHECK: store ptr [[CREATED]], ptr [[TMP]]
 
-// CHECK: [[TMP_LOAD:%.*]] = load ptr, ptr [[TMP]]
-// CHECK: call i32 @{{_ZNK21DeletedSpecialMembers4testEv|"\?test\@DeletedSpecialMembers\@\@QEBAHXZ"}}(ptr [[TMP_LOAD]])
+// CHECK: call i32 @{{_ZNK21DeletedSpecialMembers4testEv|"\?test\@DeletedSpecialMembers\@\@QEBAHXZ"}}(ptr [[CREATED]])
 
 // CHECK: call void @{{_Z8mutateItR21DeletedSpecialMembers|"\?mutateIt\@\@YAXAEAUDeletedSpecialMembers\@\@\@Z"}}(ptr [[CREATED]])
 

--- a/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-silgen.swift
@@ -15,11 +15,8 @@ import Singleton
 // CHECK: [[ACCESS_1:%.*]] = begin_access [read] [unknown] [[BOX]] : $*DeletedSpecialMembers
 // CHECK: [[X_1:%.*]] = load [trivial] [[ACCESS_1]] : $*DeletedSpecialMembers
 
-// CHECK: [[TMP:%.*]] = alloc_stack $DeletedSpecialMembers
-// CHECK: store [[X_1]] to [trivial] [[TMP]]
-
-// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK21DeletedSpecialMembers4testEv|\?test\@DeletedSpecialMembers\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed DeletedSpecialMembers) -> Int32
-// CHECK: apply [[TEST_FN]]([[TMP]]) : $@convention(cxx_method) (@in_guaranteed DeletedSpecialMembers) -> Int32
+// CHECK: [[TEST_FN:%.*]] = function_ref @{{_ZNK21DeletedSpecialMembers4testEv|\?test\@DeletedSpecialMembers\@\@QEBAHXZ}} : $@convention(cxx_method) (DeletedSpecialMembers) -> Int32
+// CHECK: apply [[TEST_FN]]([[X_1]]) : $@convention(cxx_method) (DeletedSpecialMembers) -> Int32
 // CHECK: [[ACCESS_2:%.*]] = begin_access [read] [unknown] [[BOX]] : $*DeletedSpecialMembers
 // CHECK: [[X_2:%.*]] = load [trivial] [[ACCESS_2]] : $*DeletedSpecialMembers
 
@@ -36,6 +33,6 @@ public func test() {
 
 // CHECK-LABEL: sil{{ \[available .*\] | }}[clang DeletedSpecialMembers.create] @{{_ZN21DeletedSpecialMembers6createEv|\?create\@DeletedSpecialMembers\@\@SAPEAU1\@XZ}} : $@convention(c) () -> DeletedSpecialMembers
 
-// CHECK-LABEL: sil{{ \[available .*\] | }}[clang DeletedSpecialMembers.test] @{{_ZNK21DeletedSpecialMembers4testEv|\?test\@DeletedSpecialMembers\@\@QEBAHXZ}} : $@convention(cxx_method) (@in_guaranteed DeletedSpecialMembers) -> Int32
+// CHECK-LABEL: sil{{ \[available .*\] | }}[clang DeletedSpecialMembers.test] @{{_ZNK21DeletedSpecialMembers4testEv|\?test\@DeletedSpecialMembers\@\@QEBAHXZ}} : $@convention(cxx_method) (DeletedSpecialMembers) -> Int32
 
 // CHECK-LABEL: sil{{ \[available .*\] | }}[serialized] [clang mutateIt] @{{_Z8mutateItR21DeletedSpecialMembers|\?mutateIt\@\@YAXAEAUDeletedSpecialMembers\@\@\@Z}} : $@convention(c) (DeletedSpecialMembers) -> ()


### PR DESCRIPTION
Explanation: There was an inconsistency between non-const and const FRT pointers. The former used Direct_Unowned the latter used Indirect calling convention. We want to use Direct_Unowned for both cases. The crash was the result of a calling convention mismatch between the SILFunctionType of a Swift closure and the SILFunctionType of the C++ function's formal parameter that is taking a function pointer. The compiler tried to insert a conversion between the two function types that does not exist and caused an assertion in debug compilers and miscompilation in production compilers.
Issue: rdar://149398905
Risk: Low, the fix is targeted and we change to a well-tested behavior with non-const FRT pointers.
Testing: Regression test added.
Original PR: #81070
Reviewer: @j-hui
