### PR TITLE
[6.2][cxx-interop] Proper conversions between MutableSpan and C++ span

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-span.swift
+++ b/test/Interop/Cxx/stdlib/use-std-span.swift
@@ -687,6 +687,30 @@ StdSpanTestSuite.test("Convert between Swift and C++ span types")
       expectEqual(cxxSpan[2], 3)
     }
   }
+  do {
+    var arr: [Int32] = [1, 2, 3]
+    arr.withUnsafeMutableBufferPointer{ ubpointer in
+      let s = SpanOfInt(ubpointer.baseAddress!, ubpointer.count)
+      let swiftSpan = MutableSpan(_unsafeCxxSpan: s)
+      expectEqual(swiftSpan.count, 3)
+      expectFalse(swiftSpan.isEmpty)
+      expectEqual(swiftSpan[0], 1)
+      expectEqual(swiftSpan[1], 2)
+      expectEqual(swiftSpan[2], 3)
+    }
+  }
+  do {
+    var arr: [Int32] = [1, 2, 3]
+    arr.withUnsafeMutableBufferPointer{ ubpointer in
+      let s = MutableSpan(_unsafeElements: ubpointer)
+      let cxxSpan = SpanOfInt(s)
+      expectEqual(cxxSpan.size(), 3)
+      expectFalse(cxxSpan.empty())
+      expectEqual(cxxSpan[0], 1)
+      expectEqual(cxxSpan[1], 2)
+      expectEqual(cxxSpan[2], 3)
+    }
+  }
 }
 
 runAllTests()


### PR DESCRIPTION
Explanation: One of the initializers were missing and the other was crashing at runtime due to a faulty signature in the overlay.
Issue: rdar://149846666
Risk: Low, the fix is additive.
Testing: Regression test added.
Original PR: #81097
Reviewer:
