### PR TITLE
[Concurrency] Add nonisolated(nonsending) to completion lookup

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3139,6 +3139,7 @@ void CompletionLookup::getAttributeDeclParamCompletions(
     break;
   case ParameterizedDeclAttributeKind::Nonisolated:
     addDeclAttrParamKeyword("unsafe", /*Parameters=*/{}, "", false);
+    addDeclAttrParamKeyword("nonsending", /*Parameters=*/{}, "", false);
     break;
   case ParameterizedDeclAttributeKind::AccessControl:
     addDeclAttrParamKeyword("set", /*Parameters=*/{}, "", false);

--- a/test/IDE/complete_nonisolated.swift
+++ b/test/IDE/complete_nonisolated.swift
@@ -1,0 +1,10 @@
+// RUN: %batch-code-completion
+
+// NONISOLATED-DAG: Keyword/None:                       unsafe; name=unsafe
+// NONISOLATED-DAG: Keyword/None:                       nonsending; name=nonsending
+
+nonisolated(#^NONISOLATED_UNSAFE_TOP_LEVEL?check=NONISOLATED^#) var count = 0
+
+struct MyStruct {
+  nonisolated(#^NONISOLATED_UNSAFE_IN_STRUCT?check=NONISOLATED^#) var prop = 0
+}

--- a/test/IDE/complete_nonisolated_unsafe.swift
+++ b/test/IDE/complete_nonisolated_unsafe.swift
@@ -1,9 +1,0 @@
-// RUN: %batch-code-completion
-
-// NONISOLATED_UNSAFE: Keyword/None:                       unsafe; name=unsafe
-
-nonisolated(#^NONISOLATED_UNSAFE_TOP_LEVEL?check=NONISOLATED_UNSAFE^#) var count = 0
-
-struct MyStruct {
-  nonisolated(#^NONISOLATED_UNSAFE_IN_STRUCT?check=NONISOLATED_UNSAFE^#) var prop = 0
-}


### PR DESCRIPTION
Seems we perhaps missed adding the completion for `nonsending` here?


cc @xedin

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
