### PR TITLE
XFAIL `Cxx/stdlib/use-std-function.swift` on Fedora 41

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -16,6 +16,7 @@
 // XFAIL: LinuxDistribution=rhel-9.4
 // XFAIL: LinuxDistribution=rhel-9.5
 // XFAIL: LinuxDistribution=fedora-39
+// XFAIL: LinuxDistribution=fedora-41
 // XFAIL: LinuxDistribution=debian-12
 
 import StdlibUnittest


### PR DESCRIPTION
Unblocks toolchain builds which fail on this test https://ci.swift.org/job/oss-swift-package-fedora-41/2/console

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
