### PR TITLE
Frontend: use preferred path spellings for paths

### DIFF
--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -17,6 +17,7 @@
 #include "swift/Basic/PrimarySpecificPaths.h"
 #include "swift/Basic/SupplementaryOutputPaths.h"
 #include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include <string>
@@ -63,11 +64,13 @@ public:
   /// Constructs an input file from the provided data.
   InputFile(StringRef name, bool isPrimary, llvm::MemoryBuffer *buffer,
             file_types::ID FileID)
-      : Filename(
-            convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(name)),
-        FileID(FileID), BufferAndIsPrimary(buffer, isPrimary),
+      : FileID(FileID), BufferAndIsPrimary(buffer, isPrimary),
         PSPs(PrimarySpecificPaths()) {
     assert(!name.empty());
+    llvm::SmallString<261> Path{
+        convertBufferNameFromLLVM_getFileOrSTDIN_toSwiftConventions(name)};
+    llvm::sys::path::make_preferred(Path);
+    Filename = Path.str().str();
   }
 
 public:

--- a/lib/Basic/OutputFileMap.cpp
+++ b/lib/Basic/OutputFileMap.cpp
@@ -108,7 +108,9 @@ void OutputFileMap::dump(llvm::raw_ostream &os, bool Sort) const {
 
 static void writeQuotedEscaped(llvm::raw_ostream &os,
                                const StringRef fileName) {
-  os << "\"" << llvm::yaml::escape(fileName) << "\"";
+  llvm::SmallString<261> Path{fileName};
+  llvm::sys::path::make_preferred(Path);
+  os << "\"" << llvm::yaml::escape(Path.str()) << "\"";
 }
 
 void OutputFileMap::write(llvm::raw_ostream &os,
@@ -130,9 +132,11 @@ void OutputFileMap::write(llvm::raw_ostream &os,
     // DenseMap is unordered. If you write a test, please sort the output.
     for (auto &typeAndOutputPath : *outputMap) {
       file_types::ID type = typeAndOutputPath.getFirst();
-      StringRef output = typeAndOutputPath.getSecond();
       os << "  " << file_types::getTypeName(type) << ": ";
-      writeQuotedEscaped(os, output);
+
+      llvm::SmallString<261> Path{typeAndOutputPath.getSecond()};
+      llvm::sys::path::make_preferred(Path);
+      writeQuotedEscaped(os, Path.str());
       os << "\n";
     }
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -934,7 +934,9 @@ importer::addCommonInvocationArguments(
         invocationArgStrs.push_back("-isystem");
         invocationArgStrs.push_back(path.Path);
       } else {
-        invocationArgStrs.push_back("-I" + path.Path);
+        llvm::SmallString<261> Path{path.Path};
+        llvm::sys::path::make_preferred(Path);
+        invocationArgStrs.push_back(("-I" + Path.str()).str());
       }
     }
   }

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -1289,15 +1289,17 @@ bool DiagnosticVerifier::finishProcessing() {
 
   SmallVector<unsigned, 4> additionalBufferIDs;
   for (auto path : AdditionalFilePaths) {
-    auto bufferID = SM.getIDForBufferIdentifier(path);
+    llvm::SmallString<261> buffer{path};
+    llvm::sys::path::make_preferred(buffer);
+    auto bufferID = SM.getIDForBufferIdentifier(buffer);
     if (!bufferID) {
       // Still need to scan this file for expectations.
-      auto result = SM.getFileSystem()->getBufferForFile(path);
+      auto result = SM.getFileSystem()->getBufferForFile(buffer);
       if (!result) {
         auto message = SM.GetMessage(
            SourceLoc(), llvm::SourceMgr::DiagKind::DK_Error,
            llvm::Twine("unable to open file in '-verify-additional-file ") +
-           path + "': " + result.getError().message(), {}, {});
+           buffer + "': " + result.getError().message(), {}, {});
         printDiagnostic(message);
         Result.HadError |= true;
         continue;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -747,6 +747,7 @@ std::string SerializedModuleBaseName::getName(file_types::ID fileTy) const {
   result += '.';
   result += file_types::getExtension(fileTy);
 
+  llvm::sys::path::make_preferred(result);
   return std::string(result.str());
 }
 

--- a/test/ClangImporter/pcm-emit-and-import.swift
+++ b/test/ClangImporter/pcm-emit-and-import.swift
@@ -4,7 +4,7 @@
 
 // Verify some of the output of the -dump-pcm flag.
 // RUN: %swift-dump-pcm %t/script.pcm | %FileCheck %s --check-prefix=CHECK-DUMP
-// CHECK-DUMP: Information for module file '{{.*}}/script.pcm':
+// CHECK-DUMP: Information for module file '{{.*}}{{/|\\}}script.pcm':
 // CHECK-DUMP:   Module name: script
 // CHECK-DUMP:   Module map file: {{.*[/\\]}}Inputs{{/|\\}}custom-modules{{/|\\}}module.modulemap
 

--- a/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
+++ b/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
@@ -4,7 +4,7 @@
 
 // Verify some of the output of the -dump-pcm flag.
 // RUN: %swift-dump-pcm %t/script.pcm | %FileCheck %s --check-prefix=CHECK-DUMP
-// CHECK-DUMP: Information for module file '{{.*}}/script.pcm':
+// CHECK-DUMP: Information for module file '{{.*}}{{/|\\}}script.pcm':
 // CHECK-DUMP:   Module name: script
 // CHECK-DUMP:   Module map file: {{.*[/\\]}}Inputs{{/|\\}}custom-modules{{/|\\}}module.modulemap
 

--- a/test/DebugInfo/basic.swift
+++ b/test/DebugInfo/basic.swift
@@ -72,7 +72,7 @@ func foo(_ a: Int64, _ b: Int64) -> Int64 {
      }
 }
 
-// CHECK-DAG: ![[MAINFILE:[0-9]+]] = !DIFile(filename: "{{.*}}DebugInfo/basic.swift", directory: "{{.*}}")
+// CHECK-DAG: ![[MAINFILE:[0-9]+]] = !DIFile(filename: "{{.*}}DebugInfo{{/|\\\\}}basic.swift", directory: "{{.*}}")
 // CHECK-DAG: !DICompileUnit(language: DW_LANG_Swift, file: ![[MAINFILE]],{{.*}} producer: "{{.*}}Swift version{{.*}},{{.*}}
 // CHECK-DAG: !DISubprogram(name: "main", {{.*}}file: ![[MAINFILE]],
 

--- a/test/DebugInfo/debug_prefix_map.swift
+++ b/test/DebugInfo/debug_prefix_map.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
-// RUN: %target-swiftc_driver -g -debug-prefix-map %/S=/var/empty -debug-prefix-map %t=/var/empty %/s -I %t -emit-ir -o - | %FileCheck %s
+// RUN: %target-swiftc_driver -g -debug-prefix-map %S=/var/empty -debug-prefix-map %t=/var/empty %/s -I %t -emit-ir -o - | %FileCheck %s
 
 import Globals
 
@@ -8,5 +8,5 @@ func square(_ n: Int) -> Int {
   return n * n
 }
 
-// CHECK: !DIFile(filename: "/var/empty/debug_prefix_map.swift"
+// CHECK: !DIFile(filename: "/var/empty{{/|\\\\}}debug_prefix_map.swift"
 // CHECK: !DIModule(scope: null, name: "Globals", {{.*}}includePath: "/var/empty{{(/|\\\\)}}Globals.swiftmodule"

--- a/test/DebugInfo/line-directive.swift
+++ b/test/DebugInfo/line-directive.swift
@@ -24,7 +24,7 @@ func f() {
 // CHECK: .loc	[[ABC]] 142
 // CHECK: .file	[[DEF:[0-9]+]] "{{(//|\\\\\\\\)}}absolute{{(/|\\\\)}}path" "def.swift"
 // CHECK: .loc	[[DEF]] 142
-// CHECK: .asciz "{{.*}}test/DebugInfo"
+// CHECK: .asciz "{{.*}}test{{/|\\\\}}DebugInfo"
 
 // RUN: %empty-directory(%t)
 // RUN: sed -e "s|LINE_DIRECTIVE_DIR|%/S|g" %S/Inputs/vfsoverlay.yaml > %t/overlay.yaml
@@ -37,4 +37,4 @@ func f() {
 // VFS: .loc  [[ABC]] 142
 // VFS: .file  [[DEF:[0-9]+]] "{{(//|\\\\\\\\)}}absolute{{(/|\\\\)}}path" "def.swift"
 // VFS: .loc  [[DEF]] 142
-// VFS: .asciz "{{.*}}test/DebugInfo"
+// VFS: .asciz "{{.*}}test{{/|\\\\}}DebugInfo"

--- a/test/Frontend/ast-dump-json.swift
+++ b/test/Frontend/ast-dump-json.swift
@@ -8,19 +8,19 @@
 // RUN: %target-swift-frontend -dump-ast -dump-ast-format json %t/a.swift %t/b.swift -primary-file %t/main.swift -module-name main -o - 2>%t/main.swift.stderr | %FileCheck -check-prefix MAIN-AST %s
 
 // Check a.swift's AST
-// A-AST: "filename":"{{[^"]+}}/a.swift"
+// A-AST: "filename":"{{[^"]+}}a.swift"
 // A-AST-SAME: "_kind":"func_decl"
 // A-AST-SAME: "usr":"s:4main1ayyF"
 
 
 // Check b.swift's AST
-// B-AST: "filename":"{{[^"]+}}/b.swift"
+// B-AST: "filename":"{{[^"]+}}b.swift"
 // B-AST-SAME: "_kind":"func_decl"
 // B-AST-SAME: "usr":"s:4main1byyF"
 
 
 // Check main.swift's AST
-// MAIN-AST: "filename":"{{[^"]+}}/main.swift"
+// MAIN-AST: "filename":"{{[^"]+}}main.swift"
 // MAIN-AST-SAME: "_kind":"func_decl"
 // MAIN-AST-SAME: "usr":"s:4mainAAyyF"
 

--- a/test/Frontend/vfs.swift
+++ b/test/Frontend/vfs.swift
@@ -7,12 +7,12 @@
 // RUN: not %target-swift-frontend -vfsoverlay %/t/overlay.yaml -typecheck %s %/t/mapped-file.swift -serialize-diagnostics-path %/t/basic.dia 2>&1 | %FileCheck -check-prefix=BASIC_MAPPING_ERROR %s
 // RUN: c-index-test -read-diagnostics %/t/basic.dia 2>&1 | %FileCheck -check-prefix=BASIC_MAPPING_ERROR %s
 
-// BASIC_MAPPING_ERROR: {{.*}}/mapped-file.swift:2:17: error:
+// BASIC_MAPPING_ERROR: {{.*}}mapped-file.swift:2:17: error:
 
 // RUN: not %target-swift-frontend -vfsoverlay %/t/overlay.yaml -vfsoverlay %/t/secondary-overlay.yaml -vfsoverlay %/t/tertiary-overlay.yaml -typecheck %/s %/t/triple-mapped-swift-file.swift -serialize-diagnostics-path %/t/complex.dia 2>&1 | %FileCheck -check-prefix=COMPLEX_MAPPING_ERROR %s
 // RUN: c-index-test -read-diagnostics %/t/complex.dia 2>&1 | %FileCheck -check-prefix=COMPLEX_MAPPING_ERROR %s
 
-// COMPLEX_MAPPING_ERROR: {{.*}}/triple-mapped-swift-file.swift:2:17: error:
+// COMPLEX_MAPPING_ERROR: {{.*}}triple-mapped-swift-file.swift:2:17: error:
 
 // The Clang Importer should inherit Swift's VFS
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %/t -DTEST_VFS_CLANG_IMPORTER -vfsoverlay %/t//overlay.yaml -typecheck %/s

--- a/test/IRGen/multithread_module.swift
+++ b/test/IRGen/multithread_module.swift
@@ -72,8 +72,8 @@ public func mutateBaseArray(_ arr: inout [Base], _ x: Base) {
 
 // Check if the DI filename is correct and not "<unknown>".
 
-// CHECK-MAINLL: [[F:![0-9]+]] = !DIFile(filename: "{{.*}}IRGen/Inputs/multithread_module/main.swift", directory: "{{.*}}")
+// CHECK-MAINLL: [[F:![0-9]+]] = !DIFile(filename: "{{.*}}IRGen{{/|\\\\}}Inputs{{/|\\\\}}multithread_module{{/|\\\\}}main.swift", directory: "{{.*}}")
 // CHECK-MAINLL: DICompileUnit(language: DW_LANG_Swift, file: [[F]],
 
-// CHECK-MODULELL: [[F:![0-9]]] = !DIFile(filename: "{{.*}}IRGen/multithread_module.swift", directory: "{{.*}}")
+// CHECK-MODULELL: [[F:![0-9]]] = !DIFile(filename: "{{.*}}IRGen{{/|\\\\}}multithread_module.swift", directory: "{{.*}}")
 // CHECK-MODULELL: DICompileUnit(language: DW_LANG_Swift, file: [[F]],

--- a/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
+++ b/test/Interop/Cxx/foreign-reference/frt-retained-unretained-attributes-error.swift
@@ -1,8 +1,5 @@
 // RUN: rm -rf %t
- // RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -verify-additional-file %S/Inputs/cxx-functions-and-methods-returning-frt.h -Xcc -Wno-return-type -Xcc -Wno-nullability-completeness
-
-// XFAIL: OS=windows-msvc
-// TODO: Enable this on windows when -verify-additional-file issue on Windows Swift CI is resolved 
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs  %s -cxx-interoperability-mode=upcoming-swift -verify-additional-file %S/Inputs/cxx-functions-and-methods-returning-frt.h -Xcc -Wno-return-type -Xcc -Wno-nullability-completeness
 
 import FunctionsAndMethodsReturningFRT
 import CxxStdlib

--- a/test/ModuleInterface/BadStdlib.swiftinterface
+++ b/test/ModuleInterface/BadStdlib.swiftinterface
@@ -14,6 +14,3 @@
 import ClangMod
 
 public func useHasPointer(_: HasPointer)
-
-// FIXME: https://github.com/apple/swift/issues/56844
-// UNSUPPORTED: OS=windows-msvc

--- a/test/PlaygroundTransform/extended_callbacks.swift
+++ b/test/PlaygroundTransform/extended_callbacks.swift
@@ -21,26 +21,26 @@ if (a) {
 for i in 0..<3 {
   i
 }
-// CHECK: [{{.*}}] __builtin_log_with_id_extended[a='true' module: main. file: {{.*/main.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='5' module: main. file: {{.*/main.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*/main.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main. file: {{.*/main.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main. file: {{.*/main.swift}}]
+// CHECK: [{{.*}}] __builtin_log_with_id_extended[a='true' module: main. file: {{.*main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='5' module: main. file: {{.*main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main. file: {{.*main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main. file: {{.*main.swift}}]
 
 var b = true
 for i in 0..<3 {
   i
   continue
 }
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[b='true' module: main. file: {{.*/main.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*/main.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main. file: {{.*/main.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[b='true' module: main. file: {{.*main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='1' module: main. file: {{.*main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='2' module: main. file: {{.*main.swift}}]
 
 var c = true
 for i in 0..<3 {
   i
   break
 }
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[c='true' module: main. file: {{.*/main.swift}}]
-// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*/main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[c='true' module: main. file: {{.*main.swift}}]
+// CHECK-NEXT: [{{.*}}] __builtin_log_with_id_extended[='0' module: main. file: {{.*main.swift}}]

--- a/test/Profiler/coverage_relative_path.swift
+++ b/test/Profiler/coverage_relative_path.swift
@@ -10,6 +10,6 @@
 //
 // ABSOLUTE: @__llvm_coverage_mapping = {{.*"\\02.*root[^/\\]*nested[/\\]*coverage_relative_path\.swift}}
 
-// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -Xllvm -enable-name-compression=false -coverage-prefix-map %t/root=. -emit-ir %t/root/nested/coverage_relative_path.swift | %FileCheck -check-prefix=RELATIVE %s
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -Xllvm -enable-name-compression=false -coverage-prefix-map %t%{fs-sep}root=. -emit-ir %t%{fs-sep}root/nested/coverage_relative_path.swift | %FileCheck -check-prefix=RELATIVE %s
 //
 // RELATIVE: @__llvm_coverage_mapping = {{.*"\\02.*\\01[^/]*\.[/\\]*nested[/\\]*coverage_relative_path\.swift}}

--- a/test/SILOptimizer/devirt_speculate.swift
+++ b/test/SILOptimizer/devirt_speculate.swift
@@ -98,7 +98,7 @@ class Sub7 : Base {
 // YAML:      Pass:            sil-speculative-devirtualizer
 // YAML-NEXT: Name:            sil.PartialSpecDevirt
 // YAML-NEXT: DebugLoc:
-// YAML:   File:            {{.*}}/devirt_speculate.swift
+// YAML:   File:            {{.*}}devirt_speculate.swift
 // YAML:   Line:            118
 // YAML:   Column:          5
 // YAML-NEXT: Function:        'testMaxNumSpeculativeTargets(_:)'

--- a/test/ScanDependencies/unicode_filename.swift
+++ b/test/ScanDependencies/unicode_filename.swift
@@ -14,6 +14,6 @@ public func bar() {
 // CHECK-NEXT:    {
 // CHECK-NEXT:      "modulePath": "deps.swiftmodule",
 // CHECK-NEXT:      "sourceFiles": [
-// CHECK-NEXT:        "{{.*}}ScanDependencies/unicode_filename.swift",
-// CHECK-NEXT:        "{{.*}}ScanDependencies/Inputs/unicode_filёnamё.swift"
+// CHECK-NEXT:        "{{.*}}ScanDependencies{{/|\\\\}}unicode_filename.swift",
+// CHECK-NEXT:        "{{.*}}ScanDependencies{{/|\\\\}}Inputs{{/|\\\\}}unicode_filёnamё.swift"
 // CHECK-NEXT:      ],

--- a/test/Serialization/comments-batch-mode.swift
+++ b/test/Serialization/comments-batch-mode.swift
@@ -6,8 +6,8 @@
 // RUN: %target-swift-frontend -wmo -emit-module -emit-module-doc -emit-module-path %t/Foo.swiftmodule %S/Inputs/comments-batch/File1.swift %S/Inputs/comments-batch/File2.swift %S/Inputs/comments-batch/File3.swift %S/Inputs/comments-batch/File4.swift %S/Inputs/comments-batch/File5.swift -module-name Foo -emit-module-source-info-path %t/Foo.swiftsourceinfo -emit-module-doc-path %t/Foo.swiftdoc
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=Foo -enable-swiftsourceinfo -source-filename %s -I %t | %FileCheck %s
 
-// CHECK: Inputs/comments-batch/File1.swift:2:13: Func/FuncFromFile1 RawComment=[/// Comment in File1\n]
-// CHECK: Inputs/comments-batch/File2.swift:2:13: Func/FuncFromFile2 RawComment=[/// Comment in File2\n]
-// CHECK: Inputs/comments-batch/File3.swift:2:13: Func/FuncFromFile3 RawComment=[/// Comment in File3\n]
-// CHECK: Inputs/comments-batch/File4.swift:2:13: Func/FuncFromFile4 RawComment=[/// Comment in File4\n]
-// CHECK: Inputs/comments-batch/File5.swift:2:13: Func/FuncFromFile5 RawComment=[/// Comment in File5\n]
+// CHECK: Inputs{{[/\\]}}comments-batch{{[/\\]}}File1.swift:2:13: Func/FuncFromFile1 RawComment=[/// Comment in File1\n]
+// CHECK: Inputs{{[/\\]}}comments-batch{{[/\\]}}File2.swift:2:13: Func/FuncFromFile2 RawComment=[/// Comment in File2\n]
+// CHECK: Inputs{{[/\\]}}comments-batch{{[/\\]}}File3.swift:2:13: Func/FuncFromFile3 RawComment=[/// Comment in File3\n]
+// CHECK: Inputs{{[/\\]}}comments-batch{{[/\\]}}File4.swift:2:13: Func/FuncFromFile4 RawComment=[/// Comment in File4\n]
+// CHECK: Inputs{{[/\\]}}comments-batch{{[/\\]}}File5.swift:2:13: Func/FuncFromFile5 RawComment=[/// Comment in File5\n]

--- a/test/Serialization/comments.swift
+++ b/test/Serialization/comments.swift
@@ -80,26 +80,26 @@ package func first_package_function() {}
 // SECOND: comments.swift:61:1: Extension/ RawComment=[/// Comment for no member extension\n] BriefComment=[Comment for no member extension]
 // SECOND: comments.swift:64:14: Func/first_package_function RawComment=[/// Comment on package function\n]
 // SECOND: comments.swift:67:27: Func/first_spi_function RawComment=[/// Comment on SPI function\n]
-// SECOND: Inputs/def_comments.swift:2:14: Class/second_decl_class_1 RawComment=[/// second_decl_class_1 Aaa.\n]
-// SECOND: Inputs/def_comments.swift:5:15: Struct/second_decl_struct_1
-// SECOND: Inputs/def_comments.swift:7:9: Accessor/second_decl_struct_1.<getter for second_decl_struct_1.instanceVar>
-// SECOND: Inputs/def_comments.swift:8:9: Accessor/second_decl_struct_1.<setter for second_decl_struct_1.instanceVar>
-// SECOND: Inputs/def_comments.swift:10:17: Enum/second_decl_struct_1.NestedEnum
-// SECOND: Inputs/def_comments.swift:11:22: TypeAlias/second_decl_struct_1.NestedTypealias
-// SECOND: Inputs/def_comments.swift:14:13: Enum/second_decl_enum_1
-// SECOND: Inputs/def_comments.swift:15:10: EnumElement/second_decl_enum_1.Case1
-// SECOND: Inputs/def_comments.swift:16:10: EnumElement/second_decl_enum_1.Case2
-// SECOND: Inputs/def_comments.swift:20:12: Constructor/second_decl_class_2.init
-// SECOND: Inputs/def_comments.swift:23:17: Protocol/second_decl_protocol_1
-// SECOND: Inputs/def_comments.swift:24:20: AssociatedType/second_decl_protocol_1.NestedTypealias
-// SECOND: Inputs/def_comments.swift:25:5: Subscript/second_decl_protocol_1.subscript
-// SECOND: Inputs/def_comments.swift:25:35: Accessor/second_decl_protocol_1.<getter for second_decl_protocol_1.subscript>
-// SECOND: Inputs/def_comments.swift:25:39: Accessor/second_decl_protocol_1.<setter for second_decl_protocol_1.subscript>
-// SECOND: Inputs/def_comments.swift:28:13: Var/decl_var_2 RawComment=none BriefComment=none DocCommentAsXML=none
-// SECOND: Inputs/def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
-// SECOND: Inputs/def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
-// SECOND: Inputs/def_comments.swift:31:14: Func/second_package_function RawComment=[/// Comment on package function\n]
-// SECOND: Inputs/def_comments.swift:34:27: Func/second_spi_function RawComment=[/// Comment on SPI function\n]
+// SECOND: def_comments.swift:2:14: Class/second_decl_class_1 RawComment=[/// second_decl_class_1 Aaa.\n]
+// SECOND: def_comments.swift:5:15: Struct/second_decl_struct_1
+// SECOND: def_comments.swift:7:9: Accessor/second_decl_struct_1.<getter for second_decl_struct_1.instanceVar>
+// SECOND: def_comments.swift:8:9: Accessor/second_decl_struct_1.<setter for second_decl_struct_1.instanceVar>
+// SECOND: def_comments.swift:10:17: Enum/second_decl_struct_1.NestedEnum
+// SECOND: def_comments.swift:11:22: TypeAlias/second_decl_struct_1.NestedTypealias
+// SECOND: def_comments.swift:14:13: Enum/second_decl_enum_1
+// SECOND: def_comments.swift:15:10: EnumElement/second_decl_enum_1.Case1
+// SECOND: def_comments.swift:16:10: EnumElement/second_decl_enum_1.Case2
+// SECOND: def_comments.swift:20:12: Constructor/second_decl_class_2.init
+// SECOND: def_comments.swift:23:17: Protocol/second_decl_protocol_1
+// SECOND: def_comments.swift:24:20: AssociatedType/second_decl_protocol_1.NestedTypealias
+// SECOND: def_comments.swift:25:5: Subscript/second_decl_protocol_1.subscript
+// SECOND: def_comments.swift:25:35: Accessor/second_decl_protocol_1.<getter for second_decl_protocol_1.subscript>
+// SECOND: def_comments.swift:25:39: Accessor/second_decl_protocol_1.<setter for second_decl_protocol_1.subscript>
+// SECOND: def_comments.swift:28:13: Var/decl_var_2 RawComment=none BriefComment=none DocCommentAsXML=none
+// SECOND: def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
+// SECOND: def_comments.swift:28:25: Var/decl_var_3 RawComment=none BriefComment=none DocCommentAsXML=none
+// SECOND: def_comments.swift:31:14: Func/second_package_function RawComment=[/// Comment on package function\n]
+// SECOND: def_comments.swift:34:27: Func/second_spi_function RawComment=[/// Comment on SPI function\n]
 // SECOND: NonExistingSource.swift:100000:13: Func/functionAfterPoundSourceLoc
 
 // Package and SPI functions won't show up in the (public) swiftinterface

--- a/test/Serialization/module_defining_interface.swift
+++ b/test/Serialization/module_defining_interface.swift
@@ -14,12 +14,12 @@
 
 // --- Verify that an SDK module gets its SDK-relative path serialized into the binary '.swiftmodule'
 // RUN: cp %t/modules/Foo.swiftinterface %t/test-sdk/usr/lib/Foo.swiftmodule
-// RUN: %target-swift-frontend(mock-sdk: -sdk %t/test-sdk) -compile-module-from-interface -module-name Foo %t/test-sdk/usr/lib/Foo.swiftmodule/Foo.swiftinterface -o %t/inputs/Foo.swiftmodule
+// RUN: %target-swift-frontend(mock-sdk: -sdk %t%{fs-sep}test-sdk) -compile-module-from-interface -module-name Foo %t/test-sdk/usr/lib/Foo.swiftmodule/Foo.swiftinterface -o %t/inputs/Foo.swiftmodule
 // RUN: llvm-bcanalyzer -dump %t/inputs/Foo.swiftmodule > %t/Foo.sdk.moduledump.txt
 // RUN: cat %t/Foo.sdk.moduledump.txt | %FileCheck %s -check-prefix CHECK-SDK-FOO
 
 // CHECK-FREESTANDING-FOO: <MODULE_INTERFACE_PATH abbrevid={{[0-9]+}} op0=0/> blob data = '{{.*}}{{/|\\}}modules{{/|\\}}Foo.swiftinterface'
-// CHECK-SDK-FOO: <MODULE_INTERFACE_PATH abbrevid={{[0-9]+}} op0=1/> blob data = 'usr/lib/Foo.swiftmodule/Foo.swiftinterface'
+// CHECK-SDK-FOO: <MODULE_INTERFACE_PATH abbrevid={{[0-9]+}} op0=1/> blob data = 'usr{{[/\\]}}lib{{[/\\]}}Foo.swiftmodule{{[/\\]}}Foo.swiftinterface'
 
 //--- modules/Foo.swiftinterface
 // swift-interface-format-version: 1.0

--- a/test/Serialization/version-mismatches.swift
+++ b/test/Serialization/version-mismatches.swift
@@ -8,11 +8,11 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-old-language/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
 
 import Library
-// TOO-OLD: :[[@LINE-1]]:8: error: compiled module was created by an older version of the compiler; rebuild 'Library' and try again: {{.*}}too-old/Library.swiftmodule{{$}}
-// TOO-NEW: :[[@LINE-2]]:8: error: compiled module was created by a newer version of the compiler: {{.*}}too-new/Library.swiftmodule{{$}}
+// TOO-OLD: :[[@LINE-1]]:8: error: compiled module was created by an older version of the compiler; rebuild 'Library' and try again: {{.*}}too-old{{[/\\]}}Library.swiftmodule{{$}}
+// TOO-NEW: :[[@LINE-2]]:8: error: compiled module was created by a newer version of the compiler: {{.*}}too-new{{[/\\]}}Library.swiftmodule{{$}}
 
 // Update this line when the compiler version changes.
-// LANGUAGE: :[[@LINE-5]]:8: error: module compiled with Swift X.Y cannot be imported by the Swift 6.{{.+}} compiler: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
+// LANGUAGE: :[[@LINE-5]]:8: error: module compiled with Swift X.Y cannot be imported by the Swift 6.{{.+}} compiler: {{.*}}too-{{old|new}}-language{{[/\\]}}Library.swiftmodule{{$}}
 
 // Compiler thinks that the module is empty in all cases.
 // CHECK: :[[@LINE+1]]:1: error: module 'Library' has no member named 'foo'

--- a/test/SourceKit/CursorInfo/cursor_symbol_graph_referenced.swift
+++ b/test/SourceKit/CursorInfo/cursor_symbol_graph_referenced.swift
@@ -225,7 +225,7 @@ extension Parent {
 // NESTED-NEXT: [[ExtInner_USR]] | internal | {{.*}}cursor_symbol_graph_referenced.swift | cursor_symbol_graph_referenced | User | NonSPI | source.lang.swift
 // NESTED-NEXT:   Parent swift.struct s:30cursor_symbol_graph_referenced6ParentV
 // NESTED-NEXT:   ExtInner swift.struct [[ExtInner_USR]]
-// NESTED-NEXT: [[FromSomeModule_USR]] | public | {{.*}}/SomeModule.swift | SomeModule | User | NonSPI | source.lang.swift
+// NESTED-NEXT: [[FromSomeModule_USR]] | public | {{.*}}SomeModule.swift | SomeModule | User | NonSPI | source.lang.swift
 // NESTED-NEXT:   FromSomeModule swift.struct [[FromSomeModule_USR]]
 // NESTED-NEXT: REFERENCED DECLS END
 

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -396,7 +396,9 @@ int main(int argc, char *argv[]) {
   SourceFile *SF = nullptr;
   for (auto Unit : CI.getMainModule()->getFiles()) {
     if (auto Current = dyn_cast<SourceFile>(Unit)) {
-      if (Current->getFilename() == options::SourceFilename)
+      llvm::SmallString<261> Path{options::SourceFilename};
+      llvm::sys::path::make_preferred(Path);
+      if (Current->getFilename() == Path)
         SF = Current;
     }
     if (SF)


### PR DESCRIPTION
Convert paths to the preferred spelling before passing it to the SourceManager to ensure that we have the canonical spelling. This is important as a path with a non-canonical path separator would otherwise fail to be looked up in the source manager buffer.