### PR TITLE
[AST] Temporarily downgrade value generic redeclaration to warning

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -310,6 +310,9 @@ struct OverloadSignature {
   /// Whether this is a macro.
   unsigned IsMacro : 1;
 
+  /// Whether this is a generic argument.
+  unsigned IsGenericArg : 1;
+
   /// Whether this signature is part of a protocol extension.
   unsigned InProtocolExtension : 1;
 
@@ -323,8 +326,10 @@ struct OverloadSignature {
   OverloadSignature()
       : UnaryOperator(UnaryOperatorKind::None), IsInstanceMember(false),
         IsVariable(false), IsFunction(false), IsAsyncFunction(false),
-        IsDistributed(false), InProtocolExtension(false),
-        InExtensionOfGenericType(false), HasOpaqueReturnType(false) { }
+        IsDistributed(false), IsEnumElement(false), IsNominal(false),
+        IsTypeAlias(false), IsMacro(false), IsGenericArg(false),
+        InProtocolExtension(false), InExtensionOfGenericType(false),
+        HasOpaqueReturnType(false) { }
 };
 
 /// Determine whether two overload signatures conflict.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3859,6 +3859,13 @@ bool swift::conflicting(ASTContext &ctx,
   if (sig1.IsFunction != sig2.IsFunction)
     return true;
 
+  // Gracefully handle the case where value generic arguments were introduced
+  // as a conflicting value with static variables of the same name.
+  if (sig1.IsGenericArg != sig2.IsGenericArg) {
+    *wouldConflictInSwift5 = true;
+    return true;
+  }
+
   // Variables always conflict with non-variables with the same signature.
   // (e.g variables with zero argument functions, variables with type
   //  declarations)
@@ -4037,6 +4044,7 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
   signature.IsNominal = isa<NominalTypeDecl>(this);
   signature.IsTypeAlias = isa<TypeAliasDecl>(this);
   signature.IsMacro = isa<MacroDecl>(this);
+  signature.IsGenericArg = isa<GenericTypeParamDecl>(this);
   signature.HasOpaqueReturnType =
                        !signature.IsVariable && (bool)getOpaqueResultTypeDecl();
 

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -121,7 +121,7 @@ func testC4<let T: Int>(with c: C<T, T>) {
 struct D<let N: Int & P> {} // expected-error {{non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type}}
 
 struct E<A, let b: Int> { // expected-note {{'b' previously declared here}}
-  static var b: Int { // expected-error {{invalid redeclaration of 'b'}}
+  static var b: Int { // expected-warning {{redeclaration of 'b' is deprecated and will be an error in Swift 5}}
                       // expected-note@-1 {{'b' declared here}}
     123
   }
@@ -183,7 +183,7 @@ func testTypeOf2<let c: Int>(_: E<Int, c>.Type) -> Int {
 }
 
 struct H<let I: Int> { // expected-note {{'I' previously declared here}}
-  struct I {} // expected-error {{invalid redeclaration of 'I'}}
+  struct I {} // expected-warning {{redeclaration of 'I' is deprecated and will be an error in Swift 5}}
 }
 
 typealias J = E<Int, 123>.b // expected-error {{static property 'b' is not a member type of 'E<Int, 123>'}}


### PR DESCRIPTION
Due to a newer compiler attempting to compile an older stdlib interface, we're seeing a build failure compiling a version of `InlineArray` that still has the static property with the same name as the generic argument. Temporarily downgrade this until that version of the stdlib interface has been updated with the removal of the static property.

Resolves: rdar://149763839