### PR TITLE
Do not export symbols for compiler executables under Darwin.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -843,6 +843,7 @@ endmacro()
 #   add_swift_host_tool(name
 #     [HAS_SWIFT_MODULES | DOES_NOT_USE_SWIFT]
 #     [THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY]
+#     [EXPORT_SYMBOLS_WITH_APPLE_LINKER]
 #
 #     [BOOTSTRAPPING 0|1]
 #     [SWIFT_COMPONENT component]
@@ -861,6 +862,9 @@ endmacro()
 # THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
 #   Opt-out of LLVM IR optimizations when linking ThinLTO with ld64
 #
+# EXPORT_SYMBOLS_WITH_APPLE_LINKER
+#   Export symbols when using ld on Apple platforms
+#
 # BOOTSTRAPPING
 #   Bootstrapping stage.
 #
@@ -873,7 +877,7 @@ endmacro()
 # source1 ...
 #   Sources to add into this executable.
 function(add_swift_host_tool executable)
-  set(options HAS_SWIFT_MODULES DOES_NOT_USE_SWIFT THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY)
+  set(options HAS_SWIFT_MODULES DOES_NOT_USE_SWIFT THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY EXPORT_SYMBOLS_WITH_APPLE_LINKER)
   set(single_parameter_options SWIFT_COMPONENT BOOTSTRAPPING)
   set(multiple_parameter_options LLVM_LINK_COMPONENTS)
 
@@ -998,7 +1002,7 @@ function(add_swift_host_tool executable)
     string(CONCAT lto_codegen_only_link_options
       "$<"
         "$<AND:"
-          "$<BOOL:${LLVM_LINKER_IS_LD64}>,"
+          "$<BOOL:${LLVM_LINKER_IS_APPLE}>,"
           "$<BOOL:${SWIFT_TOOLS_LD64_LTO_CODEGEN_ONLY_FOR_SUPPORTING_TARGETS}>,"
           "$<STREQUAL:${SWIFT_TOOLS_ENABLE_LTO},thin>"
         ">:"
@@ -1006,6 +1010,16 @@ function(add_swift_host_tool executable)
       ">")
     target_link_options(${executable} PRIVATE "${lto_codegen_only_link_options}")
   endif()
+
+  string(CONCAT no_exported_symbols_link_option
+  "$<"
+      "$<AND:"
+      "$<BOOL:${LLVM_LINKER_IS_APPLE}>,"
+      "$<NOT:$<BOOL:${ASHT_EXPORT_SYMBOLS_WITH_APPLE_LINKER}>>"
+      ">:"
+      "LINKER:-no_exported_symbols"
+  ">")
+  target_link_options(${executable} PRIVATE "${no_exported_symbols_link_option}")
 
   if(NOT ASHT_SWIFT_COMPONENT STREQUAL "no_component")
     add_dependencies(${ASHT_SWIFT_COMPONENT} ${executable})

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -66,6 +66,7 @@ add_swift_host_tool(swift-frontend
   driver.cpp
   SWIFT_COMPONENT compiler
   HAS_SWIFT_MODULES
+  EXPORT_SYMBOLS_WITH_APPLE_LINKER
 )
 target_link_libraries(swift-frontend
                       PUBLIC

--- a/tools/swift-remoteast-test/CMakeLists.txt
+++ b/tools/swift-remoteast-test/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_host_tool(swift-remoteast-test
   swift-remoteast-test.cpp
   SWIFT_COMPONENT testsuite-tools
   THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY
+  EXPORT_SYMBOLS_WITH_APPLE_LINKER
 )
 target_link_libraries(swift-remoteast-test
                       PRIVATE


### PR DESCRIPTION
This should help reduce the size of the `bin` folder by about 2%.

Executables that do need these symbols for plugins or similar can opt out of this by passing `EXPORT_SYMBOLS_WITH_APPLE_LINKER` to `add_swift_host_tool`  -- for instance that's needed by `swift-frontend` and `swift-remoteast-test`.


Addresses rdar://147888376