### PR TITLE
[stdlib] Consistency tweaks for `Unsafe[Mutable][Raw]BufferPointer`

### DIFF
--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -227,9 +227,7 @@ extension Hasher {
           remaining -= c
         }
       }
-      _internalInvariant(
-        remaining == 0 ||
-        Int(bitPattern: data) & (MemoryLayout<UInt64>.alignment - 1) == 0)
+      _internalInvariant(remaining == 0 || data._isWellAligned(for: UInt64.self))
 
       // Load as many aligned words as there are in the input buffer
       while remaining >= MemoryLayout<UInt64>.size {

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -72,9 +72,8 @@ extension MutableSpan where Element: ~Copyable {
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
   ) {
     _precondition(
-      ((Int(bitPattern: buffer.baseAddress) &
-        (MemoryLayout<Element>.alignment &- 1)) == 0),
-      "baseAddress must be properly aligned to access Element"
+      buffer._isWellAligned(for: Element.self),
+      "buffer must be properly aligned to access Element"
     )
     let ms = unsafe MutableSpan<Element>(_unchecked: buffer)
     self = unsafe _overrideLifetime(ms, borrowing: buffer)
@@ -121,9 +120,8 @@ extension MutableSpan where Element: BitwiseCopyable {
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
     _precondition(
-      ((Int(bitPattern: buffer.baseAddress) &
-        (MemoryLayout<Element>.alignment &- 1)) == 0),
-      "baseAddress must be properly aligned to access Element"
+      buffer._isWellAligned(for: Element.self),
+      "buffer must be properly aligned to access Element"
     )
     let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
     let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -108,14 +108,11 @@ extension Span where Element: ~Copyable {
   public init(
     _unsafeElements buffer: UnsafeBufferPointer<Element>
   ) {
-    //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
-    let baseAddress = unsafe UnsafeRawPointer(buffer.baseAddress)
     _precondition(
-      ((Int(bitPattern: baseAddress) &
-        (MemoryLayout<Element>.alignment &- 1)) == 0),
-      "baseAddress must be properly aligned to access Element"
+      buffer._isWellAligned(for: Element.self),
+      "buffer must be properly aligned to access Element"
     )
-    let span = unsafe Span(_unchecked: baseAddress, count: buffer.count)
+    let span = unsafe Span(_unchecked: buffer.baseAddress, count: buffer.count)
     // As a trivial value, 'baseAddress' does not formally depend on the
     // lifetime of 'buffer'. Make the dependence explicit.
     self = unsafe _overrideLifetime(span, borrowing: buffer)
@@ -237,19 +234,16 @@ extension Span where Element: BitwiseCopyable {
   public init(
     _unsafeBytes buffer: UnsafeRawBufferPointer
   ) {
-    //FIXME: Workaround for https://github.com/swiftlang/swift/issues/77235
-    let baseAddress = buffer.baseAddress
     _precondition(
-      ((Int(bitPattern: baseAddress) &
-        (MemoryLayout<Element>.alignment &- 1)) == 0),
-      "baseAddress must be properly aligned to access Element"
+      buffer._isWellAligned(for: Element.self),
+      "buffer must be properly aligned to access Element"
     )
     let (byteCount, stride) = (buffer.count, MemoryLayout<Element>.stride)
     let (count, remainder) = byteCount.quotientAndRemainder(dividingBy: stride)
     _precondition(
       remainder == 0, "Span must contain a whole number of elements"
     )
-    let span = unsafe Span(_unchecked: baseAddress, count: count)
+    let span = unsafe Span(_unchecked: buffer.baseAddress, count: count)
     // As a trivial value, 'baseAddress' does not formally depend on the
     // lifetime of 'buffer'. Make the dependence explicit.
     self = unsafe _overrideLifetime(span, borrowing: buffer)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -780,6 +780,22 @@ extension Unsafe${Mutable}BufferPointer:
 %  end
 }
 
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
+  @safe
+  @_alwaysEmitIntoClient
+  public func _isWellAligned() -> Bool {
+    guard let p = baseAddress else { return true }
+    return p._isWellAligned()
+  }
+
+  @safe
+  @_alwaysEmitIntoClient
+  public func _isWellAligned<T: ~Copyable>(for: T.Type) -> Bool {
+    guard let p = baseAddress else { return true }
+    return p._isWellAligned(for: T.self)
+  }
+}
+
 extension Unsafe${Mutable}BufferPointer {
 %  if not Mutable:
   /// Creates a buffer over the same memory as the given buffer slice.
@@ -1404,7 +1420,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
     }
 
     _debugPrecondition(
-      unsafe Int(bitPattern: .init(base)) & (MemoryLayout<T>.alignment-1) == 0,
+      _isWellAligned(for: T.self),
       "baseAddress must be a properly aligned pointer for types Element and T"
     )
 

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -410,6 +410,19 @@ extension UnsafePointer where Pointee: ~Copyable {
       ),
       "self must be a properly aligned pointer for types Pointee and T"
     )
+    return try unsafe _uncheckedWithMemoryRebound(
+      to: type, capacity: count, body)
+  }
+
+  @_alwaysEmitIntoClient
+  @_transparent
+  internal func _uncheckedWithMemoryRebound<
+    T: ~Copyable, E: Error, Result: ~Copyable
+  >(
+    to type: T.Type,
+    capacity count: Int,
+    _ body: (_ pointer: UnsafePointer<T>) throws(E) -> Result
+  ) throws(E) -> Result {
     let binding = Builtin.bindMemory(_rawValue, count._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(_rawValue, binding) }
     return try unsafe body(.init(_rawValue))

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -100,6 +100,19 @@ public struct Unsafe${Mutable}RawBufferPointer {
   @usableFromInline
   internal let _position, _end: Unsafe${Mutable}RawPointer?
 
+  // This works around _debugPrecondition() impacting the performance of
+  // optimized code. (rdar://72246338)
+  @_alwaysEmitIntoClient
+  internal init(
+    @_nonEphemeral _uncheckedStart start: Unsafe${Mutable}RawPointer?,
+    count: Int
+  ) {
+    _internalInvariant(count >= 0)
+    _internalInvariant(unsafe count == 0 || start != nil)
+    unsafe _position = start
+    unsafe _end = start.map { unsafe $0 + _assumeNonNegative(count) }
+  }
+
   /// Creates a buffer over the specified number of contiguous bytes starting
   /// at the given pointer.
   ///
@@ -116,9 +129,14 @@ public struct Unsafe${Mutable}RawBufferPointer {
     _debugPrecondition(count >= 0, "${Self} with negative count")
     _debugPrecondition(unsafe count == 0 || start != nil,
       "${Self} has a nil start and nonzero count")
+    unsafe self.init(_uncheckedStart: start, count: count)
+  }
 
-    unsafe _position = start
-    unsafe _end = start.map { unsafe $0 + _assumeNonNegative(count) }
+  @safe
+  @_alwaysEmitIntoClient
+  public init(_empty: ()) {
+    unsafe _position = nil
+    unsafe _end = nil
   }
 }
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -834,7 +834,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }  
 
     _debugPrecondition(
-      Int(bitPattern: base) & (MemoryLayout<S.Element>.alignment-1) == 0,
+      _isWellAligned(for: S.Element.self),
       "buffer base address must be properly aligned to access S.Element"
     )
 
@@ -893,7 +893,7 @@ extension Unsafe${Mutable}RawBufferPointer {
         return unsafe .init(start: nil, count: 0)
       }
       _debugPrecondition(
-        Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
+        _isWellAligned(for: C.Element.self),
         "buffer base address must be properly aligned to access C.Element"
       )
       _precondition(
@@ -918,7 +918,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }
     _internalInvariant(unsafe _end != nil)
     _debugPrecondition(
-      Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
+      _isWellAligned(for: C.Element.self),
       "buffer base address must be properly aligned to access C.Element"
     )
     var iterator = source.makeIterator()
@@ -979,7 +979,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       return unsafe .init(start: nil, count: 0)
     }
     _debugPrecondition(
-      Int(bitPattern: baseAddress) & (MemoryLayout<T>.alignment-1) == 0,
+      _isWellAligned(for: T.self),
       "buffer base address must be properly aligned to access T"
     )
     _precondition(
@@ -1121,7 +1121,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       return try unsafe body(.init(start: nil, count: 0))
     }
     _debugPrecondition(
-      Int(bitPattern: s) & (MemoryLayout<T>.alignment-1) == 0,
+      _isWellAligned(for: T.self),
       "baseAddress must be a properly aligned pointer for type T"
     )
     // initializer ensures _end is nil only when _position is nil.
@@ -1131,6 +1131,13 @@ extension Unsafe${Mutable}RawBufferPointer {
     let binding = Builtin.bindMemory(s._rawValue, n._builtinWordValue, T.self)
     defer { Builtin.rebindMemory(s._rawValue, binding) }
     return try unsafe body(.init(start: .init(s._rawValue), count: n))
+  }
+
+  @safe
+  @_alwaysEmitIntoClient
+  public func _isWellAligned<T: ~Copyable>(for type: T.Type) -> Bool {
+    guard let s = baseAddress else { return true }
+    return s._isWellAligned(for: T.self)
   }
 
   /// Returns a typed buffer to the memory referenced by this buffer,


### PR DESCRIPTION
These are tweaks to `UnsafeBufferPointer` we noticed were missing and/or inconsistently applied while implementing `Span` and `OutputSpan`.