### PR TITLE
Finish implementing `@abi` (SE-0476)

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -861,7 +861,6 @@ DECL_ATTR(abi, ABI,
   OnConstructor | OnFunc | OnSubscript | OnVar,
   LongAttribute | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   165)
-DECL_ATTR_FEATURE_REQUIREMENT(ABI, ABIAttribute)
 
 // Unused '166': Used to be `@execution(caller | concurrent)` replaced with `@concurrent` and `nonisolated(nonsending)`
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8481,14 +8481,10 @@ ERROR(attr_abi_mismatched_async,none,
       "cannot give %0 the ABI of %select{a non-async|an async}1 %kindonly0",
       (Decl *, /*abiIsAsync=*/bool))
 
-ERROR(attr_abi_mismatched_pbd_size,none,
-      "cannot give pattern binding the ABI of a binding with "
-      "%select{more|fewer}0 patterns",
-      (/*abiHasExtra=*/bool))
-
-ERROR(attr_abi_mismatched_var,none,
-      "no match for %select{%kind0 in the ABI|ABI %kind0}1",
-      (Decl *, /*isABI=*/bool))
+ERROR(attr_abi_multiple_vars,none,
+      "'abi' attribute can only be applied to a single %0; declare each "
+      "%0 separately",
+      (DescriptiveDeclKind))
 
 ERROR(attr_abi_incompatible_with_silgen_name,none,
       "cannot use '@_silgen_name' and '@abi' on the same %kindonly0 because "

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -258,6 +258,7 @@ LANGUAGE_FEATURE(AsyncExecutionBehaviorAttributes, 0, "@concurrent and nonisolat
 LANGUAGE_FEATURE(IsolatedConformances, 407, "Global-actor isolated conformances")
 LANGUAGE_FEATURE(ValueGenericsNameLookup, 452, "Value generics appearing as static members for namelookup")
 LANGUAGE_FEATURE(GeneralizedIsSameMetaTypeBuiltin, 465, "Builtin.is_same_metatype with support for noncopyable/nonescapable types")
+SUPPRESSIBLE_LANGUAGE_FEATURE(ABIAttributeSE0479, 479, "@abi attribute on functions, initializers, properties, and subscripts")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -482,9 +483,6 @@ EXPERIMENTAL_FEATURE(CoroutineAccessorsUnwindOnCallerError, false)
 
 EXPERIMENTAL_FEATURE(AddressableParameters, true)
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(AddressableTypes, true)
-
-/// Allow the @abi attribute.
-SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ABIAttribute, true)
 
 /// Allow custom availability domains to be defined and referenced.
 EXPERIMENTAL_FEATURE(CustomAvailability, true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3283,8 +3283,8 @@ suppressingFeatureCoroutineAccessors(PrintOptions &options,
 }
 
 static void
-suppressingFeatureABIAttribute(PrintOptions &options,
-                               llvm::function_ref<void()> action) {
+suppressingFeatureABIAttributeSE0479(PrintOptions &options,
+                                     llvm::function_ref<void()> action) {
   llvm::SaveAndRestore<bool> scope1(options.PrintSyntheticSILGenName, true);
   ExcludeAttrRAII scope2(options.ExcludeAttrList, DeclAttrKind::ABI);
   action();

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -387,7 +387,7 @@ static ABIAttr *getABIAttr(Decl *decl) {
   return decl->getAttrs().getAttribute<ABIAttr>();
 }
 
-static bool usesFeatureABIAttribute(Decl *decl) {
+static bool usesFeatureABIAttributeSE0479(Decl *decl) {
   return getABIAttr(decl) != nullptr;
 }
 

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -75,7 +75,6 @@ extension Parser.ExperimentalFeatures {
     mapFeature(.NonescapableTypes, to: .nonescapableTypes)
     mapFeature(.TrailingComma, to: .trailingComma)
     mapFeature(.CoroutineAccessors, to: .coroutineAccessors)
-    mapFeature(.ABIAttribute, to: .abiAttribute)
     mapFeature(.OldOwnershipOperatorSpellings, to: .oldOwnershipOperatorSpellings)
     mapFeature(.KeyPathWithMethodMembers, to: .keypathWithMethodMembers)
     mapFeature(.InlineArrayTypeSugar, to: .inlineArrayTypeSugar)

--- a/lib/Sema/TypeCheckAttrABI.cpp
+++ b/lib/Sema/TypeCheckAttrABI.cpp
@@ -1102,59 +1102,28 @@ public:
 };
 
 void checkABIAttrPBD(PatternBindingDecl *APBD, VarDecl *VD) {
-  auto &diags = VD->getASTContext().Diags;
   auto PBD = VD->getParentPatternBinding();
 
-  // To make sure we only diagnose this stuff once, check that VD is the first
-  // anchoring variable in the PBD.
-  bool isFirstAnchor = false;
+  Decl *anchorVD = nullptr;
   for (auto i : range(PBD->getNumPatternEntries())) {
-    auto anchorVD = PBD->getAnchoringVarDecl(i);
-    if (anchorVD) {
-      isFirstAnchor = (anchorVD == VD);
+    anchorVD = PBD->getAnchoringVarDecl(i);
+    if (anchorVD)
       break;
-    }
   }
 
-  if (!isFirstAnchor)
+  // To make sure we only diagnose this stuff once, check that VD is the
+  // first anchoring variable in the PBD.
+  if (anchorVD != VD)
     return;
 
-  // Check that the PBDs have the same number of patterns.
-  if (PBD->getNumPatternEntries() < APBD->getNumPatternEntries()) {
-    diags.diagnose(APBD->getPattern(PBD->getNumPatternEntries())->getLoc(),
-                   diag::attr_abi_mismatched_pbd_size, /*abiHasExtra=*/false);
+  // In the final approved feature, we only permit single-variable patterns.
+  // (However, the rest of the compiler tolerates them.)
+  if (!PBD->getSingleVar() || !APBD->getSingleVar()) {
+    PBD->diagnose(diag::attr_abi_multiple_vars,
+                  anchorVD ? anchorVD->getDescriptiveKind()
+                           : PBD->getDescriptiveKind());
     return;
   }
-  if (PBD->getNumPatternEntries() > APBD->getNumPatternEntries()) {
-    diags.diagnose(PBD->getPattern(APBD->getNumPatternEntries())->getLoc(),
-                   diag::attr_abi_mismatched_pbd_size, /*abiHasExtra=*/true);
-    return;
-  }
-
-  // Check that each pattern has the same number of variables.
-  bool didDiagnose = false;
-  for (auto i : range(PBD->getNumPatternEntries())) {
-    SmallVector<VarDecl *, 8> VDs;
-    SmallVector<VarDecl *, 8> AVDs;
-
-    PBD->getPattern(i)->collectVariables(VDs);
-    APBD->getPattern(i)->collectVariables(AVDs);
-
-    if (VDs.size() < AVDs.size()) {
-      for (auto AVD : drop_begin(AVDs, VDs.size())) {
-        AVD->diagnose(diag::attr_abi_mismatched_var, AVD, /*isABI=*/true);
-        didDiagnose = true;
-      }
-    }
-    else if (VDs.size() > AVDs.size()) {
-      for (auto VD : drop_begin(VDs, AVDs.size())) {
-        VD->diagnose(diag::attr_abi_mismatched_var, VD, /*isABI=*/false);
-        didDiagnose = true;
-      }
-    }
-  }
-  if (didDiagnose)
-    return;
 
   // Check the ABI PBD--this is what checks the underlying vars.
   TypeChecker::typeCheckDecl(APBD);

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend-dump-parse \
-// RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature RawLayout \
@@ -12,7 +11,6 @@
 // RUN:   | %sanitize-address > %t/astgen.ast
 
 // RUN: %target-swift-frontend-dump-parse \
-// RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature RawLayout \
@@ -26,7 +24,6 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -module-abi-name ASTGen \
 // RUN:   -enable-experimental-feature ParserASTGen \
-// RUN:   -enable-experimental-feature ABIAttribute \
 // RUN:   -enable-experimental-feature Extern \
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature RawLayout \
@@ -38,7 +35,6 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_ParserASTGen
-// REQUIRES: swift_feature_ABIAttribute
 // REQUIRES: swift_feature_Extern
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_RawLayout

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -19,6 +19,11 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_INDEPENDENT_2 | %FileCheck %s -check-prefix=KEYWORD_LAST
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=KEYWORD_LAST | %FileCheck %s -check-prefix=KEYWORD_LAST
 
+// NOTE: If you want to test code completion for an experimental feature, please
+// put your tests in complete_decl_attribute_feature_requirement.swift, not
+// here. That file has the infrastructure to test that completions are not
+// offered when the feature is disabled.
+
 struct MyStruct {}
 
 @propertyWrapper
@@ -112,6 +117,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD2-NEXT:             Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
 // KEYWORD2-NEXT:             Keyword/None:                       backDeployed[#Func Attribute#]; name=backDeployed
 // KEYWORD2-NEXT:             Keyword/None:                       lifetime[#Func Attribute#]; name=lifetime
+// KEYWORD2-NEXT:             Keyword/None:                       abi[#Func Attribute#]; name=abi{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       concurrent[#Func Attribute#]; name=concurrent
 // KEYWORD2-NOT:              Keyword
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
@@ -169,6 +175,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD5-NEXT:             Keyword/None:                       preconcurrency[#Struct Attribute#]; name=preconcurrency
 
 @#^ON_GLOBALVAR^# var globalVar
+// ON_GLOBALVAR-DAG: Keyword/None:                       abi[#Var Attribute#]; name=abi
 // ON_GLOBALVAR-DAG: Keyword/None:                       available[#Var Attribute#]; name=available
 // ON_GLOBALVAR-DAG: Keyword/None:                       objc[#Var Attribute#]; name=objc
 // ON_GLOBALVAR-DAG: Keyword/None:                       NSCopying[#Var Attribute#]; name=NSCopying
@@ -197,6 +204,7 @@ actor MyGenericGlobalActor<T> {
 
 struct _S {
   @#^ON_INIT^# init()
+// ON_INIT-DAG: Keyword/None:                       abi[#Constructor Attribute#]; name=abi
 // ON_INIT-DAG: Keyword/None:                       available[#Constructor Attribute#]; name=available
 // ON_INIT-DAG: Keyword/None:                       objc[#Constructor Attribute#]; name=objc
 // ON_INIT-DAG: Keyword/None:                       inline[#Constructor Attribute#]; name=inline
@@ -207,6 +215,7 @@ struct _S {
 // ON_INIT-DAG: Keyword/None:                       preconcurrency[#Constructor Attribute#]; name=preconcurrency
 
   @#^ON_PROPERTY^# var foo
+// ON_PROPERTY-DAG: Keyword/None:                       abi[#Var Attribute#]; name=abi
 // ON_PROPERTY-DAG: Keyword/None:                       available[#Var Attribute#]; name=available
 // ON_PROPERTY-DAG: Keyword/None:                       objc[#Var Attribute#]; name=objc
 // ON_PROPERTY-DAG: Keyword/None:                       NSCopying[#Var Attribute#]; name=NSCopying
@@ -234,8 +243,12 @@ struct _S {
 // ON_PROPERTY-DAG: Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGenericGlobalActor[#Global Actor#]; name=MyGenericGlobalActor
 // ON_PROPERTY-NOT: Decl[PrecedenceGroup]
 
+  @#^ON_SUBSCR^# subscript
+// ON_SUBSCR-DAG:  Keyword/None:                        abi[#Declaration Attribute#]; name=abi
+
   @#^ON_METHOD^# private
   func foo()
+// ON_METHOD-DAG: Keyword/None:                       abi[#Func Attribute#]; name=abi
 // ON_METHOD-DAG: Keyword/None:                       available[#Func Attribute#]; name=available
 // ON_METHOD-DAG: Keyword/None:                       objc[#Func Attribute#]; name=objc
 // ON_METHOD-DAG: Keyword/None:                       IBAction[#Func Attribute#]; name=IBAction
@@ -293,6 +306,7 @@ struct _S {
 
 
   @#^ON_MEMBER_LAST^#
+// ON_MEMBER_LAST-DAG: Keyword/None:                       abi[#Declaration Attribute#]; name=abi
 // ON_MEMBER_LAST-DAG: Keyword/None:                       available[#Declaration Attribute#]; name=available
 // ON_MEMBER_LAST-DAG: Keyword/None:                       objc[#Declaration Attribute#]; name=objc
 // ON_MEMBER_LAST-DAG: Keyword/None:                       dynamicCallable[#Declaration Attribute#]; name=dynamicCallable
@@ -347,6 +361,8 @@ func takeClosure(_: () -> Void) {
     print("x")
   }
 }
+// FIXME: Not valid in this position (but CompletionLookup can't tell that)
+// IN_CLOSURE-DAG:  Keyword/None:              abi[#Declaration Attribute#]; name=abi
 // FIXME: We should mark MyPropertyWrapper and MyResultBuilder as Unrelated
 // IN_CLOSURE-DAG: Decl[Struct]/CurrModule: MyStruct[#MyStruct#]; name=MyStruct
 // IN_CLOSURE-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#Property Wrapper#]; name=MyPropertyWrapper
@@ -365,6 +381,7 @@ func dummy2() {}
 
 @#^KEYWORD_LAST^#
 
+// KEYWORD_LAST-DAG: Keyword/None:                       abi[#Declaration Attribute#]; name=abi
 // KEYWORD_LAST-DAG: Keyword/None:                       available[#Declaration Attribute#]; name=available{{$}}
 // KEYWORD_LAST-DAG: Keyword/None:                       freestanding[#Declaration Attribute#]; name=freestanding{{$}}
 // KEYWORD_LAST-DAG: Keyword/None:                       objc[#Declaration Attribute#]; name=objc{{$}}

--- a/test/IDE/complete_decl_attribute_feature_requirement.swift
+++ b/test/IDE/complete_decl_attribute_feature_requirement.swift
@@ -3,6 +3,11 @@
 // it's enabled. When a feature becomes non-experimental, move its test cases
 // into the normal complete_decl_attribute.swift test file.
 
+// NOTE: There are currently no experimental features that need code completion
+// testing, but this test file is being left in place for when it's needed
+// again. At that time, please remove the ABIAttribute tests.
+// REQUIRES: new_use_case
+
 // REQUIRES: asserts
 
 // RUN: %batch-code-completion -filecheck-additional-suffix _DISABLED

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -1,9 +1,8 @@
-// RUN: %target-swift-frontend -enable-experimental-feature ABIAttribute %s -emit-ir > %t.ir
+// RUN: %target-swift-frontend %s -emit-ir > %t.ir
 // RUN: %FileCheck --input-file %t.ir %s
 // RUN: %FileCheck --check-prefix NEGATIVE --input-file %t.ir %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64 || CPU=arm64
-// REQUIRES: swift_feature_ABIAttribute
 
 // Non-Swift _silgen_name definitions
 

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -1,23 +1,24 @@
 // REQUIRES: swift_swift_parser, executable_test
+// REQUIRES: swift_feature_ABIAttribute
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
 
 // Diagnostics testing
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -enable-experimental-feature ABIAttribute
 
 // Diagnostics testing by importing macros from a module
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/freestanding_macro_library.swiftmodule %S/Inputs/freestanding_macro_library.swift -module-name freestanding_macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/freestanding_macro_library_2.swiftmodule %S/Inputs/freestanding_macro_library_2.swift -module-name freestanding_macro_library_2 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %t
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -I %t -DIMPORT_MACRO_LIBRARY
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -I %t -DIMPORT_MACRO_LIBRARY -enable-experimental-feature ABIAttribute
 
-// RUN: not %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics -Rmacro-loading > %t/macro-printing.txt
+// RUN: not %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics -Rmacro-loading > %t/macro-printing.txt -enable-experimental-feature ABIAttribute
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK-DIAGS -dump-input=always %s
 
 // RUN: %FileCheck %s  --check-prefix CHECK-MACRO-PRINTED < %t/macro-printing.txt
 
-// RUN: not %target-swift-frontend -swift-version 5 -typecheck -diagnostic-style=swift -load-plugin-library %t/%target-library-name(MacroDefinition)  -module-name MacroUser -DTEST_DIAGNOSTICS %s > %t/pretty-macro-diagnostics.txt 2>&1
+// RUN: not %target-swift-frontend -swift-version 5 -typecheck -diagnostic-style=swift -load-plugin-library %t/%target-library-name(MacroDefinition)  -module-name MacroUser -DTEST_DIAGNOSTICS %s -enable-experimental-feature ABIAttribute > %t/pretty-macro-diagnostics.txt 2>&1
 // RUN: %FileCheck %s --check-prefix PRETTY-DIAGS < %t/pretty-macro-diagnostics.txt
 
 // Debug info SIL testing
@@ -718,6 +719,29 @@ func testPropertyWrapperMacro() {
   #hasPropertyWrapperParam(x: 0)
   #hasPropertyWrapperParam($x: .init(wrappedValue: 0))
 }
+
+#if swift(>=1.0) && TEST_DIAGNOSTICS
+// Test that macros can't be used in @abi
+
+struct ABIAttrWithFreestandingMacro1 {
+  // expected-error@+1 {{cannot use pound literal in '@abi'}}
+  @abi(#varValue)
+  #varValue
+  // expected-note@-1 {{in expansion of macro 'varValue' here}}
+}
+
+struct ABIAttrWithFreestandingMacro2 {
+  // expected-error@+1 {{cannot use pound literal in '@abi'}}
+  @abi(#varValue)
+  var value: Int { 0 }
+}
+
+struct ABIAttrWithFreestandingMacro3 {
+  @abi(var value: Int)
+  #varValue
+}
+
+#endif
 
 #if TEST_DIAGNOSTICS
 @freestanding(expression)

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -1,24 +1,23 @@
 // REQUIRES: swift_swift_parser, executable_test
-// REQUIRES: swift_feature_ABIAttribute
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
 
 // Diagnostics testing
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -enable-experimental-feature ABIAttribute
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS
 
 // Diagnostics testing by importing macros from a module
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/freestanding_macro_library.swiftmodule %S/Inputs/freestanding_macro_library.swift -module-name freestanding_macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/freestanding_macro_library_2.swiftmodule %S/Inputs/freestanding_macro_library_2.swift -module-name freestanding_macro_library_2 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %t
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -I %t -DIMPORT_MACRO_LIBRARY -enable-experimental-feature ABIAttribute
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -I %t -DIMPORT_MACRO_LIBRARY
 
-// RUN: not %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics -Rmacro-loading > %t/macro-printing.txt -enable-experimental-feature ABIAttribute
+// RUN: not %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics -Rmacro-loading > %t/macro-printing.txt
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK-DIAGS -dump-input=always %s
 
 // RUN: %FileCheck %s  --check-prefix CHECK-MACRO-PRINTED < %t/macro-printing.txt
 
-// RUN: not %target-swift-frontend -swift-version 5 -typecheck -diagnostic-style=swift -load-plugin-library %t/%target-library-name(MacroDefinition)  -module-name MacroUser -DTEST_DIAGNOSTICS %s -enable-experimental-feature ABIAttribute > %t/pretty-macro-diagnostics.txt 2>&1
+// RUN: not %target-swift-frontend -swift-version 5 -typecheck -diagnostic-style=swift -load-plugin-library %t/%target-library-name(MacroDefinition)  -module-name MacroUser -DTEST_DIAGNOSTICS %s > %t/pretty-macro-diagnostics.txt 2>&1
 // RUN: %FileCheck %s --check-prefix PRETTY-DIAGS < %t/pretty-macro-diagnostics.txt
 
 // Debug info SIL testing

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -1,5 +1,4 @@
 // REQUIRES: swift_swift_parser, executable_test
-// REQUIRES: swift_feature_ABIAttribute
 
 // For _Concurrency.
 // UNSUPPORTED: use_os_stdlib
@@ -7,12 +6,12 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -parse-as-library -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -enable-experimental-feature ABIAttribute -DTEST_DIAGNOSTICS
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DTEST_DIAGNOSTICS
 
 // Check with the imported macro library vs. the local declaration of the macro.
 // RUN: %target-swift-frontend -swift-version 5 -emit-module -o %t/macro_library.swiftmodule %S/Inputs/macro_library.swift -module-name macro_library -load-plugin-library %t/%target-library-name(MacroDefinition)
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t -enable-experimental-feature ABIAttribute -DTEST_DIAGNOSTICS
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -disable-availability-checking -DIMPORT_MACRO_LIBRARY -I %t -DTEST_DIAGNOSTICS
 
 
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library %s -disable-availability-checking -dump-macro-expansions > %t/expansions-dump.txt 2>&1

--- a/test/ModuleInterface/attrs.swift
+++ b/test/ModuleInterface/attrs.swift
@@ -1,14 +1,11 @@
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name attrs \
-// RUN:  -emit-private-module-interface-path %t.private.swiftinterface \
-// RUN:  -enable-experimental-feature ABIAttribute
+// RUN:  -emit-private-module-interface-path %t.private.swiftinterface
 
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs
 // RUN: %target-swift-typecheck-module-from-interface(%t.private.swiftinterface) -module-name attrs
 
 // RUN: %FileCheck %s --check-prefixes CHECK,PUBLIC-CHECK --input-file %t.swiftinterface
 // RUN: %FileCheck %s --check-prefixes CHECK,PRIVATE-CHECK --input-file %t.private.swiftinterface
-
-// REQUIRES: swift_feature_ABIAttribute
 
 // CHECK: @_transparent public func glass() -> Swift.Int { return 0 }{{$}}
 @_transparent public func glass() -> Int { return 0 }
@@ -38,7 +35,7 @@ internal func __specialize_someGenericFunction<T>(_ t: T) -> Int {
 
 @abi(func __abi__abiAttrOnFunction(param: Int))
 public func abiAttrOnFunction(param: Int) {}
-// CHECK: #if {{.*}} $ABIAttribute
+// CHECK: #if {{.*}} $ABIAttributeSE0479
 // CHECK: @abi(func __abi__abiAttrOnFunction(param: Swift.Int))
 // CHECK: public func abiAttrOnFunction(param: Swift.Int)
 // CHECK: #else
@@ -48,7 +45,7 @@ public func abiAttrOnFunction(param: Int) {}
 
 @abi(let __abi__abiAttrOnVar: Int)
 public var abiAttrOnVar: Int = 42
-// CHECK: #if {{.*}} $ABIAttribute
+// CHECK: #if {{.*}} $ABIAttributeSE0479
 // CHECK: @abi(var __abi__abiAttrOnVar: Swift.Int)
 // CHECK: public var abiAttrOnVar: Swift.Int
 // CHECK: #else
@@ -57,7 +54,7 @@ public var abiAttrOnVar: Int = 42
 // CHECK: #endif
 
 public struct MutatingTest {
-  // CHECK: #if {{.*}} $ABIAttribute
+  // CHECK: #if {{.*}} $ABIAttributeSE0479
   // CHECK: @abi(mutating func abiMutFunc())
   // CHECK: public mutating func abiMutFunc()
   // CHECK: #else
@@ -68,14 +65,14 @@ public struct MutatingTest {
   public mutating func abiMutFunc() {}
 }
 
-// PUBLIC-CHECK-NOT: #if {{.*}} $ABIAttribute
+// PUBLIC-CHECK-NOT: #if {{.*}} $ABIAttributeSE0479
 // PUBLIC-CHECK-NOT: @abi(func abiSpiFunc())
 // PUBLIC-CHECK-NOT: public func abiSpiFunc()
 // PUBLIC-CHECK-NOT: #else
 // PUBLIC-CHECK-NOT: @_silgen_name("$s5attrs10abiSpiFuncyyF")
 // PUBLIC-CHECK-NOT: public func abiSpiFunc()
 // PUBLIC-CHECK-NOT: #endif
-// PRIVATE-CHECK: #if {{.*}} $ABIAttribute
+// PRIVATE-CHECK: #if {{.*}} $ABIAttributeSE0479
 // PRIVATE-CHECK: @abi(func abiSpiFunc())
 // PRIVATE-CHECK: public func abiSpiFunc()
 // PRIVATE-CHECK: #else
@@ -88,7 +85,7 @@ public struct MutatingTest {
 // We should print feature guards outside, but not inside, an @abi attribute.
 @abi(func sendingABI() -> sending Any?)
 public func sendingABI() -> Any? { nil }
-// CHECK: #if {{.*}} && $ABIAttribute
+// CHECK: #if {{.*}} && $ABIAttributeSE0479
 // CHECK: @abi(func sendingABI() -> sending Any?)
 // CHECK: public func sendingABI() -> Any?
 // CHECK: #elseif {{.*}} && $SendingArgsAndResults

--- a/test/ModuleInterface/attrs_objc.swift
+++ b/test/ModuleInterface/attrs_objc.swift
@@ -1,19 +1,17 @@
 // RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s \
-// RUN:  -enable-objc-interop -module-name attrs_objc \
-// RUN:  -enable-experimental-feature ABIAttribute
+// RUN:  -enable-objc-interop -module-name attrs_objc
 
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name attrs_objc
 
 // RUN: %FileCheck %s --input-file %t.swiftinterface
 
 // REQUIRES: objc_interop
-// REQUIRES: swift_feature_ABIAttribute
 
 import Foundation
 
 @objcMembers
 public class ObjCTest: NSObject {
-  // CHECK: #if {{.*}} $ABIAttribute
+  // CHECK: #if {{.*}} $ABIAttributeSE0479
   // CHECK: @abi(func abiObjCFunc())
   // CHECK: @objc public func abiObjCFunc()
   // CHECK: #else
@@ -23,7 +21,7 @@ public class ObjCTest: NSObject {
   @abi(func abiObjCFunc())
   @objc public func abiObjCFunc() {}
 
-  // CHECK: #if {{.*}} $ABIAttribute
+  // CHECK: #if {{.*}} $ABIAttributeSE0479
   // CHECK: @abi(func abiImplicitObjCFunc())
   // CHECK: @objc public func abiImplicitObjCFunc()
   // CHECK: #else
@@ -33,7 +31,7 @@ public class ObjCTest: NSObject {
   @abi(func abiImplicitObjCFunc())
   public func abiImplicitObjCFunc() {}
 
-  // CHECK: #if {{.*}} $ABIAttribute
+  // CHECK: #if {{.*}} $ABIAttributeSE0479
   // CHECK: @abi(func abiIBActionFunc(_: Any))
   // CHECK: @objc @IBAction @_Concurrency.MainActor @preconcurrency public func abiIBActionFunc(_: Any)
   // CHECK: #else

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -279,17 +279,20 @@ var async11Var: Int { get async { fatalError() } }
 // PBD shape checking
 //
 
-@abi(var x1, y1: Int) // expected-error {{cannot give pattern binding the ABI of a binding with more patterns}}
-var x1: Int = 0
+@abi(var x1, y1: Int)
+var x1: Int = 0 // expected-error {{'abi' attribute can only be applied to a single var; declare each var separately}}
 
 @abi(var x2: Int)
-var x2 = 0, y2: Int = 0 // expected-error {{cannot give pattern binding the ABI of a binding with fewer patterns}}
+var x2 = 0, y2: Int = 0 // expected-error {{'abi' attribute can only be applied to a single var; declare each var separately}}
 
-@abi(var (x3, y3): (Int, Int), (a3, b3): (Int, Int)) // expected-error {{no match for ABI var 'b3'}}
-var (x3, y3): (Int, Int) = (0, 0), a3: Int = 0
+@abi(var (x3, y3): (Int, Int), (a3, b3): (Int, Int))
+var (x3, y3): (Int, Int) = (0, 0), a3: Int = 0 // expected-error {{'abi' attribute can only be applied to a single var; declare each var separately}}
 
 @abi(var (x4, y4): (Int, Int), a4: Int)
-var (x4, y4): (Int, Int) = (0, 0), (a4, b4): (Int, Int) = (0, 0) // expected-error {{no match for var 'b4' in the ABI}}
+var (x4, y4): (Int, Int) = (0, 0), (a4, b4): (Int, Int) = (0, 0) // expected-error {{'abi' attribute can only be applied to a single var; declare each var separately}}
+
+@abi(var x5: Int)
+var x5: Int = 0
 
 //
 // Redeclaration diagnostics

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -enable-experimental-feature ABIAttribute -enable-experimental-feature AddressableParameters -enable-experimental-feature NoImplicitCopy -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature StrictMemorySafety -enable-experimental-feature LifetimeDependence -enable-experimental-feature CImplementation -import-bridging-header %S/Inputs/attr_abi.h -parse-as-library -debugger-support
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -enable-experimental-feature AddressableParameters -enable-experimental-feature NoImplicitCopy -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature StrictMemorySafety -enable-experimental-feature LifetimeDependence -enable-experimental-feature CImplementation -import-bridging-header %S/Inputs/attr_abi.h -parse-as-library -debugger-support
 
-// REQUIRES: swift_feature_ABIAttribute
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_CImplementation
 // REQUIRES: swift_feature_Extern

--- a/test/attr/attr_abi_objc.swift
+++ b/test/attr/attr_abi_objc.swift
@@ -1,6 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ABIAttribute -parse-as-library
+// RUN: %target-typecheck-verify-swift -parse-as-library
 
-// REQUIRES: swift_feature_ABIAttribute
 // REQUIRES: objc_interop
 
 import Foundation

--- a/test/attr/attr_weaklinked.swift
+++ b/test/attr/attr_weaklinked.swift
@@ -1,7 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature ABIAttribute
+// RUN: %target-typecheck-verify-swift
 
 // UNSUPPORTED: OS=windows-msvc
-// REQUIRES: swift_feature_ABIAttribute
 
 @_weakLinked public func f() { }
 

--- a/test/attr/feature_requirement.swift
+++ b/test/attr/feature_requirement.swift
@@ -1,19 +1,10 @@
 // RUN: %target-typecheck-verify-swift -parse-as-library -disable-experimental-parser-round-trip -verify-additional-prefix disabled-
-// RUN: %target-typecheck-verify-swift -parse-as-library -verify-additional-prefix enabled- -enable-experimental-feature ABIAttribute -enable-experimental-feature ExtensibleAttribute
+// RUN: %target-typecheck-verify-swift -parse-as-library -verify-additional-prefix enabled- -enable-experimental-feature ExtensibleAttribute
 
 // REQUIRES: asserts
 
 // This test checks whether DECL_ATTR_FEATURE_REQUIREMENT is being applied correctly.
 // It is expected to need occasional edits as experimental features are stabilized.
-
-@abi(func fn())
-func fn() {}  // expected-disabled-error@-1 {{'abi' attribute is only valid when experimental feature ABIAttribute is enabled}}
-
-#if hasAttribute(abi)
-  #error("does have @abi")  // expected-enabled-error {{does have @abi}}
-#else
-  #error("doesn't have @abi")  // expected-disabled-error {{doesn't have @abi}}
-#endif
 
 @extensible
 public enum E {}  // expected-disabled-error@-1 {{'extensible' attribute is only valid when experimental feature ExtensibleAttribute is enabled}}


### PR DESCRIPTION
This PR contains the last few changes to officially implement `@abi` as a supported feature:

* Adds some macro tests that haven't landed yet.
* Restricts `@abi` to PatternBindingDecls with a single variable, per review feedback.
* Makes `@abi` a supported feature:
    * Changes the feature name from `ABIAttribute` to `ABIAttributeSE0476` to defend against condfails.
    * Removes ASTGen mapping to experimental SwiftSyntax feature.

This change requires a matching SwiftSyntax PR to make the syntax nodes no longer experimental: https://github.com/swiftlang/swift-syntax/pull/3065

Resolves rdar://150065196.