### PR TITLE
[AST] Temporarily turn off an assert on empty scopeLifetimeParamIndices

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -220,13 +220,16 @@ public:
         targetIndex(targetIndex) {
     assert(this->isImmortal() || inheritLifetimeParamIndices ||
            scopeLifetimeParamIndices);
-    // FIXME: This assert can trigger when Optional/Result support ~Escapable use (rdar://147765187)
+    // FIXME: These asserts can trigger when Optional/Result support ~Escapable use (rdar://147765187)
     // assert(!inheritLifetimeParamIndices ||
     //        !inheritLifetimeParamIndices->isEmpty());
+    // assert(!scopeLifetimeParamIndices || !scopeLifetimeParamIndices->isEmpty());
     if (inheritLifetimeParamIndices && inheritLifetimeParamIndices->isEmpty()) {
       inheritLifetimeParamIndices = nullptr;
     }
-    assert(!scopeLifetimeParamIndices || !scopeLifetimeParamIndices->isEmpty());
+    if (scopeLifetimeParamIndices && scopeLifetimeParamIndices->isEmpty()) {
+      scopeLifetimeParamIndices = nullptr;
+    }
     assert((!addressableParamIndices
             || !conditionallyAddressableParamIndices
             || conditionallyAddressableParamIndices->isDisjointWith(


### PR DESCRIPTION
`scopeLifetimeParamIndices` sometimes ends up non-null but empty, which triggers an assert module deserialization, blocking cross-module work on nonescapable types.

This appears to be the same underlying issue as the `inheritLifetimeParamIndices` assert we caught during `Optional`/`Result`'s generalization, but on a different input argument.

It seems reasonable to mitigate this problem the same way.

rdar://147765187
