### PR TITLE
[6.2] Bypass lifetime diagnostics in interfaces for copied arguments.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -53,7 +53,7 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
     }
   }
   for instruction in function.instructions {
-    if let markDep = instruction as? MarkDependenceInst, markDep.isUnresolved {
+    if let markDep = instruction as? MarkDependenceInstruction, markDep.isUnresolved {
       if let lifetimeDep = LifetimeDependence(markDep, context) {
         if analyze(dependence: lifetimeDep, context) {
           // Note: This promotes the mark_dependence flag but does not invalidate analyses; preserving analyses is good,

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -219,6 +219,12 @@ private struct DiagnoseDependence {
         log("  has dependent function result")
         return .continueWalk
       }
+      // Briefly (April 2025), RawSpan._extracting, Span._extracting, and UTF8Span.span returned a borrowed value that
+      // depended on a copied argument. Continue to support those interfaces. The implementations were correct but
+      // needed an explicit _overrideLifetime.
+      if let sourceFileKind = dependence.function.sourceFileKind, sourceFileKind == .interface {
+        return .continueWalk
+      }
     }
     return .abortWalk
   }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -202,12 +202,23 @@ private struct DiagnoseDependence {
     // Check that the parameter dependence for this result is the same
     // as the current dependence scope.
     if let arg = dependence.scope.parentValue as? FunctionArgument,
-       function.argumentConventions[resultDependsOn: arg.index] != nil {
-      // The returned value depends on a lifetime that is inherited or
-      // borrowed in the caller. The lifetime of the argument value
-      // itself is irrelevant here.
-      log("  has dependent function result")
-      return .continueWalk
+       let argDep = function.argumentConventions[resultDependsOn: arg.index] {
+      switch argDep {
+      case .inherit:
+        if dependence.markDepInst != nil {
+          // A mark_dependence represents a "borrow" scope. A local borrow scope cannot inherit the caller's dependence
+          // because the borrow scope depends on the argument value itself, while the caller allows the result to depend
+          // on a value that the argument was copied from.
+          break
+        }
+        fallthrough
+      case .scope:
+        // The returned value depends on a lifetime that is inherited or
+        // borrowed in the caller. The lifetime of the argument value
+        // itself is irrelevant here.
+        log("  has dependent function result")
+        return .continueWalk
+      }
     }
     return .abortWalk
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -161,7 +161,7 @@ extension LifetimeDependence {
 
   // Construct a LifetimeDependence from a return value. This only
   // constructs a dependence for ~Escapable results that do not have a
-  // lifetime dependence (@_unsafeNonescapableResult).
+  // lifetime dependence (@lifetime(immortal), @_unsafeNonescapableResult).
   //
   // This is necessary because inserting a mark_dependence placeholder for such an unsafe dependence would illegally
   // have the same base and value operand.

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -790,7 +790,8 @@ protected:
         auto immortalParam =
           std::find_if(afd->getParameters()->begin(),
                        afd->getParameters()->end(), [](ParamDecl *param) {
-                         return strcmp(param->getName().get(), "immortal") == 0;
+                         return param->getName().nonempty()
+                           && strcmp(param->getName().get(), "immortal") == 0;
                        });
         if (immortalParam != afd->getParameters()->end()) {
           diagnose(*immortalParam,

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -711,7 +711,8 @@ extension RawSpan {
   public func _extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, byteCount)
-    return unsafe Self(_unchecked: _pointer, byteCount: newCount)
+    let newSpan = unsafe Self(_unchecked: _pointer, byteCount: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
   }
 
   /// Returns a span over all but the given number of trailing bytes.
@@ -734,7 +735,8 @@ extension RawSpan {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)
     let count = byteCount &- droppedCount
-    return unsafe Self(_unchecked: _pointer, byteCount: count)
+    let newSpan = unsafe Self(_unchecked: _pointer, byteCount: count)
+    return unsafe _overrideLifetime(newSpan, copying: self)
   }
 
   /// Returns a span containing the trailing bytes of the span,

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -764,7 +764,8 @@ extension Span where Element: ~Copyable {
   public func _extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, count)
-    return unsafe Self(_unchecked: _pointer, count: newCount)
+    let newSpan = unsafe Self(_unchecked: _pointer, count: newCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
   }
 
   /// Returns a span over all but the given number of trailing elements.
@@ -786,7 +787,8 @@ extension Span where Element: ~Copyable {
   public func _extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, count)
-    return unsafe Self(_unchecked: _pointer, count: count &- droppedCount)
+    let newSpan = unsafe Self(_unchecked: _pointer, count: count &- droppedCount)
+    return unsafe _overrideLifetime(newSpan, copying: self)
   }
 
   /// Returns a span containing the final elements of the span,

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -181,7 +181,8 @@ extension UTF8Span {
   public var span: Span<UInt8> {
     @lifetime(copy self)
     get {
-      unsafe Span(_unchecked: _unsafeBaseAddress, count: self.count)
+      let newSpan = unsafe Span<UInt8>(_unchecked: _unsafeBaseAddress, count: self.count)
+      return unsafe _overrideLifetime(newSpan, copying: self)
     }
   }
 

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -105,7 +105,8 @@ func deriveThisOrThat1(_ this: borrowing BufferView, _ that: borrowing BufferVie
   if (Int.random(in: 1..<100) == 0) {
     return BufferView(independent: this.ptr)
   }
-  return BufferView(independent: that.ptr)
+  let newThat = BufferView(independent: that.ptr)
+  return _overrideLifetime(newThat, copying: that)
 }
 
 // CHECK-LABEL: sil hidden @$s39explicit_lifetime_dependence_specifiers17deriveThisOrThat2yAA10BufferViewVAD_ADntF : $@convention(thin) (@guaranteed BufferView, @owned BufferView) -> @lifetime(copy 1, borrow 0)  @owned BufferView {

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -85,12 +85,14 @@ func testBasic() {
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(copy 0)  @owned BufferView {
 @lifetime(copy x)
 func derive(_ x: borrowing BufferView) -> BufferView {
-  return BufferView(x.ptr, x.c)
+  let newBV = BufferView(x.ptr, x.c)
+  return _overrideLifetime(newBV, copying: x)
 }
 
 @lifetime(copy x)
 func derive(_ unused: Int, _ x: borrowing BufferView) -> BufferView {
-  return BufferView(independent: x.ptr, x.c)
+  let newBV = BufferView(independent: x.ptr, x.c)
+  return _overrideLifetime(newBV, copying: x)
 }
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> @lifetime(copy 0)  @owned BufferView {
@@ -212,7 +214,9 @@ struct GenericBufferView<Element> : ~Escapable {
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence23tupleLifetimeDependenceyAA10BufferViewV_ADtADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(copy 0)  (@owned BufferView, @owned BufferView) {
 @lifetime(copy x)
 func tupleLifetimeDependence(_ x: borrowing BufferView) -> (BufferView, BufferView) {
-  return (BufferView(x.ptr, x.c), BufferView(x.ptr, x.c))
+  let newX1 = BufferView(x.ptr, x.c)
+  let newX2 = BufferView(x.ptr, x.c)
+  return (_overrideLifetime(newX1, copying: x), _overrideLifetime(newX2, copying: x))
 }
 
 public struct OuterNE: ~Escapable {

--- a/test/SILOptimizer/lifetime_dependence/Inputs/lifetime_depend_diagnose.swiftinterface
+++ b/test/SILOptimizer/lifetime_dependence/Inputs/lifetime_depend_diagnose.swiftinterface
@@ -1,0 +1,27 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name lifetime_depend_diagnose -enable-experimental-feature LifetimeDependence -swift-version 5 -enable-library-evolution
+import Swift
+import _Concurrency
+import _StringProcessing
+import _SwiftConcurrencyShims
+
+#if $LifetimeDependence
+public struct NE : ~Swift.Escapable {
+  @usableFromInline
+  internal let _pointer: Swift.UnsafeRawPointer?
+
+  @lifetime(borrow pointer)
+  public init(pointer: Swift.UnsafeRawPointer?) {
+    self._pointer = pointer
+  }
+}
+
+extension NE {
+  // This is illegal at the source level because NE.init is implicitly @lifetime(borrow),
+  // so we can't return it as dependent on @lifetime(copy self).
+  @lifetime(copy self)
+  @unsafe @_alwaysEmitIntoClient public func forward() -> NE {
+    return NE(pointer: _pointer)
+  }
+}
+#endif

--- a/test/SILOptimizer/lifetime_dependence/diagnose_interface.swift
+++ b/test/SILOptimizer/lifetime_dependence/diagnose_interface.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -I %S/Inputs \
+// RUN:   -verify \
+// RUN:   -enable-experimental-feature LifetimeDependence
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
+
+// Test that lifetime dependence diagnostics continues to older (early
+// 2025) .swiftinterface files. Source-level diagnostics are stricter.
+
+import lifetime_depend_diagnose

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
@@ -8,6 +8,16 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_LifetimeDependence
 
+@_unsafeNonescapableResult
+@lifetime(copy source)
+internal func _overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, copying source: borrowing U
+) -> T {
+  dependent
+}
+
 // Some container-ish thing.
 struct CN: ~Copyable {
   let p: UnsafeRawPointer
@@ -47,7 +57,8 @@ struct MBV : ~Escapable, ~Copyable {
   // Requires a borrow.
   @lifetime(copy self)
   borrowing func getBV() -> BV {
-    BV(p, i)
+    let bv = BV(p, i)
+    return _overrideLifetime(bv, copying: self)
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
@@ -93,7 +93,10 @@ struct MutableSpan : ~Escapable, ~Copyable {
 
   var iterator: Iter {
     @lifetime(copy self)
-    get { Iter(base: base, count: count) }
+    get {
+      let newIter = Iter(base: base, count: count)
+      return _overrideLifetime(newIter, copying: self)
+    }
   }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -56,6 +56,9 @@ sil @getNE : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow addr
 sil @initTrivialHolder : $@convention(thin) () -> @out TrivialHolder
 sil @getTrivialNE : $@convention(thin) (@in_guaranteed TrivialHolder) -> @lifetime(borrow address_for_deps 0) @owned NE
 
+sil @makeHolder: $@convention(method) (@thin Holder.Type) -> @owned Holder // user: %6
+sil @getGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : ~Escapable> (@guaranteed Holder, @thick τ_0_0.Type) -> @lifetime(borrow 0) @out τ_0_0 // user: %12
+
 // Test returning a owned dependence on a trivial value
 sil [ossa] @return_trivial_dependence : $@convention(thin) (@guaranteed C) -> @lifetime(borrow 0) @owned NE {
 entry(%0 : @guaranteed $C):
@@ -162,4 +165,35 @@ bb0:
   destroy_value %6
   %12 = tuple ()
   return %12
+}
+
+// Test a borrowed dependency on an address
+sil [ossa] @testBorrowAddress : $@convention(thin) <T where T : ~Escapable> (@thick T.Type) -> @lifetime(immortal) @out T {
+bb0(%0 : $*T, %1 : $@thick T.Type):
+  debug_value %1, let, name "type", argno 1
+  %3 = alloc_stack [lexical] [var_decl] $Holder, var, name "holder", type $Holder
+  %4 = metatype $@thin Holder.Type
+
+  %5 = function_ref @makeHolder : $@convention(method) (@thin Holder.Type) -> @owned Holder
+  %6 = apply %5(%4) : $@convention(method) (@thin Holder.Type) -> @owned Holder
+  store %6 to [init] %3
+  %8 = alloc_stack [lexical] [var_decl] $T, let, name "result"
+  // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  %9 = begin_access [read] [static] %3
+  // expected-note  @-1{{it depends on this scoped access to variable}}
+  %10 = load [copy] %9
+
+  %11 = function_ref @getGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : ~Escapable> (@guaranteed Holder, @thick τ_0_0.Type) -> @lifetime(borrow 0) @out τ_0_0
+  %12 = apply %11<T>(%8, %10, %1) : $@convention(thin) <τ_0_0 where τ_0_0 : ~Escapable> (@guaranteed Holder, @thick τ_0_0.Type) -> @lifetime(borrow 0) @out τ_0_0
+  mark_dependence_addr [unresolved] %8 on %9
+  destroy_value %10
+  copy_addr %8 to [init] %0
+  // expected-note @-1{{this use causes the lifetime-dependent value to escape}}
+  end_access %9
+  destroy_addr %8
+  dealloc_stack %8
+  destroy_addr %3
+  dealloc_stack %3
+  %21 = tuple ()
+  return %21
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -49,6 +49,7 @@ sil @useA : $@convention(thin) (A) -> ()
 sil @makeNE : $@convention(thin) () -> @lifetime(immortal) @owned NE
 sil @makeNEObject : $@convention(thin) () -> @lifetime(immortal) @owned NEObject
 sil @useNE : $@convention(thin) (@guaranteed NE) -> ()
+sil @reborrowNE : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
 
 sil @initHolder : $@convention(thin) () -> @out Holder
 sil @getNE : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @owned NE
@@ -165,6 +166,26 @@ bb0:
   destroy_value %6
   %12 = tuple ()
   return %12
+}
+
+// Test that a borrowed dependency cannot inherit a copied dependency.
+sil [ossa] @testReborrow : $@convention(thin) (@guaranteed NE) -> @lifetime(copy 0) @owned NE {
+bb0(%0 : @guaranteed $NE):
+  debug_value %0, let, name "ne", argno 1
+  %2 = function_ref @reborrowNE : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
+  %3 = apply %2(%0) : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
+  // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  %4 = mark_dependence [unresolved] %3 on %0
+  return %4 // expected-note {{this use causes the lifetime-dependent value to escape}}
+}
+
+sil [ossa] @testBorrowValue : $@convention(thin) (@guaranteed NE) -> @lifetime(copy 0) @owned NE {
+bb0(%0 : @guaranteed $NE):
+  %2 = function_ref @reborrowNE : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
+  %3 = apply %2(%0) : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
+  // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  %4 = mark_dependence [unresolved] %3 on %0
+  return %4 // expected-note {{this use causes the lifetime-dependent value to escape}}
 }
 
 // Test a borrowed dependency on an address

--- a/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
+++ b/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
@@ -1,7 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-compiler-version: Swift version 6.2-dev effective-5.10 (LLVM 09f3cd831902283, Swift 889522485775a5d)
 // swift-module-flags: -module-name lifetime_depend_infer -enable-experimental-feature LifetimeDependence -swift-version 5 -enable-library-evolution
-// swift-module-flags-ignorable:  -formal-cxx-interoperability-mode=off -interface-compiler-version 6.2
 import Swift
 import _Concurrency
 import _StringProcessing

--- a/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
+++ b/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
@@ -253,12 +253,15 @@ public struct NoncopyableSelfAccessors : ~Copyable & ~Escapable {
     _modify
   }
   
+  // FIXME: rdar://150073405 ([SILGen] support synthesized _modify on top of borrowed getters with library evolution)
+  /*
   public var neComputedBorrow: lifetime_depend_infer.NE {
     @lifetime(borrow self)
     get
     @lifetime(&self)
     set
   }
+  */
   
   public var neYieldedBorrow: lifetime_depend_infer.NE {
     @lifetime(borrow self)

--- a/test/Sema/lifetime_depend_infer_interface.swift
+++ b/test/Sema/lifetime_depend_infer_interface.swift
@@ -7,6 +7,6 @@
 
 // Test that type checking continues to handle inference of lifetime
 // dependencies that may be required in older (early
-// 2025) .swiftinterface files. Source-level type checking is more strict.
+// 2025) .swiftinterface files. Source-level type checking is stricter.
 
 import lifetime_depend_infer


### PR DESCRIPTION

main PR: https://github.com/swiftlang/swift/pull/81105

- **LifetimeDependenceScopeFixup: cleanup for clarity**
  (cherry picked from commit bb9e52c3f2f95adbfd0ebf548a850389eb067f6e)
  

- **[NFC] LifetimeDependenceUtils comment**
  (cherry picked from commit 060364546abba1b7201d75a32b1d06384edc70b7)
  

- **Fix LifetimeDependence attribute checking**
  Handle parameters with no name: foo(_:T)
  
  (cherry picked from commit a7c9b6ecccdd1ad98d25c7205689ae38bfd8f749)
  

- **Fix LifetimeDependenceDiagnostics: handle mark_dependence_addr**
  A small typo meant that scoped dependencies modeled with mark_dependence_addr
  were not diagnosed.
  
  (cherry picked from commit 92b2a8587f08c3ae0e99ea61680bf9f942b9abb3)
  

- **Fix LifetimeDependenceDiagnostics: scoped dependence on a copy**
  Diagnose a scoped dependence on an argument that inherits its lifetime as an
  error:
  
  @lifetime(borrow arg)
  func reborrowSpan<T>(_ arg: Span<T>) -> Span<T> { arg }
  
  @lifetime(copy span)
  public func testBorrowInheritedArg<T>(_ span: Span<T>) -> Span<T> {
    reborrowSpan(span) // expected-error {{lifetime-dependent value escapes its scope}}
  }
  
  Fixes: rdar://146319009 ([nonescapable] enforce borrow constraint narrowing of inherited lifetime)
  (cherry picked from commit 4f470a1d3463fae50ff6c89589df4cd8e81e2392)
  

- **Add .swiftinterface tests to check backward compatibility.**
  (cherry picked from commit 49a8770792d1dbe2fcff1249a53785054f61ba9d)
  

- **Add _overrideLifetime to Span APIs**
  The implementation previously took advantage of a missing diagnostic. They
  returned a borrowed Span with a dependency on a copied argument. This illegally
  promotes the dependency. This is what the author intended to do (the
  implementation was correct) but the compiler can't know that so the code needs
  to be explicit about overriding the lifetime.
  
  (cherry picked from commit e9d11283b925675d10882f940ca7cf545fce7bb7)
  

- **Update tests for stricter diagnostics on borrowed argument lifetime**
  (cherry picked from commit 4ef3b4fa2d0290352ff2f415894b8c66c284b1d3)
  

- **Disable a test until SILGen supports borrowing getter + library evo**
  rdar://150073405 ([SILGen] support synthesized _modify on top of borrowed
  getters with library evolution)
  
  (cherry picked from commit 78758dad3f32d4e522d26255084a200a531557f6)
  

- **Bypass lifetime diagnostics in interfaces for copied arguments.**
  Briefly (April 2025), RawSpan._extracting, Span._extracting, and UTF8Span.span
  returned a borrowed value that depended on a copied argument. Continue to
  support those interfaces. The implementations were correct but needed an
  explicit _overrideLifetime.
  
  (cherry picked from commit 8a48cd979b8c6d2f9a7c81a846bd7afa41c88dfc)
  