### PR TITLE
[Strict memory safety] Provide argument-specific diagnostics for calls

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8411,9 +8411,9 @@ GROUPED_WARNING(unsafe_without_unsafe,StrictMemorySafety,none,
       "expression uses unsafe constructs but is not marked with 'unsafe'", ())
 GROUPED_WARNING(for_unsafe_without_unsafe,StrictMemorySafety,none,
       "for-in loop uses unsafe constructs but is not marked with 'unsafe'", ())
-GROUPED_WARNING(no_unsafe_in_unsafe,StrictMemorySafety,none,
+WARNING(no_unsafe_in_unsafe,none,
         "no unsafe operations occur within 'unsafe' expression", ())
-GROUPED_WARNING(no_unsafe_in_unsafe_for,StrictMemorySafety,none,
+WARNING(no_unsafe_in_unsafe_for,none,
         "no unsafe operations occur within 'unsafe' for-in loop", ())
 NOTE(make_subclass_unsafe,none,
      "make class %0 '@unsafe' to allow unsafe overrides of safe superclass "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8341,6 +8341,15 @@ NOTE(note_reference_to_unsafe_decl,none,
 NOTE(note_reference_to_unsafe_typed_decl,none,
      "%select{reference|call}0 to %kind1 involves unsafe type %2",
      (bool, const ValueDecl *, Type))
+NOTE(note_unsafe_call_decl_argument_named,none,
+     "argument %1 in call to %kindbase0 has unsafe type %2",
+     (const ValueDecl *, Identifier, Type))
+NOTE(note_unsafe_call_decl_argument_indexed,none,
+     "argument #%1 in call to %kindbase0 has unsafe type %2",
+     (const ValueDecl *, unsigned, Type))
+NOTE(note_unsafe_call_argument_indexed,none,
+     "argument #%0 in call has unsafe type %1",
+     (unsigned, Type))
 NOTE(note_reference_to_unsafe_through_typealias,none,
      "reference to %kind0 whose underlying type involves unsafe type %1",
      (const ValueDecl *, Type))

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8149,7 +8149,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
     Diag<> brokenProtocolDiag, Diag<> brokenBuiltinProtocolDiag) {
   // If coercing a literal to an unresolved type, we don't try to look up the
   // witness members, just do it.
-  if (type->is<UnresolvedType>()) {
+  if (type->is<UnresolvedType>() || type->is<ErrorType>()) {
     cs.setType(literal, type);
     return literal;
   }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2699,6 +2699,7 @@ diagnoseDeclUnsafe(ConcreteDeclRef declRef, SourceRange R,
 
   SourceLoc diagLoc = call ? call->getLoc() : R.Start;
   enumerateUnsafeUses(declRef, diagLoc, call != nullptr,
+                      /*skipTypeCheck=*/false,
                       [&](UnsafeUse unsafeUse) {
     unsafeUses->push_back(unsafeUse);
     return false;

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1187,8 +1187,7 @@ public:
     Classification result;
     bool considerAsync = !onlyEffect || *onlyEffect == EffectKind::Async;
     bool considerThrows = !onlyEffect || *onlyEffect == EffectKind::Throws;
-    bool considerUnsafe = (!onlyEffect || *onlyEffect == EffectKind::Unsafe) &&
-        ctx.LangOpts.hasFeature(Feature::StrictMemorySafety);
+    bool considerUnsafe = (!onlyEffect || *onlyEffect == EffectKind::Unsafe);
 
     // If we're tracking "unsafe" effects, compute them here.
     if (considerUnsafe) {
@@ -1708,8 +1707,7 @@ public:
         !fnType->isAsync() &&
         !E->isImplicitlyAsync() &&
         !hasAnyConformances &&
-        (fnRef.getExplicitSafety() == ExplicitSafety::Safe ||
-         !ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))) {
+        fnRef.getExplicitSafety() == ExplicitSafety::Safe) {
       return Classification();
     }
 
@@ -1928,7 +1926,6 @@ public:
     // If the safety of the callee is unspecified, check the safety of the
     // arguments specifically.
     if (hasUnspecifiedSafety &&
-        ctx.LangOpts.hasFeature(Feature::StrictMemorySafety) &&
         !(assumedSafeArguments && assumedSafeArguments->contains(E))) {
       classifyApplyEffect(EffectKind::Unsafe);
     }
@@ -4554,8 +4551,7 @@ private:
         Ctx.Diags.diagnose(S->getForLoc(), diag::for_unsafe_without_unsafe)
           .fixItInsert(insertionLoc, "unsafe ");
       }
-    } else if (S->getUnsafeLoc().isValid() &&
-               Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety)) {
+    } else if (S->getUnsafeLoc().isValid()) {
       // Extraneous "unsafe" on the sequence.
       Ctx.Diags.diagnose(S->getUnsafeLoc(), diag::no_unsafe_in_unsafe_for)
         .fixItRemove(S->getUnsafeLoc());
@@ -4600,9 +4596,6 @@ private:
   }
 
   void diagnoseRedundantUnsafe(UnsafeExpr *E) const {
-    if (!Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
-      return;
-
     // Silence this warning in the expansion of the _SwiftifyImport macro.
     // This is a hack because it's tricky to determine when to insert "unsafe".
     unsigned bufferID =

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -335,6 +335,7 @@ private:
   PolymorphicEffectKind RethrowsKind = PolymorphicEffectKind::None;
   PolymorphicEffectKind ReasyncKind = PolymorphicEffectKind::None;
   SubstitutionMap Substitutions;
+  bool AppliedSelf = false;
 
 public:
   explicit AbstractFunction(Kind kind, Expr *fn)
@@ -342,11 +343,13 @@ public:
     TheExpr = fn;
   }
 
-  explicit AbstractFunction(AbstractFunctionDecl *fn, SubstitutionMap subs)
+  explicit AbstractFunction(AbstractFunctionDecl *fn, SubstitutionMap subs,
+                            bool appliedSelf)
     : TheKind(Kind::Function),
       RethrowsKind(fn->getPolymorphicEffectKind(EffectKind::Throws)),
       ReasyncKind(fn->getPolymorphicEffectKind(EffectKind::Async)),
-      Substitutions(subs) {
+      Substitutions(subs),
+      AppliedSelf(appliedSelf) {
     TheFunction = fn;
   }
 
@@ -377,7 +380,7 @@ public:
     case Kind::Opaque: return getOpaqueFunction()->getType();
     case Kind::Function: {
       auto *AFD = getFunction();
-      if (AFD->hasImplicitSelfDecl())
+      if (AFD->hasImplicitSelfDecl() && AppliedSelf)
         return AFD->getMethodInterfaceType();
       return AFD->getInterfaceType();
     }
@@ -398,6 +401,11 @@ public:
                  .getParameterType();
 
     case Kind::Function: {
+      if (getFunction()->hasImplicitSelfDecl() && !AppliedSelf) {
+        assert(substIndex == 0);
+        return getFunction()->getImplicitSelfDecl()->getInterfaceType();
+      }
+
       auto *params = getFunction()->getParameters();
       auto origIndex = params->getOrigParamIndex(getSubstitutions(), substIndex);
       return params->get(origIndex)->getInterfaceType();
@@ -435,10 +443,13 @@ public:
   static AbstractFunction getAppliedFn(ApplyExpr *apply) {
     Expr *fn = apply->getFn()->getValueProvidingExpr();
 
-    if (auto *selfCall = dyn_cast<SelfApplyExpr>(fn))
+    bool appliedSelf = false;
+    if (auto *selfCall = dyn_cast<SelfApplyExpr>(fn)) {
       fn = selfCall->getFn()->getValueProvidingExpr();
+      appliedSelf = true;
+    }
 
-    return decomposeFunction(fn);
+    return decomposeFunction(fn, appliedSelf);
   }
 
   bool isPreconcurrency() const {
@@ -457,7 +468,7 @@ public:
     }
   }
 
-  static AbstractFunction decomposeFunction(Expr *fn) {
+  static AbstractFunction decomposeFunction(Expr *fn, bool appliedSelf) {
     assert(fn->getValueProvidingExpr() == fn);
 
     while (true) {
@@ -493,14 +504,16 @@ public:
     // Constructor delegation.
     if (auto otherCtorDeclRef = dyn_cast<OtherConstructorDeclRefExpr>(fn)) {
       return AbstractFunction(otherCtorDeclRef->getDecl(),
-                              otherCtorDeclRef->getDeclRef().getSubstitutions());
+                              otherCtorDeclRef->getDeclRef().getSubstitutions(),
+                              appliedSelf);
     }
 
     // Normal function references.
     if (auto DRE = dyn_cast<DeclRefExpr>(fn)) {
       ValueDecl *decl = DRE->getDecl();
       if (auto fn = dyn_cast<AbstractFunctionDecl>(decl)) {
-        return AbstractFunction(fn, DRE->getDeclRef().getSubstitutions());
+        return AbstractFunction(fn, DRE->getDeclRef().getSubstitutions(),
+                                appliedSelf);
       } else if (auto param = dyn_cast<ParamDecl>(decl)) {
         SubstitutionMap subs;
         if (auto genericEnv = param->getDeclContext()->getGenericEnvironmentOfContext())
@@ -2541,7 +2554,8 @@ private:
 
     // Decompose the function reference, then consider the type
     // of the decomposed function.
-    AbstractFunction fn = AbstractFunction::decomposeFunction(arg);
+    AbstractFunction fn = AbstractFunction::decomposeFunction(
+        arg, /*appliedSelf=*/false);
 
     // If it doesn't have function type, we must have invalid code.
     Type argType = fn.getType();

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4595,6 +4595,15 @@ private:
     if (!Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
       return;
 
+    // Silence this warning in the expansion of the _SwiftifyImport macro.
+    // This is a hack because it's tricky to determine when to insert "unsafe".
+    unsigned bufferID =
+        Ctx.SourceMgr.findBufferContainingLoc(E->getUnsafeLoc());
+    if (auto sourceInfo = Ctx.SourceMgr.getGeneratedSourceInfo(bufferID)) {
+      if (sourceInfo->macroName == "_SwiftifyImport")
+        return;
+    }
+
     if (auto *SVE = SingleValueStmtExpr::tryDigOutSingleValueStmtExpr(E)) {
       // For an if/switch expression, produce a tailored warning.
       Ctx.Diags.diagnose(E->getUnsafeLoc(),

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -385,7 +385,8 @@ public:
 
   Type getType() const {
     switch (getKind()) {
-    case Kind::Opaque: return getOpaqueFunction()->getType();
+    case Kind::Opaque:
+      return getOpaqueFunction()->getType()->lookThroughSingleOptionalType();
     case Kind::Function: {
       auto *AFD = getFunction();
       if (AFD->hasImplicitSelfDecl() && AppliedSelf)
@@ -393,7 +394,9 @@ public:
       return AFD->getInterfaceType();
     }
     case Kind::Closure: return getClosure()->getType();
-    case Kind::Parameter: return getParameter()->getInterfaceType();
+    case Kind::Parameter:
+      return getParameter()->getInterfaceType()
+          ->lookThroughSingleOptionalType();
     }
     llvm_unreachable("bad kind");
   }
@@ -1826,6 +1829,11 @@ public:
           result.merge(Classification::forInvalidCode());
           return;
         }
+
+        // Can end up with an optional type when dynamically dispatching to
+        // @objc.
+        if (auto optFnType = fnInterfaceType->getOptionalObjectType())
+          fnInterfaceType = optFnType;
 
         // Use the most significant result from the arguments.
         FunctionType *fnSubstType = nullptr;

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -151,6 +151,40 @@ void swift::diagnoseUnsafeUse(const UnsafeUse &use) {
     return;
   }
 
+  case UnsafeUse::CallArgument: {
+    auto [argumentName, argumentIndex, argument] = use.getCallArgument();
+    Type paramType = use.getType();
+    ASTContext &ctx = paramType->getASTContext();
+
+    SourceLoc loc = argument->getLoc();
+    if (loc.isInvalid())
+      loc = use.getLocation();
+
+    if (auto calleeDecl = dyn_cast_or_null<ValueDecl>(use.getDecl())) {
+      if (argumentName.empty()) {
+        ctx.Diags.diagnose(
+            loc,
+            diag::note_unsafe_call_decl_argument_indexed,
+            calleeDecl, argumentIndex, paramType)
+          .highlight(argument->getSourceRange());
+      } else {
+        ctx.Diags.diagnose(
+            loc,
+            diag::note_unsafe_call_decl_argument_named,
+            calleeDecl, argumentName, paramType)
+          .highlight(argument->getSourceRange());
+      }
+    } else {
+      ctx.Diags.diagnose(
+          loc,
+          diag::note_unsafe_call_argument_indexed,
+          argumentIndex, paramType)
+        .highlight(argument->getSourceRange());
+    }
+
+    return;
+  }
+
   case UnsafeUse::TemporarilyEscaping: {
     Type type = use.getType();
     ASTContext &ctx = type->getASTContext();
@@ -177,6 +211,7 @@ static bool isReferenceToNonisolatedUnsafe(ValueDecl *decl) {
 bool swift::enumerateUnsafeUses(ConcreteDeclRef declRef,
                                 SourceLoc loc,
                                 bool isCall,
+                                bool skipTypeCheck,
                                 llvm::function_ref<bool(UnsafeUse)> fn) {
   // If the declaration is explicitly unsafe, note that.
   auto decl = declRef.getDecl();
@@ -203,7 +238,7 @@ bool swift::enumerateUnsafeUses(ConcreteDeclRef declRef,
   // If the type of this declaration involves unsafe types, diagnose that.
   ASTContext &ctx = decl->getASTContext();
   auto subs = declRef.getSubstitutions();
-  {
+  if (!skipTypeCheck) {
     auto type = decl->getInterfaceType();
     if (subs) {
       if (auto *genericFnType = type->getAs<GenericFunctionType>())
@@ -343,7 +378,8 @@ bool swift::enumerateUnsafeUses(SubstitutionMap subs,
 
 bool swift::isUnsafe(ConcreteDeclRef declRef) {
   return enumerateUnsafeUses(
-      declRef, SourceLoc(), /*isCall=*/false, [&](UnsafeUse) {
+      declRef, SourceLoc(), /*isCall=*/false, /*skipTypeCheck=*/false,
+      [&](UnsafeUse) {
     return true;
   });
 }

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -338,10 +338,6 @@ bool swift::enumerateUnsafeUses(ArrayRef<ProtocolConformanceRef> conformances,
     if (conformance.isInvalid())
       continue;
 
-    ASTContext &ctx = conformance.getProtocol()->getASTContext();
-    if (!ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
-      return false;
-
     if (!conformance.hasEffect(EffectKind::Unsafe))
       continue;
 
@@ -410,9 +406,6 @@ bool swift::isUnsafeInConformance(const ValueDecl *requirement,
 
 void swift::diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
                                llvm::function_ref<void(Type)> diagnose) {
-  if (!ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
-    return;
-
   if (!type->isUnsafe())
     return;
 

--- a/lib/Sema/TypeCheckUnsafe.h
+++ b/lib/Sema/TypeCheckUnsafe.h
@@ -34,6 +34,7 @@ void diagnoseUnsafeUse(const UnsafeUse &use);
 bool enumerateUnsafeUses(ConcreteDeclRef declRef,
                          SourceLoc loc,
                          bool isCall,
+                         bool skipTypeCheck,
                          llvm::function_ref<bool(UnsafeUse)> fn);
 
 /// Enumerate all of the unsafe uses that occur within this array of protocol

--- a/stdlib/public/Concurrency/CheckedContinuation.swift
+++ b/stdlib/public/Concurrency/CheckedContinuation.swift
@@ -162,7 +162,7 @@ public struct CheckedContinuation<T, E: Error>: Sendable {
   /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   public func resume(returning value: sending T) {
-    if let c: UnsafeContinuation<T, E> = unsafe canary.takeContinuation() {
+    if let c: UnsafeContinuation<T, E> = canary.takeContinuation() {
       unsafe c.resume(returning: value)
     } else {
       #if !$Embedded
@@ -186,7 +186,7 @@ public struct CheckedContinuation<T, E: Error>: Sendable {
   /// the caller. The task continues executing when its executor is
   /// able to reschedule it.
   public func resume(throwing error: __owned E) {
-    if let c: UnsafeContinuation<T, E> = unsafe canary.takeContinuation() {
+    if let c: UnsafeContinuation<T, E> = canary.takeContinuation() {
       unsafe c.resume(throwing: error)
     } else {
       #if !$Embedded

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -886,7 +886,7 @@ internal func _task_serialExecutor_getExecutorRef<E>(_ executor: E) -> Builtin.E
 @_silgen_name("_task_taskExecutor_getTaskExecutorRef")
 internal func _task_taskExecutor_getTaskExecutorRef<E>(_ taskExecutor: E) -> Builtin.Executor
     where E: TaskExecutor {
-  return unsafe taskExecutor.asUnownedTaskExecutor().executor
+  return taskExecutor.asUnownedTaskExecutor().executor
 }
 
 // Used by the concurrency runtime

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -324,7 +324,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
   /// Returns the result of executing the closure.
   @available(SwiftStdlib 6.2, *)
   public func withUnsafeExecutorPrivateData<R, E>(body: (UnsafeMutableRawBufferPointer) throws(E) -> R) throws(E) -> R {
-    let base = unsafe _jobGetExecutorPrivateData(self.context)
+    let base = _jobGetExecutorPrivateData(self.context)
     let size = unsafe 2 * MemoryLayout<OpaquePointer>.stride
     return unsafe try body(UnsafeMutableRawBufferPointer(start: base,
                                                          count: size))
@@ -476,13 +476,13 @@ extension ExecutorJob {
 
     /// Allocate a specified number of bytes of uninitialized memory.
     public func allocate(capacity: Int) -> UnsafeMutableRawBufferPointer {
-      let base = unsafe _jobAllocate(context, capacity)
+      let base = _jobAllocate(context, capacity)
       return unsafe UnsafeMutableRawBufferPointer(start: base, count: capacity)
     }
 
     /// Allocate uninitialized memory for a single instance of type `T`.
     public func allocate<T>(as type: T.Type) -> UnsafeMutablePointer<T> {
-      let base = unsafe _jobAllocate(context, MemoryLayout<T>.size)
+      let base = _jobAllocate(context, MemoryLayout<T>.size)
       return unsafe base.bindMemory(to: type, capacity: 1)
     }
 
@@ -490,7 +490,7 @@ extension ExecutorJob {
     /// instances of type `T`.
     public func allocate<T>(capacity: Int, as type: T.Type)
       -> UnsafeMutableBufferPointer<T> {
-      let base = unsafe _jobAllocate(context, MemoryLayout<T>.stride * capacity)
+      let base = _jobAllocate(context, MemoryLayout<T>.stride * capacity)
       let typedBase = unsafe base.bindMemory(to: T.self, capacity: capacity)
       return unsafe UnsafeMutableBufferPointer<T>(start: typedBase, count: capacity)
     }

--- a/stdlib/public/Concurrency/Task+PriorityEscalation.swift
+++ b/stdlib/public/Concurrency/Task+PriorityEscalation.swift
@@ -125,7 +125,7 @@ func __withTaskPriorityEscalationHandler0<T, E>(
   onPriorityEscalated handler0: @Sendable (UInt8, UInt8) -> Void,
   isolation: isolated (any Actor)? = #isolation
 ) async throws(E) -> T {
-  let record = unsafe _taskAddPriorityEscalationHandler(handler: handler0)
+  let record = _taskAddPriorityEscalationHandler(handler: handler0)
   defer { unsafe _taskRemovePriorityEscalationHandler(record: record) }
 
   return try await operation()

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -146,9 +146,9 @@ public func withTaskExecutorPreference<T, Failure>(
   }
 
   let taskExecutorBuiltin: Builtin.Executor =
-    unsafe taskExecutor.asUnownedTaskExecutor().executor
+    taskExecutor.asUnownedTaskExecutor().executor
 
-  let record = unsafe _pushTaskExecutorPreference(taskExecutorBuiltin)
+  let record = _pushTaskExecutorPreference(taskExecutorBuiltin)
   defer {
     unsafe _popTaskExecutorPreference(record: record)
   }
@@ -177,9 +177,9 @@ public func _unsafeInheritExecutor_withTaskExecutorPreference<T: Sendable>(
   }
 
   let taskExecutorBuiltin: Builtin.Executor =
-    unsafe taskExecutor.asUnownedTaskExecutor().executor
+    taskExecutor.asUnownedTaskExecutor().executor
 
-  let record = unsafe _pushTaskExecutorPreference(taskExecutorBuiltin)
+  let record = _pushTaskExecutorPreference(taskExecutorBuiltin)
   defer {
     unsafe _popTaskExecutorPreference(record: record)
   }

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1301,7 +1301,7 @@ extension Task where Success == Never, Failure == Never {
 @available(SwiftStdlib 5.1, *)
 public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) rethrows -> T {
   guard let _task = _getCurrentAsyncTask() else {
-    return try unsafe body(nil)
+    return try body(nil)
   }
 
   // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
@@ -1315,7 +1315,7 @@ public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) throws -> T) ret
 @available(SwiftStdlib 6.0, *)
 public func withUnsafeCurrentTask<T>(body: (UnsafeCurrentTask?) async throws -> T) async rethrows -> T {
   guard let _task = _getCurrentAsyncTask() else {
-    return try unsafe await body(nil)
+    return try await body(nil)
   }
 
   // FIXME: This retain seems pretty wrong, however if we don't we WILL crash
@@ -1601,7 +1601,7 @@ internal func _getCurrentTaskName() -> UnsafePointer<UInt8>?
 
 @available(SwiftStdlib 6.2, *)
 internal func _getCurrentTaskNameString() -> String? {
-  if let stringPtr = unsafe _getCurrentTaskName() {
+  if let stringPtr = _getCurrentTaskName() {
     unsafe String(cString: stringPtr)
   } else {
     nil

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -77,7 +77,7 @@ public func withTaskCancellationHandler<T>(
 ) async rethrows -> T {
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
-  let record = unsafe _taskAddCancellationHandler(handler: handler)
+  let record = _taskAddCancellationHandler(handler: handler)
   defer { unsafe _taskRemoveCancellationHandler(record: record) }
 
   return try await operation()
@@ -98,7 +98,7 @@ public func _unsafeInheritExecutor_withTaskCancellationHandler<T>(
 ) async rethrows -> T {
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
-  let record = unsafe _taskAddCancellationHandler(handler: handler)
+  let record = _taskAddCancellationHandler(handler: handler)
   defer { unsafe _taskRemoveCancellationHandler(record: record) }
 
   return try await operation()

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -178,7 +178,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// or if the task-local has no value bound, this will return the `defaultValue`
   /// of the task local.
   public func get() -> Value {
-    guard let rawValue = unsafe _taskLocalValueGet(key: key) else {
+    guard let rawValue = _taskLocalValueGet(key: key) else {
       return self.defaultValue
     }
 

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -549,7 +549,7 @@ extension DistributedActorSystem {
         errorCode: .typeDeserializationFailure)
     }
 
-    guard let resultBuffer = _openExistential(returnTypeFromTypeInfo, do: unsafe doAllocateReturnTypeBuffer) else {
+    guard let resultBuffer = _openExistential(returnTypeFromTypeInfo, do: doAllocateReturnTypeBuffer) else {
       throw ExecuteDistributedTargetError(
         message: "Failed to allocate buffer for distributed target return type",
         errorCode: .typeDeserializationFailure)

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -951,6 +951,7 @@ extension Array: RangeReplaceableCollection {
   /// Entry point for `Array` literal construction; builds and returns
   /// an Array of `count` uninitialized elements.
   @inlinable
+  @unsafe
   @_semantics("array.uninitialized")
   internal static func _allocateUninitialized(
     _ count: Int
@@ -966,6 +967,7 @@ extension Array: RangeReplaceableCollection {
   ///
   /// - Precondition: `storage is _ContiguousArrayStorage`.
   @inlinable
+  @unsafe
   @_semantics("array.uninitialized")
   @_effects(escaping storage => return.0.value**)
   @_effects(escaping storage.class*.value** => return.0.value**.class*.value**)

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -73,7 +73,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
     }
 
     // Look for contiguous storage in the NSArray
-    let cocoaStorageBaseAddress = unsafe self.contiguousStorage(self.indices)
+    let cocoaStorageBaseAddress = self.contiguousStorage(self.indices)
 
     if let cocoaStorageBaseAddress = unsafe cocoaStorageBaseAddress {
       return unsafe _SliceBuffer(
@@ -113,7 +113,7 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
   ) -> UnsafeMutablePointer<AnyObject>?
   {
     _internalInvariant(!subRange.isEmpty)
-    var enumerationState = unsafe _makeSwiftNSFastEnumerationState()
+    var enumerationState = _makeSwiftNSFastEnumerationState()
 
     // This function currently returns nil unless the first
     // subRange.upperBound items are stored contiguously.  This is an

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -190,13 +190,13 @@ internal final class _ContiguousArrayStorage<
   @objc(objectAtIndexedSubscript:)
   @_effects(readonly)
   final override internal func objectAtSubscript(_ index: Int) -> Unmanaged<AnyObject> {
-    return unsafe _objectAt(index)
+    return _objectAt(index)
   }
   
   @objc(objectAtIndex:)
   @_effects(readonly)
   final override internal func objectAt(_ index: Int) -> Unmanaged<AnyObject> {
-    return unsafe _objectAt(index)
+    return _objectAt(index)
   }
   
   @objc internal override final var count: Int {

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -315,8 +315,8 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   ) {
     _precondition(count >= 0, "Invalid count")
     guard count > 0 else { return }
-    let bridgedKeys = unsafe bridgeKeys()
-    let bridgedValues = unsafe bridgeValues()
+    let bridgedKeys = bridgeKeys()
+    let bridgedValues = bridgeValues()
     var i = 0 // Current position in the output buffers
 
     defer { _fixLifetime(self) }
@@ -355,8 +355,8 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
       Unmanaged<AnyObject>,
       UnsafeMutablePointer<UInt8>
     ) -> Void) {
-    let bridgedKeys = unsafe bridgeKeys()
-    let bridgedValues = unsafe bridgeValues()
+    let bridgedKeys = bridgeKeys()
+    let bridgedValues = bridgeValues()
 
     defer { _fixLifetime(self) }
 
@@ -409,7 +409,7 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
     var stored = 0
 
     // Only need to bridge once, so we can hoist it out of the loop.
-    let bridgedKeys = unsafe bridgeKeys()
+    let bridgedKeys = bridgeKeys()
     for i in 0..<count {
       if bucket == endBucket { break }
 
@@ -700,7 +700,7 @@ extension __CocoaDictionary: Sequence {
     // This stored property should be stored at offset zero.  There's code below
     // relying on this.
     internal var _fastEnumerationState: _SwiftNSFastEnumerationState =
-      unsafe _makeSwiftNSFastEnumerationState()
+      _makeSwiftNSFastEnumerationState()
 
     // This stored property should be stored right after
     // `_fastEnumerationState`.  There's code below relying on this.

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -157,7 +157,7 @@ public func swift_slowAlloc(_ size: Int, _ alignMask: Int) -> UnsafeMutableRawPo
   } else {
     alignment = alignMask + 1
   }
-  return unsafe alignedAlloc(size: size, alignment: alignment)
+  return alignedAlloc(size: size, alignment: alignment)
 }
 
 @_cdecl("swift_slowDealloc")
@@ -171,7 +171,7 @@ public func swift_allocObject(metadata: Builtin.RawPointer, requiredSize: Int, r
 }
 
 func swift_allocObject(metadata: UnsafeMutablePointer<ClassMetadata>, requiredSize: Int, requiredAlignmentMask: Int) -> UnsafeMutablePointer<HeapObject> {
-  let p = unsafe swift_slowAlloc(requiredSize, requiredAlignmentMask)!
+  let p = swift_slowAlloc(requiredSize, requiredAlignmentMask)!
   let object = unsafe p.assumingMemoryBound(to: HeapObject.self)
   unsafe _swift_embedded_set_heap_object_metadata_pointer(object, metadata)
   unsafe object.pointee.refcount = 1

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -106,6 +106,7 @@ extension InlineArray where Element: ~Copyable {
   /// Converts the given raw pointer, which points at an uninitialized array
   /// instance, to a mutable buffer suitable for initialization.
   @available(SwiftStdlib 6.2, *)
+  @unsafe
   @_alwaysEmitIntoClient
   @_transparent
   internal static func _initializationBuffer(

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -629,7 +629,7 @@ public class ReferenceWritableKeyPath<
           return unsafe UnsafeMutablePointer(mutating: typedPointer)
         }
       }
-      return _openExistential(base, do: unsafe formalMutation(_:))
+      return _openExistential(base, do: formalMutation(_:))
     }
     
     return unsafe (address, keepAlive)
@@ -1825,7 +1825,7 @@ internal struct RawKeyPathComponent {
     case .get(id: _, accessors: let accessors, argument: let argument),
          .mutatingGetSet(id: _, accessors: let accessors, argument: let argument),
          .nonmutatingGetSet(id: _, accessors: let accessors, argument: let argument):
-      let getter: ComputedAccessorsPtr.Getter<CurValue, NewValue> = unsafe accessors.getter()
+      let getter: ComputedAccessorsPtr.Getter<CurValue, NewValue> = accessors.getter()
 
       unsafe pointer.initialize(
         to: getter(
@@ -2263,7 +2263,7 @@ func _modifyAtReferenceWritableKeyPath_impl<Root, Value>(
   root: Root,
   keyPath: ReferenceWritableKeyPath<Root, Value>
 ) -> (UnsafeMutablePointer<Value>, AnyObject?) {
-  return unsafe keyPath._projectMutableAddress(from: root)
+  return keyPath._projectMutableAddress(from: root)
 }
 
 @_silgen_name("swift_setAtWritableKeyPath")
@@ -2299,7 +2299,7 @@ func _setAtReferenceWritableKeyPath<Root, Value>(
   value: __owned Value
 ) {
   // TODO: we should be able to do this more efficiently than projecting.
-  let (addr, owner) = unsafe keyPath._projectMutableAddress(from: root)
+  let (addr, owner) = keyPath._projectMutableAddress(from: root)
   unsafe addr.pointee = value
   _fixLifetime(owner)
   // FIXME: this needs a deallocation barrier to ensure that the
@@ -3222,7 +3222,7 @@ internal func _walkKeyPathPattern<W: KeyPathPatternVisitor>(
       let witnessesRef = unsafe _pop(from: &componentBuffer, as: Int32.self)
       let witnesses: UnsafeRawPointer
       if witnessesRef == 0 {
-        unsafe witnesses = unsafe __swift_keyPathGenericWitnessTable_addr()
+        unsafe witnesses = __swift_keyPathGenericWitnessTable_addr()
       } else {
         unsafe witnesses = unsafe _resolveRelativeAddress(witnessesBase, witnessesRef)
       }
@@ -4353,7 +4353,7 @@ fileprivate func dynamicLibraryAddress<Base, Leaf>(
   _: Base.Type,
   _ leaf: Leaf.Type
 ) -> String {
-  let getter: ComputedAccessorsPtr.Getter<Base, Leaf> = unsafe pointer.getter()
+  let getter: ComputedAccessorsPtr.Getter<Base, Leaf> = pointer.getter()
   let pointer = unsafe unsafeBitCast(getter, to: UnsafeRawPointer.self)
   if let cString = unsafe keyPath_copySymbolName(UnsafeRawPointer(pointer)) {
     defer {

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -90,7 +90,7 @@ public func _getTypeName(_ type: Any.Type, qualified: Bool)
 @_unavailableInEmbedded
 public // @testable
 func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
-  let (stringPtr, count) = unsafe _getTypeName(type, qualified: qualified)
+  let (stringPtr, count) = _getTypeName(type, qualified: qualified)
   return unsafe String._fromUTF8Repairing(
     UnsafeBufferPointer(start: stringPtr, count: count)).0
 }
@@ -107,7 +107,7 @@ public func _getMangledTypeName(_ type: any (~Copyable & ~Escapable).Type)
 @_preInverseGenerics
 public // SPI
 func _mangledTypeName(_ type: any (~Copyable & ~Escapable).Type) -> String? {
-  let (stringPtr, count) = unsafe _getMangledTypeName(type)
+  let (stringPtr, count) = _getMangledTypeName(type)
   guard count > 0 else {
     return nil
   }

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -354,7 +354,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
         }
         target.write(")")
       case .enum:
-        if let cString = unsafe _getEnumCaseName(value),
+        if let cString = _getEnumCaseName(value),
             let caseName = unsafe String(validatingCString: cString) {
           // Write the qualified type name in debugPrint.
           if isDebugPrint {
@@ -389,7 +389,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
     printTypeName(metatypeValue)
   } else {
     // Fall back to the type or an opaque summary of the kind
-    if let cString = unsafe _opaqueSummary(mirror.subjectType),
+    if let cString = _opaqueSummary(mirror.subjectType),
         let opaqueSummary = unsafe String(validatingCString: cString) {
       target.write(opaqueSummary)
     } else {
@@ -533,7 +533,7 @@ internal func _dumpPrint_unlocked<T, TargetStream: TextOutputStream>(
       return
     case .`enum`:
       target.write(_typeName(mirror.subjectType, qualified: true))
-      if let cString = unsafe _getEnumCaseName(value),
+      if let cString = _getEnumCaseName(value),
           let caseName = unsafe String(validatingCString: cString) {
         target.write(".")
         target.write(caseName)

--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -434,7 +434,7 @@ func _convertConstArrayToPointerArgument<
   FromElement,
   ToPointer: _Pointer
 >(_ arr: [FromElement]) -> (AnyObject?, ToPointer) {
-  let (owner, opaquePointer) = unsafe arr._cPointerArgs()
+  let (owner, opaquePointer) = arr._cPointerArgs()
 
   let validPointer: ToPointer
   if let addr = unsafe opaquePointer {
@@ -453,7 +453,7 @@ func _convertConstArrayToPointerArgument<
   FromElement,
   ToPointer: _Pointer
 >(_ arr: [FromElement]) -> (Builtin.NativeObject?, ToPointer) {
-  let (owner, opaquePointer) = unsafe arr._cPointerArgs()
+  let (owner, opaquePointer) = arr._cPointerArgs()
 
   let validPointer: ToPointer
   if let addr = unsafe opaquePointer {

--- a/stdlib/public/core/RuntimeFunctionCounters.swift
+++ b/stdlib/public/core/RuntimeFunctionCounters.swift
@@ -106,7 +106,7 @@ struct _RuntimeFunctionCounters {
   public static let runtimeFunctionNames =
     getRuntimeFunctionNames()
   public static let runtimeFunctionCountersOffsets =
-    unsafe _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
+    _RuntimeFunctionCounters.getRuntimeFunctionCountersOffsets()
   public static let numRuntimeFunctionCounters =
     Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())
   public static let runtimeFunctionNameToIndex: [String: Int] =
@@ -119,7 +119,7 @@ struct _RuntimeFunctionCounters {
     UnsafePointer<UnsafePointer<CChar>>
 
   public static func getRuntimeFunctionNames() -> [String] {
-    let names = unsafe _RuntimeFunctionCounters._getRuntimeFunctionNames()
+    let names = _RuntimeFunctionCounters._getRuntimeFunctionNames()
     let numRuntimeFunctionCounters =
       Int(_RuntimeFunctionCounters.getNumRuntimeFunctionCounters())
     var functionNames: [String] = []
@@ -504,7 +504,7 @@ public // @testable
 func _collectReferencesInsideObject(_ value: Any) -> [UnsafeRawPointer] {
   let savedMode = _RuntimeFunctionCounters.disableRuntimeFunctionCountersUpdates()
   // Collect all references inside the object
-  let refs = unsafe _RuntimeFunctionCounters.collectAllReferencesInsideObject(value)
+  let refs = _RuntimeFunctionCounters.collectAllReferencesInsideObject(value)
   _RuntimeFunctionCounters.enableRuntimeFunctionCountersUpdates(mode: savedMode)
   return unsafe refs
 }

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -227,7 +227,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
 
     let (bucket, found) = native.find(element)
     guard found else { return nil }
-    let bridged = unsafe bridgeElements()
+    let bridged = bridgeElements()
     return unsafe bridged[bucket]
   }
 
@@ -272,7 +272,7 @@ final internal class _SwiftDeferredNSSet<Element: Hashable>
       "Invalid fast enumeration state")
 
     // Only need to bridge once, so we can hoist it out of the loop.
-    let bridgedElements = unsafe bridgeElements()
+    let bridgedElements = bridgeElements()
 
     var stored = 0
     for i in 0..<count {
@@ -526,7 +526,7 @@ extension __CocoaSet: Sequence {
     // This stored property should be stored at offset zero.  There's code below
     // relying on this.
     internal var _fastEnumerationState: _SwiftNSFastEnumerationState =
-      unsafe _makeSwiftNSFastEnumerationState()
+      _makeSwiftNSFastEnumerationState()
 
     // This stored property should be stored right after
     // `_fastEnumerationState`.  There's code below relying on this.

--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -171,7 +171,7 @@ extension RawSpan {
   @_alwaysEmitIntoClient
   @lifetime(borrow mutableRawSpan)
   public init(_mutableRawSpan mutableRawSpan: borrowing MutableRawSpan) {
-    let (start, count) = unsafe (mutableRawSpan._start(), mutableRawSpan._count)
+    let (start, count) = (mutableRawSpan._start(), mutableRawSpan._count)
     let span = unsafe RawSpan(_unsafeStart: start, byteCount: count)
     self = unsafe _overrideLifetime(span, borrowing: mutableRawSpan)
   }

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -600,7 +600,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   ) where Element: BitwiseCopyable {
     guard count > 0 else { return }
     // rebind _start manually in order to avoid assumptions about alignment.
-    let rp = unsafe _start()._rawValue
+    let rp = _start()._rawValue
     let binding = Builtin.bindMemory(rp, count._builtinWordValue, Element.self)
     let rebound = unsafe UnsafeMutablePointer<Element>(rp)
     unsafe rebound.update(repeating: repeatedValue, count: count)

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -81,7 +81,7 @@ private func _objc(_ str: _CocoaString) -> _StringSelectorHolder {
 
 @_effects(releasenone)
 private func _copyNSString(_ str: _StringSelectorHolder) -> _CocoaString {
-  return unsafe str.copy(with: nil)
+  return str.copy(with: nil)
 }
 
 @usableFromInline // @testable
@@ -127,7 +127,7 @@ private func _stdlib_binary_createIndirectTaggedPointerNSString(
 internal func _stdlib_binary_CFStringGetCharactersPtr(
   _ source: _CocoaString
 ) -> UnsafeMutablePointer<UTF16.CodeUnit>? {
-  return unsafe _NSStringCharactersPtr(_objc(source))
+  return _NSStringCharactersPtr(_objc(source))
 }
 
 @_effects(releasenone)
@@ -284,7 +284,7 @@ internal func _cocoaHashASCIIBytes(
 internal func _cocoaCStringUsingEncodingTrampoline(
   _ string: _CocoaString, _ encoding: UInt
 ) -> UnsafePointer<UInt8>? {
-  return unsafe _swift_stdlib_NSStringCStringUsingEncodingTrampoline(string, encoding)
+  return _swift_stdlib_NSStringCStringUsingEncodingTrampoline(string, encoding)
 }
 
 @_effects(releasenone)
@@ -373,7 +373,7 @@ private func _NSStringASCIIPointer(_ str: _StringSelectorHolder) -> UnsafePointe
 @_effects(readonly)
 private func _NSStringUTF8Pointer(_ str: _StringSelectorHolder) -> UnsafePointer<UInt8>? {
   //We don't have a way to ask for UTF8 here currently
-  return unsafe _NSStringASCIIPointer(str)
+  return _NSStringASCIIPointer(str)
 }
 
 @_effects(readonly)
@@ -405,7 +405,7 @@ private func _withCocoaASCIIPointer<R>(
   }
   #endif
   defer { _fixLifetime(str) }
-  if let ptr = unsafe _NSStringASCIIPointer(_objc(str)) {
+  if let ptr = _NSStringASCIIPointer(_objc(str)) {
     return unsafe work(ptr)
   }
   return nil
@@ -430,7 +430,7 @@ private func _withCocoaUTF8Pointer<R>(
   }
   #endif
   defer { _fixLifetime(str) }
-  if let ptr = unsafe _NSStringUTF8Pointer(_objc(str)) {
+  if let ptr = _NSStringUTF8Pointer(_objc(str)) {
     return unsafe work(ptr)
   }
   return nil
@@ -476,7 +476,7 @@ private enum CocoaStringPointer {
 private func _getCocoaStringPointer(
   _ cfImmutableValue: _CocoaString
 ) -> CocoaStringPointer {
-  if let ascii = unsafe stableCocoaASCIIPointer(cfImmutableValue) {
+  if let ascii = stableCocoaASCIIPointer(cfImmutableValue) {
     return unsafe .ascii(ascii)
   }
   // We could ask for UTF16 here via _stdlib_binary_CFStringGetCharactersPtr,
@@ -527,7 +527,7 @@ internal func _bridgeCocoaString(_ cocoaString: _CocoaString) -> _StringGuts {
 #endif
 
     let (fastUTF8, isASCII): (Bool, Bool)
-    switch unsafe _getCocoaStringPointer(immutableCopy) {
+    switch _getCocoaStringPointer(immutableCopy) {
     case .ascii(_): (fastUTF8, isASCII) = (true, true)
     case .utf8(_): (fastUTF8, isASCII) = (true, false)
     default:  (fastUTF8, isASCII) = (false, false)

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -973,7 +973,7 @@ extension _StringObject {
 #if _runtime(_ObjC)
     if largeFastIsConstantCocoa {
       return unsafe withCocoaObject {
-        unsafe _getNSCFConstantStringContentsPointer($0)
+        _getNSCFConstantStringContentsPointer($0)
       }
     }
     if largeIsCocoa {
@@ -989,7 +989,7 @@ extension _StringObject {
   internal var sharedUTF8: UnsafeBufferPointer<UInt8> {
     @_effects(releasenone) @inline(never) get {
       _internalInvariant(largeFastIsShared)
-      let start = unsafe self.getSharedUTF8Start()
+      let start = self.getSharedUTF8Start()
       return unsafe UnsafeBufferPointer(start: start, count: largeCount)
     }
   }

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -87,7 +87,7 @@ extension _AbstractStringStorage {
          (_cocoaUTF8Encoding, _):
       return unsafe start
     default:
-      return unsafe _cocoaCStringUsingEncodingTrampoline(self, encoding)
+      return _cocoaCStringUsingEncodingTrampoline(self, encoding)
     }
   }
 
@@ -212,7 +212,7 @@ extension __StringStorage {
   @objc(cStringUsingEncoding:)
   @_effects(readonly)
   final internal func cString(encoding: UInt) -> UnsafePointer<UInt8>? {
-    return unsafe _cString(encoding: encoding)
+    return _cString(encoding: encoding)
   }
 
   @objc(getCString:maxLength:encoding:)
@@ -318,7 +318,7 @@ extension __SharedStringStorage {
   @objc(cStringUsingEncoding:)
   @_effects(readonly)
   final internal func cString(encoding: UInt) -> UnsafePointer<UInt8>? {
-    return unsafe _cString(encoding: encoding)
+    return _cString(encoding: encoding)
   }
 
   @objc(getCString:maxLength:encoding:)

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -178,7 +178,7 @@ extension _StringGuts {
         usesScratch: false, allocatedMemory: false)
     }
 
-    let (object, ptr, len) = unsafe self._allocateForDeconstruct()
+    let (object, ptr, len) = self._allocateForDeconstruct()
     return unsafe (
       owner: object,
       _convertPointerToPointerArgument(ptr),

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -852,7 +852,7 @@ extension String.UTF16View {
       return _utf16Distance(from: startIndex, to: idx)
     }
 
-    let breadcrumbs = unsafe _guts.loadUnmanagedBreadcrumbs()
+    let breadcrumbs = _guts.loadUnmanagedBreadcrumbs()
 
     // Simple and common: endIndex aka `length`.
     if idx == endIndex {
@@ -896,7 +896,7 @@ extension String.UTF16View {
     }
 
     // Simple and common: endIndex aka `length`.
-    let breadcrumbs = unsafe _guts.loadUnmanagedBreadcrumbs()
+    let breadcrumbs = _guts.loadUnmanagedBreadcrumbs()
     let utf16Count = unsafe breadcrumbs._withUnsafeGuaranteedRef { $0.utf16Length }
     if offset == utf16Count { return endIndex }
 

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -84,13 +84,13 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
   @objc(objectAtIndexedSubscript:)
   @_effects(readonly)
   dynamic internal func objectAtSubscript(_ index: Int) -> Unmanaged<AnyObject> {
-    return unsafe _objectAt(index)
+    return _objectAt(index)
   }
   
   @objc(objectAtIndex:)
   @_effects(readonly)
   dynamic internal func objectAt(_ index: Int) -> Unmanaged<AnyObject> {
-    return unsafe _objectAt(index)
+    return _objectAt(index)
   }
 
   @objc internal func getObjects(

--- a/stdlib/public/core/UTF8SpanIterators.swift
+++ b/stdlib/public/core/UTF8SpanIterators.swift
@@ -28,7 +28,7 @@ extension UTF8Span {
     }
 
     private var _start: UnsafeRawPointer {
-      unsafe codeUnits._start()
+      codeUnits._start()
     }
 
     /// Decode and return the scalar starting at `currentCodeUnitOffset`.
@@ -227,7 +227,7 @@ extension UTF8Span {
     }
 
     private var _start: UnsafeRawPointer {
-      unsafe codeUnits._start()
+      codeUnits._start()
     }
 
     /// Return the `Character` starting at `currentCodeUnitOffset`. After the

--- a/stdlib/public/core/UnicodeScalarProperties.swift
+++ b/stdlib/public/core/UnicodeScalarProperties.swift
@@ -1277,7 +1277,7 @@ extension Unicode.Scalar.Properties {
   /// This property corresponds to the "Name_Alias" property in the
   /// [Unicode Standard](http://www.unicode.org/versions/latest/).
   public var nameAlias: String? {
-    guard let nameAliasPtr = unsafe _swift_stdlib_getNameAlias(_scalar.value) else {
+    guard let nameAliasPtr = _swift_stdlib_getNameAlias(_scalar.value) else {
       return nil
     }
 

--- a/test/Constraints/issue-66553.swift
+++ b/test/Constraints/issue-66553.swift
@@ -4,7 +4,7 @@
 
 func baz(y: [Int], z: Int) -> Int {
   switch z {
-  case y[let z]: // expected-error {{'let' binding pattern cannot appear in an expression}}
+  case y[let z]: // expected-error 2{{'let' binding pattern cannot appear in an expression}}
     z
   default:
     z

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -406,7 +406,7 @@ func testNonBinding5(_ x: Int, y: [Int]) {
 func testNonBinding6(y: [Int], z: Int) -> Int {
   switch 0 {
   // We treat 'z' here as a binding, which is invalid.
-  case let y[z]: // expected-error {{pattern variable binding cannot appear in an expression}}
+  case let y[z]: // expected-error 2{{pattern variable binding cannot appear in an expression}}
     z
   case y[z]: // This is fine
     0

--- a/test/Unsafe/safe_argument_suppression.swift
+++ b/test/Unsafe/safe_argument_suppression.swift
@@ -38,7 +38,7 @@ class NotSafeSubclass: NotSafe {
 
   ns.stillUnsafe() // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{documentation-file=strict-memory-safety}}
   // expected-note@-1{{reference to parameter 'ns' involves unsafe type 'NotSafe'}}
-  // expected-note@-2{{reference to instance method 'stillUnsafe()' involves unsafe type 'NotSafe'}}
+  // expected-note@-2{{argument 'self' in call to instance method 'stillUnsafe' has unsafe type 'NotSafe'}}
 }
 
 @safe func testImpliedSafetySubclass(ns: NotSafeSubclass) {

--- a/test/Unsafe/unsafe-suppression.swift
+++ b/test/Unsafe/unsafe-suppression.swift
@@ -11,7 +11,9 @@ func iAmImpliedUnsafe() -> UnsafeType? { nil }
 @unsafe
 func labeledUnsafe(_: UnsafeType) {
   unsafe iAmUnsafe()
-  let _ = unsafe iAmImpliedUnsafe()
+  let _ = iAmImpliedUnsafe() // okay, since the unsafety is captured in the result type
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  let _ = iAmImpliedUnsafe // expected-note{{reference to global function 'iAmImpliedUnsafe()' involves unsafe type 'UnsafeType'}}
 }
 
 

--- a/test/Unsafe/unsafe.swift
+++ b/test/Unsafe/unsafe.swift
@@ -49,7 +49,7 @@ extension ConformsToMultiP: MultiP {
   // expected-note@-1{{unsafe type 'UnsafeSuper' cannot satisfy safe associated type 'Ptr'}}
   @unsafe func f() -> UnsafeSuper {
     .init() // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}
-    // expected-note@-1{{reference to initializer 'init()' involves unsafe type 'UnsafeSuper'}}
+    // expected-note@-1{{argument 'self' in call to initializer 'init' has unsafe type 'UnsafeSuper'}}
   }
 }
 
@@ -141,11 +141,13 @@ func testRHS(b: Bool, x: Int) {
 }
 
 // -----------------------------------------------------------------------
-// Declaration references
+// Calls and declaration references
 // -----------------------------------------------------------------------
 @unsafe func unsafeF() { }
 @unsafe var unsafeVar: Int = 0
 
+func acceptUnsafeArgument(_: UnsafePointer<Int>?) { }
+func acceptUnsafeNamedArgument(arg: UnsafePointer<Int>?) { }
 
 func testMe(
   _ pointer: PointerType,
@@ -156,11 +158,28 @@ func testMe(
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{7-7=unsafe }}
   _ = unsafeVar // expected-note{{reference to unsafe var 'unsafeVar'}}
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{3-3=unsafe }}
-  unsafeSuper.f() // expected-note{{reference to instance method 'f()' involves unsafe type 'UnsafeSuper'}}
+  unsafeSuper.f() // expected-note{{argument 'self' in call to instance method 'f' has unsafe type 'UnsafeSuper'}}
   // expected-note@-1{{reference to parameter 'unsafeSuper' involves unsafe type 'UnsafeSuper'}}
 
+  _ = getPointers() // unsafe return is fine
+
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{7-7=unsafe }}
-  _ = getPointers() // expected-note{{reference to global function 'getPointers()' involves unsafe type 'PointerType'}}
+  _ = getPointers // expected-note{{reference to global function 'getPointers()' involves unsafe type 'PointerType'}}
+
+  var i = 17
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  acceptUnsafeArgument(&i) // expected-note{{argument #0 in call to global function 'acceptUnsafeArgument' has unsafe type 'UnsafePointer<Int>?'}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  acceptUnsafeNamedArgument(arg: &i) // expected-note{{argument 'arg' in call to global function 'acceptUnsafeNamedArgument' has unsafe type 'UnsafePointer<Int>?'}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  let fn: (UnsafePointer<Int>?) -> Void = acceptUnsafeArgument // expected-note{{reference to global function 'acceptUnsafeArgument' involves unsafe type 'UnsafePointer<Int>'}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  fn(&i) // expected-note{{argument #0 in call has unsafe type 'UnsafePointer<Int>?'}}
+
+  // Nil isn't unsafe
+  acceptUnsafeArgument(nil)
+  acceptUnsafeNamedArgument(arg: nil)
+  fn(nil)
 }
 
 // -----------------------------------------------------------------------

--- a/test/Unsafe/unsafe_imports.swift
+++ b/test/Unsafe/unsafe_imports.swift
@@ -13,7 +13,10 @@ func testUnsafe(_ ut: UnsafeType) {
   var array: [CInt] = [1, 2, 3, 4, 5]
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{3-3=unsafe }}
   print_ints(&array, CInt(array.count))
-  // expected-note@-1{{reference to global function 'print_ints' involves unsafe type 'UnsafeMutablePointer<Int32>'}}
+  // expected-note@-1{{argument #0 in call to global function 'print_ints' has unsafe type 'UnsafeMutablePointer<Int32>?'}}
+
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{7-7=unsafe }}
+  _ = print_ints // expected-note{{reference to global function 'print_ints' involves unsafe type 'UnsafeMutablePointer<Int32>'}}
 }
 
 // Reference a typealias that isn't itself @unsafe, but refers to an unsafe
@@ -25,7 +28,7 @@ func testUnsafeThroughAlias(_ ut: UnsafeTypeAlias) {
 
 func callThroughAlias(ut: UnsafeTypeAlias) {
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
-  testUnsafeThroughAlias(ut) // expected-note{{reference to global function 'testUnsafeThroughAlias' involves unsafe type 'UnsafeTypeAlias' (aka 'PointerType')}}
+  testUnsafeThroughAlias(ut) // expected-note{{argument #0 in call to global function 'testUnsafeThroughAlias' has unsafe type 'UnsafeTypeAlias' (aka 'PointerType')}}
   // expected-note@-1{{reference to parameter 'ut' involves unsafe type 'UnsafeTypeAlias' (aka 'PointerType')}}
 }
 

--- a/test/Unsafe/unsafe_nonstrict.swift
+++ b/test/Unsafe/unsafe_nonstrict.swift
@@ -14,5 +14,5 @@ func acceptP<T: P>(_: T) { }
 func testItAll(ut: UnsafeType, x: X, i: Int) {
   _ = unsafe ut
   unsafe acceptP(x)
-  _ = unsafe i
+  _ = unsafe i // expected-warning{{no unsafe operations occur within 'unsafe' expression}}
 }

--- a/test/Unsafe/unsafe_stdlib.swift
+++ b/test/Unsafe/unsafe_stdlib.swift
@@ -9,7 +9,7 @@ func test(
 ) {
   var array = [1, 2, 3]
   // expected-warning@+2{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{3-3=unsafe }}
-  // expected-note@+1{{reference to instance method 'withUnsafeBufferPointer' involves unsafe type 'UnsafeBufferPointer<Int>'}}
+  // expected-note@+1{{argument #0 in call to instance method 'withUnsafeBufferPointer' has unsafe type '(UnsafeBufferPointer<Element>) throws(E) -> R'}}
   array.withUnsafeBufferPointer{ buffer in
   // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{5-5=unsafe }}
     print(buffer) // expected-note{{reference to parameter 'buffer' involves unsafe type 'UnsafeBufferPointer<Int>'}}

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -361,11 +361,11 @@ func testSequenceExpr() async throws(Never) {
 
   _ = unsafe await try! getIntAsync() + getIntAsync()
   // expected-warning@-1 {{'try' must precede 'await'}}
-
+  // expected-warning@-2{{no unsafe operations occur within 'unsafe' expression}}
   _ = try unsafe await try! getIntAsync() + getIntAsync()
   // expected-warning@-1 {{'try' must precede 'await'}}
   // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
-
+  // expected-warning@-3{{no unsafe operations occur within 'unsafe' expression}}
   try _ = (try! getInt()) + getInt()
   // expected-error@-1:29 {{thrown expression type 'any Error' cannot be converted to error type 'Never'}}
 


### PR DESCRIPTION
Similar to what we do for 'throws' checking, perform argument-specific checking for unsafe call arguments. This provides more detailed failures:

```
example.swift:18:3: warning: expression uses unsafe constructs but is not
marked with 'unsafe' [#StrictMemorySafety]
16 |   x.f(a: 0, b: 17, c: nil)
17 |
18 |   x.f(a: 0, b: 17, c: &i)
   |   |                   `- note: argument 'c' in call to instance
method 'f' has unsafe type 'UnsafePointer<Int>?'
   |   `- warning: expression uses unsafe constructs but is not marked
with 'unsafe' [#StrictMemorySafety]
19 |   unsafeF()
20 | }
```

It also means that we won't complain for `nil` or `Optional.none` arguments passed to unsafe types, which eliminates some false positives, and won't complain about unsafe result types when there is a call---because we'd still get complaints later about the actually-unsafe bit, which is using those results.

Fixes rdar://149629670.