### PR TITLE
[6.2][Concurrency] Add nonisolated(nonsending) to completion lookup

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3139,6 +3139,7 @@ void CompletionLookup::getAttributeDeclParamCompletions(
     break;
   case ParameterizedDeclAttributeKind::Nonisolated:
     addDeclAttrParamKeyword("unsafe", /*Parameters=*/{}, "", false);
+    addDeclAttrParamKeyword("nonsending", /*Parameters=*/{}, "", false);
     break;
   case ParameterizedDeclAttributeKind::AccessControl:
     addDeclAttrParamKeyword("set", /*Parameters=*/{}, "", false);

--- a/test/IDE/complete_nonisolated.swift
+++ b/test/IDE/complete_nonisolated.swift
@@ -1,0 +1,10 @@
+// RUN: %batch-code-completion
+
+// NONISOLATED-DAG: Keyword/None:                       unsafe; name=unsafe
+// NONISOLATED-DAG: Keyword/None:                       nonsending; name=nonsending
+
+nonisolated(#^NONISOLATED_UNSAFE_TOP_LEVEL?check=NONISOLATED^#) var count = 0
+
+struct MyStruct {
+  nonisolated(#^NONISOLATED_UNSAFE_IN_STRUCT?check=NONISOLATED^#) var prop = 0
+}

--- a/test/IDE/complete_nonisolated_unsafe.swift
+++ b/test/IDE/complete_nonisolated_unsafe.swift
@@ -1,9 +1,0 @@
-// RUN: %batch-code-completion
-
-// NONISOLATED_UNSAFE: Keyword/None:                       unsafe; name=unsafe
-
-nonisolated(#^NONISOLATED_UNSAFE_TOP_LEVEL?check=NONISOLATED_UNSAFE^#) var count = 0
-
-struct MyStruct {
-  nonisolated(#^NONISOLATED_UNSAFE_IN_STRUCT?check=NONISOLATED_UNSAFE^#) var prop = 0
-}


### PR DESCRIPTION
**Description**: We didn't add the autocompletion for `nonisolated(nonsending)` while this combo of keywords was introduced, this fixes that missing IDE autocompletion.

**Scope/Impact**: Just adds which autocomplete we offer, now including "nonsending" which was added in 6.2.
**Risk:** Low, just adds a case to autocompletion
**Testing**: CI testing, added test covering this completion
**Reviewed by**: @xedin

**Original PR:** https://github.com/swiftlang/swift/pull/81099
**Radar:**