### PR TITLE
[Concurrency] Hashable funcs should be inlinable for AsyncStream

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -177,6 +177,7 @@ public struct AsyncStream<Element> {
       case bufferingNewest(Int)
     }
 
+    @usableFromInline
     let storage: _Storage
 
     /// Resume the task awaiting the next iteration point by having it return
@@ -477,14 +478,17 @@ extension AsyncStream.Continuation.YieldResult: Sendable where Element: Sendable
 
 @available(SwiftStdlib 6.2, *)
 extension AsyncStream.Continuation: Hashable {
+  @inlinable
   @available(SwiftStdlib 6.2, *)
   public func hash(into hasher: inout Hasher) {
     return hasher.combine(ObjectIdentifier(storage))
   }
+  @inlinable
   @available(SwiftStdlib 6.2, *)
   public var hashValue: Int {
     return _hashValue(for: self)
   }
+  @inlinable
   @available(SwiftStdlib 6.2, *)
   public static func == (lhs: Self, rhs: Self) -> Bool {
     return lhs.storage === rhs.storage

--- a/stdlib/public/Concurrency/AsyncStreamBuffer.swift
+++ b/stdlib/public/Concurrency/AsyncStreamBuffer.swift
@@ -55,6 +55,7 @@ func _unlock(_ ptr: UnsafeRawPointer)
 @available(SwiftStdlib 5.1, *)
 extension AsyncStream {
   @safe
+  @usableFromInline
   internal final class _Storage: @unchecked Sendable {
     typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void
 
@@ -281,6 +282,7 @@ extension AsyncStream {
 @available(SwiftStdlib 5.1, *)
 extension AsyncThrowingStream {
   @safe
+  @usableFromInline
   internal final class _Storage: @unchecked Sendable {
     typealias TerminationHandler = @Sendable (Continuation.Termination) -> Void
     enum Terminal {

--- a/stdlib/public/Concurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingStream.swift
@@ -199,6 +199,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
       case bufferingNewest(Int)
     }
 
+    @usableFromInline
     let storage: _Storage
 
     /// Resume the task awaiting the next iteration point by having it return
@@ -523,14 +524,17 @@ extension AsyncThrowingStream.Continuation.YieldResult: Sendable where Element: 
 
 @available(SwiftStdlib 6.2, *)
 extension AsyncThrowingStream.Continuation: Hashable {
+  @inlinable
   @available(SwiftStdlib 6.2, *)
   public func hash(into hasher: inout Hasher) {
     return hasher.combine(ObjectIdentifier(storage))
   }
+  @inlinable
   @available(SwiftStdlib 6.2, *)
   public var hashValue: Int {
     return _hashValue(for: self)
   }
+  @inlinable
   @available(SwiftStdlib 6.2, *)
   public static func == (lhs: Self, rhs: Self) -> Bool {
     return lhs.storage === rhs.storage

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -416,3 +416,21 @@ Added: _swift_task_dealloc_through
 
 // SwiftSettings
 Added: _$ss12SwiftSettingVsE16defaultIsolationyABScA_pXpSgFZ
+
+// Hashable for (Throwing)AsyncStream
+Added: _$sScS12ContinuationV7storageScS8_StorageCyx_Gvg
+Added: _$sScS12ContinuationV7storageScS8_StorageCyx_GvpMV
+Added: _$sScS8_StorageCMa
+Added: _$sScS8_StorageCMn
+Added: _$sScS8_StorageCMo
+Added: _$sScS8_StorageCMu
+Added: _$sScS8_StorageCfD
+Added: _$sScS8_StorageCfd
+Added: _$sScs12ContinuationV7storageScs8_StorageCyxq__Gvg
+Added: _$sScs12ContinuationV7storageScs8_StorageCyxq__GvpMV
+Added: _$sScs8_StorageCMa
+Added: _$sScs8_StorageCMn
+Added: _$sScs8_StorageCMo
+Added: _$sScs8_StorageCMu
+Added: _$sScs8_StorageCfD
+Added: _$sScs8_StorageCfd

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -416,3 +416,21 @@ Added: _swift_task_dealloc_through
 
 // SwiftSettings
 Added: _$ss12SwiftSettingVsE16defaultIsolationyABScA_pXpSgFZ
+
+// Hashable for (Throwing)AsyncStream
+Added: _$sScS12ContinuationV7storageScS8_StorageCyx_Gvg
+Added: _$sScS12ContinuationV7storageScS8_StorageCyx_GvpMV
+Added: _$sScS8_StorageCMa
+Added: _$sScS8_StorageCMn
+Added: _$sScS8_StorageCMo
+Added: _$sScS8_StorageCMu
+Added: _$sScS8_StorageCfD
+Added: _$sScS8_StorageCfd
+Added: _$sScs12ContinuationV7storageScs8_StorageCyxq__Gvg
+Added: _$sScs12ContinuationV7storageScs8_StorageCyxq__GvpMV
+Added: _$sScs8_StorageCMa
+Added: _$sScs8_StorageCMn
+Added: _$sScs8_StorageCMo
+Added: _$sScs8_StorageCMu
+Added: _$sScs8_StorageCfD
+Added: _$sScs8_StorageCfd

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -128,6 +128,13 @@ Func withThrowingTaskGroup(of:returning:body:) has parameter 2 type change from 
 Func withTaskGroup(of:returning:body:) has been renamed to Func withTaskGroup(of:returning:isolation:body:)
 Func withTaskGroup(of:returning:body:) has mangled name changing from '_Concurrency.withTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, body: (inout Swift.TaskGroup<A>) async -> B) async -> B' to '_Concurrency.withTaskGroup<A, B where A: Swift.Sendable>(of: A.Type, returning: B.Type, isolation: isolated Swift.Optional<Swift.Actor>, body: (inout Swift.TaskGroup<A>) async -> B) async -> B'
 
+// Hashable for (Throwing)AsyncStream
+// These are just @usableFromInline:
+Var AsyncStream.Continuation.storage is a new API without '@available'
+Var AsyncThrowingStream.Continuation.storage is a new API without '@available'
+Class AsyncStream._Storage is a new API without '@available'
+Class AsyncThrowingStream._Storage is a new API without '@available'
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
 


### PR DESCRIPTION
Follow up for https://github.com/swiftlang/swift/pull/81064/

Radar rdar://149914179