### PR TITLE
Bootstrap: Install dispatch in stage0

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3128,6 +3128,7 @@ swift-include-tests=0
 llvm-include-tests=0
 
 release
+libdispatch
 
 skip-early-swiftsyntax
 skip-early-swift-driver
@@ -3160,6 +3161,7 @@ llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;compile
 
 install-llvm
 install-swift
+install-libdispatch
 
 # Build Toolchain Requirements:
 # - C/C++ compiler


### PR DESCRIPTION
The concurrency runtimes require that dispatch is installed or it will fail to load at launch. The C library is built as part of the concurrency build but is not installed. We need to install a copy of dispatch so that programs that link concurrency run.

This is to fix the failure to launch the [Swift compiler](https://ci.swift.org/job/swift-bootstrap-ubuntu-24_04-x86_64/101/): 
```
: && /home/build-user/stages/stage0/usr/bin/swiftc -j 36 -num-threads 36 -emit-executable -o cmTC_5fc48  CMakeFiles/cmTC_5fc48.dir/main.swift.o    && :
 <unknown>:0: warning: using (deprecated) legacy driver, Swift installation does not contain swift-driver at: '/home/build-user/stages/stage0/usr/bin/swift-driver-new'
    /usr/bin/ld: warning: libdispatch.so, needed by /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so, not found (try using -rpath or -rpath-link)
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_release'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_queue_create'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_assert_queue'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_set_context'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_after_f'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `_dispatch_main_q'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_main'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_source_create'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `_dispatch_source_type_timer'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_queue_attr_make_with_qos_class'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_source_set_event_handler_f'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_source_set_timer'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_async_f'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `_dispatch_queue_attr_concurrent'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_queue_set_width'
    /usr/bin/ld: /home/build-user/stages/stage0/usr/lib/swift/linux/libswift_Concurrency.so: undefined reference to `dispatch_activate'
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    <unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
```