### PR TITLE
LifetimeDependence: fix a type checker crash on implicit init

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -962,7 +962,7 @@ protected:
         diagnose(returnLoc,
                  diag::lifetime_dependence_cannot_infer_scope_ownership,
                  param->getParameterName().str(), diagnosticQualifier());
-        continue;
+        return;
       }
       targetDeps = std::move(targetDeps).add(paramIndex, *kind);
     }

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -168,6 +168,12 @@ struct EscapableNonTrivialSelf {
 // (for initializers and stand-alone functions)
 // =============================================================================
 
+// An implicit initializer illegally consumes its nontrivial parameter.
+public struct NonescapableImplicitInitializer: ~Escapable {
+  // expected-error @-1{{cannot borrow the lifetime of 'c', which has consuming ownership on an implicit initializer}}
+  var c: C
+}
+
 struct NonescapableInitializers: ~Escapable {
   var c: C
 


### PR DESCRIPTION
When the type checker diagnoses an error on an implicit initializer,
return immediately before handling its parameter to avoid an assert.
