### PR TITLE
SIL: some API improvements for the `ScopedInstruction` and `BorrowIntroducingInstruction` protocols

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -358,7 +358,7 @@ struct AliasAnalysis {
       return defaultEffects(of: endBorrow, on: memLoc)
     case .box, .class, .tail:
       // Check if the memLoc is "derived" from the begin_borrow, i.e. is an interior pointer.
-      var walker = FindBeginBorrowWalker(beginBorrow: endBorrow.borrow as! BorrowIntroducingInstruction)
+      var walker = FindBeginBorrowWalker(beginBorrow: endBorrow.borrow as! BeginBorrowInstruction)
       return walker.visitAccessStorageRoots(of: accessPath) ? .noEffects : .worstEffects
     }
   }
@@ -704,7 +704,7 @@ private enum ImmutableScope {
 }
 
 private struct FindBeginBorrowWalker : ValueUseDefWalker {
-  let beginBorrow: BorrowIntroducingInstruction
+  let beginBorrow: BeginBorrowInstruction
   var walkUpCache = WalkerCache<Path>()
 
   mutating func walkUp(value: Value, path: SmallProjectionPath) -> WalkResult {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
@@ -136,7 +136,7 @@ private func constructLetInitRegion(
   // root-class initializer).
   initRegion.insert(markUninitialized)
 
-  var borrows = Stack<BorrowIntroducingInstruction>(context)
+  var borrows = Stack<BeginBorrowInstruction>(context)
   defer { borrows.deinitialize() }
 
   for inst in markUninitialized.parentFunction.instructions {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -298,7 +298,7 @@ private struct ExtendableScope {
   var endInstructions: LazyMapSequence<LazyFilterSequence<UseList>, Instruction> {
     switch introducer {
     case let .scoped(scopedInst):
-      return scopedInst.endOperands.users
+      return scopedInst.scopeEndingOperands.users
     case let .owned(value):
       return value.uses.endingLifetime.users
     }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -287,7 +287,7 @@ private struct ExtendableScope {
   var firstInstruction: Instruction {
     switch introducer {
     case let .scoped(scopedInst):
-      return scopedInst.instruction
+      return scopedInst
     case let .owned(value):
       if let definingInst = value.definingInstructionOrTerminator {
         return definingInst

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -826,7 +826,7 @@ extension GlobalVariable {
 
 extension InstructionRange {
   /// Adds the instruction range of a borrow-scope by transitively visiting all (potential) re-borrows.
-  mutating func insert(borrowScopeOf borrow: BorrowIntroducingInstruction, _ context: some Context) {
+  mutating func insert(borrowScopeOf borrow: BeginBorrowInstruction, _ context: some Context) {
     var worklist = ValueWorklist(context)
     defer { worklist.deinitialize() }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -685,7 +685,7 @@ extension InteriorUseWalker: AddressUseVisitor {
       if handleInner(borrowed: ba) == .abortWalk {
         return .abortWalk
       }
-      return ba.endOperands.walk { useVisitor($0) }
+      return ba.scopeEndingOperands.walk { useVisitor($0) }
     case let ba as BeginApplyInst:
       if handleInner(borrowed: ba.token) == .abortWalk {
         return .abortWalk

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1415,9 +1415,7 @@ final public class AllocExistentialBoxInst : SingleValueInstruction, Allocation 
 /// An instruction whose side effects extend across a scope including other instructions. These are always paired with a
 /// scope ending instruction such as `begin_access` (ending with `end_access`) and `begin_borrow` (ending with
 /// `end_borrow`).
-public protocol ScopedInstruction {
-  var instruction: Instruction { get }
-
+public protocol ScopedInstruction: Instruction {
   var endOperands: LazyFilterSequence<UseList> { get }
 
   var endInstructions: EndInstructions { get }
@@ -1437,17 +1435,13 @@ extension Instruction {
 public protocol BorrowIntroducingInstruction : SingleValueInstruction, ScopedInstruction {
 }
 
-extension BorrowIntroducingInstruction {
-  public var instruction: Instruction { get { self } }
-}
-
 final public class EndBorrowInst : Instruction, UnaryInstruction {
   public var borrow: Value { operand.value }
 }
 
 extension BorrowIntroducingInstruction {
   public var endOperands: LazyFilterSequence<UseList> {
-    return uses.lazy.filter { $0.instruction is EndBorrowInst }
+    return self.uses.lazy.filter { $0.instruction is EndBorrowInst }
   }
 }
 
@@ -1518,8 +1512,6 @@ final public class EndAccessInst : Instruction, UnaryInstruction {
 }
 
 extension BeginAccessInst : ScopedInstruction {
-  public var instruction: Instruction { get { self } }
-
   public var endOperands: LazyFilterSequence<UseList> {
     return uses.lazy.filter { $0.instruction is EndAccessInst }
   }
@@ -1556,8 +1548,6 @@ final public class AbortApplyInst : Instruction, UnaryInstruction {
 }
 
 extension BeginApplyInst : ScopedInstruction {
-  public var instruction: Instruction { get { self } }
-
   public var endOperands: LazyFilterSequence<UseList> {
     return token.uses.lazy.filter { $0.isScopeEndingUse }
   }


### PR DESCRIPTION
* Make `protocol ScopeInstruction` an `Instruction` protocol: this allows to remove the `var instruction` property.
* Rename `protocol BorrowIntroducingInstruction` -> `BeginBorrowInstruction`: to match with `BeginBorrowValue`
* Make `BeginBorrowInstruction.endOperands` and `BeginBorrowValue.scopeEndingOperands` consistent:
  * Rename `ScopedInstruction.endOperands` -> `scopeEndingOperands`
  * Let them behave the same way. For `load_borrow` there was a difference because `endOperands` didn't consider branches to re-borrow phis.