### PR TITLE
Fix `test/Misc/target-cpu.swift`

### DIFF
--- a/test/Misc/target-cpu.swift
+++ b/test/Misc/target-cpu.swift
@@ -14,7 +14,7 @@
 // WATCHTARGETCPU1: "-target-cpu" "cortex-a7"
 
 // RUN: not %swift -typecheck -target arm64-apple-watchos2 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=WATCHTARGETCPU2 %s
-// WATCHTARGETCPU2: "-target-cpu" "apple-a7"
+// WATCHTARGETCPU2: "-target-cpu" "apple-s4"
 
 // RUN: not %swift -typecheck -target armv7s-apple-ios7 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=TARGETCPU2 %s
 // TARGETCPU2: "-target-cpu" "swift"

--- a/test/Misc/target-cpu.swift
+++ b/test/Misc/target-cpu.swift
@@ -13,7 +13,7 @@
 // RUN: not %swift -typecheck -target armv7k-apple-watchos2 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=WATCHTARGETCPU1 %s
 // WATCHTARGETCPU1: "-target-cpu" "cortex-a7"
 
-// RUN: not %swift -typecheck -target arm64-apple-watchos2 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=WATCHTARGETCPU2 %s
+// RUN: not %swift -typecheck -target arm64_32-apple-watchos2 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=WATCHTARGETCPU2 %s
 // WATCHTARGETCPU2: "-target-cpu" "apple-s4"
 
 // RUN: not %swift -typecheck -target armv7s-apple-ios7 -Xcc -### %s 2>&1 | %FileCheck -check-prefix=TARGETCPU2 %s


### PR DESCRIPTION
It expected `apple-a7`, while the new value is `apple-s4` for `WATCHTARGETCPU2`.

rdar://150074485