### PR TITLE
Optimize keypaths in language 6 mode

### DIFF
--- a/lib/SILOptimizer/Utils/KeyPathProjector.cpp
+++ b/lib/SILOptimizer/Utils/KeyPathProjector.cpp
@@ -674,8 +674,8 @@ private:
 
 KeyPathInst *
 KeyPathProjector::getLiteralKeyPath(SILValue keyPath) {
-  while (auto *upCast = dyn_cast<UpcastInst>(keyPath)) {
-    keyPath = lookThroughOwnershipInsts(upCast->getOperand());
+  while (isa<UpcastInst>(keyPath) || isa<OpenExistentialRefInst>(keyPath)) {
+    keyPath = lookThroughOwnershipInsts(cast<SingleValueInstruction>(keyPath)->getOperand(0));
   }
 
   return dyn_cast<KeyPathInst>(keyPath);

--- a/test/SILOptimizer/capture_propagate_keypath.swift
+++ b/test/SILOptimizer/capture_propagate_keypath.swift
@@ -60,6 +60,8 @@ func testGenStr(_ mymap: ((GenStr<Int>)->Int) -> ()) {
 
 // CHECK-LABEL: sil {{.*}} @$s4test0A22GenericEscapingClosureAA5GetIDVySayAA3StrVGSiGyF :
 // CHECK-NOT:     keypath
+// CHECK:         = function_ref @[[SPECIALIZED_CLOSURE:.*]] : $@convention(thin) (@in_guaranteed Str) -> @out Int
+// CHECK-NOT:     keypath
 // CHECK-LABEL:  } // end sil function '$s4test0A22GenericEscapingClosureAA5GetIDVySayAA3StrVGSiGyF'
 @inline(never)
 func testGenericEscapingClosure() -> GetID<[Str], Int> {
@@ -84,6 +86,10 @@ func testGeneric<T>(_ mymap: ((GenStr<T>)->T) -> ()) {
 public func _opaqueIdentity<T>(_ x: T) -> T {
   return x
 }
+
+// CHECK:       sil shared {{.*}}@[[SPECIALIZED_CLOSURE]] :
+// CHECK-NOT:     keypath
+// CHECK:       } // end sil function '[[SPECIALIZED_CLOSURE]]'
 
 func calltests() {
   // CHECK-OUTPUT-LABEL: testSimple:


### PR DESCRIPTION
In language 6 mode keypath instructions are created as existentials and the optimizer needs to look through the `open_existential_ref` instructions to recognize a keypath.

rdar://150173106
