### PR TITLE
Clean up duplicated opened existential archetype handling in SIL and more

### DIFF
--- a/SwiftCompilerSources/Sources/AST/Type.swift
+++ b/SwiftCompilerSources/Sources/AST/Type.swift
@@ -64,10 +64,6 @@ public struct Type: TypeProperties, CustomStringConvertible, NoReflectionChildre
   public func subst(with substitutionMap: SubstitutionMap) -> Type {
     return Type(bridged: bridged.subst(substitutionMap.bridged))
   }
-
-  public func subst(type: Type, with targetType: Type) -> Type {
-    return Type(bridged: bridged.subst(type.bridged, targetType.bridged))
-  }
 }
 
 /// A Type that is statically known to be canonical.
@@ -87,10 +83,6 @@ public struct CanonicalType: TypeProperties, CustomStringConvertible, NoReflecti
 
   public func subst(with substitutionMap: SubstitutionMap) -> CanonicalType {
     return rawType.subst(with: substitutionMap).canonical
-  }
-
-  public func subst(type: CanonicalType, with targetType: CanonicalType) -> CanonicalType {
-    return self.rawType.subst(type: type.rawType, with: targetType.rawType).canonical
   }
 }
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -3115,7 +3115,6 @@ struct BridgedASTType {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getContextSubstitutionMap() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedGenericSignature getInvocationGenericSignatureOfFunctionType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType subst(BridgedSubstitutionMap substMap) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType subst(BridgedASTType fromType, BridgedASTType toType) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedConformance checkConformance(BridgedDeclObj proto) const;  
 };
 

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -596,17 +596,6 @@ BridgedASTType BridgedASTType::subst(BridgedSubstitutionMap substMap) const {
   return {unbridged().subst(substMap.unbridged()).getPointer()};
 }
 
-
-BridgedASTType BridgedASTType::subst(BridgedASTType fromType, BridgedASTType toType) const {
-  auto *fromTy = fromType.unbridged()->castTo<swift::SubstitutableType>();
-  swift::Type toTy = toType.unbridged();
-  return {unbridged().subst([fromTy, toTy](swift::SubstitutableType *t) -> swift::Type {
-    if (t == fromTy)
-      return toTy;
-    return t;
-  }, swift::LookUpConformanceInModule(), swift::SubstFlags::SubstituteLocalArchetypes).getPointer()};
-}
-
 BridgedConformance BridgedASTType::checkConformance(BridgedDeclObj proto) const {
   return swift::checkConformance(unbridged(), proto.getAs<swift::ProtocolDecl>(), /*allowMissing=*/ false);
 }  

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1051,6 +1051,9 @@ public:
   const CanType TheUnconstrainedAnyType;  /// This is 'any ~Copyable & ~Escapable',
                                           /// the empty protocol composition
                                           /// without any implicit constraints.
+  const CanGenericTypeParamType TheSelfType; /// The protocol 'Self' type;
+                                             /// a generic parameter with
+                                             /// depth 0 index 0
 #define SINGLETON_TYPE(SHORT_ID, ID) \
   const CanType The##SHORT_ID##Type;
 #include "swift/AST/TypeNodes.def"

--- a/include/swift/AST/InFlightSubstitution.h
+++ b/include/swift/AST/InFlightSubstitution.h
@@ -52,8 +52,7 @@ public:
   Type substType(SubstitutableType *origType, unsigned level);
 
   /// Perform primitive conformance lookup on the given type.
-  ProtocolConformanceRef lookupConformance(CanType dependentType,
-                                           Type conformingReplacementType,
+  ProtocolConformanceRef lookupConformance(Type dependentType,
                                            ProtocolDecl *conformedProtocol,
                                            unsigned level);
 

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -181,12 +181,6 @@ public:
   /// subsystem.
   SubstitutionMap subst(InFlightSubstitution &subs) const;
 
-  /// Apply type expansion lowering to all types in the substitution map. Opaque
-  /// archetypes will be lowered to their underlying types if the type expansion
-  /// context allows.
-  SubstitutionMap mapIntoTypeExpansionContext(
-      TypeExpansionContext context) const;
-
   /// Create a substitution map for a protocol conformance.
   static SubstitutionMap
   getProtocolSubstitutions(ProtocolConformanceRef conformance);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5032,9 +5032,15 @@ Type substOpaqueTypesWithUnderlyingTypes(Type type,
 
 CanType substOpaqueTypesWithUnderlyingTypes(CanType type,
                                             TypeExpansionContext context);
+
 ProtocolConformanceRef
 substOpaqueTypesWithUnderlyingTypes(ProtocolConformanceRef ref,
                                     TypeExpansionContext context);
+
+SubstitutionMap
+substOpaqueTypesWithUnderlyingTypes(SubstitutionMap subs,
+                                    TypeExpansionContext context);
+
 namespace Lowering {
   class TypeConverter;
 }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -7082,6 +7082,32 @@ private:
   bool isWholeModule() const { return inContextAndIsWholeModule.getInt(); }
 };
 
+/// A function object that can be used as a \c TypeSubstitutionFn and
+/// \c LookupConformanceFn for \c Type::subst style APIs to map existential
+/// archetypes in the given generic environment to known concrete types from
+/// the given substitution map.
+class ReplaceExistentialArchetypesWithConcreteTypes {
+private:
+  GenericEnvironment *env;
+  SubstitutionMap subs;
+
+  Type getInterfaceType(ExistentialArchetypeType *type) const;
+
+public:
+  ReplaceExistentialArchetypesWithConcreteTypes(GenericEnvironment *env,
+                                                SubstitutionMap subs)
+      : env(env), subs(subs) {}
+
+  /// TypeSubstitutionFn
+  Type operator()(SubstitutableType *type) const;
+
+  /// LookupConformanceFn
+  ProtocolConformanceRef operator()(CanType origType,
+                                    Type substType,
+                                    ProtocolDecl *protocol) const;
+
+};
+
 /// An archetype that's only valid in a portion of a local context.
 class LocalArchetypeType : public ArchetypeType {
 protected:

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -590,7 +590,7 @@ protected:
           !context.shouldLookThroughOpaqueTypeArchetypes())
         return Subs;
 
-      return Subs.mapIntoTypeExpansionContext(context);
+      return substOpaqueTypesWithUnderlyingTypes(Subs, context);
     }
 
     return Subs;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -817,6 +817,8 @@ ASTContext::ASTContext(
       TheAnyType(ProtocolCompositionType::theAnyType(*this)),
       TheUnconstrainedAnyType(
           ProtocolCompositionType::theUnconstrainedAnyType(*this)),
+      TheSelfType(CanGenericTypeParamType(
+          GenericTypeParamType::getType(0, 0, *this))),
 #define SINGLETON_TYPE(SHORT_ID, ID) \
     The##SHORT_ID##Type(new (*this, AllocationArena::Permanent) \
                           ID##Type(*this)),
@@ -6639,8 +6641,7 @@ CanGenericSignature ASTContext::getSingleGenericParameterSignature() const {
   if (auto theSig = getImpl().SingleGenericParameterSignature)
     return theSig;
 
-  auto param = GenericTypeParamType::getType(/*depth*/ 0, /*index*/ 0, *this);
-  auto sig = GenericSignature::get(param, { });
+  auto sig = GenericSignature::get({TheSelfType}, { });
   auto canonicalSig = CanGenericSignature(sig);
   getImpl().SingleGenericParameterSignature = canonicalSig;
   return canonicalSig;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -395,7 +395,7 @@ std::string ASTMangler::mangleKeyPathGetterThunkHelper(
       sub = sub.transformRec([](Type t) -> std::optional<Type> {
         if (auto *openedExistential = t->getAs<ExistentialArchetypeType>()) {
           auto &ctx = openedExistential->getASTContext();
-          return GenericTypeParamType::getType(0, 0, ctx);
+          return ctx.TheSelfType;
         }
         return std::nullopt;
       });
@@ -431,7 +431,7 @@ std::string ASTMangler::mangleKeyPathSetterThunkHelper(
       sub = sub.transformRec([](Type t) -> std::optional<Type> {
         if (auto *openedExistential = t->getAs<ExistentialArchetypeType>()) {
           auto &ctx = openedExistential->getASTContext();
-          return GenericTypeParamType::getType(0, 0, ctx);
+          return ctx.TheSelfType;
         }
         return std::nullopt;
       });
@@ -5274,15 +5274,11 @@ static void extractExistentialInverseRequirements(
 
   auto &ctx = PCT->getASTContext();
 
-  // Form a parameter referring to the existential's Self.
-  auto existentialSelf =
-      GenericTypeParamType::getType(/*depth=*/0, /*index=*/0, ctx);
-
   for (auto ip : PCT->getInverses()) {
     auto *proto = ctx.getProtocol(getKnownProtocolKind(ip));
     assert(proto);
     ASSERT(!getABIDecl(proto) && "can't use @abi on inverse protocols");
-    inverses.push_back({existentialSelf, proto, SourceLoc()});
+    inverses.push_back({ctx.TheSelfType, proto, SourceLoc()});
   }
 }
 

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -111,9 +111,7 @@ ProtocolConformanceRef::subst(InFlightSubstitution &IFS) const {
 
   // Local conformance lookup into the substitution map.
   // FIXME: Pack element level?
-  return IFS.lookupConformance(origType->getCanonicalType(),
-                               origType.subst(IFS), proto,
-                               /*level=*/0);
+  return IFS.lookupConformance(origType, proto, /*level=*/0);
 }
 
 ProtocolConformanceRef ProtocolConformanceRef::mapConformanceOutOfContext() const {

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -98,7 +98,7 @@ RequirementEnvironment::RequirementEnvironment(
       // type.
       if (type->isEqual(selfType)) {
         if (covariantSelf)
-          return GenericTypeParamType::getType(/*depth=*/0, /*index=*/0, ctx);
+          return ctx.TheSelfType;
         return substConcreteType;
       }
       // Other requirement generic parameters map 1:1 with their depth
@@ -173,8 +173,7 @@ RequirementEnvironment::RequirementEnvironment(
   // If the conforming type is a class, add a class-constrained 'Self'
   // parameter.
   if (covariantSelf) {
-    auto paramTy = GenericTypeParamType::getType(/*depth=*/0, /*index=*/0, ctx);
-    genericParamTypes.push_back(paramTy);
+    genericParamTypes.push_back(ctx.TheSelfType);
   }
 
   // Now, add all generic parameters from the conforming type.
@@ -188,8 +187,7 @@ RequirementEnvironment::RequirementEnvironment(
   // Next, add requirements.
   SmallVector<Requirement, 2> requirements;
   if (covariantSelf) {
-    auto paramTy = GenericTypeParamType::getType(/*depth=*/0, /*index=*/0, ctx);
-    Requirement reqt(RequirementKind::Superclass, paramTy, substConcreteType);
+    Requirement reqt(RequirementKind::Superclass, ctx.TheSelfType, substConcreteType);
     requirements.push_back(reqt);
   }
 

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -281,11 +281,11 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
         continue;
 
       case Symbol::Kind::Protocol:
-        handleRoot(GenericTypeParamType::getType(0, 0, ctx.getASTContext()));
+        handleRoot(ctx.getASTContext().TheSelfType);
         continue;
 
       case Symbol::Kind::AssociatedType:
-        handleRoot(GenericTypeParamType::getType(0, 0, ctx.getASTContext()));
+        handleRoot(ctx.getASTContext().TheSelfType);
 
         // An associated type symbol at the root means we have a dependent
         // member type rooted at Self; handle the associated type below.

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -174,14 +174,12 @@ SubstitutionMap SubstitutionMap::get(GenericSignature genericSig,
   // Form the stored conformances.
   SmallVector<ProtocolConformanceRef, 4> conformances;
   for (const auto &req : genericSig.getRequirements()) {
-    if (req.getKind() != RequirementKind::Conformance) continue;
+    if (req.getKind() != RequirementKind::Conformance)
+      continue;
 
-    Type depTy = req.getFirstType();
-    auto replacement = depTy.subst(IFS);
-    auto *proto = req.getProtocolDecl();
-    auto conformance = IFS.lookupConformance(
-        depTy->getCanonicalType(), replacement, proto, /*level=*/0);
-    conformances.push_back(conformance);
+    conformances.push_back(
+      IFS.lookupConformance(
+        req.getFirstType(), req.getProtocolDecl(), /*level=*/0));
   }
 
   return SubstitutionMap(genericSig, types, conformances);

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -651,14 +651,14 @@ bool SubstitutionMap::isIdentity() const {
   return !hasNonIdentityReplacement;
 }
 
-SubstitutionMap SubstitutionMap::mapIntoTypeExpansionContext(
-    TypeExpansionContext context) const {
+SubstitutionMap swift::substOpaqueTypesWithUnderlyingTypes(
+    SubstitutionMap subs, TypeExpansionContext context) {
   ReplaceOpaqueTypesWithUnderlyingTypes replacer(
       context.getContext(), context.getResilienceExpansion(),
       context.isWholeModuleContext());
-  return this->subst(replacer, replacer,
-                     SubstFlags::SubstituteOpaqueArchetypes |
-                     SubstFlags::PreservePackExpansionLevel);
+  return subs.subst(replacer, replacer,
+                    SubstFlags::SubstituteOpaqueArchetypes |
+                    SubstFlags::PreservePackExpansionLevel);
 }
 
 bool OuterSubstitutions::isUnsubstitutedTypeParameter(Type type) const {

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -277,8 +277,7 @@ static CanSILFunctionType getAccessorType(IRGenModule &IGM) {
   SmallVector<GenericFunctionType::Param, 8> parameters;
 
   // A generic parameter that represents instance of invocation decoder.
-  auto *decoderType =
-      GenericTypeParamType::getType(/*depth=*/ 0, /*index=*/ 0, Context);
+  auto decoderType = Context.TheSelfType;
 
   // decoder
   parameters.push_back(GenericFunctionType::Param(

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1587,7 +1587,7 @@ public:
               .transformRec([](Type t) -> std::optional<Type> {
                 if (auto *openedExistential = t->getAs<ExistentialArchetypeType>()) {
                   auto &ctx = openedExistential->getASTContext();
-                  return GenericTypeParamType::getType(0, 0, ctx);
+                  return ctx.TheSelfType;
                 }
                 return std::nullopt;
               })

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -783,7 +783,7 @@ emitKeyPathComponent(IRGenModule &IGM,
                                 if (auto *openedExistential =
                                         t->getAs<ExistentialArchetypeType>()) {
                                   auto &ctx = openedExistential->getASTContext();
-                                  return GenericTypeParamType::getType(0, 0, ctx);
+                                  return ctx.TheSelfType;
                                 }
                                 return std::nullopt;
                               })

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -68,7 +68,7 @@ public:
     if (!typeExpansionContext.shouldLookThroughOpaqueTypeArchetypes())
       return subs;
 
-    return subs.mapIntoTypeExpansionContext(typeExpansionContext);
+    return substOpaqueTypesWithUnderlyingTypes(subs, typeExpansionContext);
   }
 
   // Substitute a function type.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -452,7 +452,7 @@ public:
     auto &ci = SGF.getConstantInfo(SGF.getTypeExpansionContext(), c);
     return Callee(
         SGF, c, ci.FormalPattern, ci.FormalType,
-        subs.mapIntoTypeExpansionContext(SGF.getTypeExpansionContext()),
+        substOpaqueTypesWithUnderlyingTypes(subs, SGF.getTypeExpansionContext()),
         subs,
         l,
         callPreviousDynamicReplaceableImpl);
@@ -465,7 +465,7 @@ public:
     auto &ci = SGF.getConstantInfo(SGF.getTypeExpansionContext(), c);
     return Callee(
         Kind::EnumElement, SGF, c, ci.FormalPattern, ci.FormalType,
-        subs.mapIntoTypeExpansionContext(SGF.getTypeExpansionContext()), l);
+        substOpaqueTypesWithUnderlyingTypes(subs, SGF.getTypeExpansionContext()), l);
   }
   static Callee forClassMethod(SILGenFunction &SGF,
                                SILDeclRef c, SubstitutionMap subs,
@@ -473,7 +473,7 @@ public:
     auto base = c.getOverriddenVTableEntry();
     auto &baseCI = SGF.getConstantInfo(SGF.getTypeExpansionContext(), base);
     auto &derivedCI = SGF.getConstantInfo(SGF.getTypeExpansionContext(), c);
-    subs = subs.mapIntoTypeExpansionContext(SGF.getTypeExpansionContext());
+    subs = substOpaqueTypesWithUnderlyingTypes(subs, SGF.getTypeExpansionContext());
 
     // We use an orig function type based on the overridden vtable entry, but
     // the substitutions we have are for the current function.  To get subs
@@ -497,7 +497,7 @@ public:
                                SILDeclRef c, SubstitutionMap subs,
                                SILLocation l) {
     auto &ci = SGF.getConstantInfo(SGF.getTypeExpansionContext(), c);
-    subs = subs.mapIntoTypeExpansionContext(SGF.getTypeExpansionContext());
+    subs = substOpaqueTypesWithUnderlyingTypes(subs, SGF.getTypeExpansionContext());
     auto origFunctionType = ci.FormalPattern.withSubstitutions(subs);
     return Callee(
         Kind::SuperMethod, SGF, c, origFunctionType, ci.FormalType, subs, l);
@@ -524,7 +524,7 @@ public:
     auto &ci = SGF.getConstantInfo(SGF.getTypeExpansionContext(), c);
     return Callee(
         Kind::WitnessMethod, SGF, c, ci.FormalPattern, ci.FormalType,
-        subs.mapIntoTypeExpansionContext(SGF.getTypeExpansionContext()), l);
+        substOpaqueTypesWithUnderlyingTypes(subs, SGF.getTypeExpansionContext()), l);
   }
   static Callee forDynamic(SILGenFunction &SGF,
                            SILDeclRef c, SubstitutionMap constantSubs,
@@ -550,7 +550,7 @@ public:
 
     return Callee(
         Kind::DynamicMethod, SGF, c, origFormalType, substFormalType,
-        subs.mapIntoTypeExpansionContext(SGF.getTypeExpansionContext()), l);
+        substOpaqueTypesWithUnderlyingTypes(subs, SGF.getTypeExpansionContext()), l);
   }
 
   static Callee formCallee(SILGenFunction &SGF, AbstractFunctionDecl *decl,

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1667,8 +1667,7 @@ static ManagedValue emitCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
             .build();
 
     auto genericSig = subs.getGenericSignature().getCanonicalSignature();
-    auto genericResult = GenericTypeParamType::getType(/*depth*/ 0, /*index*/ 0,
-                                                       SGF.getASTContext());
+    auto genericResult = SGF.getASTContext().TheSelfType;
 
     // <T> () async throws -> T
     CanType functionTy =

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1576,9 +1576,7 @@ RValueEmitter::visitConditionalBridgeFromObjCExpr(
   auto conversion = cast<FuncDecl>(conversionRef.getDecl());
   auto subs = conversionRef.getSubstitutions();
 
-  auto nativeType = Type(GenericTypeParamType::getType(/*depth*/ 0, /*index*/ 0,
-                                                       SGF.getASTContext()))
-                        .subst(subs);
+  auto nativeType = Type(SGF.getASTContext().TheSelfType).subst(subs);
 
   auto metatypeType = SGF.getLoweredType(MetatypeType::get(nativeType));
   auto metatype = ManagedValue::forObjectRValueWithoutOwnership(
@@ -4153,9 +4151,7 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
       auto formalCanTy = formalTy->getCanonicalType();
       
       // Get the Equatable conformance from the Hashable conformance.
-      auto equatable = hashable.getAssociatedConformance(
-          GenericTypeParamType::getType(/*depth*/ 0, /*index*/ 0, C),
-          equatableProtocol);
+      auto equatable = hashable.getAssociatedConformance(C.TheSelfType, equatableProtocol);
 
       assert(equatable.isAbstract() == hashable.isAbstract());
       if (equatable.isConcrete())

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1222,23 +1222,11 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
         NewArgs.push_back(cast);
         // Form a new set of substitutions where the argument is
         // replaced with a concrete type.
-        NewCallSubs = NewCallSubs.subst(
-            [&](SubstitutableType *type) -> Type {
-              if (type == OAI.OpenedArchetype)
-                return CEI.ConcreteType;
-              return type;
-            },
-            [&](CanType origTy, Type substTy,
-                ProtocolDecl *proto) -> ProtocolConformanceRef {
-              if (origTy->isEqual(OAI.OpenedArchetype)) {
-                assert(substTy->isEqual(CEI.ConcreteType));
-                // Do a conformance lookup on this witness requirement using the
-                // existential's conformances. The witness requirement may be a
-                // base type of the existential's requirements.
-                return CEI.lookupExistentialConformance(proto);
-              }
-              return ProtocolConformanceRef::forAbstract(substTy, proto);
-            }, SubstFlags::SubstituteLocalArchetypes);
+        ReplaceExistentialArchetypesWithConcreteTypes replacer(
+            OAI.OpenedArchetype->getGenericEnvironment(),
+            CEI.ExistentialSubs);
+        NewCallSubs = NewCallSubs.subst(replacer, replacer,
+                                        SubstFlags::SubstituteLocalArchetypes);
         continue;
       }
       // Otherwise, use the original argument.
@@ -1263,23 +1251,11 @@ SILInstruction *SILCombiner::createApplyWithConcreteType(
 
     // Form a new set of substitutions where the argument is
     // replaced with a concrete type.
-    NewCallSubs = NewCallSubs.subst(
-        [&](SubstitutableType *type) -> Type {
-          if (type == OAI.OpenedArchetype)
-            return CEI.ConcreteType;
-          return type;
-        },
-        [&](CanType origTy, Type substTy,
-            ProtocolDecl *proto) -> ProtocolConformanceRef {
-          if (origTy->isEqual(OAI.OpenedArchetype)) {
-            assert(substTy->isEqual(CEI.ConcreteType));
-            // Do a conformance lookup on this witness requirement using the
-            // existential's conformances. The witness requirement may be a
-            // base type of the existential's requirements.
-            return CEI.lookupExistentialConformance(proto);
-          }
-          return ProtocolConformanceRef::forAbstract(substTy, proto);
-        }, SubstFlags::SubstituteLocalArchetypes);
+    ReplaceExistentialArchetypesWithConcreteTypes replacer(
+        OAI.OpenedArchetype->getGenericEnvironment(),
+        CEI.ExistentialSubs);
+    NewCallSubs = NewCallSubs.subst(replacer, replacer,
+                                    SubstFlags::SubstituteLocalArchetypes);
   }
 
   // We need to make sure that we can a) update Apply to use the new args and b)

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -3458,8 +3458,7 @@ static Comparison compareDeclsForInference(DeclContext *DC, ValueDecl *decl1,
   if (!sig1 || !sig2)
     return TypeChecker::compareDeclarations(DC, decl1, decl2);
 
-  auto selfParam = GenericTypeParamType::getType(/*depth*/ 0, /*index*/ 0,
-                                                 decl1->getASTContext());
+  auto selfParam = DC->getASTContext().TheSelfType;
 
   // Collect the protocols required by extension 1.
   Type class1;

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -1077,11 +1077,8 @@ GetDistributedActorAsActorConformanceRequest::evaluate(
   if (!ext)
     return nullptr;
 
-  auto genericParam = GenericTypeParamType::getType(/*depth=*/0, /*index=*/0,
-                                                    ctx);
-
   auto distributedActorAsActorConformance = ctx.getNormalConformance(
-      Type(genericParam), actorProto, SourceLoc(), ext,
+      Type(ctx.TheSelfType), actorProto, SourceLoc(), ext,
       ProtocolConformanceState::Incomplete, ProtocolConformanceOptions());
   // NOTE: Normally we "register" a conformance, but here we don't
   // because we cannot (currently) register them in a protocol,

--- a/unittests/AST/ASTDumperTests.cpp
+++ b/unittests/AST/ASTDumperTests.cpp
@@ -26,15 +26,14 @@ TEST(ASTDumper, ArchetypeType) {
   TestContext C;
   auto &ctx = C.Ctx;
 
-  auto *genericParamTy = GenericTypeParamType::getType(0, 0, ctx);
-  auto sig = buildGenericSignature(ctx, nullptr, {genericParamTy}, {},
+  auto sig = buildGenericSignature(ctx, nullptr, {ctx.TheSelfType}, {},
                                    /*allowInverses=*/true);
 
   TypeBase *archetype = nullptr;
   {
     llvm::SmallVector<ProtocolDecl *> protocols;
     archetype = PrimaryArchetypeType::getNew(ctx, sig.getGenericEnvironment(),
-                                             genericParamTy, protocols, Type(),
+                                             ctx.TheSelfType, protocols, Type(),
                                              nullptr);
   }
 


### PR DESCRIPTION
I noticed that SIL had three copy and pasted implementations of the algorithm for replacing opened existential archetypes with concrete types. This optimization comes up if inlining produces an existential value formed from a concrete type which is then immediately opened; we can eliminate the existential archetype in that case. However, this bit of copy and paste predated the introduction of generalized existentials, so it did not handle member types at all. This is a potential landmine if it ends up being used in more places in SIL.

This PR factors out one of the duplicate copies into a new "official" `ReplaceExistentialArchetypesWithConcreteTypes`, analogous to the transformer used for opaque archetypes. The new version is more complicated but it handles existential archetypes in full generality now. The other duplicate copy was a special case of an existing utility in `SILCloner`, and the third one was dead.