### PR TITLE
[6.2🍒] Bootstrap: Install dispatch in stage0

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3127,6 +3127,7 @@ swift-include-tests=0
 llvm-include-tests=0
 
 release
+libdispatch
 
 skip-early-swiftsyntax
 skip-early-swift-driver
@@ -3159,6 +3160,7 @@ llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;compile
 
 install-llvm
 install-swift
+install-libdispatch
 
 # Build Toolchain Requirements:
 # - C/C++ compiler


### PR DESCRIPTION
Cherry-pick of: https://github.com/swiftlang/swift/pull/81128

The concurrency runtimes require that dispatch is installed or it will fail to load at launch. The C library is built as part of the concurrency build but is not installed. We need to install a copy of dispatch so that programs that link concurrency run.

(cherry picked from commit f36391d4c803f00fc5e4cebca910114dfadbfdd7)

- Explanation:
Concurrency depends on corelibs-libdispatch. It builds part of corelibs libdispatch as part of the concurrency build but does not install it so installing the compiler that uses concurrency fails to launch because libdispatch isn't found. Build and install corelibs libdispatch as part of the stage0 toolchain build.
- Scope: This only impacts bootstrap builds and has no impact on Apple platforms.
- Risk: Low. The bootstrap build is only used for bringing up the compiler in new environments, not on Apple platforms.
- Reviewers: @MaxDesiatov 
- Testing: Local testing. This patch fixed the same issue on the main branch.
- Fixes: rdar://150159526