### PR TITLE
[cxx-interop] Temporarily exclude CxxSetToCollection benchmark from the build

### DIFF
--- a/benchmark/cxx-source/CxxSetToCollection.swift
+++ b/benchmark/cxx-source/CxxSetToCollection.swift
@@ -13,6 +13,8 @@
 // This is a benchmark that tracks how quickly Swift can convert a C++ set
 // to a Swift collection.
 
+/* FIXME: rdar://150067288
+
 import TestsUtils
 import CxxStdlibPerformance
 import Cxx
@@ -64,3 +66,5 @@ public func run_CxxSetOfU32_forEach(_ n: Int) {
     }
   }
 }
+
+*/

--- a/benchmark/cxx-source/CxxStringConversion.swift
+++ b/benchmark/cxx-source/CxxStringConversion.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+/* FIXME: rdar://150067288
+
 import TestsUtils
 import CxxStdlibPerformance
 import CxxStdlib
@@ -58,3 +60,5 @@ public func run_cxxToSwift(_ n: Int) {
     blackHole(x)
   }
 }
+
+*/

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -13,6 +13,8 @@
 // This is a benchmark that tracks how quickly Swift can sum up a C++ vector
 // as compared to the C++ implementation of such sum.
 
+/* FIXME: rdar://150067288
+
 import TestsUtils
 import CxxStdlibPerformance
 import Cxx
@@ -119,3 +121,5 @@ public func run_CxxVectorOfU32_Sum_Swift_Reduce(_ n: Int) {
     }
     blackHole(sum)
 }
+
+*/


### PR DESCRIPTION
This is needed to unblock nightly toolchains, which are currently failing to build with an assertion:
```
swift-frontend: /home/build-user/build/buildbot_linux/llvm-linux-x86_64/tools/clang/include/clang/AST/TypeNodes.inc:79: TypeInfo clang::ASTContext::getTypeInfoImpl(const Type *) const: Assertion `!T->isDependentType() && "should not see dependent types here"' failed.
```

rdar://150067288

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
