### PR TITLE
[Sema] Support additional args in @dynamicMemberLookup subscripts

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -545,7 +545,7 @@ protected:
   SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2+2,
     StaticSpelling : 2
   );
-
+  
   SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+2+2+2+8+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -65,6 +65,7 @@ class PointerAuthQualifier;
 
 namespace {
 class AttributeChecker;
+class DeclChecker;
 } // end anonymous namespace
 
 namespace swift {
@@ -7569,10 +7570,13 @@ enum class ObjCSubscriptKind {
 ///
 /// `@dynamicMemberLookup` requires that a subscript:
 ///
-///   1. Take a single argument with an explicit `dynamicMember` argument label,
+///   1. Take an initial argument with an explicit `dynamicMember` argument
+///      label,
 ///   2. Whose parameter type is non-variadic and is either
 ///      * A `{{Reference}Writable}KeyPath`, or
 ///      * A concrete type conforming to `ExpressibleByStringLiteral`,
+///   3. And whose following arguments (if any) are all either variadic or have
+///      a default value
 ///
 /// Subscripts which don't meet these requirements strictly are not eligible.
 enum class DynamicMemberLookupSubscriptEligibility : uint8_t {
@@ -7621,6 +7625,7 @@ enum class DynamicMemberLookupSubscriptEligibility : uint8_t {
 ///
 class SubscriptDecl : public GenericContext, public AbstractStorageDecl {
   friend AttributeChecker;
+  friend DeclChecker;
   friend class ResultTypeRequest;
 
   SourceLoc StaticLoc;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -542,7 +542,7 @@ protected:
     defaultArgumentKind : NumDefaultArgumentKindBits
   );
 
-  SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2+2,
+  SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
     StaticSpelling : 2
   );
   

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7614,7 +7614,7 @@ private:
     setIndices(Indices);
   }
 
-  /// Returns the given as a `BoundGenericType` if it is a
+  /// Returns the given type as a `BoundGenericType` if it is a
   /// `{{Reference}Writable}KeyPath` type which could be used to fulfill
   /// `@dynamicMemberLookup` requirements; `nullptr` otherwise.
   static BoundGenericType *getDynamicMemberParamTypeAsKeyPathType(Type paramTy);

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -545,7 +545,6 @@ protected:
   SWIFT_INLINE_BITFIELD(SubscriptDecl, VarDecl, 2,
     StaticSpelling : 2
   );
-  
   SWIFT_INLINE_BITFIELD(AbstractFunctionDecl, ValueDecl, 3+2+2+2+8+1+1+1+1+1+1,
     /// \see AbstractFunctionDecl::BodyKind
     BodyKind : 3,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1746,9 +1746,14 @@ ERROR(invalid_dynamic_member_lookup_type,none,
       "'@dynamicMemberLookup' requires %0 to have a "
       "'subscript(dynamicMember:)' method that accepts either "
       "'ExpressibleByStringLiteral' or a key path", (Type))
-NOTE(invalid_dynamic_member_subscript, none,
-     "add an explicit argument label to this subscript to satisfy "
-     "the '@dynamicMemberLookup' requirement", ())
+NOTE(invalid_dynamic_member_subscript_missing_label, none,
+     "add an explicit argument label to this subscript to satisfy the "
+     "'@dynamicMemberLookup' requirement", ())
+NOTE(invalid_dynamic_member_subscript_out_of_order, none,
+     "'dynamicMember' argument must appear first in the argument list", ())
+NOTE(invalid_dynamic_member_subscript_missing_default, none,
+     "add a default value to this argument to satisfy the "
+     "'@dynamicMemberLookup' requirement", ())
 ERROR(dynamic_member_lookup_candidate_inaccessible,none,
       "'@dynamicMemberLookup' requires %0 to be as accessible as its "
       "enclosing type",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1746,15 +1746,25 @@ ERROR(invalid_dynamic_member_lookup_type,none,
       "'@dynamicMemberLookup' requires %0 to have a "
       "'subscript(dynamicMember:)' method that accepts either "
       "'ExpressibleByStringLiteral' or a key path", (Type))
-NOTE(invalid_dynamic_member_subscript_missing_label, none,
-     "add an explicit argument label to this subscript to satisfy the "
-     "'@dynamicMemberLookup' requirement", ())
-NOTE(invalid_dynamic_member_subscript_out_of_order, none,
-     "'dynamicMember' argument must appear first in the argument list", ())
-NOTE(invalid_dynamic_member_subscript_missing_default, none,
-     "add a default value to this argument to satisfy the "
-     "'@dynamicMemberLookup' requirement", ())
-ERROR(dynamic_member_lookup_candidate_inaccessible,none,
+ERROR(invalid_dynamic_member_subscript_missing_param_label, none,
+      "'@dynamicMemberLookup' requires %0 to have an explicit parameter label",
+      (ParamDecl *))
+ERROR(invalid_dynamic_member_subscript_invalid_arg_label, none,
+      "'@dynamicMemberLookup' requires %0 to have an explicit 'dynamicMember' "
+      "argument label",
+      (ParamDecl *))
+ERROR(invalid_dynamic_member_subscript_invalid_order, none,
+      "'@dynamicMemberLookup' requires %0 to appear first in the parameter "
+      "list",
+      (ParamDecl *))
+ERROR(invalid_dynamic_member_subscript_invalid_type, none,
+      "'@dynamicMemberLookup' requires %0 to be either "
+      "'ExpressibleByStringLiteral' or a key path",
+      (ParamDecl *))
+ERROR(invalid_dynamic_member_subscript_missing_default, none,
+      "'@dynamicMemberLookup' requires %0 to have a default value",
+      (ParamDecl *))
+ERROR(dynamic_member_lookup_candidate_inaccessible, none,
       "'@dynamicMemberLookup' requires %0 to be as accessible as its "
       "enclosing type",
       (ValueDecl *))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5691,9 +5691,8 @@ public:
     // We can offer a fix-it to insert a `dynamicMember` argument label iff the
     // subscript is only missing the label itself.
     return !DynamicMemberIdx && Kind &&
-           ParamFlags[0].toRaw() ==
-               llvm::to_underlying(
-                   InvalidParameterFlag::DynamicMemberMissingArgumentLabel) &&
+           ParamFlags[0].containsOnly(
+               InvalidParameterFlag::DynamicMemberMissingArgumentLabel) &&
            std::all_of(ParamFlags.begin() + 1, ParamFlags.end(),
                        [&](const InvalidParameterFlags &f) { return !f; });
   }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5730,12 +5730,11 @@ public:
            lhs.Kind == rhs.Kind &&
            // `OptionSet` intentionally does not offer `==` in favor of
            // requiring `containsOnly`.
-           std::equal(lhs.ParamFlags.begin(), lhs.ParamFlags.end(),
-                      rhs.ParamFlags.begin(), rhs.ParamFlags.end(),
-                      [&](const InvalidParameterFlags &lhs,
-                          const InvalidParameterFlags &rhs) {
-                        return lhs.containsOnly(rhs);
-                      });
+           llvm::equal(lhs.ParamFlags, rhs.ParamFlags,
+                       [&](const InvalidParameterFlags &lhs,
+                           const InvalidParameterFlags &rhs) {
+                         return lhs.containsOnly(rhs);
+                       });
   }
 
   friend bool operator!=(const DynamicMemberLookupSubscriptEligibility &lhs,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -33,6 +33,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeResolutionStage.h"
+#include "swift/Basic/Assertions.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/TaggedUnion.h"
 #include "swift/Basic/TypeID.h"
@@ -5677,7 +5678,7 @@ public:
       SmallVector<InvalidParameterFlags> paramFlags)
       : Decl(decl), DynamicMemberIdx(dynamicMemberIdx), Kind(kind),
         ParamFlags(paramFlags) {
-    assert(decl->getIndices()->size() == paramFlags.size());
+    ASSERT(decl->getIndices()->size() == paramFlags.size());
   }
 
   bool isValid() const {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5594,6 +5594,189 @@ public:
   void cacheResult(BraceStmt *stmt) const;
 };
 
+/// Describes how a `SubscriptDecl` is (or is not) be eligible to fulfill a
+/// `@dynamicMemberLookup` requirement.
+///
+/// `@dynamicMemberLookup` requires that a subscript:
+///
+///   1. Take an initial argument with an explicit `dynamicMember` argument
+///      label,
+///   2. Whose parameter type is non-variadic and is either
+///      * A `{{Reference}Writable}KeyPath`, or
+///      * A concrete type conforming to `ExpressibleByStringLiteral`,
+///   3. And whose following arguments (if any) are all either variadic or have
+///      a default value
+///
+/// Subscripts which don't meet these requirements strictly are not eligible.
+class DynamicMemberLookupSubscriptEligibility {
+public:
+  /// The kind of `dynamicMember` parameter the subscript takes (or could take,
+  /// if eligible for a fix-it for a missing `dynamicMember` label).
+  using DynamicMemberKind = SubscriptDecl::DynamicMemberLookupKind;
+
+  /// Reasons why a parameter disqualifies the subscript from meeting a
+  /// `@dynamicMemberLookup` requirement.
+  enum class InvalidParameterFlag {
+    /// The subscript has no `dynamicMember` parameter (so likely isn't eligible
+    /// for `@dynamicMemberLookup` subscript checking at all), but _could_ be
+    /// made valid if the parameter had a `"dynamicMember"` argument label
+    /// (e.g., `subscript(member: String)`).
+    ///
+    /// A fix-it can be provided to insert an argument label.
+    DynamicMemberMissingArgumentLabel = 1 << 0,
+
+    /// The parameter has a `dynamicMember` parameter label but no explicit
+    /// argument label (e.g., `subscript(dynamicMember: String)`). Since the
+    /// subscript must have `dynamicMember` as its argument label, we treat this
+    /// _as if_ the parameter label is missing.
+    ///
+    /// A fix-it can be provided to insert a parameter label.
+    DynamicMemberMissingParameterLabel = 1 << 1,
+
+    /// The parameter has a `"dynamicMember"` parameter label but a different
+    /// argument label (e.g., `subscript(_ dynamicMember: String)`).
+    ///
+    /// While it's possible that such a subscript isn't intended to implement a
+    /// `@dynamicMemberLookup` requirement, it's much more likely to be a
+    /// mistake than not and is worth diagnosing.
+    DynamicMemberInvalidArgumentLabel = 1 << 2,
+
+    /// The `dynamicMember` parameter does not appear first in the argument
+    /// list (e.g., `subscript(foo: Int = 42, dynamicMember member: String)`).
+    DynamicMemberInvalidOrder = 1 << 3,
+
+    /// The `dynamicMember` parameter has a type that does not meet the
+    /// requirements of being either key-path- or string-based.
+    DynamicMemberInvalidType = 1 << 4,
+
+    /// The parameter is a non-`dynamicMember` parameter which does not have a
+    /// default value.
+    ParameterMissingDefaultValue = 1 << 5,
+  };
+
+  using InvalidParameterFlags = OptionSet<InvalidParameterFlag>;
+
+private:
+  /// The declaration this eligibility describes.
+  const SubscriptDecl *Decl;
+
+  /// The subscript index of the `dynamicMember` parameter, if present.
+  std::optional<unsigned> DynamicMemberIdx;
+
+  /// The type of the `dynamicMember` parameter; separately-optional from
+  /// `DynamicMemberIdx` to represent an invalid parameter type.
+  std::optional<DynamicMemberKind> Kind;
+
+  /// Flags describing the validity of each of the subscript parameters.
+  SmallVector<InvalidParameterFlags> ParamFlags;
+
+public:
+  DynamicMemberLookupSubscriptEligibility(
+      const SubscriptDecl *decl, std::optional<unsigned> dynamicMemberIdx,
+      std::optional<DynamicMemberKind> kind,
+      SmallVector<InvalidParameterFlags> paramFlags)
+      : Decl(decl), DynamicMemberIdx(dynamicMemberIdx), Kind(kind),
+        ParamFlags(paramFlags) {
+    assert(decl->getIndices()->size() == paramFlags.size());
+  }
+
+  bool isValid() const {
+    return DynamicMemberIdx == 0 && Kind &&
+           std::all_of(ParamFlags.begin(), ParamFlags.end(),
+                       [&](const InvalidParameterFlags &f) { return !f; });
+  }
+
+  bool isEligibleForArgumentLabelFixIt() const {
+    // We can offer a fix-it to insert a `dynamicMember` argument label iff the
+    // subscript is only missing the label itself.
+    return !DynamicMemberIdx && Kind &&
+           ParamFlags[0].toRaw() ==
+               llvm::to_underlying(
+                   InvalidParameterFlag::DynamicMemberMissingArgumentLabel) &&
+           std::all_of(ParamFlags.begin() + 1, ParamFlags.end(),
+                       [&](const InvalidParameterFlags &f) { return !f; });
+  }
+
+  const SubscriptDecl *getDecl() const { return Decl; }
+
+  /// Returns the kind of the `dynamicMember` parameter if the decl is eligible
+  /// for dynamic member lookup; `std::nullopt` otherwise.
+  std::optional<DynamicMemberKind> getDynamicMemberKind() const {
+    return isValid() ? Kind : std::nullopt;
+  }
+
+  /// If invalid, produces diagnostics describing the ineligibility.
+  ///
+  /// Uses the `SubscriptDecl`'s AST context for diagnostics unless an explicit
+  /// diagnostic engine is given.
+  ///
+  /// Returns whether an error diagnostic was produced.
+  bool diagnose(DiagnosticEngine *diags = nullptr);
+
+  friend llvm::hash_code
+  hash_value(const DynamicMemberLookupSubscriptEligibility &e) {
+    auto hash = llvm::hash_combine(llvm::hash_value(e.DynamicMemberIdx),
+                                   llvm::hash_value(e.Kind));
+    for (auto flags : e.ParamFlags) {
+      hash = llvm::hash_combine(hash, flags.toRaw());
+    }
+
+    return hash;
+  }
+
+  friend bool operator==(const DynamicMemberLookupSubscriptEligibility &lhs,
+                         const DynamicMemberLookupSubscriptEligibility &rhs) {
+    return lhs.DynamicMemberIdx == rhs.DynamicMemberIdx &&
+           lhs.Kind == rhs.Kind &&
+           // `OptionSet` intentionally does not offer `==` in favor of
+           // requiring `containsOnly`.
+           std::equal(lhs.ParamFlags.begin(), lhs.ParamFlags.end(),
+                      rhs.ParamFlags.begin(), rhs.ParamFlags.end(),
+                      [&](const InvalidParameterFlags &lhs,
+                          const InvalidParameterFlags &rhs) {
+                        return lhs.containsOnly(rhs);
+                      });
+  }
+
+  friend bool operator!=(const DynamicMemberLookupSubscriptEligibility &lhs,
+                         const DynamicMemberLookupSubscriptEligibility &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+class DynamicMemberLookupSubscriptRequest
+    : public SimpleRequest<
+          DynamicMemberLookupSubscriptRequest,
+          std::pair<DynamicMemberLookupSubscriptEligibility, bool>(
+              const SubscriptDecl *, const DeclContext *),
+          RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+  // This type alias is provided primarily for use from
+  // `TypeCheckerTypeIDZone.def`, where the comma inside `std::pair<>`
+  // interferes with macro parsing.
+  using Result = std::pair<DynamicMemberLookupSubscriptEligibility,
+                           bool /* isAccessible */>;
+
+private:
+  friend SimpleRequest;
+
+  /// Given a `SubscriptDecl` and its use (`useDC`), returns whether the decl is
+  /// a viable candidate for `@dynamicMemberLookup` accessible from that point
+  /// of use.
+  Result evaluate(Evaluator &evaluator, const SubscriptDecl *decl,
+                  const DeclContext *useDC) const;
+
+public:
+  SourceLoc getNearestLoc() const {
+    return std::get<0>(getStorage())->getLoc();
+  }
+
+  bool isCached() const { return true; }
+};
+
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5707,11 +5707,10 @@ public:
 
   /// If invalid, produces diagnostics describing the ineligibility.
   ///
-  /// Uses the `SubscriptDecl`'s AST context for diagnostics unless an explicit
-  /// diagnostic engine is given.
+  /// Uses the diagnostic engine belonging to the `SubscriptDecl`'s AST context.
   ///
   /// Returns whether an error diagnostic was produced.
-  bool diagnose(DiagnosticEngine *diags = nullptr);
+  bool diagnose();
 
   friend llvm::hash_code
   hash_value(const DynamicMemberLookupSubscriptEligibility &e) {

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -668,7 +668,8 @@ SWIFT_REQUEST(TypeChecker, IsCustomAvailabilityDomainPermanentlyEnabled,
               SeparatelyCached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, EmitPerformanceHints,
-              evaluator::SideEffect(SourceFile *), Cached, NoLocationInfo)
+              evaluator::SideEffect(SourceFile *),
+              Cached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, DynamicMemberLookupSubscriptRequest,
               std::optional<DynamicMemberLookupSubscriptRequest::Result>

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -668,7 +668,11 @@ SWIFT_REQUEST(TypeChecker, IsCustomAvailabilityDomainPermanentlyEnabled,
               SeparatelyCached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, EmitPerformanceHints,
-              evaluator::SideEffect(SourceFile *),
+              evaluator::SideEffect(SourceFile *), Cached, NoLocationInfo)
+
+SWIFT_REQUEST(TypeChecker, DynamicMemberLookupSubscriptRequest,
+              std::optional<DynamicMemberLookupSubscriptRequest::Result>
+              (const SubscriptDecl *, const DeclContext *),
               Cached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, DesugarForEachStmtRequest,

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -354,13 +354,6 @@ namespace swift {
   llvm::TinyPtrVector<ValueDecl *>
   findWitnessedObjCRequirements(const ValueDecl *witness,
                                 bool anySingleRequirement);
-  /// Returns true if the given subscript method is a valid implementation of
-  /// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
-  /// @dynamicMemberLookup.
-  /// The method is given to be defined as `subscript(dynamicMember:)` which
-  /// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
-  bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl,
-                                         bool ignoreLabel = false);
 }
 
 #endif

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -221,7 +221,7 @@ public:
   }
 
   /// Retrieve an overload choice for a declaration that was found via
-  /// dynamic member lookup. The `ValueDecl` is a `subscript(dynamicMember:)`
+  /// dynamic member lookup. The `ValueDecl` is a `subscript(dynamicMember:...)`
   /// method.
   static OverloadChoice getDynamicMemberLookup(Type base, ValueDecl *value,
                                                Identifier name,

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -10,13 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/IDE/SourceEntityWalker.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
-#include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -25,7 +26,6 @@
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
-#include "swift/IDE/SourceEntityWalker.h"
 #include "swift/IDE/Utils.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/Basic/Module.h"
@@ -43,11 +43,9 @@ class SemaAnnotator : public ASTWalker {
   std::optional<AccessKind> OpAccess;
 
 public:
-  explicit SemaAnnotator(SourceEntityWalker &SEWalker)
-    : SEWalker(SEWalker) { }
+  explicit SemaAnnotator(SourceEntityWalker &SEWalker) : SEWalker(SEWalker) {}
 
 private:
-
   // FIXME: Remove this
   bool shouldWalkAccessorsTheOldWay() override { return true; }
 
@@ -55,9 +53,7 @@ private:
     return SEWalker.shouldWalkIntoGenericParams();
   }
 
-  bool shouldWalkSerializedTopLevelInternalDecls() override {
-    return false;
-  }
+  bool shouldWalkSerializedTopLevelInternalDecls() override { return false; }
 
   bool shouldWalkIntoForEachDesugaredStmt() override {
     return SEWalker.shouldWalkIntoForEachDesugaredStmt();
@@ -101,7 +97,8 @@ private:
 
   bool passReference(ValueDecl *D, Type Ty, SourceLoc Loc, SourceRange Range,
                      ReferenceMetaData Data);
-  bool passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data);
+  bool passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc,
+                     ReferenceMetaData Data);
   bool passReference(ModuleEntity Mod, ImportPath::Element IdLoc);
 
   bool passSubscriptReference(ValueDecl *D, SourceLoc Loc,
@@ -226,13 +223,13 @@ ASTWalker::PreWalkAction SemaAnnotator::walkToDeclPreProper(Decl *D) {
     }
   }
 
-  CharSourceRange Range = (Loc.isValid()) ? CharSourceRange(Loc, NameLen)
-                                          : CharSourceRange();
+  CharSourceRange Range =
+      (Loc.isValid()) ? CharSourceRange(Loc, NameLen) : CharSourceRange();
   bool ShouldVisitChildren = SEWalker.walkToDeclPre(D, Range);
   // walkToDeclPost is only called when visiting children, so make sure to only
   // push the extension decl in that case (otherwise it won't be popped)
   if (IsExtension && ShouldVisitChildren) {
-    ExtDecls.push_back(static_cast<ExtensionDecl*>(D));
+    ExtDecls.push_back(static_cast<ExtensionDecl *>(D));
   }
   return Action::VisitNodeIf(ShouldVisitChildren);
 }
@@ -246,14 +243,16 @@ ASTWalker::PostWalkAction SemaAnnotator::walkToDeclPost(Decl *D) {
 
   // Walk into peer and conformance expansions if walking expansions
   if (shouldWalkMacroArgumentsAndExpansion().second) {
-    D->visitAuxiliaryDecls([&](Decl *auxDecl) {
-      if (Action.Action == PostWalkAction::Stop)
-        return;
+    D->visitAuxiliaryDecls(
+        [&](Decl *auxDecl) {
+          if (Action.Action == PostWalkAction::Stop)
+            return;
 
-      if (auxDecl->walk(*this)) {
-        Action = Action::Stop();
-      }
-    }, /*visitFreestandingExpanded=*/false);
+          if (auxDecl->walk(*this)) {
+            Action = Action::Stop();
+          }
+        },
+        /*visitFreestandingExpanded=*/false);
   }
 
   return Action;
@@ -320,7 +319,8 @@ SemaAnnotator::walkToArgumentListPre(ArgumentList *ArgList) {
   if (ArgList->isImplicit())
     return Action::Continue(ArgList);
 
-  // FIXME(https://github.com/apple/swift/issues/57390): What about SubscriptExpr and KeyPathExpr arg labels?
+  // FIXME(https://github.com/apple/swift/issues/57390): What about
+  // SubscriptExpr and KeyPathExpr arg labels?
   if (auto CallE = dyn_cast_or_null<CallExpr>(Parent.getAsExpr())) {
     if (!passCallArgNames(CallE->getFn(), ArgList))
       return Action::Stop();
@@ -378,8 +378,8 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       !isa<MakeTemporarilyEscapableExpr>(E) &&
       !isa<CollectionUpcastConversionExpr>(E) && !isa<OpaqueValueExpr>(E) &&
       !isa<SubscriptExpr>(E) && !isa<KeyPathExpr>(E) && !isa<LiteralExpr>(E) &&
-      !isa<CollectionExpr>(E) && !isa<DeclRefExpr>(E) && !isa<MemberRefExpr>(E) &&
-      E->isImplicit())
+      !isa<CollectionExpr>(E) && !isa<DeclRefExpr>(E) &&
+      !isa<MemberRefExpr>(E) && E->isImplicit())
     return Action::Continue(E);
 
   if (auto LE = dyn_cast<LiteralExpr>(E)) {
@@ -405,10 +405,10 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       if (!passReference(ModuleEntity(module),
                          {module->getName(), E->getLoc()}))
         return Action::Stop();
-    } else if (!passReference(DRE->getDecl(), DRE->getType(),
-                              DRE->getNameLoc(),
-                      ReferenceMetaData(getReferenceKind(Parent.getAsExpr(), DRE),
-                                        OpAccess, DRE->isImplicit()))) {
+    } else if (!passReference(
+                   DRE->getDecl(), DRE->getType(), DRE->getNameLoc(),
+                   ReferenceMetaData(getReferenceKind(Parent.getAsExpr(), DRE),
+                                     OpAccess, DRE->isImplicit()))) {
       return Action::Stop();
     }
   } else if (auto *MRE = dyn_cast<MemberRefExpr>(E)) {
@@ -441,10 +441,10 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     return Action::SkipChildren(E);
 
   } else if (auto OtherCtorE = dyn_cast<OtherConstructorDeclRefExpr>(E)) {
-    if (!passReference(OtherCtorE->getDecl(), OtherCtorE->getType(),
-                       OtherCtorE->getConstructorLoc(),
-                       ReferenceMetaData(SemaReferenceKind::DeclConstructorRef,
-                                         OpAccess)))
+    if (!passReference(
+            OtherCtorE->getDecl(), OtherCtorE->getType(),
+            OtherCtorE->getConstructorLoc(),
+            ReferenceMetaData(SemaReferenceKind::DeclConstructorRef, OpAccess)))
       return Action::Stop();
 
   } else if (auto *SE = dyn_cast<SubscriptExpr>(E)) {
@@ -464,11 +464,12 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
         return Action::Stop();
     }
 
-    // For regular subscripts (not dynamic member lookups), the index expressions
-    // are always read, regardless of how the subscript is being used (read or write).
-    // Do not propagate a write access kind into the subscript arguments.
-    // However, for dynamic member lookup subscripts, the argument represents
-    // a member being accessed, so it should reflect the access kind.
+    // For regular subscripts (not dynamic member lookups), the index
+    // expressions are always read, regardless of how the subscript is being
+    // used (read or write). Do not propagate a write access kind into the
+    // subscript arguments. However, for dynamic member lookup subscripts, the
+    // argument represents a member being accessed, so it should reflect the
+    // access kind.
     bool isKeyPathDynamicMemberLookup = false;
     if (auto *SD = dyn_cast_or_null<SubscriptDecl>(SubscrD)) {
       // Check if the base type has @dynamicMemberLookup
@@ -476,15 +477,16 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
       if (baseType) {
         baseType = baseType->getWithoutSpecifierType();
         if (baseType->hasDynamicMemberLookupAttribute() &&
-            isValidKeyPathDynamicMemberLookup(SD)) {
+            SD->getDynamicMemberLookupKind(SD->getDeclContext()) ==
+                SubscriptDecl::DynamicMemberLookupKind::KeyPath) {
           isKeyPathDynamicMemberLookup = true;
         }
       }
     }
 
     if (!isKeyPathDynamicMemberLookup) {
-      llvm::SaveAndRestore<std::optional<AccessKind>>
-          C(this->OpAccess, std::nullopt);
+      llvm::SaveAndRestore<std::optional<AccessKind>> C(this->OpAccess,
+                                                        std::nullopt);
       if (!SE->getArgs()->walk(*this))
         return Action::Stop();
     } else {
@@ -580,9 +582,7 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
   } else if (auto OEE = dyn_cast<OpenExistentialExpr>(E)) {
     // Record opaque value.
     OpaqueValueMap[OEE->getOpaqueValue()] = OEE->getExistentialValue();
-    SWIFT_DEFER {
-      OpaqueValueMap.erase(OEE->getOpaqueValue());
-    };
+    SWIFT_DEFER { OpaqueValueMap.erase(OEE->getOpaqueValue()); };
 
     if (!OEE->getSubExpr()->walk(*this))
       return Action::Stop();
@@ -623,19 +623,18 @@ ASTWalker::PreWalkResult<Expr *> SemaAnnotator::walkToExprPre(Expr *E) {
     // Visit in source order.
     if (!DMRE->getBase()->walk(*this))
       return Action::Stop();
-    if (!passReference(DMRE->getMember().getDecl(), DMRE->getType(),
-                       DMRE->getNameLoc(),
-                       ReferenceMetaData(SemaReferenceKind::DynamicMemberRef,
-                                         OpAccess))) {
+    if (!passReference(
+            DMRE->getMember().getDecl(), DMRE->getType(), DMRE->getNameLoc(),
+            ReferenceMetaData(SemaReferenceKind::DynamicMemberRef, OpAccess))) {
       return Action::Stop();
     }
     // We already visited the children.
     return Action::SkipChildren(E);
   } else if (auto ME = dyn_cast<MacroExpansionExpr>(E)) {
-    // Add a reference to the macro if this is a true macro expansion *expression*.
-    // If this is a `MacroExpansionExpr` that expands a declaration macro, the
-    // substitute decl will be visited by ASTWalker and we would be passing its
-    // reference if we didn't have this check.
+    // Add a reference to the macro if this is a true macro expansion
+    // *expression*. If this is a `MacroExpansionExpr` that expands a
+    // declaration macro, the substitute decl will be visited by ASTWalker and
+    // we would be passing its reference if we didn't have this check.
     if (!ME->getSubstituteDecl()) {
       auto macroRef = ME->getMacroRef();
       if (auto *macroDecl = dyn_cast_or_null<MacroDecl>(macroRef.getDecl())) {
@@ -871,9 +870,8 @@ bool SemaAnnotator::handleImports(ImportDecl *Import) {
   return true;
 }
 
-bool SemaAnnotator::passModulePathElements(
-    ImportPath::Module Path,
-    const clang::Module *ClangMod) {
+bool SemaAnnotator::passModulePathElements(ImportPath::Module Path,
+                                           const clang::Module *ClangMod) {
 
   assert(ClangMod && "can't passModulePathElements of null ClangMod");
 
@@ -896,14 +894,13 @@ bool SemaAnnotator::passCallAsFunctionReference(ValueDecl *D, SourceLoc Loc,
   return SEWalker.visitCallAsFunctionReference(D, Loc, Data);
 }
 
-bool SemaAnnotator::
-passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data) {
+bool SemaAnnotator::passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc,
+                                  ReferenceMetaData Data) {
   return passReference(D, Ty, Loc.getBaseNameLoc(), Loc.getSourceRange(), Data);
 }
 
-bool SemaAnnotator::
-passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
-              ReferenceMetaData Data) {
+bool SemaAnnotator::passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc,
+                                  SourceRange Range, ReferenceMetaData Data) {
   TypeDecl *CtorTyRef = nullptr;
   ExtensionDecl *ExtDecl = nullptr;
 
@@ -946,12 +943,11 @@ passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
   return SEWalker.visitDeclReference(D, Range, CtorTyRef, ExtDecl, Ty, Data);
 }
 
-bool SemaAnnotator::passReference(ModuleEntity Mod,
-                                  ImportPath::Element IdLoc) {
+bool SemaAnnotator::passReference(ModuleEntity Mod, ImportPath::Element IdLoc) {
   if (IdLoc.Loc.isInvalid())
     return true;
   unsigned NameLen = IdLoc.Item.getLength();
-  CharSourceRange Range{ IdLoc.Loc, NameLen };
+  CharSourceRange Range{IdLoc.Loc, NameLen};
   return SEWalker.visitModuleReference(Mod, Range);
 }
 
@@ -969,7 +965,7 @@ bool SemaAnnotator::passCallArgNames(Expr *Fn, ArgumentList *ArgList) {
     if (Loc.isInvalid())
       continue;
 
-    CharSourceRange Range{ Loc, Name.getLength() };
+    CharSourceRange Range{Loc, Name.getLength()};
     bool Continue = SEWalker.visitCallArgName(Name, Range, D);
     if (!Continue)
       return false;
@@ -1034,11 +1030,11 @@ bool SourceEntityWalker::walk(DeclContext *DC) {
 }
 
 bool SourceEntityWalker::walk(ASTNode N) {
-  if (auto *E = N.dyn_cast<Expr*>())
+  if (auto *E = N.dyn_cast<Expr *>())
     return walk(E);
-  if (auto *S = N.dyn_cast<Stmt*>())
+  if (auto *S = N.dyn_cast<Stmt *>())
     return walk(S);
-  if (auto *D = N.dyn_cast<Decl*>())
+  if (auto *D = N.dyn_cast<Decl *>())
     return walk(D);
 
   llvm_unreachable("unsupported AST node");
@@ -1070,13 +1066,13 @@ bool SourceEntityWalker::visitCallAsFunctionReference(ValueDecl *D,
 }
 
 bool SourceEntityWalker::visitCallArgName(Identifier Name,
-                                          CharSourceRange Range,
-                                          ValueDecl *D) {
+                                          CharSourceRange Range, ValueDecl *D) {
   return true;
 }
 
-bool SourceEntityWalker::
-visitDeclarationArgumentName(Identifier Name, SourceLoc Start, ValueDecl *D) {
+bool SourceEntityWalker::visitDeclarationArgumentName(Identifier Name,
+                                                      SourceLoc Start,
+                                                      ValueDecl *D) {
   return true;
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2425,12 +2425,10 @@ namespace {
 
       auto appliedWrappers =
           solution.getAppliedPropertyWrappers(memberLoc->getAnchor());
-      
       args = coerceCallArguments(
           args, fullSubscriptTy, subscriptRef, nullptr,
           locator.withPathElement(ConstraintLocator::ApplyArgument),
           appliedWrappers);
-      
       if (!args)
         return nullptr;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2425,12 +2425,12 @@ namespace {
 
       auto appliedWrappers =
           solution.getAppliedPropertyWrappers(memberLoc->getAnchor());
-
+      
       args = coerceCallArguments(
           args, fullSubscriptTy, subscriptRef, nullptr,
           locator.withPathElement(ConstraintLocator::ApplyArgument),
           appliedWrappers);
-
+      
       if (!args)
         return nullptr;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2527,36 +2527,39 @@ AssignmentFailure::getMemberRef(ConstraintLocator *locator) const {
   if (!member)
     return std::nullopt;
 
-  if (!member->choice.isDecl())
+  // If the member is a subscript, it might be a dynamic member lookup access,
+  // in which case we need to peer through the keypath parameter to get the
+  // underlying member.
+  auto *SD = member->choice.isDecl()
+                 ? dyn_cast<SubscriptDecl>(member->choice.getDecl())
+                 : nullptr;
+  auto eligibility = SD ? SD->getDynamicMemberLookupSubscriptEligibility()
+                        : DynamicMemberLookupSubscriptEligibility::None;
+  switch (eligibility) {
+  case DynamicMemberLookupSubscriptEligibility::None:
+    // Not a decl, subscript, or dynamic member lookup subscript; stick with the
+    // existing overload choice.
     return member->choice;
 
-  auto *decl = member->choice.getDecl();
-  if (isa<SubscriptDecl>(decl) &&
-      isValidDynamicMemberLookupSubscript(cast<SubscriptDecl>(decl))) {
-    auto *subscript = cast<SubscriptDecl>(decl);
-    // If this is a keypath dynamic member lookup, we have to
-    // adjust the locator to find member referred by it.
-    if (isValidKeyPathDynamicMemberLookup(subscript)) {
-      // Type has a following format:
-      // `(Self) -> (dynamicMember: {Writable}KeyPath<T, U>) -> U`
-      auto *fullType = member->adjustedOpenedFullType->castTo<FunctionType>();
-      auto *fnType = fullType->getResult()->castTo<FunctionType>();
-
-      auto paramTy = fnType->getParams()[0].getPlainType();
-      auto keyPath = paramTy->getAnyNominal();
-      auto memberLoc = getConstraintLocator(
-          locator, LocatorPathElt::KeyPathDynamicMember(keyPath));
-
-      auto memberRef = getOverloadChoiceIfAvailable(memberLoc);
-      return memberRef ? std::optional<OverloadChoice>(memberRef->choice)
-                       : std::nullopt;
-    }
-
-    // If this is a string based dynamic lookup, there is no member declaration.
+  case DynamicMemberLookupSubscriptEligibility::String:
+    // There is no member declaration for string-based dynamic member lookup
+    // subscripts.
     return std::nullopt;
-  }
 
-  return member->choice;
+  case DynamicMemberLookupSubscriptEligibility::KeyPath: {
+    auto keyPathType = SD->getDynamicMemberLookupKeyPathType();
+    assert(keyPathType && "KeyPath-based dynamic member lookup subscripts must "
+                          "have a valid dynamic member type");
+
+    auto memberLoc = getConstraintLocator(
+        locator,
+        LocatorPathElt::KeyPathDynamicMember(keyPathType->getAnyNominal()));
+
+    auto memberRef = getOverloadChoiceIfAvailable(memberLoc);
+    return memberRef ? std::optional<OverloadChoice>(memberRef->choice)
+                     : std::nullopt;
+  }
+  }
 }
 
 Diag<StringRef> AssignmentFailure::findDeclDiagnostic(ASTContext &ctx,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -2552,7 +2552,7 @@ AssignmentFailure::getMemberRef(ConstraintLocator *locator) const {
     // need to repeat here.
     auto keyPathType =
         SD->getDynamicMemberLookupKeyPathType(/*useDC=*/std::nullopt);
-    assert(keyPathType && "KeyPath-based dynamic member lookup subscripts must "
+    ASSERT(keyPathType && "KeyPath-based dynamic member lookup subscripts must "
                           "have a valid dynamic member type");
 
     auto memberLoc = getConstraintLocator(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10853,10 +10853,10 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     }
 
     // While looking for subscript choices it's possible to find
-    // `subscript(dynamicMember: {Reference{Writable}}KeyPath)` on types marked
-    // as `@dynamicMemberLookup`; let's mark this candidate as representing
-    // "dynamic lookup" unless it's a direct call to such subscript (in that
-    // case label is expected to match).
+    // `subscript(dynamicMember: {Reference{Writable}}KeyPath, ...)` on types
+    // marked as `@dynamicMemberLookup`; let's mark this candidate as
+    // representing "dynamic lookup" unless it's a direct call to such subscript
+    // (in that case label is expected to match).
     if (auto *SD = dyn_cast<SubscriptDecl>(cand)) {
       if (memberLocator && instanceTy->hasDynamicMemberLookupAttribute()) {
         if (SD->getDynamicMemberLookupSubscriptEligibility() ==
@@ -10979,7 +10979,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // or if all of the candidates come from conditional conformances (which
   // might not be applicable), and we are looking for members in a type with
   // the @dynamicMemberLookup attribute, then we resolve a reference to a
-  // `subscript(dynamicMember:)` method and pass the member name as a string
+  // `subscript(dynamicMember:...)` method and pass the member name as a string
   // parameter.
   if (constraintKind == ConstraintKind::ValueMember &&
       memberName.isSimpleName() && !memberName.isSpecial() &&

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11002,8 +11002,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
         auto *SD = cast<SubscriptDecl>(candidate.getDecl());
         bool isKeyPathBased = isValidKeyPathDynamicMemberLookup(SD);
 
-        if (isValidStringDynamicMemberLookup(SD, DC->getParentModule()) ||
-            isKeyPathBased)
+        if (isValidStringDynamicMemberLookup(SD) || isKeyPathBased)
           result.addViable(OverloadChoice::getDynamicMemberLookup(
               baseTy, SD, name, isKeyPathBased));
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4001,8 +4001,8 @@ ConstraintSystem::getArgumentInfoLocator(ConstraintLocator *locator) {
   if (auto *UME = getAsExpr<UnresolvedMemberExpr>(anchor))
     return getConstraintLocator(UME);
 
-  // All implicit x[dynamicMember:] subscript calls can share the same argument
-  // list.
+  // All implicit `x[dynamicMember:...]` subscript calls can share the same
+  // argument list.
   if (locator->findLast<LocatorPathElt::ImplicitDynamicMemberSubscript>()) {
     return getConstraintLocator(
         ASTNode(), LocatorPathElt::ImplicitDynamicMemberSubscript());

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -258,7 +258,7 @@ TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
 TypePair
 RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(Evaluator &evaluator,
                                               SubscriptDecl *subscript) const {
-  auto keyPathType = getKeyPathTypeForDynamicMemberLookup(subscript);
+  auto keyPathType = subscript->getDynamicMemberLookupKeyPathType();
   if (!keyPathType)
     return TypePair();
 

--- a/lib/Sema/IDETypeCheckingRequests.cpp
+++ b/lib/Sema/IDETypeCheckingRequests.cpp
@@ -255,10 +255,10 @@ TypeRelationCheckRequest::evaluate(Evaluator &evaluator,
                                              *CKind, Owner.DC);
 }
 
-TypePair
-RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(Evaluator &evaluator,
-                                              SubscriptDecl *subscript) const {
-  auto keyPathType = subscript->getDynamicMemberLookupKeyPathType();
+TypePair RootAndResultTypeOfKeypathDynamicMemberRequest::evaluate(
+    Evaluator &evaluator, SubscriptDecl *subscript) const {
+  auto keyPathType =
+      subscript->getDynamicMemberLookupKeyPathType(/*useDC=*/std::nullopt);
   if (!keyPathType)
     return TypePair();
 

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1125,7 +1125,7 @@ static void lookupVisibleDynamicMemberLookupDecls(
                       NL_QualifiedDefault | NL_ProtocolMembers, subscripts);
 
   for (ValueDecl *VD : subscripts) {
-    auto *subscript = cast<SubscriptDecl>(VD);
+    auto *subscript = dyn_cast<SubscriptDecl>(VD);
     if (!subscript || subscript->getDynamicMemberLookupKind(dc) !=
                           SubscriptDecl::DynamicMemberLookupKind::KeyPath) {
       continue;

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -40,7 +40,6 @@
 #include "clang/Basic/Module.h"
 #include "clang/Lex/Preprocessor.h"
 #include "llvm/ADT/SetVector.h"
-#include <algorithm>
 #include <set>
 
 using namespace swift;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2172,29 +2172,6 @@ SubscriptDecl::evaluateDynamicMemberLookupEligibility(
   return eligibility;
 }
 
-/// Returns true if the given subscript method is an valid implementation of
-/// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)`.
-bool swift::isValidDynamicMemberLookupSubscript(SubscriptDecl *decl) {
-  return decl->getDynamicMemberLookupSubscriptEligibility() !=
-         DynamicMemberLookupSubscriptEligibility::None;
-}
-
-bool swift::isValidStringDynamicMemberLookup(SubscriptDecl *decl) {
-  return decl->getDynamicMemberLookupSubscriptEligibility() ==
-         DynamicMemberLookupSubscriptEligibility::String;
-}
-
-BoundGenericType *
-swift::getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl) {
-  return decl->getDynamicMemberLookupKeyPathType();
-}
-
-bool swift::isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl) {
-  return decl->getDynamicMemberLookupSubscriptEligibility() ==
-         DynamicMemberLookupSubscriptEligibility::KeyPath;
-}
-
 /// The @dynamicMemberLookup attribute is only allowed on types that have at
 /// least one subscript member declared like this:
 ///

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -58,7 +58,6 @@
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
-#include <algorithm>
 #include <optional>
 
 using namespace swift;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3457,6 +3457,11 @@ bool DynamicMemberLookupSubscriptEligibility::diagnose() {
           .fixItInsertAfter(param->getEndLoc(), " = <#Default#>");
       diagnosed = true;
     }
+
+    // At least one flag has been set (or else we would have continued early);
+    // light-weight sanity check that we'll be reporting we've diagnosed at
+    // least once.
+    ASSERT(diagnosed);
   }
 
   return diagnosed;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2868,13 +2868,10 @@ public:
           if (outerTy->hasDynamicMemberLookupAttribute()) {
             auto D = outerTy->getAnyNominal();
             if (!D->getAttrs().hasAttribute<DynamicMemberLookupAttr>()) {
-              if (overriddenDecl
-                      ->getDynamicMemberLookupSubscriptEligibility() !=
-                  DynamicMemberLookupSubscriptEligibility::None) {
-                auto accessScope = D->getFormalAccessScope();
-                if (SD->evaluateDynamicMemberLookupEligibility(
-                        &accessScope, &SD->getDiags()) ==
-                    DynamicMemberLookupSubscriptEligibility::None) {
+              if (overriddenDecl->isValidDynamicMemberLookupSubscript(
+                      /*useDC=*/std::nullopt)) {
+                if (!SD->isValidDynamicMemberLookupSubscript(
+                        /*useDC=*/std::nullopt)) {
                   SD->setInvalid();
                 }
               }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2840,11 +2840,10 @@ public:
     checkExplicitAvailability(SD);
 
     if (!checkOverrides(SD)) {
+      // If a subscript has an override attribute but does not override
+      // anything, complain.
       if (auto *OA = SD->getAttrs().getAttribute<OverrideAttr>()) {
-        auto *overriddenDecl = SD->getOverriddenDecl();
-        if (!overriddenDecl) {
-          // If a subscript has an override attribute but does not override
-          // anything, complain.
+        if (!SD->getOverriddenDecl()) {
           auto DC = SD->getDeclContext();
           auto isClassContext = DC->getSelfClassDecl() != nullptr;
           auto isStructOrEnumContext = DC->getSelfEnumDecl() != nullptr ||
@@ -2858,25 +2857,6 @@ public:
                 .highlight(OA->getLocation());
           }
           OA->setInvalid();
-        } else if (auto outerTy = DC->getDeclaredInterfaceType()) {
-          // This is an overridden subscript; if the outer type has
-          // `@dynamicMemberLookup` but isn't directly annotated with it (e.g.,
-          // it's inherited), its members won't go through
-          // `@dynamicMemberLookup` checking via `AttributeChecker`. We need to
-          // ensure that if the overridden decl was a valid dynamic member
-          // lookup subscript, this override remains valid.
-          if (outerTy->hasDynamicMemberLookupAttribute()) {
-            auto D = outerTy->getAnyNominal();
-            if (!D->getAttrs().hasAttribute<DynamicMemberLookupAttr>()) {
-              if (overriddenDecl->isValidDynamicMemberLookupSubscript(
-                      /*useDC=*/std::nullopt)) {
-                if (!SD->isValidDynamicMemberLookupSubscript(
-                        /*useDC=*/std::nullopt)) {
-                  SD->setInvalid();
-                }
-              }
-            }
-          }
         }
       }
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2840,10 +2840,11 @@ public:
     checkExplicitAvailability(SD);
 
     if (!checkOverrides(SD)) {
-      // If a subscript has an override attribute but does not override
-      // anything, complain.
       if (auto *OA = SD->getAttrs().getAttribute<OverrideAttr>()) {
-        if (!SD->getOverriddenDecl()) {
+        auto *overriddenDecl = SD->getOverriddenDecl();
+        if (!overriddenDecl) {
+          // If a subscript has an override attribute but does not override
+          // anything, complain.
           auto DC = SD->getDeclContext();
           auto isClassContext = DC->getSelfClassDecl() != nullptr;
           auto isStructOrEnumContext = DC->getSelfEnumDecl() != nullptr ||
@@ -2857,6 +2858,28 @@ public:
                 .highlight(OA->getLocation());
           }
           OA->setInvalid();
+        } else if (auto outerTy = DC->getDeclaredInterfaceType()) {
+          // This is an overridden subscript; if the outer type has
+          // `@dynamicMemberLookup` but isn't directly annotated with it (e.g.,
+          // it's inherited), its members won't go through
+          // `@dynamicMemberLookup` checking via `AttributeChecker`. We need to
+          // ensure that if the overridden decl was a valid dynamic member
+          // lookup subscript, this override remains valid.
+          if (outerTy->hasDynamicMemberLookupAttribute()) {
+            auto D = outerTy->getAnyNominal();
+            if (!D->getAttrs().hasAttribute<DynamicMemberLookupAttr>()) {
+              if (overriddenDecl
+                      ->getDynamicMemberLookupSubscriptEligibility() !=
+                  DynamicMemberLookupSubscriptEligibility::None) {
+                auto accessScope = D->getFormalAccessScope();
+                if (SD->evaluateDynamicMemberLookupEligibility(
+                        &accessScope, &SD->getDiags()) ==
+                    DynamicMemberLookupSubscriptEligibility::None) {
+                  SD->setInvalid();
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1318,36 +1318,6 @@ diag::RequirementKind getProtocolRequirementKind(ValueDecl *Requirement);
 bool isValidDynamicCallableMethod(FuncDecl *decl,
                                   bool hasKeywordArguments);
 
-/// Returns true if the given subscript method is an valid implementation of
-/// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)`.
-bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl);
-
-/// Returns true if the given subscript method is an valid implementation of
-/// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)` which
-/// takes a single non-variadic parameter that conforms to
-/// `ExpressibleByStringLiteral` protocol.
-bool isValidStringDynamicMemberLookup(SubscriptDecl *decl);
-
-/// Returns the KeyPath parameter type for a valid implementation of
-/// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
-/// @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)` which
-/// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
-///
-/// Returns null if the given subscript is not a valid dynamic member lookup
-/// implementation.
-BoundGenericType *
-getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl);
-
-/// Returns true if the given subscript method is an valid implementation of
-/// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
-/// @dynamicMemberLookup.
-/// The method is given to be defined as `subscript(dynamicMember:)` which
-/// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
-bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl);
-
 /// Compute the wrapped value type for the given property that has attached
 /// property wrappers, when the backing storage is known to have the given type.
 ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1321,16 +1321,14 @@ bool isValidDynamicCallableMethod(FuncDecl *decl,
 /// Returns true if the given subscript method is an valid implementation of
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)`.
-bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl,
-                                         bool ignoreLabel = false);
+bool isValidDynamicMemberLookupSubscript(SubscriptDecl *decl);
 
 /// Returns true if the given subscript method is an valid implementation of
 /// the `subscript(dynamicMember:)` requirement for @dynamicMemberLookup.
 /// The method is given to be defined as `subscript(dynamicMember:)` which
 /// takes a single non-variadic parameter that conforms to
 /// `ExpressibleByStringLiteral` protocol.
-bool isValidStringDynamicMemberLookup(SubscriptDecl *decl,
-                                      bool ignoreLabel = false);
+bool isValidStringDynamicMemberLookup(SubscriptDecl *decl);
 
 /// Returns the KeyPath parameter type for a valid implementation of
 /// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
@@ -1341,8 +1339,14 @@ bool isValidStringDynamicMemberLookup(SubscriptDecl *decl,
 /// Returns null if the given subscript is not a valid dynamic member lookup
 /// implementation.
 BoundGenericType *
-getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl,
-                                     bool ignoreLabel = false);
+getKeyPathTypeForDynamicMemberLookup(SubscriptDecl *decl);
+
+/// Returns true if the given subscript method is an valid implementation of
+/// the `subscript(dynamicMember: {Writable}KeyPath<...>)` requirement for
+/// @dynamicMemberLookup.
+/// The method is given to be defined as `subscript(dynamicMember:)` which
+/// takes a single non-variadic parameter of `{Writable}KeyPath<T, U>` type.
+bool isValidKeyPathDynamicMemberLookup(SubscriptDecl *decl);
 
 /// Compute the wrapped value type for the given property that has attached
 /// property wrappers, when the backing storage is known to have the given type.

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2347,17 +2347,17 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
     }
   };
   auto addDynamicMemberSubscriptConstraints = [&](Type argTy, Type resultTy) {
-    // DynamicMemberLookup results are always a (dynamicMember: T1) -> T2
+    // DynamicMemberLookup results are always a `(dynamicMember: T1, ...) -> T2`
     // subscript.
     auto *fnTy = openedType->castTo<FunctionType>();
-    assert(fnTy->getParams().size() == 1 &&
-           "subscript always has one argument");
+    assert(fnTy->getParams().size() > 0 &&
+           "subscript always has at least one argument");
 
     auto *callLoc = getConstraintLocator(
         locator, LocatorPathElt::ImplicitDynamicMemberSubscript());
 
-    // Associate an argument list for the implicit x[dynamicMember:] subscript
-    // if we haven't already.
+    // Associate an argument list for the implicit `x[dynamicMember:...]`
+    // subscript if we haven't already.
     auto *argLoc = getArgumentInfoLocator(callLoc);
     if (ArgumentLists.find(argLoc) == ArgumentLists.end()) {
       auto *argList = ArgumentList::createImplicit(
@@ -2422,9 +2422,9 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
     if (!stringLiteral)
       return;
 
-    // Form constraints for a x[dynamicMember:] subscript with a string literal
-    // argument, where the overload type is bound to the result to model the
-    // fact that this a property access in the source.
+    // Form constraints for a `x[dynamicMember:...]` subscript with a string
+    // literal argument, where the overload type is bound to the result to model
+    // the fact that this a property access in the source.
     auto argTy = createTypeVariable(locator, /*options*/ 0);
     addConstraint(ConstraintKind::LiteralConformsTo, argTy,
                   stringLiteral->getDeclaredInterfaceType(), locator);
@@ -2433,8 +2433,8 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
   }
   case OverloadChoiceKind::KeyPathDynamicMemberLookup: {
     auto *fnType = openedType->castTo<FunctionType>();
-    assert(fnType->getParams().size() == 1 &&
-           "subscript always has one argument");
+    assert(fnType->getParams().size() > 0 &&
+           "subscript always has at least one argument");
     // Parameter type is KeyPath<T, U> where `T` is a root type
     // and U is a leaf type (aka member type).
     auto paramTy = fnType->getParams()[0].getPlainType();
@@ -2588,7 +2588,7 @@ void ConstraintSystem::bindOverloadType(const SelectedOverload &overload,
       // type into "leaf" directly.
       addConstraint(ConstraintKind::Equal, memberTy, leafTy, keyPathLoc);
 
-      // Form constraints for a x[dynamicMember:] subscript with a key path
+      // Form constraints for a `x[dynamicMember:...]` subscript with a key path
       // argument, where the overload type is bound to the result to model the
       // fact that this a property access in the source.
       addDynamicMemberSubscriptConstraints(/*argTy*/ paramTy, boundType);

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -23,6 +23,7 @@
 #include "TypeChecker.h"
 #include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/Effects.h"
+#include "swift/AST/ExtInfo.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/MacroDefinition.h"
 #include "swift/AST/ParameterList.h"
@@ -1609,6 +1610,13 @@ std::pair<Type, Type> ConstraintSystem::getOpenedStorageType(
     if (thrownErrorType) {
       info = info.withThrows(true, thrownErrorType);
       thrownErrorType = Type();
+    }
+
+    // Mark the isolation if any parameter is isolated.
+    if (llvm::any_of(indices, [&](AnyFunctionType::Param p) {
+          return p.isIsolated();
+        })) {
+      info = info.withIsolation(FunctionTypeIsolation::forParameter());
     }
 
     refType = FunctionType::get(indices, elementTy, info);

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -136,6 +136,127 @@ func testIUOResult(x: IUOResult) {
 }
 
 //===----------------------------------------------------------------------===//
+// Taking multiple arguments
+//===----------------------------------------------------------------------===//
+
+// Parameters after the initial `dynamicMember:` are valid as long as they
+// have default arguments or are variadic. These can be concrete or generic.
+
+protocol MultiArgDefaultValue {
+  static var defaultValue: Self { get }
+}
+
+@dynamicMemberLookup
+struct ValidMultiArg1 {
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: KeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> KeyPath<T, U> {
+    get { member }
+    set {}
+  }
+}
+
+@dynamicMemberLookup
+struct ValidMultiArg2 {
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: WritableKeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> WritableKeyPath<T, U> {
+    get { member }
+    set {}
+  }
+}
+
+@dynamicMemberLookup
+struct ValidMultiArg3 {
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: ReferenceWritableKeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> WritableKeyPath<T, U> {
+    get { member }
+    set {}
+  }
+}
+
+@dynamicMemberLookup
+struct ValidMultiArg4 {
+  subscript<V: MultiArgDefaultValue, each W>(
+    dynamicMember member: String,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> String {
+    get { member }
+    set {}
+  }
+}
+
+// Simultaneous overloads don't introduce ambiguity
+
+@dynamicMemberLookup
+struct ValidMultiArg5 {
+  subscript(dynamicMember member: StaticString) -> Int {
+    get { return 42 }
+    set {}
+  }
+
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: KeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> KeyPath<T, U> {
+    get { member }
+    set {}
+  }
+
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: WritableKeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> WritableKeyPath<T, U> {
+    get { member }
+    set {}
+  }
+
+  subscript<T, U, V: MultiArgDefaultValue, each W>(
+    dynamicMember member: ReferenceWritableKeyPath<T, U>,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> WritableKeyPath<T, U> {
+    get { member }
+    set {}
+  }
+
+  subscript<V: MultiArgDefaultValue, each W>(
+    dynamicMember member: String,
+    magic: StaticString = #function,
+    generic: V = .defaultValue,
+    variadic: KeyPath<V, V>...,
+    parameterPack pack: repeat each W
+  ) -> String {
+    get { member }
+    set {}
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // Error cases
 //===----------------------------------------------------------------------===//
 
@@ -157,6 +278,25 @@ struct Invalid2 {
   }
 }
 
+// Given multiple arguments, all values after `dynamicMember:` must have a
+// default value.
+@dynamicMemberLookup
+struct InvalidMultiArg1 {
+  // expected-error@+1{{'@dynamicMemberLookup' requires 'InvalidMultiArg1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  subscript(dynamicMember member: String, magic: StaticString) -> String { // expected-note{{add a default value to this argument to satisfy the '@dynamicMemberLookup' requirement}} {{62-62= = <#Default#>}}
+    member
+  }
+}
+
+// `dynamicMember:` must still be the first argument among multiple.
+@dynamicMemberLookup
+struct InvalidMultiArg2 {
+  // expected-error@+1{{'@dynamicMemberLookup' requires 'InvalidMultiArg2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  subscript(magic: StaticString = #function, dynamicMember member: String) -> String { // expected-note{{'dynamicMember' argument must appear first in the argument list}}
+    member
+  }
+}
+
 // References to overloads are resolved just like normal subscript lookup:
 // they are either contextually disambiguated or are invalid.
 @dynamicMemberLookup
@@ -173,6 +313,81 @@ func testAmbiguity(a: Ambiguity) {
   let _: Int = a.flexibility
   let _: Float = a.dynamism
   _ = a.dynamism // expected-error {{ambiguous use of 'subscript(dynamicMember:)'}}
+}
+
+// References to overloads are also resolved just like normal subscript and
+// function lookup in the presence of overloads with default arguments: they are
+// either contextually disambiguated or are invalid, with a preference for
+// overloads with fewer arguments.
+@dynamicMemberLookup
+struct MultiArgAmbiguity {
+  subscript(dynamicMember member: String) -> String {
+    member
+  }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function, variadic: Any...) -> Int {
+    42
+  }
+
+  subscript<V: MultiArgDefaultValue>(dynamicMember member: String, generic: V = .defaultValue, variadic: Any...) -> V {
+    generic
+  }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function) -> Float {
+    42.0
+  }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function) -> Double {
+    42.0
+  }
+
+  subscript<T, U>(dynamicMember member: KeyPath<T, U>, magic: StaticString = #function, variadic: Any...) -> KeyPath<T, U> {
+    member
+  }
+
+  subscript<T, U>(dynamicMember member: WritableKeyPath<T, U>, magic: StaticString = #function, variadic: Any...) -> WritableKeyPath<T, U> {
+    member
+  }
+
+  subscript<T, U>(dynamicMember member: ReferenceWritableKeyPath<T, U>, magic: StaticString = #function, variadic: Any...) -> ReferenceWritableKeyPath<T, U> {
+    member
+  }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function, variadic: Any...) -> String {
+    member
+  }
+}
+
+extension Int: MultiArgDefaultValue {
+  static var defaultValue: Int { 0 }
+}
+
+func testMultiArgAmbiguity(a: MultiArgAmbiguity) {
+  // `subscript(dynamicMember: String) -> String` is preferred over other
+  // overloads as it has fewer parameters; even though the other subscripts can
+  // be ambiguous.
+  let _ = a.foo
+
+  // This is also true when selecting between specific overloads by return type:
+  // `subscript(dynamicMember:) -> String` is preferred over
+  // `subscript<V>(dynamicMember:magic:variadic:) -> String`.
+  let _: String = a.foo
+
+  // Normal disambiguation rules also apply to multi-arg subscripts:
+  // `subscript(dynamicMember:magic:variadic:) -> Int` is preferred over
+  // `subscript<V>(dynamicMember:generic:varadic:) -> V` because it's more
+  // specific.
+  let _: Int = a.foo
+
+  // Other normal ambiguity rules still apply too.
+  let _: Float = a.foo
+  let _: Double = a.foo
+  let _: any BinaryFloatingPoint = a.foo // expected-error{{ambiguous use of 'subscript(dynamicMember:_:)'}}
+
+  class Cls { var foo: Int = 42 }
+  let _: KeyPath<Cls, _> = a.foo
+  let _: WritableKeyPath<Cls, _> = a.foo
+  let _: ReferenceWritableKeyPath<Cls, _> = a.foo
 }
 
 // expected-error @+1 {{'@dynamicMemberLookup' attribute cannot be applied to this declaration}}
@@ -393,7 +608,22 @@ class BaseClass {
   subscript(dynamicMember member: String) -> Int {
     return 42
   }
+
+  subscript(dynamicMember member: String, magic: StaticString = #function) -> String {
+    return member
+  }
+
+  // These overloads are disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<each W>(dynamicMember member: String, magic: StaticString = #function, pack: repeat each W) -> Int {
+    return 42
+  }
+
+  subscript<each W>(dynamicMember member: String, magic: StaticString = #function, pack: repeat each W) -> String {
+    return member
+  }
 }
+
 class DerivedClass : BaseClass {}
 
 func testDerivedClass(x: BaseClass, y: DerivedClass) -> Int {
@@ -414,6 +644,31 @@ func testOverrideSubscript(a: BaseClass, b: DerivedClassWithSetter) {
   a.balboza = 12 // expected-error {{cannot assign through dynamic lookup property: 'a' is a 'let' constant}}
 }
 
+// Overriding with a different default value is valid.
+class DerivedClassWithOverriddenDefault : BaseClass {
+  override subscript(dynamicMember member: String, magic: StaticString = #fileID) -> String {
+    return member
+  }
+}
+
+func testOverrideSubscript(a: BaseClass, b: DerivedClassWithOverriddenDefault) {
+  let _: String = a.magic
+  let _: String = b.magic
+}
+
+// Overriding with a different default value is valid.
+class DerivedClassWithMissingDefault : BaseClass {
+  // expected-error@+1{{'@dynamicMemberLookup' requires 'DerivedClassWithMissingDefault' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  override subscript(dynamicMember member: String, magic: StaticString) -> String { // expected-note{{add a default value to this argument to satisfy the '@dynamicMemberLookup' requirement}} {{71-71= = <#Default#>}}
+    return member
+  }
+}
+
+func testOverrideSubscript(a: BaseClass, b: DerivedClassWithMissingDefault) {
+  let _: String = a.magic
+  let _: String = b.magic
+}
+
 //===----------------------------------------------------------------------===//
 // Generics
 //===----------------------------------------------------------------------===//
@@ -421,6 +676,13 @@ func testOverrideSubscript(a: BaseClass, b: DerivedClassWithSetter) {
 @dynamicMemberLookup
 struct SettableGeneric1<T> {
   subscript(dynamicMember member: StaticString) -> T? {
+    get {}
+    nonmutating set {}
+  }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<each W>(dynamicMember member: StaticString, variadic: T..., parameterPack pack: repeat each W) -> T? {
     get {}
     nonmutating set {}
   }
@@ -439,6 +701,13 @@ func testConcreteGenericType(a: SettableGeneric1<Int>) -> Int? {
 @dynamicMemberLookup
 struct SettableGeneric2<T> {
   subscript<U: ExpressibleByStringLiteral>(dynamicMember member: U) -> T {
+    get {}
+    nonmutating set {}
+  }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U: ExpressibleByStringLiteral, each W>(dynamicMember member: U, variadic: U..., parameterPack pack: repeat each W) -> T {
     get {}
     nonmutating set {}
   }
@@ -488,8 +757,17 @@ func testGenerics<S, T, P: GenericProtocol>(
 @dynamicMemberLookup
 class KP {
   subscript(dynamicMember member: String) -> Int { return 7 }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  //
+  // We're using `String` here instead of `StaticString` since a `KeyPath`
+  // reference below requires arguments to be `Hashable` and `StaticString`
+  // isn't.
+  subscript(dynamicMember member: String, magic: String = #function) -> Int { return 42 }
 }
 _ = \KP.[dynamicMember: "hi"]
+_ = \KP.[dynamicMember: "hi", #fileID]
 _ = \KP.testLookup
 
 /* KeyPath based dynamic lookup */
@@ -518,6 +796,17 @@ struct Lens<T> {
   }
 
   subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+    set { obj[keyPath: member] = newValue.obj }
+  }
+
+  // These overloads are disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U, each W>(dynamicMember member: KeyPath<T, U>, magic: StaticString = #function, pack: repeat each W) -> Lens<U> {
+    get { return Lens<U>(obj[keyPath: member]) }
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>, magic: StaticString = #function) -> Lens<U> {
     get { return Lens<U>(obj[keyPath: member]) }
     set { obj[keyPath: member] = newValue.obj }
   }
@@ -630,6 +919,12 @@ class AMetatype<T> {
   subscript<U>(dynamicMember member: KeyPath<T.Type, U>) -> U {
     get { return value[keyPath: member] }
   }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U, each W>(dynamicMember member: KeyPath<T.Type, U>, magic: StaticString = #function, pack: repeat each W) -> U {
+    get { return value[keyPath: member] }
+  }
 }
 
 // Let's make sure that keypath dynamic member lookup
@@ -659,6 +954,12 @@ extension KeyPathLookup {
   subscript(dynamicMember member: KeyPath<T, Int>) -> Int! {
     get { return value[keyPath: member] }
   }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<each W>(dynamicMember member: KeyPath<T, Int>, magic: StaticString = #function, pack: repeat each W) -> Int! {
+    get { return value[keyPath: member] }
+  }
 }
 
 class C<T> : KeyPathLookup {
@@ -684,6 +985,12 @@ class D<T> {
   }
 
   subscript<U: Numeric>(dynamicMember member: KeyPath<T, U>) -> (U) -> U {
+    get { return { offset in self.value[keyPath: member] + offset } }
+  }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U: Numeric, each W>(dynamicMember member: KeyPath<T, U>, magic: StaticString = #function, pack: repeat each W) -> (U) -> U {
     get { return { offset in self.value[keyPath: member] + offset } }
   }
 }
@@ -715,6 +1022,26 @@ struct SubscriptLens<T> {
   }
 
   subscript<U>(dynamicMember member: WritableKeyPath<T, U>) -> U {
+    get { return value[keyPath: member] }
+    set { value[keyPath: member] = newValue }
+  }
+
+  // These overloads are disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<each W>(foo: String, magic: StaticString = #function, pack: repeat each W) -> Int {
+    get { return 42 }
+  }
+
+  subscript(offset: Int, magic: StaticString = #function) -> Int {
+    get { return counter }
+    set { counter = counter + newValue }
+  }
+
+  subscript<U>(dynamicMember member: KeyPath<T, U>, magic: StaticString = #function) -> U! {
+    get { return value[keyPath: member] }
+  }
+
+  subscript<U>(dynamicMember member: WritableKeyPath<T, U>, magic: StaticString = #function) -> U {
     get { return value[keyPath: member] }
     set { value[keyPath: member] = newValue }
   }
@@ -789,6 +1116,13 @@ struct SingleChoiceLens<T> {
     get { return obj[keyPath: member] }
     set { obj[keyPath: member] = newValue }
   }
+
+  // This overload is disfavored at callsites compared to the above and
+  // shouldn't introduce ambiguity.
+  subscript<U, each W>(dynamicMember member: WritableKeyPath<T, U>, magic: StaticString = #function, pack: repeat each W) -> U {
+    get { return obj[keyPath: member] }
+    set { obj[keyPath: member] = newValue }
+  }
 }
 
 // Make sure that disjunction filtering optimization doesn't
@@ -837,6 +1171,10 @@ func invalid_refs_through_dynamic_lookup() {
     _ = lens.baz("hello")
   }
 }
+
+//===----------------------------------------------------------------------===//
+// Specific Issues
+//===----------------------------------------------------------------------===//
 
 // https://github.com/apple/swift/issues/52997
 

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -263,7 +263,7 @@ struct ValidMultiArg5 {
 // Subscript index must be ExpressibleByStringLiteral.
 @dynamicMemberLookup
 struct Invalid1 {
-  // expected-error @+1 {{'@dynamicMemberLookup' requires 'Invalid1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'member' to be either 'ExpressibleByStringLiteral' or a key path}}
   subscript(dynamicMember member: Int) -> Int {
     return 42
   }
@@ -272,7 +272,7 @@ struct Invalid1 {
 // Subscript may not be variadic.
 @dynamicMemberLookup
 struct Invalid2 {
-  // expected-error @+1 {{'@dynamicMemberLookup' requires 'Invalid2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'member' to be either 'ExpressibleByStringLiteral' or a key path}}
   subscript(dynamicMember member: String...) -> Int {
     return 42
   }
@@ -282,8 +282,8 @@ struct Invalid2 {
 // default value.
 @dynamicMemberLookup
 struct InvalidMultiArg1 {
-  // expected-error@+1{{'@dynamicMemberLookup' requires 'InvalidMultiArg1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  subscript(dynamicMember member: String, magic: StaticString) -> String { // expected-note{{add a default value to this argument to satisfy the '@dynamicMemberLookup' requirement}} {{62-62= = <#Default#>}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'magic' to have a default value}} {{62-62= = <#Default#>}}
+  subscript(dynamicMember member: String, magic: StaticString) -> String {
     member
   }
 }
@@ -291,8 +291,8 @@ struct InvalidMultiArg1 {
 // `dynamicMember:` must still be the first argument among multiple.
 @dynamicMemberLookup
 struct InvalidMultiArg2 {
-  // expected-error@+1{{'@dynamicMemberLookup' requires 'InvalidMultiArg2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  subscript(magic: StaticString = #function, dynamicMember member: String) -> String { // expected-note{{'dynamicMember' argument must appear first in the argument list}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'member' to appear first in the parameter list}}
+  subscript(magic: StaticString = #function, dynamicMember member: String) -> String {
     member
   }
 }
@@ -658,8 +658,8 @@ func testOverrideSubscript(a: BaseClass, b: DerivedClassWithOverriddenDefault) {
 
 // Overriding with a different default value is valid.
 class DerivedClassWithMissingDefault : BaseClass {
-  // expected-error@+1{{'@dynamicMemberLookup' requires 'DerivedClassWithMissingDefault' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  override subscript(dynamicMember member: String, magic: StaticString) -> String { // expected-note{{add a default value to this argument to satisfy the '@dynamicMemberLookup' requirement}} {{71-71= = <#Default#>}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'magic' to have a default value}} {{71-71= = <#Default#>}}
+  override subscript(dynamicMember member: String, magic: StaticString) -> String {
     return member
   }
 }
@@ -1219,20 +1219,21 @@ do {
 
 @dynamicMemberLookup
 struct S1_52957 {
-  subscript(dynamicMember: String) -> String { // expected-error {{'@dynamicMemberLookup' requires 'S1_52957' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  // expected-note@-1 {{add an explicit argument label to this subscript to satisfy the '@dynamicMemberLookup' requirement}}{{13-13=dynamicMember }}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'dynamicMember' to have an explicit parameter label}}{{26-26= <#label#>}}
+  subscript(dynamicMember: String) -> String {
     fatalError()
   }
 }
 
 @dynamicMemberLookup
 struct S2_52957 {
-  subscript(foo bar: String) -> String { // expected-error {{'@dynamicMemberLookup' requires 'S2_52957' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'bar' to have an explicit 'dynamicMember' argument label}}
+  subscript(foo bar: String) -> String {
     fatalError()
   }
 
-  subscript(foo: String) -> String { // expected-error {{'@dynamicMemberLookup' requires 'S2_52957' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
-  // expected-note@-1 {{add an explicit argument label to this subscript to satisfy the '@dynamicMemberLookup' requirement}} {{13-13=dynamicMember }}
+  // expected-error @+1 {{'@dynamicMemberLookup' requires 'foo' to have an explicit 'dynamicMember' argument label}} {{13-13=dynamicMember }}
+  subscript(foo: String) -> String {
     fatalError()
   }
 }

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -457,6 +457,7 @@ public struct Accessible5 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible1' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible1 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-3=public }}
@@ -466,6 +467,7 @@ public struct Inaccessible1 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible2' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible2 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{21-29=public}}
@@ -475,6 +477,7 @@ public struct Inaccessible2 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible3' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 internal struct Inaccessible3 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-10=internal}}
@@ -484,6 +487,7 @@ internal struct Inaccessible3 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible4' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 private struct Inaccessible4 {
   // expected-non-resilient-warning @+2 {{'@dynamicMemberLookup' requires 'subscript(dynamicMember:)' to be as accessible as its enclosing type; this will be an error in a future Swift language mode}}{{3-10=fileprivate}}
@@ -493,6 +497,7 @@ private struct Inaccessible4 {
   }
 }
 
+// expected-non-resilient-error @+1 {{'@dynamicMemberLookup' requires 'Inaccessible5' to have a 'subscript(dynamicMember:)' method that accepts either 'ExpressibleByStringLiteral' or a key path}}
 @dynamicMemberLookup
 public struct Inaccessible5 {
   internal struct Nested { }

--- a/test/attr/attr_dynamic_member_lookup.swift
+++ b/test/attr/attr_dynamic_member_lookup.swift
@@ -661,7 +661,7 @@ func testOverrideSubscript(a: BaseClass, b: DerivedClassWithOverriddenDefault) {
   let _: String = b.magic
 }
 
-// Overriding with a different default value is valid.
+// Overriding without a default value is invalid.
 class DerivedClassWithMissingDefault : BaseClass {
   // expected-error @+1 {{'@dynamicMemberLookup' requires 'magic' to have a default value}} {{71-71= = <#Default#>}}
   override subscript(dynamicMember member: String, magic: StaticString) -> String {

--- a/test/attr/attr_dynamic_member_lookup_default_args.swift
+++ b/test/attr/attr_dynamic_member_lookup_default_args.swift
@@ -14,6 +14,7 @@ struct Magic: Hashable {
   let line: Int
   let column: Int
   let dsohandle: UnsafeRawPointer
+  let extra: Int
 
   init(
     fileID: String = #fileID,
@@ -22,7 +23,8 @@ struct Magic: Hashable {
     function: String = #function,
     line: Int = #line,
     column: Int = #column,
-    dsohandle: UnsafeRawPointer = #dsohandle
+    dsohandle: UnsafeRawPointer = #dsohandle,
+    extra: Int = 42
   ) {
     self.fileID = fileID
     self.file = file
@@ -31,6 +33,7 @@ struct Magic: Hashable {
     self.line = line
     self.column = column
     self.dsohandle = dsohandle
+    self.extra = extra
   }
 
   subscript(
@@ -41,7 +44,8 @@ struct Magic: Hashable {
     function: String = #function,
     line: Int = #line,
     column: Int = #column,
-    dsohandle: UnsafeRawPointer = #dsohandle
+    dsohandle: UnsafeRawPointer = #dsohandle,
+    extra: Int = 42
   ) -> Magic {
     return Magic(
       fileID: fileID,
@@ -50,7 +54,8 @@ struct Magic: Hashable {
       function: function,
       line: line,
       column: column,
-      dsohandle: dsohandle
+      dsohandle: dsohandle,
+      extra: extra
     )
   }
 
@@ -62,23 +67,24 @@ struct Magic: Hashable {
       function: function,
       line: line + lineOffset,
       column: column + columnOffset,
-      dsohandle: dsohandle
+      dsohandle: dsohandle,
+      extra: extra
     )
   }
 }
 
 /* ! ENSURE FORMATTERS ARE DISABLED TO PRESERVE WHITESPACE ! */
-let m1 = Magic() // 71:15
-let m2 = m1.member // 72:13
+let m1 = Magic() // 77:15
+let m2 = m1.member // 78:13
 assert(m1.offset(lineBy: +1, columnBy: -2) == m2)
 
 let m3 = m1
-  .member // 76:4
+  .member // 82:4
 assert(m1.offset(lineBy: +5, columnBy: -11) == m3)
 
 let m4 = m1
   .
-  member // 81:3
+  member // 87:3
 assert(m1.offset(lineBy: +10, columnBy: -12) == m4)
 
 //===----------------------------------------------------------------------===//

--- a/test/attr/attr_dynamic_member_lookup_default_args.swift
+++ b/test/attr/attr_dynamic_member_lookup_default_args.swift
@@ -1,0 +1,157 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
+// REQUIRES: executable_test
+
+//===----------------------------------------------------------------------===//
+// Magic Literals
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+struct Magic: Hashable {
+  let fileID: String
+  let file: String
+  let filePath: String
+  let function: String
+  let line: Int
+  let column: Int
+  let dsohandle: UnsafeRawPointer
+
+  init(
+    fileID: String = #fileID,
+    file: String = #file,
+    filePath: String = #filePath,
+    function: String = #function,
+    line: Int = #line,
+    column: Int = #column,
+    dsohandle: UnsafeRawPointer = #dsohandle
+  ) {
+    self.fileID = fileID
+    self.file = file
+    self.filePath = filePath
+    self.function = function
+    self.line = line
+    self.column = column
+    self.dsohandle = dsohandle
+  }
+
+  subscript(
+    dynamicMember member: String,
+    fileID: String = #fileID,
+    file: String = #file,
+    filePath: String = #filePath,
+    function: String = #function,
+    line: Int = #line,
+    column: Int = #column,
+    dsohandle: UnsafeRawPointer = #dsohandle
+  ) -> Magic {
+    return Magic(
+      fileID: fileID,
+      file: file,
+      filePath: filePath,
+      function: function,
+      line: line,
+      column: column,
+      dsohandle: dsohandle
+    )
+  }
+
+  func offset(lineBy lineOffset: Int, columnBy columnOffset: Int) -> Magic {
+    Magic(
+      fileID: fileID,
+      file: file,
+      filePath: filePath,
+      function: function,
+      line: line + lineOffset,
+      column: column + columnOffset,
+      dsohandle: dsohandle
+    )
+  }
+}
+
+/* ! ENSURE FORMATTERS ARE DISABLED TO PRESERVE WHITESPACE ! */
+let m1 = Magic() // 71:15
+let m2 = m1.member // 72:13
+assert(m1.offset(lineBy: +1, columnBy: -2) == m2)
+
+let m3 = m1
+  .member // 76:4
+assert(m1.offset(lineBy: +5, columnBy: -11) == m3)
+
+let m4 = m1
+  .
+  member // 81:3
+assert(m1.offset(lineBy: +10, columnBy: -12) == m4)
+
+//===----------------------------------------------------------------------===//
+// Inheritance
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+class Parent {
+  subscript(
+    dynamicMember member: String,
+    kept: String = #fileID,
+    overridden: String = #fileID
+  ) -> String {
+    [member, kept, overridden].joined(separator: ":")
+  }
+}
+
+@dynamicMemberLookup
+class Child: Parent {
+  override subscript(
+    dynamicMember member: String,
+    kept: String = #fileID,
+    overridden: String = #filePath
+  ) -> String {
+    [member, kept, overridden].joined(separator: ":")
+  }
+}
+
+assert(Parent().member == ["member", #fileID, #fileID].joined(separator: ":"))
+assert(Child().member == ["member", #fileID, #filePath].joined(separator: ":"))
+
+//===----------------------------------------------------------------------===//
+// Parameter Packs
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+struct Pack {
+  subscript<each T>(dynamicMember member: String, pack: repeat each T) -> (repeat each T) {
+    (repeat each pack)
+  }
+
+  subscript<each T, each U>(
+    dynamicMember member: String, pack1 pack1: repeat each T, pack2 pack2: repeat each U
+  ) -> Int {
+    var count = 0
+    for _ in repeat each pack1 {
+      count += 1
+    }
+
+    for _ in repeat each pack2 {
+      count += 1
+    }
+
+    return count
+  }
+}
+
+let p = Pack()
+assert(p.member == ())
+assert(p.member == 0)
+
+//===----------------------------------------------------------------------===//
+// Isolation
+//===----------------------------------------------------------------------===//
+
+@dynamicMemberLookup
+struct Isolated {
+  subscript(dynamicMember member: String, isolation: isolated (any Actor)? = #isolation) -> (any Actor)? {
+    isolation
+  }
+}
+
+Task<Void, Never>.immediate { @MainActor in
+  let `actor` = await Isolated().actor
+  assert(`actor` === MainActor.shared)
+}


### PR DESCRIPTION
Adds support for satisfying `@dynamicMemberLookup` requirements using subscripts which have arguments following `dynamicMember:` so long as they are either variadic or have default arguments. This allows transforming member references into `x[dynamicMember:...]` calls which can pass in arguments such as `#function`, `#fileID`, `#line`, etc.

* Pitch: https://forums.swift.org/t/dynamicmemberlookup-subscript-with-additional-defaulted-arguments/78471
* Proposal: https://github.com/swiftlang/swift-evolution/pull/2814

Main changes:

1. Allows `SubscriptDecl`s to satisfy `@dynamicMemberLookup` requirements as long as `dynamicMember:` remains the first explicitly-labeled argument, and all following arguments are either `isDefaultArgument()` or `isVariadic()`
2. Caches the result of checking for eligibility in `SubscriptDecl.Bits`; this was being checked multiple times per decl and it seems prudent to just store the info since we have the bits
3. Updates `ExprRewriter` to produce `ArgumentList`s for these subscripts by filling in `DefaultArgumentExpr`s as needed
4. Adds unit tests

The PR has been split into individual commits for (ideally) ease of review.