### PR TITLE
[Basic] Features: Align "migration" mode with the latest proposal draft

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -59,9 +59,9 @@ GROUPED_WARNING(cannot_disable_feature_with_mode, StrictLanguageFeatures, none,
                 "'%0' argument '%1' cannot specify a mode",
                 (StringRef, StringRef))
 
-GROUPED_WARNING(feature_does_not_support_adoption_mode, StrictLanguageFeatures,
+GROUPED_WARNING(feature_does_not_support_migration_mode, StrictLanguageFeatures,
                 none,
-                "feature '%0' does not support adoption mode",
+                "feature '%0' does not support migration mode",
                 (StringRef))
 
 ERROR(error_unknown_library_level, none,

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -57,8 +57,8 @@ struct Feature {
   /// Determine the in-source name of the given feature.
   llvm::StringRef getName() const;
 
-  /// Determine whether the given feature supports adoption mode.
-  bool isAdoptable() const;
+  /// Determine whether the given feature supports migration mode.
+  bool isMigratable() const;
 
   /// Determine whether this feature should be included in the
   /// module interface

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -121,36 +121,36 @@
     LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #endif
 
-// An upcoming feature that supports adoption mode.
+// An upcoming feature that supports migration mode.
 //
 // If the feature is source-breaking and provides for a
-// mechanical code migration, it should implement adoption mode.
+// mechanical code migration, it should implement migration mode.
 //
-// Adoption mode is a feature-oriented code migration mechanism: a mode
+// Migration mode is a feature-oriented code migration mechanism: a mode
 // of operation that should produce compiler warnings with attached
 // fix-its that can be applied to preserve the behavior of the code once
 // the upcoming feature is enacted.
 // These warnings must belong to a diagnostic group named after the
-// feature. Adoption mode itself *and* the fix-its it produces must be
+// feature. Migration mode itself *and* the fix-its it produces must be
 // source and binary compatible with how the code is compiled when the
 // feature is disabled.
-#ifndef ADOPTABLE_UPCOMING_FEATURE
+#ifndef MIGRATABLE_UPCOMING_FEATURE
   #if defined(UPCOMING_FEATURE)
-    #define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
+    #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
       UPCOMING_FEATURE(FeatureName, SENumber, Version)
   #else
-    #define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
+    #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
       LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName)
   #endif
 #endif
 
-// See `ADOPTABLE_UPCOMING_FEATURE`.
-#ifndef ADOPTABLE_EXPERIMENTAL_FEATURE
+// See `MIGRATABLE_UPCOMING_FEATURE`.
+#ifndef MIGRATABLE_EXPERIMENTAL_FEATURE
   #if defined(EXPERIMENTAL_FEATURE)
-    #define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)       \
+    #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)       \
       EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
   #else
-    #define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)       \
+    #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)       \
       LANGUAGE_FEATURE(FeatureName, 0, #FeatureName)
   #endif
 #endif
@@ -276,11 +276,11 @@ UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, 6)
 UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
 
 // Swift 7
-ADOPTABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
+MIGRATABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
 UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
 UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
-ADOPTABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
+MIGRATABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
 
 // Optional language features / modes
 
@@ -520,8 +520,8 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ExtensibleAttribute, false)
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
-#undef ADOPTABLE_UPCOMING_FEATURE
-#undef ADOPTABLE_EXPERIMENTAL_FEATURE
+#undef MIGRATABLE_UPCOMING_FEATURE
+#undef MIGRATABLE_EXPERIMENTAL_FEATURE
 #undef BASELINE_LANGUAGE_FEATURE
 #undef OPTIONAL_LANGUAGE_FEATURE
 #undef CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -830,7 +830,7 @@ namespace swift {
 
     /// A wrapper around the feature state enumeration.
     struct FeatureState {
-      enum class Kind : uint8_t { Off, EnabledForAdoption, Enabled };
+      enum class Kind : uint8_t { Off, EnabledForMigration, Enabled };
 
     private:
       Feature feature;
@@ -843,9 +843,9 @@ namespace swift {
       /// Returns whether the feature is enabled.
       bool isEnabled() const;
 
-      /// Returns whether the feature is enabled in adoption mode. Should only
+      /// Returns whether the feature is enabled in migration mode. Should only
       /// be called if the feature is known to support this mode.
-      bool isEnabledForAdoption() const;
+      bool isEnabledForMigration() const;
 
       operator Kind() const { return state; }
     };
@@ -878,9 +878,9 @@ namespace swift {
     /// `false` if a feature by this name is not known.
     bool hasFeature(llvm::StringRef featureName) const;
 
-    /// Enables the given feature (enables in adoption mode if `forAdoption` is
-    /// `true`).
-    void enableFeature(Feature feature, bool forAdoption = false);
+    /// Enables the given feature (enables in migration mode if `forMigration`
+    /// is `true`).
+    void enableFeature(Feature feature, bool forMigration = false);
 
     /// Disables the given feature.
     void disableFeature(Feature feature);

--- a/lib/Basic/Feature.cpp
+++ b/lib/Basic/Feature.cpp
@@ -69,7 +69,7 @@ std::optional<unsigned> Feature::getLanguageVersion() const {
   }
 }
 
-bool Feature::isAdoptable() const {
+bool Feature::isMigratable() const {
   switch (kind) {
 #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
 #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)

--- a/lib/Basic/Feature.cpp
+++ b/lib/Basic/Feature.cpp
@@ -71,16 +71,16 @@ std::optional<unsigned> Feature::getLanguageVersion() const {
 
 bool Feature::isAdoptable() const {
   switch (kind) {
-#define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
-#define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
+#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
+#define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
   case Feature::FeatureName:
 #include "swift/Basic/Features.def"
     return false;
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
-#define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)             \
+#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)            \
   case Feature::FeatureName:
-#define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)           \
+#define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)          \
   case Feature::FeatureName:
 #include "swift/Basic/Features.def"
     return true;

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -298,10 +298,10 @@ bool LangOptions::FeatureState::isEnabled() const {
   return state == FeatureState::Kind::Enabled;
 }
 
-bool LangOptions::FeatureState::isEnabledForAdoption() const {
-  ASSERT(feature.isAdoptable() && "You forgot to make the feature adoptable!");
+bool LangOptions::FeatureState::isEnabledForMigration() const {
+  ASSERT(feature.isMigratable() && "You forgot to make the feature migratable!");
 
-  return state == FeatureState::Kind::EnabledForAdoption;
+  return state == FeatureState::Kind::EnabledForMigration;
 }
 
 LangOptions::FeatureStateStorage::FeatureStateStorage()
@@ -357,10 +357,10 @@ bool LangOptions::hasFeature(llvm::StringRef featureName) const {
   return false;
 }
 
-void LangOptions::enableFeature(Feature feature, bool forAdoption) {
-  if (forAdoption) {
-    ASSERT(feature.isAdoptable());
-    featureStates.setState(feature, FeatureState::Kind::EnabledForAdoption);
+void LangOptions::enableFeature(Feature feature, bool forMigration) {
+  if (forMigration) {
+    ASSERT(feature.isMigratable());
+    featureStates.setState(feature, FeatureState::Kind::EnabledForMigration);
     return;
   }
 

--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -48,7 +48,7 @@ void printSupportedFeatures(llvm::raw_ostream &out) {
   auto printFeature = [&out](const Feature &feature) {
     out << "      ";
     out << "{ \"name\": \"" << feature.getName() << "\"";
-    if (feature.isAdoptable()) {
+    if (feature.isMigratable()) {
       out << ", \"migratable\": true";
     }
     if (auto version = feature.getLanguageVersion()) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -872,7 +872,7 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
 
     if (featureMode) {
       if (isEnableFeatureFlag) {
-        const auto isAdoptable = feature->isAdoptable();
+        const auto isMigratable = feature->isMigratable();
 
         // Diagnose an invalid mode.
         StringRef validModeName = "adoption";
@@ -880,13 +880,13 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
           Diags.diagnose(SourceLoc(), diag::invalid_feature_mode, *featureMode,
                          featureName,
                          /*didYouMean=*/validModeName,
-                         /*showDidYouMean=*/isAdoptable);
+                         /*showDidYouMean=*/isMigratable);
           continue;
         }
 
-        if (!isAdoptable) {
+        if (!isMigratable) {
           Diags.diagnose(SourceLoc(),
-                         diag::feature_does_not_support_adoption_mode,
+                         diag::feature_does_not_support_migration_mode,
                          featureName);
           continue;
         }
@@ -904,7 +904,7 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
 
     // Enable the feature if requested.
     if (isEnableFeatureFlag)
-      Opts.enableFeature(*feature, /*forAdoption=*/featureMode.has_value());
+      Opts.enableFeature(*feature, /*forMigration=*/featureMode.has_value());
   }
 
   // Since pseudo-features don't have a boolean on/off state, process them in

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -816,7 +816,7 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
       continue;
     }
 
-    // For all other features, the argument format is `<name>[:adoption]`.
+    // For all other features, the argument format is `<name>[:migrate]`.
     StringRef featureName;
     std::optional<StringRef> featureMode;
     std::tie(featureName, featureMode) = argValue.rsplit(':');
@@ -875,7 +875,7 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
         const auto isMigratable = feature->isMigratable();
 
         // Diagnose an invalid mode.
-        StringRef validModeName = "adoption";
+        StringRef validModeName = "migrate";
         if (*featureMode != validModeName) {
           Diags.diagnose(SourceLoc(), diag::invalid_feature_mode, *featureMode,
                          featureName,

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -60,7 +60,7 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
   const auto feature = Feature::NonisolatedNonsendingByDefault;
 
   ASSERT(node);
-  ASSERT(ctx.LangOpts.getFeatureState(feature).isEnabledForAdoption());
+  ASSERT(ctx.LangOpts.getFeatureState(feature).isEnabledForMigration());
 
   ValueDecl *decl = nullptr;
   ClosureExpr *closure = nullptr;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4752,7 +4752,7 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
   isolation = isolation.withPreconcurrency(preconcurrency);
 
   if (ctx.LangOpts.getFeatureState(Feature::NonisolatedNonsendingByDefault)
-          .isEnabledForAdoption()) {
+          .isEnabledForMigration()) {
     warnAboutNewNonisolatedAsyncExecutionBehavior(ctx, closure, isolation);
   }
 
@@ -6260,7 +6260,7 @@ InferredActorIsolation ActorIsolationRequest::evaluate(Evaluator &evaluator,
 
   auto &ctx = value->getASTContext();
   if (ctx.LangOpts.getFeatureState(Feature::NonisolatedNonsendingByDefault)
-          .isEnabledForAdoption()) {
+          .isEnabledForMigration()) {
     warnAboutNewNonisolatedAsyncExecutionBehavior(ctx, value,
                                                   inferredIsolation.isolation);
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4246,7 +4246,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
       isolation = FunctionTypeIsolation::forNonIsolated();
   } else {
     if (ctx.LangOpts.getFeatureState(Feature::NonisolatedNonsendingByDefault)
-            .isEnabledForAdoption()) {
+            .isEnabledForMigration()) {
       // Diagnose only in the interface stage, which is run once.
       if (inStage(TypeResolutionStage::Interface)) {
         warnAboutNewNonisolatedAsyncExecutionBehavior(ctx, repr, isolation);
@@ -6572,7 +6572,7 @@ private:
     // A missing `any` or `some` is always diagnosed if this feature not
     // disabled.
     auto featureState = ctx.LangOpts.getFeatureState(Feature::ExistentialAny);
-    if (featureState.isEnabled() || featureState.isEnabledForAdoption()) {
+    if (featureState.isEnabled() || featureState.isEnabledForMigration()) {
       return true;
     }
 
@@ -6665,10 +6665,10 @@ private:
                                       /*isAlias=*/isa<TypeAliasDecl>(decl)));
     }
 
-    // If `ExistentialAny` is enabled in adoption mode, warn unconditionally.
+    // If `ExistentialAny` is enabled in migration mode, warn unconditionally.
     // Otherwise, warn until the feature's coming-of-age language mode.
     const auto feature = Feature::ExistentialAny;
-    if (Ctx.LangOpts.getFeatureState(feature).isEnabledForAdoption()) {
+    if (Ctx.LangOpts.getFeatureState(feature).isEnabledForMigration()) {
       diag->limitBehavior(DiagnosticBehavior::Warning);
     } else {
       diag->warnUntilSwiftVersion(feature.getLanguageVersion().value());

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -enable-upcoming-feature NonisolatedNonsendingByDefault:adoption
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault:adoption
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -enable-upcoming-feature NonisolatedNonsendingByDefault:migrate
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault:migrate
 
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 

--- a/test/Frontend/features/adoption_mode.swift
+++ b/test/Frontend/features/adoption_mode.swift
@@ -4,29 +4,29 @@
 // RUN: %target-swift-frontend -parse -swift-version 5                         \
 // RUN:   -enable-upcoming-feature      DynamicActorIsolation:invalid1         \
 // RUN:   -enable-upcoming-feature      DynamicActorIsolation:invalid2         \
-// RUN:   -enable-upcoming-feature      DynamicActorIsolation:adoption         \
-// RUN:   -enable-upcoming-feature      DynamicActorIsolation:adoption         \
+// RUN:   -enable-upcoming-feature      DynamicActorIsolation:migrate         \
+// RUN:   -enable-upcoming-feature      DynamicActorIsolation:migrate         \
 // RUN:   -enable-experimental-feature  DynamicActorIsolation:invalid3         \
 // RUN:   -enable-experimental-feature  DynamicActorIsolation:invalid4         \
-// RUN:   -enable-experimental-feature  DynamicActorIsolation:adoption         \
-// RUN:   -enable-experimental-feature  DynamicActorIsolation:adoption         \
+// RUN:   -enable-experimental-feature  DynamicActorIsolation:migrate         \
+// RUN:   -enable-experimental-feature  DynamicActorIsolation:migrate         \
 // RUN:   -disable-upcoming-feature     DynamicActorIsolation:invalid5         \
 // RUN:   -disable-upcoming-feature     DynamicActorIsolation:invalid6         \
-// RUN:   -disable-upcoming-feature     DynamicActorIsolation:adoption         \
+// RUN:   -disable-upcoming-feature     DynamicActorIsolation:migrate         \
 // RUN:   -disable-experimental-feature DynamicActorIsolation:invalid7         \
 // RUN:   -disable-experimental-feature DynamicActorIsolation:invalid8         \
-// RUN:   -disable-experimental-feature DynamicActorIsolation:adoption         \
+// RUN:   -disable-experimental-feature DynamicActorIsolation:migrate         \
 // RUN:   %s 2>&1 | %FileCheck %s --check-prefix=CHECK-SWIFT-5
 
 // RUN: %target-swift-frontend -parse -swift-version 6                         \
 // RUN:   -enable-upcoming-feature      DynamicActorIsolation:invalid1         \
-// RUN:   -enable-upcoming-feature      DynamicActorIsolation:adoption         \
+// RUN:   -enable-upcoming-feature      DynamicActorIsolation:migrate         \
 // RUN:   -enable-experimental-feature  DynamicActorIsolation:invalid2         \
-// RUN:   -enable-experimental-feature  DynamicActorIsolation:adoption         \
+// RUN:   -enable-experimental-feature  DynamicActorIsolation:migrate         \
 // RUN:   -disable-upcoming-feature     DynamicActorIsolation:invalid3         \
-// RUN:   -disable-upcoming-feature     DynamicActorIsolation:adoption         \
+// RUN:   -disable-upcoming-feature     DynamicActorIsolation:migrate         \
 // RUN:   -disable-experimental-feature DynamicActorIsolation:invalid4         \
-// RUN:   -disable-experimental-feature DynamicActorIsolation:adoption         \
+// RUN:   -disable-experimental-feature DynamicActorIsolation:migrate         \
 // RUN:   %s 2>&1 | %FileCheck %s --check-prefix=CHECK-SWIFT-6
 
 // REQUIRES: swift_feature_DynamicActorIsolation
@@ -34,18 +34,18 @@
 // CHECK-NOT: error:
 
 // CHECK-SWIFT-5-NOT: warning:
-// CHECK-SWIFT-5: warning: '-disable-experimental-feature' argument 'DynamicActorIsolation:adoption' cannot specify a mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5: warning: '-disable-experimental-feature' argument 'DynamicActorIsolation:migrate' cannot specify a mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: '-disable-experimental-feature' argument 'DynamicActorIsolation:invalid8' cannot specify a mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: '-disable-experimental-feature' argument 'DynamicActorIsolation:invalid7' cannot specify a mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'DynamicActorIsolation:adoption' cannot specify a mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'DynamicActorIsolation:migrate' cannot specify a mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'DynamicActorIsolation:invalid6' cannot specify a mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'DynamicActorIsolation:invalid5' cannot specify a mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support adoption mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support adoption mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support migration mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support migration mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: 'invalid4' is not a recognized mode for feature 'DynamicActorIsolation' [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: 'invalid3' is not a recognized mode for feature 'DynamicActorIsolation' [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support adoption mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support adoption mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support migration mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support migration mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: 'invalid2' is not a recognized mode for feature 'DynamicActorIsolation' [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: 'invalid1' is not a recognized mode for feature 'DynamicActorIsolation' [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NOT: warning:

--- a/test/Frontend/features/adoption_mode_adoptable_feature.swift
+++ b/test/Frontend/features/adoption_mode_adoptable_feature.swift
@@ -3,20 +3,20 @@
 
 // RUN: %target-swift-frontend -parse -swift-version 6                         \
 // RUN:   -enable-upcoming-feature      ExistentialAny:invalid1                \
-// RUN:   -enable-upcoming-feature      ExistentialAny:adoption                \
+// RUN:   -enable-upcoming-feature      ExistentialAny:migrate                \
 // RUN:   -enable-experimental-feature  ExistentialAny:invalid2                \
-// RUN:   -enable-experimental-feature  ExistentialAny:adoption                \
-// RUN:   -disable-upcoming-feature     ExistentialAny:adoption                \
-// RUN:   -disable-experimental-feature ExistentialAny:adoption                \
+// RUN:   -enable-experimental-feature  ExistentialAny:migrate                \
+// RUN:   -disable-upcoming-feature     ExistentialAny:migrate                \
+// RUN:   -disable-experimental-feature ExistentialAny:migrate                \
 // RUN:   %s 2>&1 | %FileCheck %s --check-prefix=CHECK-SWIFT-5
 
 // RUN: %target-swift-frontend -parse -swift-version 7                         \
 // RUN:   -enable-upcoming-feature      ExistentialAny:invalid1                \
-// RUN:   -enable-upcoming-feature      ExistentialAny:adoption                \
+// RUN:   -enable-upcoming-feature      ExistentialAny:migrate                \
 // RUN:   -enable-experimental-feature  ExistentialAny:invalid2                \
-// RUN:   -enable-experimental-feature  ExistentialAny:adoption                \
-// RUN:   -disable-upcoming-feature     ExistentialAny:adoption                \
-// RUN:   -disable-experimental-feature ExistentialAny:adoption                \
+// RUN:   -enable-experimental-feature  ExistentialAny:migrate                \
+// RUN:   -disable-upcoming-feature     ExistentialAny:migrate                \
+// RUN:   -disable-experimental-feature ExistentialAny:migrate                \
 // RUN:   %s 2>&1 | %FileCheck %s --check-prefix=CHECK-SWIFT-7
 
 // REQUIRES: swift_feature_ExistentialAny
@@ -25,10 +25,10 @@
 // CHECK-NOT: error:
 
 // CHECK-SWIFT-5-NOT: warning:
-// CHECK-SWIFT-5: warning: '-disable-experimental-feature' argument 'ExistentialAny:adoption' cannot specify a mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'ExistentialAny:adoption' cannot specify a mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: 'invalid2' is not a recognized mode for feature 'ExistentialAny'; did you mean 'adoption'? [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: 'invalid1' is not a recognized mode for feature 'ExistentialAny'; did you mean 'adoption'? [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5: warning: '-disable-experimental-feature' argument 'ExistentialAny:migrate' cannot specify a mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'ExistentialAny:migrate' cannot specify a mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: 'invalid2' is not a recognized mode for feature 'ExistentialAny'; did you mean 'migrate'? [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: 'invalid1' is not a recognized mode for feature 'ExistentialAny'; did you mean 'migrate'? [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NOT: warning:
 
 // CHECK-SWIFT-7-NOT: warning:

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -8,7 +8,7 @@
 // RUN:   -verify-additional-prefix default-swift-mode- \
 // RUN:   -verify-additional-prefix explicit-any-
 
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature ExistentialAny:adoption \
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature ExistentialAny:migrate \
 //        To verify that the message is not followed by
 //        "; this will be an error ...".
 // RUN:   -verify-additional-prefix default-swift-mode- \

--- a/unittests/Frontend/FeatureParsingTest.cpp
+++ b/unittests/Frontend/FeatureParsingTest.cpp
@@ -51,8 +51,8 @@ void swift::PrintTo(const LangOptions::FeatureState::Kind &value,
   case LangOptions::FeatureState::Kind::Off:
     *os << "Off";
     break;
-  case LangOptions::FeatureState::Kind::EnabledForAdoption:
-    *os << "EnabledForAdoption";
+  case LangOptions::FeatureState::Kind::EnabledForMigration:
+    *os << "EnabledForMigration";
     break;
   case LangOptions::FeatureState::Kind::Enabled:
     *os << "Enabled";

--- a/unittests/Frontend/IsFeatureEnabledTests.cpp
+++ b/unittests/Frontend/IsFeatureEnabledTests.cpp
@@ -119,7 +119,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", baselineF.name + ":undef"},
       {{baselineF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", baselineF.name + ":adoption"},
+      {"-enable-upcoming-feature", baselineF.name + ":migrate"},
       {{baselineF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", baselineF.name},
@@ -128,7 +128,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", baselineF.name + ":undef"},
       {{baselineF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", baselineF.name + ":adoption"},
+      {"-enable-experimental-feature", baselineF.name + ":migrate"},
       {{baselineF, FeatureState::Enabled}}),
 
   IsFeatureEnabledTestCase(
@@ -138,7 +138,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", upcomingF.name + ":undef"},
       {{upcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", upcomingF.name + ":adoption"},
+      {"-enable-upcoming-feature", upcomingF.name + ":migrate"},
       {{upcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", upcomingF.name},
@@ -147,7 +147,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", upcomingF.name + ":undef"},
       {{upcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", upcomingF.name + ":adoption"},
+      {"-enable-experimental-feature", upcomingF.name + ":migrate"},
       {{upcomingF, FeatureState::Off}}),
 
   IsFeatureEnabledTestCase(
@@ -157,14 +157,14 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", adoptableUpcomingF.name + ":undef"},
       {{adoptableUpcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption"},
+      {"-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate"},
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 // Swift 7 is asserts-only.
 #ifndef NDEBUG
-  // Requesting adoption mode in target language mode has no effect.
+  // Requesting migration mode in target language mode has no effect.
   IsFeatureEnabledTestCase({
         "-swift-version", adoptableUpcomingF.langMode,
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
 #endif
@@ -175,14 +175,14 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", adoptableUpcomingF.name + ":undef"},
       {{adoptableUpcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", adoptableUpcomingF.name + ":adoption"},
+      {"-enable-experimental-feature", adoptableUpcomingF.name + ":migrate"},
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 // Swift 7 is asserts-only.
 #ifndef NDEBUG
-  // Requesting adoption mode in target language mode has no effect.
+  // Requesting migration mode in target language mode has no effect.
   IsFeatureEnabledTestCase({
         "-swift-version", adoptableUpcomingF.langMode,
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
 #endif
@@ -193,7 +193,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", strictConcurrencyF.name + ":undef"},
       {{strictConcurrencyF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", strictConcurrencyF.name + ":adoption"},
+      {"-enable-upcoming-feature", strictConcurrencyF.name + ":migrate"},
       {{strictConcurrencyF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", strictConcurrencyF.name},
@@ -202,7 +202,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", strictConcurrencyF.name + ":undef"},
       {{strictConcurrencyF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", strictConcurrencyF.name + ":adoption"},
+      {"-enable-experimental-feature", strictConcurrencyF.name + ":migrate"},
       {{strictConcurrencyF, FeatureState::Off}}),
 
   IsFeatureEnabledTestCase(
@@ -212,7 +212,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", experimentalF.name + ":undef"},
       {{experimentalF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", experimentalF.name + ":adoption"},
+      {"-enable-upcoming-feature", experimentalF.name + ":migrate"},
       {{experimentalF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", experimentalF.name},
@@ -221,7 +221,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", experimentalF.name + ":undef"},
       {{experimentalF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", experimentalF.name + ":adoption"},
+      {"-enable-experimental-feature", experimentalF.name + ":migrate"},
       {{experimentalF, FeatureState::Off}}),
 };
 // clang-format on
@@ -300,7 +300,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-upcoming-feature", upcomingF.name + ":adoption",
+        "-enable-upcoming-feature", upcomingF.name + ":migrate",
         "-enable-upcoming-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -311,7 +311,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", upcomingF.name,
-        "-enable-upcoming-feature", upcomingF.name + ":adoption",
+        "-enable-upcoming-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -320,7 +320,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-upcoming-feature", upcomingF.name + ":adoption",
+        "-enable-upcoming-feature", upcomingF.name + ":migrate",
         "-enable-experimental-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -331,7 +331,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", upcomingF.name,
-        "-enable-experimental-feature", upcomingF.name + ":adoption",
+        "-enable-experimental-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -340,7 +340,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", upcomingF.name + ":adoption",
+        "-enable-experimental-feature", upcomingF.name + ":migrate",
         "-enable-upcoming-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -351,7 +351,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", upcomingF.name,
-        "-enable-upcoming-feature", upcomingF.name + ":adoption",
+        "-enable-upcoming-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -360,7 +360,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", upcomingF.name + ":adoption",
+        "-enable-experimental-feature", upcomingF.name + ":migrate",
         "-enable-experimental-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -371,7 +371,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", upcomingF.name,
-        "-enable-experimental-feature", upcomingF.name + ":adoption",
+        "-enable-experimental-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
 
@@ -383,7 +383,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
         "-enable-upcoming-feature", adoptableUpcomingF.name,
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -394,7 +394,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", adoptableUpcomingF.name,
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
@@ -403,7 +403,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
         "-enable-experimental-feature", adoptableUpcomingF.name,
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -414,7 +414,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", adoptableUpcomingF.name,
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
@@ -423,7 +423,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
         "-enable-upcoming-feature", adoptableUpcomingF.name,
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -434,7 +434,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", adoptableUpcomingF.name,
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
@@ -443,7 +443,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
         "-enable-experimental-feature", adoptableUpcomingF.name,
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -454,7 +454,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", adoptableUpcomingF.name,
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 
@@ -466,7 +466,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{experimentalF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", experimentalF.name + ":adoption",
+        "-enable-experimental-feature", experimentalF.name + ":migrate",
         "-enable-experimental-feature", experimentalF.name,
       },
       {{experimentalF, FeatureState::Enabled}}),
@@ -477,7 +477,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{experimentalF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", experimentalF.name,
-        "-enable-experimental-feature", experimentalF.name + ":adoption",
+        "-enable-experimental-feature", experimentalF.name + ":migrate",
       },
       {{experimentalF, FeatureState::Enabled}}),
 };
@@ -501,7 +501,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", upcomingF.name,
-        "-disable-upcoming-feature", upcomingF.name + ":adoption",
+        "-disable-upcoming-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -521,7 +521,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", upcomingF.name,
-        "-disable-upcoming-feature", upcomingF.name + ":adoption",
+        "-disable-upcoming-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -541,7 +541,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", upcomingF.name,
-        "-disable-experimental-feature", upcomingF.name + ":adoption",
+        "-disable-experimental-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -561,7 +561,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", upcomingF.name,
-        "-disable-experimental-feature", upcomingF.name + ":adoption",
+        "-disable-experimental-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -581,7 +581,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{experimentalF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", experimentalF.name,
-        "-disable-experimental-feature", experimentalF.name + ":adoption",
+        "-disable-experimental-feature", experimentalF.name + ":migrate",
       },
       {{experimentalF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({

--- a/unittests/Frontend/IsFeatureEnabledTests.cpp
+++ b/unittests/Frontend/IsFeatureEnabledTests.cpp
@@ -38,27 +38,27 @@ TEST_F(IsFeatureEnabledTest, VerifyTestedFeatures) {
   {
     ASSERT_FALSE(Feature::getUpcomingFeature(feature.name));
     ASSERT_FALSE(Feature::getExperimentalFeature(feature.name));
-    ASSERT_FALSE(feature.id.isAdoptable());
+    ASSERT_FALSE(feature.id.isMigratable());
   }
 
   feature = upcomingF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_FALSE(feature.id.isAdoptable());
+    ASSERT_FALSE(feature.id.isMigratable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
   feature = adoptableUpcomingF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_TRUE(feature.id.isAdoptable());
+    ASSERT_TRUE(feature.id.isMigratable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
   feature = strictConcurrencyF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_FALSE(feature.id.isAdoptable());
+    ASSERT_FALSE(feature.id.isMigratable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
@@ -68,7 +68,7 @@ TEST_F(IsFeatureEnabledTest, VerifyTestedFeatures) {
     // it for another experimental feature one that is available in production.
     ASSERT_TRUE(feature.id.isAvailableInProduction());
     ASSERT_TRUE(Feature::getExperimentalFeature(feature.name));
-    ASSERT_FALSE(feature.id.isAdoptable());
+    ASSERT_FALSE(feature.id.isMigratable());
   }
 }
 
@@ -158,7 +158,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption"},
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 // Swift 7 is asserts-only.
 #ifndef NDEBUG
   // Requesting adoption mode in target language mode has no effect.
@@ -176,7 +176,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", adoptableUpcomingF.name + ":adoption"},
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 // Swift 7 is asserts-only.
 #ifndef NDEBUG
   // Requesting adoption mode in target language mode has no effect.
@@ -396,7 +396,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
         "-enable-upcoming-feature", adoptableUpcomingF.name,
         "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
       },
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", adoptableUpcomingF.name + ":undef",
         "-enable-experimental-feature", adoptableUpcomingF.name,
@@ -416,7 +416,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
         "-enable-upcoming-feature", adoptableUpcomingF.name,
         "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
       },
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", adoptableUpcomingF.name + ":undef",
         "-enable-upcoming-feature", adoptableUpcomingF.name,
@@ -436,7 +436,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
         "-enable-experimental-feature", adoptableUpcomingF.name,
         "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
       },
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", adoptableUpcomingF.name + ":undef",
         "-enable-experimental-feature", adoptableUpcomingF.name,
@@ -456,7 +456,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
         "-enable-experimental-feature", adoptableUpcomingF.name,
         "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
       },
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 
   // MARK: Experimental
 

--- a/unittests/Frontend/StrictConcurrencyTests.cpp
+++ b/unittests/Frontend/StrictConcurrencyTests.cpp
@@ -42,13 +42,13 @@ static const StrictConcurrencyTestCase strictConcurrencyTestCases[] = {
       {"-enable-upcoming-feature", strictConcurrencyF.name},
       StrictConcurrency::Complete),
   StrictConcurrencyTestCase(
-      {"-enable-upcoming-feature", strictConcurrencyF.name + ":adoption"},
+      {"-enable-upcoming-feature", strictConcurrencyF.name + ":migrate"},
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(
       {"-enable-experimental-feature", strictConcurrencyF.name},
       StrictConcurrency::Complete),
   StrictConcurrencyTestCase(
-      {"-enable-experimental-feature", strictConcurrencyF.name + ":adoption"},
+      {"-enable-experimental-feature", strictConcurrencyF.name + ":migrate"},
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(
       {"-disable-upcoming-feature", strictConcurrencyF.name},
@@ -73,7 +73,7 @@ static const StrictConcurrencyTestCase strictConcurrencyTestCases[] = {
       StrictConcurrency::Targeted),
   StrictConcurrencyTestCase({
         "-enable-upcoming-feature",
-        strictConcurrencyF.name + "=targeted:adoption",
+        strictConcurrencyF.name + "=targeted:migrate",
       },
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(
@@ -81,7 +81,7 @@ static const StrictConcurrencyTestCase strictConcurrencyTestCases[] = {
       StrictConcurrency::Targeted),
   StrictConcurrencyTestCase({
         "-enable-experimental-feature",
-        strictConcurrencyF.name + "=targeted:adoption",
+        strictConcurrencyF.name + "=targeted:migrate",
       },
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(


### PR DESCRIPTION
- Name feature related macros from `ADOPTABLE_` to `MIGRATABLE_`
- Rename various `Feature` APIs to use `migration` and `migratable` instead of `adoption` and `adoptable`
- Rename feature flag postfix from `:adoption` to `:migrate`

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
