### PR TITLE
[6.2][cherrypick] Add a platform executor module for OpenBSD.

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(swift_Concurrency
   PlatformExecutorDarwin.swift
   PlatformExecutorLinux.swift
   PlatformExecutorFreeBSD.swift
+  PlatformExecutorOpenBSD.swift
   PlatformExecutorWindows.swift
   PriorityQueue.swift
   SourceCompatibilityShims.swift

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -164,6 +164,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
   PlatformExecutorDarwin.swift
   PlatformExecutorLinux.swift
   PlatformExecutorWindows.swift
+  PlatformExecutorOpenBSD.swift
   PlatformExecutorFreeBSD.swift
 )
 

--- a/stdlib/public/Concurrency/PlatformExecutorOpenBSD.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorOpenBSD.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !$Embedded && os(OpenBSD)
+
+import Swift
+
+// The default executors for now are Dispatch-based
+@available(SwiftStdlib 6.2, *)
+public struct PlatformExecutorFactory: ExecutorFactory {
+  public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
+  public static let defaultExecutor: any TaskExecutor
+    = DispatchGlobalTaskExecutor()
+}
+
+#endif


### PR DESCRIPTION
  - **Explanation**:

Add a platform executor file for OpenBSD. This cherrypick will help reduce the delta between the branch and an eventual OpenBSD platform port.

  - **Scope**:
 
Only limited to OpenBSD and the build system.

  - **Issues**:
   
See OpenBSD port issue in https://github.com/swiftlang/swift/issues/78437

  - **Original PRs**:

#80877

  - **Risk**:

Minimal, as changes are limited to OpenBSD only.

  - **Testing**:

Original change has passed CI.

  - **Reviewers**:

@ktoso 
@compnerd 
@etcwilde