### PR TITLE
[embedded] Require swift_stdlib_no_asserts in test/embedded/traps-fatalerror-ir.swift

### DIFF
--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
+// REQUIRES: swift_stdlib_no_asserts
 // REQUIRES: swift_feature_Embedded
 
 public func test() {


### PR DESCRIPTION
Fixes https://github.com/swiftlang/swift/issues/81085.