### PR TITLE
Some small deinit-barrier related optimizations

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -70,7 +70,10 @@ let computeSideEffects = FunctionPass(name: "compute-side-effects") {
 
   // Finally replace the function's side effects.
   context.modifyEffects(in: function) { (effects: inout FunctionEffects) in
-    effects.sideEffects = SideEffects(arguments: collectedEffects.argumentEffects, global: collectedEffects.globalEffects)
+    let globalEffects = function.isProgramTerminationPoint ?
+                            collectedEffects.globalEffects.forProgramTerminationPoints
+                          : collectedEffects.globalEffects
+    effects.sideEffects = SideEffects(arguments: collectedEffects.argumentEffects, global: globalEffects)
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -576,6 +576,10 @@ extension Function {
                                                 atIndex: calleeArgIdx,
                                                 withConvention: convention)
         return effects.memory.read
+      },
+      // isDeinitBarrier
+      { (f: BridgedFunction) -> Bool in
+        return f.function.getSideEffects().isDeinitBarrier
       }
     )
   }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -549,6 +549,7 @@ struct BridgedFunction {
   typedef EffectInfo (* _Nonnull GetEffectInfoFn)(BridgedFunction, SwiftInt);
   typedef BridgedMemoryBehavior (* _Nonnull GetMemBehaviorFn)(BridgedFunction, bool);
   typedef bool (* _Nonnull ArgumentMayReadFn)(BridgedFunction, BridgedOperand, BridgedValue);
+  typedef bool (* _Nonnull IsDeinitBarrierFn)(BridgedFunction);
 
   static void registerBridging(SwiftMetatype metatype,
               RegisterFn initFn, RegisterFn destroyFn,
@@ -556,7 +557,8 @@ struct BridgedFunction {
               CopyEffectsFn copyEffectsFn,
               GetEffectInfoFn effectInfoFn,
               GetMemBehaviorFn memBehaviorFn,
-              ArgumentMayReadFn argumentMayReadFn);
+              ArgumentMayReadFn argumentMayReadFn,
+              IsDeinitBarrierFn isDeinitBarrierFn);
 };
 
 struct OptionalBridgedFunction {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1218,6 +1218,8 @@ public:
   // Used by the MemoryLifetimeVerifier
   bool argumentMayRead(Operand *argOp, SILValue addr);
 
+  bool isDeinitBarrier();
+
   Purpose getSpecialPurpose() const { return specialPurpose; }
 
   /// Get this function's global_init attribute.

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -214,6 +214,7 @@ static BridgedFunction::CopyEffectsFn copyEffectsFunction = nullptr;
 static BridgedFunction::GetEffectInfoFn getEffectInfoFunction = nullptr;
 static BridgedFunction::GetMemBehaviorFn getMemBehvaiorFunction = nullptr;
 static BridgedFunction::ArgumentMayReadFn argumentMayReadFunction = nullptr;
+static BridgedFunction::IsDeinitBarrierFn isDeinitBarrierFunction = nullptr;
 
 SILFunction::SILFunction(
     SILModule &Module, SILLinkage Linkage, StringRef Name,
@@ -1175,7 +1176,8 @@ void BridgedFunction::registerBridging(SwiftMetatype metatype,
             CopyEffectsFn copyEffectsFn,
             GetEffectInfoFn effectInfoFn,
             GetMemBehaviorFn memBehaviorFn,
-            ArgumentMayReadFn argumentMayReadFn) {
+            ArgumentMayReadFn argumentMayReadFn,
+            IsDeinitBarrierFn isDeinitBarrierFn) {
   functionMetatype = metatype;
   initFunction = initFn;
   destroyFunction = destroyFn;
@@ -1185,6 +1187,7 @@ void BridgedFunction::registerBridging(SwiftMetatype metatype,
   getEffectInfoFunction = effectInfoFn;
   getMemBehvaiorFunction = memBehaviorFn;
   argumentMayReadFunction = argumentMayReadFn;
+  isDeinitBarrierFunction = isDeinitBarrierFn;
 }
 
 std::pair<const char *, int>  SILFunction::
@@ -1284,6 +1287,13 @@ bool SILFunction::argumentMayRead(Operand *argOp, SILValue addr) {
     return true;
 
   return argumentMayReadFunction({this}, {argOp}, {addr});
+}
+
+bool SILFunction::isDeinitBarrier() {
+  if (!isDeinitBarrierFunction)
+    return true;
+
+  return isDeinitBarrierFunction({this});
 }
 
 SourceFile *SILFunction::getSourceFile() const {

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -500,6 +500,9 @@ void SILInlineCloner::cloneInline(ArrayRef<SILValue> AppliedArgs) {
           if (!enableLexicalLifetimes)
             continue;
 
+          if (!Original.isDeinitBarrier())
+            continue;
+
           // Exclusive mutating accesses don't entail a lexical scope.
           if (paramInfo.getConvention() == ParameterConvention::Indirect_Inout)
             continue;

--- a/test/SIL/Serialization/effects.sil
+++ b/test/SIL/Serialization/effects.sil
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name=NonLE -emit-module -o %t/NonLE.swiftmodule
+// RUN: %target-swift-frontend %s -module-name=LE -enable-library-evolution -emit-module -o %t/LE.swiftmodule
+// RUN: %target-sil-opt %t/NonLE.swiftmodule | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-NONLE
+// RUN: %target-sil-opt %t/LE.swiftmodule | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-LE
+
+sil_stage canonical
+
+import Swift
+import Builtin
+
+// CHECK-LABEL:      sil [serialized] [canonical] [ossa] @public_func :
+// CHECK-NONLE-NEXT: [global: ]
+// CHECK-NEXT:       bb0:
+sil [serialized] [ossa] @public_func : $@convention(thin) () -> () {
+[global: ]
+bb0:
+  %r = tuple ()
+  return %r
+}
+
+// CHECK-LABEL:      sil non_abi [serialized] [canonical] [ossa] @public_non_abi_func :
+// CHECK-NEXT:       [global: ]
+// CHECK-NEXT:       bb0:
+sil non_abi [serialized] [ossa] @public_non_abi_func : $@convention(thin) () -> () {
+[global: ]
+bb0:
+  %r = tuple ()
+  return %r
+}
+

--- a/test/SILOptimizer/mandatory_inlining_ownership.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership.sil
@@ -619,6 +619,41 @@ bb3:
   return %9999 : $()
 }
 
+sil [transparent] [ossa] @deinit_barrier : $@convention(thin) (@in_guaranteed Int) -> () {
+[global: deinit_barrier]
+bb0(%0 : $*Int):
+  %1 = tuple ()
+  return %1
+}
+
+sil [transparent] [ossa] @no_deinit_barrier : $@convention(thin) (@in_guaranteed Int) -> () {
+[global: ]
+bb0(%0 : $*Int):
+  %1 = tuple ()
+  return %1
+}
+
+// CHECK-LABEL: sil [ossa] @inline_deinit_barrier :
+// CHECK:         alloc_stack [lexical] $Int
+// CHECK:         alloc_stack $Int
+// CHECK:       } // end sil function 'inline_deinit_barrier'
+sil [ossa] @inline_deinit_barrier : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $Int
+  store %0 to [trivial] %1
+  %2 = function_ref @deinit_barrier : $@convention(thin) (@in_guaranteed Int) -> ()
+  apply %2(%1) : $@convention(thin) (@in_guaranteed Int) -> ()
+  dealloc_stack %1
+
+  %10 = alloc_stack $Int
+  store %0 to [trivial] %10
+  %12 = function_ref @no_deinit_barrier : $@convention(thin) (@in_guaranteed Int) -> ()
+  apply %12(%10) : $@convention(thin) (@in_guaranteed Int) -> ()
+  dealloc_stack %10
+
+  %r = tuple ()
+  return %r
+}
 
 sil_vtable C2 {
   #C2.i!modify: (C2) -> () -> () : @devirt_callee

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -680,6 +680,13 @@ bb0(%0 : $*X):
   return %r : $()
 }
 
+sil [_semantics "programtermination_point"] @exitfunc_defined : $@convention(thin) () -> Never {
+bb0:
+  %u = function_ref @unknown_func : $@convention(thin) () -> ()
+  %a = apply %u() : $@convention(thin) () -> ()
+  unreachable
+}
+
 // CHECK-LABEL: sil @call_noreturn
 // CHECK-NEXT:  [global: read]
 // CHECK-NEXT:  {{^[^[]}}
@@ -689,6 +696,23 @@ bb0:
 
 bb1:
   %u = function_ref @exitfunc : $@convention(thin) () -> Never
+  %a = apply %u() : $@convention(thin) () -> Never
+  unreachable
+
+bb2:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_defined_noreturn
+// CHECK-NEXT:  [global: read]
+// CHECK-NEXT:  {{^[^[]}}
+sil @call_defined_noreturn : $@convention(thin) () -> () {
+bb0:
+  cond_br undef, bb1, bb2
+
+bb1:
+  %u = function_ref @exitfunc_defined : $@convention(thin) () -> Never
   %a = apply %u() : $@convention(thin) () -> Never
   unreachable
 


### PR DESCRIPTION
This PR contains a few small optimization improvements which help to reduce the optimization limitations of lexical lifetimes and deinit barriers.

* Inliner: don't set the lexical flag on an argument `alloc_stack` if the inlined function is not a deinit barrier. There is no need to do so. And this can enable other optimizations for non-lexical alloc-stacks.
* Serialize computed effects for `@alwaysEmitIntoClient` functions, even if library evolution is turned on. This is possible because no copy of the function is emitted in the original module.
* ComputeSideEffects: handle program termination functions which are defined in the same module. This case was neglected. The fix can result in better side effect analysis, e.g. in the stdlib core module.