### PR TITLE
Build CMake on macOS if one is not preinstalled

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -282,14 +282,9 @@ class CMake(object):
         os.chdir(cwd)
         return os.path.join(cmake_build_dir, 'bin', 'cmake')
 
-    # Get the path to CMake to use for the build
-    # This function will not build CMake for Apple platforms.
-    # For other platforms, this builds CMake if a new enough version is not
-    # available.
+    # Get the path to CMake to use for the build, this builds CMake if a new enough
+    # version is not available.
     def get_cmake_path(self, source_root, build_root):
-        if platform.system() == 'Darwin':
-            return self.toolchain.cmake
-
         cmake_source_dir = os.path.join(source_root, 'cmake')
         if not os.path.isdir(cmake_source_dir):
             return self.toolchain.cmake


### PR DESCRIPTION
We build CMake on all platforms (except Darwin for an unknown reason) if CMake is not preinstalled. Since CMake 4.0 regresses certain build configurations, there's currently no way to build on Darwin without installing an older CMake version 3.x manually. This can be simplified if we build a pinned version of CMake consistently on all platforms.