### PR TITLE
SILGen: Fix crash when thrown error type is loadable and has a type parameter

### DIFF
--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -37,6 +37,7 @@ SILArgument::SILArgument(ValueKind subClassKind,
   sharedUInt8().SILArgument.reborrow = reborrow;
   sharedUInt8().SILArgument.pointerEscape = pointerEscape;
   inputParentBlock->insertArgument(inputParentBlock->args_end(), this);
+  ASSERT(!type.hasTypeParameter());
 }
 
 SILFunction *SILArgument::getFunction() {

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -83,10 +83,12 @@ void SILGenFunction::prepareEpilog(
 void SILGenFunction::prepareRethrowEpilog(
     DeclContext *dc, AbstractionPattern origErrorType, Type errorType,
     CleanupLocation cleanupLoc) {
+  ASSERT(!errorType->hasPrimaryArchetype());
 
   SILBasicBlock *rethrowBB = createBasicBlock(FunctionSection::Postmatter);
   if (!IndirectErrorResult) {
-    SILType loweredErrorType = getLoweredType(origErrorType, errorType);
+    auto errorTypeInContext = dc->mapTypeIntoContext(errorType);
+    SILType loweredErrorType = getLoweredType(origErrorType, errorTypeInContext);
     rethrowBB->createPhiArgument(loweredErrorType, OwnershipKind::Owned);
   }
 

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -387,3 +387,10 @@ extension ReducedError where T == MyError {
     throw MyError.fail
   }
 }
+
+// https://github.com/swiftlang/swift/issues/74289
+struct LoadableGeneric<E>: Error {}
+
+func throwsLoadableGeneric<E>(_: E) throws(LoadableGeneric<E>) {
+  throw LoadableGeneric<E>()
+}


### PR DESCRIPTION
Fixes https://github.com/swiftlang/swift/issues/74289.
Fixes rdar://problem/146677409.

