### PR TITLE
[6.2] SILGen: Fix crash when thrown error type is loadable and has a type parameter

### DIFF
--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -83,10 +83,12 @@ void SILGenFunction::prepareEpilog(
 void SILGenFunction::prepareRethrowEpilog(
     DeclContext *dc, AbstractionPattern origErrorType, Type errorType,
     CleanupLocation cleanupLoc) {
+  ASSERT(!errorType->hasPrimaryArchetype());
 
   SILBasicBlock *rethrowBB = createBasicBlock(FunctionSection::Postmatter);
   if (!IndirectErrorResult) {
-    SILType loweredErrorType = getLoweredType(origErrorType, errorType);
+    auto errorTypeInContext = dc->mapTypeIntoContext(errorType);
+    SILType loweredErrorType = getLoweredType(origErrorType, errorTypeInContext);
     rethrowBB->createPhiArgument(loweredErrorType, OwnershipKind::Owned);
   }
 

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -387,3 +387,10 @@ extension ReducedError where T == MyError {
     throw MyError.fail
   }
 }
+
+// https://github.com/swiftlang/swift/issues/74289
+struct LoadableGeneric<E>: Error {}
+
+func throwsLoadableGeneric<E>(_: E) throws(LoadableGeneric<E>) {
+  throw LoadableGeneric<E>()
+}


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/81162.

* **Description:** Fixes a crash when a thrown error type is loadable but also contains a type parameter.

* **Origination:** This never worked. I previously fixed an IRGen crash in https://github.com/swiftlang/swift/pull/77371, but we'd hit the same SILGen issue in all but the most trivial cases.

* **Issue:** https://github.com/swiftlang/swift/issues/74289

* **Radar:** rdar://problem/146677409

* **Risk:** Low.

* **Reviewed by:** @DougGregor 
