### PR TITLE
[6.2] tests: add missing stdlib requirements in `SILOptimizer/static_init_globals.swift`

### DIFF
--- a/test/SILOptimizer/static_init_globals.swift
+++ b/test/SILOptimizer/static_init_globals.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend %s -module-name=test -emit-sil | %FileCheck %s
 
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
 public struct MyStruct {
   // CHECK-LABEL: sil_global [let] @$s4test8MyStructV1rSnySiGvpZ : $Range<Int> = {
   // CHECK-NEXT:    %0 = integer_literal $Builtin.Int{{[0-9]+}}, 1


### PR DESCRIPTION
* **Explanation**: This is a fix for a lit test which needs to be cherry-picked
* **Risk**: zero
* **Issue**: rdar://150215865
* **Reviewer**:  @MaxDesiatov
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/81077
