### PR TITLE
Utils: fix CMake not picking up the correct Python

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1175,6 +1175,16 @@ function Get-SwiftSDK {
   return ([IO.Path]::Combine((Get-PlatformRoot $OS), "Developer", "SDKs", "$Identifier.sdk"))
 }
 
+function Add-PythonDefines([hashtable] $Defines, [Hashtable] $Platform) {
+    $PythonRoot = [IO.Path]::Combine((Get-PythonPath $Platform), "tools")
+    $PythonLibName = "python{0}{1}" -f ([System.Version]$PythonVersion).Major, ([System.Version]$PythonVersion).Minor
+
+    Add-KeyValueIfNew $Defines Python3_EXECUTABLE (Get-PythonExecutable);
+    Add-KeyValueIfNew $Defines Python3_INCLUDE_DIR "$PythonRoot\include";
+    Add-KeyValueIfNew $Defines Python3_LIBRARY "$PythonRoot\libs\$PythonLibName.lib";
+    Add-KeyValueIfNew $Defines Python3_ROOT_DIR $PythonRoot;
+}
+
 function Build-CMakeProject {
   [CmdletBinding(PositionalBinding = $false)]
   param
@@ -1217,7 +1227,7 @@ function Build-CMakeProject {
     # Add additional defines (unless already present)
     $Defines = $Defines.Clone()
 
-    Add-KeyValueIfNew $Defines Python3_EXECUTABLE (Get-PythonExecutable);
+    Add-PythonDefines $Defines $Platform
 
     if (($Platform.OS -ne [OS]::Windows) -or ($Platform.Architecture.CMakeName -ne $BuildPlatform.Architecture.CMakeName)) {
       Add-KeyValueIfNew $Defines CMAKE_SYSTEM_NAME $Platform.OS.ToString()
@@ -1763,9 +1773,6 @@ function Get-CompilersDefines([Hashtable] $Platform, [switch] $Test) {
     LLVM_NATIVE_TOOL_DIR = $BuildTools;
     LLVM_TABLEGEN = (Join-Path $BuildTools -ChildPath "llvm-tblgen.exe");
     LLVM_USE_HOST_TOOLS = "NO";
-    Python3_INCLUDE_DIR = "$PythonRoot\include";
-    Python3_LIBRARY = "$PythonRoot\libs\$PythonLibName.lib";
-    Python3_ROOT_DIR = $PythonRoot;
     SWIFT_BUILD_SWIFT_SYNTAX = "YES";
     SWIFT_CLANG_LOCATION = (Get-PinnedToolchainToolsDir);
     SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY = "YES";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1217,6 +1217,8 @@ function Build-CMakeProject {
     # Add additional defines (unless already present)
     $Defines = $Defines.Clone()
 
+    Add-KeyValueIfNew $Defines Python3_EXECUTABLE (Get-PythonExecutable);
+
     if (($Platform.OS -ne [OS]::Windows) -or ($Platform.Architecture.CMakeName -ne $BuildPlatform.Architecture.CMakeName)) {
       Add-KeyValueIfNew $Defines CMAKE_SYSTEM_NAME $Platform.OS.ToString()
       Add-KeyValueIfNew $Defines CMAKE_SYSTEM_PROCESSOR $Platform.Architecture.CMakeName
@@ -1761,7 +1763,6 @@ function Get-CompilersDefines([Hashtable] $Platform, [switch] $Test) {
     LLVM_NATIVE_TOOL_DIR = $BuildTools;
     LLVM_TABLEGEN = (Join-Path $BuildTools -ChildPath "llvm-tblgen.exe");
     LLVM_USE_HOST_TOOLS = "NO";
-    Python3_EXECUTABLE = (Get-PythonExecutable);
     Python3_INCLUDE_DIR = "$PythonRoot\include";
     Python3_LIBRARY = "$PythonRoot\libs\$PythonLibName.lib";
     Python3_ROOT_DIR = $PythonRoot;


### PR DESCRIPTION
Currently, when running `build.ps1`, CMake will sometimes pick up the global Python3, and sometimes it will pick up the one the script installs manually in `T:\`. See the results of grepping `Found Python3:` on https://ci-external.swift.org/job/swift-6.2-windows-toolchain/20/consoleText.

This leads to build errors when building LLDB with Python support on Windows, as the installed modules (`psutil`, etc) are not found. This could lead to other errors in the future.

This PR imposes the use of the correct `Python` by manually setting it in `Build-CMakeProject`.

EDIT: The error also happens when building LLDB with Python support on ARM64 because it will link to the wrong Python library.