### PR TITLE
[stdlib] Wrap InlineArray inlinable code in new feature

### DIFF
--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -247,11 +247,15 @@ extension InlineArray where Element: Copyable {
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init(repeating value: Element) {
+#if $ValueGenericsNameLookup
     self = Builtin.emplace {
       let buffer = unsafe Self._initializationBuffer(start: $0)
 
       unsafe buffer.initialize(repeating: value)
     }
+#else
+    fatalError()
+#endif
   }
 }
 


### PR DESCRIPTION
With the new feature introduced in: https://github.com/swiftlang/swift/pull/78248, this particular code in inlinable code wasn't receiving the feature gate but the declaration `_initializationBuffer` was. Let's wrap this piece of code in the feature.

Resolves: rdar://150213146