### PR TITLE
AST: Use weighted reduction order for opaque return types

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -306,7 +306,6 @@ public:
 };
 
 struct OverrideSubsInfo {
-  ASTContext &Ctx;
   unsigned BaseDepth;
   unsigned OrigDepth;
   SubstitutionMap BaseSubMap;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -7254,9 +7254,10 @@ class GenericTypeParamType : public SubstitutableType,
     Identifier Name;
   };
 
-  unsigned Depth : 15;
   unsigned IsDecl : 1;
-  unsigned Index : 16;
+  unsigned Depth : 15;
+  unsigned Weight : 1;
+  unsigned Index : 15;
 
   /// The kind of generic type parameter this is.
   GenericTypeParamKind ParamKind;
@@ -7281,14 +7282,20 @@ public:
                                    Type valueType, const ASTContext &ctx);
 
   /// Retrieve a canonical generic type parameter with the given kind, depth,
-  /// index, and optional value type.
+  /// index, weight, and optional value type.
   static GenericTypeParamType *get(GenericTypeParamKind paramKind,
-                                   unsigned depth, unsigned index,
+                                   unsigned depth, unsigned index, unsigned weight,
                                    Type valueType, const ASTContext &ctx);
 
-  /// Retrieve a canonical generic type parameter at the given depth and index.
+  /// Retrieve a canonical generic type parameter at the given depth and index,
+  /// with weight 0.
   static GenericTypeParamType *getType(unsigned depth, unsigned index,
                                        const ASTContext &ctx);
+
+  /// Retrieve a canonical generic type parameter at the given depth and index
+  /// for an opaque result type, so with weight 1.
+  static GenericTypeParamType *getOpaqueResultType(unsigned depth, unsigned index,
+                                                   const ASTContext &ctx);
 
   /// Retrieve a canonical generic parameter pack at the given depth and index.
   static GenericTypeParamType *getPack(unsigned depth, unsigned index,
@@ -7345,6 +7352,14 @@ public:
     return Index;
   }
 
+  /// The weight of this generic parameter in the type parameter order.
+  ///
+  /// Opaque result types have weight 1, while all other generic parameters
+  /// have weight 0.
+  unsigned getWeight() const {
+    return Weight;
+  }
+
   /// Returns \c true if this type parameter is declared as a pack.
   ///
   /// \code
@@ -7373,15 +7388,17 @@ public:
     // which don't store an identifier we'll go create a tau based form. We
     // really want to just plumb down the null Identifier because that's what's
     // inside the cache.
-    Profile(ID, getParamKind(), getDepth(), getIndex(), getValueType(),
-            Name);
+    Profile(ID, getParamKind(), getDepth(), getIndex(), getWeight(),
+            getValueType(), Name);
   }
   static void Profile(llvm::FoldingSetNodeID &ID,
                       GenericTypeParamKind paramKind, unsigned depth,
-                      unsigned index, Type valueType, Identifier name) {
+                      unsigned index, unsigned weight, Type valueType,
+                      Identifier name) {
     ID.AddInteger((uint8_t)paramKind);
     ID.AddInteger(depth);
     ID.AddInteger(index);
+    ID.AddInteger(weight);
     ID.AddPointer(valueType.getPointer());
     ID.AddPointer(name.get());
   }
@@ -7404,7 +7421,7 @@ private:
                                 const ASTContext &ctx);
 
   explicit GenericTypeParamType(GenericTypeParamKind paramKind, unsigned depth,
-                                unsigned index, Type valueType,
+                                unsigned index, unsigned weight, Type valueType,
                                 RecursiveTypeProperties props,
                                 const ASTContext &ctx);
 };
@@ -7413,6 +7430,11 @@ static CanGenericTypeParamType getType(unsigned depth, unsigned index,
                                        const ASTContext &C) {
   return CanGenericTypeParamType(
       GenericTypeParamType::getType(depth, index, C));
+}
+static CanGenericTypeParamType getOpaqueResultType(unsigned depth, unsigned index,
+                                                   const ASTContext &C) {
+  return CanGenericTypeParamType(
+      GenericTypeParamType::getOpaqueResultType(depth, index, C));
 }
 END_CAN_TYPE_WRAPPER(GenericTypeParamType, SubstitutableType)
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -7366,6 +7366,8 @@ public:
 
   Type getValueType() const;
 
+  GenericTypeParamType *withDepth(unsigned depth) const;
+
   void Profile(llvm::FoldingSetNodeID &ID) {
     // Note: We explicitly don't use 'getName()' because for canonical forms
     // which don't store an identifier we'll go create a tau based form. We

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -46,10 +46,8 @@ RequirementEnvironment::RequirementEnvironment(
 
   auto conformanceToWitnessThunkGenericParamFn = [&](GenericTypeParamType *genericParam)
       -> GenericTypeParamType * {
-    return GenericTypeParamType::get(genericParam->getParamKind(),
-                                     genericParam->getDepth() + (covariantSelf ? 1 : 0),
-                                     genericParam->getIndex(),
-                                     genericParam->getValueType(), ctx);
+    return genericParam->withDepth(
+        genericParam->getDepth() + (covariantSelf ? 1 : 0));
   };
 
   // This is a substitution function from the generic parameters of the
@@ -109,9 +107,7 @@ RequirementEnvironment::RequirementEnvironment(
       // invalid code.
       if (genericParam->getDepth() != 1)
         return Type();
-      Type substGenericParam = GenericTypeParamType::get(
-          genericParam->getParamKind(), depth, genericParam->getIndex(),
-          genericParam->getValueType(), ctx);
+      Type substGenericParam = genericParam->withDepth(depth);
       if (genericParam->isParameterPack()) {
         substGenericParam = PackType::getSingletonPackExpansion(
             substGenericParam);
@@ -210,10 +206,7 @@ RequirementEnvironment::RequirementEnvironment(
     }
 
     // Create an equivalent generic parameter at the next depth.
-    auto substGenericParam = GenericTypeParamType::get(
-        genericParam->getParamKind(), depth, genericParam->getIndex(),
-        genericParam->getValueType(), ctx);
-
+    auto substGenericParam = genericParam->withDepth(depth);
     genericParamTypes.push_back(substGenericParam);
   }
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -427,8 +427,7 @@ OverrideSubsInfo::OverrideSubsInfo(const NominalTypeDecl *baseNominal,
                                    const NominalTypeDecl *derivedNominal,
                                    GenericSignature baseSig,
                                    const GenericParamList *derivedParams)
-  : Ctx(baseSig->getASTContext()),
-    BaseDepth(0),
+  : BaseDepth(0),
     OrigDepth(0),
     DerivedParams(derivedParams) {
 
@@ -468,10 +467,7 @@ Type QueryOverrideSubs::operator()(SubstitutableType *type) const {
             ->getDeclaredInterfaceType();
       }
 
-      return GenericTypeParamType::get(
-          gp->getParamKind(),
-          gp->getDepth() + info.OrigDepth - info.BaseDepth,
-          gp->getIndex(), gp->getValueType(), info.Ctx);
+      return gp->withDepth(gp->getDepth() + info.OrigDepth - info.BaseDepth);
     }
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2163,6 +2163,14 @@ Type GenericTypeParamType::getValueType() const {
   return ValueType;
 }
 
+GenericTypeParamType *GenericTypeParamType::withDepth(unsigned depth) const {
+  return GenericTypeParamType::get(getParamKind(),
+                                   depth,
+                                   getIndex(),
+                                   getValueType(),
+                                   getASTContext());
+}
+
 const llvm::fltSemantics &BuiltinFloatType::getAPFloatSemantics() const {
   switch (getFPKind()) {
   case BuiltinFloatType::IEEE16:  return APFloat::IEEEhalf();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1736,7 +1736,8 @@ CanType TypeBase::computeCanonicalType() {
     auto &C = gpDecl->getASTContext();
     Result =
         GenericTypeParamType::get(gp->getParamKind(), gp->getDepth(),
-                                  gp->getIndex(), gp->getValueType(),
+                                  gp->getIndex(), gp->getWeight(),
+                                  gp->getValueType(),
                                   C);
     break;
   }
@@ -2081,8 +2082,9 @@ GenericTypeParamType::GenericTypeParamType(GenericTypeParamDecl *param,
   : SubstitutableType(TypeKind::GenericTypeParam, nullptr, props),
     Decl(param) {
   ASSERT(param->getDepth() != GenericTypeParamDecl::InvalidDepth);
-  Depth = param->getDepth();
   IsDecl = true;
+  Depth = param->getDepth();
+  Weight = 0;
   Index = param->getIndex();
   ParamKind = param->getParamKind();
   ValueType = param->getValueType();
@@ -2095,8 +2097,9 @@ GenericTypeParamType::GenericTypeParamType(Identifier name,
                         canType->getRecursiveProperties()),
       Decl(nullptr) {
   Name = name;
-  Depth = canType->getDepth();
   IsDecl = false;
+  Depth = canType->getDepth();
+  Weight = canType->getWeight();
   Index = canType->getIndex();
   ParamKind = canType->getParamKind();
   ValueType = canType->getValueType();
@@ -2106,13 +2109,14 @@ GenericTypeParamType::GenericTypeParamType(Identifier name,
 
 GenericTypeParamType::GenericTypeParamType(GenericTypeParamKind paramKind,
                                            unsigned depth, unsigned index,
-                                           Type valueType,
+                                           unsigned weight, Type valueType,
                                            RecursiveTypeProperties props,
                                            const ASTContext &ctx)
     : SubstitutableType(TypeKind::GenericTypeParam, &ctx, props),
       Decl(nullptr) {
-  Depth = depth;
   IsDecl = false;
+  Depth = depth;
+  Weight = weight;
   Index = index;
   ParamKind = paramKind;
   ValueType = valueType;
@@ -2167,6 +2171,7 @@ GenericTypeParamType *GenericTypeParamType::withDepth(unsigned depth) const {
   return GenericTypeParamType::get(getParamKind(),
                                    depth,
                                    getIndex(),
+                                   getWeight(),
                                    getValueType(),
                                    getASTContext());
 }

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -2423,7 +2423,8 @@ public:
       paramKind = GenericTypeParamKind::Pack;
     }
 
-    auto gp = GenericTypeParamType::get(paramKind, 0, paramIndex, Type(),
+    auto gp = GenericTypeParamType::get(paramKind, /*depth=*/0, paramIndex,
+                                        /*weight=*/0, /*valueType=*/Type(),
                                         TC.Context);
     substGenericParams.push_back(gp);
 

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -405,8 +405,6 @@ combineSubstitutionMaps(SubstitutionMap firstSubMap,
                         unsigned firstDepth,
                         unsigned secondDepth,
                         GenericSignature genericSig) {
-  auto &ctx = genericSig->getASTContext();
-
   return SubstitutionMap::get(
     genericSig,
     [&](SubstitutableType *type) {
@@ -414,12 +412,8 @@ combineSubstitutionMaps(SubstitutionMap firstSubMap,
       if (gp->getDepth() < firstDepth)
         return QuerySubstitutionMap{firstSubMap}(gp);
 
-      auto *replacement = GenericTypeParamType::get(
-          gp->getParamKind(),
-          gp->getDepth() + secondDepth - firstDepth,
-          gp->getIndex(),
-          gp->getValueType(),
-          ctx);
+      auto *replacement = gp->withDepth(
+          gp->getDepth() + secondDepth - firstDepth);
       return QuerySubstitutionMap{secondSubMap}(replacement);
     },
     // We might not have enough information in the substitution maps alone.
@@ -1056,16 +1050,13 @@ getWitnessMethodSubstitutions(
         }
 
         if (depth < baseDepth) {
-          paramType = GenericTypeParamType::get(paramType->getParamKind(),
-              depth, paramType->getIndex(), paramType->getValueType(), ctx);
-
+          paramType = paramType->withDepth(depth);
           return Type(paramType).subst(baseSubMap);
         }
 
         depth = depth - baseDepth + 1;
 
-        paramType = GenericTypeParamType::get(paramType->getParamKind(),
-            depth, paramType->getIndex(), paramType->getValueType(), ctx);
+        paramType = paramType->withDepth(depth);
         return Type(paramType).subst(origSubMap);
       },
       [&](CanType type, Type substType, ProtocolDecl *proto) {
@@ -1084,10 +1075,8 @@ getWitnessMethodSubstitutions(
 
         if (depth < baseDepth) {
           type = CanType(type.transformRec([&](TypeBase *t) -> std::optional<Type> {
-            if (t == paramType) {
-              return Type(GenericTypeParamType::get(paramType->getParamKind(),
-                  depth, paramType->getIndex(), paramType->getValueType(), ctx));
-            }
+            if (t == paramType)
+              return paramType->withDepth(depth);
 
             assert(!isa<GenericTypeParamType>(t));
             return std::nullopt;
@@ -1099,10 +1088,8 @@ getWitnessMethodSubstitutions(
         depth = depth - baseDepth + 1;
 
         type = CanType(type.transformRec([&](TypeBase *t) -> std::optional<Type> {
-          if (t == paramType) {
-            return Type(GenericTypeParamType::get(paramType->getParamKind(),
-                depth, paramType->getIndex(), paramType->getValueType(), ctx));
-          }
+          if (t == paramType)
+            return paramType->withDepth(depth);
 
           assert(!isa<GenericTypeParamType>(t));
           return std::nullopt;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -142,7 +142,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
     for (unsigned i = 0; i < opaqueReprs.size(); ++i) {
       auto *currentRepr = opaqueReprs[i];
 
-      if( auto opaqueReturn = dyn_cast<OpaqueReturnTypeRepr>(currentRepr) ) {
+      if (auto opaqueReturn = dyn_cast<OpaqueReturnTypeRepr>(currentRepr)) {
         // Usually, we resolve the opaque constraint and bail if it isn't a class
         // or existential type (see below). However, in this case we know we will
         // fail, so we can bail early and provide a better diagnostic.
@@ -163,13 +163,13 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
         }
       }
 
-      auto *paramType = GenericTypeParamType::getType(opaqueSignatureDepth, i,
-                                                      ctx);
+      auto *paramType = GenericTypeParamType::getOpaqueResultType(
+          opaqueSignatureDepth, i, ctx);
       genericParamTypes.push_back(paramType);
     
       TypeRepr *constraint = currentRepr;
       
-      if (auto opaqueReturn = dyn_cast<OpaqueReturnTypeRepr>(currentRepr)){
+      if (auto opaqueReturn = dyn_cast<OpaqueReturnTypeRepr>(currentRepr)) {
         constraint = opaqueReturn->getConstraint();
       }
       // Try to resolve the constraint repr in the parent decl context. It

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1034,11 +1034,7 @@ findMissingGenericRequirementForSolutionFix(
           return conformance->getType();
 
         ASSERT(gp->getDepth() > 0);
-        gp = GenericTypeParamType::get(gp->getParamKind(),
-                                       gp->getDepth() - 1,
-                                       gp->getIndex(),
-                                       gp->getValueType(),
-                                       ctx);
+        gp = gp->withDepth(gp->getDepth() - 1);
       }
 
       if (!sig)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7621,12 +7621,13 @@ DESERIALIZE_TYPE(GENERIC_TYPE_PARAM_TYPE)(
   unsigned rawParamKind;
   bool hasDecl;
   unsigned depth;
+  unsigned weight;
   unsigned index;
   DeclID declOrIdentifier;
   TypeID valueTypeID;
 
   decls_block::GenericTypeParamTypeLayout::readRecord(
-      scratch, rawParamKind, hasDecl, depth, index, declOrIdentifier,
+      scratch, rawParamKind, hasDecl, depth, weight, index, declOrIdentifier,
       valueTypeID);
 
   auto paramKind = getActualParamKind(rawParamKind);
@@ -7655,10 +7656,11 @@ DESERIALIZE_TYPE(GENERIC_TYPE_PARAM_TYPE)(
     return valueType.takeError();
 
   if (declOrIdentifier == 0) {
-    return GenericTypeParamType::get(*paramKind, depth, index, *valueType,
+    return GenericTypeParamType::get(*paramKind, depth, index, weight, *valueType,
                                      MF.getContext());
   }
 
+  ASSERT(weight == 0);
   auto name = MF.getDeclBaseName(declOrIdentifier).getIdentifier();
   return GenericTypeParamType::get(name, *paramKind, depth, index, *valueType,
                                    MF.getContext());

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 944; // specialized witness tables
+const uint16_t SWIFTMODULE_VERSION_MINOR = 945; // generic parameter weight
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1290,7 +1290,8 @@ namespace decls_block {
     GenericParamKindField, // param kind
     BCFixed<1>,            // has decl?
     BCFixed<15>,           // depth
-    BCFixed<16>,           // index
+    BCFixed<1>,            // weight
+    BCFixed<15>,           // index
     DeclIDField,           // generic type parameter decl or identifier
     TypeIDField            // value type (if param kind == Value)
   );

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5812,6 +5812,7 @@ public:
                                            paramKind,
                                            hasDecl,
                                            genericParam->getDepth(),
+                                           genericParam->getWeight(),
                                            genericParam->getIndex(),
                                            declOrIdentifier,
                                            valueTypeID);

--- a/test/SILGen/opaque_result_type_reduction_order.swift
+++ b/test/SILGen/opaque_result_type_reduction_order.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-silgen %s
+
+protocol N {
+  associatedtype A: N
+}
+
+struct G<T>: N {
+  typealias A = G<G<T>>
+}
+
+protocol P<A> {
+  associatedtype A
+}
+
+struct GG<T>: P {
+  typealias A = T
+}
+
+func f<T: N>(_: T) -> some P<T.A.A> {
+  return GG<T.A.A>()
+}
+
+func g<T: P>(_: T) -> T.A { fatalError() }
+
+func h(_: G<G<G<Int>>>) {}
+
+h(g(f(G<Int>())))


### PR DESCRIPTION
This fixes a bug that has been there ever since https://github.com/swiftlang/swift-evolution/blob/main/proposals/0346-light-weight-same-type-syntax.md was first implemented.

If the opaque generic signature has a same-type requirement between an outer type parameter and an opaque type parameter, the former should always precede the latter in the type parameter order, even if it is longer. Achieve this by giving the innermost generic parameters a non-zero weight in the opaque generic signature.

Now, when we map a type parameter into an opaque generic environment, we correctly decide if it is represented by a type parameter of the outer generic signature, in which case we apply the outer substitution map instead of instantiating an archetype.

The included test case demonstrates the issue; we declare an opaque return type `some P<T.A.A>`, so the opaque generic signature has a requirement `T.A.A == <<some P>>.A`. Previously, the reduced type of `<<some P>>.A` was `<<some P>>.A`, so it remained opaque; now we apply outer substitutions to `T.A.A`.

- Fixes https://github.com/swiftlang/swift/issues/59391.
- Fixes rdar://problem/149871931.