### PR TITLE
Fixes in SILGen and SILOptimizer to generate complete lifetimes of enums on trivial/non-payloaded paths

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2753,8 +2753,6 @@ public:
   }
 
   void checkEndLifetimeInst(EndLifetimeInst *I) {
-    require(!I->getOperand()->getType().isTrivial(*I->getFunction()),
-            "Source value should be non-trivial");
     require(!fnConv.useLoweredAddresses() || F.hasOwnership(),
             "end_lifetime is only valid in functions with qualified "
             "ownership");
@@ -3024,8 +3022,7 @@ public:
           F.hasOwnership(),
           "Inst with qualified ownership in a function that is not qualified");
       SILValue Src = SI->getSrc();
-      require(Src->getType().isTrivial(*SI->getFunction()) ||
-                  Src->getOwnershipKind() == OwnershipKind::None,
+      require(Src->getType().isTrivial(*SI->getFunction()),
               "A store with trivial ownership must store a type with trivial "
               "ownership");
       break;

--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -211,7 +211,8 @@ ManagedValue ManagedValue::materialize(SILGenFunction &SGF,
   auto temporary = SGF.emitTemporaryAllocation(loc, getType());
   bool hadCleanup = hasCleanup();
 
-  if (hadCleanup) {
+  if (hadCleanup || (getValue()->getOwnershipKind() == OwnershipKind::None &&
+                     !getType().isTrivial(&SGF.getFunction()))) {
     SGF.B.emitStoreValueOperation(loc, forward(SGF), temporary,
                                   StoreOwnershipQualifier::Init);
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -442,7 +442,11 @@ ManagedValue SILGenBuilder::createUncheckedEnumData(SILLocation loc,
                                                     ManagedValue operand,
                                                     EnumElementDecl *element) {
   CleanupCloner cloner(*this, operand);
-  SILValue result = createUncheckedEnumData(loc, operand.forward(SGF), element);
+  SILValue result = createUncheckedEnumData(loc, operand.getValue(), element);
+  if (operand.hasCleanup() && !operand.getValue()->getType().isTrivial(SGF.F) &&
+      !result->getType().isTrivial(SGF.F)) {
+    operand.forwardCleanup(SGF);
+  }
   return cloner.clone(result);
 }
 
@@ -451,7 +455,11 @@ ManagedValue SILGenBuilder::createUncheckedTakeEnumDataAddr(
     SILType ty) {
   CleanupCloner cloner(*this, operand);
   SILValue result =
-      createUncheckedTakeEnumDataAddr(loc, operand.forward(SGF), element);
+      createUncheckedTakeEnumDataAddr(loc, operand.getValue(), element);
+  if (operand.hasCleanup() && !operand.getValue()->getType().isTrivial(SGF.F) &&
+    !result->getType().isTrivial(SGF.F)) {
+    operand.forwardCleanup(SGF);
+  }
   return cloner.clone(result);
 }
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -484,13 +484,16 @@ SILGenFunction::emitOptionalToOptional(SILLocation loc,
 
   SEBuilder.addOptionalNoneCase(
       isNotPresentBB, contBB,
-      [&](ManagedValue input, SwitchCaseFullExpr &&scope) {
+      [&](ManagedValue inputNone, SwitchCaseFullExpr &&scope) {
+        if (getTypeLowering(input.getValue()->getType()).isAddressOnly() &&
+            silConv.useLoweredAddresses()) {
+          enterDestroyCleanup(input.getValue());
+        }
         if (!addressOnly) {
           SILValue none =
               B.createManagedOptionalNone(loc, resultTy).forward(*this);
           return scope.exitAndBranch(loc, none);
         }
-
         emitInjectOptionalNothingInto(loc, resultAddress.getValue(), resultTL);
         return scope.exitAndBranch(loc);
       });

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2353,15 +2353,6 @@ void PatternMatchEmission::emitEnumElementDispatch(
         }
       }
 
-      // Forward src along this path so we don't emit a destroy_addr on our
-      // subject value for this case.
-      //
-      // FIXME: Do we actually want to do this? SILGen tests today assume this
-      // pattern. It might be worth leaving the destroy_addr there to create
-      // additional liveness information. For now though, we maintain the
-      // current behavior.
-      src.getFinalManagedValue().forward(SGF);
-
       SILValue result;
       if (hasNonAny) {
         result = SGF.emitEmptyTuple(loc);

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1428,6 +1428,9 @@ void StmtEmitter::visitForEachStmt(ForEachStmt *S) {
       createBasicBlock(), failExitingBlock,
       [&](ManagedValue inputValue, SwitchCaseFullExpr &&scope) {
         assert(!inputValue && "None should not be passed an argument!");
+        if (nextResultTyIsAddressOnly) {
+          SGF.enterDestroyCleanup(addrOnlyBuf);
+        }
         scope.exitAndBranch(S);
       },
       SGF.loadProfilerCount(S));

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -423,6 +423,7 @@ CastOptimizer::optimizeBridgedObjCToSwiftCast(SILDynamicCastInst dynamicCast) {
     Builder.createSwitchEnumAddr(Loc, outOptionalParam, nullptr, CaseBBs);
 
     Builder.setInsertionPoint(FailureBB->begin());
+    Builder.createDestroyAddr(Loc, Tmp);
     Builder.createDeallocStack(Loc, Tmp);
 
     Builder.setInsertionPoint(BridgeSuccessBB);

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -15,9 +15,11 @@ import resilient_enum
 // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt: bb3, case #Medium.Postcard!enumelt: bb4, default bb5
 // CHECK:       bb1:
+// CHECK-NEXT:    destroy_addr [[BOX]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb2:
+// CHECK-NEXT:    destroy_addr [[BOX]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb3:

--- a/test/SILGen/enum_resilience_testable.swift
+++ b/test/SILGen/enum_resilience_testable.swift
@@ -20,9 +20,11 @@
 // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt: bb3, case #Medium.Postcard!enumelt: bb4, default bb5
 // CHECK:       bb1:
+// CHECK-NEXT:    destroy_addr [[BOX]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb2:
+// CHECK-NEXT:    destroy_addr [[BOX]]
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb3:

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-print-types -address-lowering -enable-sil-opaque-values -emit-sorted-sil -module-name Swift -sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -address-lowering -enable-sil-opaque-values -emit-sorted-sil -module-name Swift -sil-verify-all -exclude-trivial-enum-memory-lifetime-verification %s | %FileCheck %s
 //
 // The module name must be Swift so that declarations like Error are parsed as the correct loadable type.
 

--- a/test/SILOptimizer/constant_propagation_objc.sil
+++ b/test/SILOptimizer/constant_propagation_objc.sil
@@ -45,6 +45,7 @@ sil @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Arra
 // CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[FAIL_BB]]:
+// CHECK-NEXT:   destroy_addr [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   destroy_addr [[INPUT]]
@@ -117,6 +118,7 @@ bb4:
 // CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[FAIL_BB]]:
+// CHECK-NEXT:   destroy_addr [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   destroy_addr [[INPUT]]
@@ -188,6 +190,7 @@ bb4:
 // CHECK-NEXT:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[FAIL_BB:bb[0-9]+]]:
+// CHECK-NEXT:   destroy_addr [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[CAST_TMP:%.*]]
 // CHECK-NEXT:   dealloc_stack [[OUTPUT]]
 // CHECK-NEXT:   dealloc_stack [[INPUT]]
@@ -258,6 +261,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -325,6 +329,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -394,6 +399,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -464,6 +470,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -531,6 +538,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -600,6 +608,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -670,6 +679,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -737,6 +747,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -806,6 +817,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -876,6 +888,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -943,6 +956,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -1012,6 +1026,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //

--- a/test/SILOptimizer/constant_propagation_ownership_objc.sil
+++ b/test/SILOptimizer/constant_propagation_ownership_objc.sil
@@ -165,6 +165,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -233,6 +234,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: [[UNCAST_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
 // CHECK-NEXT: store [[UNCAST_INPUT:%.*]] to [init] [[INPUT]]
@@ -305,6 +307,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -375,6 +378,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -443,6 +447,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
 // CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
@@ -515,6 +520,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -585,6 +591,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -653,6 +660,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
 // CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
@@ -725,6 +733,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -795,6 +804,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //
@@ -863,6 +873,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: [[UNCASTED_INPUT:%.*]] = unchecked_ref_cast [[CASTED_INPUT]]
 // CHECK-NEXT: store [[UNCASTED_INPUT]] to [init] [[INPUT]]
@@ -935,6 +946,7 @@ bb4:
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
 //
 // CHECK: [[COND_CAST_FAIL]]:
+// CHECK-NEXT: destroy_addr
 // CHECK-NEXT: dealloc_stack
 // CHECK-NEXT: br [[FAIL_EXIT_TRAMPOLINE]]
 //

--- a/test/SILOptimizer/devirt_deinits.sil
+++ b/test/SILOptimizer/devirt_deinits.sil
@@ -217,6 +217,7 @@ bb0(%0 : $*S3<Int>):
 // CHECK:         apply [[D]]([[L]])
 // CHECK-NEXT:    br bb4
 // CHECK:       bb2:
+// CHECK-NEXT:    end_lifetime %0
 // CHECK-NEXT:    br bb4
 // CHECK:       bb3:
 // CHECK-NEXT:    br bb4

--- a/test/SILOptimizer/init_accessors_with_indirect_newValue.swift
+++ b/test/SILOptimizer/init_accessors_with_indirect_newValue.swift
@@ -39,7 +39,7 @@ public class Test {
   //
   // CHECK: [[START_STATE:%.*]] = enum $Test.State, #Test.State.start!enumelt
   // CHECK-NEXT: [[NEW_VALUE:%.*]] = alloc_stack $Test.State
-  // CHECK-NEXT: store [[START_STATE]] to [trivial] [[NEW_VALUE]] : $*Test.State
+  // CHECK-NEXT: store [[START_STATE]] to [init] [[NEW_VALUE]] : $*Test.State
   // CHECK: assign_or_init [set] #Test.state, self [[MU]] : $Test, value [[NEW_VALUE]] : $*Test.State, init {{.*}} : $@noescape @callee_guaranteed (@in Test.State) -> @out Test.State, set {{.*}} : $@noescape @callee_guaranteed (@in Test.State) -> ()
   public init() {
     state = .start

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1,8 +1,8 @@
-// RUN: %target-sil-opt -sil-print-types -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -update-borrowed-from -sil-combine -wmo | %FileCheck %s
-// RUN: %target-sil-opt -sil-print-types -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -update-borrowed-from -sil-combine -generic-specializer | %FileCheck %s  --check-prefix=CHECK_FORWARDING_OWNERSHIP_KIND
+// RUN: %target-sil-opt -sil-print-types -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -update-borrowed-from -sil-combine -wmo -exclude-trivial-enum-memory-lifetime-verification  | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-copy-propagation=requested-passes-only -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -update-borrowed-from -sil-combine -generic-specializer -exclude-trivial-enum-memory-lifetime-verification | %FileCheck %s  --check-prefix=CHECK_FORWARDING_OWNERSHIP_KIND
 //
 // FIXME: check copy-propagation output instead once it is the default mode
-// RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -update-borrowed-from -sil-combine -enable-copy-propagation -enable-lexical-lifetimes=false | %FileCheck %s --check-prefix=CHECK_COPYPROP
+// RUN: %target-sil-opt -sil-print-types -enable-objc-interop -enforce-exclusivity=none -enable-sil-verify-all %s -update-borrowed-from -sil-combine -enable-copy-propagation -enable-lexical-lifetimes=false -exclude-trivial-enum-memory-lifetime-verification | %FileCheck %s --check-prefix=CHECK_COPYPROP
 
 // REQUIRES: swift_in_compiler
 


### PR DESCRIPTION
Currently, we do not generate destroy_addrs on trivial/non-payloaded paths of non-trivial enums as a micro optimization. This increases complexity for verification. MemoryLifetimeVerifier currently has special logic to avoid raising errors
for such missing destroy_addrs.
With OSSA, there can be optimizations which convert address forms to value forms like mem2reg and temprvalueopt. To avoid ownership verifier errors about missing destroy_values, we were using complete lifetime utility. But using this utility in the presence of pointer escapes is invalid. 

This PR completes such lifetimes in SILGen/SILOptimizer so that we don't have to call complete lifetimes utility.


Fixes rdar://145994924 