### PR TITLE
[AST/Sema] Add `@preEnumExtensibility` attribute to downgrade warning…

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -887,7 +887,13 @@ SIMPLE_DECL_ATTR(concurrent, Concurrent,
   ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove | UnconstrainedInABIAttr,
   170)
 
-LAST_DECL_ATTR(Concurrent)
+SIMPLE_DECL_ATTR(preEnumExtensibility, PreEnumExtensibility,
+  OnEnum,
+  ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove | UnconstrainedInABIAttr,
+  171)
+DECL_ATTR_FEATURE_REQUIREMENT(PreEnumExtensibility, ExtensibleAttribute)
+  
+LAST_DECL_ATTR(PreEnumExtensibility)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8698,7 +8698,7 @@ GROUPED_WARNING(
     (StringRef, DeclAttribute))
 
 //===----------------------------------------------------------------------===//
-// MARK: @extensible Attribute
+// MARK: @extensible and @preEnumExtensibility Attributes
 //===----------------------------------------------------------------------===//
 
 ERROR(extensible_attr_on_frozen_type,none,
@@ -8709,6 +8709,9 @@ ERROR(extensible_attr_on_internal_type,none,
       "declarations, but %0 is "
       "%select{private|fileprivate|internal|%error|%error|%error}1",
       (DeclName, AccessLevel))
+
+ERROR(pre_enum_extensibility_without_extensible,none,
+      "%0 can only be used together with '@extensible' attribute", (DeclAttribute))
 
 //===----------------------------------------------------------------------===//
 //                            MARK: SwiftSettings

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5062,6 +5062,7 @@ public:
   TRIVIAL_ATTR_PRINTER(WeakLinked, weak_linked)
   TRIVIAL_ATTR_PRINTER(Extensible, extensible)
   TRIVIAL_ATTR_PRINTER(Concurrent, concurrent)
+  TRIVIAL_ATTR_PRINTER(PreEnumExtensibility, preEnumExtensibility)
 
 #undef TRIVIAL_ATTR_PRINTER
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3301,7 +3301,8 @@ suppressingFeatureAddressableTypes(PrintOptions &options,
 static void
 suppressingFeatureExtensibleAttribute(PrintOptions &options,
                                       llvm::function_ref<void()> action) {
-  ExcludeAttrRAII scope(options.ExcludeAttrList, DeclAttrKind::Extensible);
+  ExcludeAttrRAII scope1(options.ExcludeAttrList, DeclAttrKind::Extensible);
+  ExcludeAttrRAII scope2(options.ExcludeAttrList, DeclAttrKind::PreEnumExtensibility);
   action();
 }
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -229,6 +229,7 @@ extension ASTGenVisitor {
         .eagerMove,
         .exported,
         .extensible,
+        .preEnumExtensibility,
         .discardableResult,
         .disfavoredOverload,
         .dynamicMemberLookup,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -258,6 +258,14 @@ public:
     }
   }
 
+  void visitPreEnumExtensibilityAttr(PreEnumExtensibilityAttr *attr) {
+    if (!D->getAttrs().hasAttribute<ExtensibleAttr>()) {
+      diagnoseAndRemoveAttr(
+          attr, diag::pre_enum_extensibility_without_extensible, attr);
+      return;
+    }
+  }
+
   void visitConcurrentAttr(ConcurrentAttr *attr) {
     checkExecutionBehaviorAttribute(attr);
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1611,6 +1611,7 @@ namespace  {
     UNINTERESTING_ATTR(Optimize)
     UNINTERESTING_ATTR(Exclusivity)
     UNINTERESTING_ATTR(Extensible)
+    UNINTERESTING_ATTR(PreEnumExtensibility)
     UNINTERESTING_ATTR(NoLocks)
     UNINTERESTING_ATTR(NoAllocation)
     UNINTERESTING_ATTR(NoRuntime)

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1154,16 +1154,28 @@ namespace {
         assert(defaultReason == RequiresDefault::No);
         Type subjectType = Switch->getSubjectExpr()->getType();
         bool shouldIncludeFutureVersionComment = false;
-        bool shouldDowngradeToWarning = true;
-        if (auto *theEnum = subjectType->getEnumOrBoundGenericEnum()) {
+        auto *theEnum = subjectType->getEnumOrBoundGenericEnum();
+
+        if (theEnum) {
           auto *enumModule = theEnum->getParentModule();
           shouldIncludeFutureVersionComment =
               enumModule->isSystemModule() ||
               theEnum->getAttrs().hasAttribute<ExtensibleAttr>();
         }
-        DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
-                    subjectType, shouldIncludeFutureVersionComment)
-          .warnUntilSwiftVersionIf(shouldDowngradeToWarning, 6);
+
+        auto diag =
+            DE.diagnose(startLoc, diag::non_exhaustive_switch_unknown_only,
+                        subjectType, shouldIncludeFutureVersionComment);
+
+        // Presence of `@preEnumExtensibility` pushed the warning farther
+        // into the future.
+        if (theEnum &&
+            theEnum->getAttrs().hasAttribute<PreEnumExtensibilityAttr>()) {
+          diag.warnUntilFutureSwiftVersion();
+        } else {
+          diag.warnUntilSwiftVersion(6);
+        }
+
         mainDiagType = std::nullopt;
       }
         break;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 946; // end_cow_mutation_addr
+const uint16_t SWIFTMODULE_VERSION_MINOR = 947; // @preEnumExtensibility attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/ModuleInterface/extensible_attr.swift
+++ b/test/ModuleInterface/extensible_attr.swift
@@ -16,3 +16,14 @@
 @extensible
 public enum E {
 }
+
+// CHECK: #if compiler(>=5.3) && $ExtensibleAttribute
+// CHECK-NEXT: @preEnumExtensibility @extensible public enum F {
+// CHECK: #else
+// CHECK-NEXT: public enum F {
+// CHECK: #endif
+@preEnumExtensibility
+@extensible
+public enum F {
+  case a
+}

--- a/test/ModuleInterface/extensible_enums.swift
+++ b/test/ModuleInterface/extensible_enums.swift
@@ -29,12 +29,23 @@
 // RUN:   -package-name Test \
 // RUN:   -verify
 
+// Different module but the same package
+// RUN: %target-swift-frontend -typecheck %t/src/TestSwift6.swift \
+// RUN:   -swift-version 6 -module-name Client -I %t \
+// RUN:   -verify
+
 // REQUIRES: swift_feature_ExtensibleAttribute
 
 //--- Lib.swift
 
 @extensible
 public enum E {
+  case a
+}
+
+@preEnumExtensibility
+@extensible
+public enum PE {
   case a
 }
 
@@ -58,7 +69,7 @@ func test_same_module(e: E, f: F) {
 //--- TestChecking.swift
 import Lib
 
-func test(e: E, f: F) {
+func test(e: E, pe: PE, f: F) {
   // `E` is marked as `@extensible` which means it gets new semantics
 
   switch e {
@@ -70,6 +81,12 @@ func test(e: E, f: F) {
   switch e { // Ok (no warnings)
   case .a: break
   @unknown default: break
+  }
+
+  switch pe {
+  // expected-warning@-1 {{switch covers known cases, but 'PE' may have additional unknown values, possibly added in future versions; this will be an error in a future Swift language mode}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}}
+  case .a: break
   }
 
   // `F` is marked as `@frozen` which means regular rules apply.
@@ -108,5 +125,27 @@ func test_no_default(e: E, f: F) {
   switch f { // expected-warning {{switch must be exhaustive}} expected-note {{dd missing case: '.b'}}
   case .a: break
   @unknown default: break
+  }
+}
+
+//--- TestSwift6.swift
+import Lib
+
+func test(e: E, pe: PE, f: F) {
+  switch e {
+  // expected-error@-1 {{switch covers known cases, but 'E' may have additional unknown values, possibly added in future versions}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}}
+  case .a: break
+  }
+
+  switch e { // Ok (no warnings)
+  case .a: break
+  @unknown default: break
+  }
+
+  switch pe {
+  // expected-warning@-1 {{switch covers known cases, but 'PE' may have additional unknown values, possibly added in future versions; this will be an error in a future Swift language mode}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}}
+  case .a: break
   }
 }

--- a/test/attr/attr_extensible.swift
+++ b/test/attr/attr_extensible.swift
@@ -38,3 +38,12 @@ struct Test {
     set { }
   }
 }
+
+@preEnumExtensibility
+@extensible
+public enum PE {
+}
+
+@preEnumExtensibility // expected-error {{@preEnumExtensibility can only be used together with '@extensible' attribute}}
+public enum WrongPreE {
+}


### PR DESCRIPTION
…s for extensible enums

Just like `@preconcurrency` for concurrency, this attribute is going to allow exhaustiveness error downgrades for enums that were retroactively marked as `@extensible`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
