### PR TITLE
[cxx-interop] Remove a workaround for CoreGraphics module interface

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2132,19 +2132,6 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
     subInvocation.setSysRoot(sysroot.value());
   }
 
-  // FIXME: Hack for CoreGraphics.swiftmodule, which cannot be rebuilt because
-  // of a CF_OPTIONS bug (rdar://142762174).
-  if (moduleName == "CoreGraphics") {
-    subInvocation.getLangOptions().EnableCXXInterop = false;
-    subInvocation.getLangOptions().cxxInteropCompatVersion = {};
-    BuildArgs.erase(llvm::remove_if(BuildArgs,
-                                    [](StringRef arg) -> bool {
-                                      return arg.starts_with(
-                                          "-cxx-interoperability-mode=");
-                                    }),
-                    BuildArgs.end());
-  }
-
   // Calculate output path of the module.
   SwiftInterfaceModuleOutputPathResolution::ResultTy resolvedOutputPath;
   getCachedOutputPath(resolvedOutputPath, moduleName, interfacePath, sdkPath);


### PR DESCRIPTION
CoreGraphics can now be rebuilt with C++ interop enabled, which makes this workaround obsolete.

rdar://150211857

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
