### PR TITLE
[Cmake] Add supplemental cmake modules

### DIFF
--- a/Runtimes/Supplemental/cmake/modules/CatalystSupport.cmake
+++ b/Runtimes/Supplemental/cmake/modules/CatalystSupport.cmake
@@ -1,0 +1,38 @@
+# Add flags for generating the zippered target variant in the build
+
+# Initialize `${PROJECT_NAME}_VARIANT_MODULE_TRIPLE` if the driver is able to emit
+# modules for the target variant.
+
+if(${PROJECT_NAME}_COMPILER_VARIANT_TARGET)
+  add_compile_options(
+    "$<$<COMPILE_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
+
+    # TODO: Remove me once we have a driver with
+    #   https://github.com/swiftlang/swift-driver/pull/1803
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xclang-linker -darwin-target-variant -Xclang-linker ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>")
+
+  add_link_options(
+    "$<$<LINK_LANGUAGE:C,CXX>:SHELL:-darwin-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
+    "$<$<LINK_LANGUAGE:Swift>:SHELL:-target-variant ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>"
+
+    # TODO: Remove me once we have a driver with
+    #   https://github.com/swiftlang/swift-driver/pull/1803
+    "$<$<LINK_LANGUAGE:Swift>:SHELL:-Xclang-linker -darwin-target-variant -Xclang-linker ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET}>")
+
+  # TODO: Once we are guaranteed to have a driver with the variant module path
+  #       support everywhere, we should integrate this into PlatformInfo.cmake
+  check_compiler_flag(Swift "-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/CompilerID/variant.swiftmodule" HAVE_Swift_VARIANT_MODULE_PATH_FLAG)
+  if(HAVE_Swift_VARIANT_MODULE_PATH_FLAG)
+    # Get variant module triple
+    set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info -target ${${PROJECT_NAME}_COMPILER_VARIANT_TARGET})
+    execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+    message(CONFIGURE_LOG "Swift target variant info: ${target_info_json}")
+
+
+    string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+    set(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used for installed swift{module,interface} files for the target variant")
+    mark_as_advanced(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
+    message(CONFIGURE_LOG "Swift target variant module triple: ${module_triple}")
+  endif()
+endif()

--- a/Runtimes/Supplemental/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Supplemental/cmake/modules/EmitSwiftInterface.cmake
@@ -1,0 +1,73 @@
+# Generate and install swift interface files
+
+# TODO: CMake should learn how to model library evolution and generate this
+#       stuff automatically.
+
+
+# Generate a swift interface file for the target if library evolution is enabled
+function(emit_swift_interface target)
+  # Generate the target-variant binary swift module when performing zippered
+  # build
+  if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
+    set(variant_module_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}")
+    file(MAKE_DIRECTORY "${variant_module_tmp_dir}")
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${variant_module_tmp_dir}/${target}.swiftmodule>")
+  endif()
+
+  # Generate textual swift interfaces is library-evolution is enabled
+  if(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION)
+    target_compile_options(${target} PRIVATE
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>
+      $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend$<SEMICOLON>-require-explicit-availability=ignore>)
+
+      # Emit catalyst swiftmodules and interfaces
+      if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
+        target_compile_options(${target} PRIVATE
+          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${variant_module_tmp_dir}/${target}.swiftinterface>"
+          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${variant_module_tmp_dir}/${target}.private.swiftinterface>")
+      endif()
+  endif()
+endfunction()
+
+# Install the generated swift interface file for the target if library evolution
+# is enabled.
+function(install_swift_interface target)
+  # Install binary swift modules
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+    RENAME "${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule"
+    DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+    COMPONENT ${PROJECT_NAME}_development)
+  if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}/${target}.swiftmodule"
+      RENAME "${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.swiftmodule"
+      DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+      COMPONENT ${PROJECT_NAME}_development)
+  endif()
+
+  # Install Swift interfaces if library-evolution is enabled
+  if(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface"
+      RENAME "${${PROJECT_NAME}_MODULE_TRIPLE}.swiftinterface"
+      DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+      COMPONENT ${PROJECT_NAME}_development)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface"
+      RENAME "${${PROJECT_NAME}_MODULE_TRIPLE}.private.swiftinterface"
+      DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+      COMPONENT ${PROJECT_NAME}_development)
+
+    # Install catalyst interface files
+    if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}/${target}.swiftinterface"
+        RENAME "${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.swiftinterface"
+        DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+        COMPONENT ${PROJECT_NAME}_development)
+      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}/${target}.private.swiftinterface"
+        RENAME "${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.private.swiftinterface"
+        DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+        COMPONENT ${PROJECT_NAME}_development)
+    endif()
+  endif()
+endfunction()

--- a/Runtimes/Supplemental/cmake/modules/PlatformInfo.cmake
+++ b/Runtimes/Supplemental/cmake/modules/PlatformInfo.cmake
@@ -1,0 +1,38 @@
+if(NOT ${PROJECT_NAME}_SIZEOF_POINTER)
+  set(${PROJECT_NAME}_SIZEOF_POINTER "${CMAKE_SIZEOF_VOID_P}" CACHE STRING "Size of a pointer in bytes")
+  message(CONFIGURE_LOG "Stdlib Pointer size: ${CMAKE_SIZEOF_VOID_P}")
+  mark_as_advanced(${PROJECT_NAME}_SIZEOF_POINTER)
+endif()
+
+# TODO: This logic should migrate to CMake once CMake supports installing swiftmodules
+set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)
+if(CMAKE_Swift_COMPILER_TARGET)
+  list(APPEND module_triple_command -target ${CMAKE_Swift_COMPILER_TARGET})
+endif()
+execute_process(COMMAND ${module_triple_command} OUTPUT_VARIABLE target_info_json)
+message(CONFIGURE_LOG "Swift target info: ${module_triple_command}\n"
+"${target_info_json}")
+
+if(NOT ${PROJECT_NAME}_MODULE_TRIPLE)
+  string(JSON module_triple GET "${target_info_json}" "target" "moduleTriple")
+  set(${PROJECT_NAME}_MODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used for installed swift{doc,module,interface} files")
+  mark_as_advanced(${PROJECT_NAME}_MODULE_TRIPLE)
+
+  message(CONFIGURE_LOG "Swift module triple: ${module_triple}")
+endif()
+
+if(NOT ${PROJECT_NAME}_PLATFORM_SUBDIR)
+  string(JSON platform GET "${target_info_json}" "target" "platform")
+  set(${PROJECT_NAME}_PLATFORM_SUBDIR "${platform}" CACHE STRING "Platform name used for installed swift{doc,module,interface} files")
+  mark_as_advanced(${PROJECT_NAME}_PLATFORM_SUBDIR)
+
+  message(CONFIGURE_LOG "Swift platform: ${platform}")
+endif()
+
+if(NOT ${PROJECT_NAME}_ARCH_SUBDIR)
+  string(JSON arch GET "${target_info_json}" "target" "arch")
+  set(${PROJECT_NAME}_ARCH_SUBDIR "${arch}" CACHE STRING "Architecture used for setting the architecture subdirectory")
+  mark_as_advanced(${PROJECT_NAME}_ARCH_SUBDIR)
+
+  message(CONFIGURE_LOG "Swift Arch: ${arch}")
+endif()

--- a/Runtimes/Supplemental/cmake/modules/ResourceEmbedding.cmake
+++ b/Runtimes/Supplemental/cmake/modules/ResourceEmbedding.cmake
@@ -1,0 +1,70 @@
+function(generate_plist project_name project_version target)
+  set(PLIST_INFO_PLIST "Info.plist")
+  set(PLIST_INFO_NAME "${project_name}")
+
+  # Underscores aren't permitted in the bundle identifier.
+  string(REPLACE "_" "" PLIST_INFO_UTI "com.apple.dt.runtime.${PLIST_INFO_NAME}")
+  set(PLIST_INFO_VERSION "${project_version}")
+  set(PLIST_INFO_BUILD_VERSION "${project_version}")
+
+  set(PLIST_INFO_PLIST_OUT "${PLIST_INFO_PLIST}")
+  set(PLIST_INFO_PLIST_IN "${PROJECT_SOURCE_DIR}/${PLIST_INFO_PLIST}.in")
+
+  if(APPLE)
+    target_link_options(${target} PRIVATE
+      "SHELL:-Xlinker -sectcreate -Xlinker __TEXT -Xlinker __info_plist -Xlinker ${CMAKE_CURRENT_BINARY_DIR}/${PLIST_INFO_PLIST_OUT}")
+  endif()
+
+  configure_file(
+      "${PLIST_INFO_PLIST_IN}"
+      "${PLIST_INFO_PLIST_OUT}"
+      @ONLY
+      NEWLINE_STYLE UNIX)
+
+  set_property(TARGET ${target} APPEND PROPERTY LINK_DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${PLIST_INFO_PLIST_OUT}")
+
+  # If Application Extensions are enabled, pass the linker flag marking
+  # the dylib as safe.
+  if (CXX_SUPPORTS_FAPPLICATION_EXTENSION AND (NOT DISABLE_APPLICATION_EXTENSION))
+    list(APPEND link_flags "-Wl,-application_extension")
+  endif()
+endfunction()
+
+# FIXME: it appears that `CMAKE_MT` evaluates to an empty string which prevents
+# the use of the variable. This aliases `MT` to `CMAKE_MT` and tries to fallback
+# to known spellings for the tool.
+if(WIN32 AND BUILD_SHARED_LIBS)
+  find_program(MT HINTS ${CMAKE_MT} NAMES mt llvm-mt REQUIRED)
+endif()
+
+function(embed_manifest target)
+  get_target_property(_EM_TARGET_TYPE ${target} TYPE)
+  if(NOT "${_EM_TARGET_TYPE}" MATCHES "SHARED_LIBRARY|EXECUTABLE")
+    return()
+  endif()
+
+  get_target_property(_EM_BINARY_DIR ${target} BINARY_DIR)
+  get_target_property(_EM_NAME ${target} NAME)
+
+  # Evaluate variables
+  file(CONFIGURE
+    OUTPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${PROJECT_VERSION}.1.manifest.in
+    CONTENT [[<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<assembly manifestversion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity
+    name="$<TARGET_NAME:@target@>"
+    processorArchitecture="@CMAKE_SYSTEM_PROCESSOR@"
+    type="win32"
+    version="@PROJECT_VERSION@" />
+  <file name="$<TARGET_FILE_NAME:@target@>" />
+</assembly>]])
+  # Evaluate generator expression
+  file(GENERATE
+    OUTPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${PROJECT_VERSION}.1.manifest
+    INPUT ${_EM_BINARY_DIR}/${_EM_NAME}-${PROJECT_VERSION}.1.manifest.in)
+
+  if(WIN32)
+    add_custom_command(TARGET ${target} POST_BUILD
+      COMMAND "${MT}" -nologo -manifest "${_EM_BINARY_DIR}/${_EM_NAME}-${PROJECT_VERSION}.1.manifest" "-outputresource:$<TARGET_FILE:${target}>;#1")
+  endif()
+endfunction()

--- a/Runtimes/Supplemental/cmake/modules/gyb.cmake
+++ b/Runtimes/Supplemental/cmake/modules/gyb.cmake
@@ -1,0 +1,47 @@
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+# Create a target to expand a gyb source
+# target_name: Name of the target
+# FLAGS  list of flags passed to gyb
+# DEPENDS list of dependencies
+# COMMENT Custom comment
+function(gyb_expand source output)
+  set(flags)
+  set(arguments)
+  set(multival_arguments FLAGS DEPENDS)
+  cmake_parse_arguments(GYB "${flags}" "${arguments}" "${multival_arguments}" ${ARGN})
+
+  get_filename_component(full_output_path ${output} ABSOLUTE BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+  get_filename_component(dir "${full_output_path}" DIRECTORY)
+  get_filename_component(fname "${full_output_path}" NAME)
+
+  file(READ "${source}" gyb_src)
+  string(REGEX MATCHALL "\\\$\{[\r\n\t ]*gyb.expand\\\([\r\n\t ]*[\'\"]([^\'\"]*)[\'\"]" gyb_expand_matches "${gyb_src}")
+  foreach(match ${gyb_expand_matches})
+    string(REGEX MATCH "[\'\"]\([^\'\"]*\)[\'\"]" gyb_dep "${match}")
+    list(APPEND gyb_expand_deps "${CMAKE_MATCH_1}")
+  endforeach()
+  list(REMOVE_DUPLICATES gyb_expand_deps)
+
+  set(utils_dir "${${PROJECT_NAME}_SWIFTC_SOURCE_DIR}/utils/")
+  set(gyb_tool "${utils_dir}/gyb")
+
+  # All the tidbits to track for changes
+  list(APPEND GYB_DEPENDS
+    "${source}"
+    "${utils_dir}/GYBUnicodeDataUtils.py"
+    "${utils_dir}/SwiftIntTypes.py"
+    "${utils_dir}/SwiftFloatingPointTypes.py"
+    "${utils_dir}/UnicodeData/GraphemeBreakProperty.txt"
+    "${utils_dir}/UnicodeData/GraphemeBreakTest.txt"
+    "${utils_dir}/gyb_stdlib_support.py")
+  add_custom_command(
+    OUTPUT  "${full_output_path}"
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${dir}"
+    COMMAND "${CMAKE_COMMAND}" -E env "$<TARGET_FILE:Python3::Interpreter>" "${gyb_tool}" ${GYB_FLAGS} -o "${full_output_path}.tmp" "${source}"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${full_output_path}.tmp" "${full_output_path}"
+    COMMAND "${CMAKE_COMMAND}" -E remove "${full_output_path}.tmp"
+    DEPENDS ${gyb_tool} ${gyb_tool}.py ${GYB_DEPENDS} ${gyb_expand_deps}
+    COMMENT "Generating GYB source ${fname} from ${source}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endfunction()


### PR DESCRIPTION
Adds common CMAKE modules to be used by the supplemental libraries. Namely:
* ResourceEmbedding
* PlatformInfo
* gyb
* EmitSwiftInterface
* CatalystSupport
