### PR TITLE
[6.2] AST: Fix existential erasure of long member types

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -340,7 +340,6 @@ struct OuterSubstitutions {
   SubstitutionMap subs;
   unsigned depth;
 
-  bool isUnsubstitutedTypeParameter(Type type) const;
   Type operator()(SubstitutableType *type) const;
   ProtocolConformanceRef operator()(CanType dependentType,
                                     Type conformingReplacementType,

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -317,9 +317,13 @@ GenericEnvironment::maybeApplyOuterContextSubstitutions(Type type) const {
   case Kind::OpenedExistential:
   case Kind::OpenedElement:
   case Kind::Opaque: {
-    OuterSubstitutions replacer{
-        getOuterSubstitutions(), getGenericSignature()->getMaxDepth()};
-    return type.subst(replacer, replacer);
+    if (auto subs = getOuterSubstitutions()) {
+      OuterSubstitutions replacer{subs,
+                                  getGenericSignature()->getMaxDepth()};
+      return type.subst(replacer, replacer);
+    }
+
+    return type;
   }
   }
 }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -669,21 +669,8 @@ SubstitutionMap SubstitutionMap::mapIntoTypeExpansionContext(
                      SubstFlags::PreservePackExpansionLevel);
 }
 
-bool OuterSubstitutions::isUnsubstitutedTypeParameter(Type type) const {
-  if (!type->isTypeParameter())
-    return false;
-
-  if (auto depMemTy = type->getAs<DependentMemberType>())
-    return isUnsubstitutedTypeParameter(depMemTy->getBase());
-
-  if (auto genericParam = type->getAs<GenericTypeParamType>())
-    return genericParam->getDepth() >= depth;
-
-  return false;
-}
-
 Type OuterSubstitutions::operator()(SubstitutableType *type) const {
-  if (isUnsubstitutedTypeParameter(type))
+  if (cast<GenericTypeParamType>(type)->getDepth() >= depth)
     return Type(type);
 
   return QuerySubstitutionMap{subs}(type);
@@ -693,9 +680,23 @@ ProtocolConformanceRef OuterSubstitutions::operator()(
                                         CanType dependentType,
                                         Type conformingReplacementType,
                                         ProtocolDecl *conformedProtocol) const {
-  if (isUnsubstitutedTypeParameter(dependentType))
-    return ProtocolConformanceRef::forAbstract(
+  auto sig = subs.getGenericSignature();
+  if (!sig->isValidTypeParameter(dependentType) ||
+      !sig->requiresProtocol(dependentType, conformedProtocol)) {
+    // FIXME: We need the isValidTypeParameter() check instead of just looking
+    // at the root generic parameter because in the case of an existential
+    // environment, the reduced type of a member type of Self might be an outer
+    // type parameter that is not formed from the outer generic signature's
+    // conformance requirements. Ideally, we'd either add these supplementary
+    // conformance requirements to the generalization signature, or we would
+    // store the supplementary conformances directly in the generic environment
+    // somehow.
+    //
+    // Once we check for that and handle it properly, the lookupConformance()
+    // can become a forAbstract().
+    return swift::lookupConformance(
       conformingReplacementType, conformedProtocol);
+  }
 
   return LookUpConformanceInSubstitutionMap(subs)(
       dependentType, conformingReplacementType, conformedProtocol);

--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -823,10 +823,11 @@ Type swift::typeEraseOpenedExistentialReference(
 
   auto applyOuterSubstitutions = [&](Type t) -> Type {
     if (t->hasTypeParameter()) {
-      auto outerSubs = existentialSig.Generalization;
-      unsigned depth = existentialSig.OpenedSig->getMaxDepth();
-      OuterSubstitutions replacer{outerSubs, depth};
-      return t.subst(replacer, replacer);
+      if (auto outerSubs = existentialSig.Generalization) {
+        unsigned depth = existentialSig.OpenedSig->getMaxDepth();
+        OuterSubstitutions replacer{outerSubs, depth};
+        return t.subst(replacer, replacer);
+      }
     }
 
     return t;

--- a/test/SILGen/existential_erasure_length_2.swift
+++ b/test/SILGen/existential_erasure_length_2.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-silgen %s
+
+protocol N {
+  associatedtype A: N
+}
+
+protocol P<A> {
+  associatedtype A: N
+  associatedtype B
+
+  func f0(_: A) -> B
+  func f1(_: A.A) -> B
+  func f2(_: A.A.A) -> B
+}
+
+struct G<T>: N {
+  typealias A = G<G<T>>
+}
+
+func call(x: any P<G<Int>>) -> (Any, Any, Any) {
+  let y0 = x.f0(G<Int>())
+  let y1 = x.f1(G<G<Int>>())
+  let y2 = x.f2(G<G<G<Int>>>())
+  return (y0, y1, y2)
+}


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/81181

* **Description:** Fixes a compiler crash in some circumstances when erasing a type parameter that is rooted in a primary associated type of an existential value.

* **Origination:** The regression shipped in Swift 6.1.

* **Reviewed by:** @AnthonyLatsis 

* **Risk:** Low. This changes a frequently-called code path, but I believe it's well-tested. The isValidTypeParameter() check does not assert on invalid inputs, and it returns true in all cases that the old check returned true.

- Fixes https://github.com/swiftlang/swift/issues/79763.
- Fixes rdar://problem/146111083.
