### PR TITLE
[AST] Rename isArrayType and split the InlineArray portion

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -987,9 +987,13 @@ public:
   /// type) from `DistributedActor`.
   bool isDistributedActor();
 
-  /// Determine if the type in question is an Array<T> and, if so, provide the
+  /// Determine if this type is an Array<T> and, if so, provide the element type
+  /// of the array.
+  Type getArrayElementType();
+
+  /// Determine if this type is an InlineArray<n, T> and, if so, provide the
   /// element type of the array.
-  Type isArrayType();
+  Type getInlineArrayElementType();
 
   /// Determines the element type of a known
   /// [Autoreleasing]Unsafe[Mutable][Raw]Pointer variant, or returns null if the

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -829,15 +829,22 @@ CanType CanType::wrapInOptionalTypeImpl(CanType type) {
   return type->wrapInOptionalType()->getCanonicalType();
 }
 
-Type TypeBase::isArrayType() {
-  if (auto boundStruct = getAs<BoundGenericStructType>()) {
-    if (isArray())
-      return boundStruct->getGenericArgs()[0];
+Type TypeBase::getArrayElementType() {
+  if (!isArray())
+    return Type();
 
-    if (isInlineArray())
-      return boundStruct->getGenericArgs()[1];
-  }
-  return Type();
+  // Array<T>
+  auto boundStruct = castTo<BoundGenericStructType>();
+  return boundStruct->getGenericArgs()[0];
+}
+
+Type TypeBase::getInlineArrayElementType() {
+  if (!isInlineArray())
+    return Type();
+
+  // InlineArray<n, T>
+  auto boundStruct = castTo<BoundGenericStructType>();
+  return boundStruct->getGenericArgs()[1];
 }
 
 Type TypeBase::getAnyPointerElementType(PointerTypeKind &PTK) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -833,6 +833,9 @@ Type TypeBase::getArrayElementType() {
   if (!isArray())
     return Type();
 
+  if (!is<BoundGenericStructType>())
+    return Type();
+
   // Array<T>
   auto boundStruct = castTo<BoundGenericStructType>();
   return boundStruct->getGenericArgs()[0];
@@ -840,6 +843,9 @@ Type TypeBase::getArrayElementType() {
 
 Type TypeBase::getInlineArrayElementType() {
   if (!isInlineArray())
+    return Type();
+
+  if (!is<BoundGenericStructType>())
     return Type();
 
   // InlineArray<n, T>

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6680,7 +6680,7 @@ static void diagnoseImplicitRawConversion(Type sourceTy, Type pointerTy,
   // Array conversion does not always go down the ArrayConverter
   // path. Recognize the Array source type here both for ArrayToPointer and
   // InoutToPointer cases and diagnose on the element type.
-  Type eltTy = sourceTy->isArrayType();
+  Type eltTy = sourceTy->getArrayElementType();
   if (!eltTy)
     eltTy = sourceTy;
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6891,7 +6891,7 @@ bool ExprRewriter::peepholeCollectionUpcast(Expr *expr, Type toType,
 
   // Array literals.
   if (auto arrayLiteral = dyn_cast<ArrayExpr>(expr)) {
-    if (Type elementType = toType->isArrayType()) {
+    if (auto elementType = toType->getArrayElementType()) {
       peepholeArrayUpcast(arrayLiteral, toType, bridged, elementType, locator);
       return true;
     }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1385,7 +1385,7 @@ static bool hasConversions(Type type) {
     return true;
 
   if (auto *structTy = type->getAs<BoundGenericStructType>()) {
-    if (auto eltTy = structTy->isArrayType()) {
+    if (auto eltTy = structTy->getArrayElementType()) {
       return hasConversions(eltTy);
     } else if (auto pair = ConstraintSystem::isDictionaryType(structTy)) {
       return hasConversions(pair->second);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1979,7 +1979,7 @@ bool RValueTreatedAsLValueFailure::diagnoseAsError() {
       auto argType = getType(inoutExpr)->getWithoutSpecifierType();
 
       PointerTypeKind ptr;
-      if (argType->isArrayType() && paramType->getAnyPointerElementType(ptr)
+      if (argType->isArray() && paramType->getAnyPointerElementType(ptr)
           && (ptr == PTK_UnsafePointer || ptr == PTK_UnsafeRawPointer)) {
         emitDiagnosticAt(inoutExpr->getLoc(),
                          diag::extra_address_of_unsafepointer, paramType)

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -219,7 +219,7 @@ TreatArrayLiteralAsDictionary *
 TreatArrayLiteralAsDictionary::attempt(ConstraintSystem &cs, Type dictionaryTy,
                                        Type arrayTy,
                                        ConstraintLocator *locator) {
-  if (!arrayTy->isArrayType())
+  if (!arrayTy->isArray())
     return nullptr;
 
   // Determine the ArrayExpr from the locator.
@@ -1814,7 +1814,7 @@ ExpandArrayIntoVarargs::attempt(ConstraintSystem &cs, Type argType,
   if (!(argLoc && argLoc->getParameterFlags().isVariadic()))
     return nullptr;
 
-  auto elementType = argType->isArrayType();
+  auto elementType = argType->getArrayElementType();
   if (!elementType)
     return nullptr;
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2157,7 +2157,8 @@ namespace {
 
       // If a contextual type exists for this expression, apply it directly.
       if (contextualType &&
-          (contextualType->isArray() || contextualType->isInlineArray())) {
+          (contextualType->getArrayElementType() ||
+           contextualType->getInlineArrayElementType())) {
         // Now that we know we're actually going to use the type, get the
         // version for use in a constraint.
         contextualType = CS.getContextualType(expr, /*forConstraint=*/true);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1085,7 +1085,12 @@ namespace {
           baseObjTy = baseObjTy->getWithoutSpecifierType();
         }
 
-        if (auto elementTy = baseObjTy->isArrayType()) {
+        auto elementTy = baseObjTy->getArrayElementType();
+
+        if (!elementTy)
+          elementTy = baseObjTy->getInlineArrayElementType();
+
+        if (elementTy) {
 
           if (auto arraySliceTy = 
                 dyn_cast<ArraySliceType>(baseObjTy.getPointer())) {
@@ -2151,18 +2156,27 @@ namespace {
       };
 
       // If a contextual type exists for this expression, apply it directly.
-      if (contextualType && contextualType->isArrayType()) {
+      if (contextualType &&
+          (contextualType->isArray() || contextualType->isInlineArray())) {
         // Now that we know we're actually going to use the type, get the
         // version for use in a constraint.
         contextualType = CS.getContextualType(expr, /*forConstraint=*/true);
         // FIXME: This is the wrong place to be opening the opaque type.
         contextualType = CS.openOpaqueType(
             contextualType, contextualPurpose, locator, /*ownerDecl=*/nullptr);
-        Type arrayElementType = contextualType->isArrayType();
+
+        Type eltType;
+
+        if (contextualType->isArray())
+          eltType = contextualType->getArrayElementType();
+
+        if (contextualType->isInlineArray())
+          eltType = contextualType->getInlineArrayElementType();
+
         CS.addConstraint(ConstraintKind::LiteralConformsTo, contextualType,
                          arrayProto->getDeclaredInterfaceType(),
                          locator);
-        joinElementTypes(arrayElementType);
+        joinElementTypes(eltType);
         return contextualType;
       }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1692,7 +1692,7 @@ struct TypeSimplifier {
             auto elementAssocTy = arrayProto->getAssociatedTypeMembers()[0];
 
             if (proto == arrayProto && assocType == elementAssocTy) {
-              return lookupBaseType->isArrayType();
+              return lookupBaseType->getInlineArrayElementType();
             }
           }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1860,8 +1860,8 @@ TypeChecker::typeCheckCheckedCast(Type fromType, Type toType,
   };
 
   // Check for casts between specific concrete types that cannot succeed.
-  if (auto toElementType = toType->isArrayType()) {
-    if (auto fromElementType = fromType->isArrayType()) {
+  if (auto toElementType = toType->getArrayElementType()) {
+    if (auto fromElementType = fromType->getArrayElementType()) {
       return checkElementCast(fromElementType, toElementType,
                               CheckedCastKind::ArrayDowncast);
     }

--- a/test/Sema/inlinearray.swift
+++ b/test/Sema/inlinearray.swift
@@ -153,3 +153,11 @@ func testMismatches(_ x: [3 x Int], _ y: InlineArray<3, Int>) {
   let _: [3 x String] = y  // expected-error {{cannot assign value of type 'InlineArray<3, Int>' to type '[3 x String]'}}
   // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
 }
+
+func testPointerConversion() {
+  var inlineArray = InlineArray<1, Int>(repeating: 0)
+  acceptPointer(&inlineArray) // expected-error {{cannot convert value of type 'UnsafeMutablePointer<InlineArray<1, Int>>' to expected argument type 'UnsafeMutablePointer<Int>'}}
+                              // expected-note@-1 {{arguments to generic parameter 'Pointee' ('InlineArray<1, Int>' and 'Int') are expected to be equal}}
+}
+
+func acceptPointer(_ pointer: UnsafeMutablePointer<Int>) {}

--- a/unittests/Sema/PlaceholderTypeInferenceTests.cpp
+++ b/unittests/Sema/PlaceholderTypeInferenceTests.cpp
@@ -49,7 +49,7 @@ TEST_F(SemaTest, TestPlaceholderInferenceForArrayLiteral) {
 
   auto &solution = solutions[0];
 
-  auto eltTy = solution.simplifyType(solution.getType(arrayExpr))->isArrayType();
+  auto eltTy = solution.simplifyType(solution.getType(arrayExpr))->getArrayElementType();
   ASSERT_TRUE(eltTy);
   ASSERT_TRUE(eltTy->is<StructType>());
   ASSERT_EQ(eltTy->getAs<StructType>()->getDecl(), intTypeDecl);


### PR DESCRIPTION
`isArrayType` was poorly named and included `InlineArray`. Let's rename it to what it actually does and create and identical `InlineArray` version as well.

Resolves: https://github.com/swiftlang/swift/issues/81072