### PR TITLE
[swift-inspect] Add json and summary options to DumpRawMetadata

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -62,10 +62,7 @@ internal struct BacktraceOptions: ParsableArguments {
   }
 }
 
-internal struct GenericMetadataOptions: ParsableArguments {
-  @Flag(help: "Show allocations in mangled form")
-  var mangled: Bool = false
-
+internal struct MetadataOptions: ParsableArguments {
   @Flag(help: "Output JSON")
   var json: Bool = false
 


### PR DESCRIPTION
Add json and summary options to `swift-inspect --dump-raw-metadata`. These options already exist for `--dump-generic-metadata` albeit with slightly different functionality.

- `--json`: This will output the list of allocations as a json list. If `--summary` is specified the summary will be included in this json. If `--output-file` is specified then this output will save to a file otherwise it is printed without formatting.
- `--summary`: This will output the amount of bytes allocated per tag type and the total amount of bytes allocated. If `--json` is specified this will be displayed as part of the larger json otherwise it is printed without formatting.
- `output-file`: As mentioned above this will save the json to the specified parameter file.

Example invocation: `swift-inspect dump-raw-metadata Finder --summary --json --output-file=example.json`
[example.json](https://github.com/user-attachments/files/19968843/example.json)

rdar://148131548