### PR TITLE
[cxx-interop] Avoid unchecked recursion when importing C++ classes with circular inheritance

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -786,6 +786,22 @@ bool declIsCxxOnly(const Decl *decl);
 
 /// Is this DeclContext an `enum` that represents a C++ namespace?
 bool isClangNamespace(const DeclContext *dc);
+
+/// For some \a templatedClass that inherits from \a base, whether they are
+/// derived from the same class template.
+///
+/// This kind of circular inheritance can happen when a templated class inherits
+/// from a specialization of itself, e.g.:
+///
+///     template <typename T> class C;
+///     template <> class C<void> { /* ... */ };
+///     template <typename T> class C<T> : C<void> { /* ... */ };
+///
+/// Checking for this kind of scenario is necessary for avoiding infinite
+/// recursion during symbolic imports (importSymbolicCXXDecls), where
+/// specialized class templates are instead imported as unspecialized.
+bool isSymbolicCircularBase(const clang::CXXRecordDecl *templatedClass,
+                            const clang::RecordDecl *base);
 } // namespace importer
 
 struct ClangInvocationFileMapping {

--- a/test/Interop/Cxx/class/inheritance/Inputs/circular-inheritance.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/circular-inheritance.h
@@ -1,0 +1,32 @@
+#ifndef CIRCULAR_INHERITANCE_H
+#define CIRCULAR_INHERITANCE_H
+
+struct DinoEgg {
+  void dinoEgg(void) const {}
+};
+
+template <typename Chicken>
+struct Egg;
+
+template <>
+struct Egg<void> : DinoEgg {
+  Egg() {}
+  void voidEgg(void) const {}
+};
+
+template <typename Chicken>
+struct Egg : Egg<void> {
+  Egg(Chicken _chicken) {}
+  Chicken chickenEgg(Chicken c) const { return c; }
+};
+
+typedef Egg<void> VoidEgg;
+typedef Egg<bool> BoolEgg;
+typedef Egg<Egg<void>> EggEgg;
+
+struct NewEgg : Egg<int> {
+  NewEgg() : Egg<int>(555) {}
+  void newEgg() const {}
+};
+
+#endif // !CIRCULAR_INHERITANCE_H

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -48,3 +48,8 @@ module InheritedLookup {
   header "inherited-lookup.h"
   requires cplusplus
 }
+
+module CircularInheritance {
+  header "circular-inheritance.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/inheritance/circular-inheritance-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/circular-inheritance-typechecker.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t/index)
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -index-store-path %t/index
+//
+// Note that we specify an -index-store-path to ensure we also test importing symbolic C++ decls,
+// to exercise code that handles importing unspecialized class templates.
+
+import CircularInheritance
+
+let voidEgg = VoidEgg()
+voidEgg.dinoEgg()
+voidEgg.voidEgg()
+
+let boolEgg = BoolEgg(false)
+boolEgg.dinoEgg()
+boolEgg.voidEgg()
+boolEgg.chickenEgg(true)
+
+let eggEgg = EggEgg(VoidEgg())
+eggEgg.dinoEgg()
+eggEgg.voidEgg()
+eggEgg.chickenEgg(VoidEgg())
+
+let newEgg = NewEgg()
+newEgg.dinoEgg()
+newEgg.voidEgg()
+newEgg.chickenEgg(555)
+newEgg.newEgg()


### PR DESCRIPTION
It is possible for a C++ class template to inherit from a specialization of itself. Normally, these are imported to Swift as separate (unrelated) types, but when symbolic import is enabled, unspecialized templates are imported in place of their specializations, leading to circularly inheriting classes to seemingly inherit from themselves.

This patch adds a check to guard against the most common case of circular inheritance, when a class template directly inherits from itself. This pattern appears in a recent version of libc++, necessitating this patch. However, the solution here is imperfect as it does not handle more complex/contrived circular inheritance patterns.

This patch also adds a test case exercising this pattern. The -index-store-path flag causes swift-frontend to index the C++ module with symbolic import enabled, without the fix in this patch, that test triggers an assertion failure due to the circular reference (and can infinitely recurse in the StorageVisitor when assertions are disabled).

rdar://148026461

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
