### PR TITLE
[6.2] LifetimeDependenceDiagnostics: bug fixes and output clarity

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -238,37 +238,51 @@ private struct DiagnoseDependence {
 
     // Identify the escaping variable.
     let escapingVar = LifetimeVariable(dependent: operand.value, context)
-    let varName = escapingVar.name
-    if let varName {
-      diagnose(escapingVar.sourceLoc, .lifetime_variable_outside_scope,
-               varName)
+    if let varDecl = escapingVar.varDecl {
+      // Use the variable location, not the access location.
+      diagnose(varDecl.nameLoc, .lifetime_variable_outside_scope, escapingVar.name ?? "")
+    } else if let sourceLoc = escapingVar.sourceLoc {
+      diagnose(sourceLoc, .lifetime_value_outside_scope)
     } else {
-      diagnose(escapingVar.sourceLoc, .lifetime_value_outside_scope)
+      // Always raise an error even if we can't find a source location.
+      let sourceLoc = function.location.sourceLoc
+      if let accessorKind =  escapingVar.accessorKind {
+        diagnose(sourceLoc, .lifetime_value_outside_accessor, accessorKind)
+      } else {
+        // Thunks do not have a source location, but we try to use the function location anyway.
+        let thunkSelect = dependence.function.thunkKind == .noThunk ? 0 : 1
+        diagnose(sourceLoc, .lifetime_value_outside_thunk, thunkSelect, function.name)
+      }
     }
     reportScope()
     // Identify the use point.
-    let userSourceLoc = operand.instruction.location.sourceLoc
-    diagnose(userSourceLoc, diagID)
+    if let userSourceLoc = operand.instruction.location.sourceLoc {
+      diagnose(userSourceLoc, diagID)
+    }
   }
 
-  // Identify the dependence scope.
+  // Identify the dependence scope. If no source location is found, bypass this diagnostic.
   func reportScope() {
-    if case let .access(beginAccess) = dependence.scope {
-      let parentVar = LifetimeVariable(dependent: beginAccess, context)
-      if let sourceLoc = beginAccess.location.sourceLoc ?? parentVar.sourceLoc {
-        diagnose(sourceLoc, .lifetime_outside_scope_access,
-                 parentVar.name ?? "")
+    let parentVar = LifetimeVariable(dependent: dependence.parentValue, context)
+    // First check if the dependency is limited to an access scope. If the access has no source location then
+    // fall-through to report possible dependence on an argument.
+    if parentVar.isAccessScope, let accessLoc = parentVar.sourceLoc {
+      diagnose(accessLoc, .lifetime_outside_scope_access, parentVar.name ?? "")
+      return
+    }
+    // If the argument does not have a source location (e.g. a synthesized accessor), report the function location. The
+    // function's source location is sufficient for argument diagnostics, but if the function has no location, don't
+    // report any scope.
+    if parentVar.isArgument, let argLoc = parentVar.sourceLoc ?? function.location.sourceLoc {
+      if let parentName = parentVar.name {
+        diagnose(argLoc, .lifetime_outside_scope_argument, parentName)
+      } else {
+        diagnose(argLoc, .lifetime_outside_scope_synthesized_argument, parentVar.accessorKind ?? function.name)
       }
       return
     }
-    if let arg = dependence.parentValue as? Argument,
-       let varDecl = arg.varDecl,
-       let sourceLoc = arg.sourceLoc {
-      diagnose(sourceLoc, .lifetime_outside_scope_argument,
-               varDecl.userFacingName)
-      return
-    }
-    let parentVar = LifetimeVariable(dependent: dependence.parentValue, context)
+    // Now diagnose dependencies on regular variable and value scopes.
+    // Thunks do not have a function location, so any scopes inside the thunk will be ignored.
     if let parentLoc = parentVar.sourceLoc {
       if let parentName = parentVar.name {
         diagnose(parentLoc, .lifetime_outside_scope_variable, parentName)
@@ -282,24 +296,34 @@ private struct DiagnoseDependence {
 // Identify a best-effort variable declaration based on a defining SIL
 // value or any lifetime dependent use of that SIL value.
 private struct LifetimeVariable {
-  var varDecl: VarDecl?
-  var sourceLoc: SourceLoc?
+  var varDecl: VarDecl? = nil
+  var sourceLoc: SourceLoc? = nil
+  var isArgument: Bool = false
+  var isAccessScope: Bool = false
+  var accessorKind: String?
+  var thunkKind: Function.ThunkKind = .noThunk
   
   var name: StringRef? {
     return varDecl?.userFacingName
   }
 
   init(dependent value: Value, _ context: some Context) {
-    if value.type.isAddress {
-      self = Self(accessBase: value.accessBase, context)
+    guard let introducer = getFirstVariableIntroducer(of: value, context) else {
       return
     }
-    if let firstIntroducer = getFirstVariableIntroducer(of: value, context) {
-      self = Self(introducer: firstIntroducer)
+    if introducer.type.isAddress {
+      if let beginAccess = introducer as? BeginAccessInst {
+        // Recurse through beginAccess to find the variable introducer rather than the variable access.
+        self = .init(dependent: beginAccess.address, context)
+        self.isAccessScope = true
+        // However, remember source location of the innermost access.
+        self.sourceLoc = beginAccess.location.sourceLoc ?? self.sourceLoc
+        return
+      }
+      self = .init(accessBase: introducer.accessBase, context)
       return
     }
-    self.varDecl = nil
-    self.sourceLoc = nil
+    self = Self(introducer: introducer, context)
   }
 
   private func getFirstVariableIntroducer(of value: Value, _ context: some Context) -> Value? {
@@ -313,15 +337,21 @@ private struct LifetimeVariable {
     return introducer
   }
 
-  private init(introducer: Value) {
+  private init(introducer: Value, _ context: some Context) {
     if let arg = introducer as? Argument {
       self.varDecl = arg.varDecl
-    } else {
-      self.sourceLoc = introducer.definingInstruction?.location.sourceLoc
-      self.varDecl = introducer.definingInstruction?.findVarDecl()
+      self.sourceLoc = arg.sourceLoc
+      self.isArgument = true
+      return
     }
-    if let varDecl {
-      sourceLoc = varDecl.nameLoc
+    if let varDecl = introducer.definingInstruction?.findVarDecl() {
+      self.varDecl = varDecl
+      self.sourceLoc = varDecl.nameLoc
+    } else if let sourceLoc = introducer.definingInstruction?.location.sourceLoc {
+      self.sourceLoc = sourceLoc
+    } else {
+      self.accessorKind = introducer.parentFunction.accessorKindName
+      self.thunkKind = introducer.parentFunction.thunkKind
     }
   }
 
@@ -335,32 +365,27 @@ private struct LifetimeVariable {
       // never be produced by one of these, except when it is redundant with the `alloc_box` VarDecl. It does not seem
       // possible for a box to be moved/borrowed directly into another variable's box. Reassignment always loads/stores
       // the value.
-      self = Self(introducer: projectBox.box.referenceRoot)
+      self = .init(introducer: projectBox.box.referenceRoot, context)
     case .stack(let allocStack):
-      self = Self(introducer: allocStack)
+      self = .init(introducer: allocStack, context)
     case .global(let globalVar):
       self.varDecl = globalVar.varDecl
       self.sourceLoc = varDecl?.nameLoc
     case .class(let refAddr):
-      self.varDecl = refAddr.varDecl
-      self.sourceLoc = refAddr.location.sourceLoc
+      self = .init(introducer: refAddr, context)
     case .tail(let refTail):
-      self = Self(introducer: refTail.instance)
+      self = .init(introducer: refTail.instance, context)
     case .argument(let arg):
-      self.varDecl = arg.varDecl
-      self.sourceLoc = arg.sourceLoc
+      self = .init(introducer: arg, context)
     case .yield(let result):
       // TODO: bridge VarDecl for FunctionConvention.Yields
-      self.varDecl = nil
-      self.sourceLoc = result.parentInstruction.location.sourceLoc
+      self = .init(introducer: result, context)
     case .storeBorrow(let sb):
       self = .init(dependent: sb.source, context)
     case .pointer(let ptrToAddr):
-      self.varDecl = nil
-      self.sourceLoc = ptrToAddr.location.sourceLoc
+      self = .init(introducer: ptrToAddr, context)
     case .index, .unidentified:
-      self.varDecl = nil
-      self.sourceLoc = nil
+      break
     }
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -1221,6 +1221,24 @@ extension LifetimeDependenceUseDefAddressWalker {
   }
 
   mutating func walkUpDefault(address: Value, access: AccessBaseAndScopes) -> WalkResult {
+    if let beginAccess = access.innermostAccess {
+      // Skip the access scope for unsafe[Mutable]Address. Treat it like a projection of 'self' rather than a separate
+      // variable access.
+      if let addressorSelf = beginAccess.unsafeAddressorSelf {
+        return walkUp(newLifetime: addressorSelf)
+      }
+      // Ignore the acces scope for trivial values regardless of whether it is singly-initialized. Trivial values do not
+      // need to be kept alive in memory and can be safely be overwritten in the same scope. Lifetime dependence only
+      // cares that the loaded value is within the lexical scope of the trivial value's variable declaration. Rather
+      // than skipping all access scopes, call 'walkUp' on each nested access in case one of them needs to redirect the
+      // walk, as required for 'access.unsafeAddressorSelf' or in case the implementation overrides certain accesses.
+      if isTrivialScope {
+        return walkUp(newLifetime: beginAccess.address)
+      }
+      // Generally assume an access scope introduces a variable borrow scope. And generally ignore address forwarding
+      // mark_dependence.
+      return addressIntroducer(beginAccess, access: access)
+    }
     // Continue walking for some kinds of access base.
     switch access.base {
     case .box, .global, .class, .tail, .pointer, .index, .unidentified:
@@ -1229,14 +1247,9 @@ extension LifetimeDependenceUseDefAddressWalker {
       // Ignore stack locations. Their access scopes do not affect lifetime dependence.
       return walkUp(stackInitializer: allocStack, at: address, access: access)
     case let .argument(arg):
-      // Ignore access scopes for @in or @in_guaranteed arguments when all scopes are reads. Do not ignore a [read]
-      // access of an inout argument or outer [modify]. Mutation later with the outer scope could invalidate the
-      // borrowed state in this narrow scope. Do not ignore any mark_depedence on the address.
-      if arg.convention.isIndirectIn && access.isOnlyReadAccess {
+      if arg.convention.isExclusiveIndirect {
         return addressIntroducer(arg, access: access)
       }
-      // @inout arguments may be singly initialized (when no modification exists in this function), but this is not
-      // relevant here because they require nested access scopes which can never be ignored.
     case let .yield(yieldedAddress):
       // Ignore access scopes for @in or @in_guaranteed yields when all scopes are reads.
       let apply = yieldedAddress.definingInstruction as! FullApplySite
@@ -1248,27 +1261,6 @@ extension LifetimeDependenceUseDefAddressWalker {
       if access.scopes.isEmpty,
          case .stack = sb.destinationOperand.value.accessBase {
         return walkUp(newLifetime: sb.source)
-      }
-    }
-    // Skip the access scope for unsafe[Mutable]Address. Treat it like a projection of 'self' rather than a separate
-    // variable access.
-    if case let .access(innerAccess) = access.scopes.first,
-       let addressorSelf = innerAccess.unsafeAddressorSelf {
-      return walkUp(newLifetime: addressorSelf)
-    }
-    // Ignore the acces scope for trivial values regardless of whether it is singly-initialized. Trivial values do not
-    // need to be kept alive in memory and can be safely be overwritten in the same scope. Lifetime dependence only
-    // cares that the loaded value is within the lexical scope of the trivial value's variable declaration. Rather than
-    // skipping all access scopes, call 'walkUp' on each nested access in case one of them needs to redirect the walk,
-    // as required for 'access.unsafeAddressorSelf'.
-    if isTrivialScope {
-      switch access.scopes.first {
-      case .none, .base:
-        break
-      case let .access(beginAccess):
-        return walkUp(newLifetime: beginAccess.address)
-      case let .dependence(markDep):
-        return walkUp(newLifetime: markDep.value)
       }
     }
     return addressIntroducer(access.enclosingAccess.address ?? address, access: access)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -1285,7 +1285,7 @@ extension LifetimeDependenceUseDefAddressWalker {
       case let store as StoringInstruction:
         return walkUp(newLifetime: store.source)
       case let srcDestInst as SourceDestAddrInstruction:
-        return walkUp(newLifetime: srcDestInst.destination)
+        return walkUp(newLifetime: srcDestInst.source)
       case let apply as FullApplySite:
         if let f = apply.referencedFunction, f.isConvertPointerToPointerArgument {
           return walkUp(newLifetime: apply.parameterOperands[0].value)

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -34,7 +34,12 @@ public class Argument : Value, Hashable {
 
   public var isLexical: Bool { false }
 
-  public var varDecl: VarDecl? { bridged.getVarDecl().getAs(VarDecl.self) }
+  public var varDecl: VarDecl? {
+    if let varDecl = bridged.getVarDecl().getAs(VarDecl.self) {
+      return varDecl
+    }
+    return debugUserDecl
+  }
 
   public var sourceLoc: SourceLoc? { varDecl?.nameLoc }
 

--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -61,6 +61,10 @@ final public class FunctionArgument : Argument {
     bridged.FunctionArgument_isLexical()
   }
 
+  public var isClosureCapture: Bool {
+    bridged.FunctionArgument_isClosureCapture()
+  }
+
   public var isSelf: Bool {
     parentFunction.argumentConventions.selfIndex == index
   }

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -219,6 +219,13 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     }
   }
 
+  public var accessorKindName: String? {
+    guard bridged.isAccessor() else {
+      return nil
+    }
+    return StringRef(bridged: bridged.getAccessorName()).string
+  }
+
   /// True, if the function runs with a swift 5.1 runtime.
   /// Note that this is function specific, because inlinable functions are de-serialized
   /// in a client module, which might be compiled with a different deployment target.

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -452,7 +452,7 @@ public enum VariableScopeInstruction {
 
   // TODO: with SIL verification, we might be able to make varDecl non-Optional.
   public var varDecl: VarDecl? {
-    if let debugVarDecl = instruction.debugVarDecl {
+    if let debugVarDecl = instruction.debugResultDecl {
       return debugVarDecl
     }
     // SILGen may produce double var_decl instructions for the same variable:
@@ -474,15 +474,31 @@ extension Instruction {
     if let varScopeInst = VariableScopeInstruction(self) {
       return varScopeInst.varDecl
     }
-    return debugVarDecl
+    return debugResultDecl
   }
 
-  var debugVarDecl: VarDecl? {
+  var debugResultDecl: VarDecl? {
     for result in results {
-      for use in result.uses {
-        if let debugVal = use.instruction as? DebugValueInst {
-          return debugVal.varDecl
-        }
+      if let varDecl = result.debugUserDecl {
+        return varDecl
+      }
+    }
+    return nil
+  }
+}
+
+extension Value {
+  var debugValDecl: VarDecl? {
+    if let arg = self as? Argument {
+      return arg.varDecl
+    }
+    return debugUserDecl
+  }
+
+  var debugUserDecl: VarDecl? {
+    for use in uses {
+      if let debugVal = use.instruction as? DebugValueInst {
+        return debugVal.varDecl
       }
     }
     return nil

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -393,6 +393,7 @@ struct BridgedDeclObj {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj Class_getDestructor() const;
   BRIDGED_INLINE bool AbstractFunction_isOverridden() const;
   BRIDGED_INLINE bool Destructor_isIsolated() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef AccessorDecl_getKindName() const;
 };
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedASTNodeKind : uint8_t {

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1171,6 +1171,8 @@ NOTE(lifetime_outside_scope_variable, none,
      "it depends on the lifetime of variable '%0'", (Identifier))
 NOTE(lifetime_outside_scope_value, none,
      "it depends on the lifetime of this parent value", ())
+NOTE(lifetime_outside_scope_capture, none,
+     "it depends on a closure capture; this is not yet supported", ())
 NOTE(lifetime_outside_scope_use, none,
      "this use of the lifetime-dependent value is out of scope", ())
 NOTE(lifetime_outside_scope_escape, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1157,8 +1157,14 @@ ERROR(lifetime_variable_outside_scope, none,
       "lifetime-dependent variable '%0' escapes its scope", (Identifier))
 ERROR(lifetime_value_outside_scope, none,
       "lifetime-dependent value escapes its scope", ())
+ERROR(lifetime_value_outside_accessor, none,
+      "lifetime-dependent value returned by generated accessor '%0'", (StringRef))
+ERROR(lifetime_value_outside_thunk, none,
+      "lifetime-dependent value returned by generated %select{function|thunk}0 '%1'", (bool, StringRef))
 NOTE(lifetime_outside_scope_argument, none,
      "it depends on the lifetime of argument '%0'", (Identifier))
+NOTE(lifetime_outside_scope_synthesized_argument, none,
+     "it depends on the lifetime of an argument of '%0'", (Identifier))
 NOTE(lifetime_outside_scope_access, none,
      "it depends on this scoped access to variable '%0'", (Identifier))
 NOTE(lifetime_outside_scope_variable, none,

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -890,6 +890,7 @@ struct BridgedArgument {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock getParent() const;
   BRIDGED_INLINE bool isReborrow() const;
   BRIDGED_INLINE bool FunctionArgument_isLexical() const;
+  BRIDGED_INLINE bool FunctionArgument_isClosureCapture() const;
   BRIDGED_INLINE void setReborrow(bool reborrow) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedDeclObj getVarDecl() const;
   BRIDGED_INLINE void copyFlags(BridgedArgument fromArgument) const;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -462,6 +462,8 @@ struct BridgedFunction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef getName() const;
   BridgedOwnedString getDebugDescription() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedLocation getLocation() const;
+  BRIDGED_INLINE bool isAccessor() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef getAccessorName() const;
   BRIDGED_INLINE bool hasOwnership() const;
   BRIDGED_INLINE bool hasLoweredAddresses() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType getLoweredFunctionTypeInContext() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -23,6 +23,7 @@
 #include "swift/AST/Builtins.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/StorageImpl.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/BasicBridging.h"
@@ -647,6 +648,18 @@ BridgedStringRef BridgedFunction::getName() const {
 
 BridgedLocation BridgedFunction::getLocation() const {
   return {swift::SILDebugLocation(getFunction()->getLocation(), getFunction()->getDebugScope())}; 
+}
+
+bool BridgedFunction::isAccessor() const {
+  if (auto *valDecl = getFunction()->getDeclRef().getDecl()) {
+    return llvm::isa<swift::AccessorDecl>(valDecl);
+  }
+  return false;
+}
+
+BridgedStringRef BridgedFunction::getAccessorName() const {
+  auto *accessorDecl  = llvm::cast<swift::AccessorDecl>(getFunction()->getDeclRef().getDecl());
+  return accessorKindName(accessorDecl->getAccessorKind());
 }
 
 bool BridgedFunction::hasOwnership() const { return getFunction()->hasOwnership(); }

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -578,6 +578,11 @@ bool BridgedArgument::FunctionArgument_isLexical() const {
   return llvm::cast<swift::SILFunctionArgument>(getArgument())->getLifetime().isLexical();
 }
 
+bool BridgedArgument::FunctionArgument_isClosureCapture() const {
+  return llvm::cast<swift::SILFunctionArgument>(
+    getArgument())->isClosureCapture();
+}
+
 OptionalBridgedDeclObj BridgedArgument::getVarDecl() const {
   return {llvm::dyn_cast_or_null<swift::VarDecl>(getArgument()->getDecl())};
 }

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -954,7 +954,7 @@ protected:
       Type paramTypeInContext =
         afd->mapTypeIntoContext(param->getInterfaceType());
       if (paramTypeInContext->hasError()) {
-        continue;
+        return;
       }
       auto kind = inferLifetimeDependenceKind(paramTypeInContext,
                                               param->getValueOwnership());

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -53,6 +53,7 @@ sil @reborrowNE : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @ow
 
 sil @initHolder : $@convention(thin) () -> @out Holder
 sil @getNE : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @owned NE
+sil @getNEIndirect : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @out NE
 
 sil @initTrivialHolder : $@convention(thin) () -> @out TrivialHolder
 sil @getTrivialNE : $@convention(thin) (@in_guaranteed TrivialHolder) -> @lifetime(borrow address_for_deps 0) @owned NE
@@ -217,4 +218,28 @@ bb0(%0 : $*T, %1 : $@thick T.Type):
   dealloc_stack %3
   %21 = tuple ()
   return %21
+}
+
+// Test VariableDefUseWalker: initialization with copy_addr.
+sil shared [thunk] [ossa] @testCopyInit : $@convention(thin) (@in_guaranteed Holder) -> @out NE {
+bb0(%0 : $*NE, %1 : $*Holder):
+  %2 = alloc_stack $Holder
+  copy_addr %1 to [init] %2
+  %4 = load [take] %2
+  %5 = alloc_stack $Holder
+  %6 = store_borrow %4 to %5
+  %7 = alloc_stack $NE // expected-error {{lifetime-dependent value escapes its scope}}
+
+  %8 = function_ref @getNEIndirect : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @out NE
+  %9 = apply %8(%7, %6) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @out NE
+  mark_dependence_addr [unresolved] %7 on %6
+  %11 = load [take] %7
+  store %11 to [init] %0 // expected-note {{this use causes the lifetime-dependent value to escape}}
+  end_borrow %6
+  dealloc_stack %7
+  dealloc_stack %5
+  destroy_value %4
+  dealloc_stack %2
+  %18 = tuple ()
+  return %18
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -176,6 +176,7 @@ bb0(%0 : @guaranteed $NE):
   %2 = function_ref @reborrowNE : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
   %3 = apply %2(%0) : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
   // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  // expected-note @-6{{it depends on the lifetime of an argument of 'testReborrow'}}
   %4 = mark_dependence [unresolved] %3 on %0
   return %4 // expected-note {{this use causes the lifetime-dependent value to escape}}
 }
@@ -185,6 +186,7 @@ bb0(%0 : @guaranteed $NE):
   %2 = function_ref @reborrowNE : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
   %3 = apply %2(%0) : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
   // expected-error @-1{{lifetime-dependent value escapes its scope}}
+  // expected-note @-5{{it depends on the lifetime of an argument of 'testBorrowValue'}}
   %4 = mark_dependence [unresolved] %3 on %0
   return %4 // expected-note {{this use causes the lifetime-dependent value to escape}}
 }
@@ -229,6 +231,7 @@ bb0(%0 : $*NE, %1 : $*Holder):
   %5 = alloc_stack $Holder
   %6 = store_borrow %4 to %5
   %7 = alloc_stack $NE // expected-error {{lifetime-dependent value escapes its scope}}
+  // expected-note @-8{{it depends on the lifetime of an argument of 'testCopyInit'}}
 
   %8 = function_ref @getNEIndirect : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @out NE
   %9 = apply %8(%7, %6) : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @out NE

--- a/test/SILOptimizer/lifetime_dependence/verify_library_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_library_diagnostics.swift
@@ -1,0 +1,68 @@
+// RUN: %target-swift-frontend %s -emit-module -emit-module-interface-path %t/test.swiftmodule \
+// RUN:   -o /dev/null \
+// RUN:   -enable-library-evolution \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -enable-builtin-module \
+// RUN:   -module-name test \
+// RUN:   -define-availability "Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999" \
+// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature AddressableParameters
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_AddressableParameters
+
+// Test diagnostic output for interesting corner cases. Similar to semantics.swift, but this tests corner cases in the
+// implementation as opposed to basic language rules.
+
+import Builtin
+
+public struct NE : ~Escapable {
+}
+
+public struct NEImmortal: ~Escapable {
+  @lifetime(immortal)
+  public init() {}
+}
+
+class C {}
+
+// Test diagnostics on keypath getter.
+//
+// FIXME: rdar://150073405 ([SILGen] support synthesized _modify on top of borrowed getters with library evolution)
+//
+// This produces the error:
+// <unknown>:0: error: unexpected error produced: lifetime-dependent value returned by generated thunk
+// '$s4test17ImplicitAccessorsV10neComputedAA10NEImmortalVvpACTK'
+//
+// Since this error has no source file, we can't verify the diagnostic!
+/*
+public struct ImplicitAccessors {
+  let c: C
+
+  public var neComputed: NEImmortal {
+    get {
+      NEImmortal()
+    }
+    set {
+    }
+  }
+}
+ */
+
+public struct NoncopyableImplicitAccessors : ~Copyable & ~Escapable {
+  public var ne: NE
+
+  public var neComputedBorrow: NE {
+    // expected-error @-1{{lifetime-dependent value returned by generated accessor '_modify'}}
+    // expected-note  @-2{{it depends on this scoped access to variable 'self'}}
+    @lifetime(borrow self)
+    get { ne }
+
+    @lifetime(&self)
+    set {
+      ne = newValue
+    }
+  }
+}


### PR DESCRIPTION
- **LifetimeDependence type checking: avoid an assertion on error.**
  When the type checker encounters incomplete type error, bail out early to avoid
  an assertion.
  
  (cherry picked from commit 36551e370d72acbe226a587d144c46312efbe170)
  

- **LifetimeDependenceDiagnostics: avoid infinite recursion on error**
  Fix a simple typo that results in infinite recursion on invalid code.
  
  Fixes rdar://147470493 ([nonescapable] LifetimeDependenceInsertion: infinite
  recursion in VariableUseDefWalker.walkup with immortal setter)
  
  (cherry picked from commit c891d8ade460a15d62135fdb0deefd2b321bc4f2)
  

- **Refactor debugVarDecl so arguments also support debug_value users.**
  (cherry picked from commit 49755bd0ed286bbaa2dbb4e792ace10ec7eca318)
  

- **[NFC] SwiftCompilerSource: bridge Function.accessorKindName**
  (cherry picked from commit 25e9cbf3f15b61adbddd0c968e893ee72f5ce5ef)
  

- **LifetimeDependence: clarify diagnostics for many unusual cases.**
  Ensure that we always issue a diagnostic on error, but avoid emitting any notes that don't have source locations.
  
  With implicit accessors and thunks, report the correct line number and indicate which accessor generates the error.
  
  Always check for debug_value users.
  
  Consistently handle access scopes across diagnostic analysis and diagnostic messages.
  
  (cherry picked from commit ec512864eb345999b3993a0d5a8991b0ad58f256)
  

- **LifetimeDependenceDiagnostics: note for unsupported closure capture**
  Add a note explaining that dependence on closure captures is not
  supported. Otherwise, the diagnostics are very confusing:
  "it depends on a closure capture; this is not yet supported"
  
  (cherry picked from commit 83b0ce109848bfd09a951227d268a92b251bbab4)
  