### PR TITLE
[wasm] Add WASI as a supported target for sanitizers

### DIFF
--- a/lib/Option/SanitizerOptions.cpp
+++ b/lib/Option/SanitizerOptions.cpp
@@ -168,7 +168,7 @@ OptionSet<SanitizerKind> swift::parseSanitizerArgValues(
   }
 
   // Check that we're one of the known supported targets for sanitizers.
-  if (!(Triple.isOSDarwin() || Triple.isOSLinux() || Triple.isOSWindows())) {
+  if (!(Triple.isOSDarwin() || Triple.isOSLinux() || Triple.isOSWindows() || Triple.isOSWASI())) {
     SmallString<128> b;
     Diags.diagnose(SourceLoc(), diag::error_unsupported_opt_for_target,
       (A->getOption().getPrefixedName() +


### PR DESCRIPTION
We are working on adding ASan support for the WASI target, and it seems like there is no major blocker in the Swift compiler side other than it raises an "unsupported" error. Let's just add WASI as a supported platform.