### PR TITLE
[Concurrency] Bring back ability to get a queue custom executor in executorForEnqueuedJob

### DIFF
--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -382,6 +382,11 @@ static SerialExecutorRef executorForEnqueuedJob(Job *job) {
     return swift_task_getMainExecutor();
   }
 
+  if (auto identity = reinterpret_cast<HeapObject *>(jobQueue)) {
+    return SerialExecutorRef::forOrdinary(
+    identity, _swift_task_getDispatchQueueSerialExecutorWitnessTable());
+  }
+
   return SerialExecutorRef::generic();
 #endif
 }

--- a/test/Concurrency/Runtime/actor_executor_tracking_custom_executor_queue.swift
+++ b/test/Concurrency/Runtime/actor_executor_tracking_custom_executor_queue.swift
@@ -1,0 +1,82 @@
+// RUN: %target-run-simple-swift( -target %target-swift-5.1-abi-triple -parse-as-library -Xfrontend -disable-availability-checking) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+// REQUIRES: concurrency_runtime
+// REQUIRES: libdispatch
+
+// REQUIRES: OS=macosx
+
+// Regression test for rdar://150213107
+
+import Darwin
+import Dispatch
+
+actor TestActor {
+    private let queue = DispatchSerialQueue(label: "MYQUEUE")
+
+    nonisolated var unownedExecutor: UnownedSerialExecutor {
+        queue.asUnownedSerialExecutor()
+    }
+
+    init() {
+        dispatchPrecondition(condition: .notOnQueue(self.queue))
+
+        Task.detached {
+            dispatchPrecondition(condition: .notOnQueue(self.queue))
+            sleep(1)
+            await self.start()
+        }
+    }
+
+    private var startupCompleted: Bool = false
+    private var startupContinuations: [CheckedContinuation<Void, Never>] = []
+
+    func waitForStartup() async {
+        self.assertIsolated()
+        guard !startupCompleted else {
+            print("waitForStartup - completed, bailing")
+            return
+        }
+
+        print("waitForStartup - adding continuation")
+        sleep(2)
+        print("waitForStartup - slept...")
+
+        print("waitForStartup - suspend")
+        await withCheckedContinuation { continuation in
+            print("waitForStartup - suspend inside")
+            dispatchPrecondition(condition: .onQueue(self.queue))
+            startupContinuations.append(continuation)
+            print("waitForStartup - added")
+        }
+    }
+
+    private func start() {
+        dispatchPrecondition(condition: .onQueue(self.queue))
+        print("start")
+
+        startupCompleted = true
+        for continuation in startupContinuations {
+            print("start - resuming")
+            continuation.resume()
+        }
+        startupContinuations = []
+        print("start - FINISHED")
+    }
+}
+
+
+@main struct Main {
+  static func main() async {
+    // CHECK: waitForStartup - adding continuation
+    // CHECK: waitForStartup - added
+    // CHECK: start
+    // CHECK: start - FINISHED
+    // CHECK: DONE
+    let test = TestActor()
+    await test.waitForStartup()
+    print("DONE")
+  }
+}


### PR DESCRIPTION
This was a regression and now even if we had a queue set in
job->SchedulerPrivate[Job::DispatchQueueIndex].

Arguably the way we're using that storage needs to be fixed somehow,
since if we're opening this storage to other executors then it means
we could have OTHER things in there, not just a dispatch queueue,
and therefore this cast would be bad.

For now though we can bring back the existing behavior while we work out
with Alastair what the right way to handle this will be -- some marker
bit somewhere that indeed this is a queue stored here?

This was accidentally removed in https://github.com/swiftlang/swift/commit/8b15b05c63ae707a6aa3ff6659d45c2ffea4633d#diff-d90051c83a2c096660ba71209df0910583b57e96b23f0135533f425c49a9baacL384-L390

resolves rdar://150213107