### PR TITLE
🍒[cxx-interop] Remove a workaround for CoreGraphics module interface

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2132,19 +2132,6 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
     subInvocation.setSysRoot(sysroot.value());
   }
 
-  // FIXME: Hack for CoreGraphics.swiftmodule, which cannot be rebuilt because
-  // of a CF_OPTIONS bug (rdar://142762174).
-  if (moduleName == "CoreGraphics") {
-    subInvocation.getLangOptions().EnableCXXInterop = false;
-    subInvocation.getLangOptions().cxxInteropCompatVersion = {};
-    BuildArgs.erase(llvm::remove_if(BuildArgs,
-                                    [](StringRef arg) -> bool {
-                                      return arg.starts_with(
-                                          "-cxx-interoperability-mode=");
-                                    }),
-                    BuildArgs.end());
-  }
-
   // Calculate output path of the module.
   SwiftInterfaceModuleOutputPathResolution::ResultTy resolvedOutputPath;
   getCachedOutputPath(resolvedOutputPath, moduleName, interfacePath, sdkPath);


### PR DESCRIPTION
  - **Explanation**: This removes a workaround in module interface rebuilding logic that applied for the CoreGraphics module specifically. The workaround used to remove the C++ interop flag from the list of compile arguments used to rebuild CoreGraphics from its textual interface. The workaround isn't needed anymore after https://github.com/swiftlang/swift/pull/79822 and https://github.com/swiftlang/swift/pull/79890.
  - **Scope**: This only changes the logic for one specific module from OS SDK.
  - **Issues**: rdar://150211857
  - **Original PRs**: https://github.com/swiftlang/swift/pull/81177
  - **Risk**: Low, this only applies to one module.
  - **Testing**: This is covered by existing tests, e.g. `test/Interop/Cxx/objc-correctness/coregraphics.swift`.
  - **Reviewers**: @artemcm @j-hui 
