### PR TITLE
[Concurrency] Fix issue with using Dispatch queues as executors.

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -340,11 +340,26 @@ extension SerialExecutor {
     #endif
   }
 
+  #if SWIFT_CONCURRENCY_USES_DISPATCH
+  @available(SwiftStdlib 6.2, *)
+  private var _dispatchQueue: OpaquePointer? {
+    return _getDispatchQueueForExecutor(self.asUnownedSerialExecutor())
+  }
+  #endif
+
   @available(SwiftStdlib 6.2, *)
   internal func _isSameExecutor(_ rhs: some SerialExecutor) -> Bool {
     if rhs === self {
       return true
     }
+    #if SWIFT_CONCURRENCY_USES_DISPATCH
+    if let rhsQueue = rhs._dispatchQueue {
+      if let ourQueue = _dispatchQueue, ourQueue == rhsQueue {
+        return true
+      }
+      return false
+    }
+    #endif
     if let rhs = rhs as? Self {
       return isSameExclusiveExecutionContext(other: rhs)
     }

--- a/stdlib/public/Concurrency/ExecutorBridge.cpp
+++ b/stdlib/public/Concurrency/ExecutorBridge.cpp
@@ -16,6 +16,7 @@
 
 #include "Error.h"
 #include "ExecutorBridge.h"
+#include "TaskPrivate.h"
 
 using namespace swift;
 
@@ -136,6 +137,15 @@ extern "C" SWIFT_CC(swift)
 void swift_dispatchAssertMainQueue() {
   dispatch_assert_queue(dispatch_get_main_queue());
 }
-#endif // SWIFT_CONCURRENCY_ENABLE_DISPATCH
+
+extern "C" SWIFT_CC(swift)
+void *swift_getDispatchQueueForExecutor(SerialExecutorRef executor) {
+  if (executor.getRawImplementation() == (uintptr_t)_swift_task_getDispatchQueueSerialExecutorWitnessTable()) {
+    return executor.getIdentity();
+  }
+  return nullptr;
+}
+
+#endif // SWIFT_CONCURRENCY_USES_DISPATCH
 
 #pragma clang diagnostic pop

--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -119,3 +119,8 @@ internal func _dispatchEnqueueWithDeadline(_ global: CBool,
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_dispatchAssertMainQueue")
 internal func _dispatchAssertMainQueue()
+
+@_silgen_name("swift_getDispatchQueueForExecutor")
+internal func _getDispatchQueueForExecutor(
+  _ executor: UnownedSerialExecutor
+) -> OpaquePointer?

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -382,6 +382,11 @@ static SerialExecutorRef executorForEnqueuedJob(Job *job) {
     return swift_task_getMainExecutor();
   }
 
+  if (auto identity = reinterpret_cast<HeapObject *>(jobQueue)) {
+    return SerialExecutorRef::forOrdinary(
+      identity, _swift_task_getDispatchQueueSerialExecutorWitnessTable());
+  }
+
   return SerialExecutorRef::generic();
 #endif
 }


### PR DESCRIPTION
We were failing to switch executors to Dispatch queues, where those were being used as executors, which caused a variety of unusual symptoms.

rdar://150310927
