### PR TITLE
AST: Change signature of LookupConformanceFn

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -294,9 +294,9 @@ public:
   explicit LookUpConformanceInSubstitutionMap(SubstitutionMap Subs)
     : Subs(Subs) {}
 
-  ProtocolConformanceRef operator()(CanType dependentType,
-                                    Type conformingReplacementType,
-                                    ProtocolDecl *conformedProtocol) const;
+  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
+                                    Type dependentType,
+                                    ProtocolDecl *proto) const;
 };
 
 struct OverrideSubsInfo {
@@ -326,8 +326,8 @@ struct LookUpConformanceInOverrideSubs {
   explicit LookUpConformanceInOverrideSubs(const OverrideSubsInfo &info)
     : info(info) {}
 
-  ProtocolConformanceRef operator()(CanType type,
-                                    Type substType,
+  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
+                                    Type dependentType,
                                     ProtocolDecl *proto) const;
 };
 
@@ -338,9 +338,9 @@ struct OuterSubstitutions {
   unsigned depth;
 
   Type operator()(SubstitutableType *type) const;
-  ProtocolConformanceRef operator()(CanType dependentType,
-                                    Type conformingReplacementType,
-                                    ProtocolDecl *conformedProtocol) const;
+  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
+                                    Type dependentType,
+                                    ProtocolDecl *proto) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -88,9 +88,9 @@ struct QueryTypeSubstitutionMap {
 };
 
 /// Function used to resolve conformances.
-using GenericFunction = auto(CanType dependentType,
-                             Type conformingReplacementType,
-                             ProtocolDecl *conformedProtocol)
+using GenericFunction = auto(InFlightSubstitution &IFS,
+                             Type dependentType,
+                             ProtocolDecl *proto)
                             -> ProtocolConformanceRef;
 using LookupConformanceFn = llvm::function_ref<GenericFunction>;
   
@@ -100,9 +100,9 @@ class LookUpConformanceInModule {
 public:
   explicit LookUpConformanceInModule() {}
 
-  ProtocolConformanceRef operator()(CanType dependentType,
-                                    Type conformingReplacementType,
-                                    ProtocolDecl *conformedProtocol) const;
+  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
+                                    Type dependentType,
+                                    ProtocolDecl *proto) const;
 };
 
 /// Functor class suitable for use as a \c LookupConformanceFn that provides
@@ -110,9 +110,9 @@ public:
 /// type is an opaque generic type.
 class MakeAbstractConformanceForGenericType {
 public:
-  ProtocolConformanceRef operator()(CanType dependentType,
-                                    Type conformingReplacementType,
-                                    ProtocolDecl *conformedProtocol) const;
+  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
+                                    Type dependentType,
+                                    ProtocolDecl *proto) const;
 };
   
 /// Flags that can be passed when substituting into a type.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -7069,8 +7069,8 @@ public:
   Type operator()(SubstitutableType *maybeOpaqueType) const;
 
   /// LookupConformanceFn
-  ProtocolConformanceRef operator()(CanType maybeOpaqueType,
-                                    Type replacementType,
+  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
+                                    Type maybeOpaqueType,
                                     ProtocolDecl *protocol) const;
 
   OpaqueSubstitutionKind
@@ -7108,8 +7108,8 @@ public:
   Type operator()(SubstitutableType *type) const;
 
   /// LookupConformanceFn
-  ProtocolConformanceRef operator()(CanType origType,
-                                    Type substType,
+  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
+                                    Type origType,
                                     ProtocolDecl *protocol) const;
 
 };

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -80,20 +80,23 @@ struct SubstitutionMapWithLocalArchetypes {
     return Type(type);
   }
 
-  ProtocolConformanceRef operator()(CanType origType,
-                                    Type substType,
+  ProtocolConformanceRef operator()(InFlightSubstitution &IFS,
+                                    Type origType,
                                     ProtocolDecl *proto) {
-    if (isa<LocalArchetypeType>(origType))
-      return swift::lookupConformance(substType, proto);
+    if (origType->is<LocalArchetypeType>())
+      return swift::lookupConformance(origType.subst(IFS), proto);
 
-    if (isa<PrimaryArchetypeType>(origType) ||
-        isa<PackArchetypeType>(origType))
-      origType = origType->mapTypeOutOfContext()->getCanonicalType();
+    if (origType->is<PrimaryArchetypeType>() ||
+        origType->is<PackArchetypeType>())
+      origType = origType->mapTypeOutOfContext();
 
-    if (SubsMap)
-      return SubsMap->lookupConformance(origType, proto);
+    if (SubsMap) {
+      return SubsMap->lookupConformance(
+        origType->getCanonicalType(), proto);
+    }
 
-    return ProtocolConformanceRef::forAbstract(substType, proto);
+    return ProtocolConformanceRef::forAbstract(
+      origType.subst(IFS), proto);
   }
 
   void dump(llvm::raw_ostream &out) const {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1914,15 +1914,9 @@ void PrintAST::printSingleDepthOfGenericSignature(
     if (subMap.empty())
       return param;
 
-    return param.subst(
-      [&](SubstitutableType *type) -> Type {
-        if (cast<GenericTypeParamType>(type)->getDepth() < typeContextDepth)
-          return Type(type).subst(subMap);
-        return type;
-      },
-      [&](CanType depType, Type substType, ProtocolDecl *proto) {
-        return lookupConformance(substType, proto);
-      });
+    OuterSubstitutions replacer{subMap, typeContextDepth};
+    return param.subst(replacer, replacer,
+                       SubstFlags::PreservePackExpansionLevel);
   };
 
   /// Separate the explicit generic parameters from the implicit, opaque

--- a/lib/AST/ExistentialGeneralization.cpp
+++ b/lib/AST/ExistentialGeneralization.cpp
@@ -68,10 +68,11 @@ public:
       assert(it != substTypes.end());
       return it->second;
     };
-    auto lookupConformance = [&](CanType dependentType,
-                                 Type conformingReplacementType,
+    auto lookupConformance = [&](InFlightSubstitution &IFS,
+                                 Type dependentType,
                                  ProtocolDecl *conformedProtocol) {
-      auto it = substConformances.find({dependentType, conformedProtocol});
+      auto it = substConformances.find(
+          {dependentType->getCanonicalType(), conformedProtocol});
       assert(it != substConformances.end());
       return it->second;
     };

--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -266,10 +266,10 @@ swift::buildSubstitutionMapWithCapturedEnvironments(
         return mapIntoLocalContext(param, baseDepth, capturedEnvs);
       return Type(type).subst(baseSubMap);
     },
-    [&](CanType origType, Type substType,
-        ProtocolDecl *proto) -> ProtocolConformanceRef {
+    [&](InFlightSubstitution &IFS, Type origType, ProtocolDecl *proto)
+          -> ProtocolConformanceRef {
       if (origType->getRootGenericParam()->getDepth() >= baseDepth)
-        return ProtocolConformanceRef::forAbstract(substType, proto);
-      return baseSubMap.lookupConformance(origType, proto);
+        return ProtocolConformanceRef::forAbstract(origType.subst(IFS), proto);
+      return baseSubMap.lookupConformance(origType->getCanonicalType(), proto);
     });
 }

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -112,10 +112,11 @@ RequirementEnvironment::RequirementEnvironment(
       return substGenericParam;
     },
     [substConcreteType, conformance, conformanceDC, covariantSelf, &ctx](
-        CanType type, Type replacement, ProtocolDecl *proto)
+        InFlightSubstitution &IFS, Type type, ProtocolDecl *proto)
           -> ProtocolConformanceRef {
       // The protocol 'Self' conforms concretely to the conforming type.
       if (type->isEqual(ctx.TheSelfType)) {
+        auto replacement = type.subst(IFS);
         ASSERT(covariantSelf || replacement->isEqual(substConcreteType));
 
         if (conformance) {
@@ -145,7 +146,7 @@ RequirementEnvironment::RequirementEnvironment(
 
       // All other generic parameters come from the requirement itself
       // and conform abstractly.
-      return MakeAbstractConformanceForGenericType()(type, replacement, proto);
+      return MakeAbstractConformanceForGenericType()(IFS, type, proto);
     });
 
   // If the requirement itself is non-generic, the witness thunk signature

--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -85,16 +85,13 @@ RequirementEnvironment::RequirementEnvironment(
   // parameters of the requirement into a combined context that provides the
   // type parameters of the conformance context and the parameters of the
   // requirement.
-  auto selfType = cast<GenericTypeParamType>(
-      proto->getSelfInterfaceType()->getCanonicalType());
-
   reqToWitnessThunkSigMap = SubstitutionMap::get(reqSig,
-    [selfType, substConcreteType, depth, covariantSelf, &ctx]
+    [substConcreteType, depth, covariantSelf, &ctx]
     (SubstitutableType *type) -> Type {
       // If the conforming type is a class, the protocol 'Self' maps to
       // the class-constrained 'Self'. Otherwise, it maps to the concrete
       // type.
-      if (type->isEqual(selfType)) {
+      if (type->isEqual(ctx.TheSelfType)) {
         if (covariantSelf)
           return ctx.TheSelfType;
         return substConcreteType;
@@ -114,11 +111,11 @@ RequirementEnvironment::RequirementEnvironment(
       }
       return substGenericParam;
     },
-    [selfType, substConcreteType, conformance, conformanceDC, covariantSelf, &ctx](
+    [substConcreteType, conformance, conformanceDC, covariantSelf, &ctx](
         CanType type, Type replacement, ProtocolDecl *proto)
           -> ProtocolConformanceRef {
       // The protocol 'Self' conforms concretely to the conforming type.
-      if (type->isEqual(selfType)) {
+      if (type->isEqual(ctx.TheSelfType)) {
         ASSERT(covariantSelf || replacement->isEqual(substConcreteType));
 
         if (conformance) {

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -272,61 +272,31 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
   auto path = genericSig->getConformancePath(type, proto);
 
-  ProtocolConformanceRef conformance;
-  for (const auto &step : path) {
-    // For the first step, grab the initial conformance.
-    if (conformance.isInvalid()) {
-      if (auto initialConformance = getSignatureConformance(
-            step.first, step.second)) {
-        conformance = *initialConformance;
-        continue;
-      }
+  // For the first step, grab the initial conformance.
+  auto iter = path.begin();
+  const auto step = *iter++;
 
-      // We couldn't find the initial conformance, fail.
-      return ProtocolConformanceRef::forInvalid();
-    }
+  ProtocolConformanceRef conformance =
+      *getSignatureConformance(step.first, step.second);
 
-    // If we've hit an abstract conformance, everything from here on out is
-    // abstract.
-    // FIXME: This may not always be true, but it holds for now.
-    if (conformance.isAbstract()) {
-      // FIXME: Rip this out once we can get a concrete conformance from
-      // an archetype.
-      return swift::lookupConformance(type.subst(*this), proto);
-    }
+  // For each remaining step, project an associated conformance.
+  while (iter != path.end()) {
+    // FIXME: Remove this hack. It is unsound, because we may not have diagnosed
+    // anything but still end up with an ErrorType in the AST.
+    if (conformance.isConcrete()) {
+      auto concrete = conformance.getConcrete();
+      auto normal = concrete->getRootNormalConformance();
 
-    // For the second step, we're looking into the requirement signature for
-    // this protocol.
-    if (conformance.isPack()) {
-      auto pack = conformance.getPack();
-      conformance = ProtocolConformanceRef(
-          pack->getAssociatedConformance(step.first, step.second));
-      if (conformance.isInvalid())
-        return conformance;
-
-      continue;
-    }
-
-    auto concrete = conformance.getConcrete();
-    auto normal = concrete->getRootNormalConformance();
-
-    // If we haven't set the signature conformances yet, force the issue now.
-    if (!normal->hasComputedAssociatedConformances()) {
-      // If we're in the process of checking the type witnesses, fail
-      // gracefully.
-      //
-      // FIXME: This is unsound, because we may not have diagnosed anything but
-      // still end up with an ErrorType in the AST.
-      if (proto->getASTContext().evaluator.hasActiveRequest(
-            ResolveTypeWitnessesRequest{normal})) {
-        return ProtocolConformanceRef::forInvalid();
+      if (!normal->hasComputedAssociatedConformances()) {
+        if (proto->getASTContext().evaluator.hasActiveRequest(
+              ResolveTypeWitnessesRequest{normal})) {
+          return ProtocolConformanceRef::forInvalid();
+        }
       }
     }
 
-    // Get the associated conformance.
-    conformance = concrete->getAssociatedConformance(step.first, step.second);
-    if (conformance.isInvalid())
-      return conformance;
+    const auto step = *iter++;
+    conformance = conformance.getAssociatedConformance(step.first, step.second);
   }
 
   return conformance;

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1876,9 +1876,10 @@ SubstitutionMap getApplySubstitutionsFromParsed(
         // Provide the replacement type.
         return parses[index].replacement;
       },
-      [&](CanType dependentType, Type replacementType,
+      [&](InFlightSubstitution &IFS, Type dependentType,
           ProtocolDecl *proto) -> ProtocolConformanceRef {
-        replacementType = replacementType->getReferenceStorageReferent();
+        auto replacementType = dependentType.subst(IFS)
+            ->getReferenceStorageReferent();
         if (auto conformance = lookupConformance(replacementType, proto))
           return conformance;
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4327,10 +4327,7 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
         hashValueVar->getDeclContext()->getGenericSignatureOfContext();
       assert(hashGenericSig);
       SubstitutionMap hashableSubsMap = SubstitutionMap::get(
-          hashGenericSig,
-          [&](SubstitutableType *type) -> Type { return formalTy; },
-          [&](CanType dependentType, Type replacementType, ProtocolDecl *proto)
-              -> ProtocolConformanceRef { return hashable; });
+          hashGenericSig, formalTy, hashable);
 
       // Read the storage.
       ManagedValue base = ManagedValue::forBorrowedAddressRValue(indexAddr);

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -1059,7 +1059,7 @@ getWitnessMethodSubstitutions(
         paramType = paramType->withDepth(depth);
         return Type(paramType).subst(origSubMap);
       },
-      [&](CanType type, Type substType, ProtocolDecl *proto) {
+      [&](InFlightSubstitution &IFS, Type type, ProtocolDecl *proto) {
         auto *paramType = type->getRootGenericParam();
         unsigned depth = paramType->getDepth();
 
@@ -1082,7 +1082,7 @@ getWitnessMethodSubstitutions(
             return std::nullopt;
           }));
 
-          return baseSubMap.lookupConformance(type, proto);
+          return baseSubMap.lookupConformance(type->getCanonicalType(), proto);
         }
 
         depth = depth - baseDepth + 1;
@@ -1095,7 +1095,7 @@ getWitnessMethodSubstitutions(
           return std::nullopt;
         }));
 
-        return origSubMap.lookupConformance(type, proto);
+        return origSubMap.lookupConformance(type->getCanonicalType(), proto);
       });
 }
 

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -262,8 +262,8 @@ void ConcreteExistentialInfo::initializeSubstitutionMap(
 
   ExistentialSubs = SubstitutionMap::get(
       ExistentialSig, [&](SubstitutableType *type) { return ConcreteType; },
-      [&](CanType /*depType*/, Type /*replaceType*/,
-          ProtocolDecl *proto) -> ProtocolConformanceRef {
+      [&](InFlightSubstitution &, Type, ProtocolDecl *proto)
+          -> ProtocolConformanceRef {
         // Directly providing ExistentialConformances to the SubstitutionMap will
         // fail because of the mismatch between opened archetype conformance and
         // existential value conformance. Instead, provide a conformance lookup

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -967,16 +967,8 @@ static Type applyGenericArguments(Type type,
     }
     
     // Try to form a substitution map.
-    auto subs = SubstitutionMap::get(bug->getGenericSignature(),
-                                     args,
-                                     [&](CanType dependentType,
-                                         Type conformingReplacementType,
-                                         ProtocolDecl *conformedProtocol)
-                                     -> ProtocolConformanceRef {
-                                       // no generic builtins have conformance
-                                       // requirements yet.
-                                       llvm_unreachable("not implemented yet");
-                                     });
+    auto subs = SubstitutionMap::get(bug->getGenericSignature(), args,
+                                     LookUpConformanceInModule());
                                      
     auto bound = bug->getBound(subs);
     


### PR DESCRIPTION
The primitive form of subst() takes a pair of callbacks, to substitute generic parameters and conformances, respectively. We then implement substitution of arbitrary types in terms of these callbacks.

The LookupConformanceFn callback used to take both the original type and the substituted type of the conformance, so to perform a substitution on a dependent member type `T.[P]A`, we would first recursively substitute `T`, and then invoke LookupConformanceFn with `T`, the substituted type for `T`, and `P`. This returns a conformance, and we then project the type witness for `A` to get the final result.

While `LookUpConformanceInModule` needs the substituted`T` for example, `LookUpConformanceInSubstitutionMap` does not; it calls `SubstitutionMap::lookupConformance()`, which only needs the original `T` and the `P`. To avoid this unnecessary bit of computation in the common case where we're calling subst() with a pair of callbacks that look into a substitution map, let's change the callback's signature to receive the `InFlightSubstitution &` instead of the substituted `T`. The substituted type can then be recovered by calling `subst(IFS)` on the original type `T`.

Also, remove an ancient hack in `SubstitutionMap::lookupConformance()` that is no longer necessary, now that we track subject types in abstract conformances. Previously, if any of the steps in a conformance path were abstract, we would fall back to global conformance lookup here, because we didn't have enough information to proceed. We do now.