### PR TITLE
Print type inheritances and dictionary types without a space before the colon by default

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -311,6 +311,14 @@ public:
     PendingNewlines++;
   }
 
+  void printColonForType(const PrintOptions &options)
+  {
+    if (options.PrintSpaceBeforeInheritance) {
+      *this << ' ';
+    }
+    *this << ": ";
+  }
+
   void forceNewlines() {
     if (PendingNewlines > 0) {
       llvm::SmallString<16> Str;

--- a/include/swift/AST/GenericParamList.h
+++ b/include/swift/AST/GenericParamList.h
@@ -215,8 +215,8 @@ public:
   }
 
   SWIFT_DEBUG_DUMP;
-  void print(raw_ostream &OS) const;
-  void print(ASTPrinter &Printer) const;
+  void print(raw_ostream &OS, const PrintOptions &Options = PrintOptions()) const;
+  void print(ASTPrinter &Printer, const PrintOptions &Options = PrintOptions()) const;
 };
 
 /// GenericParamList - A list of generic parameters that is part of a generic
@@ -400,7 +400,7 @@ public:
     return SourceRange(WhereLoc, EndLoc);
   }
 
-  void print(llvm::raw_ostream &OS, bool printWhereKeyword) const;
+  void print(llvm::raw_ostream &OS, const PrintOptions &PO, bool printWhereKeyword) const;
 
 };
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -585,7 +585,7 @@ struct PrintOptions {
 
   /// Whether to print a space before the `:` of an inheritance list in a type
   /// decl.
-  bool PrintSpaceBeforeInheritance = true;
+  bool PrintSpaceBeforeInheritance = false;
 
   /// Whether to print feature checks for compatibility with older Swift
   /// compilers that might parse the result.
@@ -653,7 +653,6 @@ struct PrintOptions {
     result.PrintDocumentationComments = true;
     result.PrintLongAttrsOnSeparateLines = true;
     result.AlwaysTryPrintParameterLabels = true;
-    result.PrintSpaceBeforeInheritance = false;
     return result;
   }
 
@@ -661,7 +660,6 @@ struct PrintOptions {
   static PrintOptions forDiagnosticArguments() {
     PrintOptions result;
     result.PrintExplicitPackTypes = false;
-    result.PrintSpaceBeforeInheritance = false;
     return result;
   }
 
@@ -688,7 +686,6 @@ struct PrintOptions {
     if (printFullConvention)
       result.PrintFunctionRepresentationAttrs =
           PrintOptions::FunctionRepresentationMode::Full;
-    result.PrintSpaceBeforeInheritance = false;
     return result;
   }
 
@@ -714,7 +711,6 @@ struct PrintOptions {
     result.MapCrossImportOverlaysToDeclaringModule = true;
     result.PrintCurrentMembersOnly = false;
     result.SuppressExpandedMacros = true;
-    result.PrintSpaceBeforeInheritance = false;
     return result;
   }
 
@@ -775,6 +771,7 @@ struct PrintOptions {
   static PrintOptions printQualifiedSILType() {
     PrintOptions result = PrintOptions::printSIL();
     result.FullyQualifiedTypesIfAmbiguous = true;
+    result.PrintSpaceBeforeInheritance = true;
     return result;
   }
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -653,6 +653,7 @@ struct PrintOptions {
     result.PrintDocumentationComments = true;
     result.PrintLongAttrsOnSeparateLines = true;
     result.AlwaysTryPrintParameterLabels = true;
+    result.PrintSpaceBeforeInheritance = false;
     return result;
   }
 
@@ -660,6 +661,7 @@ struct PrintOptions {
   static PrintOptions forDiagnosticArguments() {
     PrintOptions result;
     result.PrintExplicitPackTypes = false;
+    result.PrintSpaceBeforeInheritance = false;
     return result;
   }
 
@@ -686,6 +688,7 @@ struct PrintOptions {
     if (printFullConvention)
       result.PrintFunctionRepresentationAttrs =
           PrintOptions::FunctionRepresentationMode::Full;
+    result.PrintSpaceBeforeInheritance = false;
     return result;
   }
 
@@ -711,6 +714,7 @@ struct PrintOptions {
     result.MapCrossImportOverlaysToDeclaringModule = true;
     result.PrintCurrentMembersOnly = false;
     result.SuppressExpandedMacros = true;
+    result.PrintSpaceBeforeInheritance = false;
     return result;
   }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1471,7 +1471,7 @@ namespace {
         }, label);
       } else {
         printFieldQuotedRaw([&](raw_ostream &OS) {
-          Where->print(OS, /*printWhereKeyword*/ false);
+          Where->print(OS, PrintOptions(), /*printWhereKeyword*/ false);
         }, label);
       }
     };

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -254,6 +254,9 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
 
   // We should provide backward-compatible Swift interfaces when we can.
   result.PrintCompatibilityFeatureChecks = true;
+  
+  // Don't print a space before ':' in inheritance clauses.
+  result.PrintSpaceBeforeInheritance = false;
 
   result.FunctionBody = [](const ValueDecl *decl, ASTPrinter &printer) {
     auto AFD = dyn_cast<AbstractFunctionDecl>(decl);

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -1195,7 +1195,7 @@ TypeAliasRequirementsRequest::evaluate(Evaluator &evaluator,
         if (!assocType->getInherited().empty())
           out << ", ";
 
-        whereClause->print(out, /*printWhereKeyword*/false);
+        whereClause->print(out, PrintOptions(), /*printWhereKeyword*/false);
       }
     }
     return result;

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -500,7 +500,7 @@ void DictionaryTypeRepr::printImpl(ASTPrinter &Printer,
                                    const PrintOptions &Opts) const {
   Printer << "[";
   printTypeRepr(Key, Printer, Opts);
-  Printer << " : ";
+  Printer.printColonForType(Opts);
   printTypeRepr(Value, Printer, Opts);
   Printer << "]";
 }

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -822,7 +822,10 @@ public:
         out << "@_spi(" << DummyProtocolName << ")\n";
       out << "@available(*, unavailable)\nextension ";
       nominal->getDeclaredType().print(out, printOptions);
-      out << " : ";
+      if (printOptions.PrintSpaceBeforeInheritance) {
+        out << ' ';
+      }
+      out << ": ";
       llvm::interleave(
           conformanceProtos,
           [&out, &printOptions](const ProtocolType *protoTy) {
@@ -830,8 +833,11 @@ public:
           },
           [&out] { out << ", "; });
       out << " where "
-          << nominal->getGenericSignature().getGenericParams()[0]->getName()
-          << " : " << DummyProtocolName << " {}\n";
+          << nominal->getGenericSignature().getGenericParams()[0]->getName();
+          if (printOptions.PrintSpaceBeforeInheritance) {
+            out << ' ';
+          }
+          out << ": " << DummyProtocolName << " {}\n";
     };
 
     // We have to print conformances for invertible protocols in separate

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -4844,6 +4844,7 @@ PrintOptions PrintOptions::printSIL(const SILPrintContext *ctx) {
   result.AbstractAccessors = false;
   result.PrintForSIL = true;
   result.PrintInSILBody = true;
+  result.PrintSpaceBeforeInheritance = true;
   result.PreferTypeRepr = false;
   result.OpaqueReturnTypePrinting =
      OpaqueReturnTypePrintingMode::StableReference;

--- a/test/APINotes/properties.swift
+++ b/test/APINotes/properties.swift
@@ -7,7 +7,7 @@
 // REQUIRES: objc_interop
 
 
-// CHECK-BOTH-LABEL: class TestProperties : Base {
+// CHECK-BOTH-LABEL: class TestProperties: Base {
 
 // CHECK-BOTH-DAG: func accessorsOnly() -> Any
 // CHECK-BOTH-DAG: func setAccessorsOnly(_ accessorsOnly: Any)
@@ -34,7 +34,7 @@
 
 // CHECK-BOTH: {{^}$}}
 
-// CHECK-BOTH-LABEL: class TestPropertiesSub : TestProperties {
+// CHECK-BOTH-LABEL: class TestPropertiesSub: TestProperties {
 // CHECK-BOTH-DAG: func accessorsOnly() -> Any
 // CHECK-BOTH-DAG: func setAccessorsOnly(_ accessorsOnly: Any)
 // CHECK-BOTH-DAG: class func accessorsOnlyForClass() -> Any

--- a/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
+++ b/test/AutoDiff/Sema/DerivedConformances/derived_differentiable.swift
@@ -9,7 +9,7 @@ struct GenericTangentVectorMember<T: Differentiable>: Differentiable,
   var x: T.TangentVector
 }
 
-// CHECK-AST-LABEL: internal struct GenericTangentVectorMember<T> : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} where T : Differentiable
+// CHECK-AST-LABEL: internal struct GenericTangentVectorMember<T> : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} where T: Differentiable
 // CHECK-AST:   internal var x: T.TangentVector
 // CHECK-AST:   internal static func + (lhs: GenericTangentVectorMember<T>, rhs: GenericTangentVectorMember<T>) -> GenericTangentVectorMember<T>
 // CHECK-AST:   internal static func - (lhs: GenericTangentVectorMember<T>, rhs: GenericTangentVectorMember<T>) -> GenericTangentVectorMember<T>
@@ -24,7 +24,7 @@ public struct ConditionallyDifferentiable<T> {
 extension ConditionallyDifferentiable: Differentiable where T: Differentiable {}
 
 // CHECK-AST-LABEL: public struct ConditionallyDifferentiable<T> {
-// CHECK-AST:         @differentiable(reverse, wrt: self where T : Differentiable)
+// CHECK-AST:         @differentiable(reverse, wrt: self where T: Differentiable)
 // CHECK-AST:         public var x: T
 // CHECK-AST:         internal init(x: T)
 // CHECK-AST:       }
@@ -61,25 +61,25 @@ final class AdditiveArithmeticClass<T: AdditiveArithmetic & Differentiable>: Add
   }
 }
 
-// CHECK-AST-LABEL: final internal class AdditiveArithmeticClass<T> : AdditiveArithmetic, Differentiable where T : AdditiveArithmetic, T : Differentiable {
+// CHECK-AST-LABEL: final internal class AdditiveArithmeticClass<T> : AdditiveArithmetic, Differentiable where T : AdditiveArithmetic, T: Differentiable {
 // CHECK-AST:         final internal var x: T, y: T
-// CHECK-AST:         internal struct TangentVector : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}}
+// CHECK-AST:         internal struct TangentVector: {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}}
 // CHECK-AST:       }
 
 @frozen
 public struct FrozenStruct: Differentiable {}
 
-// CHECK-AST-LABEL: @frozen public struct FrozenStruct : Differentiable {
-// CHECK-AST:   @frozen public struct TangentVector : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
+// CHECK-AST-LABEL: @frozen public struct FrozenStruct: Differentiable {
+// CHECK-AST:   @frozen public struct TangentVector: {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
 // CHECK-AST:   internal init()
 
 @usableFromInline
 struct UsableFromInlineStruct: Differentiable {}
 
 // CHECK-AST-LABEL: @usableFromInline
-// CHECK-AST: struct UsableFromInlineStruct : Differentiable {
+// CHECK-AST: struct UsableFromInlineStruct: Differentiable {
 // CHECK-AST:   @usableFromInline
-// CHECK-AST:   struct TangentVector : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
+// CHECK-AST:   struct TangentVector: {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
 // CHECK-AST:   internal init()
 
 // Test property wrappers.
@@ -96,8 +96,8 @@ struct WrappedPropertiesStruct: Differentiable {
   @noDerivative @Wrapper var nondiff: Float
 }
 
-// CHECK-AST-LABEL: internal struct WrappedPropertiesStruct : Differentiable {
-// CHECK-AST:   internal struct TangentVector : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
+// CHECK-AST-LABEL: internal struct WrappedPropertiesStruct: Differentiable {
+// CHECK-AST:   internal struct TangentVector: {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
 // CHECK-AST:     internal var x: Float.TangentVector
 // CHECK-AST:     internal var y: Float.TangentVector
 // CHECK-AST:     internal var z: Float.TangentVector
@@ -111,8 +111,8 @@ class WrappedPropertiesClass: Differentiable {
   @noDerivative @Wrapper var noDeriv: Float = 4
 }
 
-// CHECK-AST-LABEL: internal class WrappedPropertiesClass : Differentiable {
-// CHECK-AST:   internal struct TangentVector : {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
+// CHECK-AST-LABEL: internal class WrappedPropertiesClass: Differentiable {
+// CHECK-AST:   internal struct TangentVector: {{(Differentiable, AdditiveArithmetic)|(AdditiveArithmetic, Differentiable)}} {
 // CHECK-AST:     internal var x: Float.TangentVector
 // CHECK-AST:     internal var y: Float.TangentVector
 // CHECK-AST:     internal var z: Float.TangentVector
@@ -125,8 +125,8 @@ struct AutoDeriveEncodableTV1: TangentVectorMustBeEncodable {
   var x: Float
 }
 
-// CHECK-AST-LABEL: internal struct AutoDeriveEncodableTV1 : TangentVectorMustBeEncodable {
-// CHECK-AST:   internal struct TangentVector : {{(Encodable, Differentiable, AdditiveArithmetic)|(Encodable, AdditiveArithmetic, Differentiable)|(Differentiable, Encodable, AdditiveArithmetic)|(AdditiveArithmetic, Encodable, Differentiable)|(Differentiable, AdditiveArithmetic, Encodable)|(AdditiveArithmetic, Differentiable, Encodable)}} {
+// CHECK-AST-LABEL: internal struct AutoDeriveEncodableTV1: TangentVectorMustBeEncodable {
+// CHECK-AST:   internal struct TangentVector: {{(Encodable, Differentiable, AdditiveArithmetic)|(Encodable, AdditiveArithmetic, Differentiable)|(Differentiable, Encodable, AdditiveArithmetic)|(AdditiveArithmetic, Encodable, Differentiable)|(Differentiable, AdditiveArithmetic, Encodable)|(AdditiveArithmetic, Differentiable, Encodable)}} {
 
 struct AutoDeriveEncodableTV2 {
   var x: Float
@@ -134,8 +134,8 @@ struct AutoDeriveEncodableTV2 {
 
 extension AutoDeriveEncodableTV2: TangentVectorMustBeEncodable {}
 
-// CHECK-AST-LABEL: extension AutoDeriveEncodableTV2 : TangentVectorMustBeEncodable {
-// CHECK-AST:   internal struct TangentVector : {{(Encodable, Differentiable, AdditiveArithmetic)|(Encodable, AdditiveArithmetic, Differentiable)|(Differentiable, Encodable, AdditiveArithmetic)|(AdditiveArithmetic, Encodable, Differentiable)|(Differentiable, AdditiveArithmetic, Encodable)|(AdditiveArithmetic, Differentiable, Encodable)}} {
+// CHECK-AST-LABEL: extension AutoDeriveEncodableTV2: TangentVectorMustBeEncodable {
+// CHECK-AST:   internal struct TangentVector: {{(Encodable, Differentiable, AdditiveArithmetic)|(Encodable, AdditiveArithmetic, Differentiable)|(Differentiable, Encodable, AdditiveArithmetic)|(AdditiveArithmetic, Encodable, Differentiable)|(Differentiable, AdditiveArithmetic, Encodable)|(AdditiveArithmetic, Differentiable, Encodable)}} {
 
 protocol TangentVectorP: Differentiable {
   var requirement: Int { get }
@@ -155,8 +155,8 @@ extension TangentVectorP where Self == StructWithTangentVectorConstrained.Tangen
   var requirement: Int { 42 }
 }
 
-// CHECK-AST-LABEL: internal struct StructWithTangentVectorConstrained : TangentVectorConstrained {
-// CHECK-AST:   internal struct TangentVector : {{(TangentVectorP, Differentiable, AdditiveArithmetic)|(TangentVectorP, AdditiveArithmetic, Differentiable)|(Differentiable, TangentVectorP, AdditiveArithmetic)|(AdditiveArithmetic, TangentVectorP, Differentiable)|(Differentiable, AdditiveArithmetic, TangentVectorP)|(AdditiveArithmetic, Differentiable, TangentVectorP)}} {
+// CHECK-AST-LABEL: internal struct StructWithTangentVectorConstrained: TangentVectorConstrained {
+// CHECK-AST:   internal struct TangentVector: {{(TangentVectorP, Differentiable, AdditiveArithmetic)|(TangentVectorP, AdditiveArithmetic, Differentiable)|(Differentiable, TangentVectorP, AdditiveArithmetic)|(AdditiveArithmetic, TangentVectorP, Differentiable)|(Differentiable, AdditiveArithmetic, TangentVectorP)|(AdditiveArithmetic, Differentiable, TangentVectorP)}} {
 
 // https://github.com/apple/swift/issues/56601
 
@@ -165,18 +165,18 @@ public struct S1: Differentiable {
   public var scalar: Float
 }
 
-// CHECK-AST-LABEL: public struct S1 : Differentiable {
+// CHECK-AST-LABEL: public struct S1: Differentiable {
 // CHECK-AST: public var simd: [Float]
 // CHECK-AST: public var scalar: Float
-// CHECK-AST: struct TangentVector : AdditiveArithmetic, Differentiable {
+// CHECK-AST: struct TangentVector: AdditiveArithmetic, Differentiable {
 // CHECK-AST:   var simd: Array<Float>.TangentVector
 // CHECK-AST:   var scalar: Float
 
-// CHECK-SIL-LABEL: public struct S1 : Differentiable {
+// CHECK-SIL-LABEL: public struct S1: Differentiable {
 // CHECK-SIL: @differentiable(reverse, wrt: self)
 // CHECK-SIL: @_hasStorage public var simd: [Float] { get set }
 // CHECK-SIL: @differentiable(reverse, wrt: self)
 // CHECK-SIL: @_hasStorage public var scalar: Float { get set }
-// CHECK-SIL: struct TangentVector : AdditiveArithmetic, Differentiable {
+// CHECK-SIL: struct TangentVector: AdditiveArithmetic, Differentiable {
 // CHECK-SIL:   @_hasStorage var simd: Array<Float>.DifferentiableView { get set }
 // CHECK-SIL:   @_hasStorage var scalar: Float { get set }

--- a/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
+++ b/test/ClangImporter/Inputs/SwiftPrivateAttr.txt
@@ -2,7 +2,7 @@
 
 protocol __PrivProto {
 }
-class Foo : NSObject, __PrivProto {
+class Foo: NSObject, __PrivProto {
   var __privValue: Any!
   class var __privClassValue: Any!
   func __noArgs()
@@ -26,14 +26,14 @@ class Foo : NSObject, __PrivProto {
   func setObject(_ object: Any!, atIndexedSubscript index: Int32)
   init()
 }
-class Bar : NSObject {
+class Bar: NSObject {
   init!()
   init!(__noArgs: ())
   init!(__oneArg arg: Int32)
   init!(__twoArgs arg: Int32, other arg2: Int32)
   init!(__ arg: Int32)
 }
-class __PrivFooSub : Foo {
+class __PrivFooSub: Foo {
   convenience init!(__oneArg arg: Int32)
   convenience init!(__twoArgs arg: Int32, other arg2: Int32)
   convenience init!(__ arg: Int32)
@@ -56,34 +56,34 @@ struct __PrivS2 {
   var value: Int32
 }
 var __PrivAnonymousA: Int { get }
-struct E0 : Hashable, Equatable, RawRepresentable {
+struct E0: Hashable, Equatable, RawRepresentable {
   init(_ rawValue: UInt32)
   init(rawValue: UInt32)
   var rawValue: UInt32
   typealias RawValue = UInt32
 }
 var __E0PrivA: E0 { get }
-struct __PrivE1 : Hashable, Equatable, RawRepresentable {
+struct __PrivE1: Hashable, Equatable, RawRepresentable {
   init(_ rawValue: UInt32)
   init(rawValue: UInt32)
   var rawValue: UInt32
   typealias RawValue = UInt32
 }
 var __PrivE1A: __PrivE1 { get }
-struct __PrivE2 : Hashable, Equatable, RawRepresentable {
+struct __PrivE2: Hashable, Equatable, RawRepresentable {
   init(_ rawValue: UInt32)
   init(rawValue: UInt32)
   var rawValue: UInt32
   typealias RawValue = UInt32
 }
 var __PrivE2A: __PrivE2 { get }
-enum __PrivNSEnum : Int {
+enum __PrivNSEnum: Int {
   init?(rawValue: Int)
   var rawValue: Int { get }
   typealias RawValue = Int
   case A
 }
-enum NSEnum : Int {
+enum NSEnum: Int {
   init?(rawValue: Int)
   var rawValue: Int { get }
   typealias RawValue = Int
@@ -92,7 +92,7 @@ enum NSEnum : Int {
   static var __PrivA: NSEnum { get }
   case B
 }
-struct __PrivNSOptions : OptionSet {
+struct __PrivNSOptions: OptionSet {
   init(rawValue: Int)
   let rawValue: Int
   typealias RawValue = Int
@@ -100,7 +100,7 @@ struct __PrivNSOptions : OptionSet {
   typealias ArrayLiteralElement = __PrivNSOptions
   static var A: __PrivNSOptions { get }
 }
-struct NSOptions : OptionSet {
+struct NSOptions: OptionSet {
   init(rawValue: Int)
   let rawValue: Int
   typealias RawValue = Int
@@ -111,7 +111,7 @@ struct NSOptions : OptionSet {
   static var __PrivA: NSOptions { get }
   static var B: NSOptions { get }
 }
-class __PrivCFType : _CFObject {
+class __PrivCFType: _CFObject {
 }
 @available(swift, obsoleted: 3, renamed: "__PrivCFType")
 typealias __PrivCFTypeRef = __PrivCFType

--- a/test/ClangImporter/c_inside_objc.swift
+++ b/test/ClangImporter/c_inside_objc.swift
@@ -8,7 +8,7 @@
 
 // CHECK-LABEL: struct AlreadyDeclaredStruct {
 
-// CHECK-LABEL: {{class Wrapper : Base {|extension Wrapper {|protocol Wrapper {}}
+// CHECK-LABEL: {{class Wrapper: Base {|extension Wrapper {|protocol Wrapper {}}
 // CHECK-NOT: struct
 // CHECK: var forward: ForwardDeclaredStruct
 // CHECK-NOT: struct

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -123,8 +123,8 @@ class ObjCTest {
 }
 #endif
 
-// HEADER: struct TestError : _BridgedStoredNSError {
-// HEADER:   enum Code : Int32, _ErrorCodeProtocol, @unchecked Sendable {
+// HEADER: struct TestError: _BridgedStoredNSError {
+// HEADER:   enum Code: Int32, _ErrorCodeProtocol, @unchecked Sendable {
 // HEADER:     init?(rawValue: Int32)
 // HEADER:     var rawValue: Int32 { get }
 // HEADER:     typealias _ErrorType = TestError
@@ -135,8 +135,8 @@ class ObjCTest {
 // HEADER: }
 // HEADER: func getErr() -> TestError.Code
 
-// HEADER-NO-PRIVATE: struct TestError : CustomNSError, Hashable, Error {
-// HEADER-NO-PRIVATE:   enum Code : Int32, @unchecked Sendable, Equatable {
+// HEADER-NO-PRIVATE: struct TestError: CustomNSError, Hashable, Error {
+// HEADER-NO-PRIVATE:   enum Code: Int32, @unchecked Sendable, Equatable {
 // HEADER-NO-PRIVATE:     init?(rawValue: Int32)
 // HEADER-NO-PRIVATE:     var rawValue: Int32 { get }
 // HEADER-NO-PRIVATE:     typealias _ErrorType = TestError

--- a/test/ClangImporter/enum-exhaustivity.swift
+++ b/test/ClangImporter/enum-exhaustivity.swift
@@ -2,12 +2,12 @@
 
 // RUN: %target-swift-ide-test -source-filename %s -print-module -module-to-print EnumExhaustivity -I %S/Inputs/custom-modules | %FileCheck %s
 
-// CHECK-LABEL: {{^}}enum RegularEnum : {{.+}} {
+// CHECK-LABEL: {{^}}enum RegularEnum: {{.+}} {
 // CHECK:      case A
 // CHECK-NEXT: case B
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-LABEL: {{^}}@frozen enum ExhaustiveEnum : {{.+}} {
+// CHECK-LABEL: {{^}}@frozen enum ExhaustiveEnum: {{.+}} {
 // CHECK:      case A
 // CHECK-NEXT: case B
 // CHECK-NEXT: {{^}$}}

--- a/test/ClangImporter/incomplete_objc_types_swift_ide_test.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_ide_test.swift
@@ -20,7 +20,7 @@
 // CHECK: @available(*, unavailable, message: "This Objective-C protocol has only been forward-declared; import its owning module to use it")
 // CHECK: protocol ForwardDeclaredProtocol {
 // CHECK: }
-// CHECK: class IncompleteTypeConsumer1 : NSObject {
+// CHECK: class IncompleteTypeConsumer1: NSObject {
 // CHECK:   var propertyUsingAForwardDeclaredProtocol1: (any ForwardDeclaredProtocol)!
 // CHECK:   var propertyUsingAForwardDeclaredInterface1: ForwardDeclaredInterface!
 // CHECK:   init!()

--- a/test/ClangImporter/objc_forward_declarations.swift
+++ b/test/ClangImporter/objc_forward_declarations.swift
@@ -4,7 +4,7 @@
 
 // REQUIRES: swift_feature_ImportObjcForwardDeclarations
 
-// CHECK: class Innocuous : Confusing {
+// CHECK: class Innocuous: Confusing {
 
 import ForwardDeclarationsHelper
 

--- a/test/ClangImporter/regionbasedisolation.swift
+++ b/test/ClangImporter/regionbasedisolation.swift
@@ -4,14 +4,14 @@
 // REQUIRES: objc_interop
 
 extension ObjCObject {
-  // CHECK-LABEL: sil hidden [ossa] @$sSo10ObjCObjectC20regionbasedisolationE11sendObjectsSaySo8NSObjectCGyYaKF : $@convention(method) @async (@guaranteed ObjCObject) -> (@sil_sending @owned Array<NSObject>, @error any Error) {
-  // CHECK: bb0([[SELF:%.*]] : @guaranteed $ObjCObject):
+  // CHECK-LABEL: sil hidden [ossa] @$sSo10ObjCObjectC20regionbasedisolationE11sendObjectsSaySo8NSObjectCGyYaKF: $@convention(method) @async (@guaranteed ObjCObject) -> (@sil_sending @owned Array<NSObject>, @error any Error) {
+  // CHECK: bb0([[SELF:%.*]]: @guaranteed $ObjCObject):
 
   // Our result.
   // CHECK: [[RESULT:%.*]] = alloc_stack $Array<NSObject>
 
   // Our method.
-  // CHECK: [[METHOD:%.*]] = objc_method [[SELF]], #ObjCObject.loadObjects!foreign : (ObjCObject) -> () async throws -> [NSObject], $@convention(objc_method) (@convention(block) @Sendable (Optional<NSArray>, Optional<NSError>) -> (), ObjCObject) -> ()
+  // CHECK: [[METHOD:%.*]] = objc_method [[SELF]], #ObjCObject.loadObjects!foreign: (ObjCObject) -> () async throws -> [NSObject], $@convention(objc_method) (@convention(block) @Sendable (Optional<NSArray>, Optional<NSError>) -> (), ObjCObject) -> ()
 
   // Begin setting up the unsafe continuation for our method. Importantly note
   // that [[UNSAFE_CONT]] is Sendable, so we lose any connection from the
@@ -27,7 +27,7 @@ extension ObjCObject {
 
   // Then create a checked continuation from the unsafe continuation.
   //
-  // CHECK: [[CREATE_CHECKED_CONT:%.*]] = function_ref @$ss34_createCheckedThrowingContinuationyScCyxs5Error_pGSccyxsAB_pGnlF : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
+  // CHECK: [[CREATE_CHECKED_CONT:%.*]] = function_ref @$ss34_createCheckedThrowingContinuationyScCyxs5Error_pGSccyxsAB_pGnlF: $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
   // CHECK: [[CHECKED_CONT:%.*]] = alloc_stack $CheckedContinuation<Array<NSObject>, any Error>
   // CHECK: apply [[CREATE_CHECKED_CONT]]<Array<NSObject>>([[CHECKED_CONT]], [[UNSAFE_CONT]])
 
@@ -43,7 +43,7 @@ extension ObjCObject {
   // Then create the actual block. NOTE: Since the block is @Sendable, the block
   // does not propagate regions.
   //
-  // CHECK: [[COMPLETION_HANDLER_BLOCK:%.*]] = function_ref @$sSo7NSArrayCSgSo7NSErrorCSgIeyBhyy_SaySo8NSObjectCGTz_ : $@convention(c) @Sendable (@inout_aliasable @block_storage Any, Optional<NSArray>, Optional<NSError>) -> ()
+  // CHECK: [[COMPLETION_HANDLER_BLOCK:%.*]] = function_ref @$sSo7NSArrayCSgSo7NSErrorCSgIeyBhyy_SaySo8NSObjectCGTz_: $@convention(c) @Sendable (@inout_aliasable @block_storage Any, Optional<NSArray>, Optional<NSError>) -> ()
   // CHECK: [[COMPLETION_BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]], invoke [[COMPLETION_HANDLER_BLOCK]]
   //
   // Since the block is @Sendable, it does not propagate the connection in
@@ -65,14 +65,14 @@ extension ObjCObject {
 
   // Check if we do not mark the block as NS_SWIFT_SENDABLE
   //
-  // CHECK-LABEL: sil hidden [ossa] @$sSo10ObjCObjectC20regionbasedisolationE12sendObjects2SaySo8NSObjectCGyYaKF : $@convention(method) @async (@guaranteed ObjCObject) -> (@sil_sending @owned Array<NSObject>, @error any Error) {
-  // CHECK: bb0([[SELF:%.*]] : @guaranteed $ObjCObject):
+  // CHECK-LABEL: sil hidden [ossa] @$sSo10ObjCObjectC20regionbasedisolationE12sendObjects2SaySo8NSObjectCGyYaKF: $@convention(method) @async (@guaranteed ObjCObject) -> (@sil_sending @owned Array<NSObject>, @error any Error) {
+  // CHECK: bb0([[SELF:%.*]]: @guaranteed $ObjCObject):
 
   // Our result.
   // CHECK: [[RESULT:%.*]] = alloc_stack $Array<NSObject>
 
   // Our method.
-  // CHECK: [[METHOD:%.*]] = objc_method [[SELF]], #ObjCObject.loadObjects2!foreign : (ObjCObject) -> () async throws -> [NSObject], $@convention(objc_method) (@convention(block) @Sendable (Optional<NSArray>, Optional<NSError>) -> (), ObjCObject) -> ()
+  // CHECK: [[METHOD:%.*]] = objc_method [[SELF]], #ObjCObject.loadObjects2!foreign: (ObjCObject) -> () async throws -> [NSObject], $@convention(objc_method) (@convention(block) @Sendable (Optional<NSArray>, Optional<NSError>) -> (), ObjCObject) -> ()
 
   // Begin setting up the unsafe continuation for our method. Importantly note
   // that [[UNSAFE_CONT]] is Sendable, so we lose any connection from the
@@ -88,7 +88,7 @@ extension ObjCObject {
 
   // Then create a checked continuation from the unsafe continuation.
   //
-  // CHECK: [[CREATE_CHECKED_CONT:%.*]] = function_ref @$ss34_createCheckedThrowingContinuationyScCyxs5Error_pGSccyxsAB_pGnlF : $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
+  // CHECK: [[CREATE_CHECKED_CONT:%.*]] = function_ref @$ss34_createCheckedThrowingContinuationyScCyxs5Error_pGSccyxsAB_pGnlF: $@convention(thin) <τ_0_0> (UnsafeContinuation<τ_0_0, any Error>) -> @out CheckedContinuation<τ_0_0, any Error>
   // CHECK: [[CHECKED_CONT:%.*]] = alloc_stack $CheckedContinuation<Array<NSObject>, any Error>
   // CHECK: apply [[CREATE_CHECKED_CONT]]<Array<NSObject>>([[CHECKED_CONT]], [[UNSAFE_CONT]])
 
@@ -104,7 +104,7 @@ extension ObjCObject {
   // Then create the actual block. NOTE: Since the block is @Sendable, the block
   // does not propagate regions.
   //
-  // CHECK: [[COMPLETION_HANDLER_BLOCK:%.*]] = function_ref @$sSo7NSArrayCSgSo7NSErrorCSgIeyBhyy_SaySo8NSObjectCGTz_ : $@convention(c) @Sendable (@inout_aliasable @block_storage Any, Optional<NSArray>, Optional<NSError>) -> ()
+  // CHECK: [[COMPLETION_HANDLER_BLOCK:%.*]] = function_ref @$sSo7NSArrayCSgSo7NSErrorCSgIeyBhyy_SaySo8NSObjectCGTz_: $@convention(c) @Sendable (@inout_aliasable @block_storage Any, Optional<NSArray>, Optional<NSError>) -> ()
   // CHECK: [[COMPLETION_BLOCK:%.*]] = init_block_storage_header [[BLOCK_STORAGE]], invoke [[COMPLETION_HANDLER_BLOCK]]
   //
   // Since the block is @Sendable, it does not propagate the connection in

--- a/test/IDE/import_as_member_objc.swift
+++ b/test/IDE/import_as_member_objc.swift
@@ -5,14 +5,14 @@
 // rdar://77558075
 // UNSUPPORTED: OS=tvos && CPU=x86_64
 
-// PRINT-CLASS-LABEL: class SomeClass : NSObject {
+// PRINT-CLASS-LABEL: class SomeClass: NSObject {
 // PRINT-CLASS-NEXT:   init()
 // PRINT-CLASS-NEXT: }
 // PRINT-CLASS-NEXT: extension SomeClass {
 // PRINT-CLASS-NEXT:   /*not inherited*/ init(value x: Double)
 // PRINT-CLASS-NEXT:   func applyOptions(_ options: SomeClass.Options)
 // PRINT-CLASS-NEXT:   func doIt()
-// PRINT-CLASS-NEXT:   struct Options : OptionSet {
+// PRINT-CLASS-NEXT:   struct Options: OptionSet {
 // PRINT-CLASS-NEXT:     init(rawValue rawValue: Int)
 // PRINT-CLASS-NEXT:     let rawValue: Int
 // PRINT-CLASS-NEXT:     typealias RawValue = Int

--- a/test/IDE/newtype.swift
+++ b/test/IDE/newtype.swift
@@ -5,7 +5,7 @@
 // RUN: %target-typecheck-verify-swift -sdk %clang-importer-sdk -I %S/Inputs/custom-modules -I %t
 // REQUIRES: objc_interop
 
-// PRINT-LABEL: struct ErrorDomain : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct ErrorDomain: _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
@@ -26,7 +26,7 @@
 // PRINT-NEXT:  extension Food {
 // PRINT-NEXT:    static let err: ErrorDomain
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct ClosedEnum : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT:  struct ClosedEnum: _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
@@ -37,14 +37,14 @@
 // PRINT-NEXT:    static let secondEntry: ClosedEnum
 // PRINT-NEXT:    static let thirdEntry: ClosedEnum
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct IUONewtype : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT:  struct IUONewtype: _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
 // PRINT-NEXT:    typealias RawValue = String
 // PRINT-NEXT:    typealias _ObjectiveCType = NSString
 // PRINT-NEXT:  }
-// PRINT-NEXT:  struct MyFloat : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT:  struct MyFloat: Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: Float)
 // PRINT-NEXT:    init(rawValue: Float)
 // PRINT-NEXT:    let rawValue: Float
@@ -56,7 +56,7 @@
 // PRINT-NEXT:    static let version: MyFloat{{$}}
 // PRINT-NEXT:  }
 //
-// PRINT-LABEL: struct MyInt : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct MyInt: Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: Int32)
 // PRINT-NEXT:    init(rawValue: Int32)
 // PRINT-NEXT:    let rawValue: Int32
@@ -83,7 +83,7 @@
 // PRINT-NEXT:  let Notification: String
 // PRINT-NEXT:  let swiftNamedNotification: String
 //
-// PRINT-LABEL: struct CFNewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct CFNewType: Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
@@ -97,7 +97,7 @@
 // PRINT-NEXT:  func FooAudited() -> CFNewType
 // PRINT-NEXT:  func FooUnaudited() -> Unmanaged<CFString>
 //
-// PRINT-LABEL: struct MyABINewType : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct MyABINewType: Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: CFString)
 // PRINT-NEXT:    init(rawValue: CFString)
 // PRINT-NEXT:    let rawValue: CFString
@@ -114,7 +114,7 @@
 // PRINT-NEXT:  func takeMyABIOldType(_: MyABIOldType!)
 // PRINT-NEXT:  func takeMyABINewTypeNonNull(_: MyABINewType)
 // PRINT-NEXT:  func takeMyABIOldTypeNonNull(_: MyABIOldType)
-// PRINT-LABEL: struct MyABINewTypeNS : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-LABEL: struct MyABINewTypeNS: _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:    init(_ rawValue: String)
 // PRINT-NEXT:    init(rawValue: String)
 // PRINT-NEXT:    var rawValue: String { get }
@@ -133,7 +133,7 @@
 // PRINT-NEXT:    var i: Int32
 // PRINT-NEXT:  }
 // PRINT-NEXT:  extension NSSomeContext {
-// PRINT-NEXT:    struct Name : _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT:    struct Name: _ObjectiveCBridgeable, Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:      init(_ rawValue: String)
 // PRINT-NEXT:      init(rawValue: String)
 // PRINT-NEXT:      var rawValue: String { get }
@@ -145,13 +145,13 @@
 // PRINT-NEXT:    static let myContextName: NSSomeContext.Name
 // PRINT-NEXT:  }
 //
-// PRINT-NEXT: struct TRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT: struct TRef: Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:   init(_ rawValue: OpaquePointer)
 // PRINT-NEXT:   init(rawValue: OpaquePointer)
 // PRINT-NEXT:   let rawValue: OpaquePointer
 // PRINT-NEXT:   typealias RawValue = OpaquePointer
 // PRINT-NEXT: }
-// PRINT-NEXT: struct ConstTRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT: struct ConstTRef: Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:   init(_ rawValue: OpaquePointer)
 // PRINT-NEXT:   init(rawValue: OpaquePointer)
 // PRINT-NEXT:   let rawValue: OpaquePointer
@@ -169,13 +169,13 @@
 // PRINT-NEXT:   func use()
 // PRINT-NEXT: }
 //
-// PRINT-NEXT: struct TRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT: struct TRefRef: Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:   init(_ rawValue: UnsafeMutablePointer<OpaquePointer>)
 // PRINT-NEXT:   init(rawValue: UnsafeMutablePointer<OpaquePointer>)
 // PRINT-NEXT:   let rawValue: UnsafeMutablePointer<OpaquePointer>
 // PRINT-NEXT:   typealias RawValue = UnsafeMutablePointer<OpaquePointer>
 // PRINT-NEXT: }
-// PRINT-NEXT: struct ConstTRefRef : Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
+// PRINT-NEXT: struct ConstTRefRef: Hashable, Equatable, _SwiftNewtypeWrapper, RawRepresentable, @unchecked Sendable {
 // PRINT-NEXT:   init(_ rawValue: UnsafePointer<OpaquePointer>)
 // PRINT-NEXT:   init(rawValue: UnsafePointer<OpaquePointer>)
 // PRINT-NEXT:   let rawValue: UnsafePointer<OpaquePointer>

--- a/test/IDE/newtype_objc.swift
+++ b/test/IDE/newtype_objc.swift
@@ -7,7 +7,7 @@
 
 // REQUIRES: objc_interop
 
-// PRINT: class UsesGenericClassA : NSObject {
+// PRINT: class UsesGenericClassA: NSObject {
 // PRINT:   func takeEnumValues(_ values: GenericClassA<NSString>)
 // PRINT:   func takeEnumValuesArray(_ values: [ClosedEnum])
 // PRINT: }

--- a/test/IDE/print_ast_overlay.swift
+++ b/test/IDE/print_ast_overlay.swift
@@ -30,7 +30,7 @@ public class FooOverlayClassDerived : FooOverlayClassBase {
 // declarations from both of them.
 
 // PASS_WITH_OVERLAY-LABEL: {{^}}class FooClassBase {
-// PASS_WITH_OVERLAY-LABEL: {{^}}class FooOverlayClassDerived : FooOverlayClassBase {
+// PASS_WITH_OVERLAY-LABEL: {{^}}class FooOverlayClassDerived: FooOverlayClassBase {
 // PASS_WITH_OVERLAY-NEXT:  {{^}}  override func f()
 // PASS_WITH_OVERLAY: {{^}}func overlay_func(){{$}}
 

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -457,7 +457,7 @@ class d0120_TestClassBase {
 }
 
 class d0121_TestClassDerived : d0120_TestClassBase {
-// PASS_COMMON-LABEL: {{^}}@_inheritsConvenienceInitializers {{()?}}class d0121_TestClassDerived : d0120_TestClassBase {{{$}}
+// PASS_COMMON-LABEL: {{^}}@_inheritsConvenienceInitializers {{()?}}class d0121_TestClassDerived: d0120_TestClassBase {{{$}}
 
   required init() { super.init() }
 // PASS_COMMON-NEXT: {{^}}  required init(){{$}}
@@ -504,7 +504,7 @@ protocol d0130_TestProtocol {
 }
 
 protocol d0150_TestClassProtocol : class {}
-// PASS_COMMON-LABEL: {{^}}protocol d0150_TestClassProtocol : AnyObject {{{$}}
+// PASS_COMMON-LABEL: {{^}}protocol d0150_TestClassProtocol: AnyObject {{{$}}
 
 @objc protocol d0151_TestClassProtocol {}
 // PASS_COMMON-LABEL: {{^}}@objc protocol d0151_TestClassProtocol {{{$}}
@@ -627,15 +627,15 @@ struct d0200_EscapedIdentifiers {
 // PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  typealias `protocol` = `class`{{$}}
 
   class `extension` : `class` {}
-// PASS_ONE_LINE_TYPE-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension` : d0200_EscapedIdentifiers.`class` {{{$}}
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension` : `class` {{{$}}
+// PASS_ONE_LINE_TYPE-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension`: d0200_EscapedIdentifiers.`class` {{{$}}
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  @_inheritsConvenienceInitializers class `extension`: `class` {{{$}}
 // PASS_COMMON:      {{^}}    {{(override )?}}init(){{$}}
 // PASS_COMMON-NEXT: {{^}}    @objc deinit{{$}}
 // PASS_COMMON-NEXT: {{^}}  }{{$}}
 
   func `func`<`let`: `protocol`, `where`>(
       class: Int, struct: `protocol`, foo: `let`, bar: `where`) where `where` : `protocol` {}
-// PASS_COMMON-NEXT: {{^}}  func `func`<`let`, `where`>(class: Int, struct: {{(d0200_EscapedIdentifiers.)?}}`protocol`, foo: `let`, bar: `where`) where `let` : {{(d0200_EscapedIdentifiers.)?}}`class`, `where` : {{(d0200_EscapedIdentifiers.)?}}`class`{{$}}
+// PASS_COMMON-NEXT: {{^}}  func `func`<`let`, `where`>(class: Int, struct: {{(d0200_EscapedIdentifiers.)?}}`protocol`, foo: `let`, bar: `where`) where `let` : {{(d0200_EscapedIdentifiers.)?}}`class`, `where`: {{(d0200_EscapedIdentifiers.)?}}`class`{{$}}
 
   var `var`: `struct` = `struct`()
 // PASS_COMMON-NEXT: {{^}}  @_hasInitialValue var `var`: {{(d0200_EscapedIdentifiers.)?}}`struct`{{$}}
@@ -764,7 +764,7 @@ class d0260_ExplodePattern_TestClassBase {
 }
 
 class d0261_ExplodePattern_TestClassDerived : d0260_ExplodePattern_TestClassBase {
-// PASS_EXPLODE_PATTERN-LABEL: {{^}}@_inheritsConvenienceInitializers class d0261_ExplodePattern_TestClassDerived : d0260_ExplodePattern_TestClassBase {{{$}}
+// PASS_EXPLODE_PATTERN-LABEL: {{^}}@_inheritsConvenienceInitializers class d0261_ExplodePattern_TestClassDerived: d0260_ExplodePattern_TestClassBase {{{$}}
 
   override final var baseProp2: Int {
     get {
@@ -783,15 +783,15 @@ struct StructWithoutInheritance1 {}
 // PASS_ONE_LINE-DAG: {{^}}struct StructWithoutInheritance1 {{{$}}
 
 struct StructWithInheritance1 : FooProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}struct StructWithInheritance1 : FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}struct StructWithInheritance1: FooProtocol {{{$}}
 
 struct StructWithInheritance2 : FooProtocol, BarProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}struct StructWithInheritance2 : FooProtocol, BarProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}struct StructWithInheritance2: FooProtocol, BarProtocol {{{$}}
 
 struct StructWithInheritance3 : QuxProtocol, SubFooProtocol {
   typealias Qux = Int
 }
-// PASS_ONE_LINE-DAG: {{^}}struct StructWithInheritance3 : QuxProtocol, SubFooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}struct StructWithInheritance3: QuxProtocol, SubFooProtocol {{{$}}
 
 //===---
 //===--- Inheritance list in classes.
@@ -801,24 +801,24 @@ class ClassWithoutInheritance1 {}
 // PASS_ONE_LINE-DAG: {{^}}class ClassWithoutInheritance1 {{{$}}
 
 class ClassWithInheritance1 : FooProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance1 : FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance1: FooProtocol {{{$}}
 
 class ClassWithInheritance2 : FooProtocol, BarProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance2 : FooProtocol, BarProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance2: FooProtocol, BarProtocol {{{$}}
 
 class ClassWithInheritance3 : FooClass {}
-// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance3 : FooClass {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance3: FooClass {{{$}}
 
 class ClassWithInheritance4 : FooClass, FooProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance4 : FooClass, FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance4: FooClass, FooProtocol {{{$}}
 
 class ClassWithInheritance5 : FooClass, FooProtocol, BarProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance5 : FooClass, FooProtocol, BarProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}@_inheritsConvenienceInitializers class ClassWithInheritance5: FooClass, FooProtocol, BarProtocol {{{$}}
 
 class ClassWithInheritance6 : QuxProtocol, SubFooProtocol {
   typealias Qux = Int
 }
-// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance6 : QuxProtocol, SubFooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}class ClassWithInheritance6: QuxProtocol, SubFooProtocol {{{$}}
 
 //===---
 //===--- Inheritance list in enums.
@@ -828,21 +828,21 @@ enum EnumWithoutInheritance1 {}
 // PASS_ONE_LINE-DAG: {{^}}enum EnumWithoutInheritance1 {{{$}}
 
 enum EnumWithInheritance1 : FooProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}enum EnumWithInheritance1 : FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}enum EnumWithInheritance1: FooProtocol {{{$}}
 
 enum EnumWithInheritance2 : FooProtocol, BarProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}enum EnumWithInheritance2 : FooProtocol, BarProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}enum EnumWithInheritance2: FooProtocol, BarProtocol {{{$}}
 
 enum EnumDeclWithUnderlyingType1 : Int { case X }
-// PASS_ONE_LINE-DAG: {{^}}enum EnumDeclWithUnderlyingType1 : Int {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}enum EnumDeclWithUnderlyingType1: Int {{{$}}
 
 enum EnumDeclWithUnderlyingType2 : Int, FooProtocol { case X }
-// PASS_ONE_LINE-DAG: {{^}}enum EnumDeclWithUnderlyingType2 : Int, FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}enum EnumDeclWithUnderlyingType2: Int, FooProtocol {{{$}}
 
 enum EnumWithInheritance3 : QuxProtocol, SubFooProtocol {
   typealias Qux = Int
 }
-// PASS_ONE_LINE-DAG: {{^}}enum EnumWithInheritance3 : QuxProtocol, SubFooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}enum EnumWithInheritance3: QuxProtocol, SubFooProtocol {{{$}}
 
 //===---
 //===--- Inheritance list in protocols.
@@ -852,14 +852,14 @@ protocol ProtocolWithoutInheritance1 {}
 // PASS_ONE_LINE-DAG: {{^}}protocol ProtocolWithoutInheritance1 {{{$}}
 
 protocol ProtocolWithInheritance1 : FooProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}protocol ProtocolWithInheritance1 : FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}protocol ProtocolWithInheritance1: FooProtocol {{{$}}
 
 protocol ProtocolWithInheritance2 : FooProtocol, BarProtocol { }
-// PASS_ONE_LINE-DAG: {{^}}protocol ProtocolWithInheritance2 : BarProtocol, FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}protocol ProtocolWithInheritance2: BarProtocol, FooProtocol {{{$}}
 
 protocol ProtocolWithInheritance3 : QuxProtocol, SubFooProtocol {
 }
-// PASS_ONE_LINE-DAG: {{^}}protocol ProtocolWithInheritance3 : QuxProtocol, SubFooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}protocol ProtocolWithInheritance3: QuxProtocol, SubFooProtocol {{{$}}
 
 //===---
 //===--- Inheritance list in extensions
@@ -867,7 +867,7 @@ protocol ProtocolWithInheritance3 : QuxProtocol, SubFooProtocol {
 
 struct StructInherited { }
 
-// PASS_ONE_LINE-DAG: {{.*}}extension StructInherited : QuxProtocol, SubFooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{.*}}extension StructInherited: QuxProtocol, SubFooProtocol {{{$}}
 extension StructInherited : QuxProtocol, SubFooProtocol {
   typealias Qux = Int
 }
@@ -888,16 +888,16 @@ protocol AssociatedType1 {
 // PASS_ONE_LINE-DAG: {{^}}  associatedtype AssociatedTypeDecl1 = Int{{$}}
 
   associatedtype AssociatedTypeDecl2 : FooProtocol
-// PASS_ONE_LINE-DAG: {{^}}  associatedtype AssociatedTypeDecl2 : FooProtocol{{$}}
+// PASS_ONE_LINE-DAG: {{^}}  associatedtype AssociatedTypeDecl2: FooProtocol{{$}}
 
   associatedtype AssociatedTypeDecl3 : FooProtocol, BarProtocol
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl3 : BarProtocol, FooProtocol{{$}}
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl3: BarProtocol, FooProtocol{{$}}
 
   associatedtype AssociatedTypeDecl4 where AssociatedTypeDecl4 : QuxProtocol, AssociatedTypeDecl4.Qux == Int
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl4 : QuxProtocol where Self.AssociatedTypeDecl4.Qux == Int{{$}}
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl4: QuxProtocol where Self.AssociatedTypeDecl4.Qux == Int{{$}}
 
   associatedtype AssociatedTypeDecl5: FooClass
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl5 : FooClass{{$}}
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  associatedtype AssociatedTypeDecl5: FooClass{{$}}
 }
 
 //===---
@@ -1100,7 +1100,7 @@ enum d2300_EnumDeclWithValues1 : Int {
   case EDV2_First = 10
   case EDV2_Second
 }
-// PASS_COMMON: {{^}}enum d2300_EnumDeclWithValues1 : Int {{{$}}
+// PASS_COMMON: {{^}}enum d2300_EnumDeclWithValues1: Int {{{$}}
 // PASS_COMMON-NEXT: {{^}}  case EDV2_First{{$}}
 // PASS_COMMON-NEXT: {{^}}  case EDV2_Second{{$}}
 // PASS_COMMON-DAG: {{^}}  typealias RawValue = Int
@@ -1112,7 +1112,7 @@ enum d2400_EnumDeclWithValues2 : Double {
   case EDV3_First = 10
   case EDV3_Second
 }
-// PASS_COMMON: {{^}}enum d2400_EnumDeclWithValues2 : Double {{{$}}
+// PASS_COMMON: {{^}}enum d2400_EnumDeclWithValues2: Double {{{$}}
 // PASS_COMMON-NEXT: {{^}}  case EDV3_First{{$}}
 // PASS_COMMON-NEXT: {{^}}  case EDV3_Second{{$}}
 // PASS_COMMON-DAG: {{^}}  typealias RawValue = Double
@@ -1140,7 +1140,7 @@ infix operator %%%
 func %%%(lhs: inout d2601_TestAssignment, rhs: d2601_TestAssignment) -> Int {
   return 0
 }
-// PASS_2500-LABEL: {{^}}infix operator %%% : DefaultPrecedence{{$}}
+// PASS_2500-LABEL: {{^}}infix operator %%%: DefaultPrecedence{{$}}
 // PASS_2500: {{^}}func %%% (lhs: inout d2601_TestAssignment, rhs: d2601_TestAssignment) -> Int{{$}}
 
 precedencegroup BoringPrecedence {
@@ -1198,7 +1198,7 @@ struct d2800_ProtocolWithAssociatedType1Impl : d2700_ProtocolWithAssociatedType1
   }
 }
 
-// PASS_COMMON: {{^}}struct d2800_ProtocolWithAssociatedType1Impl : d2700_ProtocolWithAssociatedType1 {{{$}}
+// PASS_COMMON: {{^}}struct d2800_ProtocolWithAssociatedType1Impl: d2700_ProtocolWithAssociatedType1 {{{$}}
 // PASS_COMMON-NEXT: {{^}}  func returnsTA1() -> Int{{$}}
 // PASS_COMMON-NEXT: {{^}}  typealias TA1 = Int
 // PASS_COMMON-NEXT: {{^}}  init(){{$}}
@@ -1213,8 +1213,8 @@ struct GenericParams1<
     StructGenericFooX : FooClass,
     StructGenericBar : FooProtocol & BarProtocol,
     StructGenericBaz> {
-// PASS_ONE_LINE_TYPE-DAG: {{^}}struct GenericParams1<StructGenericFoo, StructGenericFooX, StructGenericBar, StructGenericBaz> where StructGenericFoo : FooProtocol, StructGenericFooX : FooClass, StructGenericBar : BarProtocol, StructGenericBar : FooProtocol {{{$}}
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}struct GenericParams1<StructGenericFoo, StructGenericFooX, StructGenericBar, StructGenericBaz> where StructGenericFoo : FooProtocol, StructGenericFooX : FooClass, StructGenericBar : BarProtocol, StructGenericBar : FooProtocol {{{$}}
+// PASS_ONE_LINE_TYPE-DAG: {{^}}struct GenericParams1<StructGenericFoo, StructGenericFooX, StructGenericBar, StructGenericBaz> where StructGenericFoo : FooProtocol, StructGenericFooX : FooClass, StructGenericBar : BarProtocol, StructGenericBar: FooProtocol {{{$}}
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}struct GenericParams1<StructGenericFoo, StructGenericFooX, StructGenericBar, StructGenericBaz> where StructGenericFoo : FooProtocol, StructGenericFooX : FooClass, StructGenericBar : BarProtocol, StructGenericBar: FooProtocol {{{$}}
   init<
       GenericFoo : FooProtocol,
       GenericFooX : FooClass,
@@ -1222,10 +1222,10 @@ struct GenericParams1<
       GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz,
                   d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz)
   {}
-// PASS_ONE_LINE_TYPE-DAG: {{^}}  init<GenericFoo, GenericFooX, GenericBar, GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz, d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz) where GenericFoo : FooProtocol, GenericFooX : FooClass, GenericBar : BarProtocol, GenericBar : FooProtocol{{$}}
+// PASS_ONE_LINE_TYPE-DAG: {{^}}  init<GenericFoo, GenericFooX, GenericBar, GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz, d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz) where GenericFoo : FooProtocol, GenericFooX : FooClass, GenericBar : BarProtocol, GenericBar: FooProtocol{{$}}
 // FIXME: in protocol compositions protocols are listed in reverse order.
 //
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  init<GenericFoo, GenericFooX, GenericBar, GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz, d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz) where GenericFoo : FooProtocol, GenericFooX : FooClass, GenericBar : BarProtocol, GenericBar : FooProtocol{{$}}
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  init<GenericFoo, GenericFooX, GenericBar, GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz, d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz) where GenericFoo : FooProtocol, GenericFooX : FooClass, GenericBar : BarProtocol, GenericBar: FooProtocol{{$}}
 
   func genericParams1<
       GenericFoo : FooProtocol,
@@ -1234,10 +1234,10 @@ struct GenericParams1<
       GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz,
                   d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz)
   {}
-// PASS_ONE_LINE_TYPE-DAG: {{^}}  func genericParams1<GenericFoo, GenericFooX, GenericBar, GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz, d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz) where GenericFoo : FooProtocol, GenericFooX : FooClass, GenericBar : BarProtocol, GenericBar : FooProtocol{{$}}
+// PASS_ONE_LINE_TYPE-DAG: {{^}}  func genericParams1<GenericFoo, GenericFooX, GenericBar, GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz, d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz) where GenericFoo : FooProtocol, GenericFooX : FooClass, GenericBar : BarProtocol, GenericBar: FooProtocol{{$}}
 // FIXME: in protocol compositions protocols are listed in reverse order.
 //
-// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  func genericParams1<GenericFoo, GenericFooX, GenericBar, GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz, d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz) where GenericFoo : FooProtocol, GenericFooX : FooClass, GenericBar : BarProtocol, GenericBar : FooProtocol{{$}}
+// PASS_ONE_LINE_TYPEREPR-DAG: {{^}}  func genericParams1<GenericFoo, GenericFooX, GenericBar, GenericBaz>(a: StructGenericFoo, b: StructGenericBar, c: StructGenericBaz, d: GenericFoo, e: GenericFooX, f: GenericBar, g: GenericBaz) where GenericFoo : FooProtocol, GenericFooX : FooClass, GenericBar : BarProtocol, GenericBar: FooProtocol{{$}}
 
   func contextualWhereClause1() where StructGenericBaz == Never {}
   // PASS_PRINT_AST: func contextualWhereClause1() where StructGenericBaz == Never{{$}}
@@ -1245,36 +1245,36 @@ struct GenericParams1<
   subscript(index: Int) -> Never where StructGenericBaz: FooProtocol {
     return fatalError()
   }
-  // PASS_PRINT_AST: subscript(index: Int) -> Never where StructGenericBaz : FooProtocol { get }{{$}}
+  // PASS_PRINT_AST: subscript(index: Int) -> Never where StructGenericBaz: FooProtocol { get }{{$}}
 }
 extension GenericParams1 where StructGenericBaz: FooProtocol {
   static func contextualWhereClause2() where StructGenericBaz: FooClass {}
-  // PASS_PRINT_AST: static func contextualWhereClause2() where StructGenericBaz : FooClass{{$}}
+  // PASS_PRINT_AST: static func contextualWhereClause2() where StructGenericBaz: FooClass{{$}}
 
   typealias ContextualWhereClause3 = Never where StructGenericBaz: QuxProtocol, StructGenericBaz.Qux == Void
-  // PASS_PRINT_AST: typealias ContextualWhereClause3 = Never where StructGenericBaz : QuxProtocol, StructGenericBaz.Qux == (){{$}}
+  // PASS_PRINT_AST: typealias ContextualWhereClause3 = Never where StructGenericBaz: QuxProtocol, StructGenericBaz.Qux == (){{$}}
 }
 
 struct GenericParams2<T : FooProtocol> where T : BarProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}struct GenericParams2<T> where T : BarProtocol, T : FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}struct GenericParams2<T> where T : BarProtocol, T: FooProtocol {{{$}}
 
 struct GenericParams3<T : FooProtocol> where T : BarProtocol, T : QuxProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}struct GenericParams3<T> where T : BarProtocol, T : FooProtocol, T : QuxProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}struct GenericParams3<T> where T : BarProtocol, T : FooProtocol, T: QuxProtocol {{{$}}
 
 struct GenericParams4<T : QuxProtocol> where T.Qux : FooProtocol {}
-// PASS_ONE_LINE-DAG: {{^}}struct GenericParams4<T> where T : QuxProtocol, T.Qux : FooProtocol {{{$}}
+// PASS_ONE_LINE-DAG: {{^}}struct GenericParams4<T> where T : QuxProtocol, T.Qux: FooProtocol {{{$}}
 
 struct GenericParams5<T : QuxProtocol> where T.Qux : FooProtocol & BarProtocol {}
-// PREFER_TYPE_PRINTING: {{^}}struct GenericParams5<T> where T : QuxProtocol, T.Qux : BarProtocol, T.Qux : FooProtocol {{{$}}
-// PREFER_TYPE_REPR_PRINTING: {{^}}struct GenericParams5<T> where T : QuxProtocol, T.Qux : BarProtocol, T.Qux : FooProtocol {{{$}}
+// PREFER_TYPE_PRINTING: {{^}}struct GenericParams5<T> where T : QuxProtocol, T.Qux : BarProtocol, T.Qux: FooProtocol {{{$}}
+// PREFER_TYPE_REPR_PRINTING: {{^}}struct GenericParams5<T> where T : QuxProtocol, T.Qux : BarProtocol, T.Qux: FooProtocol {{{$}}
 
 struct GenericParams6<T : QuxProtocol, U : QuxProtocol> where T.Qux == U.Qux {}
-// PREFER_TYPE_PRINTING: {{^}}struct GenericParams6<T, U> where T : QuxProtocol, U : QuxProtocol, T.Qux == U.Qux {{{$}}
-// PREFER_TYPE_REPR_PRINTING: {{^}}struct GenericParams6<T, U> where T : QuxProtocol, U : QuxProtocol, T.Qux == U.Qux {{{$}}
+// PREFER_TYPE_PRINTING: {{^}}struct GenericParams6<T, U> where T : QuxProtocol, U: QuxProtocol, T.Qux == U.Qux {{{$}}
+// PREFER_TYPE_REPR_PRINTING: {{^}}struct GenericParams6<T, U> where T : QuxProtocol, U: QuxProtocol, T.Qux == U.Qux {{{$}}
 
 struct GenericParams7<T : QuxProtocol, U : QuxProtocol> where T.Qux : QuxProtocol, U.Qux : QuxProtocol, T.Qux.Qux == U.Qux.Qux {}
-// PREFER_TYPE_PRINTING: {{^}}struct GenericParams7<T, U> where T : QuxProtocol, U : QuxProtocol, T.Qux : QuxProtocol, U.Qux : QuxProtocol, T.Qux.Qux == U.Qux.Qux {{{$}}
-// PREFER_TYPE_REPR_PRINTING: {{^}}struct GenericParams7<T, U> where T : QuxProtocol, U : QuxProtocol, T.Qux : QuxProtocol, U.Qux : QuxProtocol, T.Qux.Qux == U.Qux.Qux {{{$}}
+// PREFER_TYPE_PRINTING: {{^}}struct GenericParams7<T, U> where T : QuxProtocol, U : QuxProtocol, T.Qux : QuxProtocol, U.Qux: QuxProtocol, T.Qux.Qux == U.Qux.Qux {{{$}}
+// PREFER_TYPE_REPR_PRINTING: {{^}}struct GenericParams7<T, U> where T : QuxProtocol, U : QuxProtocol, T.Qux : QuxProtocol, U.Qux: QuxProtocol, T.Qux.Qux == U.Qux.Qux {{{$}}
 
 //===---
 //===--- Tupe sugar for library types.
@@ -1309,12 +1309,12 @@ struct d2900_TypeSugar1 {
 // SYNTHESIZE_SUGAR_ON_TYPES-NEXT: {{^}}  func f6(x: [Int]...){{$}}
 
   func f7(x: [Int : Int]...) {}
-// PASS_COMMON-NEXT: {{^}}  func f7(x: [Int : Int]...){{$}}
-// SYNTHESIZE_SUGAR_ON_TYPES-NEXT: {{^}}  func f7(x: [Int : Int]...){{$}}
+// PASS_COMMON-NEXT: {{^}}  func f7(x: [Int: Int]...){{$}}
+// SYNTHESIZE_SUGAR_ON_TYPES-NEXT: {{^}}  func f7(x: [Int: Int]...){{$}}
 
   func f8(x: Dictionary<String, Int>...) {}
 // PASS_COMMON-NEXT: {{^}}  func f8(x: Dictionary<String, Int>...){{$}}
-// SYNTHESIZE_SUGAR_ON_TYPES-NEXT: {{^}}  func f8(x: [String : Int]...){{$}}
+// SYNTHESIZE_SUGAR_ON_TYPES-NEXT: {{^}}  func f8(x: [String: Int]...){{$}}
 }
 // PASS_COMMON-NEXT: {{^}}  init(){{$}}
 // PASS_COMMON-NEXT: {{^}}}{{$}}
@@ -1416,15 +1416,15 @@ extension ProtocolToExtend where Self.Assoc == Int {}
 // Protocol with where clauses
 
 protocol ProtocolWithWhereClause : QuxProtocol where Qux == Int {}
-// PREFER_TYPE_REPR_PRINTING: protocol ProtocolWithWhereClause : QuxProtocol where Self.Qux == Int {
+// PREFER_TYPE_REPR_PRINTING: protocol ProtocolWithWhereClause: QuxProtocol where Self.Qux == Int {
 
 protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Qux == Int {
-// PREFER_TYPE_REPR_PRINTING-DAG: protocol ProtocolWithWhereClauseAndAssoc : QuxProtocol where Self.Qux == Int {
+// PREFER_TYPE_REPR_PRINTING-DAG: protocol ProtocolWithWhereClauseAndAssoc: QuxProtocol where Self.Qux == Int {
   associatedtype A1 : QuxProtocol where A1 : FooProtocol, A1.Qux : QuxProtocol, Int == A1.Qux.Qux
-// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A1 : FooProtocol, QuxProtocol where Self.A1.Qux : QuxProtocol, Self.A1.Qux.Qux == Int{{$}}
+// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A1 : FooProtocol, QuxProtocol where Self.A1.Qux: QuxProtocol, Self.A1.Qux.Qux == Int{{$}}
 
   associatedtype A2 : QuxProtocol where A2.Qux == Self
-// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A2 : QuxProtocol where Self == Self.A2.Qux{{$}}
+// PREFER_TYPE_REPR_PRINTING-DAG: {{^}}  associatedtype A2: QuxProtocol where Self == Self.A2.Qux{{$}}
 }
 
 #if true
@@ -1439,4 +1439,4 @@ public typealias MyPairI<B> = MyPair<Int, B>
 public typealias MyPairAlias<T, U> = MyPair<T, U>
 // PASS_PRINT_AST: public typealias MyPairAlias<T, U> = MyPair<T, U>
 typealias MyPairAlias2<T: FooProtocol, U> = MyPair<T, U> where U: BarProtocol
-// PASS_PRINT_AST: typealias MyPairAlias2<T, U> = MyPair<T, U> where T : FooProtocol, U : BarProtocol
+// PASS_PRINT_AST: typealias MyPairAlias2<T, U> = MyPair<T, U> where T : FooProtocol, U: BarProtocol

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -60,104 +60,104 @@ import func     not_existent_module_c.foo // expected-error{{no such module 'not
 //===---
 
 struct StructWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
-// NO-TYPEREPR: {{^}}struct StructWithInheritance1 : <<error type>> {{{$}}
-// TYPEREPR: {{^}}struct StructWithInheritance1 : FooNonExistentProtocol {{{$}}
+// NO-TYPEREPR: {{^}}struct StructWithInheritance1: <<error type>> {{{$}}
+// TYPEREPR: {{^}}struct StructWithInheritance1: FooNonExistentProtocol {{{$}}
 
 struct StructWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}}
-// NO-TYPEREPR: {{^}}struct StructWithInheritance2 : <<error type>>, <<error type>> {{{$}}
-// TYPEREPR: {{^}}struct StructWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
+// NO-TYPEREPR: {{^}}struct StructWithInheritance2: <<error type>>, <<error type>> {{{$}}
+// TYPEREPR: {{^}}struct StructWithInheritance2: FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
 //===---
 //===--- Inheritance list in classes.
 //===---
 
 class ClassWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
-// NO-TYREPR: {{^}}class ClassWithInheritance1 : <<error type>> {{{$}}
-// TYREPR: {{^}}class ClassWithInheritance1 : FooNonExistentProtocol {{{$}}
+// NO-TYREPR: {{^}}class ClassWithInheritance1: <<error type>> {{{$}}
+// TYREPR: {{^}}class ClassWithInheritance1: FooNonExistentProtocol {{{$}}
 
 class ClassWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}}
-// NO-TYREPR: {{^}}class ClassWithInheritance2 : <<error type>>, <<error type>> {{{$}}
-// TYREPR: {{^}}class ClassWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
+// NO-TYREPR: {{^}}class ClassWithInheritance2: <<error type>>, <<error type>> {{{$}}
+// TYREPR: {{^}}class ClassWithInheritance2: FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
 class ClassWithInheritance3 : FooClass, FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
-// NO-TYREPR: {{^}}class ClassWithInheritance3 : FooClass, <<error type>> {{{$}}
-// TYREPR: {{^}}class ClassWithInheritance3 : FooClass, FooNonExistentProtocol {{{$}}
+// NO-TYREPR: {{^}}class ClassWithInheritance3: FooClass, <<error type>> {{{$}}
+// TYREPR: {{^}}class ClassWithInheritance3: FooClass, FooNonExistentProtocol {{{$}}
 
 class ClassWithInheritance4 : FooProtocol, FooClass {} // expected-error {{superclass 'FooClass' must appear first in the inheritance clause}} {{31-31=FooClass, }} {{42-52=}}
-// CHECK: {{^}}class ClassWithInheritance4 : FooProtocol, FooClass {{{$}}
+// CHECK: {{^}}class ClassWithInheritance4: FooProtocol, FooClass {{{$}}
 
 class ClassWithInheritance5 : FooProtocol, BarProtocol, FooClass {} // expected-error {{superclass 'FooClass' must appear first in the inheritance clause}} {{31-31=FooClass, }} {{55-65=}}
-// CHECK: {{^}}class ClassWithInheritance5 : FooProtocol, BarProtocol, FooClass {{{$}}
+// CHECK: {{^}}class ClassWithInheritance5: FooProtocol, BarProtocol, FooClass {{{$}}
 
 class ClassWithInheritance6 : FooClass, BarClass {} // expected-error {{multiple inheritance from classes 'FooClass' and 'BarClass'}}
-// NO-TYREPR: {{^}}class ClassWithInheritance6 : FooClass, <<error type>> {{{$}}
-// TYREPR: {{^}}class ClassWithInheritance6 : FooClass, BarClass {{{$}}
+// NO-TYREPR: {{^}}class ClassWithInheritance6: FooClass, <<error type>> {{{$}}
+// TYREPR: {{^}}class ClassWithInheritance6: FooClass, BarClass {{{$}}
 
 class ClassWithInheritance7 : FooClass, BarClass, FooProtocol {} // expected-error {{multiple inheritance from classes 'FooClass' and 'BarClass'}}
-// NO-TYREPR: {{^}}class ClassWithInheritance7 : FooClass, <<error type>>, FooProtocol {{{$}}
-// TYREPR: {{^}}class ClassWithInheritance7 : FooClass, BarClass, FooProtocol {{{$}}
+// NO-TYREPR: {{^}}class ClassWithInheritance7: FooClass, <<error type>>, FooProtocol {{{$}}
+// TYREPR: {{^}}class ClassWithInheritance7: FooClass, BarClass, FooProtocol {{{$}}
 
 class ClassWithInheritance8 : FooClass, BarClass, FooProtocol, BarProtocol {} // expected-error {{multiple inheritance from classes 'FooClass' and 'BarClass'}}
-// NO-TYREPR: {{^}}class ClassWithInheritance8 : FooClass, <<error type>>, FooProtocol, BarProtocol {{{$}}
-// TYREPR: {{^}}class ClassWithInheritance8 : FooClass, BarClass, FooProtocol, BarProtocol {{{$}}
+// NO-TYREPR: {{^}}class ClassWithInheritance8: FooClass, <<error type>>, FooProtocol, BarProtocol {{{$}}
+// TYREPR: {{^}}class ClassWithInheritance8: FooClass, BarClass, FooProtocol, BarProtocol {{{$}}
 
 class ClassWithInheritance9 : FooClass, BarClass, FooProtocol, BarProtocol, FooNonExistentProtocol {} // expected-error {{multiple inheritance from classes 'FooClass' and 'BarClass'}} expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
-// NO-TYREPR: {{^}}class ClassWithInheritance9 : FooClass, <<error type>>, FooProtocol, BarProtocol, <<error type>> {{{$}}
-// TYREPR: {{^}}class ClassWithInheritance9 : FooClass, BarClass, FooProtocol, BarProtocol, FooNonExistentProtocol {{{$}}
+// NO-TYREPR: {{^}}class ClassWithInheritance9: FooClass, <<error type>>, FooProtocol, BarProtocol, <<error type>> {{{$}}
+// TYREPR: {{^}}class ClassWithInheritance9: FooClass, BarClass, FooProtocol, BarProtocol, FooNonExistentProtocol {{{$}}
 
 //===---
 //===--- Inheritance list in enums.
 //===---
 
 enum EnumWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{an enum with no cases}}
-// NO-TYREPR: {{^}}enum EnumWithInheritance1 : <<error type>> {{{$}}
-// TYREPR: {{^}}enum EnumWithInheritance1 : FooNonExistentProtocol {{{$}}
+// NO-TYREPR: {{^}}enum EnumWithInheritance1: <<error type>> {{{$}}
+// TYREPR: {{^}}enum EnumWithInheritance1: FooNonExistentProtocol {{{$}}
 
 enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}} expected-error {{an enum with no cases}}
-// NO-TYREPR: {{^}}enum EnumWithInheritance2 : <<error type>>, <<error type>> {{{$}}
-// TYREPR: {{^}}enum EnumWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
+// NO-TYREPR: {{^}}enum EnumWithInheritance2: <<error type>>, <<error type>> {{{$}}
+// TYREPR: {{^}}enum EnumWithInheritance2: FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
 enum EnumWithInheritance3 : FooClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-note {{add stubs for conformance}}
 // expected-error@-1{{'EnumWithInheritance3' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
-// NO-TYREPR: {{^}}enum EnumWithInheritance3 : <<error type>> {{{$}}
-// TYREPR: {{^}}enum EnumWithInheritance3 : FooClass {{{$}}
+// NO-TYREPR: {{^}}enum EnumWithInheritance3: <<error type>> {{{$}}
+// TYREPR: {{^}}enum EnumWithInheritance3: FooClass {{{$}}
 
 enum EnumWithInheritance4 : FooClass, FooProtocol { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-note {{add stubs for conformance}}
 // expected-error@-1{{'EnumWithInheritance4' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
-// NO-TYREPR: {{^}}enum EnumWithInheritance4 : <<error type>>, FooProtocol {{{$}}
-// TYREPR: {{^}}enum EnumWithInheritance4 : FooClass, FooProtocol {{{$}}
+// NO-TYREPR: {{^}}enum EnumWithInheritance4: <<error type>>, FooProtocol {{{$}}
+// TYREPR: {{^}}enum EnumWithInheritance4: FooClass, FooProtocol {{{$}}
 
 enum EnumWithInheritance5 : FooClass, BarClass { case X } // expected-error {{raw type 'FooClass' is not expressible by a string, integer, or floating-point literal}} expected-error {{multiple enum raw types 'FooClass' and 'BarClass'}} expected-note {{add stubs for conformance}}
 // expected-error@-1{{'EnumWithInheritance5' declares raw type 'FooClass', but does not conform to RawRepresentable and conformance could not be synthesized}}
 // expected-error@-2{{RawRepresentable conformance cannot be synthesized because raw type 'FooClass' is not Equatable}}
-// NO-TYREPR: {{^}}enum EnumWithInheritance5 : <<error type>>, <<error type>> {{{$}}
-// TYREPR: {{^}}enum EnumWithInheritance5 : FooClass, BarClass {{{$}}
+// NO-TYREPR: {{^}}enum EnumWithInheritance5: <<error type>>, <<error type>> {{{$}}
+// TYREPR: {{^}}enum EnumWithInheritance5: FooClass, BarClass {{{$}}
 
 //===---
 //===--- Inheritance list in protocols.
 //===---
 
 protocol ProtocolWithInheritance1 : FooNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
-// NO-TYREPR: {{^}}protocol ProtocolWithInheritance1 : <<error type>> {{{$}}
-// TYREPR: {{^}}protocol ProtocolWithInheritance1 : FooNonExistentProtocol {{{$}}
+// NO-TYREPR: {{^}}protocol ProtocolWithInheritance1: <<error type>> {{{$}}
+// TYREPR: {{^}}protocol ProtocolWithInheritance1: FooNonExistentProtocol {{{$}}
 
 protocol ProtocolWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {} // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}}
-// NO-TYREPR: {{^}}protocol ProtocolWithInheritance2 : <<error type>>, <<error type>> {{{$}}
-// TYREPR: {{^}}protocol ProtocolWithInheritance2 : FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
+// NO-TYREPR: {{^}}protocol ProtocolWithInheritance2: <<error type>>, <<error type>> {{{$}}
+// TYREPR: {{^}}protocol ProtocolWithInheritance2: FooNonExistentProtocol, BarNonExistentProtocol {{{$}}
 
 protocol ProtocolWithInheritance3 : FooClass {}
-// NO-TYREPR: {{^}}protocol ProtocolWithInheritance3 : FooClass {{{$}}
-// TYREPR: {{^}}protocol ProtocolWithInheritance3 : FooClass {{{$}}
+// NO-TYREPR: {{^}}protocol ProtocolWithInheritance3: FooClass {{{$}}
+// TYREPR: {{^}}protocol ProtocolWithInheritance3: FooClass {{{$}}
 
 protocol ProtocolWithInheritance4 : FooClass, FooProtocol {}
-// NO-TYREPR: {{^}}protocol ProtocolWithInheritance4 : FooClass, FooProtocol {{{$}}
-// TYREPR: {{^}}protocol ProtocolWithInheritance4 : FooClass, FooProtocol {{{$}}
+// NO-TYREPR: {{^}}protocol ProtocolWithInheritance4: FooClass, FooProtocol {{{$}}
+// TYREPR: {{^}}protocol ProtocolWithInheritance4: FooClass, FooProtocol {{{$}}
 
-protocol ProtocolWithInheritance5 : FooClass, BarClass {} // expected-error{{multiple inheritance from classes 'FooClass' and 'BarClass'}} expected-error{{no type for 'Self' can satisfy both 'Self : BarClass' and 'Self : FooClass'}}
-// NO-TYREPR: {{^}}protocol ProtocolWithInheritance5 : <<error type>>, <<error type>> {{{$}}
-// TYREPR: {{^}}protocol ProtocolWithInheritance5 : FooClass, BarClass {{{$}}
+protocol ProtocolWithInheritance5 : FooClass, BarClass {} // expected-error{{multiple inheritance from classes 'FooClass' and 'BarClass'}} expected-error{{no type for 'Self' can satisfy both 'Self : BarClass' and 'Self: FooClass'}}
+// NO-TYREPR: {{^}}protocol ProtocolWithInheritance5: <<error type>>, <<error type>> {{{$}}
+// TYREPR: {{^}}protocol ProtocolWithInheritance5: FooClass, BarClass {{{$}}
 
 //===---
 //===--- Typealias printing.
@@ -178,21 +178,21 @@ protocol AssociatedType1 {
 // CHECK-LABEL: AssociatedType1 {
 
   associatedtype AssociatedTypeDecl1 : FooProtocol = FooClass
-// CHECK: {{^}}  associatedtype AssociatedTypeDecl1 : FooProtocol = FooClass{{$}}
+// CHECK: {{^}}  associatedtype AssociatedTypeDecl1: FooProtocol = FooClass{{$}}
 
   associatedtype AssociatedTypeDecl2 : BazProtocol = FooClass
-// CHECK: {{^}}  associatedtype AssociatedTypeDecl2 : BazProtocol = FooClass{{$}}
+// CHECK: {{^}}  associatedtype AssociatedTypeDecl2: BazProtocol = FooClass{{$}}
 
   associatedtype AssociatedTypeDecl3 : FooNonExistentProtocol // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}}
-// NO-TYREPR: {{^}}  associatedtype AssociatedTypeDecl3 : <<error type>>{{$}}
-// TYREPR: {{^}}  associatedtype AssociatedTypeDecl3 : FooNonExistentProtocol{{$}}
+// NO-TYREPR: {{^}}  associatedtype AssociatedTypeDecl3: <<error type>>{{$}}
+// TYREPR: {{^}}  associatedtype AssociatedTypeDecl3: FooNonExistentProtocol{{$}}
 
   associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol // expected-error {{cannot find type 'FooNonExistentProtocol' in scope}} expected-error {{cannot find type 'BarNonExistentProtocol' in scope}}
-// NO-TYREPR: {{^}}  associatedtype AssociatedTypeDecl4 : <<error type>>, <<error type>>{{$}}
-// TYREPR: {{^}}  associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol{{$}}
+// NO-TYREPR: {{^}}  associatedtype AssociatedTypeDecl4: <<error type>>, <<error type>>{{$}}
+// TYREPR: {{^}}  associatedtype AssociatedTypeDecl4: FooNonExistentProtocol, BarNonExistentProtocol{{$}}
 
   associatedtype AssociatedTypeDecl5 : FooClass
-// CHECK: {{^}}  associatedtype AssociatedTypeDecl5 : FooClass{{$}}
+// CHECK: {{^}}  associatedtype AssociatedTypeDecl5: FooClass{{$}}
 }
 
 //===---

--- a/test/IDE/print_clang_ObjectiveC.swift
+++ b/test/IDE/print_clang_ObjectiveC.swift
@@ -20,7 +20,7 @@
 // CHECK-WITH-FORWARD-DECLS-DAG: var description: String { get }
 // CHECK: {{^[}]$}}
 
-// CHECK-LABEL: class NSObject : NSObjectProtocol {
+// CHECK-LABEL: class NSObject: NSObjectProtocol {
 // CHECK-DAG: func copy() -> Any
 // CHECK-DAG: class func hash() -> Int
 // CHECK-WITH-FORWARD-DECLS-DAG: class func description() -> String

--- a/test/IDE/print_clang_category_ordering.swift
+++ b/test/IDE/print_clang_category_ordering.swift
@@ -10,16 +10,16 @@
 // CHECK: var foo: Any
 // CHECK: }
 
-// CHECK-LABEL: class Sub : Base {
+// CHECK-LABEL: class Sub: Base {
 // CHECK: }
 
-// CHECK-PROTO-FIRST-LABEL: extension Sub : Foo {
+// CHECK-PROTO-FIRST-LABEL: extension Sub: Foo {
 // CHECK-PROTO-FIRST-NEXT: }
 
 // CHECK-LABEL: extension Sub {
 // CHECK: var foo: Any!
 // CHECK: }
 
-// CHECK-PROP-FIRST-LABEL: extension Sub : Foo {
+// CHECK-PROP-FIRST-LABEL: extension Sub: Foo {
 // CHECK-PROP-FIRST-NEXT: }
 

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -90,12 +90,12 @@
 // NEGATIVE-NOT: typealias FooStructTypedef2
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSArray.  Bbb.{{$}}
-// FOUNDATION-NEXT: {{^}}class NSArray : NSObject {{{$}}
+// FOUNDATION-NEXT: {{^}}class NSArray: NSObject {{{$}}
 // FOUNDATION-NEXT: init!(objects: UnsafePointer<AnyObject>?, count cnt: Int)
 // FOUNDATION-NEXT: subscript(idx: Int) -> Any { get }
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSRuncingMode.  Bbb.{{$}}
-// FOUNDATION-NEXT: {{^}}enum NSRuncingMode : UInt {{{$}}
+// FOUNDATION-NEXT: {{^}}enum NSRuncingMode: UInt {{{$}}
 // FOUNDATION-NEXT: {{^}}  init?(rawValue: UInt){{$}}
 // FOUNDATION-NEXT: {{^}}  var rawValue: UInt { get }{{$}}
 // FOUNDATION-NEXT: {{^}}  typealias RawValue = UInt
@@ -108,7 +108,7 @@
 // FOUNDATION-NEXT: {{^}}}{{$}}
 
 // FOUNDATION-LABEL: {{^}}/// Aaa.  NSRuncingOptions.  Bbb.{{$}}
-// FOUNDATION-NEXT: {{^}}struct NSRuncingOptions : OptionSet {{{$}}
+// FOUNDATION-NEXT: {{^}}struct NSRuncingOptions: OptionSet {{{$}}
 // FOUNDATION-NEXT: {{^}}  init(rawValue: UInt){{$}}
 // FOUNDATION-NEXT: {{^}}  let rawValue: UInt{{$}}
 // FOUNDATION-NEXT: {{^}}  typealias RawValue = UInt

--- a/test/IDE/print_clang_decls_AppKit.swift
+++ b/test/IDE/print_clang_decls_AppKit.swift
@@ -16,7 +16,7 @@
 
 // APPKIT-LABEL: {{^}}extension NSString {{{$}}
 
-// APPKIT-LABEL: {{^}}class NSView : NSObject, NSCoding, NSAccessibility {{{$}}
+// APPKIT-LABEL: {{^}}class NSView: NSObject, NSCoding, NSAccessibility {{{$}}
 // APPKIT-NEXT: init?(coder aDecoder: NSCoder)
 // APPKIT-NEXT: func isDescendant(of aView: NSView) -> Bool
 // APPKIT-NEXT: @available(swift, obsoleted: 3, renamed: "isDescendant(of:)")
@@ -33,7 +33,7 @@
 // APPKIT-LABEL:      extension NSView {
 // APPKIT-NEXT:   unowned(unsafe) var nextKeyView: @sil_unmanaged NSView?
 
-// APPKIT-LABEL: {{^}}class NSMenuItem : NSObject, NSCopying, NSCoding {
+// APPKIT-LABEL: {{^}}class NSMenuItem: NSObject, NSCopying, NSCoding {
 // APPKIT-NEXT: unowned(unsafe) var menu: @sil_unmanaged NSMenu?
 // APPKIT-NEXT: var title: String
 // APPKIT-NEXT: @NSCopying var attributedTitle: NSAttributedString?

--- a/test/IDE/print_clang_foundation.swift
+++ b/test/IDE/print_clang_foundation.swift
@@ -14,7 +14,7 @@
 // CHECK_NSARRAY: convenience init?(contentsOf url: URL)
 
 
-// CHECK_NSARRAY: class NSMutableArray : NSArray
+// CHECK_NSARRAY: class NSMutableArray: NSArray
 // CHECK_NSARRAY:   func setArray(_ otherArray: [Any])
 
 // RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=Foundation.NSKeyValueCoding -function-definitions=false > %t/Foundation.NSKeyValueCoding.printed.txt
@@ -29,7 +29,7 @@
 // Make sure that we don't qualify 'NSErrorPointer'.
 // CHECK_NSSTRING: init(contentsOfFile path: String, encoding enc: UInt) throws
 
-// CHECK_DICTIONARY: func propertyListFromStringsFileFormat() -> [AnyHashable : Any]
+// CHECK_DICTIONARY: func propertyListFromStringsFileFormat() -> [AnyHashable: Any]
 
 // RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=Foundation -function-definitions=false > %t/Foundation.printed.txt
 // RUN: %FileCheck -input-file %t/Foundation.printed.txt -check-prefix=CHECK_DUP %s

--- a/test/IDE/print_clang_header_swift_name.swift
+++ b/test/IDE/print_clang_header_swift_name.swift
@@ -5,21 +5,21 @@
 
 // REQUIRES: objc_interop
 
-// CHECK-LABEL: enum Normal : Int, @unchecked Sendable {
+// CHECK-LABEL: enum Normal: Int, @unchecked Sendable {
 // CHECK-NOT: {{^}}}
 // CHECK: case one
 // CHECK-NEXT: case two
 // CHECK-NEXT: case three
 // CHECK-NEXT: }
 
-// CHECK-LABEL: enum SwiftEnum : Int, @unchecked Sendable {
+// CHECK-LABEL: enum SwiftEnum: Int, @unchecked Sendable {
 // CHECK-NOT: {{^}}}
 // CHECK: case one
 // CHECK-NEXT: case two
 // CHECK-NEXT: case three
 // CHECK-NEXT: }
 
-// CHECK-LABEL: enum SwiftEnumTwo : Int, @unchecked Sendable {
+// CHECK-LABEL: enum SwiftEnumTwo: Int, @unchecked Sendable {
 // CHECK-NOT: {{^}}}
 // CHECK: case SwiftEnumTwoA
 // CHECK-NEXT: case SwiftEnumTwoB

--- a/test/IDE/print_clang_objc_async.swift
+++ b/test/IDE/print_clang_objc_async.swift
@@ -8,7 +8,7 @@
 // REQUIRES: swift_feature_SendableCompletionHandlers
 import _Concurrency
 
-// CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {
+// CHECK-LABEL: class SlowServer: NSObject, ServiceProvider {
 
 // CHECK: @available(*, renamed: "doSomethingSlow(_:)")
 // CHECK-NEXT: func doSomethingSlow(_ operation: String, completionHandler handler: @escaping @Sendable (Int) -> Void)

--- a/test/IDE/print_clang_objc_effectful_properties.swift
+++ b/test/IDE/print_clang_objc_effectful_properties.swift
@@ -7,7 +7,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_SendableCompletionHandlers
 
-// CHECK-LABEL: class EffProps : NSObject {
+// CHECK-LABEL: class EffProps: NSObject {
 // CHECK:       @available(*, renamed: "getter:doggo()")
 // CHECK-NEXT:  func getDogWithCompletion(_ completionHandler: @escaping @Sendable (NSObject) -> Void)
 // CHECK:       var doggo: NSObject { get async }
@@ -42,6 +42,6 @@
 // CHECK-NEXT:  func regularMainDog() async -> String
 // CHECK: }
 
-// CHECK-LABEL: class NotEffProps : NSObject {
+// CHECK-LABEL: class NotEffProps: NSObject {
 // CHECK-NOT: var
 // CHECK: func EffPropGetDogWithCompletion(_ s: OpaquePointer, _ myBlock: @escaping (NSObject) -> Void) -> Double

--- a/test/IDE/print_objc_concurrency_interface.swift
+++ b/test/IDE/print_objc_concurrency_interface.swift
@@ -10,7 +10,7 @@
 // REQUIRES: swift_feature_SendableCompletionHandlers
 import _Concurrency
 
-// CHECK-LABEL: class SlowServer : NSObject, ServiceProvider {
+// CHECK-LABEL: class SlowServer: NSObject, ServiceProvider {
 
 // rdar://76685011: Make sure we don't print implicit @available in generated interfaces.
 // CHECK-NOT: @available
@@ -22,69 +22,69 @@ import _Concurrency
 // NEGATIVE-NOT: @Sendable{{.+}}func
 // NEGATIVE-NOT: @Sendable{{.+}}var
 
-// CHECK-LABEL: class SendableClass :
+// CHECK-LABEL: class SendableClass:
 // CHECK-SAME: @unchecked Sendable
 
 // CHECK-LABEL: class NonSendableClass
 // CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableClass : @unchecked Sendable {
+// CHECK-NEXT: extension NonSendableClass: @unchecked Sendable {
 
-// CHECK-LABEL: class AuditedSendable :
+// CHECK-LABEL: class AuditedSendable:
 // CHECK-SAME: @unchecked Sendable
 
 // CHECK-LABEL: class AuditedNonSendable
 // CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension AuditedNonSendable : @unchecked Sendable {
+// CHECK-NEXT: extension AuditedNonSendable: @unchecked Sendable {
 
 // CHECK-LABEL: class AuditedBoth
 // CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension AuditedBoth : @unchecked Sendable {
+// CHECK-NEXT: extension AuditedBoth: @unchecked Sendable {
 
 // CHECK-LABEL: public protocol SendableProtocol
-// CHECK-SAME: : Sendable
+// CHECK-SAME:: Sendable
 
-// CHECK-LABEL: enum SendableEnum :
+// CHECK-LABEL: enum SendableEnum:
 // CHECK-SAME: @unchecked Sendable
 
-// CHECK-LABEL: enum NonSendableEnum :
+// CHECK-LABEL: enum NonSendableEnum:
 // CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableEnum : @unchecked Sendable {
+// CHECK-NEXT: extension NonSendableEnum: @unchecked Sendable {
 
-// CHECK-LABEL: struct SendableOptions :
+// CHECK-LABEL: struct SendableOptions:
 // CHECK-SAME: @unchecked Sendable
 
-// CHECK-LABEL: struct NonSendableOptions :
+// CHECK-LABEL: struct NonSendableOptions:
 // CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableOptions : @unchecked Sendable {
+// CHECK-NEXT: extension NonSendableOptions: @unchecked Sendable {
 
-// CHECK-LABEL: public struct SendableError :
+// CHECK-LABEL: public struct SendableError:
 // CHECK-NOT: @unchecked Sendable
-// CHECK: public enum Code :
+// CHECK: public enum Code:
 // CHECK-SAME: @unchecked Sendable
 
-// CHECK-LABEL: public struct NonSendableError :
+// CHECK-LABEL: public struct NonSendableError:
 // CHECK-NOT: @unchecked Sendable
-// CHECK: public enum Code :
+// CHECK: public enum Code:
 // CHECK-SAME: @unchecked Sendable
 
-// CHECK-LABEL: struct SendableStringEnum :
+// CHECK-LABEL: struct SendableStringEnum:
 // CHECK-SAME: @unchecked Sendable
 
-// CHECK-LABEL: struct NonSendableStringEnum :
-// CHECK-NOT: @unchecked Sendable
-// CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableStringEnum : @unchecked Sendable {
-
-// CHECK-LABEL: struct SendableStringStruct :
-// CHECK-SAME: @unchecked Sendable
-
-// CHECK-LABEL: struct NonSendableStringStruct :
+// CHECK-LABEL: struct NonSendableStringEnum:
 // CHECK-NOT: @unchecked Sendable
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension NonSendableStringStruct : @unchecked Sendable {
+// CHECK-NEXT: extension NonSendableStringEnum: @unchecked Sendable {
+
+// CHECK-LABEL: struct SendableStringStruct:
+// CHECK-SAME: @unchecked Sendable
+
+// CHECK-LABEL: struct NonSendableStringStruct:
+// CHECK-NOT: @unchecked Sendable
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: extension NonSendableStringStruct: @unchecked Sendable {
 

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -81,7 +81,7 @@
 // CHECK-FOUNDATION: func withString(_: String!) -> Self!
 
 // Note: lowercasing enum constants.
-// CHECK-FOUNDATION: enum CountStyle : Int {
+// CHECK-FOUNDATION: enum CountStyle: Int {
 // CHECK-FOUNDATION: case file
 // CHECK-FOUNDATION-NEXT: case memory
 // CHECK-FOUNDATION-NEXT: case decimal

--- a/test/IDE/print_swift_module.swift
+++ b/test/IDE/print_swift_module.swift
@@ -39,7 +39,7 @@ public struct City {
 // CHECK1:      /// Alias comment
 // CHECK1-NEXT: typealias Alias<T> = (T, T)
 
-// CHECK1:      public class C1 : print_swift_module.P1 {
+// CHECK1:      public class C1: print_swift_module.P1 {
 // CHECK1-NEXT:   /// foo1 comment from P1
 // CHECK1-NEXT:   public func foo1()
 // CHECK1-NEXT:   /// foo2 comment from C1

--- a/test/IDE/print_synthesized_extensions.swift
+++ b/test/IDE/print_synthesized_extensions.swift
@@ -240,13 +240,13 @@ extension S13 : P5 {
   public func foo1() {}
 }
 
-// CHECK1: <synthesized>extension <ref:Struct>S1</ref> where <ref:GenericTypeParam>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P2</ref> {
+// CHECK1: <synthesized>extension <ref:Struct>S1</ref> where <ref:GenericTypeParam>T</ref>: <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P2</ref> {
 // CHECK1-NEXT:     <decl:Func>public func <loc>p2member()</loc></decl>
 // CHECK1-NEXT:     <decl:Func>public func <loc>ef1(<decl:Param>t: <ref:GenericTypeParam>T</ref></decl>)</loc></decl>
 // CHECK1-NEXT:     <decl:Func>public func <loc>ef2(<decl:Param>t: <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S2</ref></decl>)</loc></decl>
 // CHECK1-NEXT: }</synthesized>
 
-// CHECK2:  <synthesized>extension <ref:Struct>S1</ref> where <ref:GenericTypeParam>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P3</ref>  {
+// CHECK2:  <synthesized>extension <ref:Struct>S1</ref> where <ref:GenericTypeParam>T</ref>: <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P3</ref>  {
 // CHECK2-NEXT:     <decl:Func>public func <loc>p3Func(<decl:Param>i: <ref:Struct>Int</ref></decl>)</loc> -> <ref:Struct>Int</ref></decl>
 // CHECK2-NEXT: }</synthesized>
 
@@ -258,7 +258,7 @@ extension S13 : P5 {
 // CHECK4-NEXT:     <decl:Func>public func <loc>S9IntFunc()</loc></decl>
 // CHECK4-NEXT: }</synthesized>
 
-// CHECK5:      <decl:Struct>public struct <loc>S10</loc> : <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P1</ref> {
+// CHECK5:      <decl:Struct>public struct <loc>S10</loc>: <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P1</ref> {
 // CHECK5-NEXT:   <decl:TypeAlias>public typealias <loc>T1</loc> = <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S9</ref><<ref:Struct>Int</ref>></decl>
 // CHECK5-NEXT: <decl:TypeAlias>public typealias <loc>T2</loc> = <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S9</ref><<ref:Struct>Int</ref>></decl>
 // CHECK5-NEXT: <decl:Func>public func <loc>f1(<decl:Param>t: <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S10</ref>.<ref:TypeAlias>T1</ref></decl>)</loc> -> <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S10</ref>.<ref:TypeAlias>T1</ref></decl>
@@ -278,7 +278,7 @@ extension S13 : P5 {
 // CHECK7-NEXT:  <decl:Func>public func <loc>P4Func2()</loc></decl>
 // CHECK7-NEXT:  }</synthesized>
 
-// CHECK8:      <decl:Struct>public struct <loc>S4<<decl:GenericTypeParam>T</decl>></loc> : <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P1</ref> {
+// CHECK8:      <decl:Struct>public struct <loc>S4<<decl:GenericTypeParam>T</decl>></loc>: <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P1</ref> {
 // CHECK8-NEXT:   <decl:TypeAlias>public typealias <loc>T1</loc> = <ref:Struct>Int</ref></decl>
 // CHECK8-NEXT:   <decl:TypeAlias>public typealias <loc>T2</loc> = <ref:Struct>Int</ref></decl>
 // CHECK8-NEXT:   <decl:Func>public func <loc>f1(<decl:Param>t: <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S4</ref><<ref:GenericTypeParam>T</ref>>.<ref:TypeAlias>T1</ref></decl>)</loc> -> <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S4</ref><<ref:GenericTypeParam>T</ref>>.<ref:TypeAlias>T1</ref></decl>
@@ -286,7 +286,7 @@ extension S13 : P5 {
 // CHECK8-NEXT:   <decl:Func>public func <loc>p1IntFunc(<decl:Param>i: <ref:Struct>Int</ref></decl>)</loc> -> <ref:Struct>Int</ref></decl>
 // CHECK8-NEXT:   }</synthesized>
 
-// CHECK9:      <decl:Struct>public struct <loc>S6<<decl:GenericTypeParam>T</decl>></loc> : <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P1</ref> {
+// CHECK9:      <decl:Struct>public struct <loc>S6<<decl:GenericTypeParam>T</decl>></loc>: <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P1</ref> {
 // CHECK9-NEXT:    <decl:TypeAlias>public typealias <loc>T1</loc> = <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S5</ref></decl>
 // CHECK9-NEXT:    <decl:TypeAlias>public typealias <loc>T2</loc> = <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S5</ref></decl>
 // CHECK9-NEXT:    <decl:Func>public func <loc>f1(<decl:Param>t: <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S6</ref><<ref:GenericTypeParam>T</ref>>.<ref:TypeAlias>T1</ref></decl>)</loc> -> <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S6</ref><<ref:GenericTypeParam>T</ref>>.<ref:TypeAlias>T1</ref></decl>
@@ -303,7 +303,7 @@ extension S13 : P5 {
 // CHECK10-NEXT:     <decl:Func>public func <loc>ef5(<decl:Param>t: <ref:module>print_synthesized_extensions</ref>.<ref:Struct>S5</ref></decl>)</loc></decl>
 // CHECK10-NEXT: }</synthesized>
 
-// CHECK11:      <decl:Struct>public struct <loc>S12</loc> : <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P5</ref> {
+// CHECK11:      <decl:Struct>public struct <loc>S12</loc>: <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P5</ref> {
 // CHECK11-NEXT:  <decl:TypeAlias>public typealias <loc>T1</loc> = <ref:Struct>Int</ref></decl>
 // CHECK11-NEXT:  <decl:Func>/// This is picked
 // CHECK11-NEXT:    public func <loc>foo1()</loc></decl></decl>
@@ -365,36 +365,36 @@ extension C : P8 {}
 // CHECK15:      <decl:Class>public class <loc>C<<decl:GenericTypeParam>T</decl>></loc> {
 // CHECK15-NEXT: }</decl>
 
-// CHECK15:      <decl:Extension>extension <loc><ref:Class>C</ref></loc> : <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P8</ref> {
+// CHECK15:      <decl:Extension>extension <loc><ref:Class>C</ref></loc>: <ref:module>print_synthesized_extensions</ref>.<ref:Protocol>P8</ref> {
 // CHECK15-NEXT: }</decl>
 
-// CHECK15:      <decl:Extension>extension <loc><ref:Class>C</ref></loc> where <ref:GenericTypeParam>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Class>D</ref> {
+// CHECK15:      <decl:Extension>extension <loc><ref:Class>C</ref></loc> where <ref:GenericTypeParam>T</ref>: <ref:module>print_synthesized_extensions</ref>.<ref:Class>D</ref> {
 // CHECK15-NEXT:   <decl:Func>public func <loc>foo()</loc></decl></decl>
 // CHECK15-NEXT:   <decl:Func>public func <loc>bar()</loc></decl>
 // CHECK15-NEXT: }</synthesized>
 
-// CHECK15:      <synthesized>extension <ref:Class>C</ref> where <ref:GenericTypeParam>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Class>E</ref> {
+// CHECK15:      <synthesized>extension <ref:Class>C</ref> where <ref:GenericTypeParam>T</ref>: <ref:module>print_synthesized_extensions</ref>.<ref:Class>E</ref> {
 // CHECK15-NEXT:   <decl:Func>public func <loc>baz()</loc></decl>
 // CHECK15-NEXT: }</synthesized>
 
-// CHECK15:      <decl:Extension>extension <loc><ref:Protocol>P8</ref></loc> where <ref:GenericTypeParam>Self</ref>.<ref:AssociatedType>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Class>D</ref> {
+// CHECK15:      <decl:Extension>extension <loc><ref:Protocol>P8</ref></loc> where <ref:GenericTypeParam>Self</ref>.<ref:AssociatedType>T</ref>: <ref:module>print_synthesized_extensions</ref>.<ref:Class>D</ref> {
 // CHECK15-NEXT:   <decl:Func>public func <loc>bar()</loc></decl>
 // CHECK15-NEXT: }</decl>
 
-// CHECK15:      <decl:Extension>extension <loc><ref:Protocol>P8</ref></loc> where <ref:GenericTypeParam>Self</ref>.<ref:AssociatedType>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Class>E</ref> {
+// CHECK15:      <decl:Extension>extension <loc><ref:Protocol>P8</ref></loc> where <ref:GenericTypeParam>Self</ref>.<ref:AssociatedType>T</ref>: <ref:module>print_synthesized_extensions</ref>.<ref:Class>E</ref> {
 // CHECK15-NEXT:   <decl:Func>public func <loc>baz()</loc></decl>
 // CHECK15-NEXT: }</decl>
 
-// For this class, make sure we mirror the extension P8 where T : D, but not
-// the extension P8 where T : E.
+// For this class, make sure we mirror the extension P8 where T: D, but not
+// the extension P8 where T: E.
 public class F<T : D> {}
 extension F : P8 {}
 
-// CHECK16:      <decl:Class>public class <loc>F<<decl:GenericTypeParam>T</decl>></loc> where <ref:GenericTypeParam>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Class>D</ref> {</decl>
+// CHECK16:      <decl:Class>public class <loc>F<<decl:GenericTypeParam>T</decl>></loc> where <ref:GenericTypeParam>T</ref>: <ref:module>print_synthesized_extensions</ref>.<ref:Class>D</ref> {</decl>
 // CHECK16-NEXT:   <decl:Func>public func <loc>bar()</loc></decl>
 // CHECK16-NEXT: }</synthesized>
 
-// CHECK16-NOT: <synthesized>extension <ref:Class>F</ref> where <ref:GenericTypeParam>T</ref> : <ref:module>print_synthesized_extensions</ref>.<ref:Class>E</ref> {
+// CHECK16-NOT: <synthesized>extension <ref:Class>F</ref> where <ref:GenericTypeParam>T</ref>: <ref:module>print_synthesized_extensions</ref>.<ref:Class>E</ref> {
 
 
 // Parameter packs
@@ -409,5 +409,5 @@ public struct S14<each T: Equatable> {}
 extension S14 : P14 where repeat each T: Hashable {}
 
 // CHECK17:      <synthesized>extension <ref:Struct>S14</ref> {
-// CHECK17-NEXT:   <decl:Func>public func <loc>foo<each <ref:GenericTypeParam>T</ref>>(<decl:Param>_: repeat each <ref:GenericTypeParam>T</ref></decl>)</loc> where Pack{repeat each <ref:GenericTypeParam>T</ref>} : <ref:Protocol>Equatable</ref></decl>
+// CHECK17-NEXT:   <decl:Func>public func <loc>foo<each <ref:GenericTypeParam>T</ref>>(<decl:Param>_: repeat each <ref:GenericTypeParam>T</ref></decl>)</loc> where Pack{repeat each <ref:GenericTypeParam>T</ref>}: <ref:Protocol>Equatable</ref></decl>
 // CHECK17-NEXT: }</synthesized>

--- a/test/IDE/print_synthesized_extensions_superclass.swift
+++ b/test/IDE/print_synthesized_extensions_superclass.swift
@@ -27,7 +27,7 @@ public extension P where T : Most {
   func withMost() {}
 }
 
-// CHECK-LABEL: public struct S1 : print_synthesized_extensions_superclass.P {
+// CHECK-LABEL: public struct S1: print_synthesized_extensions_superclass.P {
 // CHECK-NEXT:    public typealias T = print_synthesized_extensions_superclass.Base
 // CHECK-NEXT:    public typealias U = Int
 // CHECK-NEXT:    public func withBase()
@@ -38,7 +38,7 @@ public struct S1 : P {
   public typealias U = Int
 }
 
-// CHECK-LABEL: public struct S2 : print_synthesized_extensions_superclass.P {
+// CHECK-LABEL: public struct S2: print_synthesized_extensions_superclass.P {
 // CHECK-NEXT:    public typealias T = print_synthesized_extensions_superclass.Middle<Int>
 // CHECK-NEXT:    public typealias U = Int
 // CHECK-NEXT:    public func withBase()
@@ -51,7 +51,7 @@ public struct S2 : P {
   public typealias U = Int
 }
 
-// CHECK-LABEL: public struct S3 : print_synthesized_extensions_superclass.P {
+// CHECK-LABEL: public struct S3: print_synthesized_extensions_superclass.P {
 // CHECK-NEXT:    public typealias T = print_synthesized_extensions_superclass.Middle<String>
 // CHECK-NEXT:    public typealias U = String
 // CHECK-NEXT:    public func withBase()
@@ -63,7 +63,7 @@ public struct S3 : P {
   public typealias U = String
 }
 
-// CHECK-LABEL: public struct S4 : print_synthesized_extensions_superclass.P {
+// CHECK-LABEL: public struct S4: print_synthesized_extensions_superclass.P {
 // CHECK-NEXT:    public typealias T = print_synthesized_extensions_superclass.Most
 // CHECK-NEXT:    public typealias U = Int
 // CHECK-NEXT:    public func withBase()
@@ -77,7 +77,7 @@ public struct S4 : P {
   public typealias U = Int
 }
 
-// CHECK-LABEL: public struct S5 : print_synthesized_extensions_superclass.P {
+// CHECK-LABEL: public struct S5: print_synthesized_extensions_superclass.P {
 // CHECK-NEXT:   public typealias T = print_synthesized_extensions_superclass.Most
 // CHECK-NEXT:   public typealias U = String
 // CHECK-NEXT:   public func withBase()
@@ -90,40 +90,40 @@ public struct S5 : P {
   public typealias U = String
 }
 
-// CHECK-LABEL: public struct S6<T, U> : print_synthesized_extensions_superclass.P where T : print_synthesized_extensions_superclass.Base {
+// CHECK-LABEL: public struct S6<T, U> : print_synthesized_extensions_superclass.P where T: print_synthesized_extensions_superclass.Base {
 // CHECK-NEXT:    public func withBase()
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: extension S6 where T : print_synthesized_extensions_superclass.Middle<U> {
+// CHECK-LABEL: extension S6 where T: print_synthesized_extensions_superclass.Middle<U> {
 // CHECK-NEXT:    public func withMiddleAbstract()
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: extension S6 where T : print_synthesized_extensions_superclass.Middle<Int> {
+// CHECK-LABEL: extension S6 where T: print_synthesized_extensions_superclass.Middle<Int> {
 // CHECK-NEXT:    public func withMiddleConcrete()
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: extension S6 where T : print_synthesized_extensions_superclass.Most {
+// CHECK-LABEL: extension S6 where T: print_synthesized_extensions_superclass.Most {
 // CHECK-NEXT:    public func withMost()
 // CHECK-NEXT:  }
 
 public struct S6<T, U> : P where T : Base {}
 
-// CHECK-LABEL: public struct S7<T, U> : print_synthesized_extensions_superclass.P where T : print_synthesized_extensions_superclass.Middle<U> {
+// CHECK-LABEL: public struct S7<T, U> : print_synthesized_extensions_superclass.P where T: print_synthesized_extensions_superclass.Middle<U> {
 // CHECK-NEXT:    public func withBase()
 // CHECK-NEXT:    public func withMiddleAbstract()
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: extension S7 where T : print_synthesized_extensions_superclass.Middle<Int> {
+// CHECK-LABEL: extension S7 where T: print_synthesized_extensions_superclass.Middle<Int> {
 // CHECK-NEXT:    public func withMiddleConcrete()
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: extension S7 where T : print_synthesized_extensions_superclass.Most {
+// CHECK-LABEL: extension S7 where T: print_synthesized_extensions_superclass.Most {
 // CHECK-NEXT:    public func withMost()
 // CHECK-NEXT:  }
 
 public struct S7<T, U> : P where T : Middle<U> {}
 
-// CHECK-LABEL: public struct S8<T, U> : print_synthesized_extensions_superclass.P where T : print_synthesized_extensions_superclass.Most {
+// CHECK-LABEL: public struct S8<T, U> : print_synthesized_extensions_superclass.P where T: print_synthesized_extensions_superclass.Most {
 // CHECK-NEXT:    public func withBase()
 // CHECK-NEXT:    public func withMiddleConcrete()
 // CHECK-NEXT:    public func withMost()

--- a/test/IDE/rdar141440011.swift
+++ b/test/IDE/rdar141440011.swift
@@ -5,4 +5,4 @@ public struct MyStruct: MyProto {}
 // RUN: %target-swift-frontend -emit-module -o %t/swift_mod.swiftmodule %s -parse-as-library -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -experimental-lazy-typecheck
 // RUN: %target-swift-synthesize-interface -module-name swift_mod -I %t -o - | %FileCheck %s
 
-// CHECK: public struct MyStruct : swift_mod.MyProto
+// CHECK: public struct MyStruct: swift_mod.MyProto

--- a/test/Interop/Cxx/class/access/access-inversion-module-interface.swift
+++ b/test/Interop/Cxx/class/access/access-inversion-module-interface.swift
@@ -12,14 +12,14 @@
 // CHECK:     public static var PRIVATE_REC_CONST: Bool { get }
 // CHECK:   }
 
-// CHECK:   private struct PrivateEnum : Hashable, Equatable, RawRepresentable {
+// CHECK:   private struct PrivateEnum: Hashable, Equatable, RawRepresentable {
 // CHECK:     private init(_ rawValue: [[ENUM_RV_T:.*]])
 // CHECK:     private init(rawValue: [[ENUM_RV_T]])
 // CHECK:     private var rawValue: [[ENUM_RV_T]]
 // CHECK:     private typealias RawValue = [[ENUM_RV_T]]
 // CHECK:   }
 
-// CHECK:   private enum PrivateEnumClass : [[ENUM_CLASS_RV_T:.*]] {
+// CHECK:   private enum PrivateEnumClass: [[ENUM_CLASS_RV_T:.*]] {
 // CHECK:     private init?(rawValue: [[ENUM_CLASS_RV_T]])
 // CHECK:     private var rawValue: [[ENUM_CLASS_RV_T]] { get }
 // CHECK:     private typealias RawValue = [[ENUM_CLASS_RV_T]]

--- a/test/Interop/Cxx/class/access/access-specifiers-module-interface.swift
+++ b/test/Interop/Cxx/class/access/access-specifiers-module-interface.swift
@@ -13,13 +13,13 @@
 // CHECK-NEXT:   public struct PublicStruct {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   public struct PublicEnum : Hashable, Equatable, RawRepresentable {
+// CHECK-NEXT:   public struct PublicEnum: Hashable, Equatable, RawRepresentable {
 // CHECK-NEXT:     public init(_ rawValue: [[ENUM_UNDERLYING_TYPE:Int32|UInt32]])
 // CHECK-NEXT:     public init(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     public var rawValue: [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:     public typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:   }
-// CHECK-NEXT:   @frozen public enum PublicClosedEnum : [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
+// CHECK-NEXT:   @frozen public enum PublicClosedEnum: [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
 // CHECK-NEXT:     public init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     public var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
 // CHECK-NEXT:     public typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -27,7 +27,7 @@
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     public static var Value1: PublicPrivate.PublicClosedEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   public enum PublicOpenEnum : [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
+// CHECK-NEXT:   public enum PublicOpenEnum: [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
 // CHECK-NEXT:     public init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     public var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
 // CHECK-NEXT:     public typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -35,7 +35,7 @@
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     public static var Value1: PublicPrivate.PublicOpenEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   public struct PublicFlagEnum : OptionSet, @unchecked Sendable {
+// CHECK-NEXT:   public struct PublicFlagEnum: OptionSet, @unchecked Sendable {
 // CHECK-NEXT:     public init(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     public let rawValue: [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:     public typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -48,13 +48,13 @@
 // CHECK-NEXT:   private struct PrivateStruct {
 // CHECK-NEXT:     public init()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   private struct PrivateEnum : Hashable, Equatable, RawRepresentable {
+// CHECK-NEXT:   private struct PrivateEnum: Hashable, Equatable, RawRepresentable {
 // CHECK-NEXT:     private init(_ rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     private init(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     private var rawValue: [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:     private typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:   }
-// CHECK-NEXT:   @frozen private enum PrivateClosedEnum : [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
+// CHECK-NEXT:   @frozen private enum PrivateClosedEnum: [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
 // CHECK-NEXT:     private init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     private var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
 // CHECK-NEXT:     private typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -62,7 +62,7 @@
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     private static var Value1: PublicPrivate.PrivateClosedEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   private enum PrivateOpenEnum : [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
+// CHECK-NEXT:   private enum PrivateOpenEnum: [[ENUM_UNDERLYING_TYPE]], @unchecked Sendable {
 // CHECK-NEXT:     private init?(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     private var rawValue: [[ENUM_UNDERLYING_TYPE]] { get }
 // CHECK-NEXT:     private typealias RawValue = [[ENUM_UNDERLYING_TYPE]]
@@ -70,7 +70,7 @@
 // CHECK-NEXT:     @available(swift, obsoleted: 3, renamed: "value1")
 // CHECK-NEXT:     private static var Value1: PublicPrivate.PrivateOpenEnum { get }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   private struct PrivateFlagEnum : OptionSet, @unchecked Sendable {
+// CHECK-NEXT:   private struct PrivateFlagEnum: OptionSet, @unchecked Sendable {
 // CHECK-NEXT:     private init(rawValue: [[ENUM_UNDERLYING_TYPE]])
 // CHECK-NEXT:     private let rawValue: [[ENUM_UNDERLYING_TYPE]]
 // CHECK-NEXT:     private typealias RawValue = [[ENUM_UNDERLYING_TYPE]]

--- a/test/Interop/Cxx/class/inheritance/sub-types-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/sub-types-module-interface.swift
@@ -2,7 +2,7 @@
 
 // CHECK:      struct Base {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   enum EnumClass : CChar {
+// CHECK-NEXT:   enum EnumClass: CChar {
 // CHECK-NEXT:     init?(rawValue: CChar)
 // CHECK-NEXT:     var rawValue: CChar { get }
 // CHECK-NEXT:     typealias RawValue = CChar
@@ -10,7 +10,7 @@
 // CHECK-NEXT:     case ecb
 // CHECK-NEXT:     case ecc
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct Enum : Hashable, Equatable, RawRepresentable {
+// CHECK-NEXT:   struct Enum: Hashable, Equatable, RawRepresentable {
 // CHECK-NEXT:     init(_ rawValue: {{UInt32|Int32}})
 // CHECK-NEXT:     init(rawValue: {{UInt32|Int32}})
 // CHECK-NEXT:     var rawValue: {{UInt32|Int32}}

--- a/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/using-base-members-module-interface.swift
@@ -72,7 +72,7 @@
 // CHECK-NEXT:   public func protectedGetter() -> Int32
 // CHECK-NEXT: }
 
-// CHECK:      public struct OperatorBasePrivateInheritance : CxxConvertibleToBool {
+// CHECK:      public struct OperatorBasePrivateInheritance: CxxConvertibleToBool {
 // CHECK-NEXT:   public init()
 // CHECK-NEXT:   public var pointee: Int32 { get }
 // CHECK-NEXT:   public func __convertToBool() -> Bool

--- a/test/Interop/Cxx/class/nested-records-module-interface.swift
+++ b/test/Interop/Cxx/class/nested-records-module-interface.swift
@@ -17,7 +17,7 @@
 // CHECK: }
  
 // CHECK: struct U3 {
-// CHECK:   struct E1 : Hashable, Equatable, RawRepresentable {
+// CHECK:   struct E1: Hashable, Equatable, RawRepresentable {
 // CHECK:     typealias RawValue = {{UInt32|Int32}}
 // CHECK:   }
 // CHECK: }
@@ -29,7 +29,7 @@
  
 // CHECK: struct S6 {
 // CHECK:   init()
-// CHECK:   struct E3 : Hashable, Equatable, RawRepresentable {
+// CHECK:   struct E3: Hashable, Equatable, RawRepresentable {
 // CHECK:     typealias RawValue = {{UInt32|Int32}}
 // CHECK:   }
 // CHECK: }
@@ -50,7 +50,7 @@
  
 // CHECK: struct S10 {
 // CHECK:   struct U8 {
-// CHECK:     struct E4 : Hashable, Equatable, RawRepresentable {
+// CHECK:     struct E4: Hashable, Equatable, RawRepresentable {
 // CHECK:       typealias RawValue = {{UInt32|Int32}}
 // CHECK:     }
 // CHECK:   }

--- a/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
+++ b/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
@@ -3,7 +3,7 @@
 // CHECK: @available(*, unavailable, message: "Not available in Swift")
 // CHECK: typealias SOColorMask = UInt32
 
-// CHECK: struct SOColorMask : OptionSet, @unchecked Sendable {
+// CHECK: struct SOColorMask: OptionSet, @unchecked Sendable {
 // CHECK:   init(rawValue: UInt32)
 // CHECK:   let rawValue: UInt32
 // CHECK:   typealias RawValue = UInt32
@@ -29,7 +29,7 @@
 
 // CHECK-NOT: typealias CFColorMask = UInt32
 
-// CHECK: struct CFColorMask : OptionSet {
+// CHECK: struct CFColorMask: OptionSet {
 // CHECK:   init(rawValue: UInt32)
 // CHECK:   let rawValue: UInt32
 // CHECK:   typealias RawValue = UInt32
@@ -66,7 +66,7 @@
 // CHECK:     func childFn() -> CFColorMask
 // CHECK:     @available(*, unavailable, message: "Not available in Swift")
 // CHECK:     typealias NewName = UInt32
-// CHECK:     struct NewName : OptionSet, @unchecked Sendable {
+// CHECK:     struct NewName: OptionSet, @unchecked Sendable {
 // CHECK:         init(rawValue: UInt32)
 // CHECK:         let rawValue: UInt32
 // CHECK:         typealias RawValue = UInt32
@@ -92,7 +92,7 @@
 // CHECK: @available(swift, obsoleted: 3, renamed: "GlobalNewName")
 // CHECK: @available(*, unavailable, message: "Not available in Swift")
 // CHECK: typealias GlobalOldName = GlobalNewName
-// CHECK: struct GlobalNewName : OptionSet, @unchecked Sendable {
+// CHECK: struct GlobalNewName: OptionSet, @unchecked Sendable {
 // CHECK:     init(rawValue: UInt32)
 // CHECK:     let rawValue: UInt32
 // CHECK:     typealias RawValue = UInt32

--- a/test/Interop/Cxx/enum/bool-enums-module-interface.swift
+++ b/test/Interop/Cxx/enum/bool-enums-module-interface.swift
@@ -2,7 +2,7 @@
 
 // TODO: these should be enums eventually (especially the enum class).
 
-// CHECK:       struct Maybe : Hashable, Equatable, RawRepresentable {
+// CHECK:       struct Maybe: Hashable, Equatable, RawRepresentable {
 // CHECK-NEXT:    init(_ rawValue: Bool)
 // CHECK-NEXT:    init(rawValue: Bool)
 // CHECK-NEXT:    var rawValue: Bool
@@ -11,7 +11,7 @@
 // CHECK:       var No: Maybe { get }
 // CHECK:       var Yes: Maybe { get }
 
-// CHECK:       struct BinaryNumbers : Hashable, Equatable, RawRepresentable {
+// CHECK:       struct BinaryNumbers: Hashable, Equatable, RawRepresentable {
 // CHECK-NEXT:    init(_ rawValue: Bool)
 // CHECK-NEXT:    init(rawValue: Bool)
 // CHECK-NEXT:	  var rawValue: Bool
@@ -20,7 +20,7 @@
 // CHECK:       var One: BinaryNumbers { get }
 // CHECK:       var Zero: BinaryNumbers { get }
 
-// CHECK: enum EnumClass : Bool {
+// CHECK: enum EnumClass: Bool {
 // CHECK:   init?(rawValue: Bool)
 // CHECK:   var rawValue: Bool { get }
 // CHECK:   typealias RawValue = Bool
@@ -31,7 +31,7 @@
 // CHECK:       struct WrapperStruct {
 // CHECK-NEXT:    init()
 // TODO: where is "A" and "B"? They should be member variables.
-// CHECK-NEXT:    struct InnerBoolEnum : Hashable, Equatable, RawRepresentable {
+// CHECK-NEXT:    struct InnerBoolEnum: Hashable, Equatable, RawRepresentable {
 // CHECK-NEXT:      init(_ rawValue: Bool)
 // CHECK-NEXT:      init(rawValue: Bool)
 // CHECK-NEXT:      var rawValue: Bool

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-NS_REFINED_FOR_SWIFT.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-NS_REFINED_FOR_SWIFT.swift
@@ -5,7 +5,7 @@ import CenumsNSOptions
 
 // CHECK-NOT: typealias NSAttributedStringFormattingOptions = UInt
 
-// CHECK: struct __NSAttributedStringFormattingOptions : OptionSet, @unchecked Sendable {
+// CHECK: struct __NSAttributedStringFormattingOptions: OptionSet, @unchecked Sendable {
 // CHECK-NEXT:   init(rawValue: UInt)
 // CHECK-NEXT:   let rawValue: UInt
 // CHECK-NEXT:   typealias RawValue = UInt

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS.swift
@@ -5,7 +5,7 @@ import CenumsNSOptions
 
 // CHECK-NOT: typealias NSBinarySearchingOptions = UInt
 
-// CHECK: struct NSBinarySearchingOptions : OptionSet, @unchecked Sendable {
+// CHECK: struct NSBinarySearchingOptions: OptionSet, @unchecked Sendable {
 // CHECK-NEXT:   init(rawValue: UInt)
 // CHECK-NEXT:   let rawValue: UInt
 // CHECK-NEXT:   typealias RawValue = UInt
@@ -22,7 +22,7 @@ import CenumsNSOptions
 // CHECK-NEXT:   static var InsertionIndex: NSBinarySearchingOptions { get }
 // CHECK-NEXT: }
 
-// CHECK: struct Bar : OptionSet, @unchecked Sendable
+// CHECK: struct Bar: OptionSet, @unchecked Sendable
 // CHECK: struct HasNSOptionField {
 // CHECK:   var bar: Bar
 // CHECK: }

--- a/test/Interop/Cxx/enum/nested-enums-module-interface.swift
+++ b/test/Interop/Cxx/enum/nested-enums-module-interface.swift
@@ -1,20 +1,20 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=NestedEnums -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: enum ns {
-// CHECK:  struct EnumInNS : Hashable, Equatable, RawRepresentable {
+// CHECK:  struct EnumInNS: Hashable, Equatable, RawRepresentable {
 // CHECK:  }
 // CHECK-NEXT:  static var kA: ns.EnumInNS { get }
 // CHECK-NEXT:  static var kB: ns.EnumInNS { get }
-// CHECK-NEXT:  enum ScopedEnumInNS : Int32 {
+// CHECK-NEXT:  enum ScopedEnumInNS: Int32 {
 // CHECK:    case scopeA
 // CHECK:    case scopeB
 // CHECK-NEXT:  }
 // CHECK-NEXT:  enum nestedNS {
-// CHECK-NEXT:    struct EnumInNestedNS : Hashable, Equatable, RawRepresentable {
+// CHECK-NEXT:    struct EnumInNestedNS: Hashable, Equatable, RawRepresentable {
 // CHECK:    }
 // CHECK-NEXT:    static var kNestedA: ns.nestedNS.EnumInNestedNS { get }
 // CHECK-NEXT:    static var kNestedB: ns.nestedNS.EnumInNestedNS { get }
-// CHECK-NEXT:         struct EnumInNS : Hashable, Equatable, RawRepresentable {
+// CHECK-NEXT:         struct EnumInNS: Hashable, Equatable, RawRepresentable {
 // CHECK:    }
 // CHECK-NEXT:    static var kA: ns.nestedNS.EnumInNS { get }
 // CHECK-NEXT:    static var kB: ns.nestedNS.EnumInNS { get }

--- a/test/Interop/Cxx/enum/scoped-enums-module-interface.swift
+++ b/test/Interop/Cxx/enum/scoped-enums-module-interface.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ScopedEnums -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK: enum ScopedEnumDefined : Int32 {
+// CHECK: enum ScopedEnumDefined: Int32 {
 // CHECK:   init?(rawValue: Int32)
 // CHECK:   var rawValue: Int32 { get }
 // CHECK:   typealias RawValue = Int32
@@ -8,7 +8,7 @@
 // CHECK:   case y
 // CHECK: }
 
-// CHECK: enum ScopedEnumBasic : Int32 {
+// CHECK: enum ScopedEnumBasic: Int32 {
 // CHECK:   init?(rawValue: Int32)
 // CHECK:   var rawValue: Int32 { get }
 // CHECK:   typealias RawValue = Int32
@@ -17,7 +17,7 @@
 // CHECK:   case z
 // CHECK: }
 
-// CHECK: enum ScopedEnumCharDefined : CChar {
+// CHECK: enum ScopedEnumCharDefined: CChar {
 // CHECK:   init?(rawValue: CChar)
 // CHECK:   var rawValue: CChar { get }
 // CHECK:   typealias RawValue = CChar
@@ -25,7 +25,7 @@
 // CHECK:   case y
 // CHECK: }
 
-// CHECK: enum ScopedEnumUnsignedDefined : UInt32 {
+// CHECK: enum ScopedEnumUnsignedDefined: UInt32 {
 // CHECK:   init?(rawValue: UInt32)
 // CHECK:   var rawValue: UInt32 { get }
 // CHECK:   typealias RawValue = UInt32
@@ -33,7 +33,7 @@
 // CHECK:   case y
 // CHECK: }
 
-// CHECK: enum ScopedEnumUnsignedLongDefined : [[UINT_T:UInt|UInt32]] {
+// CHECK: enum ScopedEnumUnsignedLongDefined: [[UINT_T:UInt|UInt32]] {
 // CHECK:   init?(rawValue: [[UINT_T]])
 // CHECK:   var rawValue: [[UINT_T]] { get }
 // CHECK:   typealias RawValue = [[UINT_T]]
@@ -41,7 +41,7 @@
 // CHECK:   case y
 // CHECK: }
 
-// CHECK: enum ScopedEnumChar : CChar {
+// CHECK: enum ScopedEnumChar: CChar {
 // CHECK:   init?(rawValue: CChar)
 // CHECK:   var rawValue: CChar { get }
 // CHECK:   typealias RawValue = CChar
@@ -50,7 +50,7 @@
 // CHECK:   case z
 // CHECK: }
 
-// CHECK: enum ScopedEnumUnsigned : UInt32 {
+// CHECK: enum ScopedEnumUnsigned: UInt32 {
 // CHECK:   init?(rawValue: UInt32)
 // CHECK:   var rawValue: UInt32 { get }
 // CHECK:   typealias RawValue = UInt32
@@ -59,7 +59,7 @@
 // CHECK:   case z
 // CHECK: }
 
-// CHECK: enum ScopedEnumUnsignedLong : [[UINT_T]] {
+// CHECK: enum ScopedEnumUnsignedLong: [[UINT_T]] {
 // CHECK:   init?(rawValue: [[UINT_T]])
 // CHECK:   var rawValue: [[UINT_T]] { get }
 // CHECK:   typealias RawValue = [[UINT_T]]
@@ -68,7 +68,7 @@
 // CHECK:   case z
 // CHECK: }
 
-// CHECK: enum ScopedEnumInt : Int32 {
+// CHECK: enum ScopedEnumInt: Int32 {
 // CHECK:   init?(rawValue: Int32)
 // CHECK:   var rawValue: Int32 { get }
 // CHECK:   typealias RawValue = Int32
@@ -77,7 +77,7 @@
 // CHECK:   case z
 // CHECK: }
 
-// CHECK: enum ScopedEnumNegativeElement : Int32 {
+// CHECK: enum ScopedEnumNegativeElement: Int32 {
 // CHECK:   init?(rawValue: Int32)
 // CHECK:   var rawValue: Int32 { get }
 // CHECK:   typealias RawValue = Int32

--- a/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
+++ b/test/Interop/Cxx/ergonomics/swift-bridging-annotations.swift
@@ -154,8 +154,8 @@ private:
 // CHECK: func returnsPointerToUnsafeReference() -> UnsafeNonCopyable!
 // CHECK: func takesPointerToUnsafeNonCopyable(_: UnsafeNonCopyable!)
 
-// CHECK: struct ConformsTo : Proto {
+// CHECK: struct ConformsTo: Proto {
 
-// CHECK: struct UnsafeSendable : @unchecked Sendable {
+// CHECK: struct UnsafeSendable: @unchecked Sendable {
 
 // CHECKLATEST: struct NonCopyableCopyable

--- a/test/Interop/Cxx/objc-correctness/protocol-naming-conflict.swift
+++ b/test/Interop/Cxx/objc-correctness/protocol-naming-conflict.swift
@@ -5,8 +5,8 @@
 
 import ProtocolNamingConflict
 
-// CHECK: class Thing : FooProtocol
+// CHECK: class Thing: FooProtocol
 // CHECK-IDE-TEST: protocol FooProtocol
-// CHECK-IDE-TEST: class Foo : FooProtocol
+// CHECK-IDE-TEST: class Foo: FooProtocol
 class Thing: FooProtocol {
 }

--- a/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/convertible-to-bool-module-interface.swift
@@ -2,14 +2,14 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ConvertibleToBool -source-filename=x -I %S/Inputs -cxx-interoperability-mode=swift-6 | %FileCheck %s
 // RUN: %target-swift-ide-test -print-module -module-to-print=ConvertibleToBool -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
 
-// CHECK: struct BoolBox : CxxConvertibleToBool {
+// CHECK: struct BoolBox: CxxConvertibleToBool {
 // CHECK: }
 
 // CHECK: struct NonConstBoolBox {
 // CHECK: }
 
-// CHECK: struct DualOverloadBoolBox : CxxConvertibleToBool {
+// CHECK: struct DualOverloadBoolBox: CxxConvertibleToBool {
 // CHECK: }
 
-// CHECK: struct ExplicitBoolBox : CxxConvertibleToBool {
+// CHECK: struct ExplicitBoolBox: CxxConvertibleToBool {
 // CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
@@ -2,38 +2,38 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=swift-6 -module-cache-path %t | %FileCheck %s
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -module-cache-path %t | %FileCheck %s
 
-// CHECK: struct SimpleArrayWrapper : CxxRandomAccessCollection {
+// CHECK: struct SimpleArrayWrapper: CxxRandomAccessCollection {
 // CHECK:   typealias Element = UnsafePointer<Int32>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleArrayWrapper>
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>
 // CHECK: }
 
-// CHECK: struct SimpleCollectionNoSubscript : CxxRandomAccessCollection {
+// CHECK: struct SimpleCollectionNoSubscript: CxxRandomAccessCollection {
 // CHECK:   typealias Element = ConstRACIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleCollectionNoSubscript>
 // CHECK:   typealias RawIterator = SimpleCollectionNoSubscript.iterator
 // CHECK: }
 
-// CHECK: struct SimpleCollectionReadOnly : CxxRandomAccessCollection {
+// CHECK: struct SimpleCollectionReadOnly: CxxRandomAccessCollection {
 // CHECK:   typealias Element = ConstRACIteratorRefPlusEq.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleCollectionReadOnly>
 // CHECK:   typealias RawIterator = SimpleCollectionReadOnly.iterator
 // CHECK: }
 
-// CHECK: struct SimpleCollectionReadWrite : CxxMutableRandomAccessCollection {
+// CHECK: struct SimpleCollectionReadWrite: CxxMutableRandomAccessCollection {
 // CHECK:   typealias Element = ConstRACIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleCollectionReadWrite>
 // CHECK:   typealias RawIterator = SimpleCollectionReadWrite.const_iterator
 // CHECK:   typealias RawMutableIterator = SimpleCollectionReadWrite.iterator
 // CHECK: }
 
-// CHECK: struct HasInheritedTemplatedConstRACIterator<CInt> : CxxRandomAccessCollection {
+// CHECK: struct HasInheritedTemplatedConstRACIterator<CInt>: CxxRandomAccessCollection {
 // CHECK:   typealias Element = InheritedTemplatedConstRACIterator<CInt>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<HasInheritedTemplatedConstRACIterator<CInt>>
 // CHECK:   typealias RawIterator = InheritedTemplatedConstRACIterator<CInt>
 // CHECK: }
 
-// CHECK: struct HasInheritedTemplatedConstRACIteratorOutOfLineOps<CInt> : CxxRandomAccessCollection {
+// CHECK: struct HasInheritedTemplatedConstRACIteratorOutOfLineOps<CInt>: CxxRandomAccessCollection {
 // CHECK:   typealias Element = InheritedTemplatedConstRACIteratorOutOfLineOps<CInt>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<HasInheritedTemplatedConstRACIteratorOutOfLineOps<CInt>>
 // CHECK:   typealias RawIterator = InheritedTemplatedConstRACIteratorOutOfLineOps<CInt>

--- a/test/Interop/Cxx/stdlib/overlay/custom-contiguous-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-contiguous-iterator-module-interface.swift
@@ -6,28 +6,28 @@
 // UNSUPPORTED: LinuxDistribution=ubuntu-20.04
 // UNSUPPORTED: LinuxDistribution=amzn-2
 
-// CHECK: struct ConstContiguousIterator : UnsafeCxxContiguousIterator, UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct ConstContiguousIterator: UnsafeCxxContiguousIterator, UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   func successor() -> ConstContiguousIterator
 // CHECK:   var pointee: Int32
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK: }
 
-// CHECK: struct HasCustomContiguousIteratorTag : UnsafeCxxContiguousIterator, UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct HasCustomContiguousIteratorTag: UnsafeCxxContiguousIterator, UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   func successor() -> HasCustomContiguousIteratorTag
 // CHECK:   var pointee: Int32
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK: }
 
-// CHECK: struct MutableContiguousIterator : UnsafeCxxMutableContiguousIterator, UnsafeCxxMutableRandomAccessIterator, UnsafeCxxMutableInputIterator {
+// CHECK: struct MutableContiguousIterator: UnsafeCxxMutableContiguousIterator, UnsafeCxxMutableRandomAccessIterator, UnsafeCxxMutableInputIterator {
 // CHECK:   func successor() -> MutableContiguousIterator
 // CHECK:   var pointee: Int32
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK: }
 
-// CHECK: struct HasNoContiguousIteratorConcept : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct HasNoContiguousIteratorConcept: UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   func successor() -> HasNoContiguousIteratorConcept
 // CHECK:   var pointee: Int32
 // CHECK:   typealias Pointee = Int32

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -2,14 +2,14 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=swift-6 | %FileCheck %s
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
 
-// CHECK: struct ConstIterator : UnsafeCxxInputIterator {
+// CHECK: struct ConstIterator: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> ConstIterator
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
 // CHECK: }
 
-// CHECK: struct ConstRACIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct ConstRACIterator: UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   func successor() -> ConstRACIterator
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
@@ -19,7 +19,7 @@
 // CHECK:   static func == (lhs: ConstRACIterator, other: ConstRACIterator) -> Bool
 // CHECK: }
 
-// CHECK: struct ConstRACIteratorRefPlusEq : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct ConstRACIteratorRefPlusEq: UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   func successor() -> ConstRACIterator
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
@@ -29,34 +29,34 @@
 // CHECK:   static func == (lhs: ConstRACIteratorRefPlusEq, other: ConstRACIteratorRefPlusEq) -> Bool
 // CHECK: }
 
-// CHECK: struct ConstIteratorOutOfLineEq : UnsafeCxxInputIterator {
+// CHECK: struct ConstIteratorOutOfLineEq: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> ConstIteratorOutOfLineEq
 // CHECK:   var pointee: Int32 { get }
 // CHECK: }
 // CHECK: func == (lhs: ConstIteratorOutOfLineEq, rhs: ConstIteratorOutOfLineEq) -> Bool
 
-// CHECK: struct MinimalIterator : UnsafeCxxInputIterator {
+// CHECK: struct MinimalIterator: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> MinimalIterator
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: MinimalIterator, other: MinimalIterator) -> Bool
 // CHECK: }
 
-// CHECK: struct ForwardIterator : UnsafeCxxInputIterator {
+// CHECK: struct ForwardIterator: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> ForwardIterator
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: ForwardIterator, other: ForwardIterator) -> Bool
 // CHECK: }
 
-// CHECK: struct HasCustomIteratorTag : UnsafeCxxInputIterator {
+// CHECK: struct HasCustomIteratorTag: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> HasCustomIteratorTag
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasCustomIteratorTag, other: HasCustomIteratorTag) -> Bool
 // CHECK: }
 
-// CHECK: struct HasCustomRACIteratorTag : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct HasCustomRACIteratorTag: UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   func successor() -> HasCustomRACIteratorTag
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
@@ -66,7 +66,7 @@
 // CHECK:   static func == (lhs: HasCustomRACIteratorTag, other: HasCustomRACIteratorTag) -> Bool
 // CHECK: }
 
-// CHECK: struct HasCustomInheritedRACIteratorTag : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct HasCustomInheritedRACIteratorTag: UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   func successor() -> HasCustomInheritedRACIteratorTag
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
@@ -83,49 +83,49 @@
 // CHECK:   typealias iterator_category = HasCustomInheritedRACIteratorTag.CustomTag4
 // CHECK: }
 
-// CHECK: struct HasCustomIteratorTagInline : UnsafeCxxInputIterator {
+// CHECK: struct HasCustomIteratorTagInline: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> HasCustomIteratorTagInline
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasCustomIteratorTagInline, other: HasCustomIteratorTagInline) -> Bool
 // CHECK: }
 
-// CHECK: struct HasTypedefIteratorTag : UnsafeCxxInputIterator {
+// CHECK: struct HasTypedefIteratorTag: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> HasTypedefIteratorTag
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: HasTypedefIteratorTag, other: HasTypedefIteratorTag) -> Bool
 // CHECK: }
 
-// CHECK: struct MutableRACIterator : UnsafeCxxMutableRandomAccessIterator, UnsafeCxxMutableInputIterator {
+// CHECK: struct MutableRACIterator: UnsafeCxxMutableRandomAccessIterator, UnsafeCxxMutableInputIterator {
 // CHECK:   func successor() -> MutableRACIterator
 // CHECK:   var pointee: Int32
 // CHECK:   typealias Pointee = Int32
 // CHECK:   typealias Distance = Int32
 // CHECK: }
 
-// CHECK-NOT: struct HasNoIteratorCategory : UnsafeCxxInputIterator
-// CHECK-NOT: struct HasInvalidIteratorCategory : UnsafeCxxInputIterator
-// CHECK-NOT: struct HasNoEqualEqual : UnsafeCxxInputIterator
-// CHECK-NOT: struct HasInvalidEqualEqual : UnsafeCxxInputIterator
-// CHECK-NOT: struct HasNoIncrementOperator : UnsafeCxxInputIterator
-// CHECK-NOT: struct HasNoPreIncrementOperator : UnsafeCxxInputIterator
-// CHECK-NOT: struct HasNoDereferenceOperator : UnsafeCxxInputIterator
+// CHECK-NOT: struct HasNoIteratorCategory: UnsafeCxxInputIterator
+// CHECK-NOT: struct HasInvalidIteratorCategory: UnsafeCxxInputIterator
+// CHECK-NOT: struct HasNoEqualEqual: UnsafeCxxInputIterator
+// CHECK-NOT: struct HasInvalidEqualEqual: UnsafeCxxInputIterator
+// CHECK-NOT: struct HasNoIncrementOperator: UnsafeCxxInputIterator
+// CHECK-NOT: struct HasNoPreIncrementOperator: UnsafeCxxInputIterator
+// CHECK-NOT: struct HasNoDereferenceOperator: UnsafeCxxInputIterator
 
-// CHECK: struct TemplatedIterator<CInt> : UnsafeCxxInputIterator {
+// CHECK: struct TemplatedIterator<CInt>: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> TemplatedIterator<CInt>
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK:   static func == (lhs: TemplatedIterator<CInt>, other: TemplatedIterator<CInt>) -> Bool
 // CHECK: }
 
-// CHECK: struct TemplatedIteratorOutOfLineEq<CInt> : UnsafeCxxInputIterator {
+// CHECK: struct TemplatedIteratorOutOfLineEq<CInt>: UnsafeCxxInputIterator {
 // CHECK:   func successor() -> TemplatedIteratorOutOfLineEq<CInt>
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
 // CHECK: }
 
-// CHECK: struct TemplatedRACIteratorOutOfLineEq<CInt> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct TemplatedRACIteratorOutOfLineEq<CInt>: UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   func successor() -> TemplatedRACIteratorOutOfLineEq<CInt>
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   typealias Pointee = Int32
@@ -134,31 +134,31 @@
 
 // CHECK: struct BaseIntIterator {
 // CHECK: }
-// CHECK: struct InheritedConstIterator : UnsafeCxxInputIterator {
+// CHECK: struct InheritedConstIterator: UnsafeCxxInputIterator {
 // CHECK: }
 
 // CHECK: struct InheritedTemplatedConstIterator<T> {
 // CHECK: }
-// CHECK: struct InheritedTemplatedConstIterator<CInt> : UnsafeCxxInputIterator {
+// CHECK: struct InheritedTemplatedConstIterator<CInt>: UnsafeCxxInputIterator {
 // CHECK: }
 
 // CHECK: struct InheritedTemplatedConstRACIterator<T> {
 // CHECK: }
-// CHECK: struct InheritedTemplatedConstRACIterator<CInt> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct InheritedTemplatedConstRACIterator<CInt>: UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK: }
 
 // CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<T> {
 // CHECK: }
-// CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<CInt> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct InheritedTemplatedConstRACIteratorOutOfLineOps<CInt>: UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK: }
 
-// CHECK: struct InputOutputIterator : UnsafeCxxMutableInputIterator {
+// CHECK: struct InputOutputIterator: UnsafeCxxMutableInputIterator {
 // CHECK:   func successor() -> InputOutputIterator
 // CHECK:   var pointee: Int32
 // CHECK:   typealias Pointee = Int32
 // CHECK: }
 
-// CHECK: struct InputOutputConstIterator : UnsafeCxxMutableInputIterator {
+// CHECK: struct InputOutputConstIterator: UnsafeCxxMutableInputIterator {
 // CHECK:   func successor() -> InputOutputConstIterator
 // CHECK:   var pointee: Int32 { get nonmutating set }
 // CHECK:   typealias Pointee = Int32

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -2,25 +2,25 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=swift-6 -module-cache-path %t | %FileCheck %s
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift -module-cache-path %t | %FileCheck %s
 
-// CHECK: struct SimpleSequence : CxxConvertibleToCollection {
+// CHECK: struct SimpleSequence: CxxConvertibleToCollection {
 // CHECK:   typealias Element = ConstIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleSequence>
 // CHECK:   typealias RawIterator = ConstIterator
 // CHECK: }
 
-// CHECK: struct SimpleSequenceWithOutOfLineEqualEqual : CxxConvertibleToCollection {
+// CHECK: struct SimpleSequenceWithOutOfLineEqualEqual: CxxConvertibleToCollection {
 // CHECK:   typealias Element = ConstIteratorOutOfLineEq.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleSequenceWithOutOfLineEqualEqual>
 // CHECK:   typealias RawIterator = ConstIteratorOutOfLineEq
 // CHECK: }
 
-// CHECK: struct SimpleArrayWrapperNullableIterators : CxxConvertibleToCollection {
+// CHECK: struct SimpleArrayWrapperNullableIterators: CxxConvertibleToCollection {
 // CHECK:   typealias Element = Optional<UnsafePointer<Int32>>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleArrayWrapperNullableIterators>
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>?
 // CHECK: }
 
-// CHECK: struct SimpleEmptySequence : CxxConvertibleToCollection {
+// CHECK: struct SimpleEmptySequence: CxxConvertibleToCollection {
 // CHECK:   typealias Element = Optional<UnsafePointer<Int32>>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleEmptySequence>
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>?
@@ -59,7 +59,7 @@
 // CHECK: }
 // CHECK: typealias HasUninstantiatableIterator = HasTemplatedIterator<CInt, NoDefinition<CInt>>
 
-// CHECK: struct HasInputOutputConstIterator : CxxConvertibleToCollection {
+// CHECK: struct HasInputOutputConstIterator: CxxConvertibleToCollection {
 // CHECK:   typealias Element = InputOutputConstIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<HasInputOutputConstIterator>
 // CHECK:   typealias RawIterator = HasInputOutputConstIterator.iterator

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
@@ -56,7 +56,7 @@ import ObjCxxModule
 // CHECK-NEXT:     public static func freeCxxFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK-NEXT: }
 // CHECK-EMPTY:
-// CHECK-NEXT: open class ObjCClass : NSObject {
+// CHECK-NEXT: open class ObjCClass: NSObject {
 // CHECK-EMPTY:
 // CHECK-NEXT:     open func myTestMethod()
 // CHECK-NEXT: }

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -33,7 +33,7 @@ public struct PublicEquatable {
 
 // INTERFACE-NOT: @Equatable
 // INTERFACE: public struct PublicEquatable
-// INTERFACE: extension ModuleWithEquatable.PublicEquatable : Swift.Equatable
+// INTERFACE: extension ModuleWithEquatable.PublicEquatable: Swift.Equatable
 
 #else
 import ModuleWithEquatable

--- a/test/Misc/Inputs/dumped_api.swift
+++ b/test/Misc/Inputs/dumped_api.swift
@@ -15,7 +15,7 @@ public class _AnyIteratorBase {
 ///     struct AnySequence<S: Sequence>
 ///     func anyIterator<I: IteratorProtocol>(base: I) -> AnyIterator<I.Element>
 ///     func anyIterator<T>(nextImplementation: () -> T?) -> AnyIterator<T>
-public class AnyIterator<T> : _AnyIteratorBase, IteratorProtocol {
+public class AnyIterator<T>: _AnyIteratorBase, IteratorProtocol {
 
   /// Initialize the instance.  May only be called from a subclass
   /// initializer.
@@ -30,7 +30,7 @@ public class AnyIterator<T> : _AnyIteratorBase, IteratorProtocol {
 
 /// Every `IteratorProtocol` can also be a `Sequence`.  Note that
 /// traversing the sequence consumes the iterator.
-extension AnyIterator : Sequence {
+extension AnyIterator: Sequence {
 
   /// Returns `self`.
   public func makeIterator() -> AnyIterator
@@ -53,7 +53,7 @@ public func anyIterator<I: IteratorProtocol>(base: I) -> AnyIterator<I.Element>
 
 public class FooIteratorBox<
   Base: IteratorProtocol
-> : AnyIterator<Base.Element> {
+>: AnyIterator<Base.Element> {
 
   /// Advance to the next element and return it, or `nil` if no next
   /// element exists.

--- a/test/ModuleInterface/Inputs/enums-layout-helper.swift
+++ b/test/ModuleInterface/Inputs/enums-layout-helper.swift
@@ -1,4 +1,4 @@
-// CHECK-LABEL: public enum FutureproofEnum : Swift.Int
+// CHECK-LABEL: public enum FutureproofEnum: Swift.Int
 public enum FutureproofEnum: Int {
   // CHECK-NEXT: case a{{$}}
   case a = 1
@@ -10,7 +10,7 @@ public enum FutureproofEnum: Int {
   case d
 }
 
-// CHECK-LABEL: public enum FrozenEnum : Swift.Int
+// CHECK-LABEL: public enum FrozenEnum: Swift.Int
 @_frozen public enum FrozenEnum: Int {
   // CHECK-NEXT: case a{{$}}
   case a = 1
@@ -22,7 +22,7 @@ public enum FutureproofEnum: Int {
   case d
 }
 
-// CHECK-LABEL: public enum FutureproofObjCEnum : Swift.Int32
+// CHECK-LABEL: public enum FutureproofObjCEnum: Swift.Int32
 @objc public enum FutureproofObjCEnum: Int32 {
   // CHECK-NEXT: case a = 1{{$}}
   case a = 1
@@ -34,7 +34,7 @@ public enum FutureproofEnum: Int {
   case d
 }
 
-// CHECK-LABEL: public enum FrozenObjCEnum : Swift.Int32
+// CHECK-LABEL: public enum FrozenObjCEnum: Swift.Int32
 @_frozen @objc public enum FrozenObjCEnum: Int32 {
   // CHECK-NEXT: case a = 1{{$}}
   case a = 1
@@ -46,7 +46,7 @@ public enum FutureproofEnum: Int {
   case d
 }
 
-// CHECK-LABEL: public enum FutureproofUnicodeScalarEnum : Swift.Unicode.Scalar
+// CHECK-LABEL: public enum FutureproofUnicodeScalarEnum: Swift.Unicode.Scalar
 public enum FutureproofUnicodeScalarEnum: Unicode.Scalar {
   // CHECK-NEXT: case a{{$}}
   case a = "A"

--- a/test/ModuleInterface/access-filter.swift
+++ b/test/ModuleInterface/access-filter.swift
@@ -121,7 +121,7 @@ extension InternalStruct_BAD: PublicProto {
   internal static var dummy: Int { return 0 }
 }
 
-// CHECK: extension AccessFilter.UFIStruct : AccessFilter.PublicProto {{[{]$}}
+// CHECK: extension AccessFilter.UFIStruct: AccessFilter.PublicProto {{[{]$}}
 extension UFIStruct: PublicProto {
   // CHECK-NEXT: @usableFromInline
   // CHECK-NEXT: internal func requirement()
@@ -197,12 +197,12 @@ extension GenericStruct where InternalStruct_BAD == T {
   @usableFromInline internal func constrainedToInternalStruct2_BAD() {}
 }
 
-// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.PublicProto {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T: AccessFilter.PublicProto {{[{]$}}
 extension GenericStruct where T: PublicProto {
   // CHECK-NEXT: public func constrainedToPublicProto(){{$}}
   public func constrainedToPublicProto() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.UFIProto {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T: AccessFilter.UFIProto {{[{]$}}
 extension GenericStruct where T: UFIProto {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIProto(){{$}}
@@ -212,12 +212,12 @@ extension GenericStruct where T: InternalProto_BAD {
   @usableFromInline internal func constrainedToInternalProto_BAD() {}
 }
 
-// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.PublicClass {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T: AccessFilter.PublicClass {{[{]$}}
 extension GenericStruct where T: PublicClass {
   // CHECK-NEXT: public func constrainedToPublicClass(){{$}}
   public func constrainedToPublicClass() {}
 } // CHECK-NEXT: {{^[}]$}}
-// CHECK: extension AccessFilter.GenericStruct where T : AccessFilter.UFIClass {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T: AccessFilter.UFIClass {{[{]$}}
 extension GenericStruct where T: UFIClass {
   // CHECK-NEXT: @usableFromInline{{$}}
   // CHECK-NEXT: internal func constrainedToUFIClass(){{$}}
@@ -227,7 +227,7 @@ extension GenericStruct where T: InternalClass_BAD {
   @usableFromInline internal func constrainedToInternalClass_BAD() {}
 }
 
-// CHECK: extension AccessFilter.GenericStruct where T : AnyObject {{[{]$}}
+// CHECK: extension AccessFilter.GenericStruct where T: AnyObject {{[{]$}}
 extension GenericStruct where T: AnyObject {
   // CHECK-NEXT: public func constrainedToAnyObject(){{$}}
   public func constrainedToAnyObject() {}

--- a/test/ModuleInterface/actor_isolation.swift
+++ b/test/ModuleInterface/actor_isolation.swift
@@ -58,12 +58,12 @@ public class C2 { }
 @available(SwiftStdlib 5.1, *)
 public class C3: C2 { }
 
-// CHECK: public class C4 : Swift.UnsafeSendable
+// CHECK: public class C4: Swift.UnsafeSendable
 
 @available(SwiftStdlib 5.1, *)
 public class C4: UnsafeSendable { }
 
-// CHECK: public class C5 : @unchecked Swift.Sendable
+// CHECK: public class C5: @unchecked Swift.Sendable
 
 @available(SwiftStdlib 5.1, *)
 public class C5: @unchecked Sendable { }
@@ -72,7 +72,7 @@ public class C5: @unchecked Sendable { }
 @available(SwiftStdlib 5.1, *)
 public class C6 { }
 
-// CHECK: extension {{(Test.)?}}C6 : @unchecked Swift.Sendable
+// CHECK: extension {{(Test.)?}}C6: @unchecked Swift.Sendable
 
 @available(SwiftStdlib 5.1, *)
 extension C6: @unchecked Sendable { }
@@ -81,7 +81,7 @@ extension C6: @unchecked Sendable { }
 @available(SwiftStdlib 5.1, *)
 public class C7 { }
 
-// CHECK: extension {{(Test.)?}}C7 : Swift.UnsafeSendable
+// CHECK: extension {{(Test.)?}}C7: Swift.UnsafeSendable
 
 @available(SwiftStdlib 5.1, *)
 extension C7: UnsafeSendable { }
@@ -93,7 +93,7 @@ public protocol P2 {
 }
 
 
-// CHECK: class {{(Test.)?}}C8 : {{(Test.)?}}P2 {
+// CHECK: class {{(Test.)?}}C8: {{(Test.)?}}P2 {
 @available(SwiftStdlib 5.1, *)
 public class C8 : P2 {
   // CHECK: @{{(Test.)?}}SomeGlobalActor public func method()
@@ -111,4 +111,4 @@ public struct StructWithImplicitlyNonSendable {
 // bit in conformances which is not serialized and not present in the textual
 // form.
 
-// SYNTHESIZED: extension Test.C2 : Swift.Sendable {}
+// SYNTHESIZED: extension Test.C2: Swift.Sendable {}

--- a/test/ModuleInterface/actor_objc.swift
+++ b/test/ModuleInterface/actor_objc.swift
@@ -13,7 +13,7 @@
 import Foundation
 
 // CHECK-LABEL: @objc @_inheritsConvenienceInitializers
-// CHECK: public actor SomeActor : ObjectiveC.NSObject {
+// CHECK: public actor SomeActor: ObjectiveC.NSObject {
 // CHECK: @objc override public init()
 @available(SwiftStdlib 5.1, *)
 public actor SomeActor: NSObject {

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -9,7 +9,7 @@
 /// and not via some extension. The requirement is due to the unique
 /// optimizations applied to the implementation of actors.
 
-// CHECK-NOT: extension {{.+}} : _Concurrency.Actor
+// CHECK-NOT: extension {{.+}}: _Concurrency.Actor
 
 // CHECK: public actor PlainActorClass {
 @available(SwiftStdlib 5.1, *)
@@ -17,7 +17,7 @@ public actor PlainActorClass {
   nonisolated public func enqueue(_ job: UnownedJob) { }
 }
 
-// CHECK: public actor ExplicitActorClass : _Concurrency.Actor {
+// CHECK: public actor ExplicitActorClass: _Concurrency.Actor {
 @available(SwiftStdlib 5.1, *)
 public actor ExplicitActorClass : Actor {
   nonisolated public func enqueue(_ job: UnownedJob) { }
@@ -31,13 +31,13 @@ public actor EmptyActor {}
 @available(SwiftStdlib 5.1, *)
 public actor EmptyActorClass {}
 
-// CHECK: public protocol Cat : _Concurrency.Actor {
+// CHECK: public protocol Cat: _Concurrency.Actor {
 @available(SwiftStdlib 5.1, *)
 public protocol Cat : Actor {
   func mew()
 }
 
-// CHECK: public actor HouseCat : Library.Cat {
+// CHECK: public actor HouseCat: Library.Cat {
 @available(SwiftStdlib 5.1, *)
 public actor HouseCat : Cat {
   nonisolated public func mew() {}
@@ -50,7 +50,7 @@ public protocol ToothyMouth {
   func chew()
 }
 
-// CHECK: public actor Lion : Library.ToothyMouth, _Concurrency.Actor {
+// CHECK: public actor Lion: Library.ToothyMouth, _Concurrency.Actor {
 @available(SwiftStdlib 5.1, *)
 public actor Lion : ToothyMouth, Actor {
   nonisolated public func chew() {}

--- a/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface-objc.swift
+++ b/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface-objc.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public class C: NSObject {
-  // CHECK: @objc override dynamic public func observeValue(forKeyPath keyPath: Swift.String?, of object: Any?, change: [Foundation.NSKeyValueChangeKey : Any]?, context: Swift.UnsafeMutableRawPointer?)
+  // CHECK: @objc override dynamic public func observeValue(forKeyPath keyPath: Swift.String?, of object: Any?, change: [Foundation.NSKeyValueChangeKey: Any]?, context: Swift.UnsafeMutableRawPointer?)
   public override func observeValue(
     forKeyPath keyPath: String?,
     of object: Any?,

--- a/test/ModuleInterface/bitwise_copyable.swift
+++ b/test/ModuleInterface/bitwise_copyable.swift
@@ -7,7 +7,7 @@
 @frozen
 public struct S_Implicit_Noncopyable: ~Copyable {}
 
-// CHECK-NOT: extension Test.S_Implicit_Noncopyable : Swift.BitwiseCopyable {}
+// CHECK-NOT: extension Test.S_Implicit_Noncopyable: Swift.BitwiseCopyable {}
 
 // CHECK:      public protocol BitwiseCopyable {
 // CHECK-NEXT: }

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -71,7 +71,7 @@ func callFn() async {
 // CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency func requirement()
 // CHECK-NEXT: }
 
-// CHECK:      @_Concurrency.MainActor @preconcurrency public struct InferredUnsafeMainActor :
+// CHECK:      @_Concurrency.MainActor @preconcurrency public struct InferredUnsafeMainActor:
 // CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency public func requirement()
 // CHECK-NEXT:   @preconcurrency @_Concurrency.MainActor public func explicitPreconcurrency()
 // CHECK-NEXT: }
@@ -80,16 +80,16 @@ func callFn() async {
 // CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency func requirement()
 // CHECK-NEXT: }
 
-// CHECK:      @_Concurrency.MainActor @preconcurrency public struct InferredPreconcurrencyMainActor :
+// CHECK:      @_Concurrency.MainActor @preconcurrency public struct InferredPreconcurrencyMainActor:
 // CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency public func requirement()
 // CHECK-NEXT:   @preconcurrency @_Concurrency.MainActor public func explicitPreconcurrency()
 // CHECK-NEXT: }
 
-// CHECK-TYPECHECKED: public struct UncheckedSendable : @unchecked Swift.Sendable
-// CHECK-ASWRITTEN: public struct UncheckedSendable : @unchecked Sendable
+// CHECK-TYPECHECKED: public struct UncheckedSendable: @unchecked Swift.Sendable
+// CHECK-ASWRITTEN: public struct UncheckedSendable: @unchecked Sendable
 
-// CHECK-TYPECHECKED: extension Swift.UnsafePointer : @unchecked @retroactive Swift.Sendable
-// CHECK-ASWRITTEN: extension UnsafePointer : @retroactive @unchecked Sendable
+// CHECK-TYPECHECKED: extension Swift.UnsafePointer: @unchecked @retroactive Swift.Sendable
+// CHECK-ASWRITTEN: extension UnsafePointer: @retroactive @unchecked Sendable
 
 // RUN: %target-swift-emit-module-interface(%t/LibraryPreserveTypesAsWritten.swiftinterface) %s -enable-experimental-concurrency -DLIBRARY -module-name LibraryPreserveTypesAsWritten -module-interface-preserve-types-as-written
 // RUN: %target-swift-typecheck-module-from-interface(%t/LibraryPreserveTypesAsWritten.swiftinterface) -enable-experimental-concurrency

--- a/test/ModuleInterface/conditional_pack_requirements.swift
+++ b/test/ModuleInterface/conditional_pack_requirements.swift
@@ -14,8 +14,8 @@ public struct GG1<A: P, each B: P> where A.A == C<repeat (each B).A> {}
 
 extension GG1: Q where A: Q, repeat each B: Q {}
 
-// CHECK-LABEL: public struct GG1<A, each B> where A : conditional_pack_requirements.P, repeat each B : conditional_pack_requirements.P, A.A == conditional_pack_requirements.C<repeat (each B).A> {
-// CHECK-LABEL: extension conditional_pack_requirements.GG1 : conditional_pack_requirements.Q where A : conditional_pack_requirements.Q, repeat each B : conditional_pack_requirements.Q {
+// CHECK-LABEL: public struct GG1<A, each B> where A: conditional_pack_requirements.P, repeat each B: conditional_pack_requirements.P, A.A == conditional_pack_requirements.C<repeat (each B).A> {
+// CHECK-LABEL: extension conditional_pack_requirements.GG1 : conditional_pack_requirements.Q where A: conditional_pack_requirements.Q, repeat each B: conditional_pack_requirements.Q {
 
 
 public struct GG2<each A: P> {
@@ -24,17 +24,17 @@ public struct GG2<each A: P> {
 
 extension GG2.Nested: Q where repeat each A: Q, repeat each B: Q {}
 
-// CHECK-LABEL: public struct GG2<each A> where repeat each A : conditional_pack_requirements.P {
-// CHECK-LABEL: public struct Nested<each B> where repeat each B : conditional_pack_requirements.P, repeat (each A).A == (each B).A {
-// CHECK-LABEL: extension conditional_pack_requirements.GG2.Nested : conditional_pack_requirements.Q where repeat each A : conditional_pack_requirements.Q, repeat each B : conditional_pack_requirements.Q {
+// CHECK-LABEL: public struct GG2<each A> where repeat each A: conditional_pack_requirements.P {
+// CHECK-LABEL: public struct Nested<each B> where repeat each B: conditional_pack_requirements.P, repeat (each A).A == (each B).A {
+// CHECK-LABEL: extension conditional_pack_requirements.GG2.Nested: conditional_pack_requirements.Q where repeat each A: conditional_pack_requirements.Q, repeat each B: conditional_pack_requirements.Q {
 
 
 public struct GG3<A: P, each B: P> where A.A : C<repeat (each B).A> {}
 
 extension GG3: Q where A: Q, repeat each B: Q {}
 
-// CHECK-LABEL: public struct GG3<A, each B> where A : conditional_pack_requirements.P, repeat each B : conditional_pack_requirements.P, A.A : conditional_pack_requirements.C<repeat (each B).A> {
-// CHECK-LABEL: extension conditional_pack_requirements.GG3 : conditional_pack_requirements.Q where A : conditional_pack_requirements.Q, repeat each B : conditional_pack_requirements.Q {
+// CHECK-LABEL: public struct GG3<A, each B> where A: conditional_pack_requirements.P, repeat each B: conditional_pack_requirements.P, A.A: conditional_pack_requirements.C<repeat (each B).A> {
+// CHECK-LABEL: extension conditional_pack_requirements.GG3: conditional_pack_requirements.Q where A: conditional_pack_requirements.Q, repeat each B: conditional_pack_requirements.Q {
 
 
 public struct GG4<each A: P> {
@@ -43,6 +43,6 @@ public struct GG4<each A: P> {
 
 extension GG4.Nested: Q where repeat each A: Q, repeat each B: Q {}
 
-// CHECK-LABEL: public struct GG4<each A> where repeat each A : conditional_pack_requirements.P {
-// CHECK-LABEL: public struct Nested<each B> where repeat each B : conditional_pack_requirements.P, repeat (each A).A : conditional_pack_requirements.C<(each B).A> {
-// CHECK-LABEL: extension conditional_pack_requirements.GG4.Nested : conditional_pack_requirements.Q where repeat each A : conditional_pack_requirements.Q, repeat each B : conditional_pack_requirements.Q {
+// CHECK-LABEL: public struct GG4<each A> where repeat each A: conditional_pack_requirements.P {
+// CHECK-LABEL: public struct Nested<each B> where repeat each B: conditional_pack_requirements.P, repeat (each A).A: conditional_pack_requirements.C<(each B).A> {
+// CHECK-LABEL: extension conditional_pack_requirements.GG4.Nested: conditional_pack_requirements.Q where repeat each A: conditional_pack_requirements.Q, repeat each B: conditional_pack_requirements.Q {

--- a/test/ModuleInterface/conformance_suppression.swift
+++ b/test/ModuleInterface/conformance_suppression.swift
@@ -3,6 +3,6 @@
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface -module-name Mojuel)
 
-// CHECK:     public enum RecollectionOrganization<T> : ~Swift.BitwiseCopyable, Swift.Copyable where T : ~Copyable {
+// CHECK:     public enum RecollectionOrganization<T>: ~Swift.BitwiseCopyable, Swift.Copyable where T: ~Copyable {
 // CHECK-NEXT: }
 public enum RecollectionOrganization<T : ~Copyable> : ~BitwiseCopyable, Copyable {}

--- a/test/ModuleInterface/conformances.swift
+++ b/test/ModuleInterface/conformances.swift
@@ -15,7 +15,7 @@ public protocol SimpleProto {
   func inference(_: Inferred)
 } // CHECK: {{^}$}}
 
-// CHECK-LABEL: public struct SimpleImpl<Element> : conformances.SimpleProto {
+// CHECK-LABEL: public struct SimpleImpl<Element>: conformances.SimpleProto {
 public struct SimpleImpl<Element>: SimpleProto {
   // NEGATIVE-NOT: typealias Element =
   // CHECK: public func inference(_: Swift.Int){{$}}
@@ -27,51 +27,51 @@ public struct SimpleImpl<Element>: SimpleProto {
 public protocol PublicProto {}
 private protocol PrivateProto {}
 
-// CHECK: public struct A1 : conformances.PublicProto {
+// CHECK: public struct A1: conformances.PublicProto {
 // NEGATIVE-NOT: extension conformances.A1
 public struct A1: PublicProto, PrivateProto {}
-// CHECK: public struct A2 : conformances.PublicProto {
+// CHECK: public struct A2: conformances.PublicProto {
 // NEGATIVE-NOT: extension conformances.A2
 public struct A2: PrivateProto, PublicProto {}
 // CHECK: public struct A3 {
-// CHECK-END: extension conformances.A3 : conformances.PublicProto {}
+// CHECK-END: extension conformances.A3: conformances.PublicProto {}
 public struct A3: PublicProto & PrivateProto {}
 // CHECK: public struct A4 {
-// CHECK-END: extension conformances.A4 : conformances.PublicProto {}
+// CHECK-END: extension conformances.A4: conformances.PublicProto {}
 public struct A4: PrivateProto & PublicProto {}
 
 public protocol PublicBaseProto {}
 private protocol PrivateSubProto: PublicBaseProto {}
 
 // CHECK: public struct B1 {
-// CHECK-END: extension conformances.B1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.B1: conformances.PublicBaseProto {}
 public struct B1: PrivateSubProto {}
-// CHECK: public struct B2 : conformances.PublicBaseProto {
+// CHECK: public struct B2: conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension conformances.B2
 public struct B2: PublicBaseProto, PrivateSubProto {}
 // CHECK: public struct B3 {
-// CHECK-END: extension conformances.B3 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.B3: conformances.PublicBaseProto {}
 public struct B3: PublicBaseProto & PrivateSubProto {}
-// CHECK: public struct B4 : conformances.PublicBaseProto {
+// CHECK: public struct B4: conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension conformances.B4 {
 // NEGATIVE-NOT: extension conformances.B4
 public struct B4: PublicBaseProto {}
 extension B4: PrivateSubProto {}
 // CHECK: public struct B5 {
-// CHECK: extension conformances.B5 : conformances.PublicBaseProto {
+// CHECK: extension conformances.B5: conformances.PublicBaseProto {
 // NEGATIVE-NOT: extension B5
 public struct B5: PrivateSubProto {}
 extension B5: PublicBaseProto {}
 // CHECK: public struct B6 {
-// NEGATIVE-NOT: extension conformances.B6 : conformances.PrivateSubProto
+// NEGATIVE-NOT: extension conformances.B6: conformances.PrivateSubProto
 // NEGATIVE-NOT: extension conformances.B6 {
-// CHECK: extension conformances.B6 : conformances.PublicBaseProto {
+// CHECK: extension conformances.B6: conformances.PublicBaseProto {
 public struct B6 {}
 extension B6: PrivateSubProto {}
 extension B6: PublicBaseProto {}
 // CHECK: public struct B7 {
-// CHECK: extension conformances.B7 : conformances.PublicBaseProto {
-// NEGATIVE-NOT: extension conformances.B7 : conformances.PrivateSubProto {
+// CHECK: extension conformances.B7: conformances.PublicBaseProto {
+// NEGATIVE-NOT: extension conformances.B7: conformances.PrivateSubProto {
 // NEGATIVE-NOT: extension conformances.B7 {
 public struct B7 {}
 extension B7: PublicBaseProto {}
@@ -89,54 +89,54 @@ public protocol ConditionallyConformed {}
 public protocol ConditionallyConformedAgain {}
 
 // CHECK-END: @available(*, unavailable)
-// CHECK-END-NEXT: extension conformances.OuterGeneric : conformances.ConditionallyConformed, conformances.ConditionallyConformedAgain where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-END-NEXT: extension conformances.OuterGeneric: conformances.ConditionallyConformed, conformances.ConditionallyConformedAgain where T: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 extension OuterGeneric: ConditionallyConformed where T: PrivateProto {}
 extension OuterGeneric: ConditionallyConformedAgain where T == PrivateProto {}
 
-// CHECK-END: extension conformances.OuterGeneric.Inner : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.OuterGeneric.Inner: conformances.PublicBaseProto {}
 // CHECK-END: @available(*, unavailable)
-// CHECK-END-NEXT: extension conformances.OuterGeneric.Inner : conformances.ConditionallyConformed, conformances.ConditionallyConformedAgain where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-END-NEXT: extension conformances.OuterGeneric.Inner: conformances.ConditionallyConformed, conformances.ConditionallyConformedAgain where T: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 extension OuterGeneric.Inner: ConditionallyConformed where T: PrivateProto {}
 extension OuterGeneric.Inner: ConditionallyConformedAgain where T == PrivateProto {}
 
 private protocol AnotherPrivateSubProto: PublicBaseProto {}
 
 // CHECK: public struct C1 {
-// CHECK-END: extension conformances.C1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.C1: conformances.PublicBaseProto {}
 public struct C1: PrivateSubProto, AnotherPrivateSubProto {}
 // CHECK: public struct C2 {
-// CHECK-END: extension conformances.C2 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.C2: conformances.PublicBaseProto {}
 public struct C2: PrivateSubProto & AnotherPrivateSubProto {}
 // CHECK: public struct C3 {
 // NEGATIVE-NOT: extension conformances.C3 {
-// CHECK-END: extension conformances.C3 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.C3: conformances.PublicBaseProto {}
 public struct C3: PrivateSubProto {}
 extension C3: AnotherPrivateSubProto {}
 
 public protocol PublicSubProto: PublicBaseProto {}
 public protocol APublicSubProto: PublicBaseProto {}
 
-// CHECK: public struct D1 : conformances.PublicSubProto {
+// CHECK: public struct D1: conformances.PublicSubProto {
 // NEGATIVE-NOT: extension conformances.D1
 public struct D1: PublicSubProto, PrivateSubProto {}
-// CHECK: public struct D2 : conformances.PublicSubProto {
+// CHECK: public struct D2: conformances.PublicSubProto {
 // NEGATIVE-NOT: extension conformances.D2
 public struct D2: PrivateSubProto, PublicSubProto {}
 // CHECK: public struct D3 {
-// CHECK-END: extension conformances.D3 : conformances.PublicBaseProto {}
-// CHECK-END: extension conformances.D3 : conformances.PublicSubProto {}
+// CHECK-END: extension conformances.D3: conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.D3: conformances.PublicSubProto {}
 public struct D3: PrivateSubProto & PublicSubProto {}
 // CHECK: public struct D4 {
-// CHECK-END: extension conformances.D4 : conformances.APublicSubProto {}
-// CHECK-END: extension conformances.D4 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.D4: conformances.APublicSubProto {}
+// CHECK-END: extension conformances.D4: conformances.PublicBaseProto {}
 public struct D4: APublicSubProto & PrivateSubProto {}
 // CHECK: public struct D5 {
-// NEGATIVE-NOT: extension conformances.D5 : conformances.PrivateSubProto {
+// NEGATIVE-NOT: extension conformances.D5: conformances.PrivateSubProto {
 // NEGATIVE-NOT: extension conformances.D5 {
-// CHECK: extension conformances.D5 : conformances.PublicSubProto {
+// CHECK: extension conformances.D5: conformances.PublicSubProto {
 public struct D5: PrivateSubProto {}
 extension D5: PublicSubProto {}
-// CHECK: public struct D6 : conformances.PublicSubProto {
+// CHECK: public struct D6: conformances.PublicSubProto {
 // NEGATIVE-NOT: extension conformances.D6 {
 // NEGATIVE-NOT: extension conformances.D6
 public struct D6: PublicSubProto {}
@@ -145,34 +145,34 @@ extension D6: PrivateSubProto {}
 private typealias PrivateProtoAlias = PublicProto
 
 // CHECK: public struct E1 {
-// CHECK-END: extension conformances.E1 : conformances.PublicProto {}
+// CHECK-END: extension conformances.E1: conformances.PublicProto {}
 public struct E1: PrivateProtoAlias {}
 
 private typealias PrivateSubProtoAlias = PrivateSubProto
 
 // CHECK: public struct F1 {
-// CHECK-END: extension conformances.F1 : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.F1: conformances.PublicBaseProto {}
 public struct F1: PrivateSubProtoAlias {}
 
 private protocol ClassConstrainedProto: PublicProto, AnyObject {}
 
 public class G1: ClassConstrainedProto {}
 // CHECK: public class G1 {
-// CHECK-END: extension conformances.G1 : conformances.PublicProto {}
+// CHECK-END: extension conformances.G1: conformances.PublicProto {}
 
 public class Base {}
 private protocol BaseConstrainedProto: Base, PublicProto {}
 
 public class H1: Base, ClassConstrainedProto {}
-// CHECK: public class H1 : conformances.Base {
-// CHECK-END: extension conformances.H1 : conformances.PublicProto {}
+// CHECK: public class H1: conformances.Base {
+// CHECK-END: extension conformances.H1: conformances.PublicProto {}
 
 public struct MultiGeneric<T, U, V> {}
 extension MultiGeneric: PublicProto where U: PrivateProto {}
 
 // CHECK: public struct MultiGeneric<T, U, V> {
 // CHECK-END: @available(*, unavailable)
-// CHECK-END-NEXT: extension conformances.MultiGeneric : conformances.PublicProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
+// CHECK-END-NEXT: extension conformances.MultiGeneric: conformances.PublicProto where T: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary {}
 
 
 internal struct InternalImpl_BAD: PrivateSubProto {}
@@ -199,20 +199,20 @@ public struct CoolTVType: PrivateSubProto {}
 // CHECK: public struct CoolTVType {
 // CHECK-END: @available(iOS, unavailable)
 // CHECK-END-NEXT: @available(macOS, unavailable)
-// CHECK-END-NEXT: extension conformances.CoolTVType : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances.CoolTVType: conformances.PublicBaseProto {}
 
 @available(macOS 10.99, *)
 public struct VeryNewMacType: PrivateSubProto {}
 // CHECK: public struct VeryNewMacType {
 // CHECK-END: @available(macOS 10.99, *)
-// CHECK-END-NEXT: extension conformances.VeryNewMacType : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances.VeryNewMacType: conformances.PublicBaseProto {}
 
 public struct VeryNewMacProto {}
 @available(macOS 10.98, *)
 extension VeryNewMacProto: PrivateSubProto {}
 // CHECK: public struct VeryNewMacProto {
 // CHECK-END: @available(macOS 10.98, *)
-// CHECK-END-NEXT: extension conformances.VeryNewMacProto : conformances.PublicBaseProto {}
+// CHECK-END-NEXT: extension conformances.VeryNewMacProto: conformances.PublicBaseProto {}
 
 public struct PrivateProtoConformer {}
 extension PrivateProtoConformer : PrivateProto {
@@ -224,7 +224,7 @@ extension PrivateProtoConformer : PrivateProto {
 // CHECK-NEXT:   get
 // CHECK-NEXT: }
 // CHECK-NEXT: {{^}$}}
-// NEGATIVE-NOT: extension conformances.PrivateProtoConformer : conformances.PrivateProto {
+// NEGATIVE-NOT: extension conformances.PrivateProtoConformer: conformances.PrivateProto {
 
 // NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Hashable
 // NEGATIVE-NOT: extension {{(Swift.)?}}Bool{{.+}}Equatable
@@ -242,11 +242,11 @@ public struct NestedAvailabilityOuter {
 // NEGATIVE-NOT: @_nonSendable
 // CHECK-LABEL: public struct NonSendable {
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: extension conformances.NonSendable : @unchecked Swift.Sendable {
+// CHECK-NEXT: extension conformances.NonSendable: @unchecked Swift.Sendable {
 
 // CHECK-END: @available(macOS 10.97, iOS 23, *)
 // CHECK-END: @available(tvOS, unavailable)
-// CHECK-END: extension conformances.NestedAvailabilityOuter.Inner : conformances.PublicBaseProto {}
+// CHECK-END: extension conformances.NestedAvailabilityOuter.Inner: conformances.PublicBaseProto {}
 
 
 // CHECK-END: @usableFromInline

--- a/test/ModuleInterface/default-args.swift
+++ b/test/ModuleInterface/default-args.swift
@@ -20,7 +20,7 @@ public class Base {
   public func foo(y: Int = 42) {}
 }
 
-// CHECK: class Derived : Test.Base {
+// CHECK: class Derived: Test.Base {
 public class Derived: Base {
   // CHECK: init(y: Swift.Int)
   public convenience init(y: Int) {

--- a/test/ModuleInterface/derived_conformances_nonisolated.swift
+++ b/test/ModuleInterface/derived_conformances_nonisolated.swift
@@ -5,7 +5,7 @@
 
 // REQUIRES: concurrency
 
-// CHECK: @_Concurrency.MainActor public struct X1 : Swift.Equatable, Swift.Hashable, Swift.Codable
+// CHECK: @_Concurrency.MainActor public struct X1: Swift.Equatable, Swift.Hashable, Swift.Codable
 @MainActor public struct X1: Equatable, Hashable, Codable {
   let x: Int
   let y: String

--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -53,7 +53,7 @@ public distributed actor DA {
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK: @available({{.*}})
-// CHECK-NEXT: distributed public actor DAG<ActorSystem> where ActorSystem : Distributed.DistributedActorSystem, ActorSystem.SerializationRequirement == any Swift.Decodable & Swift.Encodable {
+// CHECK-NEXT: distributed public actor DAG<ActorSystem> where ActorSystem: Distributed.DistributedActorSystem, ActorSystem.SerializationRequirement == any Swift.Decodable & Swift.Encodable {
 @available(SwiftStdlib 6.0, *)
 public distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable> {
   // CHECK: @_compilerInitialized nonisolated final public let id: ActorSystem.ActorID
@@ -75,17 +75,17 @@ public distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSys
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:extension Library.DA : Distributed.DistributedActor {}
+// CHECK-NEXT:extension Library.DA: Distributed.DistributedActor {}
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:extension Library.DA : Swift.Encodable {}
+// CHECK-NEXT:extension Library.DA: Swift.Encodable {}
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:extension Library.DA : Swift.Decodable {}
+// CHECK-NEXT:extension Library.DA: Swift.Decodable {}
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
 // CHECK: @available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)
-// CHECK-NEXT: extension Library.DAG : Distributed.DistributedActor {}
+// CHECK-NEXT: extension Library.DAG: Distributed.DistributedActor {}
 
 //--- Client.swift
 

--- a/test/ModuleInterface/execution_behavior_attrs.swift
+++ b/test/ModuleInterface/execution_behavior_attrs.swift
@@ -56,12 +56,12 @@ public struct Test {
   public func concurrentResult(_: () async -> Void) -> @concurrent (Int) async -> Void {}
 
   // CHECK: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK-NEXT: public func nestedPositions1(_: Swift.Array<[Swift.String : nonisolated(nonsending) (Swift.Int) async -> Swift.Void]>)
+  // CHECK-NEXT: public func nestedPositions1(_: Swift.Array<[Swift.String: nonisolated(nonsending) (Swift.Int) async -> Swift.Void]>)
   // CHECK-NEXT: #endif
   public func nestedPositions1(_: Array<[String: nonisolated(nonsending) (Int) async -> Void]>) {}
 
   // CHECK-NOT: #if compiler(>=5.3) && $AsyncExecutionBehaviorAttributes
-  // CHECK: public func nestedPositions2(_: Swift.Array<[Swift.String : (Swift.Int) async -> Swift.Void]>)
+  // CHECK: public func nestedPositions2(_: Swift.Array<[Swift.String: (Swift.Int) async -> Swift.Void]>)
   // CHECK-NOT: #endif
   public func nestedPositions2(_: Array<[String: @concurrent (Int) async -> Void]>) {}
 

--- a/test/ModuleInterface/existential-any.swift
+++ b/test/ModuleInterface/existential-any.swift
@@ -10,7 +10,7 @@ public protocol P { }
 
 // CHECK: public protocol Q
 public protocol Q {
-  // CHECK: associatedtype A : main.P
+  // CHECK: associatedtype A: main.P
   associatedtype A: P
 }
 
@@ -44,7 +44,7 @@ public protocol ProtocolTypealias {
   typealias A = P
 }
 
-// CHECK: public func dependentExistential<T>(value: (T) -> any main.P) where T : main.ProtocolTypealias
+// CHECK: public func dependentExistential<T>(value: (T) -> any main.P) where T: main.ProtocolTypealias
 public func dependentExistential<T: ProtocolTypealias>(value: (T) -> T.A) {}
 
 public protocol Yescopyable {}

--- a/test/ModuleInterface/exported-module-name.swift
+++ b/test/ModuleInterface/exported-module-name.swift
@@ -8,7 +8,7 @@
 // CHECK: import CoreKit
 import CoreKit
 
-// CHECK-LABEL: public struct CKThingWrapper : Swift.RawRepresentable {
+// CHECK-LABEL: public struct CKThingWrapper: Swift.RawRepresentable {
 public struct CKThingWrapper: RawRepresentable {
   public var rawValue: CKThing
   public init(rawValue: CKThing) {

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -45,11 +45,11 @@ public func globalAsync() async { }
 // CHECK-NEXT: }
 @_marker public protocol MP { }
 
-// CHECK:      @_marker public protocol MP2 : FeatureTest.MP {
+// CHECK:      @_marker public protocol MP2: FeatureTest.MP {
 // CHECK-NEXT: }
 @_marker public protocol MP2: MP { }
 
-// CHECK:      public protocol MP3 : AnyObject, FeatureTest.MP {
+// CHECK:      public protocol MP3: AnyObject, FeatureTest.MP {
 // CHECK-NEXT: }
 public protocol MP3: AnyObject, MP { }
 
@@ -59,13 +59,13 @@ extension MP2 {
   public func inMP2() { }
 }
 
-// CHECK: class OldSchool : FeatureTest.MP {
+// CHECK: class OldSchool: FeatureTest.MP {
 public class OldSchool: MP {
   // CHECK:     takeClass()
   public func takeClass() async { }
 }
 
-// CHECK: class OldSchool2 : FeatureTest.MP {
+// CHECK: class OldSchool2: FeatureTest.MP {
 public class OldSchool2: MP {
   // CHECK:     takeClass()
   public func takeClass() async { }
@@ -100,11 +100,11 @@ public struct IsRP: RP {
 // CHECK: public func acceptsRP
 public func acceptsRP<T: RP>(_: T) { }
 
-// CHECK:     extension Swift.Array : FeatureTest.MP where Element : FeatureTest.MP {
+// CHECK:     extension Swift.Array: FeatureTest.MP where Element: FeatureTest.MP {
 extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
 // CHECK: }
 
-// CHECK:     extension FeatureTest.OldSchool : Swift.UnsafeSendable {
+// CHECK:     extension FeatureTest.OldSchool: Swift.UnsafeSendable {
 extension OldSchool: UnsafeSendable { }
 // CHECK-NEXT: }
 
@@ -135,4 +135,4 @@ public func unavailableFromAsyncFunc() { }
 @available(*, noasync, message: "Test")
 public func noAsyncFunc() { }
 
-// CHECK-NOT: extension FeatureTest.MyActor : Swift.Sendable
+// CHECK-NOT: extension FeatureTest.MyActor: Swift.Sendable

--- a/test/ModuleInterface/global-actor.swift
+++ b/test/ModuleInterface/global-actor.swift
@@ -33,7 +33,7 @@ extension ClassBoundToGlobalActor {
   public func someMethod() { }
 }
 
-// CHECK: @Test.GlobalActor public class DerivedFromClassBoundToGlobalActor : Test.ClassBoundToGlobalActor
+// CHECK: @Test.GlobalActor public class DerivedFromClassBoundToGlobalActor: Test.ClassBoundToGlobalActor
 @available(SwiftStdlib 5.1, *)
 public class DerivedFromClassBoundToGlobalActor: ClassBoundToGlobalActor {}
 
@@ -52,5 +52,5 @@ public class NoActorClass {
   @GlobalActor public func methodBoundToGlobalActor() { }
 }
 
-// CHECK: extension Test.GlobalActor : _Concurrency.GlobalActor {}
-// CHECK: extension Test.ClassBoundToGlobalActor : Swift.Sendable {}
+// CHECK: extension Test.GlobalActor: _Concurrency.GlobalActor {}
+// CHECK: extension Test.ClassBoundToGlobalActor: Swift.Sendable {}

--- a/test/ModuleInterface/inherited-defaults-execution.swift
+++ b/test/ModuleInterface/inherited-defaults-execution.swift
@@ -19,7 +19,7 @@
 // INTERFACE: public class Base {
 // INTERFACE:   public init(x: Swift.Int = 45, y: Swift.Int = 98)
 // INTERFACE: }
-// INTERFACE: public class Derived : Inherited.Base {
+// INTERFACE: public class Derived: Inherited.Base {
 // INTERFACE:   override public init(x: Swift.Int = super, y: Swift.Int = super)
 // INTERFACE: }
 

--- a/test/ModuleInterface/inherited-generic-parameters.swift
+++ b/test/ModuleInterface/inherited-generic-parameters.swift
@@ -21,16 +21,16 @@ public class Base<In, Out> {
 // CHECK-NEXT: public init<A>(_ a1: A, _ a2: A)
   public init<A>(_ a1: A, _ a2: A) {}
 
-// CHECK-NEXT: public init<C>(_: C) where C : main.Base<In, Out>
+// CHECK-NEXT: public init<C>(_: C) where C: main.Base<In, Out>
   public init<C>(_: C) where C : Base<In, Out> {}
 // CHECK: }
 }
 
-// CHECK: public class Derived<T> : {{(main.)?}}Base<T, T> {
+// CHECK: public class Derived<T>: {{(main.)?}}Base<T, T> {
 public class Derived<T> : Base<T, T> {
 // CHECK-NEXT: override public init(x: @escaping (T) -> T)
 // CHECK-NEXT: override public init<A>(_ a1: A, _ a2: A)
-// CHECK-NEXT: override public init<C>(_ __argument1: C) where C : main.Base<T, T>
+// CHECK-NEXT: override public init<C>(_ __argument1: C) where C: main.Base<T, T>
 // CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: }
 }

--- a/test/ModuleInterface/inherited-objc-superclass-initializers.swift
+++ b/test/ModuleInterface/inherited-objc-superclass-initializers.swift
@@ -6,14 +6,14 @@
 
 import InheritedObjCInits
 
-// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass2 : InheritedObjCInits.HasAvailableInit {
+// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass2: InheritedObjCInits.HasAvailableInit {
 public class Subclass2: HasAvailableInit {
   // CHECK-NEXT: @objc override dynamic public init(unavailable: InheritedObjCInits.UnavailableInSwift)
   // CHECK-NEXT: @objc override dynamic public init()
   // CHECK-NEXT: @objc deinit
 } // CHECK-NEXT:{{^}$}}
 
-// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass1 : InheritedObjCInits.HasUnavailableInit {
+// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass1: InheritedObjCInits.HasUnavailableInit {
 public class Subclass1: HasUnavailableInit {
   // CHECK-NOT: InheritedObjCInits.UnavailableInSwift
   // CHECK-NEXT: @objc override dynamic public init()

--- a/test/ModuleInterface/inherits-superclass-initializers.swift
+++ b/test/ModuleInterface/inherits-superclass-initializers.swift
@@ -46,7 +46,7 @@ open class InlineBase {
   // CHECK: }
 }
 
-// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class Sub : Module.Base {
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class Sub: Module.Base {
 public class Sub : Base {
   // CHECK: override public init(arg: Swift.Int)
   public override init(arg: Int) {
@@ -61,7 +61,7 @@ public class Sub : Base {
 // CHECK: }
 }
 
-// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class SubSub : Module.Sub {
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class SubSub: Module.Sub {
 public class SubSub: Sub {
   // CHECK: override public init(arg: Swift.Int)
   public override init(arg: Int) {

--- a/test/ModuleInterface/init_accessors.swift
+++ b/test/ModuleInterface/init_accessors.swift
@@ -98,26 +98,26 @@ public struct Transparent {
 //--- Client.swift
 import A
 
-// CHECK-LABEL: sil hidden @$s6Client15testTransparentyyF : $@convention(thin) () -> ()
-// CHECK: [[X:%.*]] = struct $Int (%1 : $Builtin.Int{{[0-9]+}})
+// CHECK-LABEL: sil hidden @$s6Client15testTransparentyyF: $@convention(thin) () -> ()
+// CHECK: [[X:%.*]] = struct $Int (%1: $Builtin.Int{{[0-9]+}})
 // CHECK-NEXT: // function_ref Transparent.init(x:)
-// CHECK-NEXT: [[TRANSPARENT_REF:%.*]] = function_ref @$s1A11TransparentV1xACSi_tcfC : $@convention(method) (Int, @thin Transparent.Type) -> Transparent
-// CHECK-NEXT: apply [[TRANSPARENT_REF]]([[X]], %0) : $@convention(method) (Int, @thin Transparent.Type) -> Transparent
+// CHECK-NEXT: [[TRANSPARENT_REF:%.*]] = function_ref @$s1A11TransparentV1xACSi_tcfC: $@convention(method) (Int, @thin Transparent.Type) -> Transparent
+// CHECK-NEXT: apply [[TRANSPARENT_REF]]([[X]], %0): $@convention(method) (Int, @thin Transparent.Type) -> Transparent
 func testTransparent() {
   _ = Transparent(x: 42)
 }
 
-// CHECK-LABEL: sil shared @$s1A11TransparentV1xACSi_tcfC : $@convention(method) (Int, @thin Transparent.Type) -> Transparent
+// CHECK-LABEL: sil shared @$s1A11TransparentV1xACSi_tcfC: $@convention(method) (Int, @thin Transparent.Type) -> Transparent
 
-// CHECK-LABEL: sil hidden @$s6Client13testInlinableyyF : $@convention(thin) () -> ()
-// CHECK: [[X:%.*]] = struct $Int (%1 : $Builtin.Int{{[0-9]+}})
+// CHECK-LABEL: sil hidden @$s6Client13testInlinableyyF: $@convention(thin) () -> ()
+// CHECK: [[X:%.*]] = struct $Int (%1: $Builtin.Int{{[0-9]+}})
 // CHECK-NEXT: // function_ref Inlinable.init(x:)
-// CHECK-NEXT: [[INLINABLE_REF:%.*]] = function_ref @$s1A9InlinableV1xACSi_tcfC : $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
-// CHECK-NEXT: apply [[INLINABLE_REF]]([[X]], %0) : $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
+// CHECK-NEXT: [[INLINABLE_REF:%.*]] = function_ref @$s1A9InlinableV1xACSi_tcfC: $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
+// CHECK-NEXT: apply [[INLINABLE_REF]]([[X]], %0): $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
 func testInlinable() {
   _ = Inlinable(x: 42)
 }
 
-// CHECK-LABEL: sil @$s1A9InlinableV1xACSi_tcfC : $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
+// CHECK-LABEL: sil @$s1A9InlinableV1xACSi_tcfC: $@convention(method) (Int, @thin Inlinable.Type) -> Inlinable
 
-// CHECK-LABEL: sil shared @$s1A11TransparentV1xSivi : $@convention(thin) (Int, @thin Transparent.Type) -> @out Int
+// CHECK-LABEL: sil shared @$s1A11TransparentV1xSivi: $@convention(thin) (Int, @thin Transparent.Type) -> @out Int

--- a/test/ModuleInterface/inlinable-function.swift
+++ b/test/ModuleInterface/inlinable-function.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/TestFromModule.swiftinterface) -module-name Test
 // RUN: %FileCheck %s --check-prefix FROMMODULE --check-prefix CHECK < %t/TestFromModule.swiftinterface
 
-// CHECK-LABEL: public struct Foo : Swift.Hashable {
+// CHECK-LABEL: public struct Foo: Swift.Hashable {
 public struct Foo: Hashable {
   // CHECK: public var inlinableGetPublicSet: Swift.Int {
   public var inlinableGetPublicSet: Int {

--- a/test/ModuleInterface/isolated_conformance.swift
+++ b/test/ModuleInterface/isolated_conformance.swift
@@ -9,7 +9,7 @@ public protocol MyProtocol {
 @MainActor
 public class MyClass { }
 
-// CHECK: extension isolated_conformance.MyClass : @{{.*}}MainActor isolated_conformance.MyProtocol {
+// CHECK: extension isolated_conformance.MyClass: @{{.*}}MainActor isolated_conformance.MyProtocol {
 extension MyClass: @MainActor MyProtocol {
   @MainActor public func f() { }
 }

--- a/test/ModuleInterface/layout_pre_specialization.swift
+++ b/test/ModuleInterface/layout_pre_specialization.swift
@@ -7,7 +7,7 @@
 
 // REQUIRES: swift_feature_LayoutPrespecialization
 
-// CHECK: @_specialize(exported: true, kind: full, where @_noMetadata A : _Class)
+// CHECK: @_specialize(exported: true, kind: full, where @_noMetadata A: _Class)
 // CHECK-NEXT: public func test<A>(a: A) -> A
 @_specialize(exported: true, where @_noMetadata A : _Class)
 public func test<A>(a: A) -> A {

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -18,7 +18,7 @@
 // CHECK: @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: Swift.String) -> (T, Swift.String) = #labeledStringify(value, label: "default label")
 @freestanding(expression) public macro unlabeledStringify<T>(_ value: T, label: String) -> (T, String) = #labeledStringify(value, label: "default label")
 
-// CHECK: @freestanding(expression) public macro publicLine<T>() -> T = #externalMacro(module: "MacroDefinition", type: "Line") where T : Swift.ExpressibleByIntegerLiteral
+// CHECK: @freestanding(expression) public macro publicLine<T>() -> T = #externalMacro(module: "MacroDefinition", type: "Line") where T: Swift.ExpressibleByIntegerLiteral
 @freestanding(expression) public macro publicLine<T: ExpressibleByIntegerLiteral>() -> T = #externalMacro(module: "MacroDefinition", type: "Line")
 
 // CHECK: @attached(accessor) public macro myWrapper() = #externalMacro(module: "MacroDefinition", type: "Wrapper")

--- a/test/ModuleInterface/member-typealias.swift
+++ b/test/ModuleInterface/member-typealias.swift
@@ -17,7 +17,7 @@ public class MyBase<U> {
 }
 
 public class MyDerived<X>: MyBase<X> {
-// CHECK-LABEL: public class MyDerived<X> : MyModule.MyBase<X> {
+// CHECK-LABEL: public class MyDerived<X>: MyModule.MyBase<X> {
   public func bar(x: AliasU) -> AliasInt { fatalError() }
 // CHECK:  public func bar(x: MyModule.MyDerived<X>.AliasU) -> MyModule.MyDerived<X>.AliasInt
 }

--- a/test/ModuleInterface/modifiers.swift
+++ b/test/ModuleInterface/modifiers.swift
@@ -67,7 +67,7 @@ public class Base {
 } // CHECK-NEXT: {{^}$}}
 
 
-// CHECK-LABEL: public class SubImplicit : {{(Test[.])?Base}} {
+// CHECK-LABEL: public class SubImplicit: {{(Test[.])?Base}} {
 public class SubImplicit: Base {
   // CHECK-NEXT: @objc override public init(){{$}}
   // CHECK-NEXT: @objc required public init(x: Swift.Int){{$}}
@@ -75,7 +75,7 @@ public class SubImplicit: Base {
 } // CHECK-NEXT: {{^}$}}
 
 
-// CHECK-LABEL: public class SubExplicit : {{(Test[.])?Base}} {
+// CHECK-LABEL: public class SubExplicit: {{(Test[.])?Base}} {
 public class SubExplicit: Base {
   // Make sure adding "required" preserves both "required" and "override".
   // CHECK-NEXT: @objc override required public init(){{$}}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -56,87 +56,87 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: public struct rdar118697289_S2<Element> {
 // CHECK-MISC: public static func allCopyable1<T>(_ a: T, _ b: T) -> T
 
-// CHECK-MISC: public static func allCopyable2<T>(_ s: T) where T : NoncopyableGenerics_Misc._NoCopyP
+// CHECK-MISC: public static func allCopyable2<T>(_ s: T) where T: NoncopyableGenerics_Misc._NoCopyP
 
-// CHECK-MISC: public static func oneCopyable1<T, V>(_ s: T, _ v: borrowing V) where T : {{.*}}._NoCopyP, V : ~Copyable
+// CHECK-MISC: public static func oneCopyable1<T, V>(_ s: T, _ v: borrowing V) where T: {{.*}}._NoCopyP, V: ~Copyable
 
-// CHECK-MISC: public static func oneCopyable2<T, V>(_ s: borrowing T, _ v: V) where T : {{.*}}._NoCopyP, T : ~Copyable
+// CHECK-MISC: public static func oneCopyable2<T, V>(_ s: borrowing T, _ v: V) where T: {{.*}}._NoCopyP, T: ~Copyable
 
-// CHECK-MISC: public static func oneCopyable3<T, V>(_ s: borrowing T, _ v: V) where T : {{.*}}._NoCopyP, T : ~Copyable
+// CHECK-MISC: public static func oneCopyable3<T, V>(_ s: borrowing T, _ v: V) where T: {{.*}}._NoCopyP, T: ~Copyable
 
 // CHECK-MISC: public static func basic_some(_ s: some _NoCopyP)
 
 // CHECK-MISC: public static func basic_some_nc(_ s: borrowing some _NoCopyP & ~Copyable)
 
-// CHECK-MISC: public static func oneEscapable<T, V>(_ s: T, _ v: V) where T : NoncopyableGenerics_Misc._NoEscapableP, T : ~Escapable
+// CHECK-MISC: public static func oneEscapable<T, V>(_ s: T, _ v: V) where T: NoncopyableGenerics_Misc._NoEscapableP, T: ~Escapable
 
-// CHECK-MISC: public static func canEscapeButConforms<T>(_ t: T) where T : {{.*}}._NoEscapableP
+// CHECK-MISC: public static func canEscapeButConforms<T>(_ t: T) where T: {{.*}}._NoEscapableP
 
 // CHECK-MISC: public static func opaqueNonEscapable(_ s: some _NoEscapableP & ~Escapable)
 
 // CHECK-MISC: public static func opaqueEscapable(_ s: some _NoEscapableP)
 
-// CHECK-MISC: public struct ExplicitHello<T> : ~Swift.Copyable where T : ~Copyable {
+// CHECK-MISC: public struct ExplicitHello<T>: ~Swift.Copyable where T: ~Copyable {
 
-// CHECK-MISC: extension {{.*}}.ExplicitHello : Swift.Copyable where T : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}.ExplicitHello: Swift.Copyable where T: Swift.Copyable {
 
-// CHECK-MISC: public struct Hello<T> : ~Swift.Copyable, ~Swift.Escapable where T : ~Copyable, T : ~Escapable {
+// CHECK-MISC: public struct Hello<T>: ~Swift.Copyable, ~Swift.Escapable where T: ~Copyable, T: ~Escapable {
 
-// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello : Swift.Escapable where T : Swift.Escapable, T : ~Copyable {
+// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello: Swift.Escapable where T: Swift.Escapable, T: ~Copyable {
 // CHECK-MISC-NEXT: }
 
-// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello : Swift.Copyable where T : Swift.Copyable, T : ~Escapable {
+// CHECK-MISC: extension NoncopyableGenerics_Misc.Hello: Swift.Copyable where T: Swift.Copyable, T: ~Escapable {
 // CHECK-MISC-NEXT: }
 
 // CHECK-MISC: public protocol TestAssocTypes {
-// CHECK-MISC-NEXT:   associatedtype A : {{.*}}._NoCopyP, ~Copyable
+// CHECK-MISC-NEXT:   associatedtype A: {{.*}}._NoCopyP, ~Copyable
 
 // CHECK-MISC: public typealias SomeAlias<G> = {{.*}}.Hello<G>
 
-// CHECK-MISC: public typealias AliasWithInverse<G> = {{.*}}.Hello<G> where G : ~Copyable, G : ~Escapable
+// CHECK-MISC: public typealias AliasWithInverse<G> = {{.*}}.Hello<G> where G: ~Copyable, G: ~Escapable
 
-// CHECK-MISC: public struct RudePointer<T> : Swift.Copyable where T : ~Copyable {
+// CHECK-MISC: public struct RudePointer<T>: Swift.Copyable where T: ~Copyable {
 
 // CHECK-MISC: noInversesSTART
 // CHECK-MISC-NOT: ~
 // CHECK-MISC: noInversesEND
 
-// CHECK-MISC: public func checkAnyInv1<Result>(_ t: borrowing Result) where Result : ~Copyable
-// CHECK-MISC: public func checkAnyInv2<Result>(_ t: borrowing Result) where Result : ~Copyable, Result : ~Escapable
-// CHECK-MISC: public func checkAnyObject<Result>(_ t: Result) where Result : AnyObject
+// CHECK-MISC: public func checkAnyInv1<Result>(_ t: borrowing Result) where Result: ~Copyable
+// CHECK-MISC: public func checkAnyInv2<Result>(_ t: borrowing Result) where Result: ~Copyable, Result: ~Escapable
+// CHECK-MISC: public func checkAnyObject<Result>(_ t: Result) where Result: AnyObject
 
-// CHECK-MISC: public struct Outer<A> : ~Swift.Copyable where A : ~Copyable {
-// CHECK-MISC-NEXT:   public func innerFn<B>(_ b: borrowing B) where B : ~Copyable
-// CHECK-MISC:   public struct InnerStruct<C> : ~Swift.Copyable where C : ~Copyable {
-// CHECK-MISC-NEXT:     public func g<D>(_ d: borrowing D) where D : ~Copyable
-// CHECK-MISC:   public struct InnerVariation1<D> : ~Swift.Copyable, ~Swift.Escapable where D : ~Copyable
-// CHECK-MISC:   public struct InnerVariation2<D> : ~Swift.Copyable, ~Swift.Escapable where D : ~Escapable
+// CHECK-MISC: public struct Outer<A>: ~Swift.Copyable where A: ~Copyable {
+// CHECK-MISC-NEXT:   public func innerFn<B>(_ b: borrowing B) where B: ~Copyable
+// CHECK-MISC:   public struct InnerStruct<C>: ~Swift.Copyable where C: ~Copyable {
+// CHECK-MISC-NEXT:     public func g<D>(_ d: borrowing D) where D: ~Copyable
+// CHECK-MISC:   public struct InnerVariation1<D>: ~Swift.Copyable, ~Swift.Escapable where D: ~Copyable
+// CHECK-MISC:   public struct InnerVariation2<D>: ~Swift.Copyable, ~Swift.Escapable where D: ~Escapable
 
-// CHECK-MISC: extension {{.*}}.Outer : Swift.Copyable where A : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}.Outer: Swift.Copyable where A: Swift.Copyable {
 
-// CHECK-MISC: extension {{.*}}.Outer.InnerStruct : Swift.Copyable where A : Swift.Copyable, C : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}.Outer.InnerStruct: Swift.Copyable where A: Swift.Copyable, C: Swift.Copyable {
 
-// CHECK-MISC: extension {{.*}}.Outer.InnerVariation1 : Swift.Copyable where A : Swift.Copyable, D : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}.Outer.InnerVariation1: Swift.Copyable where A: Swift.Copyable, D: Swift.Copyable {
 
-// CHECK-MISC: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable where D : Swift.Escapable, A : ~Copyable {
+// CHECK-MISC: extension {{.*}}.Outer.InnerVariation2: Swift.Escapable where D: Swift.Escapable, A: ~Copyable {
 
 // CHECK-MISC: extension {{.*}}.Outer.InnerStruct {
 // CHECK-MISC-NEXT: #if compiler(>=5.3) && $NonescapableTypes
-// CHECK-MISC-NEXT:   public func hello<T>(_ t: T) where T : ~Escapable
+// CHECK-MISC-NEXT:   public func hello<T>(_ t: T) where T: ~Escapable
 // CHECK-MISC-NEXT:   #endif
 
-// CHECK-MISC: @_preInverseGenerics public func old_swap<T>(_ a: inout T, _ b: inout T) where T : ~Copyable
+// CHECK-MISC: @_preInverseGenerics public func old_swap<T>(_ a: inout T, _ b: inout T) where T: ~Copyable
 
-// CHECK-MISC: @_preInverseGenerics public func borrowsNoncopyable<T>(_ t: borrowing T) where T : ~Copyable
+// CHECK-MISC: @_preInverseGenerics public func borrowsNoncopyable<T>(_ t: borrowing T) where T: ~Copyable
 
-// CHECK-MISC: public func suppressesNoncopyableGenerics<T>(_ t: borrowing T) where T : ~Copyable
+// CHECK-MISC: public func suppressesNoncopyableGenerics<T>(_ t: borrowing T) where T: ~Copyable
 
-// CHECK-MISC:      public struct LoudlyNC<T> where T : ~Copyable {
+// CHECK-MISC:      public struct LoudlyNC<T> where T: ~Copyable {
 // CHECK-MISC-NEXT: }
 // CHECK-MISC-NEXT: public func _indexHumongousDonuts<TTT, T>(_ aggregate: Swift.UnsafePointer<TTT>, _ index: Swift.Int) -> T
 // CHECK-MISC-NEXT: public func referToLoud(_ t: {{.*}}.LoudlyNC<Swift.String>)
 // CHECK-MISC-NEXT: public func referToLoudProperGuarding(_ t: {{.*}}.LoudlyNC<Swift.String>)
-// CHECK-MISC-NEXT: public struct NoCopyPls : ~Swift.Copyable {
+// CHECK-MISC-NEXT: public struct NoCopyPls: ~Swift.Copyable {
 // CHECK-MISC-NEXT: }
 // CHECK-MISC-NEXT: #if compiler(>=5.3) && $NonescapableTypes
 // CHECK-MISC-NEXT: public func substCopyable(_ t: Swift.String?)
@@ -149,62 +149,62 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC-NEXT: public func substNC(_ t: borrowing {{.*}}.NoCopyPls?)
 // CHECK-MISC-NEXT: #endif
 // CHECK-MISC-NEXT: #if compiler(>=5.3) && $NonescapableTypes
-// CHECK-MISC-NEXT: public func substGenericNC<T>(_ t: borrowing T?) where T : ~Copyable
+// CHECK-MISC-NEXT: public func substGenericNC<T>(_ t: borrowing T?) where T: ~Copyable
 // CHECK-MISC-NEXT: #endif
 
-// CHECK-MISC:      public protocol Publik : ~Copyable {
+// CHECK-MISC:      public protocol Publik: ~Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public struct Concrete : ~Copyable {
+// CHECK-MISC-NEXT: public struct Concrete: ~Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public struct Generic<T> : ~Copyable where T : {{.*}}.Publik, T : ~Copyable {
+// CHECK-MISC-NEXT: public struct Generic<T>: ~Copyable where T: {{.*}}.Publik, T: ~Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public struct VeryNested : ~Copyable {
+// CHECK-MISC-NEXT: public struct VeryNested: ~Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public struct Twice : ~Copyable, ~Copyable {
+// CHECK-MISC-NEXT: public struct Twice: ~Copyable, ~Copyable {
 // CHECK-MISC-NEXT: }
-// CHECK-MISC-NEXT: public struct RegularTwice : ~Swift.Copyable, ~Swift.Copyable {
+// CHECK-MISC-NEXT: public struct RegularTwice: ~Swift.Copyable, ~Swift.Copyable {
 // CHECK-MISC-NEXT: }
 
-// CHECK-MISC-NEXT: public struct Continuation<T, E> where E : Swift.Error, T : ~Copyable {
+// CHECK-MISC-NEXT: public struct Continuation<T, E> where E: Swift.Error, T: ~Copyable {
 
-// CHECK-MISC: @frozen public enum Moptional<Wrapped> : ~Swift.Copyable, ~Swift.Escapable where Wrapped : ~Copyable, Wrapped : ~Escapable {
-// CHECK-MISC: extension {{.*}}.Moptional : Swift.Copyable where Wrapped : Swift.Copyable, Wrapped : ~Escapable {
-// CHECK-MISC: extension {{.*}}.Moptional : Swift.Escapable where Wrapped : Swift.Escapable, Wrapped : ~Copyable {
+// CHECK-MISC: @frozen public enum Moptional<Wrapped>: ~Swift.Copyable, ~Swift.Escapable where Wrapped: ~Copyable, Wrapped: ~Escapable {
+// CHECK-MISC: extension {{.*}}.Moptional: Swift.Copyable where Wrapped: Swift.Copyable, Wrapped: ~Escapable {
+// CHECK-MISC: extension {{.*}}.Moptional: Swift.Escapable where Wrapped: Swift.Escapable, Wrapped: ~Copyable {
 
 // CHECK-MISC-NOT:  ~
 
 // NOTE: below are extensions emitted at the end of NoncopyableGenerics_Misc.swift
-// CHECK-MISC: extension {{.*}}.VeryNested : {{.*}}.Publik {}
+// CHECK-MISC: extension {{.*}}.VeryNested: {{.*}}.Publik {}
 
 import Swiftskell
 
-// CHECK: public protocol Show : ~Copyable {
+// CHECK: public protocol Show: ~Copyable {
 
 // CHECK: public func print(_ s: borrowing some Show & ~Copyable)
 
-// CHECK: public protocol Eq : ~Copyable {
+// CHECK: public protocol Eq: ~Copyable {
 
-// CHECK: extension Swiftskell.Eq where Self : ~Copyable {
+// CHECK: extension Swiftskell.Eq where Self: ~Copyable {
 
-// CHECK: public enum Either<Success, Failure> : ~Swift.Copyable where Failure : Swift.Error, Success : ~Copyable {
+// CHECK: public enum Either<Success, Failure>: ~Swift.Copyable where Failure: Swift.Error, Success: ~Copyable {
 
 /// This one is position dependent so we can ensure the associated type was printed correctly.
-// CHECK: public protocol Generator : ~Copyable {
-// CHECK-NEXT:   associatedtype Element : ~Copyable
+// CHECK: public protocol Generator: ~Copyable {
+// CHECK-NEXT:   associatedtype Element: ~Copyable
 
-// CHECK: public enum Pair<L, R> : ~Swift.Copyable where L : ~Copyable, R : ~Copyable {
+// CHECK: public enum Pair<L, R>: ~Swift.Copyable where L: ~Copyable, R: ~Copyable {
 
-// CHECK: extension Swiftskell.Pair : Swift.Copyable where L : Swift.Copyable, R : Swift.Copyable {
+// CHECK: extension Swiftskell.Pair: Swift.Copyable where L: Swift.Copyable, R: Swift.Copyable {
 
-// CHECK: public enum Maybe<Wrapped> : ~Swift.Copyable where Wrapped : ~Copyable {
+// CHECK: public enum Maybe<Wrapped>: ~Swift.Copyable where Wrapped: ~Copyable {
 
-// CHECK: extension Swiftskell.Maybe : Swift.Copyable where Wrapped : Swift.Copyable {
+// CHECK: extension Swiftskell.Maybe: Swift.Copyable where Wrapped: Swift.Copyable {
 
-// CHECK: extension Swiftskell.Maybe : Swiftskell.Show where Wrapped : Swiftskell.Show, Wrapped : ~Copyable {
+// CHECK: extension Swiftskell.Maybe: Swiftskell.Show where Wrapped: Swiftskell.Show, Wrapped: ~Copyable {
 
-// CHECK: extension Swiftskell.Maybe : Swiftskell.Eq where Wrapped : Swiftskell.Eq, Wrapped : ~Copyable {
+// CHECK: extension Swiftskell.Maybe: Swiftskell.Eq where Wrapped: Swiftskell.Eq, Wrapped: ~Copyable {
 
-// CHECK: public func isJust<A>(_ m: borrowing Swiftskell.Maybe<A>) -> Swift.Bool where A : ~Copyable
+// CHECK: public func isJust<A>(_ m: borrowing Swiftskell.Maybe<A>) -> Swift.Bool where A: ~Copyable
 
 struct FileDescriptor: ~Copyable, Eq, Show {
   let id: Int

--- a/test/ModuleInterface/nonescapable_types.swift
+++ b/test/ModuleInterface/nonescapable_types.swift
@@ -6,7 +6,7 @@
 // REQUIRES: swift_feature_LifetimeDependence
 
 // CHECK: #if compiler(>=5.3) && $NonescapableTypes
-// CHECK: public protocol P : ~Escapable {
+// CHECK: public protocol P: ~Escapable {
 // CHECK:   associatedtype A
 // CHECK: }
 // CHECK: #endif
@@ -15,7 +15,7 @@ public protocol P: ~Escapable {
 }
 
 // CHECK: #if compiler(>=5.3) && $NonescapableTypes
-// CHECK: public struct X<T> : ~Swift.Escapable where T : ~Escapable {
+// CHECK: public struct X<T>: ~Swift.Escapable where T: ~Escapable {
 // CHECK: }
 // CHECK: #endif
 public struct X<T: ~Escapable>: ~Escapable { }
@@ -29,7 +29,7 @@ extension X where T: Escapable {
 }
 
 // CHECK: #if compiler(>=5.3) && $NonescapableTypes
-// CHECK: extension Test.X where T : ~Escapable {
+// CHECK: extension Test.X where T: ~Escapable {
 // CHECK:   public func g(other: borrowing T)
 // CHECK: }
 // CHECK: #endif
@@ -38,7 +38,7 @@ extension X where T: ~Escapable {
 }
 
 // CHECK: #if compiler(>=5.3) && $NonescapableTypes
-// CHECK: public enum Y<T> : ~Swift.Escapable where T : ~Escapable {
+// CHECK: public enum Y<T>: ~Swift.Escapable where T: ~Escapable {
 // CHECK:   case none
 // CHECK:   case some(T)
 // CHECK: }
@@ -51,7 +51,7 @@ extension Y: Escapable where T: Escapable { }
 
 // CHECK: #if compiler(>=5.3) && $NonescapableTypes
 // CHECK: @lifetime(copy y)
-// CHECK: public func derive<T>(_ y: Test.Y<T>) -> Test.Y<T> where T : ~Escapable
+// CHECK: public func derive<T>(_ y: Test.Y<T>) -> Test.Y<T> where T: ~Escapable
 // CHECK: #endif
 @lifetime(copy y)
 public func derive<T : ~Escapable>(_ y: Y<T>) -> Y<T> {
@@ -60,7 +60,7 @@ public func derive<T : ~Escapable>(_ y: Y<T>) -> Y<T> {
 
 // CHECK: #if compiler(>=5.3) && $NonescapableTypes
 // CHECK: @lifetime(copy x)
-// CHECK: public func derive<T>(_ x: Test.X<T>) -> Test.X<T> where T : ~Escapable
+// CHECK: public func derive<T>(_ x: Test.X<T>) -> Test.X<T> where T: ~Escapable
 // CHECK: #endif
 @lifetime(copy x)
 public func derive<T : ~Escapable>(_ x: X<T>) -> X<T> {

--- a/test/ModuleInterface/nsmanaged-attr.swift
+++ b/test/ModuleInterface/nsmanaged-attr.swift
@@ -16,7 +16,7 @@
 import CoreData
 import Foundation
 
-// CHECK: @objc @_inheritsConvenienceInitializers public class MyObject : CoreData.NSManagedObject {
+// CHECK: @objc @_inheritsConvenienceInitializers public class MyObject: CoreData.NSManagedObject {
 public class MyObject: NSManagedObject {
   // CHECK: @objc @NSManaged dynamic public var myVar: Swift.String {
   // CHECK-NEXT: @objc get

--- a/test/ModuleInterface/objc_implementation.swift
+++ b/test/ModuleInterface/objc_implementation.swift
@@ -90,7 +90,7 @@ import Foundation
 // @objc subclass of @_objcImplementation class
 //
 
-// CHECK-LABEL: @objc @_inheritsConvenienceInitializers open class SwiftSubclass : objc_implementation.ImplClass {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers open class SwiftSubclass: objc_implementation.ImplClass {
 open class SwiftSubclass: ImplClass {
   // CHECK-DAG: @objc override dynamic open func mainMethod
   override open func mainMethod(_: Int32) {

--- a/test/ModuleInterface/opaque-result-types.swift
+++ b/test/ModuleInterface/opaque-result-types.swift
@@ -19,7 +19,7 @@ public func foo(_: Int) -> some Foo {
   return 679
 }
 
-// CHECK-LABEL: public func foo<T>(_ x: T) -> some OpaqueResultTypes.Foo where T : OpaqueResultTypes.Foo
+// CHECK-LABEL: public func foo<T>(_ x: T) -> some OpaqueResultTypes.Foo where T: OpaqueResultTypes.Foo
 @available(SwiftStdlib 5.1, *)
 public func foo<T: Foo>(_ x: T) -> some Foo {
   return x
@@ -65,7 +65,7 @@ public struct Bar<T>: AssocTypeInference {
     return 219
   }
 
-  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
+  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U: OpaqueResultTypes.Foo
   @available(SwiftStdlib 5.1, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
@@ -86,7 +86,7 @@ public struct Bar<T>: AssocTypeInference {
       return 219
     }
 
-    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U: OpaqueResultTypes.Foo
     @available(SwiftStdlib 5.1, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
@@ -127,7 +127,7 @@ public struct Bar<T>: AssocTypeInference {
       return x
     }
 
-    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V: OpaqueResultTypes.Foo
     @available(SwiftStdlib 5.1, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x
@@ -174,7 +174,7 @@ public struct Zim: AssocTypeInference {
     return 219
   }
 
-  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
+  // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U: OpaqueResultTypes.Foo
   @available(SwiftStdlib 5.1, *)
   public func foo<U: Foo>(_ x: U) -> some Foo {
     return x
@@ -194,7 +194,7 @@ public struct Zim: AssocTypeInference {
       return 219
     }
 
-    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<U>(_ x: U) -> some OpaqueResultTypes.Foo where U: OpaqueResultTypes.Foo
     @available(SwiftStdlib 5.1, *)
     public func foo<U: Foo>(_ x: U) -> some Foo {
       return x
@@ -230,7 +230,7 @@ public struct Zim: AssocTypeInference {
       return x
     }
 
-    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V : OpaqueResultTypes.Foo
+    // CHECK-LABEL: public func foo<V>(_ x: V) -> some OpaqueResultTypes.Foo where V: OpaqueResultTypes.Foo
     @available(SwiftStdlib 5.1, *)
     public func foo<V: Foo>(_ x: V) -> some Foo {
       return x

--- a/test/ModuleInterface/originally-defined-attr-synthesized-extension.swift
+++ b/test/ModuleInterface/originally-defined-attr-synthesized-extension.swift
@@ -14,13 +14,13 @@ public enum MyCase: Int {
 
 // CHECK: @_originallyDefinedIn(module: "Bar", macOS 10.9)
 // CHECK: @_originallyDefinedIn(module: "Bar", iOS 13.0)
-// CHECK: public enum MyCase : Swift.Int
+// CHECK: public enum MyCase: Swift.Int
 
 // CHECK: @_originallyDefinedIn(module: "Bar", macOS 10.9)
 // CHECK: @_originallyDefinedIn(module: "Bar", iOS 13.0)
-// CHECK: extension Foo.MyCase : Swift.Equatable {}
+// CHECK: extension Foo.MyCase: Swift.Equatable {}
 
 // CHECK: @_originallyDefinedIn(module: "Bar", macOS 10.9)
 // CHECK: @_originallyDefinedIn(module: "Bar", iOS 13.0)
-// CHECK: extension Foo.MyCase : Swift.Hashable {}
+// CHECK: extension Foo.MyCase: Swift.Hashable {}
 

--- a/test/ModuleInterface/pack_expansion_type.swift
+++ b/test/ModuleInterface/pack_expansion_type.swift
@@ -4,15 +4,15 @@
 
 /// Requirements
 
-// CHECK: public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) where (repeat (each T, each U)) : Any
+// CHECK: public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) where (repeat (each T, each U)): Any
 public func variadicFunction<each T, each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) {}
 
-// CHECK: public func variadicFunctionWithRequirement<each T>(t: repeat each T) where repeat each T : Swift.Equatable
+// CHECK: public func variadicFunctionWithRequirement<each T>(t: repeat each T) where repeat each T: Swift.Equatable
 public func variadicFunctionWithRequirement<each T: Equatable>(t: repeat each T) {}
 
 // CHECK: public struct VariadicType<each T> {
 public struct VariadicType<each T> {
-  // CHECK: public func variadicMethod<each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) where (repeat (each T, each U)) : Any
+  // CHECK: public func variadicMethod<each U>(t: repeat each T, u: repeat each U) -> (repeat (each T, each U)) where (repeat (each T, each U)): Any
   public func variadicMethod<each U>(t: repeat each T, u: repeat each  U) -> (repeat (each T, each U)) {}
 
   // CHECK: public func returnsSelf() -> PackExpansionType.VariadicType<repeat each T>
@@ -21,7 +21,7 @@ public struct VariadicType<each T> {
 // CHECK: }
 
 // The second requirement should not be prefixed with 'repeat'
-// CHECK: public struct SameTypeReq<T, each U> where T : Swift.Sequence, T.Element == PackExpansionType.VariadicType<repeat each U> {
+// CHECK: public struct SameTypeReq<T, each U> where T: Swift.Sequence, T.Element == PackExpansionType.VariadicType<repeat each U> {
 public struct SameTypeReq<T: Sequence, each U> where T.Element == VariadicType<repeat each U> {}
 // CHECK: }
 

--- a/test/ModuleInterface/package_interface.swift
+++ b/test/ModuleInterface/package_interface.swift
@@ -294,7 +294,7 @@ package func pkg(x: Int, y: String) { print("pkg func") }
 func int(x: Int, y: String) { print("int func") }
 private func priv(x: Int, y: String) { print("priv func") }
 
-// CHECK: extension Bar.PubEnum : Swift.Equatable {}
-// CHECK: extension Bar.PubEnum : Swift.Hashable {}
-// CHECK: extension Bar.FrozenPub : Swift.Sendable {}
+// CHECK: extension Bar.PubEnum: Swift.Equatable {}
+// CHECK: extension Bar.PubEnum: Swift.Hashable {}
+// CHECK: extension Bar.FrozenPub: Swift.Sendable {}
 

--- a/test/ModuleInterface/parameterized-protocol-synthesized-extension.swift
+++ b/test/ModuleInterface/parameterized-protocol-synthesized-extension.swift
@@ -19,5 +19,5 @@ protocol Q1 : Q2 {}
 
 public protocol Q2 {}
 
-// CHECK: extension ParameterizedProtocols.S1 : ParameterizedProtocols.P2 {}
-// CHECK-NEXT: extension ParameterizedProtocols.S2 : ParameterizedProtocols.Q2 {}
+// CHECK: extension ParameterizedProtocols.S1: ParameterizedProtocols.P2 {}
+// CHECK-NEXT: extension ParameterizedProtocols.S2: ParameterizedProtocols.Q2 {}

--- a/test/ModuleInterface/parameterized-protocols.swift
+++ b/test/ModuleInterface/parameterized-protocols.swift
@@ -9,6 +9,6 @@ public protocol HasPrimaryAssociatedTypes<T, U> {
 }
 
 // CHECK:      public protocol HasPrimaryAssociatedTypes<T, U> {
-// CHECK-NEXT:   associatedtype T : Swift.Collection
-// CHECK-NEXT:   associatedtype U : Swift.Equatable where Self.U == Self.T.Element
+// CHECK-NEXT:   associatedtype T: Swift.Collection
+// CHECK-NEXT:   associatedtype U: Swift.Equatable where Self.U == Self.T.Element
 // CHECK-NEXT: }

--- a/test/ModuleInterface/preconcurrency_conformances.swift
+++ b/test/ModuleInterface/preconcurrency_conformances.swift
@@ -45,7 +45,7 @@ public protocol WithAssoc {
 import A
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: @_Concurrency.MainActor public struct GlobalActorTest : @preconcurrency A.P
+// CHECK: @_Concurrency.MainActor public struct GlobalActorTest: @preconcurrency A.P
 
 @MainActor
 public struct GlobalActorTest : @preconcurrency P {
@@ -57,13 +57,13 @@ public class ExtTest {
 }
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: extension Client.ExtTest : @preconcurrency A.P
+// CHECK: extension Client.ExtTest: @preconcurrency A.P
 extension ExtTest : @preconcurrency P {
   public func test() -> Int { 1 }
 }
 
 // CHECK-NOT: #if {{.*}} && $DynamicActorIsolation
-// CHECK: public actor ActorTest : @preconcurrency A.P
+// CHECK: public actor ActorTest: @preconcurrency A.P
 public actor ActorTest : @preconcurrency P {
   public func test() -> Int { 2 }
 }
@@ -72,7 +72,7 @@ public actor ActorExtTest {
 }
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: extension Client.ActorExtTest : @preconcurrency A.Q
+// CHECK: extension Client.ActorExtTest: @preconcurrency A.Q
 extension ActorExtTest : @preconcurrency Q {
   public var x: Int { 42 }
 }
@@ -80,7 +80,7 @@ extension ActorExtTest : @preconcurrency Q {
 public struct TestConditional<T> {}
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: extension Client.TestConditional : @preconcurrency A.WithAssoc where T == Swift.Int {
+// CHECK: extension Client.TestConditional: @preconcurrency A.WithAssoc where T == Swift.Int {
 // CHECK-NEXT:  @_Concurrency.MainActor public func test() -> T
 // CHECK-NEXT: }
 extension TestConditional : @preconcurrency WithAssoc where T == Int {
@@ -88,4 +88,4 @@ extension TestConditional : @preconcurrency WithAssoc where T == Int {
 }
 
 // CHECK-NOT: #if {{.*}} $DynamicActorIsolation
-// CHECK: extension Client.GlobalActorTest : Swift.Sendable {}
+// CHECK: extension Client.GlobalActorTest: Swift.Sendable {}

--- a/test/ModuleInterface/preserve-type-repr.swift
+++ b/test/ModuleInterface/preserve-type-repr.swift
@@ -39,12 +39,12 @@ extension GenericToy {
 
 public protocol Pet {}
 
-// PREFER: public struct Parrot : Pet {
-// DONTPREFER: public struct Parrot : PreferTypeRepr.Pet {
+// PREFER: public struct Parrot: Pet {
+// DONTPREFER: public struct Parrot: PreferTypeRepr.Pet {
 // CHECK-NEXT: }
 public struct Parrot: Pet {}
 
-// CHECK: public struct Ex<T> where T : PreferTypeRepr.Pet {
+// CHECK: public struct Ex<T> where T: PreferTypeRepr.Pet {
 public struct Ex<T: Pet> {
   // PREFER: public var hasCeasedToBe: Bool {
   // DONTPREFER: public var hasCeasedToBe: Swift.Bool {
@@ -59,8 +59,8 @@ public struct Ex<T: Pet> {
 // CHECK-NEXT: }
 public struct My<T> {}
 
-// PREFER: extension My where T : PreferTypeRepr.Pet
-// DONTPREFER: extension PreferTypeRepr.My where T : PreferTypeRepr.Pet
+// PREFER: extension My where T: PreferTypeRepr.Pet
+// DONTPREFER: extension PreferTypeRepr.My where T: PreferTypeRepr.Pet
 extension My where T: Pet {
   // PREFER: public func isPushingUpDaisies() -> String
   // DONTPREFER: public func isPushingUpDaisies() -> Swift.String

--- a/test/ModuleInterface/protocol-with-self-constraint.swift
+++ b/test/ModuleInterface/protocol-with-self-constraint.swift
@@ -21,6 +21,6 @@ extension P {
 // CHECK-LABEL: extension Test.P {
 // CHECK-NEXT:    public static func blah1<T>(_: Self) where Self == Test.Foo<T>
 // CHECK-NEXT:    public static func blah2<T>(_: Test.Foo<T>.Nested) where Self == Test.Foo<T>
-// CHECK-NEXT:    public static func blah3<T>(_: Self) where Self : Test.Foo<T>
-// CHECK-NEXT:    public static func blah4<T>(_: Test.Foo<T>.Nested) where Self : Test.Foo<T>
+// CHECK-NEXT:    public static func blah3<T>(_: Self) where Self: Test.Foo<T>
+// CHECK-NEXT:    public static func blah4<T>(_: Test.Foo<T>.Nested) where Self: Test.Foo<T>
 // CHECK-NEXT:  }

--- a/test/ModuleInterface/protocol_extension_type_witness.swift
+++ b/test/ModuleInterface/protocol_extension_type_witness.swift
@@ -25,7 +25,7 @@ public struct S<B>: P {
   public func d(_: String) {}
 }
 
-// CHECK-LABEL: public struct S<B> : protocol_extension_type_witness.P {
+// CHECK-LABEL: public struct S<B>: protocol_extension_type_witness.P {
 // CHECK-NEXT:    public func b(_: B)
 // CHECK-NEXT:    public func d(_: Swift.String)
 // CHECK-NEXT:    public typealias A = B

--- a/test/ModuleInterface/retroactive-conformances.swift
+++ b/test/ModuleInterface/retroactive-conformances.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: extension Swift.Int : @retroactive Swift.Identifiable {
+// CHECK: extension Swift.Int: @retroactive Swift.Identifiable {
 // CHECK:   public var id: Swift.Int {
 // CHECK:     get
 // CHECK:   }

--- a/test/ModuleInterface/skip-override-keyword.swift
+++ b/test/ModuleInterface/skip-override-keyword.swift
@@ -21,7 +21,7 @@ public class BaseClass {
   @usableFromInline func doSomethingUsableFromInline() {}
 }
 
-// CHECK: @_inheritsConvenienceInitializers public class DerivedClass : {{Foo|FooWithTesting}}.BaseClass
+// CHECK: @_inheritsConvenienceInitializers public class DerivedClass: {{Foo|FooWithTesting}}.BaseClass
 public class DerivedClass: BaseClass {
   // CHECK: public init()
   public override init() { super.init() }

--- a/test/ModuleInterface/skip-override-spi.swift
+++ b/test/ModuleInterface/skip-override-spi.swift
@@ -9,7 +9,7 @@ public class HideyHole {
   @_spi(Private) public init() {}
 }
 
-// CHECK: @_inheritsConvenienceInitializers public class StashyCache : Foo.HideyHole
+// CHECK: @_inheritsConvenienceInitializers public class StashyCache: Foo.HideyHole
 public class StashyCache: HideyHole {
   // CHECK: public init()
 }

--- a/test/ModuleInterface/skip-redundant-conformances.swift
+++ b/test/ModuleInterface/skip-redundant-conformances.swift
@@ -3,23 +3,23 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Foo.swiftinterface) -module-name Foo
 // RUN: %FileCheck %s < %t/Foo.swiftinterface
 
-// CHECK: public protocol ProtocolA : AnyObject
+// CHECK: public protocol ProtocolA: AnyObject
 public protocol ProtocolA : AnyObject {}
-// CHECK: public protocol ProtocolB : Foo.ProtocolA
+// CHECK: public protocol ProtocolB: Foo.ProtocolA
 public protocol ProtocolB: ProtocolA {}
 // CHECK-NOT: ProtocolC
 protocol ProtocolC: ProtocolA {}
 
-// CHECK: @_hasMissingDesignatedInitializers public class A : Foo.ProtocolB
+// CHECK: @_hasMissingDesignatedInitializers public class A: Foo.ProtocolB
 public class A: ProtocolB {}
-// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class B : Foo.A
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class B: Foo.A
 public class B: A, ProtocolC {}
 
 // CHECK: @_hasMissingDesignatedInitializers public class C
 public class C {}
 extension C: ProtocolC {}
-// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class D : Foo.C
+// CHECK: @_inheritsConvenienceInitializers @_hasMissingDesignatedInitializers public class D: Foo.C
 public class D: C {}
 
-// CHECK: extension Foo.C : Foo.ProtocolA {}
-// CHECK-NOT: extension Foo.D : Foo.ProtocolA {}
+// CHECK: extension Foo.C: Foo.ProtocolA {}
+// CHECK-NOT: extension Foo.D: Foo.ProtocolA {}

--- a/test/ModuleInterface/specialized-extension.swift
+++ b/test/ModuleInterface/specialized-extension.swift
@@ -35,7 +35,7 @@ extension Tree<Int>.Branch<String>.Nest<Void>.Egg { public static func twite() {
 // CHECK: }
 extension [String] { public func rejoinder() -> String { return self.joined() } }
 
-// CHECK: public typealias StringDict<T> = [Swift.String : T]
+// CHECK: public typealias StringDict<T> = [Swift.String: T]
 public typealias StringDict<T> = [String: T]
 
 // CHECK: extension Swift.Dictionary where Key == Swift.String, Value == Swift.Int

--- a/test/ModuleInterface/static-initialize-objc-metadata-attr.swift
+++ b/test/ModuleInterface/static-initialize-objc-metadata-attr.swift
@@ -17,7 +17,7 @@ public class Super<T>: NSObject, NSCoding {
 }
 
 // CHECK-NOT: @_staticInitializeObjCMetadata
-// CHECK: public class Sub : Module.Super<Swift.Int>
+// CHECK: public class Sub: Module.Super<Swift.Int>
 public class Sub: Super<Int> {
   required public init(coder: NSCoder) {}
   override public func encode(with: NSCoder) {}

--- a/test/ModuleInterface/stub-init.swift
+++ b/test/ModuleInterface/stub-init.swift
@@ -17,7 +17,7 @@ public class Derived: Base {
 // CHECK-NEXT:    {{(@objc )?}}deinit
 // CHECK-NEXT: }
 
-// CHECK-LABEL: public class Derived : test.Base {
+// CHECK-LABEL: public class Derived: test.Base {
 // CHECK-NEXT:    public init(z: Swift.Int)
 // CHECK-NEXT:    {{(@objc )?}}deinit
 // CHECK-NEXT: }

--- a/test/ModuleInterface/synthesized-conformances.swift
+++ b/test/ModuleInterface/synthesized-conformances.swift
@@ -3,7 +3,7 @@
 // RUN: %FileCheck %s < %t.swiftinterface
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.swiftinterface
 
-// CHECK-LABEL: public enum HasRawValue : Swift.Int {
+// CHECK-LABEL: public enum HasRawValue: Swift.Int {
 public enum HasRawValue: Int {
   // CHECK-NEXT: case a, b, c
   case a, b = 5, c
@@ -15,7 +15,7 @@ public enum HasRawValue: Int {
 } // CHECK: {{^}$}}
 
 // CHECK-LABEL: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-// CHECK-NEXT: public enum HasRawValueAndAvailability : Swift.Int {
+// CHECK-NEXT: public enum HasRawValueAndAvailability: Swift.Int {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public enum HasRawValueAndAvailability: Int {
   // CHECK-NEXT: case a, b, c
@@ -31,7 +31,7 @@ public enum HasRawValueAndAvailability: Int {
   case a, b = 5, c
 }
 
-// CHECK-LABEL: @objc public enum ObjCEnum : Swift.Int32 {
+// CHECK-LABEL: @objc public enum ObjCEnum: Swift.Int32 {
 // CHECK-NEXT: case a, b = 5, c
 // CHECK-DAG: public typealias RawValue = Swift.Int32
 // CHECK-DAG: public init?(rawValue: Swift.Int32)
@@ -40,7 +40,7 @@ public enum HasRawValueAndAvailability: Int {
 // CHECK-DAG: }
 // CHECK: {{^}$}}
 
-// CHECK-LABEL: public enum NoRawValueWithExplicitEquatable : Swift.Equatable {
+// CHECK-LABEL: public enum NoRawValueWithExplicitEquatable: Swift.Equatable {
 public enum NoRawValueWithExplicitEquatable : Equatable {
   // CHECK-NEXT: case a, b, c
   case a, b, c
@@ -52,29 +52,29 @@ public enum NoRawValueWithExplicitHashable {
 case a, b, c
 } // CHECK: {{^}$}}
 
-// CHECK-LABEL: extension synthesized.NoRawValueWithExplicitHashable : Swift.Hashable {
+// CHECK-LABEL: extension synthesized.NoRawValueWithExplicitHashable: Swift.Hashable {
 extension NoRawValueWithExplicitHashable : Hashable {
   // CHECK-NEXT: public func foo()
   public func foo() {}
 } // CHECK: {{^}$}}
 
-// CHECK: extension synthesized.HasRawValue : Swift.Equatable {}
-// CHECK: extension synthesized.HasRawValue : Swift.Hashable {}
-// CHECK: extension synthesized.HasRawValue : Swift.RawRepresentable {}
+// CHECK: extension synthesized.HasRawValue: Swift.Equatable {}
+// CHECK: extension synthesized.HasRawValue: Swift.Hashable {}
+// CHECK: extension synthesized.HasRawValue: Swift.RawRepresentable {}
 
 // CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.Equatable {}
+// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability: Swift.Equatable {}
 // CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.Hashable {}
+// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability: Swift.Hashable {}
 // CHECK: @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
-// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability : Swift.RawRepresentable {}
+// CHECK-NEXT: extension synthesized.HasRawValueAndAvailability: Swift.RawRepresentable {}
 
-// CHECK: extension synthesized.ObjCEnum : Swift.Equatable {}
-// CHECK: extension synthesized.ObjCEnum : Swift.Hashable {}
-// CHECK: extension synthesized.ObjCEnum : Swift.RawRepresentable {}
+// CHECK: extension synthesized.ObjCEnum: Swift.Equatable {}
+// CHECK: extension synthesized.ObjCEnum: Swift.Hashable {}
+// CHECK: extension synthesized.ObjCEnum: Swift.RawRepresentable {}
 
-// CHECK: extension synthesized.NoRawValueWithExplicitEquatable : Swift.Hashable {}
-// NEGATIVE-NOT: extension {{.+}}NoRawValueWithExplicitEquatable : Swift.Equatable
+// CHECK: extension synthesized.NoRawValueWithExplicitEquatable: Swift.Hashable {}
+// NEGATIVE-NOT: extension {{.+}}NoRawValueWithExplicitEquatable: Swift.Equatable
 
-// NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift.Equatable
-// NEGATIVE-NOT: NoRawValueWithExplicitHashable : Swift.Hashable {}
+// NEGATIVE-NOT: NoRawValueWithExplicitHashable: Swift.Equatable
+// NEGATIVE-NOT: NoRawValueWithExplicitHashable: Swift.Hashable {}

--- a/test/ModuleInterface/top-level-Type-and-Protocol.swift
+++ b/test/ModuleInterface/top-level-Type-and-Protocol.swift
@@ -15,7 +15,7 @@ public protocol Protocol {}
 // CHECK: public func usesType(_ x: MyModule.`Type`)
 public func usesType(_ x: Type) {}
 
-// CHECK: public func genericProtocol<T>(_ x: T) where T : MyModule.`Protocol`
+// CHECK: public func genericProtocol<T>(_ x: T) where T: MyModule.`Protocol`
 public func genericProtocol<T: Protocol>(_ x: T) {}
 
 // CHECK: public func existentialProtocol(_ x: any MyModule.`Protocol`)

--- a/test/ModuleInterface/value_generics.swift
+++ b/test/ModuleInterface/value_generics.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name ValueGeneric -disable-availability-checking
 // RUN: %FileCheck %s < %t.swiftinterface
 
-// CHECK: public struct Slab<Element, let N : Swift.Int>
+// CHECK: public struct Slab<Element, let N: Swift.Int>
 public struct Slab<Element, let N: Int> {
   // CHECK-LABEL: public var count: Swift.Int {
   // CHECK-NEXT:    get {
@@ -18,7 +18,7 @@ public struct Slab<Element, let N: Int> {
   public init() {}
 }
 
-// CHECK: public func usesGenericSlab<let N : Swift.Int>(_: ValueGeneric.Slab<Swift.Int, N>)
+// CHECK: public func usesGenericSlab<let N: Swift.Int>(_: ValueGeneric.Slab<Swift.Int, N>)
 public func usesGenericSlab<let N: Int>(_: Slab<Int, N>) {}
 
 // CHECK: public func usesConcreteSlab(_: ValueGeneric.Slab<Swift.Int, 2>)

--- a/test/ModuleInterface/where-clause.swift
+++ b/test/ModuleInterface/where-clause.swift
@@ -19,7 +19,7 @@ public struct Holder<Value> {
         self.value = value
     }
 
-    // CHECK-NEXT: public init<T>(_ value: T) where Value == Swift.AnyHashable, T : Swift.Hashable{{$}}
+    // CHECK-NEXT: public init<T>(_ value: T) where Value == Swift.AnyHashable, T: Swift.Hashable{{$}}
     public init<T : Hashable>(_ value: T) where Value == AnyHashable {
         self.value = value
     }

--- a/test/SPI/private_swiftinterface.swift
+++ b/test/SPI/private_swiftinterface.swift
@@ -218,7 +218,7 @@ private protocol PrivateConstraint {}
 
 @_spi(LocalSPI)
 extension PublicType: SPIProto2 where T: SPIProto2 {}
-// CHECK-PRIVATE: extension {{.*}}.PublicType : {{.*}}.SPIProto2 where T : {{.*}}.SPIProto2
+// CHECK-PRIVATE: extension {{.*}}.PublicType : {{.*}}.SPIProto2 where T: {{.*}}.SPIProto2
 // CHECK-PUBLIC-NOT: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
 
 public protocol LocalPublicProto {}
@@ -242,7 +242,7 @@ extension IOIPublicStruct : LocalPublicProto {}
 // SPI extensions.
 @_spi(LocalSPI)
 extension PublicType: SPIProto where T: PrivateConstraint {}
-// CHECK-PRIVATE: extension {{.*}}.PublicType : {{.*}}.SPIProto where T : _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
+// CHECK-PRIVATE: extension {{.*}}.PublicType : {{.*}}.SPIProto where T: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
 // CHECK-PUBLIC-NOT: _ConstraintThatIsNotPartOfTheAPIOfThisLibrary
 
 // Preserve SPI information when printing indirect conformances via
@@ -250,5 +250,5 @@ extension PublicType: SPIProto where T: PrivateConstraint {}
 @_spi(S) public protocol SPIProtocol {}
 internal protocol InternalProtocol: SPIProtocol {}
 public struct PublicStruct2: InternalProtocol {}
-// CHECK-PRIVATE: @_spi(S) extension {{.*}}PublicStruct2 : {{.*}}.SPIProtocol
+// CHECK-PRIVATE: @_spi(S) extension {{.*}}PublicStruct2: {{.*}}.SPIProtocol
 // CHECK-PUBLIC-NOT: SPIProtocol

--- a/test/Sema/accessibility_package_interface.swift
+++ b/test/Sema/accessibility_package_interface.swift
@@ -70,10 +70,10 @@
 // CHECK-PUBLIC-CLIENT: ufiPackageFunc()
 // CHECK-PUBLIC-CLIENT: let u = UfiPackageKlass()
 // CHECK-PUBLIC-CLIENT: return u.ufiPkgVar
-// CHECK-PUBLIC-CLIENT: public class ClientKlass1 : Utils.UfiPackageProto
+// CHECK-PUBLIC-CLIENT: public class ClientKlass1: Utils.UfiPackageProto
 // CHECK-PUBLIC-CLIENT: @usableFromInline
 // CHECK-PUBLIC-CLIENT: package var ufiPkgVar: Swift.String
-// CHECK-PUBLIC-CLIENT: public class ClientKlass2 : Utils.UfiPackageProto
+// CHECK-PUBLIC-CLIENT: public class ClientKlass2: Utils.UfiPackageProto
 // CHECK-PUBLIC-CLIENT: public var ufiPkgVar: Swift.String
 
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I %t -verify

--- a/test/Sema/implementation-only-override.swift
+++ b/test/Sema/implementation-only-override.swift
@@ -13,7 +13,7 @@
 import FooKit
 @_implementationOnly import FooKit_SECRET
 
-// CHECK-LABEL: class GoodChild : FooKit.Parent {
+// CHECK-LABEL: class GoodChild: FooKit.Parent {
 //  CHECK-NEXT:   @objc override dynamic public init()
 //  CHECK-NEXT:   @objc deinit
 //  CHECK-NEXT: }
@@ -38,7 +38,7 @@ public class GoodChild: Parent {
   }
 }
 
-// CHECK-LABEL: class QuietChild : FooKit.Parent {
+// CHECK-LABEL: class QuietChild: FooKit.Parent {
 //  CHECK-NEXT:   @objc deinit
 //  CHECK-NEXT: }
 public class QuietChild: Parent {
@@ -47,7 +47,7 @@ public class QuietChild: Parent {
   internal required init(requiredSECRET: Int32) {}
 }
 
-// CHECK-LABEL: class GoodGenericChild<Toy> : FooKit.Parent {
+// CHECK-LABEL: class GoodGenericChild<Toy>: FooKit.Parent {
 //  CHECK-NEXT:   @objc override dynamic public init()
 //  CHECK-NEXT:   @objc deinit
 //  CHECK-NEXT: }
@@ -102,7 +102,7 @@ internal class PrivateGrandchild: GoodChild {
   }
 }
 
-// CHECK-LABEL: class SubscriptChild : FooKit.SubscriptParent {
+// CHECK-LABEL: class SubscriptChild: FooKit.SubscriptParent {
 //  CHECK-NEXT:   @objc deinit
 //  CHECK-NEXT: }
 public class SubscriptChild: SubscriptParent {

--- a/test/Sema/struct_equatable_hashable_access.swift
+++ b/test/Sema/struct_equatable_hashable_access.swift
@@ -2,7 +2,7 @@
 
 // Check that synthesized members show up as 'fileprivate', not 'private.
 
-// CHECK-LABEL: private struct PrivateConformer : Hashable {
+// CHECK-LABEL: private struct PrivateConformer: Hashable {
 private struct PrivateConformer: Hashable {
   var value: Int
   // CHECK-DAG: fileprivate var hashValue: Int { get }

--- a/test/Serialization/Recovery/implementation-only-override.swift
+++ b/test/Serialization/Recovery/implementation-only-override.swift
@@ -9,7 +9,7 @@
 import FooKit
 @_implementationOnly import FooKit_SECRET
 
-// CHECK-LABEL: class GoodChild : Parent {
+// CHECK-LABEL: class GoodChild: Parent {
 //  CHECK-NEXT:   override init()
 //  CHECK-NEXT:   /* placeholder for init(SECRET:) */
 //  CHECK-NEXT:   /* placeholder for init(requiredSECRET:) */
@@ -40,7 +40,7 @@ public class GoodChild: Parent {
   }
 }
 
-// CHECK-LABEL: class GoodGenericChild<Toy> : Parent {
+// CHECK-LABEL: class GoodGenericChild<Toy>: Parent {
 //  CHECK-NEXT:   override init()
 //  CHECK-NEXT:   /* placeholder for init(SECRET:) */
 //  CHECK-NEXT:   /* placeholder for init(requiredSECRET:) */
@@ -71,7 +71,7 @@ public class GoodGenericChild<Toy>: Parent {
   }
 }
 
-// CHECK-LABEL: class QuietChild : Parent {
+// CHECK-LABEL: class QuietChild: Parent {
 //  CHECK-NEXT:   /* placeholder for init(SECRET:) */
 //  CHECK-NEXT:   /* placeholder for init(requiredSECRET:) */
 //  CHECK-NEXT:   deinit
@@ -110,7 +110,7 @@ internal class PrivateGrandchild: GoodChild {
   }
 }
 
-// CHECK-LABEL: class SubscriptChild : SubscriptParent {
+// CHECK-LABEL: class SubscriptChild: SubscriptParent {
 //  CHECK-NEXT:   @_implementationOnly override subscript(index: Int32) -> Parent?
 //  CHECK-NEXT:   deinit
 //  CHECK-NEXT: }

--- a/test/Serialization/Recovery/overrides.swift
+++ b/test/Serialization/Recovery/overrides.swift
@@ -95,7 +95,7 @@ public final class A_Sub3Final: Base {
 }
 
 
-// CHECK-LABEL: class A_Sub : Base {
+// CHECK-LABEL: class A_Sub: Base {
 // CHECK-NEXT: func disappearingMethod()
 // CHECK-NEXT: func nullabilityChangeMethod() -> Any?
 // CHECK-NEXT: func typeChangeMethod() -> Any
@@ -106,13 +106,13 @@ public final class A_Sub3Final: Base {
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-LABEL: class A_Sub2 : A_Sub {
+// CHECK-LABEL: class A_Sub2: A_Sub {
 // CHECK-NEXT: func disappearingMethod()
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-LABEL: final class A_Sub3Final : Base {
+// CHECK-LABEL: final class A_Sub3Final: Base {
 // CHECK-NEXT: func disappearingMethod()
 // CHECK-NEXT: func nullabilityChangeMethod() -> Any?
 // CHECK-NEXT: func typeChangeMethod() -> Any
@@ -123,7 +123,7 @@ public final class A_Sub3Final: Base {
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class A_Sub : Base {
+// CHECK-RECOVERY-LABEL: class A_Sub: Base {
 // CHECK-RECOVERY-NEXT: func disappearingMethod()
 // CHECK-RECOVERY-NEXT: func nullabilityChangeMethod() -> Any?
 // CHECK-RECOVERY-NEXT: func typeChangeMethod() -> Any
@@ -134,13 +134,13 @@ public final class A_Sub3Final: Base {
 // CHECK-RECOVERY-NEXT: deinit
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class A_Sub2 : A_Sub {
+// CHECK-RECOVERY-LABEL: class A_Sub2: A_Sub {
 // CHECK-RECOVERY-NEXT: func disappearingMethod()
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: deinit
 // CHECK-RECOVERY-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class A_Sub3Final : Base {
+// CHECK-RECOVERY-LABEL: class A_Sub3Final: Base {
 // CHECK-RECOVERY-NEXT: func disappearingMethod()
 // CHECK-RECOVERY-NEXT: func nullabilityChangeMethod() -> Any?
 // CHECK-RECOVERY-NEXT: func typeChangeMethod() -> Any
@@ -161,7 +161,7 @@ public class B_GenericSub : GenericBase<Base> {
   public override func typeChangeMethod() -> Any { return self }
 }
 
-// CHECK-LABEL: class B_GenericSub : GenericBase<Base> {
+// CHECK-LABEL: class B_GenericSub: GenericBase<Base> {
 // CHECK-NEXT: func disappearingMethod()
 // CHECK-NEXT: func nullabilityChangeMethod() -> Base?
 // CHECK-NEXT: func typeChangeMethod() -> Any
@@ -169,7 +169,7 @@ public class B_GenericSub : GenericBase<Base> {
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class B_GenericSub : GenericBase<Base> {
+// CHECK-RECOVERY-LABEL: class B_GenericSub: GenericBase<Base> {
 // CHECK-RECOVERY-NEXT: func disappearingMethod()
 // CHECK-RECOVERY-NEXT: func nullabilityChangeMethod() -> Base?
 // CHECK-RECOVERY-NEXT: func typeChangeMethod() -> Any
@@ -182,13 +182,13 @@ public class C1_IndexedSubscriptDisappears : IndexedSubscriptDisappearsBase {
   public override subscript(index: Int) -> Any { return self }
 }
 
-// CHECK-LABEL: class C1_IndexedSubscriptDisappears : IndexedSubscriptDisappearsBase {
+// CHECK-LABEL: class C1_IndexedSubscriptDisappears: IndexedSubscriptDisappearsBase {
 // CHECK-NEXT: subscript(index: Int) -> Any { get }
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class C1_IndexedSubscriptDisappears : IndexedSubscriptDisappearsBase {
+// CHECK-RECOVERY-LABEL: class C1_IndexedSubscriptDisappears: IndexedSubscriptDisappearsBase {
 // CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: deinit
@@ -199,13 +199,13 @@ public class C2_KeyedSubscriptDisappears : KeyedSubscriptDisappearsBase {
   public override subscript(key: Any) -> Any { return key }
 }
 
-// CHECK-LABEL: class C2_KeyedSubscriptDisappears : KeyedSubscriptDisappearsBase {
+// CHECK-LABEL: class C2_KeyedSubscriptDisappears: KeyedSubscriptDisappearsBase {
 // CHECK-NEXT: subscript(key: Any) -> Any { get }
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class C2_KeyedSubscriptDisappears : KeyedSubscriptDisappearsBase {
+// CHECK-RECOVERY-LABEL: class C2_KeyedSubscriptDisappears: KeyedSubscriptDisappearsBase {
 // CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: deinit
@@ -216,13 +216,13 @@ public class C3_GenericIndexedSubscriptDisappears : GenericIndexedSubscriptDisap
   public override subscript(index: Int) -> Base { fatalError() }
 }
 
-// CHECK-LABEL: class C3_GenericIndexedSubscriptDisappears : GenericIndexedSubscriptDisappearsBase<Base> {
+// CHECK-LABEL: class C3_GenericIndexedSubscriptDisappears: GenericIndexedSubscriptDisappearsBase<Base> {
 // CHECK-NEXT: subscript(index: Int) -> Base { get }
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class C3_GenericIndexedSubscriptDisappears : GenericIndexedSubscriptDisappearsBase<Base> {
+// CHECK-RECOVERY-LABEL: class C3_GenericIndexedSubscriptDisappears: GenericIndexedSubscriptDisappearsBase<Base> {
 // CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: deinit
@@ -233,13 +233,13 @@ public class C4_GenericKeyedSubscriptDisappears : GenericKeyedSubscriptDisappear
   public override subscript(key: Any) -> Base { fatalError() }
 }
 
-// CHECK-LABEL: class C4_GenericKeyedSubscriptDisappears : GenericKeyedSubscriptDisappearsBase<Base> {
+// CHECK-LABEL: class C4_GenericKeyedSubscriptDisappears: GenericKeyedSubscriptDisappearsBase<Base> {
 // CHECK-NEXT: subscript(key: Any) -> Base { get }
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class C4_GenericKeyedSubscriptDisappears : GenericKeyedSubscriptDisappearsBase<Base> {
+// CHECK-RECOVERY-LABEL: class C4_GenericKeyedSubscriptDisappears: GenericKeyedSubscriptDisappearsBase<Base> {
 // CHECK-RECOVERY-NEXT: /* placeholder for subscript(_:) */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: deinit
@@ -251,13 +251,13 @@ open class D1_DesignatedInitDisappears : DesignatedInitDisappearsBase {
   public override init(value: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class D1_DesignatedInitDisappears : DesignatedInitDisappearsBase {
+// CHECK-LABEL: class D1_DesignatedInitDisappears: DesignatedInitDisappearsBase {
 // CHECK-NEXT: init()
 // CHECK-NEXT: init(value: Int)
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D1_DesignatedInitDisappears : DesignatedInitDisappearsBase {
+// CHECK-RECOVERY-LABEL: class D1_DesignatedInitDisappears: DesignatedInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: deinit
@@ -268,12 +268,12 @@ open class D2_OnlyDesignatedInitDisappears : OnlyDesignatedInitDisappearsBase {
   public override init(value: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class D2_OnlyDesignatedInitDisappears : OnlyDesignatedInitDisappearsBase {
+// CHECK-LABEL: class D2_OnlyDesignatedInitDisappears: OnlyDesignatedInitDisappearsBase {
 // CHECK-NEXT: init(value: Int)
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D2_OnlyDesignatedInitDisappears : OnlyDesignatedInitDisappearsBase {
+// CHECK-RECOVERY-LABEL: class D2_OnlyDesignatedInitDisappears: OnlyDesignatedInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: deinit
 // CHECK-RECOVERY-NEXT: {{^}$}}
@@ -283,12 +283,12 @@ open class D3_ConvenienceInitDisappears : ConvenienceInitDisappearsBase {
   public override init() { fatalError() }
 }
 
-// CHECK-LABEL: class D3_ConvenienceInitDisappears : ConvenienceInitDisappearsBase {
+// CHECK-LABEL: class D3_ConvenienceInitDisappears: ConvenienceInitDisappearsBase {
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D3_ConvenienceInitDisappears : ConvenienceInitDisappearsBase {
+// CHECK-RECOVERY-LABEL: class D3_ConvenienceInitDisappears: ConvenienceInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: deinit
 // CHECK-RECOVERY-NEXT: {{^}$}}
@@ -299,13 +299,13 @@ open class D4_UnknownInitDisappears : UnknownInitDisappearsBase {
   public override init(value: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class D4_UnknownInitDisappears : UnknownInitDisappearsBase {
+// CHECK-LABEL: class D4_UnknownInitDisappears: UnknownInitDisappearsBase {
 // CHECK-NEXT: init()
 // CHECK-NEXT: init(value: Int)
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D4_UnknownInitDisappears : UnknownInitDisappearsBase {
+// CHECK-RECOVERY-LABEL: class D4_UnknownInitDisappears: UnknownInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: deinit
@@ -316,13 +316,13 @@ open class D5_OnlyUnknownInitDisappears : OnlyUnknownInitDisappearsBase {
   public override init(value: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class D5_OnlyUnknownInitDisappears : OnlyUnknownInitDisappearsBase {
+// CHECK-LABEL: class D5_OnlyUnknownInitDisappears: OnlyUnknownInitDisappearsBase {
 // CHECK-NEXT: init(value: Int)
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D5_OnlyUnknownInitDisappears : OnlyUnknownInitDisappearsBase {
+// CHECK-RECOVERY-LABEL: class D5_OnlyUnknownInitDisappears: OnlyUnknownInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: deinit
@@ -333,13 +333,13 @@ open class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
   public override init(value: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
+// CHECK-LABEL: class D6_UnknownInitDisappearsGrandchild: D4_UnknownInitDisappears {
 // CHECK-NEXT: init()
 // CHECK-NEXT: init(value: Int)
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D6_UnknownInitDisappearsGrandchild : D4_UnknownInitDisappears {
+// CHECK-RECOVERY-LABEL: class D6_UnknownInitDisappearsGrandchild: D4_UnknownInitDisappears {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: deinit
@@ -350,13 +350,13 @@ open class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears
   public required override init(value: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears {
+// CHECK-LABEL: class D7_UnknownInitDisappearsGrandchildRequired: D4_UnknownInitDisappears {
 // CHECK-NEXT: init()
 // CHECK-NEXT: init(value: Int)
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D7_UnknownInitDisappearsGrandchildRequired : D4_UnknownInitDisappears {
+// CHECK-RECOVERY-LABEL: class D7_UnknownInitDisappearsGrandchildRequired: D4_UnknownInitDisappears {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: deinit
@@ -367,13 +367,13 @@ open class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
   public required override init(value: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
+// CHECK-LABEL: class D8_UnknownInitDisappearsRequired: UnknownInitDisappearsBase {
 // CHECK-NEXT: init()
 // CHECK-NEXT: init(value: Int)
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D8_UnknownInitDisappearsRequired : UnknownInitDisappearsBase {
+// CHECK-RECOVERY-LABEL: class D8_UnknownInitDisappearsRequired: UnknownInitDisappearsBase {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: deinit
@@ -384,13 +384,13 @@ open class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappears
   public required init(value: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {
+// CHECK-LABEL: class D9_UnknownInitDisappearsRequiredGrandchild: D8_UnknownInitDisappearsRequired {
 // CHECK-NEXT: init()
 // CHECK-NEXT: init(value: Int)
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class D9_UnknownInitDisappearsRequiredGrandchild : D8_UnknownInitDisappearsRequired {
+// CHECK-RECOVERY-LABEL: class D9_UnknownInitDisappearsRequiredGrandchild: D8_UnknownInitDisappearsRequired {
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: /* placeholder for init(value:) */
 // CHECK-RECOVERY-NEXT: deinit
@@ -400,13 +400,13 @@ public class E1_MethodWithDisappearingType : MethodWithDisappearingType {
   public override func boxItUp() -> BoxedInt { fatalError() }
 }
 
-// CHECK-LABEL: class E1_MethodWithDisappearingType : MethodWithDisappearingType {
+// CHECK-LABEL: class E1_MethodWithDisappearingType: MethodWithDisappearingType {
 // CHECK-NEXT: override func boxItUp() -> BoxedInt
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class E1_MethodWithDisappearingType : MethodWithDisappearingType {
+// CHECK-RECOVERY-LABEL: class E1_MethodWithDisappearingType: MethodWithDisappearingType {
 // CHECK-RECOVERY-NEXT: /* placeholder for boxItUp() */
 // CHECK-RECOVERY-NEXT: init()
 // CHECK-RECOVERY-NEXT: deinit
@@ -416,14 +416,14 @@ public class E2_InitializerStub : InitializerWithDisappearingType {
   public init(unrelatedValue: Int) { fatalError() }
 }
 
-// CHECK-LABEL: class E2_InitializerStub : InitializerWithDisappearingType {
+// CHECK-LABEL: class E2_InitializerStub: InitializerWithDisappearingType {
 // CHECK-NEXT: init(unrelatedValue: Int)
 // CHECK-NEXT: init(boxedInt box: BoxedInt)
 // CHECK-NEXT: init()
 // CHECK-NEXT: deinit
 // CHECK-NEXT: {{^}$}}
 
-// CHECK-RECOVERY-LABEL: class E2_InitializerStub : InitializerWithDisappearingType {
+// CHECK-RECOVERY-LABEL: class E2_InitializerStub: InitializerWithDisappearingType {
 // CHECK-RECOVERY-NEXT: init(unrelatedValue: Int)
 // CHECK-RECOVERY-NEXT: /* placeholder for init(boxedInt:) */
 // CHECK-RECOVERY-NEXT: init()

--- a/test/Serialization/Recovery/private-conformances.swift
+++ b/test/Serialization/Recovery/private-conformances.swift
@@ -33,31 +33,31 @@ import protocol_lib
 
 public protocol PublicProtocol {}
 
-// CHECK: class C1 : PublicProtocol {
+// CHECK: class C1: PublicProtocol {
 public class C1 : PrivateProtocol, PublicProtocol {}
 
 // CHECK: class C2 {
 public class C2 {}
 
-// CHECK: extension C2 : PublicProtocol {
+// CHECK: extension C2: PublicProtocol {
 extension C2 : PrivateProtocol, PublicProtocol {}
 
-// CHECK: enum E1 : PublicProtocol {
+// CHECK: enum E1: PublicProtocol {
 public enum E1 : PrivateProtocol, PublicProtocol {}
 
 // CHECK: enum E2 {
 public enum E2 {}
 
-// CHECK: extension E2 : PublicProtocol {
+// CHECK: extension E2: PublicProtocol {
 extension E2 : PrivateProtocol, PublicProtocol {}
 
-// CHECK: struct S1 : PublicProtocol {
+// CHECK: struct S1: PublicProtocol {
 public struct S1 : PrivateProtocol, PublicProtocol {}
 
 // CHECK: struct S2 {
 public struct S2 {}
 
-// CHECK: extension S2 : PublicProtocol {
+// CHECK: extension S2: PublicProtocol {
 extension S2 : PrivateProtocol, PublicProtocol {}
 
 #elseif INHERITS_LIB

--- a/test/Serialization/Recovery/superclass.swift
+++ b/test/Serialization/Recovery/superclass.swift
@@ -23,31 +23,31 @@ func use(_: A2_Grandchild) {} // expected-error {{cannot find type 'A2_Grandchil
 
 import SuperclassObjC
 
-// CHECK-LABEL: class A1_Sub : DisappearingSuperclass {
+// CHECK-LABEL: class A1_Sub: DisappearingSuperclass {
 // CHECK-RECOVERY-NOT: class A1_Sub
 public class A1_Sub: DisappearingSuperclass {}
-// CHECK-LABEL: class A2_Grandchild : A1_Sub {
+// CHECK-LABEL: class A2_Grandchild: A1_Sub {
 // CHECK-RECOVERY-NOT: class A2_Grandchild
 public class A2_Grandchild: A1_Sub {}
 
-// CHECK-LABEL: class B1_ConstrainedGeneric<T> where T : DisappearingSuperclass {
+// CHECK-LABEL: class B1_ConstrainedGeneric<T> where T: DisappearingSuperclass {
 // CHECK-RECOVERY-NOT: class B1_ConstrainedGeneric
 public class B1_ConstrainedGeneric<T> where T: DisappearingSuperclass {}
 
-// CHECK-LABEL: struct B2_ConstrainedGeneric<T> where T : DisappearingSuperclass {
+// CHECK-LABEL: struct B2_ConstrainedGeneric<T> where T: DisappearingSuperclass {
 // CHECK-RECOVERY-NOT: struct B2_ConstrainedGeneric
 public struct B2_ConstrainedGeneric<T> where T: DisappearingSuperclass {}
 
 // CHECK-ALWAYS-LABEL: class C1_GenericBase<T> {
 public class C1_GenericBase<T> {}
 
-// CHECK-ALWAYS-LABEL: class C2_CRTPish : C1_GenericBase<C2_CRTPish> {
+// CHECK-ALWAYS-LABEL: class C2_CRTPish: C1_GenericBase<C2_CRTPish> {
 public class C2_CRTPish: C1_GenericBase<C2_CRTPish> {}
-// CHECK-ALWAYS-LABEL: class C3_NestingCRTPish : C1_GenericBase<C3_NestingCRTPish.Nested> {
+// CHECK-ALWAYS-LABEL: class C3_NestingCRTPish: C1_GenericBase<C3_NestingCRTPish.Nested> {
 public class C3_NestingCRTPish: C1_GenericBase<C3_NestingCRTPish.Nested> {
   public struct Nested {}
 }
-// CHECK-ALWAYS-LABEL: class C4_ExtensionNestingCRTPish : C1_GenericBase<C4_ExtensionNestingCRTPish.Nested> {
+// CHECK-ALWAYS-LABEL: class C4_ExtensionNestingCRTPish: C1_GenericBase<C4_ExtensionNestingCRTPish.Nested> {
 public class C4_ExtensionNestingCRTPish: C1_GenericBase<C4_ExtensionNestingCRTPish.Nested> {}
 extension C4_ExtensionNestingCRTPish {
   public struct Nested {}

--- a/test/Serialization/Recovery/typedefs-in-protocols.swift
+++ b/test/Serialization/Recovery/typedefs-in-protocols.swift
@@ -89,8 +89,8 @@ public protocol Proto {
 // CHECK: {{^}$}}
 // CHECK-RECOVERY: {{^}$}}
 
-// CHECK-LABEL: struct ProtoLibImpl : Proto {
-// CHECK-RECOVERY-LABEL: struct ProtoLibImpl : Proto {
+// CHECK-LABEL: struct ProtoLibImpl: Proto {
+// CHECK-RECOVERY-LABEL: struct ProtoLibImpl: Proto {
 public struct ProtoLibImpl : Proto {
   public var unwrappedProp: UnwrappedInt?
   public var wrappedProp: WrappedInt?

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -127,10 +127,10 @@ open class User {
   // CHECK-RECOVERY: /* placeholder for returnsWrappedMethod() (vtable entries: 1) */
   public func returnsWrappedMethod() -> WrappedInt { fatalError() }
 
-  // CHECK: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == Int32
-  // CHECK-RECOVERY: func constrainedUnwrapped<T>(_: T) where T : HasAssoc, T.Assoc == Int32
+  // CHECK: func constrainedUnwrapped<T>(_: T) where T: HasAssoc, T.Assoc == Int32
+  // CHECK-RECOVERY: func constrainedUnwrapped<T>(_: T) where T: HasAssoc, T.Assoc == Int32
   public func constrainedUnwrapped<T: HasAssoc>(_: T) where T.Assoc == UnwrappedInt { fatalError() }
-  // CHECK: func constrainedWrapped<T>(_: T) where T : HasAssoc, T.Assoc == WrappedInt
+  // CHECK: func constrainedWrapped<T>(_: T) where T: HasAssoc, T.Assoc == WrappedInt
   // CHECK-RECOVERY: /* placeholder for constrainedWrapped(_:) (vtable entries: 1) */
   public func constrainedWrapped<T: HasAssoc>(_: T) where T.Assoc == WrappedInt { fatalError() }
 
@@ -138,7 +138,7 @@ open class User {
   // CHECK-RECOVERY: /* placeholder for subscript(_:) (vtable entries: 1) */
   public subscript(_: WrappedInt) -> () { return () }
 
-  // CHECK: subscript<T>(_: T) -> () where T : HasAssoc, T.Assoc == WrappedInt { get }
+  // CHECK: subscript<T>(_: T) -> () where T: HasAssoc, T.Assoc == WrappedInt { get }
   // CHECK-RECOVERY: /* placeholder for subscript(_:) (vtable entries: 1) */
   public subscript<T: HasAssoc>(_: T) -> () where T.Assoc == WrappedInt { return () }
 
@@ -154,7 +154,7 @@ open class User {
   // CHECK-RECOVERY: convenience init(conveniently: Int)
   public convenience init(conveniently: Int) { self.init() }
 
-  // CHECK: convenience init<T>(generic: T) where T : HasAssoc, T.Assoc == WrappedInt
+  // CHECK: convenience init<T>(generic: T) where T: HasAssoc, T.Assoc == WrappedInt
   // CHECK-RECOVERY: /* placeholder for init(generic:) */
   public convenience init<T: HasAssoc>(generic: T) where T.Assoc == WrappedInt { self.init() }
 
@@ -324,7 +324,7 @@ public let wrappedIUO: WrappedInt! = nil
 // CHECK-DAG: let wrappedArray: [WrappedInt]
 // CHECK-RECOVERY-NEGATIVE-NOT: let wrappedArray:
 public let wrappedArray: [WrappedInt] = []
-// CHECK-DAG: let wrappedDictionary: [Int : WrappedInt]
+// CHECK-DAG: let wrappedDictionary: [Int: WrappedInt]
 // CHECK-RECOVERY-NEGATIVE-NOT: let wrappedDictionary:
 public let wrappedDictionary: [Int: WrappedInt] = [:]
 // CHECK-DAG: let wrappedTuple: (WrappedInt, Int)?
@@ -387,11 +387,11 @@ public typealias UnwrappedAlias = UnwrappedInt
 public typealias ConstrainedWrapped<T: HasAssoc> = T where T.Assoc == WrappedInt
 public typealias ConstrainedUnwrapped<T: HasAssoc> = T where T.Assoc == UnwrappedInt
 
-// CHECK-LABEL: extension Int32 : UnwrappedProto {
+// CHECK-LABEL: extension Int32: UnwrappedProto {
 // CHECK-NEXT: func unwrappedMethod()
 // CHECK-NEXT: prefix static func *** (x: UnwrappedInt)
 // CHECK-NEXT: }
-// CHECK-RECOVERY-LABEL: extension Int32 : UnwrappedProto {
+// CHECK-RECOVERY-LABEL: extension Int32: UnwrappedProto {
 // CHECK-RECOVERY-NEXT: func unwrappedMethod()
 // CHECK-RECOVERY-NEXT: prefix static func *** (x: Int32)
 // CHECK-RECOVERY-NEXT: }
@@ -401,7 +401,7 @@ extension UnwrappedInt: UnwrappedProto {
   public static prefix func ***(x: UnwrappedInt) {}
 }
 
-// CHECK-LABEL: extension WrappedInt : WrappedProto {
+// CHECK-LABEL: extension WrappedInt: WrappedProto {
 // CHECK-NEXT: func wrappedMethod()
 // CHECK-NEXT: prefix static func *** (x: WrappedInt)
 // CHECK-NEXT: }

--- a/test/Serialization/Recovery/types-4-to-5.swift
+++ b/test/Serialization/Recovery/types-4-to-5.swift
@@ -61,23 +61,23 @@ public func A_renameAllTheThings(
 public func A_renameGeneric<T: Swift4RenamedProtocol>(obj: T) {}
 
 // CHECK-5-LABEL: func A_renameGeneric<T>(
-// CHECK-5-SAME: where T : RenamedProtocol
+// CHECK-5-SAME: where T: RenamedProtocol
 
 // FIXME: Preserve sugar in requirements.
 // CHECK-4-LABEL: func A_renameGeneric<T>(
-// CHECK-4-SAME: where T : RenamedProtocol
+// CHECK-4-SAME: where T: RenamedProtocol
 
 public class B_ConformsToProto: Swift4RenamedProtocol {}
 
-// CHECK-5-LABEL: class B_ConformsToProto : RenamedProtocol
-// CHECK-4-LABEL: class B_ConformsToProto : Swift4RenamedProtocol
+// CHECK-5-LABEL: class B_ConformsToProto: RenamedProtocol
+// CHECK-4-LABEL: class B_ConformsToProto: Swift4RenamedProtocol
 
 public struct B_RequiresConformance<T: Swift4RenamedProtocol> {}
 
-// CHECK-5-LABEL: struct B_RequiresConformance<T> where T : RenamedProtocol
+// CHECK-5-LABEL: struct B_RequiresConformance<T> where T: RenamedProtocol
 
 // FIXME: Preserve sugar in requirements.
-// CHECK-4-LABEL: struct B_RequiresConformance<T> where T : RenamedProtocol
+// CHECK-4-LABEL: struct B_RequiresConformance<T> where T: RenamedProtocol
 
 public protocol C_RelyOnConformance {
   associatedtype Assoc: Swift4RenamedProtocol

--- a/test/Serialization/Recovery/types-5-to-4.swift
+++ b/test/Serialization/Recovery/types-5-to-4.swift
@@ -50,13 +50,13 @@ public func A_renameAllTheThings(
 public func A_renameGeneric<T: RenamedProtocol>(obj: T) {}
 
 // CHECK-LABEL: func A_renameGeneric<T>(
-// CHECK-SAME: where T : RenamedProtocol
+// CHECK-SAME: where T: RenamedProtocol
 
 public class B_ConformsToProto: RenamedProtocol {}
-// CHECK-LABEL: class B_ConformsToProto : RenamedProtocol
+// CHECK-LABEL: class B_ConformsToProto: RenamedProtocol
 
 public struct B_RequiresConformance<T: RenamedProtocol> {}
-// CHECK-LABEL: struct B_RequiresConformance<T> where T : RenamedProtocol
+// CHECK-LABEL: struct B_RequiresConformance<T> where T: RenamedProtocol
 
 public protocol C_RelyOnConformance {
   associatedtype Assoc: RenamedProtocol

--- a/test/Serialization/Safety/indirect-conformance.swift
+++ b/test/Serialization/Safety/indirect-conformance.swift
@@ -23,10 +23,10 @@ public class IndirectConformant {
 }
 
 extension IndirectConformant: InternalProtocol {}
-// CHECK: extension Lib.IndirectConformant : Lib.PublicProtocol {}
+// CHECK: extension Lib.IndirectConformant: Lib.PublicProtocol {}
 
 extension String: InternalProtocol {}
-// CHECK: extension Swift.String : Lib.PublicProtocol {}
+// CHECK: extension Swift.String: Lib.PublicProtocol {}
 
 //--- Client.swift
 

--- a/test/Serialization/noncopyable_generics.swift
+++ b/test/Serialization/noncopyable_generics.swift
@@ -19,12 +19,12 @@
 // CHECK-NOT: UnknownCode
 
 // CHECK-PRINT-DAG: protocol Generator<Value> {
-// CHECK-PRINT-DAG: enum Maybe<Wrapped> : ~Copyable where Wrapped : ~Copyable {
-// CHECK-PRINT-DAG: extension Maybe : Copyable where Wrapped : Copyable {
-// CHECK-PRINT-DAG: func ncIdentity<T>(_ t: consuming T) -> T where T : ~Copyable
-// CHECK-PRINT-DAG: protocol Either<Left, Right> : ~Copyable {
-// CHECK-PRINT-DAG:   associatedtype Left : ~Copyable
-// CHECK-PRINT-DAG:   associatedtype Right : ~Copyable
+// CHECK-PRINT-DAG: enum Maybe<Wrapped> : ~Copyable where Wrapped: ~Copyable {
+// CHECK-PRINT-DAG: extension Maybe : Copyable where Wrapped: Copyable {
+// CHECK-PRINT-DAG: func ncIdentity<T>(_ t: consuming T) -> T where T: ~Copyable
+// CHECK-PRINT-DAG: protocol Either<Left, Right>: ~Copyable {
+// CHECK-PRINT-DAG:   associatedtype Left: ~Copyable
+// CHECK-PRINT-DAG:   associatedtype Right: ~Copyable
 
 import ncgenerics
 

--- a/test/SourceKit/DocSupport/doc_error_domain.swift
+++ b/test/SourceKit/DocSupport/doc_error_domain.swift
@@ -3,8 +3,8 @@
 // RUN:         -sdk %sdk | %sed_clean > %t.response
 // RUN: %FileCheck -input-file=%t.response %s
 
-// CHECK: struct MyError : CustomNSError, Hashable, Error {
-// CHECK:     enum Code : Int32, @unchecked Sendable, Equatable {
+// CHECK: struct MyError: CustomNSError, Hashable, Error {
+// CHECK:     enum Code: Int32, @unchecked Sendable, Equatable {
 // CHECK:         case errFirst
 // CHECK:         case errSecond
 // CHECK:     }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -3,7 +3,7 @@ import FooHelper
 import SwiftOnoneSupport
 
 /// Aaa.  FooEnum1.  Bbb.
-public struct FooEnum1 : Hashable, Equatable, RawRepresentable {
+public struct FooEnum1: Hashable, Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
 
@@ -15,7 +15,7 @@ public struct FooEnum1 : Hashable, Equatable, RawRepresentable {
 /// Aaa.  FooEnum1X.  Bbb.
 public var FooEnum1X: FooEnum1 { get }
 
-public struct FooEnum2 : Hashable, Equatable, RawRepresentable {
+public struct FooEnum2: Hashable, Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
 
@@ -28,7 +28,7 @@ public var FooEnum2X: FooEnum2 { get }
 
 public var FooEnum2Y: FooEnum2 { get }
 
-public struct FooEnum3 : Hashable, Equatable, RawRepresentable {
+public struct FooEnum3: Hashable, Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
 
@@ -42,7 +42,7 @@ public var FooEnum3X: FooEnum3 { get }
 public var FooEnum3Y: FooEnum3 { get }
 
 /// Aaa.  FooComparisonResult.  Bbb.
-public enum FooComparisonResult : Int {
+public enum FooComparisonResult: Int {
 
     case orderedAscending = -1
 
@@ -52,7 +52,7 @@ public enum FooComparisonResult : Int {
 }
 
 /// Aaa.  FooRuncingOptions.  Bbb.
-public struct FooRuncingOptions : OptionSet {
+public struct FooRuncingOptions: OptionSet {
 
     public init(rawValue: Int)
 
@@ -181,7 +181,7 @@ public protocol FooProtocolBase {
     var fooProperty3: Int32 { get }
 }
 
-public protocol FooProtocolDerived : FooProtocolBase {
+public protocol FooProtocolDerived: FooProtocolBase {
 }
 
 open class FooClassBase {
@@ -200,7 +200,7 @@ open class FooClassBase {
 }
 
 /// Aaa.  FooClassDerived.  Bbb.
-open class FooClassDerived : FooClassBase, FooProtocolDerived {
+open class FooClassDerived: FooClassBase, FooProtocolDerived {
 
     open var fooProperty1: Int32
 
@@ -288,10 +288,10 @@ extension FooClassBase {
 public protocol _InternalProt {
 }
 
-open class ClassWithInternalProt : _InternalProt {
+open class ClassWithInternalProt: _InternalProt {
 }
 
-open class FooClassPropertyOwnership : FooClassBase {
+open class FooClassPropertyOwnership: FooClassBase {
 
     unowned(unsafe) open var assignable: AnyObject!
 
@@ -308,7 +308,7 @@ open class FooClassPropertyOwnership : FooClassBase {
     open var scalar: Int32
 }
 
-open class FooUnavailableMembers : FooClassBase {
+open class FooUnavailableMembers: FooClassBase {
 
     public convenience init!(int i: Int32)
 
@@ -326,7 +326,7 @@ public class FooCFType {
 }
 
 @available(*, deprecated, message: "use CNAuthorizationStatus")
-public enum ABAuthorizationStatus : Int {
+public enum ABAuthorizationStatus: Int {
 
     case notDetermined = 0
 
@@ -338,7 +338,7 @@ public class FooOverlayClassBase {
     public func f()
 }
 
-public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
+public class FooOverlayClassDerived: Foo.FooOverlayClassBase {
 
     override public func f()
 }

--- a/test/SourceKit/InterfaceGen/gen_stdlib.swift
+++ b/test/SourceKit/InterfaceGen/gen_stdlib.swift
@@ -8,7 +8,7 @@ var x: Int
 
 // Just check a small part, mainly to make sure we can print the interface of the stdlib.
 // CHECK-STDLIB-NOT: extension _SwiftNSOperatingSystemVersion
-// CHECK-STDLIB-LABEL: struct Int : FixedWidthInteger, SignedInteger {
+// CHECK-STDLIB-LABEL: struct Int: FixedWidthInteger, SignedInteger {
 // CHECK-STDLIB-DAG:   static var bitWidth: Int { get }
 // CHECK-STDLIB-DAG:   var nonzeroBitCount: Int { get }
 // CHECK-STDLIB: }
@@ -39,7 +39,7 @@ var x: Int
 // CHECK1-NEXT: <Group>Math/Integers</Group>
 // CHECK1-NEXT: {{[A-Za-z]:\\|/}}<interface-gen>{{$}}
 // CHECK1-NEXT: SYSTEM
-// CHECK1-NEXT: <Declaration>@frozen struct Int : <Type usr="s:s17FixedWidthIntegerP">FixedWidthInteger</Type>{{.*}}<Type usr="s:SZ">SignedInteger</Type>{{.*}}</Declaration>
+// CHECK1-NEXT: <Declaration>@frozen struct Int: <Type usr="s:s17FixedWidthIntegerP">FixedWidthInteger</Type>{{.*}}<Type usr="s:SZ">SignedInteger</Type>{{.*}}</Declaration>
 
 // RUN: %sourcekitd-test -req=module-groups -module Swift | %FileCheck -check-prefix=GROUP1 %s
 // GROUP1: <GROUPS>
@@ -48,7 +48,7 @@ var x: Int
 
 // RUN: %sourcekitd-test -req=interface-gen -module Swift -group-name Bool > %t.Bool.response
 // RUN: %FileCheck -check-prefix=CHECK-BOOL -input-file %t.Bool.response %s
-// CHECK-BOOL-DAG: extension Bool : ExpressibleByBooleanLiteral {
+// CHECK-BOOL-DAG: extension Bool: ExpressibleByBooleanLiteral {
 
 // These are not in the bool group:
 // CHECK-BOOL-NOT: Zip2Iterator

--- a/test/SourceKit/Misc/load-module-with-errors.swift
+++ b/test/SourceKit/Misc/load-module-with-errors.swift
@@ -72,16 +72,16 @@ func testInvalidTopLevelCompletion() {
 // Read the module back in to make sure it can be deserialized
 // RUN: %target-swift-ide-test -print-module -source-filename dummy -module-to-print errors -I %t -allow-compiler-errors | %FileCheck %s
 // CHECK: typealias InvalidAlias = <<error type>>
-// CHECK: class InvalidClass : <<error type>>, InvalidProtocol
+// CHECK: class InvalidClass: <<error type>>, InvalidProtocol
 // CHECK: var classMemberA: <<error type>>
 // CHECK: init(param1: <<error type>>, param2: <<error type>>)
 // CHECK: convenience init()
 // CHECK: convenience init(param: <<error type>>)
-// CHECK: class InvalidClassSub1 : InvalidClass
+// CHECK: class InvalidClassSub1: InvalidClass
 // CHECK: var classMemberB: <<error type>>
 // CHECK: init(param1: <<error type>>, param2: <<error type>>)
 // CHECK: convenience init()
-// CHECK: class InvalidClassSub2 : InvalidClass
+// CHECK: class InvalidClassSub2: InvalidClass
 // CHECK: var classMemberC: <<error type>>
 // CHECK: convenience init()
 // CHECK: enum InvalidEnum
@@ -95,7 +95,7 @@ func testInvalidTopLevelCompletion() {
 // CHECK: mutating func add(_: <<error type>>)
 // CHECK: func get() -> Self.Item
 // CHECK: func set(item: Self.Item)
-// CHECK: struct InvalidStruct : <<error type>>, InvalidProtocol
+// CHECK: struct InvalidStruct: <<error type>>, InvalidProtocol
 // CHECK: typealias Item = <<error type>>
 // CHECK: let memberA: Int
 // CHECK: let memberB: <<error type>>

--- a/test/Unsafe/module-interface.swift
+++ b/test/Unsafe/module-interface.swift
@@ -34,11 +34,11 @@ public protocol P {
 }
 
 // CHECK:  #if compiler(>=5.3) && $MemorySafetyAttributes
-// CHECK: public struct X : @unsafe UserModule.P
+// CHECK: public struct X: @unsafe UserModule.P
 public struct X: @unsafe P {
 // CHECK:  @unsafe public func f()
 // CHECK:  #else
-// CHECK: public struct X : UserModule.P
+// CHECK: public struct X: UserModule.P
 // CHECK:  public func f()
 // CHECK:  #endif
   @unsafe public func f() { }

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -333,7 +333,7 @@ fileprivate protocol IB_FilePrivateAssocTypeProto {
   associatedtype FilePrivateValue
   var filePrivateValue: FilePrivateValue { get }
 }
-// CHECK-LABEL: public{{(\*/)?}} class IC_PublicAssocTypeImpl : IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
+// CHECK-LABEL: public{{(\*/)?}} class IC_PublicAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
 public class IC_PublicAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
   public var publicValue: Int = 0
   public var filePrivateValue: Int = 0
@@ -341,7 +341,7 @@ public class IC_PublicAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAsso
   // CHECK-DAG: {{^}} public typealias PublicValue
 } // CHECK: {{^[}]}}
 
-// CHECK-LABEL: private{{(\*/)?}} class ID_PrivateAssocTypeImpl : IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
+// CHECK-LABEL: private{{(\*/)?}} class ID_PrivateAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
 private class ID_PrivateAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
   public var publicValue: Int = 0
   public var filePrivateValue: Int = 0
@@ -363,13 +363,13 @@ public class PublicInitBase {
   fileprivate init(other: PublicInitBase) {}
 } // CHECK: {{^[}]}}
 
-// CHECK-LABEL: public{{(\*/)?}} class PublicInitInheritor : PublicInitBase {
+// CHECK-LABEL: public{{(\*/)?}} class PublicInitInheritor: PublicInitBase {
 public class PublicInitInheritor : PublicInitBase {
   // CHECK: {{^}} override public init()
   // CHECK: {{^}} override fileprivate init(other: PublicInitBase)
 } // CHECK: {{^[}]}}
 
-// CHECK-LABEL: {{(/\*)?private(\*/)?}} class PublicInitPrivateInheritor : PublicInitBase {
+// CHECK-LABEL: {{(/\*)?private(\*/)?}} class PublicInitPrivateInheritor: PublicInitBase {
 private class PublicInitPrivateInheritor : PublicInitBase {
   // CHECK: {{^}} override internal init()
   // CHECK: {{^}} override fileprivate init(other: PublicInitBase)

--- a/test/attr/accessibility_print_inferred_type_witnesses.swift
+++ b/test/attr/accessibility_print_inferred_type_witnesses.swift
@@ -23,7 +23,7 @@ fileprivate protocol FilePrivateAssocTypeProto {
   var filePrivateValue: FilePrivateValue { get }
 }
 
-// CHECK-LABEL: private{{(\*/)?}} class PrivateImpl : PublicAssocTypeProto, FilePrivateAssocTypeProto {
+// CHECK-LABEL: private{{(\*/)?}} class PrivateImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
 private class PrivateImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
   fileprivate var publicValue: InternalStruct?
   fileprivate var filePrivateValue: Int?
@@ -31,7 +31,7 @@ private class PrivateImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
   // CHECK-DAG: {{^}} fileprivate typealias PublicValue
 } // CHECK: {{^[}]}}
 
-// CHECK-LABEL: public{{(\*/)?}} class PublicImpl : PublicAssocTypeProto, FilePrivateAssocTypeProto {
+// CHECK-LABEL: public{{(\*/)?}} class PublicImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
 public class PublicImpl: PublicAssocTypeProto, FilePrivateAssocTypeProto {
   public var publicValue: Int?
   fileprivate var filePrivateValue: InternalStruct?

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1667,7 +1667,7 @@ class infer_instanceVar2<
     GP_Class_ObjC : Class_ObjC1,
     GP_Protocol_Class : Protocol_Class1,
     GP_Protocol_ObjC : Protocol_ObjC1> : ObjCBase {
-// CHECK-LABEL: class infer_instanceVar2<{{.*}}> : ObjCBase where {{.*}} {
+// CHECK-LABEL: class infer_instanceVar2<{{.*}}>: ObjCBase where {{.*}} {
   override init() {}
 
   var var_GP_Unconstrained: GP_Unconstrained
@@ -1738,7 +1738,7 @@ class infer_instanceVar2<
 }
 
 class infer_instanceVar3 : Class_ObjC1 {
-// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_instanceVar3 : Class_ObjC1 {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_instanceVar3: Class_ObjC1 {
 
   var v1: Int = 0
 // CHECK-LABEL: {{^}}  @_hasInitialValue var v1: Int
@@ -1803,19 +1803,19 @@ protocol infer_throughConformanceProto1 {
 }
 
 class infer_class1 : PlainClass {}
-// CHECK-LABEL: {{^}}@_inheritsConvenienceInitializers class infer_class1 : PlainClass {
+// CHECK-LABEL: {{^}}@_inheritsConvenienceInitializers class infer_class1: PlainClass {
 
 class infer_class2 : Class_ObjC1 {}
-// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_class2 : Class_ObjC1 {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_class2: Class_ObjC1 {
 
 class infer_class3 : infer_class2 {}
-// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_class3 : infer_class2 {
+// CHECK-LABEL: @objc @_inheritsConvenienceInitializers class infer_class3: infer_class2 {
 
 class infer_class4 : Protocol_Class1 {}
-// CHECK-LABEL: {{^}}class infer_class4 : Protocol_Class1 {
+// CHECK-LABEL: {{^}}class infer_class4: Protocol_Class1 {
 
 class infer_class5 : Protocol_ObjC1 {}
-// CHECK-LABEL: {{^}}class infer_class5 : Protocol_ObjC1 {
+// CHECK-LABEL: {{^}}class infer_class5: Protocol_ObjC1 {
 
 //
 // If a protocol conforms to an @objc protocol, this does not infer @objc on
@@ -1832,25 +1832,25 @@ protocol infer_protocol1 {
 }
 
 protocol infer_protocol2 : Protocol_Class1 {
-// CHECK-LABEL: {{^}}protocol infer_protocol2 : Protocol_Class1 {
+// CHECK-LABEL: {{^}}protocol infer_protocol2: Protocol_Class1 {
   func nonObjC1()
   // CHECK: {{^}} func nonObjC1()
 }
 
 protocol infer_protocol3 : Protocol_ObjC1 {
-// CHECK-LABEL: {{^}}protocol infer_protocol3 : Protocol_ObjC1 {
+// CHECK-LABEL: {{^}}protocol infer_protocol3: Protocol_ObjC1 {
   func nonObjC1()
   // CHECK: {{^}} func nonObjC1()
 }
 
 protocol infer_protocol4 : Protocol_Class1, Protocol_ObjC1 {
-// CHECK-LABEL: {{^}}protocol infer_protocol4 : Protocol_Class1, Protocol_ObjC1 {
+// CHECK-LABEL: {{^}}protocol infer_protocol4: Protocol_Class1, Protocol_ObjC1 {
   func nonObjC1()
   // CHECK: {{^}} func nonObjC1()
 }
 
 protocol infer_protocol5 : Protocol_ObjC1, Protocol_Class1 {
-// CHECK-LABEL: {{^}}protocol infer_protocol5 : Protocol_Class1, Protocol_ObjC1 {
+// CHECK-LABEL: {{^}}protocol infer_protocol5: Protocol_Class1, Protocol_ObjC1 {
   func nonObjC1()
   // CHECK: {{^}} func nonObjC1()
 }

--- a/test/attr/attr_objc_foreign.swift
+++ b/test/attr/attr_objc_foreign.swift
@@ -24,7 +24,7 @@ extension CGColor {
   func foo() // expected-note{{satisfying requirement for instance method 'foo()' in protocol 'Foo'}}
 }
 
-// CHECK-LABEL: extension CGColor : Foo
+// CHECK-LABEL: extension CGColor: Foo
 extension CGColor: Foo { // expected-error{{Core Foundation class 'CGColor' cannot conform to '@objc' protocol 'Foo' because Core Foundation types are not classes in Objective-C}}
   // CHECK-LABEL: {{^}} func foo()
   func foo() {} // expected-error{{method cannot be an implementation of an '@objc' requirement because Core Foundation types are not classes in Objective-C}}

--- a/test/decl/enum/derived_hashable_equatable.swift
+++ b/test/decl/enum/derived_hashable_equatable.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -print-ast %s | %FileCheck %s
 
-// CHECK-LABEL: internal enum Simple : Hashable
+// CHECK-LABEL: internal enum Simple: Hashable
 enum Simple: Hashable {
   // CHECK:        case a
   case a
@@ -43,7 +43,7 @@ enum Simple: Hashable {
   // CHECK-NEXT:   }
 }
 
-// CHECK-LABEL: internal enum HasAssociatedValues : Hashable
+// CHECK-LABEL: internal enum HasAssociatedValues: Hashable
 enum HasAssociatedValues: Hashable {
   // CHECK:        case a(Int)
   case a(Int)
@@ -91,7 +91,7 @@ enum HasAssociatedValues: Hashable {
   // CHECK-NEXT:   }
 }
 
-// CHECK-LABEL: internal enum HasUnavailableElement : Hashable
+// CHECK-LABEL: internal enum HasUnavailableElement: Hashable
 enum HasUnavailableElement: Hashable {
   // CHECK:       case a
   case a
@@ -136,7 +136,7 @@ enum HasUnavailableElement: Hashable {
   // CHECK-NEXT:  }
 }
 
-// CHECK-LABEL: internal enum HasAssociatedValuesAndUnavailableElement : Hashable
+// CHECK-LABEL: internal enum HasAssociatedValuesAndUnavailableElement: Hashable
 enum HasAssociatedValuesAndUnavailableElement: Hashable {
   // CHECK:        case a(Int)
   case a(Int)
@@ -177,7 +177,7 @@ enum HasAssociatedValuesAndUnavailableElement: Hashable {
   // CHECK-NEXT:  }
 }
 
-// CHECK-LABEL: internal enum UnavailableEnum : Hashable
+// CHECK-LABEL: internal enum UnavailableEnum: Hashable
 @available(*, unavailable)
 enum UnavailableEnum: Hashable {
   // CHECK:        case a

--- a/test/decl/enum/derived_hashable_equatable_macos.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx14 -print-ast %s | %FileCheck %s
 // REQUIRES: OS=macosx
 
-// CHECK-LABEL: internal enum HasElementsWithAvailability : Hashable
+// CHECK-LABEL: internal enum HasElementsWithAvailability: Hashable
 enum HasElementsWithAvailability: Hashable {
   // CHECK:       case alwaysAvailable
   case alwaysAvailable

--- a/test/decl/enum/derived_hashable_equatable_macos_zippered.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos_zippered.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -print-ast %s | %FileCheck %s
 // REQUIRES: OS=macosx
 
-// CHECK-LABEL: internal enum HasElementsWithAvailability : Hashable
+// CHECK-LABEL: internal enum HasElementsWithAvailability: Hashable
 enum HasElementsWithAvailability: Hashable {
   // CHECK:       case alwaysAvailable
   case alwaysAvailable

--- a/test/expr/print/discard.swift
+++ b/test/expr/print/discard.swift
@@ -8,7 +8,7 @@ struct S: ~Copyable {
   deinit {}
 }
 
-// CHECK:  internal struct S : ~Copyable {
+// CHECK:  internal struct S: ~Copyable {
 // CHECK:   internal consuming func c() {
 // CHECK:     discard self
 // CHECK:   }

--- a/test/expr/print/misc_expr.swift
+++ b/test/expr/print/misc_expr.swift
@@ -17,7 +17,7 @@ class B: A {
     super.x = 2;
   }
 }
-// CHECK: @_inheritsConvenienceInitializers internal class B : A {
+// CHECK: @_inheritsConvenienceInitializers internal class B: A {
 // CHECK:   override internal init() {
 // CHECK:     super.init()
 // CHECK:     super.x = 2


### PR DESCRIPTION
This updates the AST printer to respect `PrintOptions::PrintSpaceBeforeInheritance` wherever an inheritance clause or dictionary type is printed, and flips the default to false for every client other than SIL.