### PR TITLE
🍒 [6.2] [cxx-interop] Avoid unchecked recursion when importing C++ classes with circular inheritance

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -786,6 +786,22 @@ bool declIsCxxOnly(const Decl *decl);
 
 /// Is this DeclContext an `enum` that represents a C++ namespace?
 bool isClangNamespace(const DeclContext *dc);
+
+/// For some \a templatedClass that inherits from \a base, whether they are
+/// derived from the same class template.
+///
+/// This kind of circular inheritance can happen when a templated class inherits
+/// from a specialization of itself, e.g.:
+///
+///     template <typename T> class C;
+///     template <> class C<void> { /* ... */ };
+///     template <typename T> class C<T> : C<void> { /* ... */ };
+///
+/// Checking for this kind of scenario is necessary for avoiding infinite
+/// recursion during symbolic imports (importSymbolicCXXDecls), where
+/// specialized class templates are instead imported as unspecialized.
+bool isSymbolicCircularBase(const clang::CXXRecordDecl *templatedClass,
+                            const clang::RecordDecl *base);
 } // namespace importer
 
 struct ClangInvocationFileMapping {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6388,6 +6388,11 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
         continue;
 
       auto *baseRecord = baseType->getAs<clang::RecordType>()->getDecl();
+
+      if (isSymbolicCircularBase(cxxRecord, baseRecord))
+        // Skip circular bases to avoid unbounded recursion
+        continue;
+
       if (auto import = clangModuleLoader->importDeclDirectly(baseRecord)) {
         // If we are looking up the base class, go no further. We will have
         // already found it during the other lookup.
@@ -8797,4 +8802,19 @@ bool importer::isClangNamespace(const DeclContext *dc) {
     return isa_and_nonnull<clang::NamespaceDecl>(ed->getClangDecl());
 
   return false;
+}
+
+bool importer::isSymbolicCircularBase(const clang::CXXRecordDecl *symbolicClass,
+                                      const clang::RecordDecl *base) {
+  auto *classTemplate = symbolicClass->getDescribedClassTemplate();
+  if (!classTemplate)
+    return false;
+
+  auto *specializedBase =
+      dyn_cast<clang::ClassTemplateSpecializationDecl>(base);
+  if (!specializedBase)
+    return false;
+
+  return classTemplate->getCanonicalDecl() ==
+         specializedBase->getSpecializedTemplate()->getCanonicalDecl();
 }

--- a/test/Interop/Cxx/class/inheritance/Inputs/circular-inheritance.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/circular-inheritance.h
@@ -1,0 +1,32 @@
+#ifndef CIRCULAR_INHERITANCE_H
+#define CIRCULAR_INHERITANCE_H
+
+struct DinoEgg {
+  void dinoEgg(void) const {}
+};
+
+template <typename Chicken>
+struct Egg;
+
+template <>
+struct Egg<void> : DinoEgg {
+  Egg() {}
+  void voidEgg(void) const {}
+};
+
+template <typename Chicken>
+struct Egg : Egg<void> {
+  Egg(Chicken _chicken) {}
+  Chicken chickenEgg(Chicken c) const { return c; }
+};
+
+typedef Egg<void> VoidEgg;
+typedef Egg<bool> BoolEgg;
+typedef Egg<Egg<void>> EggEgg;
+
+struct NewEgg : Egg<int> {
+  NewEgg() : Egg<int>(555) {}
+  void newEgg() const {}
+};
+
+#endif // !CIRCULAR_INHERITANCE_H

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -48,3 +48,8 @@ module InheritedLookup {
   header "inherited-lookup.h"
   requires cplusplus
 }
+
+module CircularInheritance {
+  header "circular-inheritance.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/inheritance/circular-inheritance-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/circular-inheritance-typechecker.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t/index)
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -index-store-path %t/index
+//
+// Note that we specify an -index-store-path to ensure we also test importing symbolic C++ decls,
+// to exercise code that handles importing unspecialized class templates.
+
+import CircularInheritance
+
+let voidEgg = VoidEgg()
+voidEgg.dinoEgg()
+voidEgg.voidEgg()
+
+let boolEgg = BoolEgg(false)
+boolEgg.dinoEgg()
+boolEgg.voidEgg()
+boolEgg.chickenEgg(true)
+
+let eggEgg = EggEgg(VoidEgg())
+eggEgg.dinoEgg()
+eggEgg.voidEgg()
+eggEgg.chickenEgg(VoidEgg())
+
+let newEgg = NewEgg()
+newEgg.dinoEgg()
+newEgg.voidEgg()
+newEgg.chickenEgg(555)
+newEgg.newEgg()


### PR DESCRIPTION
**Explanation**: This patch adds a check to guard against unbounded recursion when importing class templates that inherit from a specialization of themselves, a pattern appears in libc++. The unbounded recursion only happens with symbolic imports enabled, which is why this was not caught before.

**Issue**: rdar://148026461
**Risk**: low
**Testing**: added a new test case
**Original PRs**: #81188
**Reviewer**: @egorzhdan