### PR TITLE
[cmake] add FindSwiftCore module for supplemental libraries

### DIFF
--- a/Runtimes/Supplemental/cmake/modules/FindSwiftCore.cmake
+++ b/Runtimes/Supplemental/cmake/modules/FindSwiftCore.cmake
@@ -1,0 +1,123 @@
+#[=======================================================================[.rst:
+FindSwiftCore
+------------
+
+Find SwiftCore, deferring to SwiftCoreConfig.cmake when requested.
+This is meant to find the core library to be linked by the Supplemental libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+The following :prop_tgt:`IMPORTED` TARGETS may be defined:
+
+ ``SwiftCore``
+
+Hint Variables
+^^^^^^^^^^^^^^
+
+ ``SDKROOT``
+   Set the path to the Swift SDK Root.
+   This only affects Windows builds.
+
+ ``Swift_SDKROOT``
+   Set the path to the Swift SDK installation.
+   This only affects Linux and Windows builds.
+   Apple builds always use the library provided by the SDK.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+The module may set the following variables if `SwiftCore_DIR` is not set.
+
+ ``SwiftCore_FOUND``
+   true if core was found
+
+ ``SwiftCore_LIBRARIES`` OR ``SwiftCore_IMPLIB``
+   the libraries to be linked
+
+ ``SwiftCore_INCLUDE_DIR``
+   the directory containing the Swift.swiftmodule folder
+
+#]=======================================================================]
+
+# If the SwiftCore_DIR_FLAG is specified, look there instead. The cmake-generated
+# config file is more accurate, but requires that the SDK has one available.
+if(SwiftCore_DIR)
+  if(SwiftCore_FIND_REQUIRED)
+    list(APPEND args REQUIRED)
+  endif()
+  if(SwiftCore_FIND_QUIETLY)
+    list(APPEND args QUIET)
+  endif()
+  find_package(SwiftCore NO_MODULE ${args})
+  return()
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+if(APPLE)
+  # When building for Apple platforms, SwiftCore always comes from within the
+  # SDK as a tbd for a shared library in the shared cache.
+  find_path(SwiftCore_INCLUDE_DIR
+      "Swift.swiftmodule"
+    HINTS
+      "${CMAKE_OSX_SYSROOT}/usr/lib/swift")
+  find_library(SwiftCore_IMPLIB
+    NAMES "libswiftCore.tbd"
+    HINTS
+      "${CMAKE_OSX_SYSROOT}/usr/lib/swift")
+  add_library(SwiftCore SHARED IMPORTED GLOBAL)
+  set_target_properties(SwiftCore PROPERTIES
+    IMPORTED_IMPLIB "${SwiftCore_IMPLIB}")
+  find_package_handle_standard_args(SwiftCore DEFAULT_MSG
+    SwiftCore_IMPLIB SwiftCore_INCLUDE_DIR)
+elseif(LINUX)
+  if(SwiftCore_STATIC)
+    find_path(SwiftCore_INCLUDE_DIR
+      "Swift.swiftmodule"
+      HINTS
+        "${Swift_SDKROOT}/usr/lib/swift_static/linux-static")
+    find_library(SwiftCore_LIBRARY
+      NAMES "libswiftCore.a"
+      HINTS "${Swift_SDKROOT}/usr/lib/swift_static/linux-static")
+    add_library(SwiftCore STATIC IMPORTED GLOBAL)
+  else()
+    find_path(SwiftCore_INCLUDE_DIR
+      "Swift.swiftmodule"
+      HINTS
+        "${Swift_SDKROOT}/usr/lib/swift/linux")
+    find_library(SwiftCore_LIBRARY
+      NAMES "libswiftCore.so"
+      HINTS "${Swift_SDKROOT}/usr/lib/swift/linux")
+    add_library(SwiftCore SHARED IMPORTED GLOBAL)
+  endif()
+  set_target_properties(SwiftCore PROPERTIES
+    IMPORTED_LOCATION "${SwiftCore_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SwiftCore_INCLUDE_DIR}")
+  find_package_handle_standard_args(SwiftCore DEFAULT_MSG
+    SwiftCore_LIBRARY SwiftCore_INCLUDE_DIR)
+elseif(WIN32)
+  find_path(SwiftCore_INCLUDE_DIR
+    "Swift.swiftmodule"
+    HINTS
+      "${Swift_SDKROOT}/usr/lib/swift/windows"
+      "$ENV{SDKROOT}/usr/lib/swift/windows")
+  find_library(SwiftCore_LIBRARY
+    NAMES "libswiftCore.lib"
+    HINTS
+      "${Swift_SDKROOT}/usr/lib/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
+      "${Swift_SDKROOT}/usr/lib/swift"
+      "$ENV{SDKROOT}/usr/lib/swift/${SwiftCore_PLATFORM_SUBDIR}/${SwiftCore_ARCH_SUBDIR}"
+      "$ENV{SDKROOT}/usr/lib/swift")
+
+  add_library(SwiftCore SHARED IMPORTED GLOBAL)
+  set_target_properties(SwiftCore PROPERTIES
+    IMPORTED_LOCATION "${SwiftCore_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SwiftCore_INCLUDE_DIR}")
+  find_package_handle_standard_args(SwiftCore DEFAULT_MSG
+    SwiftCore_LIBRARY SwiftCore_INCLUDE_DIR)
+else()
+  message(FATAL_ERROR "FindSwiftCore.cmake module search not implemented for targeted platform\n"
+  " Build Core for your platform and set `SwiftCore_DIR` to"
+  " the directory containing SwiftCoreConfig.cmake\n")
+endif()

--- a/Runtimes/Supplemental/cmake/modules/FindSwiftCore.cmake
+++ b/Runtimes/Supplemental/cmake/modules/FindSwiftCore.cmake
@@ -15,7 +15,7 @@ The following :prop_tgt:`IMPORTED` TARGETS may be defined:
 Hint Variables
 ^^^^^^^^^^^^^^
 
- ``SDKROOT``
+ ``SDKROOT`` (environment variable)
    Set the path to the Swift SDK Root.
    This only affects Windows builds.
 
@@ -65,7 +65,8 @@ if(APPLE)
       "${CMAKE_OSX_SYSROOT}/usr/lib/swift")
   add_library(SwiftCore SHARED IMPORTED GLOBAL)
   set_target_properties(SwiftCore PROPERTIES
-    IMPORTED_IMPLIB "${SwiftCore_IMPLIB}")
+    IMPORTED_IMPLIB "${SwiftCore_IMPLIB}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SwiftCore_INCLUDE_DIR}")
   find_package_handle_standard_args(SwiftCore DEFAULT_MSG
     SwiftCore_IMPLIB SwiftCore_INCLUDE_DIR)
 elseif(LINUX)

--- a/Runtimes/Supplemental/cmake/modules/FindSwiftCore.cmake
+++ b/Runtimes/Supplemental/cmake/modules/FindSwiftCore.cmake
@@ -32,9 +32,6 @@ The module may set the following variables if `SwiftCore_DIR` is not set.
  ``SwiftCore_FOUND``
    true if core was found
 
- ``SwiftCore_LIBRARIES`` OR ``SwiftCore_IMPLIB``
-   the libraries to be linked
-
  ``SwiftCore_INCLUDE_DIR``
    the directory containing the Swift.swiftmodule folder
 
@@ -72,7 +69,7 @@ if(APPLE)
   find_package_handle_standard_args(SwiftCore DEFAULT_MSG
     SwiftCore_IMPLIB SwiftCore_INCLUDE_DIR)
 elseif(LINUX)
-  if(SwiftCore_STATIC)
+  if (NOT BUILD_SHARED_LIBS)
     find_path(SwiftCore_INCLUDE_DIR
       "Swift.swiftmodule"
       HINTS
@@ -112,7 +109,7 @@ elseif(WIN32)
 
   add_library(SwiftCore SHARED IMPORTED GLOBAL)
   set_target_properties(SwiftCore PROPERTIES
-    IMPORTED_LOCATION "${SwiftCore_LIBRARY}"
+    IMPORTED_IMPLIB "${SwiftCore_LIBRARY}"
     INTERFACE_INCLUDE_DIRECTORIES "${SwiftCore_INCLUDE_DIR}")
   find_package_handle_standard_args(SwiftCore DEFAULT_MSG
     SwiftCore_LIBRARY SwiftCore_INCLUDE_DIR)


### PR DESCRIPTION
Add FindSwiftCore to Supplemental cmake modules so we can link against libswiftCore in a given end users SDK if `SwiftCore_DIR ` is not provided