### PR TITLE
preset: build with no assertion for swiftpm on linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1945,7 +1945,9 @@ mixin-preset=mixin_swiftpm_linux_platform
 
 # Build Release without debug info, because it is faster to build.
 release
+# work around https://github.com/swiftlang/swift/issues/81144
 assertions
+no-swift-stdlib-assertions
 
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
@@ -1956,6 +1958,7 @@ toolchain-benchmarks
 skip-test-toolchain-benchmarks
 
 skip-test-llbuild
+
 
 #===------------------------------------------------------------------------===#
 # Test llbuild on macOS builder


### PR DESCRIPTION
To work around https://github.com/swiftlang/swift/issues/81144, build the Swift PM linux pseudo-toolchain without assertion

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
