### PR TITLE
Fix LifetimeDependenceInsertion: handle boxed indirect out arguments

### DIFF
--- a/test/ModuleInterface/Inputs/lifetime_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_dependence.swift
@@ -69,13 +69,17 @@ public func consumeAndCreate(_ view: consuming BufferView) -> BufferView {
   return _overrideLifetime(bv, copying: view)
 }
 
+// FIXME: Filed rdar://150398673 ([nonescapable] allocbox-to-stack fails causing lifetime diagnostics to fail)
+// Remove _overrideLifetime when this is fixed.
 @inlinable
 @lifetime(copy this, copy that)
 public func deriveThisOrThat(_ this: consuming BufferView, _ that: consuming BufferView) -> BufferView {
   if (Int.random(in: 1..<100) == 0) {
-    return BufferView(this._ptr, this._count)
+    let thisView = BufferView(this._ptr, this._count)
+    return _overrideLifetime(thisView, copying: this)
   }
-  return BufferView(that._ptr, that._count)
+  let thatView = BufferView(that._ptr, that._count)
+  return _overrideLifetime(thatView, copying: that)
 }
 
 public struct Container {

--- a/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
+++ b/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
@@ -41,12 +41,17 @@ struct Holder {
 @_addressableForDependencies
 struct AddressableForDeps {}
 
+protocol PAny : ~Copyable, ~Escapable {}
+
 sil @getPtr : $@convention(thin) () -> @out UnsafeRawPointer
 sil @getSpan : $@convention(thin) (@in_guaranteed AnyObject) -> @lifetime(borrow 0) @out NE
 sil @getInoutSpan : $@convention(thin) (@inout AnyObject) -> @lifetime(borrow 0) @out NCE
 
 sil @useNE : $@convention(thin) (@guaranteed NE) -> ()
 
+sil @getExistential : $@convention(thin) (@inout Holder) -> @lifetime(borrow 0) @out any PAny & ~Copyable & ~Escapable
+sil @useExistential : $@convention(thin) (@in_guaranteed any PAny & ~Copyable & ~Escapable) -> ()
+ 
 // Check that the inserted dependence is on the 'self' argument, not the temporary borrow.
 //
 // CHECK-LABEL: sil [available 9999] [ossa] @testSpanProp : $@convention(method) (@guaranteed AnyObject) -> @lifetime(borrow 0) @owned NE {
@@ -171,4 +176,32 @@ bb0(%0 : @guaranteed $Holder):
   dealloc_stack %2
   %99 = tuple ()
   return %99 : $()
+}
+
+// Test that source of a dependency may be a project_box and the mark_dependence will be inserted.
+//
+// CHECK-LABEL: sil hidden [ossa] @testBoxDependenceSource : $@convention(thin) (@inout Holder) -> () {
+// CHECK: [[BOX:%[0-9]+]] = project_box %2, 0
+// CHECK: [[ARG:%[0-9]+]] = begin_access [modify] [unknown] %0
+// CHECK: apply %{{.*}}([[BOX]], [[ARG]]) : $@convention(thin) (@inout Holder) -> @lifetime(borrow 0) @out any PAny & ~Copyable & ~Escapable
+// CHECK: mark_dependence_addr [unresolved] [[BOX]] on [[ARG]]
+// CHECK-LABEL: } // end sil function 'testBoxDependenceSource'
+sil hidden [ossa] @testBoxDependenceSource : $@convention(thin) (@inout Holder) -> () {
+bb0(%0 : $*Holder):
+  %1 = alloc_box ${ let any PAny & ~Copyable & ~Escapable }, let, name "span"
+  %2 = begin_borrow [lexical] [var_decl] %1
+  %3 = project_box %2, 0
+  %4 = begin_access [modify] [unknown] %0
+
+  %5 = function_ref @getExistential : $@convention(thin) (@inout Holder) -> @lifetime(borrow 0) @out any PAny & ~Copyable & ~Escapable
+  %6 = apply %5(%3, %4) : $@convention(thin) (@inout Holder) -> @lifetime(borrow 0) @out any PAny & ~Copyable & ~Escapable
+  end_access %4
+  %8 = mark_unresolved_non_copyable_value [no_consume_or_assign] %3
+
+  %9 = function_ref @useExistential : $@convention(thin) (@in_guaranteed any PAny & ~Copyable & ~Escapable) -> ()
+  %10 = apply %9(%8) : $@convention(thin) (@in_guaranteed any PAny & ~Copyable & ~Escapable) -> ()
+  end_borrow %2
+  destroy_value %1
+  %13 = tuple ()
+  return %13
 }


### PR DESCRIPTION
Correctly generate dependency tracking for functions that return a non-Escapable
existential, such as:

func getMutableSpanWithOpaqueReturn(_ array: inout [Int]) -> any PAny & ~Copyable & ~Escapable

Previously, dependency insertion assumed that @out storage always initialized an
alloc_stack. But existentials are always boxed.

First, add a diagnostic to catch any missing dependency insertions now that
we're past the bootstrapping phase.

Then, generalize handling of dependency insertion to handle any access base as
long as it has a recognizable address source.

Fixes rdar://150388126 (Missing mark_dependence for opaque lifetime dependent
value)
