### PR TITLE
[cxx-interop] Avoid querying layout of dependent types during symbolic import

### DIFF
--- a/benchmark/cxx-source/CxxSetToCollection.swift
+++ b/benchmark/cxx-source/CxxSetToCollection.swift
@@ -13,8 +13,6 @@
 // This is a benchmark that tracks how quickly Swift can convert a C++ set
 // to a Swift collection.
 
-/* FIXME: rdar://150067288
-
 import TestsUtils
 import CxxStdlibPerformance
 import Cxx
@@ -66,5 +64,3 @@ public func run_CxxSetOfU32_forEach(_ n: Int) {
     }
   }
 }
-
-*/

--- a/benchmark/cxx-source/CxxStringConversion.swift
+++ b/benchmark/cxx-source/CxxStringConversion.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/* FIXME: rdar://150067288
-
 import TestsUtils
 import CxxStdlibPerformance
 import CxxStdlib
@@ -60,5 +58,3 @@ public func run_cxxToSwift(_ n: Int) {
     blackHole(x)
   }
 }
-
-*/

--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -13,8 +13,6 @@
 // This is a benchmark that tracks how quickly Swift can sum up a C++ vector
 // as compared to the C++ implementation of such sum.
 
-/* FIXME: rdar://150067288
-
 import TestsUtils
 import CxxStdlibPerformance
 import Cxx
@@ -121,5 +119,3 @@ public func run_CxxVectorOfU32_Sum_Swift_Reduce(_ n: Int) {
     }
     blackHole(sum)
 }
-
-*/

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -27,23 +27,23 @@ struct HasZeroSizedField {
   void set_c(short c) { this->c = c; }
 };
 
-struct ReuseFieldPadding {
+struct ReuseOptionalFieldPadding {
   [[no_unique_address]] std::optional<int> a = {2};
   char c;
   char get_c() const { return c; }
   void set_c(char c) { this->c = c; }
-  int offset() const { return offsetof(ReuseFieldPadding, c); }
+  int offset() const { return offsetof(ReuseOptionalFieldPadding, c); }
   std::optional<int> getOptional() { return a; }
 };
 
 using OptInt = std::optional<int>;
 
-struct ReuseFieldPaddingWithTypedef {
+struct ReuseOptionalFieldPaddingWithTypedef {
   [[no_unique_address]] OptInt a;
   char c;
   char get_c() const { return c; }
   void set_c(char c) { this->c = c; }
-  int offset() const { return offsetof(ReuseFieldPadding, c); }
+  int offset() const { return offsetof(ReuseOptionalFieldPadding, c); }
 };
 
 

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -67,6 +67,18 @@ struct ReuseNonStandardLayoutFieldPadding {
   int offset() const { return (char *) &this->c - (char *) this; }
 };
 
+template<typename T>
+struct ReuseDependentFieldPadding {
+  [[no_unique_address]] struct { private: T x; public: char pad_me; } a;
+  char c;
+  char get_c() const { return c; }
+  void set_c(char c) { this->c = c; }
+  // C-style implementation of offsetof() to avoid non-standard-layout warning
+  int offset() const { return (char *) &this->c - (char *) this; }
+};
+
+typedef ReuseDependentFieldPadding<int> ReuseDependentFieldPaddingInt;
+
 inline int takesZeroSizedInCpp(HasZeroSizedField x) {
   return x.a;
 }

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
+// RUN: %empty-directory(%t/index)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xfrontend -index-store-path -Xfrontend %t/index)
 //
 // REQUIRES: executable_test
 
@@ -58,6 +59,20 @@ FieldsTestSuite.test("Non-standard-layout field padding reused") {
   var s = ReuseNonStandardLayoutFieldPadding()
   s.c = 5
   expectEqual(Int(s.offset()),  MemoryLayout<ReuseNonStandardLayoutFieldPadding>.offset(of: \.c)!)
+  expectEqual(s.c, 5)
+  expectEqual(s.get_c(), 5)
+  s.set_c(6)
+  expectEqual(s.c, 6)
+  expectEqual(s.get_c(), 6)
+  let s2 = s
+  expectEqual(s2.c, 6)
+  expectEqual(s2.get_c(), 6)
+}
+
+FieldsTestSuite.test("Non-standard-layout field padding in templated class reused") {
+  var s = ReuseDependentFieldPaddingInt()
+  s.c = 5
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseDependentFieldPaddingInt>.offset(of: \.c)!)
   expectEqual(s.c, 5)
   expectEqual(s.get_c(), 5)
   s.set_c(6)

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -54,4 +54,18 @@ FieldsTestSuite.test("Typedef'd optional field padding reused") {
   expectEqual(s2.get_c(), 6)
 }
 
+FieldsTestSuite.test("Non-standard-layout field padding reused") {
+  var s = ReuseNonStandardLayoutFieldPadding()
+  s.c = 5
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseNonStandardLayoutFieldPadding>.offset(of: \.c)!)
+  expectEqual(s.c, 5)
+  expectEqual(s.get_c(), 5)
+  s.set_c(6)
+  expectEqual(s.c, 6)
+  expectEqual(s.get_c(), 6)
+  let s2 = s
+  expectEqual(s2.c, 6)
+  expectEqual(s2.get_c(), 6)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -24,12 +24,12 @@ FieldsTestSuite.test("Zero sized field") {
   expectEqual(s.b.getNum(), 42)
 }
 
-FieldsTestSuite.test("Field padding reused") {
-  var s = ReuseFieldPadding()
+FieldsTestSuite.test("Optional field padding reused") {
+  var s = ReuseOptionalFieldPadding()
   let opt = s.getOptional()
   expectEqual(Int(opt.pointee), 2)
   s.c = 5
-  expectEqual(Int(s.offset()),  MemoryLayout<ReuseFieldPadding>.offset(of: \.c)!)
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseOptionalFieldPadding>.offset(of: \.c)!)
   expectEqual(s.c, 5)
   expectEqual(s.get_c(), 5)
   s.set_c(6)
@@ -40,10 +40,10 @@ FieldsTestSuite.test("Field padding reused") {
   expectEqual(s2.get_c(), 6)
 }
 
-FieldsTestSuite.test("Typedef'd field padding reused") {
-  var s = ReuseFieldPaddingWithTypedef()
+FieldsTestSuite.test("Typedef'd optional field padding reused") {
+  var s = ReuseOptionalFieldPaddingWithTypedef()
   s.c = 5
-  expectEqual(Int(s.offset()),  MemoryLayout<ReuseFieldPadding>.offset(of: \.c)!)
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseOptionalFieldPadding>.offset(of: \.c)!)
   expectEqual(s.c, 5)
   expectEqual(s.get_c(), 5)
   s.set_c(6)


### PR DESCRIPTION
In #80786, we started importing certain padded fields as opaque blobs.
Part of this logic involved querying those fields' ASTRecordLayout.
However, dependent types (which are imported symbolically) do not have
an ASTRecordLayout, so calling Clang's getASTRecordLayout() would lead
to an assertion error for class templates where a no_unique_address
field is some kind of dependent C++ record type.

This PR includes a patch that avoids the field padding check during symbolic import mode
because that check is only relevant for codegen anyway.

This PR also includes some small test case updates to increase coverage of padded fields other than `std::optional`.

rdar://150067288
