### PR TITLE
[Concurrency] Fix ptr auth for task priority escalation handler

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1745,7 +1745,7 @@ namespace SpecialPointerAuthDiscriminators {
   const uint16_t AsyncContextParent = 0xbda2; // = 48546
   const uint16_t AsyncContextResume = 0xd707; // = 55047
   const uint16_t AsyncContextYield = 0xe207; // = 57863
-  const uint16_t CancellationNotificationFunction = 0x1933; // = 6451
+  const uint16_t CancellationNotificationFunction = 0x2E3F; // = 11839 (TaskPriority, TaskPriority) -> Void
   const uint16_t EscalationNotificationFunction = 0x7861; // = 30817
   const uint16_t AsyncThinNullaryFunction = 0x0f08; // = 3848
   const uint16_t AsyncFutureFunction = 0x720f; // = 29199

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1812,8 +1812,9 @@ swift_task_addPriorityEscalationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(EscalationNotificationStatusRecord));
+  auto unsigned_handler = swift_auth_code(handler, 11839);
   auto *record = ::new (allocation)
-      EscalationNotificationStatusRecord(handler, context);
+      EscalationNotificationStatusRecord(unsigned_handler, context);
 
   addStatusRecordToSelf(record, [&](ActiveTaskStatus oldStatus, ActiveTaskStatus& newStatus) {
     return true;


### PR DESCRIPTION
We missed to sign the handler. Along the way the signature of it changed, so adjust for that.

How to get the number:

```
func PROPER(bar: (TaskPriority, TaskPriority) -> Void) {
   let p = TaskPriority.default
   bar(p, p)
}
```

```
-> % swiftc -target arm64e-apple-macos13 example.swift -S -o - | swift demangle | grep -a3 autda
            stur    x8, [x29, #-64]
            mov     x17, x8
            movk    x17, #11839, lsl #48 <<<<<<<<<
            autda   x16, x17
            ldr     x8, [x16, #64]
            lsr     x8, x8, #0
            add     x8, x8, #15
```

Resolves rdar://150378890