### PR TITLE
[6.2][Concurrency] Fix ptr auth for task priority escalation handler

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1765,7 +1765,7 @@ namespace SpecialPointerAuthDiscriminators {
   const uint16_t AsyncContextParent = 0xbda2; // = 48546
   const uint16_t AsyncContextResume = 0xd707; // = 55047
   const uint16_t AsyncContextYield = 0xe207; // = 57863
-  const uint16_t CancellationNotificationFunction = 0x1933; // = 6451
+  const uint16_t CancellationNotificationFunction = 0x2E3F; // = 11839 (TaskPriority, TaskPriority) -> Void
   const uint16_t EscalationNotificationFunction = 0x7861; // = 30817
   const uint16_t AsyncThinNullaryFunction = 0x0f08; // = 3848
   const uint16_t AsyncFutureFunction = 0x720f; // = 29199

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1811,8 +1811,9 @@ swift_task_addPriorityEscalationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(EscalationNotificationStatusRecord));
+  auto unsigned_handler = swift_auth_code(handler, 11839);
   auto *record = ::new (allocation)
-      EscalationNotificationStatusRecord(handler, context);
+      EscalationNotificationStatusRecord(unsigned_handler, context);
 
   addStatusRecordToSelf(record, [&](ActiveTaskStatus oldStatus, ActiveTaskStatus& newStatus) {
     return true;


### PR DESCRIPTION
**Description:** the new task priority escalation API was missing pointer auth signing on when we use the handler.

**Scope/Impact:** Makes withTaskPriorityEscalationHandler usable with pointer authentication.

**Risk:** Low, this was broken on ptr-auth before, no impact on other code.

**Testing:** CI testing
**Reviewed by:** @rjmccall 

**Original PR:** https://github.com/swiftlang/swift/pull/81229
**Radar:** rdar://150378890