### PR TITLE
[SILGen] Handle struct `projectedValue` in struct property wrapper that has mutating setter

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3510,6 +3510,15 @@ void LValue::addNonMemberVarComponent(
       }
 
       if (!address.isLValue()) {
+        // When the `projectedValue` is a struct
+        // within a struct property wrapper that has a mutating setter
+        if (!address.getType().isAddress() &&
+            AccessKind == SGFAccessKind::ReadWrite) {
+          LV.add<ValueComponent>(address.materialize(SGF, Loc), std::nullopt,
+                                 typeData,
+                                 /*rvalue*/ true);
+          return;
+        }
         assert((AccessKind == SGFAccessKind::BorrowedObjectRead
                 || AccessKind == SGFAccessKind::BorrowedAddressRead)
                && "non-borrow component requires an address base");

--- a/test/SILGen/property_wrappers.swift
+++ b/test/SILGen/property_wrappers.swift
@@ -1018,3 +1018,33 @@ struct TestReabstractableWrappedValue<T1> {
   @AutoclosureWrapper var v: S<T1> = S()
   init() where T1 == Int { }
 }
+
+// https://github.com/swiftlang/swift/issues/81021
+@propertyWrapper
+struct Clamping {
+    private var value: Int
+    private var range: ClosedRange<Int>
+
+    init(wrappedValue: Int, _ range: ClosedRange<Int>) {
+        self.range = range
+        self.value = range.clamp(wrappedValue)
+    }
+
+    var wrappedValue: Int {
+        get { value }
+        set { value = range.clamp(newValue) }
+    }
+
+    var projectedValue: ClosedRange<Int> {
+        get { range }
+        set { range = newValue }
+    }
+}
+
+extension ClosedRange where Bound: Comparable {
+    func clamp(_ value: Bound) -> Bound {
+        return min(max(lowerBound, value), upperBound)
+    }
+}
+
+func clampingArg(@Clamping(0...10) _ value: Int) {}


### PR DESCRIPTION
Resolves #81021 

When the `projectedValue` is a struct within a struct property wrapper that has a mutating setter, and we use the property wrapper as a function parameter, the `projectedValue` becomes an Rvalue and does not have an address.

This issue does not occur if the property wrapper is a class, or if the projectedValue itself is a class.

Previously, we did not handle this case, which led to an assertion failure in the following code:

```
if (!address.isLValue()) { 
       // If it is a case described the above, `AccessKind` is `SGFAccessKind::ReadWrite`
        assert((AccessKind == SGFAccessKind::BorrowedObjectRead
                || AccessKind == SGFAccessKind::BorrowedAddressRead)
               && "non-borrow component requires an address base");
``` 

Since it is not an address, we could not treat it the same as the borrow cases.


Therefore, we needed to handle this scenario differently.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:


For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
