### PR TITLE
Fix compilation errors appearing due to missing `<cstdint>` include

### DIFF
--- a/include/swift/AST/FunctionRefInfo.h
+++ b/include/swift/AST/FunctionRefInfo.h
@@ -21,6 +21,8 @@
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 
+#include <cstdint>
+
 namespace swift {
 
 class DeclNameLoc;

--- a/stdlib/include/llvm/ADT/SmallVector.h
+++ b/stdlib/include/llvm/ADT/SmallVector.h
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>


### PR DESCRIPTION
I've recently started to face compilation issues related to types like `uint32_t` not found. The issues remained even when rolling back to Apr 15 state of the repositories - at that point, no issues were present.

Compilation errors have probably started to occur after my Linux system LLVM installation was recently updated to 19.1.7.

This patch resolves the issue by adding missing `<cstdint>` includes. For SmallVector.h, such a change was already introduced in LLVM repository: https://github.com/llvm/llvm-project/commit/7e44305041d96b064c197216b931ae3917a34ac1

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
