### PR TITLE
[Concurrency] Remove useless comment about assert in AsyncTask::complete().

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -831,11 +831,6 @@ struct AsyncTask::PrivateStorage {
     while (true) {
       assert(oldStatus.getInnermostRecord() == NULL &&
              "Status records should have been removed by this time!");
-
-      // Don't assert !isStatusRecordLocked(). It can be legitimately true here,
-      // for example if another thread is canceling this task right as it
-      // completes.
-
       assert(oldStatus.isRunning());
 
       // Remove drainer, enqueued and override bit if any


### PR DESCRIPTION
This comment is really about an assert that's no longer present, so it should just go away.