### PR TITLE
🍒 [6.2] [cxx-interop] Avoid querying layout of dependent types during symbolic import

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4472,11 +4472,17 @@ namespace {
     }
 
     Decl *VisitFieldDecl(const clang::FieldDecl *decl) {
-      if (decl->hasAttr<clang::NoUniqueAddressAttr>()) {
+      if (!Impl.importSymbolicCXXDecls &&
+          decl->hasAttr<clang::NoUniqueAddressAttr>()) {
         if (const auto *rd = decl->getType()->getAsRecordDecl()) {
           // Clang can store the next field in the padding of this one. Swift
           // does not support this yet so let's not import the field and
           // represent it with an opaque blob in codegen.
+          //
+          // This check is not relevant when importing the decl symbolically
+          // (since that isn't used for codegen). In fact, we need to avoid this
+          // check because symbolic imports can expose us to dependent types
+          // whose ASTRecordLayout cannot be queried.
           const auto &fieldLayout =
               decl->getASTContext().getASTRecordLayout(rd);
           auto &clangCtx = decl->getASTContext();

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -27,23 +27,23 @@ struct HasZeroSizedField {
   void set_c(short c) { this->c = c; }
 };
 
-struct ReuseFieldPadding {
+struct ReuseOptionalFieldPadding {
   [[no_unique_address]] std::optional<int> a = {2};
   char c;
   char get_c() const { return c; }
   void set_c(char c) { this->c = c; }
-  int offset() const { return offsetof(ReuseFieldPadding, c); }
+  int offset() const { return offsetof(ReuseOptionalFieldPadding, c); }
   std::optional<int> getOptional() { return a; }
 };
 
 using OptInt = std::optional<int>;
 
-struct ReuseFieldPaddingWithTypedef {
+struct ReuseOptionalFieldPaddingWithTypedef {
   [[no_unique_address]] OptInt a;
   char c;
   char get_c() const { return c; }
   void set_c(char c) { this->c = c; }
-  int offset() const { return offsetof(ReuseFieldPadding, c); }
+  int offset() const { return offsetof(ReuseOptionalFieldPadding, c); }
 };
 
 

--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -67,6 +67,18 @@ struct ReuseNonStandardLayoutFieldPadding {
   int offset() const { return (char *) &this->c - (char *) this; }
 };
 
+template<typename T>
+struct ReuseDependentFieldPadding {
+  [[no_unique_address]] struct { private: T x; public: char pad_me; } a;
+  char c;
+  char get_c() const { return c; }
+  void set_c(char c) { this->c = c; }
+  // C-style implementation of offsetof() to avoid non-standard-layout warning
+  int offset() const { return (char *) &this->c - (char *) this; }
+};
+
+typedef ReuseDependentFieldPadding<int> ReuseDependentFieldPaddingInt;
+
 inline int takesZeroSizedInCpp(HasZeroSizedField x) {
   return x.a;
 }

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -1,4 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20)
+// RUN: %empty-directory(%t/index)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++20 -Xfrontend -index-store-path -Xfrontend %t/index)
 //
 // REQUIRES: executable_test
 
@@ -58,6 +59,20 @@ FieldsTestSuite.test("Non-standard-layout field padding reused") {
   var s = ReuseNonStandardLayoutFieldPadding()
   s.c = 5
   expectEqual(Int(s.offset()),  MemoryLayout<ReuseNonStandardLayoutFieldPadding>.offset(of: \.c)!)
+  expectEqual(s.c, 5)
+  expectEqual(s.get_c(), 5)
+  s.set_c(6)
+  expectEqual(s.c, 6)
+  expectEqual(s.get_c(), 6)
+  let s2 = s
+  expectEqual(s2.c, 6)
+  expectEqual(s2.get_c(), 6)
+}
+
+FieldsTestSuite.test("Non-standard-layout field padding in templated class reused") {
+  var s = ReuseDependentFieldPaddingInt()
+  s.c = 5
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseDependentFieldPaddingInt>.offset(of: \.c)!)
   expectEqual(s.c, 5)
   expectEqual(s.get_c(), 5)
   s.set_c(6)

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -54,4 +54,18 @@ FieldsTestSuite.test("Typedef'd optional field padding reused") {
   expectEqual(s2.get_c(), 6)
 }
 
+FieldsTestSuite.test("Non-standard-layout field padding reused") {
+  var s = ReuseNonStandardLayoutFieldPadding()
+  s.c = 5
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseNonStandardLayoutFieldPadding>.offset(of: \.c)!)
+  expectEqual(s.c, 5)
+  expectEqual(s.get_c(), 5)
+  s.set_c(6)
+  expectEqual(s.c, 6)
+  expectEqual(s.get_c(), 6)
+  let s2 = s
+  expectEqual(s2.c, 6)
+  expectEqual(s2.get_c(), 6)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -24,12 +24,12 @@ FieldsTestSuite.test("Zero sized field") {
   expectEqual(s.b.getNum(), 42)
 }
 
-FieldsTestSuite.test("Field padding reused") {
-  var s = ReuseFieldPadding()
+FieldsTestSuite.test("Optional field padding reused") {
+  var s = ReuseOptionalFieldPadding()
   let opt = s.getOptional()
   expectEqual(Int(opt.pointee), 2)
   s.c = 5
-  expectEqual(Int(s.offset()),  MemoryLayout<ReuseFieldPadding>.offset(of: \.c)!)
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseOptionalFieldPadding>.offset(of: \.c)!)
   expectEqual(s.c, 5)
   expectEqual(s.get_c(), 5)
   s.set_c(6)
@@ -40,10 +40,10 @@ FieldsTestSuite.test("Field padding reused") {
   expectEqual(s2.get_c(), 6)
 }
 
-FieldsTestSuite.test("Typedef'd field padding reused") {
-  var s = ReuseFieldPaddingWithTypedef()
+FieldsTestSuite.test("Typedef'd optional field padding reused") {
+  var s = ReuseOptionalFieldPaddingWithTypedef()
   s.c = 5
-  expectEqual(Int(s.offset()),  MemoryLayout<ReuseFieldPadding>.offset(of: \.c)!)
+  expectEqual(Int(s.offset()),  MemoryLayout<ReuseOptionalFieldPadding>.offset(of: \.c)!)
   expectEqual(s.c, 5)
   expectEqual(s.get_c(), 5)
   s.set_c(6)


### PR DESCRIPTION
**Explanation**: This patch avoids querying the ASTRecordLayout of `[[no_unique_address]]` fields when symbolic import is enabled. Symbolic import mode causes ClangImporter to import uninstantiated class templates, which may contain dependent-typed fields that trigger an assertion failure when querying their layout (since their layout depends on a non-concrete template argument).

**Issue**: rdar://150067288
**Risk**: low
**Testing**: added tests
**Original PRs**: #81228
**Reviewer**: @egorzhdan 