### PR TITLE
[6.2] Add static .nanoseconds(_: Double) to Duration (#81210)

### DIFF
--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -250,6 +250,17 @@ extension Duration {
     let highScaled = high * 1_000_000_000
     return Duration(_high: highScaled + Int64(lowScaled.high), low: lowScaled.low)
   }
+  
+  /// Construct a `Duration` given a number of seconds nanoseconds as a
+  /// `Double` by converting the value into the closest attosecond scale value.
+  ///
+  ///       let d: Duration = .nanoseconds(382.9)
+  ///
+  /// - Returns: A `Duration` representing a given number of nanoseconds.
+  @available(SwiftStdlib 6.2, *)
+  public static func nanoseconds(_ nanoseconds: Double) -> Duration {
+    Duration(nanoseconds, scale: 1_000_000_000)
+  }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1128,3 +1128,6 @@ Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7Ra
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVMa$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVMn$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVN$
+
+// Duration.nanoseconds(_:)
+Added: _$ss8DurationV11nanosecondsyABSdFZ

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1130,3 +1130,5 @@ Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7Ra
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVMn$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVN$
 
+// Duration.nanoseconds(_:)
+Added: _$ss8DurationV11nanosecondsyABSdFZ

--- a/test/stdlib/Duration.swift
+++ b/test/stdlib/Duration.swift
@@ -28,11 +28,11 @@ if #available(SwiftStdlib 5.7, *) {
     // Divide by 1000 to get back to a duration with representable components:
     let smallerDuration = duration / 1000
     expectEqual(smallerDuration.components, (170_000_000_000_000_000, 0))
-    #if !os(WASI)
+#if !os(WASI)
     // Now check that the components of the original value trap:
     expectCrashLater()
     let _ = duration.components
-    #endif
+#endif
   }
   
   suite.test("milliseconds from Double") {
@@ -264,5 +264,16 @@ if #available(SwiftStdlib 6.0, *) {
     expectEqual(max.attoseconds, .max)
     let min = Duration(_high: -9_223_372_036_854_775_808, low: 0)
     expectEqual(min.attoseconds, .min)
+  }
+}
+
+if #available(SwiftStdlib 6.2, *) {
+  suite.test("nanoseconds from Double") {
+    for _ in 0 ..< 100 {
+      let integerValue = Double(Int64.random(in: 0 ... 0x7fff_ffff_ffff_fc00))
+      let (sec, attosec) = Duration.nanoseconds(integerValue).components
+      expectEqual(sec, Int64(integerValue) / 1_000_000_000)
+      expectEqual(attosec, Int64(integerValue) % 1_000_000_000 * 1_000_000_000)
+    }
   }
 }


### PR DESCRIPTION
SE-0329 defines the following static factory methods:
```
public static func seconds<T: BinaryInteger>(_ seconds: T) -> Duration
public static func seconds(_ seconds: Double) -> Duration
public static func milliseconds<T: BinaryInteger>(_ milliseconds: T) -> Duration
public static func milliseconds(_ milliseconds: Double) -> Duration
public static func microseconds<T: BinaryInteger>(_ microseconds: T) -> Duration
public static func microseconds(_ microseconds: Double) -> Duration
public static func nanoseconds<T: BinaryInteger>(_ value: T) -> Duration
```
For no good reason, the obvious additional method:
```
public static func nanoseconds(_ nanoseconds: Double) -> Duration
```
was omitted. After talking this through with the LSG, we have decided that this is simply a bug, and we will add this method without formal evolution review.