### PR TITLE
[6.2][Concurrency] SE-0461: Allow `nonisolated(nonsending)` inference on properties…

### DIFF
--- a/test/SILGen/nonisolated_inherits_isolation.swift
+++ b/test/SILGen/nonisolated_inherits_isolation.swift
@@ -151,3 +151,21 @@ class MainActorKlass {
     await unspecifiedAsyncUse(n)
   }
 }
+
+struct TestVarUse {
+  var test: Int {
+    // CHECK-LABEL: sil hidden [ossa] @$s30nonisolated_inherits_isolation10TestVarUseV4testSivg : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, TestVarUse) -> Int
+    get async {
+      42
+    }
+  }
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30nonisolated_inherits_isolation12testUseOfVar1tyAA04TestgE0V_tYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, TestVarUse) -> ()
+// CHECK: bb0([[ISOLATION:%.*]] : @guaranteed $Optional<any Actor>, [[BASE:%.*]] : $TestVarUse)
+// CHECK:   [[GETTER:%.*]] = function_ref @$s30nonisolated_inherits_isolation10TestVarUseV4testSivg : $@convention(method) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, TestVarUse) -> Int
+// CHECK:   {{.*}} = apply [[GETTER]]([[ISOLATION]], [[BASE]])
+// CHECK: } // end sil function '$s30nonisolated_inherits_isolation12testUseOfVar1tyAA04TestgE0V_tYaF'
+func testUseOfVar(t: TestVarUse) async {
+  _ = await t.test
+}


### PR DESCRIPTION
… with async getters

Cherry-pick of https://github.com/swiftlang/swift/pull/81219

--- 

- Explanation:
  
  When `NonisolatedNonsendingByDefault` is enabled it should infer `nonisolated(nonsending)` for both async functions and storage as specified by the proposal.

- Main Branch PR: https://github.com/swiftlang/swift/pull/81219

- Risk: Very Low (This is related only to the code that has `NonisolatedNonsendingByDefault` enabled).

- Reviewed By: @hborla @ktoso 

- Testing: Added new tests to the test suite.

(cherry picked from commit 8a9bbd51148efc53145dd4a3d3c12efc1cb06884)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
