### PR TITLE
[Dependency Scanning] Fix search path context hashing hole and avoid serializing unnecessary field

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1097,9 +1097,6 @@ public:
   /// $SDKROOT/System/Library/Frameworks/ and $SDKROOT/Library/Frameworks/.
   std::vector<std::string> getDarwinImplicitFrameworkSearchPaths() const;
 
-  /// Return a set of all possible filesystem locations where modules can be found.
-  llvm::StringSet<> getAllModuleSearchPathsSet() const;
-
   /// Load extensions to the given nominal type from the external
   /// module loaders.
   ///

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -787,11 +787,6 @@ public:
     return storage->auxiliaryFiles;
   }
 
-  void
-  setAuxiliaryFiles(const ArrayRef<std::string> auxiliaryFiles) {
-    storage->auxiliaryFiles.assign(auxiliaryFiles.begin(), auxiliaryFiles.end());
-  }
-
   bool isStaticLibrary() const {
     if (auto *detail = getAsSwiftInterfaceModule())
       return detail->isStatic;

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -80,7 +80,6 @@ using LinkLibrariesArrayIDField = IdentifierIDField;
 using MacroDependenciesArrayIDField = IdentifierIDField;
 using FlagIDArrayIDField = IdentifierIDField;
 using DependencyIDArrayIDField = IdentifierIDField;
-using AuxiliaryFilesArrayIDField = IdentifierIDField;
 using SourceLocationIDArrayIDField = IdentifierIDField;
 
 /// The ID of the top-level block containing the dependency graph
@@ -204,8 +203,7 @@ using ModuleInfoLayout =
                    DependencyIDArrayIDField,       // importedClangModules
                    DependencyIDArrayIDField,       // crossImportOverlayModules
                    DependencyIDArrayIDField,       // swiftOverlayDependencies
-                   ModuleCacheKeyIDField,          // moduleCacheKey
-                   AuxiliaryFilesArrayIDField      // auxiliaryFiles
+                   ModuleCacheKeyIDField           // moduleCacheKey
                    >;
 
 using SwiftInterfaceModuleDetailsLayout =

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -41,7 +41,7 @@ using llvm::BCVBR;
 const unsigned char MODULE_DEPENDENCY_CACHE_FORMAT_SIGNATURE[] = {'I', 'M', 'D','C'};
 const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 9;
 /// Increment this on every change.
-const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 1;
+const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 2;
 
 /// Various identifiers in this format will rely on having their strings mapped
 /// using this ID.

--- a/test/ScanDependencies/Incremental/system_search_path_invalidate.swift
+++ b/test/ScanDependencies/Incremental/system_search_path_invalidate.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/Frameworks)
+
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %t/ExtraCModules -I %S/../Inputs/CHeaders -F %t/Frameworks &> %t/first_scan_output.txt
+// RUN: cat %t/first_scan_output.txt | %FileCheck %s
+
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %t/ExtraCModules -I %S/../Inputs/CHeaders -F %t/Frameworks &> %t/second_scan_output.txt
+// RUN: cat %t/second_scan_output.txt | %FileCheck %s -check-prefix=INCREMENTAL-CHECK
+
+// Change an '-F' to a '-Fsystem' and ensure that the serialized cache does not get reused
+// RUN: %target-swift-frontend -scan-dependencies -scanner-module-validation -module-load-mode prefer-interface -Rdependency-scan-cache -load-dependency-scan-cache -serialize-dependency-scan-cache -dependency-scan-cache-path %t/cache.moddepcache -module-cache-path %t/module-cache %s -o %t/deps.json -I %t/ExtraCModules -I %S/../Inputs/CHeaders -Fsystem %t/Frameworks &> %t/second_system_scan_output.txt
+// RUN: cat %t/second_system_scan_output.txt | %FileCheck %s
+
+// CHECK: remark: Incremental module scan: Failed to load module scanning dependency cache from:
+// INCREMENTAL-CHECK-NOT: remark: Incremental module scan: Failed to load module scanning dependency cache from:
+


### PR DESCRIPTION
- **[Dependency Scanning][Serialization] Do not serialize auxiliary files**
The field is only used to store information to be used in finalize stage, in caching builds. When loading scan results from the cache, the entries are finalized already and have the file info encoded in CASIDs already.
Resolves rdar://150307865

- **Include system-ness of framework and import search paths in the PCH hash**
This hash is also used for the dependency scanning hash. In both cases, PCH contents may differ based on whether a certain module they depend on is found in a system or non-system search path. In dependency scanning, systemness should cause a full change of scanning context requiring a from-scratch scan.
Resolves rdar://150334077
