### PR TITLE
[6.2] LifetimeDependenceDefUseAddressWalker: avoid infinite recursion.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -424,6 +424,10 @@ struct VariableIntroducerUseDefWalker : LifetimeDependenceUseDefValueWalker, Lif
     visitedValues.insert(value)
   }
 
+  mutating func needWalk(for address: Value) -> Bool {
+    visitedValues.insert(address)
+  }
+
   mutating func walkUp(newLifetime: Value) -> WalkResult {
     if newLifetime.type.isAddress {
       return walkUp(address: newLifetime)


### PR DESCRIPTION
This utility is used by DependentAddressUseDefWalker which now conservatively
follows all possible uses. This could result in the same address being reached
multiple times during a def-use walk. Ensure that we don't infinitely recurse.

There is no small test case for this, but the fix is trivial and standard
practice for such walkers, and this is hit quickly in real usage, so there is no
danger of it regressing.

Fixes rdar://150403948 ([nonescapable] Infinite recursion compiler crash in
lifetime dependence checking)

(cherry picked from commit 4512927d2ba3ae6cbbf076d736c6ef64b0ccd723)

main PR: https://github.com/swiftlang/swift/pull/81246

Risk: Very low. Simply enables an existing recursion check. It can only affect the code path that was already crashing.

Testing: The radar includes a unit test but it isn't appropriate as a lit test.

Reviewed by: @meg-gupta 
