### PR TITLE
[6.2] [Observation] Create nonisolated conformances to Observable

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -311,7 +311,7 @@ extension ObservableMacro: ExtensionMacro {
     }
 
     let decl: DeclSyntax = """
-        extension \(raw: type.trimmedDescription): \(raw: qualifiedConformanceName) {}
+        extension \(raw: type.trimmedDescription): nonisolated \(raw: qualifiedConformanceName) {}
         """
     let ext = decl.cast(ExtensionDeclSyntax.self)
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -2148,8 +2148,8 @@ std::optional<unsigned> swift::expandExtensions(CustomAttr *attr,
     for (auto i : inheritedTypes.getIndices()) {
       auto constraint =
           TypeResolution::forInterface(
-              extension->getDeclContext(),
-              TypeResolverContext::GenericRequirement,
+              extension,
+              TypeResolverContext::Inherited,
               /*unboundTyOpener*/ nullptr,
               /*placeholderHandler*/ nullptr,
               /*packElementOpener*/ nullptr)


### PR DESCRIPTION
  - **Explanation**: The Observable macro generates a conformance that's meant to be nonisolated. When default-main-actor mode is enabled, the conformance ended up being `@MainActor`, causing errors in its use. Add `nonisolated` to the generated `Observable` conformance to avoid this problem
  - **Scope**: Limited to the Observable macro.
  - **Issues**: rdar://150419628
  - **Original PRs**: https://github.com/swiftlang/swift/pull/81249
  - **Risk**: Low. Provides 
  - **Testing**: CI
  - **Reviewers**: @hborla 
