### PR TITLE
[6.2][InterfaceGen] Merge exported modules with the same public name in generated interface

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -234,6 +234,12 @@ struct PrintOptions {
   /// \see FileUnit::getExportedModuleName
   bool UseExportedModuleNames = false;
 
+  /// If true, printed module names will use the "public" (for documentation)
+  /// name, which may be different from the regular name.
+  ///
+  /// \see FileUnit::getPublicModuleName
+  bool UsePublicModuleNames = false;
+
   /// Use the original module name to qualify a symbol.
   bool UseOriginallyDefinedInModuleNames = false;
 
@@ -704,6 +710,7 @@ struct PrintOptions {
     result.MapCrossImportOverlaysToDeclaringModule = true;
     result.PrintCurrentMembersOnly = false;
     result.SuppressExpandedMacros = true;
+    result.UsePublicModuleNames = true;
     return result;
   }
 

--- a/include/swift/IDE/ModuleInterfacePrinting.h
+++ b/include/swift/IDE/ModuleInterfacePrinting.h
@@ -38,11 +38,14 @@ namespace ide {
 /// Flags used when traversing a module for printing.
 enum class ModuleTraversal : unsigned {
   /// Visit modules even if their contents wouldn't be visible to name lookup.
-  VisitHidden     = 0x01,
+  VisitHidden = 0x01,
   /// Visit submodules.
   VisitSubmodules = 0x02,
   /// Skip the declarations in a Swift overlay module.
-  SkipOverlay     = 0x04,
+  SkipOverlay = 0x04,
+  /// Visit exported modules where their public module name matches the current
+  /// module.
+  VisitMatchingExported = 0x08,
 };
 
 /// Options used to describe the traversal of a module for printing.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6012,6 +6012,11 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
       Name = Mod->getASTContext().getIdentifier(ExportedModuleName);
     }
 
+    StringRef PublicModuleName = File->getPublicModuleName();
+    if (Options.UsePublicModuleNames && !PublicModuleName.empty()) {
+      Name = Mod->getASTContext().getIdentifier(PublicModuleName);
+    }
+
     if (Options.UseOriginallyDefinedInModuleNames) {
       Decl *D = Ty->getDecl();
       for (auto attr: D->getAttrs().getAttributes<OriginallyDefinedInAttr>()) {

--- a/test/IDE/Inputs/foo_swift_module.printed.comments.txt
+++ b/test/IDE/Inputs/foo_swift_module.printed.comments.txt
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 func %%% (lhs: Int, rhs: Int) -> Int
 postfix func =-> (lhs: Int) -> Int
 postfix func => (lhs: Int) -> Int

--- a/test/IDE/print_clang_framework_with_overlay.swift
+++ b/test/IDE/print_clang_framework_with_overlay.swift
@@ -10,7 +10,5 @@ import FooOverlay
 // CHECK: @_exported import Foo
 // CHECK: @_exported import struct Foo.FooStruct1
 // CHECK: @_exported import Foo.FooSub
-// CHECK: @_exported import func Foo.FooSub.fooSubFunc1
-// FIXME: this duplicate import is silly, but not harmful.
 // CHECK: @_exported import func Foo.fooSubFunc1
 // CHECK: func fooSubOverlayFunc1(x: Int32) -> Int32

--- a/test/SourceKit/CursorInfo/cursor_generated_interface.swift
+++ b/test/SourceKit/CursorInfo/cursor_generated_interface.swift
@@ -41,7 +41,7 @@ public class ASwiftType {
 }
 
 // LibA is a mixed framework with no source info and a submodule
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
 // CHECKA: key.name: "ASwiftType"
 // CHECKA: key.modulename: "LibA"
 // CHECKA: key.decl_lang: source.lang.swift
@@ -60,7 +60,7 @@ framework module LibA {
 @interface AObjcType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
 // CHECKAOBJ: key.name: "AObjcType"
 // CHECKAOBJ: key.line: [[@LINE-5]]
 // CHECKAOBJ: key.column: 12
@@ -72,7 +72,7 @@ framework module LibA {
 @interface ASubType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
 // CHECKASUB: key.name: "ASubType"
 // CHECKASUB: key.line: [[@LINE-5]]
 // CHECKASUB: key.column: 12
@@ -84,7 +84,7 @@ framework module LibA {
 public class BType {}
 
 // LibB has source info
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
 // CHECKB: key.name: "BType"
 // CHECKB: key.line: [[@LINE-5]]
 // CHECKB: key.column: 14
@@ -96,7 +96,7 @@ public class BType {}
 public class CType {}
 
 // LibC has no source info
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
 // CHECKC: key.name: "CType"
 // CHECKC: key.modulename: "LibC"
 // CHECKC: key.decl_lang: source.lang.swift
@@ -105,7 +105,7 @@ public class CType {}
 @interface DType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
 // CHECKD: key.name: "DType"
 // CHECKD: key.line: [[@LINE-5]]
 // CHECKD: key.column: 12

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.sub.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.sub.response
@@ -1,4 +1,3 @@
-
 func fooSubFunc1(_ a: Int32) -> Int32
 
 struct FooSubEnum1 : Hashable, Equatable, RawRepresentable {
@@ -26,314 +25,314 @@ var FooSubUnnamedEnumeratorA1: Int { get }
 [
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6,
+    key.offset: 5,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 18,
+    key.offset: 17,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 20,
+    key.offset: 19,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 23,
+    key.offset: 22,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 33,
+    key.offset: 32,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 40,
+    key.offset: 39,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 47,
+    key.offset: 46,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Hashable",
     key.usr: "s:SH",
-    key.offset: 61,
+    key.offset: 60,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 71,
+    key.offset: 70,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:SY",
-    key.offset: 82,
+    key.offset: 81,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 106,
+    key.offset: 105,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 111,
+    key.offset: 110,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 113,
+    key.offset: 112,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 123,
+    key.offset: 122,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 136,
+    key.offset: 135,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 141,
+    key.offset: 140,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 150,
+    key.offset: 149,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 160,
+    key.offset: 159,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 173,
+    key.offset: 172,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 177,
+    key.offset: 176,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 187,
+    key.offset: 186,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 199,
+    key.offset: 198,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 210,
+    key.offset: 209,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 214,
+    key.offset: 213,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 225,
+    key.offset: 224,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 231,
+    key.offset: 230,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 242,
+    key.offset: 241,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 253,
+    key.offset: 252,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 258,
+    key.offset: 257,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 263,
+    key.offset: 262,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 268,
+    key.offset: 267,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 276,
+    key.offset: 275,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Hasher",
     key.usr: "s:s6HasherV",
-    key.offset: 282,
+    key.offset: 281,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 295,
+    key.offset: 294,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 302,
+    key.offset: 301,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 307,
+    key.offset: 306,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 311,
+    key.offset: 310,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 313,
+    key.offset: 312,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 318,
+    key.offset: 317,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 331,
+    key.offset: 330,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 333,
+    key.offset: 332,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 338,
+    key.offset: 337,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 354,
+    key.offset: 353,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 362,
+    key.offset: 361,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 366,
+    key.offset: 365,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 380,
+    key.offset: 379,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 394,
+    key.offset: 393,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 401,
+    key.offset: 400,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 405,
+    key.offset: 404,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 419,
+    key.offset: 418,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 433,
+    key.offset: 432,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 440,
+    key.offset: 439,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 444,
+    key.offset: 443,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 471,
+    key.offset: 470,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 477,
+    key.offset: 476,
     key.length: 3
   }
 ]
@@ -342,7 +341,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooSubFunc1(_:)",
     key.usr: "c:@F@fooSubFunc1",
-    key.offset: 1,
+    key.offset: 0,
     key.length: 37,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -350,7 +349,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 23,
+        key.offset: 22,
         key.length: 5
       }
     ],
@@ -360,7 +359,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 40,
+    key.offset: 39,
     key.length: 320,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooSubEnum1</decl.name> : <ref.protocol usr=\"s:SH\">Hashable</ref.protocol>, <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol>, <ref.protocol usr=\"s:SY\">RawRepresentable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -385,7 +384,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:So11FooSubEnum1VyABs6UInt32Vcfc",
-        key.offset: 106,
+        key.offset: 105,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -393,7 +392,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 123,
+            key.offset: 122,
             key.length: 6
           }
         ]
@@ -402,7 +401,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:So11FooSubEnum1V8rawValueABs6UInt32V_tcfc",
-        key.offset: 136,
+        key.offset: 135,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -410,7 +409,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 160,
+            key.offset: 159,
             key.length: 6
           }
         ]
@@ -419,7 +418,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:So11FooSubEnum1V8rawValues6UInt32Vvp",
-        key.offset: 173,
+        key.offset: 172,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -428,7 +427,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hashValue",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@FooSubEnum1",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp",
-        key.offset: 199,
+        key.offset: 198,
         key.length: 37,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>hashValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -437,7 +436,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hash(into:)",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@FooSubEnum1",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF",
-        key.offset: 242,
+        key.offset: 241,
         key.length: 47,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hash</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>into</decl.var.parameter.argument_label> <decl.var.parameter.name>hasher</decl.var.parameter.name>: <syntaxtype.keyword>inout</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"s:s6HasherV\">Hasher</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -445,7 +444,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "into",
             key.name: "hasher",
-            key.offset: 282,
+            key.offset: 281,
             key.length: 6
           }
         ]
@@ -456,7 +455,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1</USR><Declaration>static func != (lhs: FooSubEnum1, rhs: FooSubEnum1) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 295,
+        key.offset: 294,
         key.length: 63,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -464,14 +463,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 318,
+            key.offset: 317,
             key.length: 11
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 338,
+            key.offset: 337,
             key.length: 11
           }
         ]
@@ -483,7 +482,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1X",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1X",
-    key.offset: 362,
+    key.offset: 361,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"
@@ -492,7 +491,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1Y",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1Y",
-    key.offset: 401,
+    key.offset: 400,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"
@@ -501,7 +500,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubUnnamedEnumeratorA1",
     key.usr: "c:@Ea@FooSubUnnamedEnumeratorA1@FooSubUnnamedEnumeratorA1",
-    key.offset: 440,
+    key.offset: 439,
     key.length: 42,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubUnnamedEnumeratorA1</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.ClangFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.ClangFramework.response
@@ -1,10 +1,7 @@
-
 func fromClangFramework()
 
 
 // MARK: - BystandingLibrary Additions
-
-import SwiftOnoneSupport
 
 // Available when BystandingLibrary is imported with ClangFramework
 func fromClangFrameworkCrossImport()
@@ -13,47 +10,37 @@ func fromClangFrameworkCrossImport()
 [
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6,
+    key.offset: 5,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 29,
+    key.offset: 28,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 32,
+    key.offset: 31,
     key.length: 35
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 69,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 76,
-    key.length: 17
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 95,
+    key.offset: 68,
     key.length: 68
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 163,
+    key.offset: 136,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 168,
+    key.offset: 141,
     key.length: 29
   }
 ]
@@ -62,7 +49,7 @@ func fromClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromClangFramework()",
     key.usr: "c:@F@fromClangFramework",
-    key.offset: 1,
+    key.offset: 0,
     key.length: 25,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromClangFramework</decl.name>()</decl.function.free>"
   },
@@ -70,7 +57,7 @@ func fromClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromClangFrameworkCrossImport()",
     key.usr: "s:33_ClangFramework_BystandingLibrary04fromaB11CrossImportyyF",
-    key.offset: 163,
+    key.offset: 136,
     key.length: 36,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromClangFrameworkCrossImport</decl.name>()</decl.function.free>",
     key.required_bystanders: [

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.OverlaidClangFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.OverlaidClangFramework.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 func fromOverlaidClangFramework()
 
 func fromOverlaidClangFrameworkOverlay()
@@ -15,56 +13,46 @@ func fromOverlaidClangFrameworkCrossImport()
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 0,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 5,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 61,
+    key.offset: 35,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 66,
+    key.offset: 40,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 104,
+    key.offset: 78,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 107,
+    key.offset: 81,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 144,
+    key.offset: 118,
     key.length: 76
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 220,
+    key.offset: 194,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 225,
+    key.offset: 199,
     key.length: 37
   }
 ]
@@ -73,7 +61,7 @@ func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromOverlaidClangFramework()",
     key.usr: "c:@F@fromOverlaidClangFramework",
-    key.offset: 26,
+    key.offset: 0,
     key.length: 33,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFramework</decl.name>()</decl.function.free>"
   },
@@ -81,7 +69,7 @@ func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromOverlaidClangFrameworkOverlay()",
     key.usr: "s:22OverlaidClangFramework04fromabC7OverlayyyF",
-    key.offset: 61,
+    key.offset: 35,
     key.length: 40,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFrameworkOverlay</decl.name>()</decl.function.free>"
   },
@@ -89,7 +77,7 @@ func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromOverlaidClangFrameworkCrossImport()",
     key.usr: "s:41_OverlaidClangFramework_BystandingLibrary04fromabC11CrossImportyyF",
-    key.offset: 220,
+    key.offset: 194,
     key.length: 44,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFrameworkCrossImport</decl.name>()</decl.function.free>",
     key.required_bystanders: [

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.SwiftFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.SwiftFramework.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 func fromSwiftFramework()
 
 
@@ -13,46 +11,36 @@ func fromSwiftFrameworkCrossImport()
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 0,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 5,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 54,
+    key.offset: 28,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 57,
+    key.offset: 31,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 94,
+    key.offset: 68,
     key.length: 68
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 162,
+    key.offset: 136,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 167,
+    key.offset: 141,
     key.length: 29
   }
 ]
@@ -61,7 +49,7 @@ func fromSwiftFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromSwiftFramework()",
     key.usr: "s:14SwiftFramework04fromaB0yyF",
-    key.offset: 26,
+    key.offset: 0,
     key.length: 25,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromSwiftFramework</decl.name>()</decl.function.free>"
   },
@@ -69,7 +57,7 @@ func fromSwiftFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromSwiftFrameworkCrossImport()",
     key.usr: "s:33_SwiftFramework_BystandingLibrary04fromaB11CrossImportyyF",
-    key.offset: 162,
+    key.offset: 136,
     key.length: 36,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromSwiftFrameworkCrossImport</decl.name>()</decl.function.free>",
     key.required_bystanders: [

--- a/test/SourceKit/DocSupport/doc_internal_closure_label.swift.response
+++ b/test/SourceKit/DocSupport/doc_internal_closure_label.swift.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 func foo(_ callback: (_ myInternalParam: Int) -> Void)
 
 
@@ -7,55 +5,45 @@ func foo(_ callback: (_ myInternalParam: Int) -> Void)
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 0,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 5,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 35,
+    key.offset: 9,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 37,
+    key.offset: 11,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 48,
+    key.offset: 22,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 50,
+    key.offset: 24,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 67,
+    key.offset: 41,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "Void",
     key.usr: "s:s4Voida",
-    key.offset: 75,
+    key.offset: 49,
     key.length: 4
   }
 ]
@@ -64,7 +52,7 @@ func foo(_ callback: (_ myInternalParam: Int) -> Void)
     key.kind: source.lang.swift.decl.function.free,
     key.name: "foo(_:)",
     key.usr: "s:5label3fooyyySiXEF",
-    key.offset: 26,
+    key.offset: 0,
     key.length: 54,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>callback</decl.var.parameter.name>: <decl.var.parameter.type>(<decl.var.parameter>_ <decl.var.parameter.name>myInternalParam</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.typealias usr=\"s:s4Voida\">Void</ref.typealias></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -72,7 +60,7 @@ func foo(_ callback: (_ myInternalParam: Int) -> Void)
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "callback",
-        key.offset: 47,
+        key.offset: 21,
         key.length: 32
       }
     ]

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 struct Box<Wrapped> {
 
     func boxes() -> [cake.Box<Wrapped.Element>] where Wrapped : Sequence
@@ -183,971 +181,985 @@ func shouldPrintAnyAsKeyword(x x: Any)
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 33,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 37,
+    key.offset: 11,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 53,
+    key.offset: 27,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 58,
+    key.offset: 32,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 70,
+    key.offset: 44,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Box",
     key.usr: "s:4cake3BoxV",
-    key.offset: 75,
+    key.offset: 49,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Wrapped",
     key.usr: "s:4cake3BoxV7Wrappedxmfp",
-    key.offset: 79,
+    key.offset: 53,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
     key.usr: "s:ST7ElementQa",
-    key.offset: 87,
+    key.offset: 61,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 97,
+    key.offset: 71,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Wrapped",
     key.usr: "s:4cake3BoxV7Wrappedxmfp",
-    key.offset: 103,
+    key.offset: 77,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Sequence",
     key.usr: "s:ST",
-    key.offset: 113,
+    key.offset: 87,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 125,
+    key.offset: 99,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 131,
+    key.offset: 105,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 136,
+    key.offset: 110,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 141,
+    key.offset: 115,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 153,
+    key.offset: 127,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 163,
+    key.offset: 137,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 173,
+    key.offset: 147,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 182,
+    key.offset: 156,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 186,
+    key.offset: 160,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 189,
+    key.offset: 163,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 198,
+    key.offset: 172,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 203,
+    key.offset: 177,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 214,
+    key.offset: 188,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 219,
+    key.offset: 193,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 224,
+    key.offset: 198,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 227,
+    key.offset: 201,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 231,
+    key.offset: 205,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 236,
+    key.offset: 210,
     key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 213,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
+    key.offset: 217,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 227,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 237,
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
     key.offset: 239,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int",
-    key.usr: "s:Si",
-    key.offset: 243,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 253,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 263,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 265,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 272,
+    key.offset: 246,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 280,
+    key.offset: 254,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 286,
+    key.offset: 260,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 297,
+    key.offset: 271,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 307,
+    key.offset: 281,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 313,
+    key.offset: 287,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 316,
+    key.offset: 290,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 326,
+    key.offset: 300,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 306,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 317,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 322,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
     key.offset: 332,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 343,
+    key.offset: 347,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 348,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int",
-    key.usr: "s:Si",
-    key.offset: 358,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 373,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 378,
+    key.offset: 352,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 395,
+    key.offset: 369,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 400,
+    key.offset: 374,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 414,
+    key.offset: 388,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 419,
+    key.offset: 393,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 431,
+    key.offset: 405,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 441,
+    key.offset: 415,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 443,
+    key.offset: 417,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 450,
+    key.offset: 424,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 458,
+    key.offset: 432,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 464,
+    key.offset: 438,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 473,
+    key.offset: 447,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 483,
+    key.offset: 457,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 493,
+    key.offset: 467,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 498,
+    key.offset: 472,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 512,
+    key.offset: 486,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 522,
+    key.offset: 496,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 527,
+    key.offset: 501,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P4",
     key.usr: "s:4cake2P4P",
-    key.offset: 532,
+    key.offset: 506,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 542,
+    key.offset: 516,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 547,
+    key.offset: 521,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 560,
+    key.offset: 534,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 567,
+    key.offset: 541,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 583,
+    key.offset: 557,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 588,
+    key.offset: 562,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 596,
+    key.offset: 570,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 598,
+    key.offset: 572,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 601,
+    key.offset: 575,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 605,
+    key.offset: 579,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P4",
     key.usr: "s:4cake2P4P",
-    key.offset: 610,
+    key.offset: 584,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 623,
+    key.offset: 597,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 633,
+    key.offset: 607,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "C1Cases",
     key.usr: "s:4cake2C1C0B5CasesO",
-    key.offset: 636,
+    key.offset: 610,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 651,
+    key.offset: 625,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 662,
+    key.offset: 636,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 666,
+    key.offset: 640,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 677,
+    key.offset: 651,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 683,
+    key.offset: 657,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 694,
+    key.offset: 668,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 705,
+    key.offset: 679,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 710,
+    key.offset: 684,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 715,
+    key.offset: 689,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 720,
+    key.offset: 694,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 702,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Hasher",
+    key.usr: "s:s6HasherV",
+    key.offset: 708,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 721,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 728,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Hasher",
-    key.usr: "s:s6HasherV",
-    key.offset: 734,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 747,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 754,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 759,
+    key.offset: 733,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 763,
+    key.offset: 737,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 765,
+    key.offset: 739,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 770,
+    key.offset: 744,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 775,
+    key.offset: 749,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "C1Cases",
     key.usr: "s:4cake2C1C0B5CasesO",
-    key.offset: 778,
+    key.offset: 752,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 787,
+    key.offset: 761,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 789,
+    key.offset: 763,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 794,
+    key.offset: 768,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 799,
+    key.offset: 773,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "C1Cases",
     key.usr: "s:4cake2C1C0B5CasesO",
-    key.offset: 802,
+    key.offset: 776,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 814,
+    key.offset: 788,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 822,
+    key.offset: 796,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 828,
+    key.offset: 802,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 833,
+    key.offset: 807,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 838,
+    key.offset: 812,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 848,
+    key.offset: 822,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 853,
+    key.offset: 827,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 864,
+    key.offset: 838,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 869,
+    key.offset: 843,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 878,
+    key.offset: 852,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 889,
+    key.offset: 863,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 894,
+    key.offset: 868,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 904,
+    key.offset: 878,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 915,
+    key.offset: 889,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 919,
+    key.offset: 893,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 930,
+    key.offset: 904,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 936,
+    key.offset: 910,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 947,
+    key.offset: 921,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 958,
+    key.offset: 932,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 963,
+    key.offset: 937,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 968,
+    key.offset: 942,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 973,
+    key.offset: 947,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 981,
+    key.offset: 955,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Hasher",
     key.usr: "s:s6HasherV",
-    key.offset: 987,
+    key.offset: 961,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1000,
+    key.offset: 974,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1007,
+    key.offset: 981,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 1012,
+    key.offset: 986,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1016,
+    key.offset: 990,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1018,
+    key.offset: 992,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1023,
+    key.offset: 997,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "MyEnum",
     key.usr: "s:4cake6MyEnumO",
-    key.offset: 1028,
+    key.offset: 1002,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1036,
+    key.offset: 1010,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1038,
+    key.offset: 1012,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1043,
+    key.offset: 1017,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "MyEnum",
     key.usr: "s:4cake6MyEnumO",
-    key.offset: 1048,
+    key.offset: 1022,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1059,
+    key.offset: 1033,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1067,
+    key.offset: 1041,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1076,
+    key.offset: 1050,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1085,
+    key.offset: 1059,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1090,
+    key.offset: 1064,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1099,
+    key.offset: 1073,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P",
     key.usr: "s:4cake1PP",
-    key.offset: 1109,
+    key.offset: 1083,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1118,
+    key.offset: 1092,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1123,
+    key.offset: 1097,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1129,
+    key.offset: 1103,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:4cake1PP4Selfxmfp",
-    key.offset: 1135,
+    key.offset: 1109,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 1142,
+    key.offset: 1116,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1155,
+    key.offset: 1129,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1161,
+    key.offset: 1135,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1170,
+    key.offset: 1144,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1180,
+    key.offset: 1154,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1186,
+    key.offset: 1160,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1195,
+    key.offset: 1169,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1200,
+    key.offset: 1174,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1210,
+    key.offset: 1184,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1219,
+    key.offset: 1193,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1229,
+    key.offset: 1203,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1244,
+    key.offset: 1218,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1223,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1232,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1240,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1249,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1258,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1266,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1275,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1285,
+    key.offset: 1259,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1300,
+    key.offset: 1274,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1311,
+    key.offset: 1285,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1320,
+    key.offset: 1294,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1325,
+    key.offset: 1299,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P5",
     key.usr: "s:4cake2P5P",
-    key.offset: 1330,
+    key.offset: 1304,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1338,
+    key.offset: 1312,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P6",
     key.usr: "s:4cake2P6P",
-    key.offset: 1348,
+    key.offset: 1322,
     key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1332,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1336,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "Self",
+    key.usr: "s:4cake2P6P4Selfxmfp",
+    key.offset: 1342,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.associatedtype,
+    key.name: "Element",
+    key.usr: "s:4cake2P5P7ElementQa",
+    key.offset: 1347,
+    key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -1155,616 +1167,623 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1362,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "Self",
-    key.usr: "s:4cake2P6P4Selfxmfp",
-    key.offset: 1368,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.ref.associatedtype,
-    key.name: "Element",
-    key.usr: "s:4cake2P5P7ElementQa",
-    key.offset: 1373,
-    key.length: 7
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1384,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1393,
+    key.offset: 1367,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1402,
+    key.offset: 1376,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1414,
+    key.offset: 1388,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1429,
+    key.offset: 1403,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1442,
+    key.offset: 1416,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1446,
+    key.offset: 1420,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1449,
+    key.offset: 1423,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1455,
+    key.offset: 1429,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1466,
+    key.offset: 1440,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1445,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1456,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1461,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1471,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1482,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1487,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1497,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1507,
+    key.offset: 1481,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1519,
+    key.offset: 1493,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1524,
+    key.offset: 1498,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1536,
+    key.offset: 1510,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1546,
+    key.offset: 1520,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1548,
+    key.offset: 1522,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1555,
+    key.offset: 1529,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1563,
+    key.offset: 1537,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1569,
+    key.offset: 1543,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1578,
+    key.offset: 1552,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1588,
+    key.offset: 1562,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1593,
+    key.offset: 1567,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:4cake4ProtP4Selfxmfp",
-    key.offset: 1599,
+    key.offset: 1573,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
     key.usr: "s:4cake4ProtP7ElementQa",
-    key.offset: 1604,
+    key.offset: 1578,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 1612,
+    key.offset: 1586,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1615,
+    key.offset: 1589,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1626,
+    key.offset: 1600,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1631,
+    key.offset: 1605,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1643,
+    key.offset: 1617,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1650,
+    key.offset: 1624,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1660,
+    key.offset: 1634,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1665,
+    key.offset: 1639,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1679,
+    key.offset: 1653,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1684,
+    key.offset: 1658,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1695,
+    key.offset: 1669,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1700,
+    key.offset: 1674,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1711,
+    key.offset: 1685,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1716,
+    key.offset: 1690,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1729,
+    key.offset: 1703,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1734,
+    key.offset: 1708,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1746,
+    key.offset: 1720,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1753,
+    key.offset: 1727,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1767,
+    key.offset: 1741,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1771,
+    key.offset: 1745,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1774,
+    key.offset: 1748,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1787,
+    key.offset: 1761,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1797,
+    key.offset: 1771,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "SE",
     key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1800,
+    key.offset: 1774,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1810,
+    key.offset: 1784,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1817,
+    key.offset: 1791,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 1822,
+    key.offset: 1796,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 1800,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1802,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1807,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "S1",
+    key.usr: "s:4cake2S1V",
+    key.offset: 1812,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.ref.enum,
+    key.name: "SE",
+    key.usr: "s:4cake2S1V2SEO",
+    key.offset: 1815,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 1819,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1821,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1826,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1828,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1833,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1838,
+    key.offset: 1831,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "SE",
     key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1841,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1845,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1847,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1852,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "S1",
-    key.usr: "s:4cake2S1V",
-    key.offset: 1857,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.ref.enum,
-    key.name: "SE",
-    key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1860,
+    key.offset: 1834,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1867,
+    key.offset: 1841,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1875,
+    key.offset: 1849,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1882,
+    key.offset: 1856,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1887,
+    key.offset: 1861,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P3",
     key.usr: "s:4cake2P3P",
-    key.offset: 1892,
+    key.offset: 1866,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1902,
+    key.offset: 1876,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1912,
+    key.offset: 1886,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1916,
+    key.offset: 1890,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S2",
     key.usr: "s:4cake2S2V",
-    key.offset: 1921,
+    key.offset: 1895,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1927,
+    key.offset: 1901,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1934,
+    key.offset: 1908,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1937,
+    key.offset: 1911,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1948,
+    key.offset: 1922,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P5",
     key.usr: "s:4cake2P5P",
-    key.offset: 1953,
+    key.offset: 1927,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1956,
+    key.offset: 1930,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Wrapped",
     key.usr: "s:4cake2S3V7Wrappedxmfp",
-    key.offset: 1962,
+    key.offset: 1936,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1972,
+    key.offset: 1946,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P5",
     key.usr: "s:4cake2P5P",
-    key.offset: 1977,
+    key.offset: 1951,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1987,
+    key.offset: 1961,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1997,
+    key.offset: 1971,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Wrapped",
     key.usr: "s:4cake2S3V7Wrappedxmfp",
-    key.offset: 2007,
+    key.offset: 1981,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
     key.usr: "s:4cake2P5P7ElementQa",
-    key.offset: 2015,
+    key.offset: 1989,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2026,
+    key.offset: 2000,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S3",
     key.usr: "s:4cake2S3V",
-    key.offset: 2036,
+    key.offset: 2010,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2039,
+    key.offset: 2013,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Wrapped",
     key.usr: "s:4cake2S3V7Wrappedxmfp",
-    key.offset: 2045,
+    key.offset: 2019,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2055,
+    key.offset: 2029,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P6",
     key.usr: "s:4cake2P6P",
-    key.offset: 2060,
+    key.offset: 2034,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2070,
+    key.offset: 2044,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2074,
+    key.offset: 2048,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Wrapped",
     key.usr: "s:4cake2S3V7Wrappedxmfp",
-    key.offset: 2080,
+    key.offset: 2054,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
     key.usr: "s:4cake2P5P7ElementQa",
-    key.offset: 2088,
+    key.offset: 2062,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2099,
+    key.offset: 2073,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2108,
+    key.offset: 2082,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2113,
+    key.offset: 2087,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2120,
+    key.offset: 2094,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2124,
+    key.offset: 2098,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2128,
+    key.offset: 2102,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2130,
+    key.offset: 2104,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T1",
     key.usr: "s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp",
-    key.offset: 2134,
+    key.offset: 2108,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2138,
+    key.offset: 2112,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2140,
+    key.offset: 2114,
     key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "T2",
+    key.usr: "s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T2L_q_mfp",
+    key.offset: 2118,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2122,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "T1",
+    key.usr: "s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp",
+    key.offset: 2128,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2133,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.protocol,
+    key.name: "Prot",
+    key.usr: "s:4cake4ProtP",
+    key.offset: 2138,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
@@ -1774,97 +1793,66 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.length: 2
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2148,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "T1",
-    key.usr: "s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp",
-    key.offset: 2154,
-    key.length: 2
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2159,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.ref.protocol,
-    key.name: "Prot",
-    key.usr: "s:4cake4ProtP",
-    key.offset: 2164,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "T2",
-    key.usr: "s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T2L_q_mfp",
-    key.offset: 2170,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2175,
+    key.offset: 2149,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 2180,
+    key.offset: 2154,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T1",
     key.usr: "s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp",
-    key.offset: 2184,
+    key.offset: 2158,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
     key.usr: "s:4cake4ProtP7ElementQa",
-    key.offset: 2187,
+    key.offset: 2161,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 2195,
+    key.offset: 2169,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 2198,
+    key.offset: 2172,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2203,
+    key.offset: 2177,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2208,
+    key.offset: 2182,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2232,
+    key.offset: 2206,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2234,
+    key.offset: 2208,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2237,
+    key.offset: 2211,
     key.length: 3
   }
 ]
@@ -1878,7 +1866,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "Wrapped"
       }
     ],
-    key.offset: 26,
+    key.offset: 0,
     key.length: 97,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>Box</decl.name>&lt;<decl.generic_type_param usr=\"s:4cake3BoxV7Wrappedxmfp\"><decl.generic_type_param.name>Wrapped</decl.generic_type_param.name></decl.generic_type_param>&gt;</decl.struct>",
     key.entities: [
@@ -1891,7 +1879,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.description: "Wrapped : Sequence"
           }
         ],
-        key.offset: 53,
+        key.offset: 27,
         key.length: 68,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>boxes</decl.name>() -&gt; <decl.function.returntype>[<ref.struct usr=\"s:4cake3BoxV\">Box</ref.struct>&lt;<ref.generic_type_param usr=\"s:4cake3BoxV7Wrappedxmfp\">Wrapped</ref.generic_type_param>.<ref.associatedtype usr=\"s:ST7ElementQa\">Element</ref.associatedtype>&gt;]</decl.function.returntype> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake3BoxV7Wrappedxmfp\">Wrapped</ref.generic_type_param> : <ref.protocol usr=\"s:ST\">Sequence</ref.protocol></decl.generic_type_requirement></decl.function.method.instance>"
       }
@@ -1901,7 +1889,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 125,
+    key.offset: 99,
     key.length: 346,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>C1</decl.name> : <ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.class>",
     key.conforms: [
@@ -1916,7 +1904,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Element",
         key.usr: "s:4cake2C1C7Elementa",
-        key.offset: 153,
+        key.offset: 127,
         key.length: 23,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<decl.name>Element</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
         key.conforms: [
@@ -1941,7 +1929,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "p",
         key.usr: "s:4cake2C1C1pSivp",
-        key.offset: 182,
+        key.offset: 156,
         key.length: 10,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>p</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.instance>",
         key.conforms: [
@@ -1956,7 +1944,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:4cake2C1C3fooyyF",
-        key.offset: 198,
+        key.offset: 172,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>",
         key.conforms: [
@@ -1971,7 +1959,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1(i0:i1:)",
         key.usr: "s:4cake2C1C4foo12i02i1ySin_SihtF",
-        key.offset: 214,
+        key.offset: 188,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>i0</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>i1</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1979,14 +1967,14 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "i0",
             key.name: "i0",
-            key.offset: 231,
+            key.offset: 205,
             key.length: 3
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "i1",
             key.name: "i1",
-            key.offset: 243,
+            key.offset: 217,
             key.length: 3
           }
         ]
@@ -1995,7 +1983,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
         key.usr: "s:4cake2C1CyS2icip",
-        key.offset: 253,
+        key.offset: 227,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -2003,7 +1991,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "index",
-            key.offset: 272,
+            key.offset: 246,
             key.length: 3
           }
         ]
@@ -2012,7 +2000,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(index:)",
         key.usr: "s:4cake2C1C5indexSiSf_tcip",
-        key.offset: 297,
+        key.offset: 271,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>index</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -2020,7 +2008,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "index",
             key.name: "i",
-            key.offset: 316,
+            key.offset: 290,
             key.length: 5
           }
         ]
@@ -2029,7 +2017,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.enum,
         key.name: "C1Cases",
         key.usr: "s:4cake2C1C0B5CasesO",
-        key.offset: 343,
+        key.offset: 317,
         key.length: 46,
         key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>C1Cases</decl.name> : <ref.struct usr=\"s:Si\">Int</ref.struct></decl.enum>",
         key.inherits: [
@@ -2044,7 +2032,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "case1",
             key.usr: "s:4cake2C1C0B5CasesO5case1yA2EmF",
-            key.offset: 373,
+            key.offset: 347,
             key.length: 10,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>case1</decl.name></decl.enumelement>"
           }
@@ -2055,7 +2043,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "extfoo()",
         key.usr: "s:4cake4ProtPAASi7ElementRtzrlE6extfooyyF::SYNTHESIZED::s:4cake2C1C",
         key.original_usr: "s:4cake4ProtPAASi7ElementRtzrlE6extfooyyF",
-        key.offset: 395,
+        key.offset: 369,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>extfoo</decl.name>()</decl.function.method.instance>"
       },
@@ -2064,7 +2052,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "foo1()",
         key.usr: "s:4cake4ProtPAAE4foo1yyF::SYNTHESIZED::s:4cake2C1C",
         key.original_usr: "s:4cake4ProtPAAE4foo1yyF",
-        key.offset: 414,
+        key.offset: 388,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -2073,7 +2061,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "subscript(_:)",
         key.usr: "s:4cake4ProtPAAEyS2icip::SYNTHESIZED::s:4cake2C1C",
         key.original_usr: "s:4cake4ProtPAAEyS2icip",
-        key.offset: 431,
+        key.offset: 405,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -2081,7 +2069,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "index",
-            key.offset: 450,
+            key.offset: 424,
             key.length: 3
           }
         ]
@@ -2091,7 +2079,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
   {
     key.kind: source.lang.swift.decl.extension.class,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)\nextension C1</Declaration><CommentParts><Abstract><Para>some comments</Para></Abstract></CommentParts></Other>",
-    key.offset: 473,
+    key.offset: 447,
     key.length: 37,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.name></decl.extension.class>",
     key.extends: {
@@ -2104,7 +2092,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "addition()",
         key.usr: "s:4cake2C1C8additionyyF",
-        key.offset: 493,
+        key.offset: 467,
         key.length: 15,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>addition</decl.name>()</decl.function.method.instance>"
       }
@@ -2134,7 +2122,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 512,
+    key.offset: 486,
     key.length: 109,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.name> : <ref.protocol usr=\"s:4cake2P4P\">P4</ref.protocol></decl.extension.class>",
     key.conforms: [
@@ -2154,7 +2142,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "C1foo()",
         key.usr: "s:4cake2C1C5C1fooyyF",
-        key.offset: 542,
+        key.offset: 516,
         key.length: 12,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>C1foo</decl.name>()</decl.function.method.instance>"
       },
@@ -2162,7 +2150,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.struct,
         key.name: "C1S1",
         key.usr: "s:4cake2C1C0B2S1V",
-        key.offset: 560,
+        key.offset: 534,
         key.length: 59,
         key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>C1S1</decl.name></decl.struct>",
         key.entities: [
@@ -2170,7 +2158,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.function.method.instance,
             key.name: "C1S1foo(a:)",
             key.usr: "s:4cake2C1C0B2S1V0B5S1foo1ayAA2P4_p_tF",
-            key.offset: 583,
+            key.offset: 557,
             key.length: 30,
             key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>C1S1foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>a</decl.var.parameter.argument_label>: <decl.var.parameter.type>any <ref.protocol usr=\"s:4cake2P4P\">P4</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
             key.entities: [
@@ -2178,7 +2166,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
                 key.kind: source.lang.swift.decl.var.local,
                 key.keyword: "a",
                 key.name: "a",
-                key.offset: 601,
+                key.offset: 575,
                 key.length: 11
               }
             ]
@@ -2189,7 +2177,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
   },
   {
     key.kind: source.lang.swift.decl.extension.enum,
-    key.offset: 623,
+    key.offset: 597,
     key.length: 197,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum>",
     key.extends: {
@@ -2203,7 +2191,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "hashValue",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:4cake2C1C0B5CasesO",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp",
-        key.offset: 651,
+        key.offset: 625,
         key.length: 37,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>hashValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -2212,7 +2200,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "hash(into:)",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:4cake2C1C0B5CasesO",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF",
-        key.offset: 694,
+        key.offset: 668,
         key.length: 47,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hash</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>into</decl.var.parameter.argument_label> <decl.var.parameter.name>hasher</decl.var.parameter.name>: <syntaxtype.keyword>inout</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"s:s6HasherV\">Hasher</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -2220,7 +2208,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "into",
             key.name: "hasher",
-            key.offset: 734,
+            key.offset: 708,
             key.length: 6
           }
         ]
@@ -2231,7 +2219,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake2C1C0B5CasesO",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake2C1C0B5CasesO</USR><Declaration>static func != (lhs: cake.C1.C1Cases, rhs: cake.C1.C1Cases) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 747,
+        key.offset: 721,
         key.length: 71,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -2239,14 +2227,14 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 770,
+            key.offset: 744,
             key.length: 15
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 794,
+            key.offset: 768,
             key.length: 15
           }
         ]
@@ -2257,7 +2245,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.class,
     key.name: "C2",
     key.usr: "s:4cake2C2C",
-    key.offset: 822,
+    key.offset: 796,
     key.length: 40,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>C2</decl.name> : <ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.class>",
     key.inherits: [
@@ -2272,7 +2260,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "C2foo()",
         key.usr: "s:4cake2C2C5C2fooyyF",
-        key.offset: 848,
+        key.offset: 822,
         key.length: 12,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>C2foo</decl.name>()</decl.function.method.instance>"
       }
@@ -2282,7 +2270,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.enum,
     key.name: "MyEnum",
     key.usr: "s:4cake6MyEnumO",
-    key.offset: 864,
+    key.offset: 838,
     key.length: 201,
     key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>MyEnum</decl.name> : <ref.struct usr=\"s:Si\">Int</ref.struct></decl.enum>",
     key.inherits: [
@@ -2297,7 +2285,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "Blah",
         key.usr: "s:4cake6MyEnumO4BlahyA2CmF",
-        key.offset: 889,
+        key.offset: 863,
         key.length: 9,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>Blah</decl.name></decl.enumelement>"
       },
@@ -2306,7 +2294,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "hashValue",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::s:4cake6MyEnumO",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp",
-        key.offset: 904,
+        key.offset: 878,
         key.length: 37,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>hashValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -2315,7 +2303,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "hash(into:)",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::s:4cake6MyEnumO",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF",
-        key.offset: 947,
+        key.offset: 921,
         key.length: 47,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hash</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>into</decl.var.parameter.argument_label> <decl.var.parameter.name>hasher</decl.var.parameter.name>: <syntaxtype.keyword>inout</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"s:s6HasherV\">Hasher</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -2323,7 +2311,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "into",
             key.name: "hasher",
-            key.offset: 987,
+            key.offset: 961,
             key.length: 6
           }
         ]
@@ -2334,7 +2322,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake6MyEnumO",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake6MyEnumO</USR><Declaration>static func != (lhs: cake.MyEnum, rhs: cake.MyEnum) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 1000,
+        key.offset: 974,
         key.length: 63,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:4cake6MyEnumO\">MyEnum</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:4cake6MyEnumO\">MyEnum</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -2342,14 +2330,14 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 1023,
+            key.offset: 997,
             key.length: 11
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 1043,
+            key.offset: 1017,
             key.length: 11
           }
         ]
@@ -2360,7 +2348,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P",
     key.usr: "s:4cake1PP",
-    key.offset: 1067,
+    key.offset: 1041,
     key.length: 30,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P</decl.name></decl.protocol>",
     key.entities: [
@@ -2368,7 +2356,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:4cake1PP3fooyyF",
-        key.offset: 1085,
+        key.offset: 1059,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
       }
@@ -2376,7 +2364,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 1099,
+    key.offset: 1073,
     key.length: 54,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:4cake1PP\">P</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
@@ -2394,7 +2382,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.description: "Self : Equatable"
           }
         ],
-        key.offset: 1118,
+        key.offset: 1092,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>() <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake1PP4Selfxmfp\">Self</ref.generic_type_param> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol></decl.generic_type_requirement></decl.function.method.instance>"
       }
@@ -2404,7 +2392,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P2",
     key.usr: "c:@M@cake@objc(pl)P2",
-    key.offset: 1155,
+    key.offset: 1129,
     key.length: 53,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@objc</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name></decl.protocol>",
     key.entities: [
@@ -2412,7 +2400,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "c:@M@cake@objc(pl)P2(im)foo1",
-        key.offset: 1180,
+        key.offset: 1154,
         key.length: 26,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@objc</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>optional</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>",
         key.is_optional: 1
@@ -2423,7 +2411,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P3",
     key.usr: "s:4cake2P3P",
-    key.offset: 1210,
+    key.offset: 1184,
     key.length: 37,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P3</decl.name></decl.protocol>",
     key.entities: [
@@ -2431,7 +2419,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "T",
         key.usr: "s:4cake2P3P1TQa",
-        key.offset: 1229,
+        key.offset: 1203,
         key.length: 16,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>T</decl.name></decl.associatedtype>"
       }
@@ -2441,7 +2429,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P4",
     key.usr: "s:4cake2P4P",
-    key.offset: 1249,
+    key.offset: 1223,
     key.length: 15,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P4</decl.name></decl.protocol>"
   },
@@ -2449,7 +2437,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P5",
     key.usr: "s:4cake2P5P",
-    key.offset: 1266,
+    key.offset: 1240,
     key.length: 43,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P5</decl.name></decl.protocol>",
     key.entities: [
@@ -2457,7 +2445,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
         key.usr: "s:4cake2P5P7ElementQa",
-        key.offset: 1285,
+        key.offset: 1259,
         key.length: 22,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
       }
@@ -2467,7 +2455,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P6",
     key.usr: "s:4cake2P6P",
-    key.offset: 1311,
+    key.offset: 1285,
     key.length: 25,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P6</decl.name> : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol></decl.protocol>",
     key.conforms: [
@@ -2480,7 +2468,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 1338,
+    key.offset: 1312,
     key.length: 53,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:4cake2P6P\">P6</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
@@ -2493,7 +2481,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "null",
         key.usr: "s:4cake2P6PAAE4null7ElementQzSgvp",
-        key.offset: 1358,
+        key.offset: 1332,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>null</decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:4cake2P6P4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:4cake2P5P7ElementQa\">Element</ref.associatedtype>?</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -2503,7 +2491,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1393,
+    key.offset: 1367,
     key.length: 102,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Prot</decl.name></decl.protocol>",
     key.entities: [
@@ -2511,7 +2499,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
         key.usr: "s:4cake4ProtP7ElementQa",
-        key.offset: 1414,
+        key.offset: 1388,
         key.length: 22,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
       },
@@ -2519,7 +2507,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "p",
         key.usr: "s:4cake4ProtP1pSivp",
-        key.offset: 1442,
+        key.offset: 1416,
         key.length: 18,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>p</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -2527,7 +2515,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:4cake4ProtP3fooyyF",
-        key.offset: 1466,
+        key.offset: 1440,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
       },
@@ -2535,7 +2523,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:4cake4ProtP4foo1yyF",
-        key.offset: 1482,
+        key.offset: 1456,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       }
@@ -2543,7 +2531,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 1497,
+    key.offset: 1471,
     key.length: 79,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
@@ -2557,7 +2545,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "foo1()",
         key.usr: "s:4cake4ProtPAAE4foo1yyF",
         key.default_implementation_of: "s:4cake4ProtP4foo1yyF",
-        key.offset: 1519,
+        key.offset: 1493,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -2565,7 +2553,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
         key.usr: "s:4cake4ProtPAAEyS2icip",
-        key.offset: 1536,
+        key.offset: 1510,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -2573,7 +2561,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "index",
-            key.offset: 1555,
+            key.offset: 1529,
             key.length: 3
           }
         ]
@@ -2587,7 +2575,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.description: "Self.Element == Int"
       }
     ],
-    key.offset: 1578,
+    key.offset: 1552,
     key.length: 63,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake4ProtP4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:4cake4ProtP7ElementQa\">Element</ref.associatedtype> == <ref.struct usr=\"s:Si\">Int</ref.struct></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
@@ -2600,7 +2588,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "extfoo()",
         key.usr: "s:4cake4ProtPAASi7ElementRtzrlE6extfooyyF",
-        key.offset: 1626,
+        key.offset: 1600,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>extfoo</decl.name>()</decl.function.method.instance>"
       }
@@ -2610,7 +2598,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1643,
+    key.offset: 1617,
     key.length: 142,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>",
     key.entities: [
@@ -2618,7 +2606,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.enum,
         key.name: "SE",
         key.usr: "s:4cake2S1V2SEO",
-        key.offset: 1660,
+        key.offset: 1634,
         key.length: 63,
         key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<decl.name>SE</decl.name></decl.enum>",
         key.entities: [
@@ -2626,7 +2614,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "a",
             key.usr: "s:4cake2S1V2SEO1ayA2EmF",
-            key.offset: 1679,
+            key.offset: 1653,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>a</decl.name></decl.enumelement>"
           },
@@ -2634,7 +2622,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "b",
             key.usr: "s:4cake2S1V2SEO1byA2EmF",
-            key.offset: 1695,
+            key.offset: 1669,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>b</decl.name></decl.enumelement>"
           },
@@ -2642,7 +2630,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "c",
             key.usr: "s:4cake2S1V2SEO1cyA2EmF",
-            key.offset: 1711,
+            key.offset: 1685,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>c</decl.name></decl.enumelement>"
           }
@@ -2652,7 +2640,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:4cake2S1V4foo1yyF",
-        key.offset: 1729,
+        key.offset: 1703,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -2660,7 +2648,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.struct,
         key.name: "S2",
         key.usr: "s:4cake2S1V2S2V",
-        key.offset: 1746,
+        key.offset: 1720,
         key.length: 37,
         key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name></decl.struct>",
         key.entities: [
@@ -2668,7 +2656,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.instance,
             key.name: "b",
             key.usr: "s:4cake2S1V2S2V1bSivp",
-            key.offset: 1767,
+            key.offset: 1741,
             key.length: 10,
             key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>b</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.instance>"
           }
@@ -2678,7 +2666,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
   },
   {
     key.kind: source.lang.swift.decl.extension.enum,
-    key.offset: 1787,
+    key.offset: 1761,
     key.length: 86,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum>",
     key.extends: {
@@ -2693,7 +2681,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake2S1V2SEO",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake2S1V2SEO</USR><Declaration>static func != (lhs: cake.S1.SE, rhs: cake.S1.SE) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 1810,
+        key.offset: 1784,
         key.length: 61,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -2701,14 +2689,14 @@ func shouldPrintAnyAsKeyword(x x: Any)
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 1833,
+            key.offset: 1807,
             key.length: 10
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 1852,
+            key.offset: 1826,
             key.length: 10
           }
         ]
@@ -2719,7 +2707,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.struct,
     key.name: "S2",
     key.usr: "s:4cake2S2V",
-    key.offset: 1875,
+    key.offset: 1849,
     key.length: 50,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name> : <ref.protocol usr=\"s:4cake2P3P\">P3</ref.protocol></decl.struct>",
     key.conforms: [
@@ -2734,7 +2722,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.typealias,
         key.name: "T",
         key.usr: "s:4cake2S2V1Ta",
-        key.offset: 1902,
+        key.offset: 1876,
         key.length: 21,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct>.<decl.name>T</decl.name> = <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct></decl.typealias>",
         key.conforms: [
@@ -2761,7 +2749,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.description: "Wrapped : P5"
       }
     ],
-    key.offset: 1927,
+    key.offset: 1901,
     key.length: 97,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S3</decl.name>&lt;<decl.generic_type_param usr=\"s:4cake2S3V7Wrappedxmfp\"><decl.generic_type_param.name>Wrapped</decl.generic_type_param.name></decl.generic_type_param>&gt; : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake2S3V7Wrappedxmfp\">Wrapped</ref.generic_type_param> : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol></decl.generic_type_requirement></decl.struct>",
     key.conforms: [
@@ -2776,7 +2764,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Element",
         key.usr: "s:4cake2S3V7Elementa",
-        key.offset: 1987,
+        key.offset: 1961,
         key.length: 35,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S3V\">S3</ref.struct>&lt;<ref.generic_type_param usr=\"s:4cake2S3V7Wrappedxmfp\">Wrapped</ref.generic_type_param>&gt;.<decl.name>Element</decl.name> = <ref.generic_type_param usr=\"s:4cake2S3V7Wrappedxmfp\">Wrapped</ref.generic_type_param>.<ref.associatedtype usr=\"s:4cake2P5P7ElementQa\">Element</ref.associatedtype></decl.typealias>",
         key.conforms: [
@@ -2801,7 +2789,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.description: "Wrapped : P6"
       }
     ],
-    key.offset: 2026,
+    key.offset: 2000,
     key.length: 80,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S3V\">S3</ref.struct> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake2S3V7Wrappedxmfp\">Wrapped</ref.generic_type_param> : <ref.protocol usr=\"s:4cake2P6P\">P6</ref.protocol></decl.generic_type_requirement>",
     key.extends: {
@@ -2815,7 +2803,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.name: "null",
         key.usr: "s:4cake2P6PAAE4null7ElementQzSgvp::SYNTHESIZED::s:4cake2S3V",
         key.original_usr: "s:4cake2P6PAAE4null7ElementQzSgvp",
-        key.offset: 2070,
+        key.offset: 2044,
         key.length: 34,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>null</decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:4cake2S3V7Wrappedxmfp\">Wrapped</ref.generic_type_param>.<ref.associatedtype usr=\"s:4cake2P5P7ElementQa\">Element</ref.associatedtype>?</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -2844,7 +2832,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.description: "T1.Element == Int"
       }
     ],
-    key.offset: 2108,
+    key.offset: 2082,
     key.length: 93,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>genfoo</decl.name>&lt;<decl.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp\"><decl.generic_type_param.name>T1</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T2L_q_mfp\"><decl.generic_type_param.name>T2</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label> <decl.var.parameter.name>ix</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp\">T1</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label> <decl.var.parameter.name>iy</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T2L_q_mfp\">T2</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp\">T1</ref.generic_type_param> : <ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T2L_q_mfp\">T2</ref.generic_type_param> : <ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp\">T1</ref.generic_type_param>.<ref.associatedtype usr=\"s:4cake4ProtP7ElementQa\">Element</ref.associatedtype> == <ref.struct usr=\"s:Si\">Int</ref.struct></decl.generic_type_requirement></decl.function.free>",
     key.entities: [
@@ -2852,14 +2840,14 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "x",
         key.name: "ix",
-        key.offset: 2134,
+        key.offset: 2108,
         key.length: 2
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "y",
         key.name: "iy",
-        key.offset: 2144,
+        key.offset: 2118,
         key.length: 2
       }
     ]
@@ -2868,7 +2856,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
     key.kind: source.lang.swift.decl.function.free,
     key.name: "shouldPrintAnyAsKeyword(x:)",
     key.usr: "s:4cake23shouldPrintAnyAsKeyword1xyyp_tF",
-    key.offset: 2203,
+    key.offset: 2177,
     key.length: 38,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>shouldPrintAnyAsKeyword</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><syntaxtype.keyword>Any</syntaxtype.keyword></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -2876,7 +2864,7 @@ func shouldPrintAnyAsKeyword(x x: Any)
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "x",
         key.name: "x",
-        key.offset: 2237,
+        key.offset: 2211,
         key.length: 3
       }
     ]

--- a/test/SourceKit/DocSupport/doc_swift_module1.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module1.swift.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 class InitClassImpl : cake1.InitProto {
 
     required init(x x: Int)
@@ -80,610 +78,600 @@ extension Dictionary.Keys where Key : cake1.P1 {
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 0,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 32,
+    key.offset: 6,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 48,
+    key.offset: 22,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "InitProto",
     key.usr: "s:5cake19InitProtoP",
-    key.offset: 54,
+    key.offset: 28,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 71,
+    key.offset: 45,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 80,
+    key.offset: 54,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 85,
+    key.offset: 59,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 87,
+    key.offset: 61,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 90,
+    key.offset: 64,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 100,
+    key.offset: 74,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 112,
+    key.offset: 86,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 122,
+    key.offset: 96,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 131,
+    key.offset: 105,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 148,
+    key.offset: 122,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 153,
+    key.offset: 127,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 155,
+    key.offset: 129,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 158,
+    key.offset: 132,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 166,
+    key.offset: 140,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "InitProto",
     key.usr: "s:5cake19InitProtoP",
-    key.offset: 176,
+    key.offset: 150,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 193,
+    key.offset: 167,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 203,
+    key.offset: 177,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 210,
+    key.offset: 184,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 227,
+    key.offset: 201,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "InitProto",
     key.usr: "s:5cake19InitProtoP",
-    key.offset: 233,
+    key.offset: 207,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 250,
+    key.offset: 224,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 255,
+    key.offset: 229,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 257,
+    key.offset: 231,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 260,
+    key.offset: 234,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 270,
+    key.offset: 244,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 280,
+    key.offset: 254,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 289,
+    key.offset: 263,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 299,
+    key.offset: 273,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 304,
+    key.offset: 278,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 316,
+    key.offset: 290,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 320,
+    key.offset: 294,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
+    key.offset: 299,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 305,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 309,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 320,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 325,
-    key.length: 3
+    key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 331,
-    key.length: 3
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 330,
+    key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 332,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
     key.offset: 335,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 346,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 351,
-    key.length: 4
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 356,
+    key.offset: 340,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 358,
+    key.offset: 342,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 361,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 366,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 368,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int",
-    key.usr: "s:Si",
-    key.offset: 371,
+    key.offset: 345,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 381,
+    key.offset: 355,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 391,
+    key.offset: 365,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 393,
+    key.offset: 367,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 396,
+    key.offset: 370,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 404,
+    key.offset: 378,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 410,
+    key.offset: 384,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 414,
+    key.offset: 388,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 425,
+    key.offset: 399,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 430,
+    key.offset: 404,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 449,
+    key.offset: 423,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 458,
+    key.offset: 432,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 463,
+    key.offset: 437,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P1",
     key.usr: "s:5cake12P1P",
-    key.offset: 469,
+    key.offset: 443,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 479,
+    key.offset: 453,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 484,
+    key.offset: 458,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 496,
+    key.offset: 470,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 501,
+    key.offset: 475,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 511,
+    key.offset: 485,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P2",
     key.usr: "s:5cake12P2P",
-    key.offset: 521,
+    key.offset: 495,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 505,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 510,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 522,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 526,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
     key.offset: 531,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 536,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 548,
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 540,
+    key.length: 4
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 545,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 550,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
     key.offset: 552,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int",
-    key.usr: "s:Si",
-    key.offset: 557,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 566,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 571,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 576,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 578,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 581,
+    key.offset: 555,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 586,
+    key.offset: 560,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 588,
+    key.offset: 562,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 591,
+    key.offset: 565,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 601,
+    key.offset: 575,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 611,
+    key.offset: 585,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 613,
+    key.offset: 587,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 616,
+    key.offset: 590,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 624,
+    key.offset: 598,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 631,
+    key.offset: 605,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P2",
     key.usr: "s:5cake12P2P",
-    key.offset: 641,
+    key.offset: 615,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 644,
+    key.offset: 618,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:5cake12P2P4Selfxmfp",
-    key.offset: 650,
+    key.offset: 624,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 657,
+    key.offset: 631,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P3",
     key.usr: "s:5cake12P3P",
-    key.offset: 663,
+    key.offset: 637,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 673,
+    key.offset: 647,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 678,
+    key.offset: 652,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 697,
+    key.offset: 671,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 706,
+    key.offset: 680,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 716,
+    key.offset: 690,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 695,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 711,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Dictionary",
+    key.usr: "s:SD",
     key.offset: 721,
     key.length: 10
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 737,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Dictionary",
-    key.usr: "s:SD",
-    key.offset: 747,
-    key.length: 10
-  },
-  {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Keys",
     key.usr: "s:SD4KeysV",
-    key.offset: 758,
+    key.offset: 732,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 770,
+    key.offset: 744,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 775,
+    key.offset: 749,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 784,
+    key.offset: 758,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Dictionary",
     key.usr: "s:SD",
-    key.offset: 794,
+    key.offset: 768,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Keys",
     key.usr: "s:SD4KeysV",
-    key.offset: 805,
+    key.offset: 779,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 810,
+    key.offset: 784,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Key",
     key.usr: "s:SD3Keyxmfp",
-    key.offset: 816,
+    key.offset: 790,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 822,
+    key.offset: 796,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P1",
     key.usr: "s:5cake12P1P",
-    key.offset: 828,
+    key.offset: 802,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 838,
+    key.offset: 812,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 843,
+    key.offset: 817,
     key.length: 3
   }
 ]
@@ -692,7 +680,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     key.kind: source.lang.swift.decl.class,
     key.name: "InitClassImpl",
     key.usr: "s:5cake113InitClassImplC",
-    key.offset: 26,
+    key.offset: 0,
     key.length: 94,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>InitClassImpl</decl.name> : <ref.protocol usr=\"s:5cake19InitProtoP\">InitProto</ref.protocol></decl.class>",
     key.conforms: [
@@ -707,7 +695,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
         key.usr: "s:5cake113InitClassImplC1xACSi_tcfc",
-        key.offset: 71,
+        key.offset: 45,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>required</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.conforms: [
@@ -722,7 +710,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 90,
+            key.offset: 64,
             key.length: 3
           }
         ]
@@ -732,7 +720,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.name: "init()",
         key.usr: "s:5cake19InitProtoPAAExycfc::SYNTHESIZED::s:5cake113InitClassImplC",
         key.original_usr: "s:5cake19InitProtoPAAExycfc",
-        key.offset: 100,
+        key.offset: 74,
         key.length: 18,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       }
@@ -742,7 +730,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "InitProto",
     key.usr: "s:5cake19InitProtoP",
-    key.offset: 122,
+    key.offset: 96,
     key.length: 42,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>InitProto</decl.name></decl.protocol>",
     key.entities: [
@@ -750,7 +738,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
         key.usr: "s:5cake19InitProtoP1xxSi_tcfc",
-        key.offset: 148,
+        key.offset: 122,
         key.length: 14,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -758,7 +746,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 158,
+            key.offset: 132,
             key.length: 3
           }
         ]
@@ -767,7 +755,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 166,
+    key.offset: 140,
     key.length: 35,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:5cake19InitProtoP\">InitProto</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
@@ -780,7 +768,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:5cake19InitProtoPAAExycfc",
-        key.offset: 193,
+        key.offset: 167,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       }
@@ -790,7 +778,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     key.kind: source.lang.swift.decl.struct,
     key.name: "InitStructImpl",
     key.usr: "s:5cake114InitStructImplV",
-    key.offset: 203,
+    key.offset: 177,
     key.length: 75,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>InitStructImpl</decl.name> : <ref.protocol usr=\"s:5cake19InitProtoP\">InitProto</ref.protocol></decl.struct>",
     key.conforms: [
@@ -805,7 +793,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
         key.usr: "s:5cake114InitStructImplV1xACSi_tcfc",
-        key.offset: 250,
+        key.offset: 224,
         key.length: 14,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.conforms: [
@@ -820,7 +808,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 260,
+            key.offset: 234,
             key.length: 3
           }
         ]
@@ -830,7 +818,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.name: "init()",
         key.usr: "s:5cake19InitProtoPAAExycfc::SYNTHESIZED::s:5cake114InitStructImplV",
         key.original_usr: "s:5cake19InitProtoPAAExycfc",
-        key.offset: 270,
+        key.offset: 244,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       }
@@ -840,7 +828,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P1",
     key.usr: "s:5cake12P1P",
-    key.offset: 280,
+    key.offset: 254,
     key.length: 167,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P1</decl.name></decl.protocol>",
     key.entities: [
@@ -848,7 +836,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:5cake12P1P4foo1yyF",
-        key.offset: 299,
+        key.offset: 273,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -856,7 +844,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "Ins",
         key.usr: "s:5cake12P1P3InsSivp",
-        key.offset: 316,
+        key.offset: 290,
         key.length: 24,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>Ins</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -864,7 +852,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo2(a:b:)",
         key.usr: "s:5cake12P1P4foo21a1bySi_SitF",
-        key.offset: 346,
+        key.offset: 320,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>a</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>b</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -872,14 +860,14 @@ extension Dictionary.Keys where Key : cake1.P1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "a",
             key.name: "a",
-            key.offset: 361,
+            key.offset: 335,
             key.length: 3
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "b",
             key.name: "b",
-            key.offset: 371,
+            key.offset: 345,
             key.length: 3
           }
         ]
@@ -888,7 +876,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
         key.usr: "s:5cake12P1PyS2icip",
-        key.offset: 381,
+        key.offset: 355,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -896,7 +884,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 396,
+            key.offset: 370,
             key.length: 3
           }
         ]
@@ -905,7 +893,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooConstraint()",
         key.usr: "s:5cake12P1P13fooConstraintyyF",
-        key.offset: 425,
+        key.offset: 399,
         key.length: 20,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooConstraint</decl.name>()</decl.function.method.instance>"
       }
@@ -915,7 +903,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P2",
     key.usr: "s:5cake12P2P",
-    key.offset: 449,
+    key.offset: 423,
     key.length: 60,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name> : <ref.protocol usr=\"s:5cake12P1P\">P1</ref.protocol></decl.protocol>",
     key.conforms: [
@@ -930,7 +918,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "bar1()",
         key.usr: "s:5cake12P2P4bar1yyF",
-        key.offset: 479,
+        key.offset: 453,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar1</decl.name>()</decl.function.method.instance>"
       },
@@ -938,7 +926,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "bar2()",
         key.usr: "s:5cake12P2P4bar2yyF",
-        key.offset: 496,
+        key.offset: 470,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar2</decl.name>()</decl.function.method.instance>"
       }
@@ -946,7 +934,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 511,
+    key.offset: 485,
     key.length: 118,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:5cake12P2P\">P2</ref.protocol></decl.name></decl.extension.protocol>",
     key.extends: {
@@ -960,7 +948,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.name: "foo1()",
         key.usr: "s:5cake12P2PAAE4foo1yyF",
         key.default_implementation_of: "s:5cake12P1P4foo1yyF",
-        key.offset: 531,
+        key.offset: 505,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -969,7 +957,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.name: "Ins",
         key.usr: "s:5cake12P2PAAE3InsSivp",
         key.default_implementation_of: "s:5cake12P1P3InsSivp",
-        key.offset: 548,
+        key.offset: 522,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>Ins</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -978,7 +966,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.name: "foo2(a:b:)",
         key.usr: "s:5cake12P2PAAE4foo21a1bySi_SitF",
         key.default_implementation_of: "s:5cake12P1P4foo21a1bySi_SitF",
-        key.offset: 566,
+        key.offset: 540,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>a</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>b</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -986,14 +974,14 @@ extension Dictionary.Keys where Key : cake1.P1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "a",
             key.name: "a",
-            key.offset: 581,
+            key.offset: 555,
             key.length: 3
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "b",
             key.name: "b",
-            key.offset: 591,
+            key.offset: 565,
             key.length: 3
           }
         ]
@@ -1003,7 +991,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.name: "subscript(_:)",
         key.usr: "s:5cake12P2PAAEyS2icip",
         key.default_implementation_of: "s:5cake12P1PyS2icip",
-        key.offset: 601,
+        key.offset: 575,
         key.length: 26,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -1011,7 +999,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 616,
+            key.offset: 590,
             key.length: 3
           }
         ]
@@ -1025,7 +1013,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.description: "Self : P3"
       }
     ],
-    key.offset: 631,
+    key.offset: 605,
     key.length: 64,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:5cake12P2P\">P2</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:5cake12P2P4Selfxmfp\">Self</ref.generic_type_param> : <ref.protocol usr=\"s:5cake12P3P\">P3</ref.protocol></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
@@ -1039,7 +1027,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.name: "fooConstraint()",
         key.usr: "s:5cake12P2PA2A2P3RzrlE13fooConstraintyyF",
         key.default_implementation_of: "s:5cake12P1P13fooConstraintyyF",
-        key.offset: 673,
+        key.offset: 647,
         key.length: 20,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooConstraint</decl.name>()</decl.function.method.instance>"
       }
@@ -1049,7 +1037,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P3",
     key.usr: "s:5cake12P3P",
-    key.offset: 697,
+    key.offset: 671,
     key.length: 38,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P3</decl.name></decl.protocol>",
     key.entities: [
@@ -1057,7 +1045,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "p3Required()",
         key.usr: "s:5cake12P3P10p3RequiredyyF",
-        key.offset: 716,
+        key.offset: 690,
         key.length: 17,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>p3Required</decl.name>()</decl.function.method.instance>"
       }
@@ -1078,7 +1066,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.description: "Key : Hashable"
       }
     ],
-    key.offset: 737,
+    key.offset: 711,
     key.length: 45,
     key.fully_annotated_decl: "<decl.extension.struct><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.struct usr=\"s:SD\">Dictionary</ref.struct>.<ref.struct usr=\"s:SD4KeysV\">Keys</ref.struct></decl.name></decl.extension.struct>",
     key.extends: {
@@ -1091,7 +1079,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:SD4KeysV5cake1E3fooyyF",
-        key.offset: 770,
+        key.offset: 744,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
       }
@@ -1115,7 +1103,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.description: "Key : P1"
       }
     ],
-    key.offset: 784,
+    key.offset: 758,
     key.length: 66,
     key.fully_annotated_decl: "<decl.extension.struct><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.struct usr=\"s:SD\">Dictionary</ref.struct>.<ref.struct usr=\"s:SD4KeysV\">Keys</ref.struct></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:SD3Keyxmfp\">Key</ref.generic_type_param> : <ref.protocol usr=\"s:5cake12P1P\">P1</ref.protocol></decl.generic_type_requirement></decl.extension.struct>",
     key.extends: {
@@ -1128,7 +1116,7 @@ extension Dictionary.Keys where Key : cake1.P1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "bar()",
         key.usr: "s:SD4KeysV5cake1AC2P1RzrlE3baryyF",
-        key.offset: 838,
+        key.offset: 812,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>()</decl.function.method.instance>"
       }

--- a/test/SourceKit/DocSupport/doc_swift_module_class_extension.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module_class_extension.swift.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 class C<T> {
 }
 
@@ -52,153 +50,163 @@ extension P8 where Self.T : module_with_class_extension.E {
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 0,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 32,
+    key.offset: 6,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 34,
+    key.offset: 8,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 42,
+    key.offset: 16,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C",
     key.usr: "s:27module_with_class_extension1CC",
-    key.offset: 52,
+    key.offset: 26,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 56,
+    key.offset: 30,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 84,
+    key.offset: 58,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 92,
+    key.offset: 66,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C",
     key.usr: "s:27module_with_class_extension1CC",
-    key.offset: 102,
+    key.offset: 76,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 104,
+    key.offset: 78,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:27module_with_class_extension1CC1Txmfp",
-    key.offset: 110,
+    key.offset: 84,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 114,
+    key.offset: 88,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "D",
     key.usr: "s:27module_with_class_extension1DC",
-    key.offset: 142,
+    key.offset: 116,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 151,
+    key.offset: 125,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 156,
+    key.offset: 130,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 167,
+    key.offset: 141,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 172,
+    key.offset: 146,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 181,
+    key.offset: 155,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C",
     key.usr: "s:27module_with_class_extension1CC",
-    key.offset: 191,
+    key.offset: 165,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 193,
+    key.offset: 167,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:27module_with_class_extension1CC1Txmfp",
-    key.offset: 199,
+    key.offset: 173,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 203,
+    key.offset: 177,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "E",
     key.usr: "s:27module_with_class_extension1EC",
-    key.offset: 231,
+    key.offset: 205,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 240,
+    key.offset: 214,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 245,
+    key.offset: 219,
     key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 228,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 234,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 241,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 247,
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -211,212 +219,192 @@ extension P8 where Self.T : module_with_class_extension.E {
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 267,
-    key.length: 5
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 273,
+    key.offset: 262,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 280,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 286,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 288,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 291,
+    key.offset: 265,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:27module_with_class_extension1FC1Txmfp",
-    key.offset: 297,
+    key.offset: 271,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 301,
+    key.offset: 275,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "D",
     key.usr: "s:27module_with_class_extension1DC",
-    key.offset: 329,
+    key.offset: 303,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 338,
+    key.offset: 312,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 343,
+    key.offset: 317,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 352,
+    key.offset: 326,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "F",
     key.usr: "s:27module_with_class_extension1FC",
-    key.offset: 362,
+    key.offset: 336,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 366,
+    key.offset: 340,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 394,
+    key.offset: 368,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 402,
+    key.offset: 376,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 411,
+    key.offset: 385,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 421,
+    key.offset: 395,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 436,
+    key.offset: 410,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 441,
+    key.offset: 415,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 451,
+    key.offset: 425,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 454,
+    key.offset: 428,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:27module_with_class_extension2P8P4Selfxmfp",
-    key.offset: 460,
+    key.offset: 434,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "T",
     key.usr: "s:27module_with_class_extension2P8P1TQa",
-    key.offset: 465,
+    key.offset: 439,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 469,
+    key.offset: 443,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "D",
     key.usr: "s:27module_with_class_extension1DC",
-    key.offset: 497,
+    key.offset: 471,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 506,
+    key.offset: 480,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 511,
+    key.offset: 485,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 520,
+    key.offset: 494,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 530,
+    key.offset: 504,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 533,
+    key.offset: 507,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:27module_with_class_extension2P8P4Selfxmfp",
-    key.offset: 539,
+    key.offset: 513,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "T",
     key.usr: "s:27module_with_class_extension2P8P1TQa",
-    key.offset: 544,
+    key.offset: 518,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 548,
+    key.offset: 522,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "E",
     key.usr: "s:27module_with_class_extension1EC",
-    key.offset: 576,
+    key.offset: 550,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 585,
+    key.offset: 559,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 590,
+    key.offset: 564,
     key.length: 3
   }
 ]
@@ -430,7 +418,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.name: "T"
       }
     ],
-    key.offset: 26,
+    key.offset: 0,
     key.length: 14,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>C</decl.name>&lt;<decl.generic_type_param usr=\"s:27module_with_class_extension1CC1Txmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt;</decl.class>"
   },
@@ -441,7 +429,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.name: "T"
       }
     ],
-    key.offset: 42,
+    key.offset: 16,
     key.length: 48,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:27module_with_class_extension1CC\">C</ref.class></decl.name> : <ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.extension.class>",
     key.conforms: [
@@ -469,7 +457,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "T : D"
       }
     ],
-    key.offset: 92,
+    key.offset: 66,
     key.length: 87,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:27module_with_class_extension1CC\">C</ref.class></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension1CC1Txmfp\">T</ref.generic_type_param> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.extension.class>",
     key.extends: {
@@ -482,7 +470,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:27module_with_class_extension1CCA2A1DCRbzlE3fooyyF",
-        key.offset: 151,
+        key.offset: 125,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
       },
@@ -491,7 +479,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.name: "bar()",
         key.usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF::SYNTHESIZED::s:27module_with_class_extension1CC",
         key.original_usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF",
-        key.offset: 167,
+        key.offset: 141,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>()</decl.function.method.instance>"
       }
@@ -504,7 +492,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "T : E"
       }
     ],
-    key.offset: 181,
+    key.offset: 155,
     key.length: 71,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.class usr=\"s:27module_with_class_extension1CC\">C</ref.class> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension1CC1Txmfp\">T</ref.generic_type_param> : <ref.class usr=\"s:27module_with_class_extension1EC\">E</ref.class></decl.generic_type_requirement>",
     key.extends: {
@@ -518,7 +506,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.name: "baz()",
         key.usr: "s:27module_with_class_extension2P8PA2A1EC1TRczrlE3bazyyF::SYNTHESIZED::s:27module_with_class_extension1CC",
         key.original_usr: "s:27module_with_class_extension2P8PA2A1EC1TRczrlE3bazyyF",
-        key.offset: 240,
+        key.offset: 214,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>baz</decl.name>()</decl.function.method.instance>"
       }
@@ -528,7 +516,7 @@ extension P8 where Self.T : module_with_class_extension.E {
     key.kind: source.lang.swift.decl.class,
     key.name: "D",
     key.usr: "s:27module_with_class_extension1DC",
-    key.offset: 254,
+    key.offset: 228,
     key.length: 11,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>D</decl.name></decl.class>"
   },
@@ -536,7 +524,7 @@ extension P8 where Self.T : module_with_class_extension.E {
     key.kind: source.lang.swift.decl.class,
     key.name: "E",
     key.usr: "s:27module_with_class_extension1EC",
-    key.offset: 267,
+    key.offset: 241,
     key.length: 11,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>E</decl.name></decl.class>"
   },
@@ -554,7 +542,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "T : D"
       }
     ],
-    key.offset: 280,
+    key.offset: 254,
     key.length: 70,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>F</decl.name>&lt;<decl.generic_type_param usr=\"s:27module_with_class_extension1FC1Txmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt; <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension1FC1Txmfp\">T</ref.generic_type_param> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.class>",
     key.entities: [
@@ -563,7 +551,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.name: "bar()",
         key.usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF::SYNTHESIZED::s:27module_with_class_extension1FC",
         key.original_usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF",
-        key.offset: 338,
+        key.offset: 312,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>()</decl.function.method.instance>"
       }
@@ -581,7 +569,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "T : D"
       }
     ],
-    key.offset: 352,
+    key.offset: 326,
     key.length: 48,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"s:27module_with_class_extension1FC\">F</ref.class></decl.name> : <ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.extension.class>",
     key.conforms: [
@@ -601,7 +589,7 @@ extension P8 where Self.T : module_with_class_extension.E {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P8",
     key.usr: "s:27module_with_class_extension2P8P",
-    key.offset: 402,
+    key.offset: 376,
     key.length: 37,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P8</decl.name></decl.protocol>",
     key.entities: [
@@ -609,7 +597,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "T",
         key.usr: "s:27module_with_class_extension2P8P1TQa",
-        key.offset: 421,
+        key.offset: 395,
         key.length: 16,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>T</decl.name></decl.associatedtype>"
       }
@@ -622,7 +610,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "Self.T : D"
       }
     ],
-    key.offset: 441,
+    key.offset: 415,
     key.length: 77,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension2P8P4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:27module_with_class_extension2P8P1TQa\">T</ref.associatedtype> : <ref.class usr=\"s:27module_with_class_extension1DC\">D</ref.class></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
@@ -635,7 +623,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "bar()",
         key.usr: "s:27module_with_class_extension2P8PA2A1DC1TRczrlE3baryyF",
-        key.offset: 506,
+        key.offset: 480,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>bar</decl.name>()</decl.function.method.instance>"
       }
@@ -648,7 +636,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.description: "Self.T : E"
       }
     ],
-    key.offset: 520,
+    key.offset: 494,
     key.length: 77,
     key.fully_annotated_decl: "<decl.extension.protocol><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.protocol usr=\"s:27module_with_class_extension2P8P\">P8</ref.protocol></decl.name> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:27module_with_class_extension2P8P4Selfxmfp\">Self</ref.generic_type_param>.<ref.associatedtype usr=\"s:27module_with_class_extension2P8P1TQa\">T</ref.associatedtype> : <ref.class usr=\"s:27module_with_class_extension1EC\">E</ref.class></decl.generic_type_requirement></decl.extension.protocol>",
     key.extends: {
@@ -661,7 +649,7 @@ extension P8 where Self.T : module_with_class_extension.E {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "baz()",
         key.usr: "s:27module_with_class_extension2P8PA2A1EC1TRczrlE3bazyyF",
-        key.offset: 585,
+        key.offset: 559,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>baz</decl.name>()</decl.function.method.instance>"
       }

--- a/test/SourceKit/DocSupport/doc_swift_module_cross_import.swift.A.response
+++ b/test/SourceKit/DocSupport/doc_swift_module_cross_import.swift.A.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 func fromA()
 
 
@@ -30,143 +28,133 @@ func other(x x: A.From_ABAdditionsType)
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 0,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 5,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 41,
+    key.offset: 15,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 44,
+    key.offset: 18,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 65,
+    key.offset: 39,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 72,
+    key.offset: 46,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 75,
+    key.offset: 49,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 114,
+    key.offset: 88,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 121,
+    key.offset: 95,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 147,
+    key.offset: 121,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 186,
+    key.offset: 160,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 191,
+    key.offset: 165,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 212,
+    key.offset: 186,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 215,
+    key.offset: 189,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 242,
+    key.offset: 216,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 249,
+    key.offset: 223,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 252,
+    key.offset: 226,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 298,
+    key.offset: 272,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 303,
+    key.offset: 277,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 334,
+    key.offset: 308,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 380,
+    key.offset: 354,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 385,
+    key.offset: 359,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 391,
+    key.offset: 365,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 393,
+    key.offset: 367,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 396,
+    key.offset: 370,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "From_ABAdditionsType",
     key.usr: "s:12_ABAdditions05From_A4TypeV",
-    key.offset: 398,
+    key.offset: 372,
     key.length: 20
   }
 ]
@@ -175,7 +163,7 @@ func other(x x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromA()",
     key.usr: "s:1A5fromAyyF",
-    key.offset: 26,
+    key.offset: 0,
     key.length: 12,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromA</decl.name>()</decl.function.free>"
   },
@@ -183,7 +171,7 @@ func other(x x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.struct,
     key.name: "From_ABAdditionsType",
     key.usr: "s:12_ABAdditions05From_A4TypeV",
-    key.offset: 114,
+    key.offset: 88,
     key.length: 31,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>From_ABAdditionsType</decl.name></decl.struct>",
     key.required_bystanders: [
@@ -194,7 +182,7 @@ func other(x x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.function.free,
     key.name: "from_ABAdditions()",
     key.usr: "s:12_ABAdditions05from_A0yyF",
-    key.offset: 186,
+    key.offset: 160,
     key.length: 23,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>from_ABAdditions</decl.name>()</decl.function.free>",
     key.required_bystanders: [
@@ -205,7 +193,7 @@ func other(x x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.function.free,
     key.name: "from__ABAdditionsCAdditions()",
     key.usr: "s:23__ABAdditionsCAdditions06from__aB0yyF",
-    key.offset: 298,
+    key.offset: 272,
     key.length: 34,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>from__ABAdditionsCAdditions</decl.name>()</decl.function.free>",
     key.required_bystanders: [
@@ -217,7 +205,7 @@ func other(x x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.function.free,
     key.name: "other(x:)",
     key.usr: "s:23__ABAdditionsCAdditions5other1xy01_A005From_A4TypeV_tF",
-    key.offset: 380,
+    key.offset: 354,
     key.length: 39,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>other</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:12_ABAdditions05From_A4TypeV\">From_ABAdditionsType</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -225,7 +213,7 @@ func other(x x: A.From_ABAdditionsType)
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "x",
         key.name: "x",
-        key.offset: 396,
+        key.offset: 370,
         key.length: 22
       }
     ],

--- a/test/SourceKit/DocSupport/doc_swift_module_cross_import.swift.Other.response
+++ b/test/SourceKit/DocSupport/doc_swift_module_cross_import.swift.Other.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 func fromOther()
 
 
@@ -7,7 +5,6 @@ func fromOther()
 
 import B
 import C
-import A
 
 // Available when C is imported with Other
 func filtered()
@@ -20,91 +17,71 @@ func from_OtherCAdditions()
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 0,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 5,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 45,
+    key.offset: 19,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 48,
+    key.offset: 22,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 69,
+    key.offset: 43,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 76,
+    key.offset: 50,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 78,
+    key.offset: 52,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 85,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 87,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 94,
+    key.offset: 59,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 97,
+    key.offset: 62,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 140,
+    key.offset: 105,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 145,
+    key.offset: 110,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 157,
+    key.offset: 122,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 200,
+    key.offset: 165,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 205,
+    key.offset: 170,
     key.length: 20
   }
 ]
@@ -113,7 +90,7 @@ func from_OtherCAdditions()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromOther()",
     key.usr: "s:5Other04fromA0yyF",
-    key.offset: 26,
+    key.offset: 0,
     key.length: 16,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOther</decl.name>()</decl.function.free>"
   },
@@ -121,7 +98,7 @@ func from_OtherCAdditions()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "filtered()",
     key.usr: "s:16_OtherCAdditions8filteredyyF",
-    key.offset: 140,
+    key.offset: 105,
     key.length: 15,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>filtered</decl.name>()</decl.function.free>",
     key.attributes: [
@@ -140,7 +117,7 @@ func from_OtherCAdditions()
     key.name: "from_OtherCAdditions()",
     key.usr: "s:16_OtherCAdditions05from_aB0yyF",
     key.doc.full_as_xml: "<Function><Name>from_OtherCAdditions()</Name><USR>s:16_OtherCAdditions05from_aB0yyF</USR><Declaration>func from_OtherCAdditions()</Declaration><CommentParts><Abstract><Para>This has some interesting documentation that shouldn’t be separated from the decl when we print the comment detailing its required bystanders in the generated interface of ‘Other’.</Para></Abstract></CommentParts></Function>",
-    key.offset: 200,
+    key.offset: 165,
     key.length: 27,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>from_OtherCAdditions</decl.name>()</decl.function.free>",
     key.required_bystanders: [

--- a/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
+++ b/test/SourceKit/DocSupport/doc_system_module_underscored.swift.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 struct A<T> {
 
     func fromA(takesT takesT: T)
@@ -96,399 +94,423 @@ protocol Other1 {
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 33,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 35,
+    key.offset: 9,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 45,
+    key.offset: 19,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 50,
+    key.offset: 24,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 56,
+    key.offset: 30,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 63,
+    key.offset: 37,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1AV1Txmfp",
-    key.offset: 71,
+    key.offset: 45,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 79,
+    key.offset: 53,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 84,
+    key.offset: 58,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 99,
+    key.offset: 73,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 106,
+    key.offset: 80,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1AV1Txmfp",
-    key.offset: 114,
+    key.offset: 88,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 122,
+    key.offset: 96,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 127,
+    key.offset: 101,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 151,
+    key.offset: 125,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "A",
     key.usr: "s:16UnderscoredProto1AV",
-    key.offset: 161,
+    key.offset: 135,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 170,
+    key.offset: 144,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 175,
+    key.offset: 149,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 209,
+    key.offset: 183,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "A",
     key.usr: "s:16UnderscoredProto1AV",
-    key.offset: 219,
+    key.offset: 193,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 221,
+    key.offset: 195,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1AV1Txmfp",
-    key.offset: 227,
+    key.offset: 201,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 229,
+    key.offset: 203,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "String",
     key.usr: "s:SS",
-    key.offset: 232,
+    key.offset: 206,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 246,
+    key.offset: 220,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 256,
+    key.offset: 230,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 263,
+    key.offset: 237,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 272,
+    key.offset: 246,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 277,
+    key.offset: 251,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 303,
+    key.offset: 277,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 318,
+    key.offset: 292,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1AVAASSRszlE1Txmfp",
-    key.offset: 334,
+    key.offset: 308,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 342,
+    key.offset: 316,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 347,
+    key.offset: 321,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 367,
+    key.offset: 341,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 377,
+    key.offset: 351,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 388,
+    key.offset: 362,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 396,
+    key.offset: 370,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "A",
     key.usr: "s:16UnderscoredProto1AV",
-    key.offset: 406,
+    key.offset: 380,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 415,
+    key.offset: 389,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 420,
+    key.offset: 394,
     key.length: 40
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 461,
+    key.offset: 435,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 474,
+    key.offset: 448,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 488,
+    key.offset: 462,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 496,
+    key.offset: 470,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 502,
+    key.offset: 476,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 504,
+    key.offset: 478,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 514,
+    key.offset: 488,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 519,
+    key.offset: 493,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 525,
+    key.offset: 499,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 532,
+    key.offset: 506,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1BC1Txmfp",
-    key.offset: 540,
+    key.offset: 514,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 548,
+    key.offset: 522,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 558,
+    key.offset: 532,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "String",
     key.usr: "s:SS",
-    key.offset: 565,
+    key.offset: 539,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 577,
+    key.offset: 551,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 582,
+    key.offset: 556,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 608,
+    key.offset: 582,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 613,
+    key.offset: 587,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 633,
+    key.offset: 607,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 643,
+    key.offset: 617,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "String",
     key.usr: "s:SS",
-    key.offset: 654,
+    key.offset: 628,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 667,
+    key.offset: 641,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 672,
+    key.offset: 646,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 703,
+    key.offset: 677,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 721,
+    key.offset: 695,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "String",
     key.usr: "s:SS",
-    key.offset: 740,
+    key.offset: 714,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 751,
+    key.offset: 725,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "B",
     key.usr: "s:16UnderscoredProto1BC",
-    key.offset: 761,
+    key.offset: 735,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 770,
+    key.offset: 744,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 775,
+    key.offset: 749,
     key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 783,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 789,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 791,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 794,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.name: "B",
+    key.usr: "s:16UnderscoredProto1BC",
+    key.offset: 799,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "String",
+    key.usr: "s:SS",
+    key.offset: 801,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -496,472 +518,438 @@ protocol Other1 {
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 815,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 817,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 820,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.name: "B",
-    key.usr: "s:16UnderscoredProto1BC",
-    key.offset: 825,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "String",
-    key.usr: "s:SS",
-    key.offset: 827,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 835,
-    key.length: 5
-  },
-  {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1CC1Uxmfp",
-    key.offset: 841,
+    key.offset: 815,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 845,
+    key.offset: 819,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 862,
+    key.offset: 836,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 867,
+    key.offset: 841,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 873,
+    key.offset: 847,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 891,
+    key.offset: 865,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1CC1Uxmfp",
+    key.offset: 884,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 892,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 902,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "V",
+    key.usr: "s:16UnderscoredProto1CC1Vq_mfp",
     key.offset: 910,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 918,
+    key.offset: 917,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 928,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "V",
-    key.usr: "s:16UnderscoredProto1CC1Vq_mfp",
-    key.offset: 936,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 943,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 953,
+    key.offset: 927,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1CC1Uxmfp",
-    key.offset: 961,
+    key.offset: 935,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 968,
+    key.offset: 942,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 973,
+    key.offset: 947,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 998,
+    key.offset: 972,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1005,
+    key.offset: 979,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1CC1Uxmfp",
-    key.offset: 1013,
+    key.offset: 987,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1021,
+    key.offset: 995,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1026,
+    key.offset: 1000,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1046,
+    key.offset: 1020,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1068,
+    key.offset: 1042,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1CC1Uxmfp",
-    key.offset: 1091,
+    key.offset: 1065,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1099,
+    key.offset: 1073,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1104,
+    key.offset: 1078,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1124,
+    key.offset: 1098,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1135,
+    key.offset: 1109,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "V",
     key.usr: "s:16UnderscoredProto1CC1Vq_mfp",
-    key.offset: 1147,
+    key.offset: 1121,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1155,
+    key.offset: 1129,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1160,
+    key.offset: 1134,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1180,
+    key.offset: 1154,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1191,
+    key.offset: 1165,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1CC1Uxmfp",
-    key.offset: 1203,
+    key.offset: 1177,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1209,
+    key.offset: 1183,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C",
     key.usr: "s:16UnderscoredProto1CC",
-    key.offset: 1219,
+    key.offset: 1193,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1221,
+    key.offset: 1195,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1CC1Uxmfp",
-    key.offset: 1227,
+    key.offset: 1201,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Hashable",
     key.usr: "s:SH",
-    key.offset: 1231,
+    key.offset: 1205,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1247,
+    key.offset: 1221,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1252,
+    key.offset: 1226,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1272,
+    key.offset: 1246,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1293,
+    key.offset: 1267,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1CC1Uxmfp",
-    key.offset: 1315,
+    key.offset: 1289,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1321,
+    key.offset: 1295,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1328,
+    key.offset: 1302,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1330,
+    key.offset: 1304,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1333,
+    key.offset: 1307,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1343,
+    key.offset: 1317,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1348,
+    key.offset: 1322,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1354,
+    key.offset: 1328,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1361,
+    key.offset: 1335,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1DV1Txmfp",
-    key.offset: 1369,
+    key.offset: 1343,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1372,
+    key.offset: 1346,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1379,
+    key.offset: 1353,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "U",
     key.usr: "s:16UnderscoredProto1DV1Uq_mfp",
-    key.offset: 1387,
+    key.offset: 1361,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1393,
+    key.offset: 1367,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "D",
     key.usr: "s:16UnderscoredProto1DV",
-    key.offset: 1403,
+    key.offset: 1377,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1405,
+    key.offset: 1379,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1DV1Txmfp",
-    key.offset: 1411,
+    key.offset: 1385,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 1415,
+    key.offset: 1389,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1432,
+    key.offset: 1406,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1442,
+    key.offset: 1416,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1DVAASQRzrlE1Txmfp",
-    key.offset: 1449,
+    key.offset: 1423,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1454,
+    key.offset: 1428,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "D",
     key.usr: "s:16UnderscoredProto1DV",
-    key.offset: 1464,
+    key.offset: 1438,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1466,
+    key.offset: 1440,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1DV1Txmfp",
-    key.offset: 1472,
+    key.offset: 1446,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Other1",
     key.usr: "s:16UnderscoredProto6Other1P",
-    key.offset: 1476,
+    key.offset: 1450,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1DV1Txmfp",
-    key.offset: 1484,
+    key.offset: 1458,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 1488,
+    key.offset: 1462,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1505,
+    key.offset: 1479,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1510,
+    key.offset: 1484,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1548,
+    key.offset: 1522,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1566,
+    key.offset: 1540,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
     key.usr: "s:16UnderscoredProto1DV1Txmfp",
-    key.offset: 1585,
+    key.offset: 1559,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1591,
+    key.offset: 1565,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1600,
+    key.offset: 1574,
     key.length: 6
   }
 ]
@@ -975,7 +963,7 @@ protocol Other1 {
         key.name: "T"
       }
     ],
-    key.offset: 26,
+    key.offset: 0,
     key.length: 123,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>A</decl.name>&lt;<decl.generic_type_param usr=\"s:16UnderscoredProto1AV1Txmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt;</decl.struct>",
     key.entities: [
@@ -983,7 +971,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fromA(takesT:)",
         key.usr: "s:16UnderscoredProto1AV5fromA6takesTyx_tF",
-        key.offset: 45,
+        key.offset: 19,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromA</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesT</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1AV1Txmfp\">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -991,7 +979,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesT",
             key.name: "takesT",
-            key.offset: 71,
+            key.offset: 45,
             key.length: 1
           }
         ]
@@ -1000,7 +988,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fromAExtension(takesT:)",
         key.usr: "s:16UnderscoredProto1AV14fromAExtension6takesTyx_tF",
-        key.offset: 79,
+        key.offset: 53,
         key.length: 37,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromAExtension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesT</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1AV1Txmfp\">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1008,7 +996,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesT",
             key.name: "takesT",
-            key.offset: 114,
+            key.offset: 88,
             key.length: 1
           }
         ]
@@ -1018,7 +1006,7 @@ protocol Other1 {
         key.name: "fromProtoExtension()",
         key.usr: "s:16UnderscoredProto01_aB0PAAE04fromB9ExtensionyyF::SYNTHESIZED::s:16UnderscoredProto1AV",
         key.original_usr: "s:16UnderscoredProto01_aB0PAAE04fromB9ExtensionyyF",
-        key.offset: 122,
+        key.offset: 96,
         key.length: 25,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromProtoExtension</decl.name>()</decl.function.method.instance>"
       }
@@ -1026,7 +1014,7 @@ protocol Other1 {
   },
   {
     key.kind: source.lang.swift.decl.extension.struct,
-    key.offset: 151,
+    key.offset: 125,
     key.length: 56,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"s:16UnderscoredProto1AV\">A</ref.struct>",
     key.extends: {
@@ -1040,7 +1028,7 @@ protocol Other1 {
         key.name: "fromDeprecatedProtoExtension()",
         key.usr: "s:16UnderscoredProto01_aB0PAAE014fromDeprecatedB9ExtensionyyF::SYNTHESIZED::s:16UnderscoredProto1AV",
         key.original_usr: "s:16UnderscoredProto01_aB0PAAE014fromDeprecatedB9ExtensionyyF",
-        key.offset: 170,
+        key.offset: 144,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromDeprecatedProtoExtension</decl.name>()</decl.function.method.instance>"
       }
@@ -1065,7 +1053,7 @@ protocol Other1 {
         key.description: "T == String"
       }
     ],
-    key.offset: 209,
+    key.offset: 183,
     key.length: 185,
     key.fully_annotated_decl: "<decl.extension.struct><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.struct usr=\"s:16UnderscoredProto1AV\">A</ref.struct></decl.name> : <ref.protocol usr=\"s:16UnderscoredProto01_A6Proto2P\">_UnderscoredProto2</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1AV1Txmfp\">T</ref.generic_type_param> == <ref.struct usr=\"s:SS\">String</ref.struct></decl.generic_type_requirement></decl.extension.struct>",
     key.conforms: [
@@ -1085,7 +1073,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Elem",
         key.usr: "s:16UnderscoredProto1AVAASSRszlE4Elema",
-        key.offset: 246,
+        key.offset: 220,
         key.length: 20,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Elem</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
         key.conforms: [
@@ -1110,7 +1098,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fromAConditionalExtension(takesTIfString:)",
         key.usr: "s:16UnderscoredProto1AVAASSRszlE25fromAConditionalExtension14takesTIfStringySS_tF",
-        key.offset: 272,
+        key.offset: 246,
         key.length: 64,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromAConditionalExtension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesTIfString</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1AVAASSRszlE1Txmfp\">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1118,7 +1106,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesTIfString",
             key.name: "takesTIfString",
-            key.offset: 334,
+            key.offset: 308,
             key.length: 1
           }
         ]
@@ -1128,7 +1116,7 @@ protocol Other1 {
         key.name: "fromProto2Extension(takesElem:)",
         key.usr: "s:16UnderscoredProto01_A6Proto2PAAE04fromC9Extension9takesElemy0G0Qz_tF::SYNTHESIZED::s:16UnderscoredProto1AV",
         key.original_usr: "s:16UnderscoredProto01_A6Proto2PAAE04fromC9Extension9takesElemy0G0Qz_tF",
-        key.offset: 342,
+        key.offset: 316,
         key.length: 50,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromProto2Extension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesElem</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1136,7 +1124,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesElem",
             key.name: "takesElem",
-            key.offset: 388,
+            key.offset: 362,
             key.length: 3
           }
         ]
@@ -1155,7 +1143,7 @@ protocol Other1 {
         key.description: "T == String"
       }
     ],
-    key.offset: 396,
+    key.offset: 370,
     key.length: 98,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"s:16UnderscoredProto1AV\">A</ref.struct>",
     key.extends: {
@@ -1169,7 +1157,7 @@ protocol Other1 {
         key.name: "fromDeprecatedConditionalProto2Extension(takesElemInt:)",
         key.usr: "s:16UnderscoredProto01_A6Proto2PAASi4ElemRtzrlE025fromDeprecatedConditionalC9Extension05takesD3IntySi_tF::SYNTHESIZED::s:16UnderscoredProto1AV",
         key.original_usr: "s:16UnderscoredProto01_A6Proto2PAASi4ElemRtzrlE025fromDeprecatedConditionalC9Extension05takesD3IntySi_tF",
-        key.offset: 415,
+        key.offset: 389,
         key.length: 77,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromDeprecatedConditionalProto2Extension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesElemInt</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1177,7 +1165,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesElemInt",
             key.name: "takesElemInt",
-            key.offset: 488,
+            key.offset: 462,
             key.length: 3
           }
         ]
@@ -1200,7 +1188,7 @@ protocol Other1 {
         key.name: "T"
       }
     ],
-    key.offset: 496,
+    key.offset: 470,
     key.length: 253,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>B</decl.name>&lt;<decl.generic_type_param usr=\"s:16UnderscoredProto1BC1Txmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt; : <ref.protocol usr=\"s:16UnderscoredProto01_aB0P\">_UnderscoredProto</ref.protocol></decl.class>",
     key.conforms: [
@@ -1215,7 +1203,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fromB(takesT:)",
         key.usr: "s:16UnderscoredProto1BC5fromB6takesTyx_tF",
-        key.offset: 514,
+        key.offset: 488,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromB</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesT</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1BC1Txmfp\">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1223,7 +1211,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesT",
             key.name: "takesT",
-            key.offset: 540,
+            key.offset: 514,
             key.length: 1
           }
         ]
@@ -1232,7 +1220,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Elem",
         key.usr: "s:16UnderscoredProto1BC4Elema",
-        key.offset: 548,
+        key.offset: 522,
         key.length: 23,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Elem</decl.name> = <ref.struct usr=\"s:SS\">String</ref.struct></decl.typealias>"
       },
@@ -1241,7 +1229,7 @@ protocol Other1 {
         key.name: "fromProtoExtension()",
         key.usr: "s:16UnderscoredProto01_aB0PAAE04fromB9ExtensionyyF::SYNTHESIZED::s:16UnderscoredProto1BC",
         key.original_usr: "s:16UnderscoredProto01_aB0PAAE04fromB9ExtensionyyF",
-        key.offset: 577,
+        key.offset: 551,
         key.length: 25,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromProtoExtension</decl.name>()</decl.function.method.instance>"
       },
@@ -1250,7 +1238,7 @@ protocol Other1 {
         key.name: "fromProto2Extension(takesElem:)",
         key.usr: "s:16UnderscoredProto01_A6Proto2PAAE04fromC9Extension9takesElemy0G0Qz_tF::SYNTHESIZED::s:16UnderscoredProto1BC",
         key.original_usr: "s:16UnderscoredProto01_A6Proto2PAAE04fromC9Extension9takesElemy0G0Qz_tF",
-        key.offset: 608,
+        key.offset: 582,
         key.length: 53,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromProto2Extension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesElem</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1258,7 +1246,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesElem",
             key.name: "takesElem",
-            key.offset: 654,
+            key.offset: 628,
             key.length: 6
           }
         ]
@@ -1268,7 +1256,7 @@ protocol Other1 {
         key.name: "fromConditionalProto2Extension(takesElemIfString:)",
         key.usr: "s:16UnderscoredProto01_A6Proto2PAASS4ElemRtzrlE015fromConditionalC9Extension05takesD8IfStringySS_tF::SYNTHESIZED::s:16UnderscoredProto1BC",
         key.original_usr: "s:16UnderscoredProto01_A6Proto2PAASS4ElemRtzrlE015fromConditionalC9Extension05takesD8IfStringySS_tF",
-        key.offset: 667,
+        key.offset: 641,
         key.length: 80,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromConditionalProto2Extension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesElemIfString</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:SS\">String</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1276,7 +1264,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesElemIfString",
             key.name: "takesElemIfString",
-            key.offset: 740,
+            key.offset: 714,
             key.length: 6
           }
         ]
@@ -1285,7 +1273,7 @@ protocol Other1 {
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 751,
+    key.offset: 725,
     key.length: 56,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.class usr=\"s:16UnderscoredProto1BC\">B</ref.class>",
     key.extends: {
@@ -1299,7 +1287,7 @@ protocol Other1 {
         key.name: "fromDeprecatedProtoExtension()",
         key.usr: "s:16UnderscoredProto01_aB0PAAE014fromDeprecatedB9ExtensionyyF::SYNTHESIZED::s:16UnderscoredProto1BC",
         key.original_usr: "s:16UnderscoredProto01_aB0PAAE014fromDeprecatedB9ExtensionyyF",
-        key.offset: 770,
+        key.offset: 744,
         key.length: 35,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromDeprecatedProtoExtension</decl.name>()</decl.function.method.instance>"
       }
@@ -1329,7 +1317,7 @@ protocol Other1 {
         key.description: "U : Equatable"
       }
     ],
-    key.offset: 809,
+    key.offset: 783,
     key.length: 398,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>C</decl.name>&lt;<decl.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\"><decl.generic_type_param.name>U</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr=\"s:16UnderscoredProto1CC1Vq_mfp\"><decl.generic_type_param.name>V</decl.generic_type_param.name></decl.generic_type_param>&gt; : <ref.class usr=\"s:16UnderscoredProto1BC\">B</ref.class>&lt;<ref.struct usr=\"s:SS\">String</ref.struct>&gt; <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\">U</ref.generic_type_param> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol></decl.generic_type_requirement></decl.class>",
     key.inherits: [
@@ -1344,7 +1332,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fromC(takesUIfEquatable:)",
         key.usr: "s:16UnderscoredProto1CC5fromC17takesUIfEquatableyx_tF",
-        key.offset: 862,
+        key.offset: 836,
         key.length: 50,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromC</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesUIfEquatable</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\">U</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1352,7 +1340,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesUIfEquatable",
             key.name: "takesUIfEquatable",
-            key.offset: 910,
+            key.offset: 884,
             key.length: 1
           }
         ]
@@ -1361,7 +1349,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Elem1",
         key.usr: "s:16UnderscoredProto1CC5Elem1a",
-        key.offset: 918,
+        key.offset: 892,
         key.length: 19,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Elem1</decl.name> = <ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Vq_mfp\">V</ref.generic_type_param></decl.typealias>",
         key.conforms: [
@@ -1376,7 +1364,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Elem2",
         key.usr: "s:16UnderscoredProto1CC5Elem2a",
-        key.offset: 943,
+        key.offset: 917,
         key.length: 19,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Elem2</decl.name> = <ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\">U</ref.generic_type_param></decl.typealias>",
         key.conforms: [
@@ -1391,7 +1379,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fromCConditionlExtension(takesU:)",
         key.usr: "s:16UnderscoredProto1CC24fromCConditionlExtension6takesUyx_tF",
-        key.offset: 968,
+        key.offset: 942,
         key.length: 47,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromCConditionlExtension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesU</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\">U</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1399,7 +1387,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesU",
             key.name: "takesU",
-            key.offset: 1013,
+            key.offset: 987,
             key.length: 1
           }
         ]
@@ -1409,7 +1397,7 @@ protocol Other1 {
         key.name: "fromProto4Extension(takesElem2IfEquatable:)",
         key.usr: "s:16UnderscoredProto01_A6Proto4PAAE04fromC9Extension21takesElem2IfEquatabley0G0Qz_tF::SYNTHESIZED::s:16UnderscoredProto1CC",
         key.original_usr: "s:16UnderscoredProto01_A6Proto4PAAE04fromC9Extension21takesElem2IfEquatabley0G0Qz_tF",
-        key.offset: 1021,
+        key.offset: 995,
         key.length: 72,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromProto4Extension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesElem2IfEquatable</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\">U</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1417,7 +1405,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesElem2IfEquatable",
             key.name: "takesElem2IfEquatable",
-            key.offset: 1091,
+            key.offset: 1065,
             key.length: 1
           }
         ]
@@ -1427,7 +1415,7 @@ protocol Other1 {
         key.name: "fromProto3Extension(takesElem1:)",
         key.usr: "s:16UnderscoredProto01_A6Proto3PAAE04fromC9Extension10takesElem1y0G0Qz_tF::SYNTHESIZED::s:16UnderscoredProto1CC",
         key.original_usr: "s:16UnderscoredProto01_A6Proto3PAAE04fromC9Extension10takesElem1y0G0Qz_tF",
-        key.offset: 1099,
+        key.offset: 1073,
         key.length: 50,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromProto3Extension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesElem1</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Vq_mfp\">V</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1435,7 +1423,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesElem1",
             key.name: "takesElem1",
-            key.offset: 1147,
+            key.offset: 1121,
             key.length: 1
           }
         ]
@@ -1445,7 +1433,7 @@ protocol Other1 {
         key.name: "fromProto3Extension(takesElem2:)",
         key.usr: "s:16UnderscoredProto01_A6Proto3PAAE04fromC9Extension10takesElem2y0G0Qz_tF::SYNTHESIZED::s:16UnderscoredProto1CC",
         key.original_usr: "s:16UnderscoredProto01_A6Proto3PAAE04fromC9Extension10takesElem2y0G0Qz_tF",
-        key.offset: 1155,
+        key.offset: 1129,
         key.length: 50,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromProto3Extension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesElem2</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\">U</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1453,7 +1441,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesElem2",
             key.name: "takesElem2",
-            key.offset: 1203,
+            key.offset: 1177,
             key.length: 1
           }
         ]
@@ -1467,7 +1455,7 @@ protocol Other1 {
         key.description: "U : Hashable"
       }
     ],
-    key.offset: 1209,
+    key.offset: 1183,
     key.length: 110,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.class usr=\"s:16UnderscoredProto1CC\">C</ref.class> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\">U</ref.generic_type_param> : <ref.protocol usr=\"s:SH\">Hashable</ref.protocol></decl.generic_type_requirement>",
     key.extends: {
@@ -1481,7 +1469,7 @@ protocol Other1 {
         key.name: "fromProto4Extension(takesElem2IfHashable:)",
         key.usr: "s:16UnderscoredProto01_A6Proto4PAASH5Elem2RpzrlE04fromC9Extension05takesD10IfHashableyAE_tF::SYNTHESIZED::s:16UnderscoredProto1CC",
         key.original_usr: "s:16UnderscoredProto01_A6Proto4PAASH5Elem2RpzrlE04fromC9Extension05takesD10IfHashableyAE_tF",
-        key.offset: 1247,
+        key.offset: 1221,
         key.length: 70,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromProto4Extension</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesElem2IfHashable</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1CC1Uxmfp\">U</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1489,7 +1477,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesElem2IfHashable",
             key.name: "takesElem2IfHashable",
-            key.offset: 1315,
+            key.offset: 1289,
             key.length: 1
           }
         ]
@@ -1508,7 +1496,7 @@ protocol Other1 {
         key.name: "U"
       }
     ],
-    key.offset: 1321,
+    key.offset: 1295,
     key.length: 70,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>D</decl.name>&lt;<decl.generic_type_param usr=\"s:16UnderscoredProto1DV1Txmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr=\"s:16UnderscoredProto1DV1Uq_mfp\"><decl.generic_type_param.name>U</decl.generic_type_param.name></decl.generic_type_param>&gt;</decl.struct>",
     key.entities: [
@@ -1516,7 +1504,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fromD(takesT:takesU:)",
         key.usr: "s:16UnderscoredProto1DV5fromD6takesT0D1Uyx_q_tF",
-        key.offset: 1343,
+        key.offset: 1317,
         key.length: 46,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromD</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesT</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1DV1Txmfp\">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>takesU</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1DV1Uq_mfp\">U</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1524,14 +1512,14 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesT",
             key.name: "takesT",
-            key.offset: 1369,
+            key.offset: 1343,
             key.length: 1
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesU",
             key.name: "takesU",
-            key.offset: 1387,
+            key.offset: 1361,
             key.length: 1
           }
         ]
@@ -1553,7 +1541,7 @@ protocol Other1 {
         key.description: "T : Equatable"
       }
     ],
-    key.offset: 1393,
+    key.offset: 1367,
     key.length: 59,
     key.fully_annotated_decl: "<decl.extension.struct><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.struct usr=\"s:16UnderscoredProto1DV\">D</ref.struct></decl.name> : <ref.protocol usr=\"s:16UnderscoredProto05_SomeB0P\">_SomeProto</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1DV1Txmfp\">T</ref.generic_type_param> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol></decl.generic_type_requirement></decl.extension.struct>",
     key.conforms: [
@@ -1573,7 +1561,7 @@ protocol Other1 {
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Item",
         key.usr: "s:16UnderscoredProto1DVAASQRzrlE4Itema",
-        key.offset: 1432,
+        key.offset: 1406,
         key.length: 18,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Item</decl.name> = <ref.generic_type_param usr=\"s:16UnderscoredProto1DVAASQRzrlE1Txmfp\">T</ref.generic_type_param></decl.typealias>",
         key.conforms: [
@@ -1604,7 +1592,7 @@ protocol Other1 {
         key.description: "T : Equatable"
       }
     ],
-    key.offset: 1454,
+    key.offset: 1428,
     key.length: 135,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"s:16UnderscoredProto1DV\">D</ref.struct> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1DV1Txmfp\">T</ref.generic_type_param> : <ref.protocol usr=\"s:16UnderscoredProto6Other1P\">Other1</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.generic_type_param usr=\"s:16UnderscoredProto1DV1Txmfp\">T</ref.generic_type_param> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol></decl.generic_type_requirement>",
     key.extends: {
@@ -1618,7 +1606,7 @@ protocol Other1 {
         key.name: "fromSomeProtoExtensionSplitConditions(takesItemIfOther1:)",
         key.usr: "s:16UnderscoredProto05_SomeB0PA2A6Other14ItemRpzrlE04fromcB24ExtensionSplitConditions05takese2IfD0yAF_tF::SYNTHESIZED::s:16UnderscoredProto1DV",
         key.original_usr: "s:16UnderscoredProto05_SomeB0PA2A6Other14ItemRpzrlE04fromcB24ExtensionSplitConditions05takese2IfD0yAF_tF",
-        key.offset: 1505,
+        key.offset: 1479,
         key.length: 82,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromSomeProtoExtensionSplitConditions</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>takesItemIfOther1</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:16UnderscoredProto1DV1Txmfp\">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -1626,7 +1614,7 @@ protocol Other1 {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "takesItemIfOther1",
             key.name: "takesItemIfOther1",
-            key.offset: 1585,
+            key.offset: 1559,
             key.length: 1
           }
         ]
@@ -1637,7 +1625,7 @@ protocol Other1 {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "Other1",
     key.usr: "s:16UnderscoredProto6Other1P",
-    key.offset: 1591,
+    key.offset: 1565,
     key.length: 19,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Other1</decl.name></decl.protocol>"
   }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -31,7 +31,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=191:67 | %FileCheck -check-prefix=CHECK1 %s
+// RUN:      == -req=cursor -pos=190:57 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooClassBase' inside the list of base classes, see 'gen_clang_module.swift.response'
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
@@ -47,7 +47,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=211:20 | %FileCheck -check-prefix=CHECK2 %s
+// RUN:      == -req=cursor -pos=210:15 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
 // CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:10-170:27)
@@ -61,7 +61,7 @@ var x: FooClassBase
 // RUN:      == -req=find-usr -usr "c:objc(cs)FooClassDerived(im)fooInstanceFunc0" | %FileCheck -check-prefix=CHECK-USR %s
 // The returned line:col points inside the interface, see 'gen_clang_module.swift.response'
 
-// CHECK-USR: (211:15-211:33)
+// CHECK-USR: (210:15-210:33)
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
@@ -1,54 +1,53 @@
-
 public func fooHelperExplicitFrameworkFunc1(_ a: Int32) -> Int32
 
 
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 13,
+    key.offset: 12,
     key.length: 31
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 45,
+    key.offset: 44,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 47,
+    key.offset: 46,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 50,
+    key.offset: 49,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 60,
+    key.offset: 59,
     key.length: 5
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 50,
+    key.offset: 49,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 60,
+    key.offset: 59,
     key.length: 5,
     key.is_system: 1
   }
@@ -58,14 +57,14 @@ public func fooHelperExplicitFrameworkFunc1(_ a: Int32) -> Int32
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooHelperExplicitFrameworkFunc1(_:)",
-    key.offset: 8,
+    key.offset: 7,
     key.length: 57,
     key.typename: "Int32",
-    key.nameoffset: 13,
+    key.nameoffset: 12,
     key.namelength: 43,
     key.attributes: [
       {
-        key.offset: 1,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -74,7 +73,7 @@ public func fooHelperExplicitFrameworkFunc1(_ a: Int32) -> Int32
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 45,
+        key.offset: 44,
         key.length: 10,
         key.typename: "Int32"
       }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -1,6 +1,5 @@
 import Foo.FooSub
 import FooHelper
-import SwiftOnoneSupport
 
 /// Aaa.  FooEnum1.  Bbb.
 public struct FooEnum1 : Hashable, Equatable, RawRepresentable {
@@ -371,574 +370,579 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 9
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 35,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 42,
-    key.length: 17
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 61,
+    key.offset: 36,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 87,
+    key.offset: 62,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 94,
+    key.offset: 69,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 101,
+    key.offset: 76,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 112,
+    key.offset: 87,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 122,
+    key.offset: 97,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 133,
+    key.offset: 108,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 157,
+    key.offset: 132,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 164,
+    key.offset: 139,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 169,
+    key.offset: 144,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 171,
+    key.offset: 146,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 181,
+    key.offset: 156,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 194,
+    key.offset: 169,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 201,
+    key.offset: 176,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 206,
+    key.offset: 181,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 216,
+    key.offset: 191,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 229,
+    key.offset: 204,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 236,
+    key.offset: 211,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 240,
+    key.offset: 215,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 250,
+    key.offset: 225,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 260,
+    key.offset: 235,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 287,
+    key.offset: 262,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 294,
+    key.offset: 269,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 298,
+    key.offset: 273,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 284,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 295,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 302,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 309,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 316,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 320,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 327,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 334,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 341,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 352,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 362,
+    key.offset: 337,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 373,
+    key.offset: 348,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 397,
+    key.offset: 372,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 404,
+    key.offset: 379,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 384,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 386,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 396,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 409,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 411,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 421,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 434,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 441,
+    key.offset: 416,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 446,
+    key.offset: 421,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 456,
+    key.offset: 431,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 469,
+    key.offset: 444,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 476,
+    key.offset: 451,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 480,
+    key.offset: 455,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 490,
+    key.offset: 465,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 500,
+    key.offset: 475,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 507,
+    key.offset: 482,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 511,
+    key.offset: 486,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 497,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 508,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 515,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 522,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 533,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 540,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 547,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 551,
+    key.offset: 526,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 537,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 548,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 555,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 562,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 573,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 580,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 587,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 594,
+    key.offset: 569,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 605,
+    key.offset: 580,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 615,
+    key.offset: 590,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 626,
+    key.offset: 601,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 650,
+    key.offset: 625,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 657,
+    key.offset: 632,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 662,
+    key.offset: 637,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 664,
+    key.offset: 639,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 674,
+    key.offset: 649,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 687,
+    key.offset: 662,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 694,
+    key.offset: 669,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 699,
+    key.offset: 674,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 709,
+    key.offset: 684,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 722,
+    key.offset: 697,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 729,
+    key.offset: 704,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 733,
+    key.offset: 708,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 743,
+    key.offset: 718,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 753,
+    key.offset: 728,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 760,
+    key.offset: 735,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 764,
+    key.offset: 739,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 750,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 761,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 768,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 775,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 786,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 793,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 800,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 804,
+    key.offset: 779,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 815,
+    key.offset: 790,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 826,
+    key.offset: 801,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 833,
+    key.offset: 808,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 870,
+    key.offset: 845,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 877,
+    key.offset: 852,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 882,
+    key.offset: 857,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 904,
+    key.offset: 879,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 915,
+    key.offset: 890,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 920,
+    key.offset: 895,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 939,
+    key.offset: 914,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 947,
+    key.offset: 922,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 952,
+    key.offset: 927,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 966,
+    key.offset: 941,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 973,
+    key.offset: 948,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 978,
+    key.offset: 953,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 998,
+    key.offset: 973,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1003,
+    key.offset: 978,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1038,
+    key.offset: 1013,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1045,
+    key.offset: 1020,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1052,
+    key.offset: 1027,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1072,
+    key.offset: 1047,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1089,
+    key.offset: 1064,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1096,
+    key.offset: 1071,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1101,
+    key.offset: 1076,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1111,
+    key.offset: 1086,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1121,
+    key.offset: 1096,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1128,
+    key.offset: 1103,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1135,
+    key.offset: 1110,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1139,
+    key.offset: 1114,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1152,
+    key.offset: 1127,
     key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1147,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1158,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1165,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -946,89 +950,94 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1183,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1190,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1197,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1201,
+    key.offset: 1176,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1215,
+    key.offset: 1190,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1235,
+    key.offset: 1210,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1244,
+    key.offset: 1219,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1251,
+    key.offset: 1226,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1258,
+    key.offset: 1233,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1276,
+    key.offset: 1251,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1283,
+    key.offset: 1258,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1295,
+    key.offset: 1270,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1302,
+    key.offset: 1277,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1307,
+    key.offset: 1282,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1310,
+    key.offset: 1285,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1317,
+    key.offset: 1292,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1320,
+    key.offset: 1295,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1308,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1315,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1319,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1322,
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
@@ -1048,107 +1057,107 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1347,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1358,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1365,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1369,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1372,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1382,
+    key.offset: 1357,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1389,
+    key.offset: 1364,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1399,
+    key.offset: 1374,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1419,
+    key.offset: 1394,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1440,
+    key.offset: 1415,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1453,
+    key.offset: 1428,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1435,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1442,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 1460,
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1467,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1485,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1492,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1504,
+    key.offset: 1479,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1511,
+    key.offset: 1486,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1516,
+    key.offset: 1491,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1519,
+    key.offset: 1494,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1526,
+    key.offset: 1501,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1529,
+    key.offset: 1504,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1517,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1524,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1528,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1531,
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
@@ -1168,102 +1177,102 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1556,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1567,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1574,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1578,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1581,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1591,
+    key.offset: 1566,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1598,
+    key.offset: 1573,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1608,
+    key.offset: 1583,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1628,
+    key.offset: 1603,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1640,
+    key.offset: 1615,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1647,
+    key.offset: 1622,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1654,
+    key.offset: 1629,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1679,
+    key.offset: 1654,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1686,
+    key.offset: 1661,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1698,
+    key.offset: 1673,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1705,
+    key.offset: 1680,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1710,
+    key.offset: 1685,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1713,
+    key.offset: 1688,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1720,
+    key.offset: 1695,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1723,
+    key.offset: 1698,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1711,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1718,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1722,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1725,
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
@@ -1283,177 +1292,187 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1750,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1761,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1768,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1772,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1775,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1785,
+    key.offset: 1760,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1814,
+    key.offset: 1789,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1821,
+    key.offset: 1796,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1831,
+    key.offset: 1806,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1845,
+    key.offset: 1820,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1852,
+    key.offset: 1827,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1879,
+    key.offset: 1854,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1886,
+    key.offset: 1861,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1890,
+    key.offset: 1865,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1901,
+    key.offset: 1876,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1908,
+    key.offset: 1883,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1934,
+    key.offset: 1909,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1941,
+    key.offset: 1916,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1946,
+    key.offset: 1921,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1955,
+    key.offset: 1930,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1957,
+    key.offset: 1932,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1960,
+    key.offset: 1935,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1970,
+    key.offset: 1945,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1977,
+    key.offset: 1952,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1984,
+    key.offset: 1959,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1989,
+    key.offset: 1964,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2012,
+    key.offset: 1987,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2015,
+    key.offset: 1990,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2025,
+    key.offset: 2000,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2032,
+    key.offset: 2007,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2039,
+    key.offset: 2014,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2044,
+    key.offset: 2019,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2053,
+    key.offset: 2028,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2055,
+    key.offset: 2030,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2058,
+    key.offset: 2033,
     key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2040,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2042,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2045,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2052,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2054,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2057,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -1468,897 +1487,882 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 2070,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2077,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2079,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2082,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2090,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2092,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2095,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2116,
+    key.offset: 2091,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2128,
+    key.offset: 2103,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2135,
+    key.offset: 2110,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2142,
+    key.offset: 2117,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2147,
+    key.offset: 2122,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2164,
+    key.offset: 2139,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2166,
+    key.offset: 2141,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2173,
+    key.offset: 2148,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2183,
+    key.offset: 2158,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2193,
+    key.offset: 2168,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2200,
+    key.offset: 2175,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2205,
+    key.offset: 2180,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2232,
+    key.offset: 2207,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2234,
+    key.offset: 2209,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2241,
+    key.offset: 2216,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2253,
+    key.offset: 2228,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2257,
+    key.offset: 2232,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2267,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2277,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2284,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2289,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2311,
+    key.offset: 2242,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2318,
+    key.offset: 2252,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2325,
+    key.offset: 2259,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2330,
+    key.offset: 2264,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2352,
+    key.offset: 2286,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2293,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2300,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2305,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2327,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2359,
+    key.offset: 2334,
     key.length: 62
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2422,
+    key.offset: 2397,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2429,
+    key.offset: 2404,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2434,
+    key.offset: 2409,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2457,
+    key.offset: 2432,
     key.length: 42
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2500,
+    key.offset: 2475,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2507,
+    key.offset: 2482,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2512,
+    key.offset: 2487,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2535,
+    key.offset: 2510,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2579,
+    key.offset: 2554,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2595,
+    key.offset: 2570,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2602,
+    key.offset: 2577,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2607,
+    key.offset: 2582,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2630,
+    key.offset: 2605,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2674,
+    key.offset: 2649,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2683,
+    key.offset: 2658,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2690,
+    key.offset: 2665,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2695,
+    key.offset: 2670,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2718,
+    key.offset: 2693,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2755,
+    key.offset: 2730,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2764,
+    key.offset: 2739,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2768,
+    key.offset: 2743,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2777,
+    key.offset: 2752,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2784,
+    key.offset: 2759,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2789,
+    key.offset: 2764,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2812,
+    key.offset: 2787,
     key.length: 50
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2862,
+    key.offset: 2837,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2869,
+    key.offset: 2844,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2874,
+    key.offset: 2849,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2907,
+    key.offset: 2882,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2909,
+    key.offset: 2884,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2912,
+    key.offset: 2887,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2922,
+    key.offset: 2897,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2929,
+    key.offset: 2904,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2962,
+    key.offset: 2937,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2969,
+    key.offset: 2944,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2978,
+    key.offset: 2953,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3001,
+    key.offset: 2976,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3035,
+    key.offset: 3010,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3048,
+    key.offset: 3023,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3053,
+    key.offset: 3028,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3073,
+    key.offset: 3048,
     key.length: 51
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3128,
+    key.offset: 3103,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3141,
+    key.offset: 3116,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3146,
+    key.offset: 3121,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3187,
+    key.offset: 3162,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3269,
+    key.offset: 3244,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3274,
+    key.offset: 3249,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3315,
+    key.offset: 3290,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3322,
+    key.offset: 3297,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3327,
+    key.offset: 3302,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3352,
+    key.offset: 3327,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3356,
+    key.offset: 3331,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3370,
+    key.offset: 3345,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3378,
+    key.offset: 3353,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3382,
+    key.offset: 3357,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3393,
+    key.offset: 3368,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3397,
+    key.offset: 3372,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3411,
+    key.offset: 3386,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3419,
+    key.offset: 3394,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3423,
+    key.offset: 3398,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3434,
+    key.offset: 3409,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3438,
+    key.offset: 3413,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3452,
+    key.offset: 3427,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3460,
+    key.offset: 3435,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3469,
+    key.offset: 3444,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3476,
+    key.offset: 3451,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3485,
+    key.offset: 3460,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3506,
+    key.offset: 3481,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3527,
+    key.offset: 3502,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3532,
+    key.offset: 3507,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3538,
+    key.offset: 3513,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3558,
+    key.offset: 3533,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3563,
+    key.offset: 3538,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3568,
+    key.offset: 3543,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3596,
+    key.offset: 3571,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3601,
+    key.offset: 3576,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3606,
+    key.offset: 3581,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3627,
+    key.offset: 3602,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3629,
+    key.offset: 3604,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3639,
+    key.offset: 3614,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3648,
+    key.offset: 3623,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3667,
+    key.offset: 3642,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3674,
+    key.offset: 3649,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3687,
+    key.offset: 3662,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3694,
+    key.offset: 3669,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3706,
+    key.offset: 3681,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3712,
+    key.offset: 3687,
     key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3693,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3696,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3708,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3713,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 3718,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3721,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3733,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3738,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3743,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3780,
+    key.offset: 3755,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3785,
+    key.offset: 3760,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3791,
+    key.offset: 3766,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3796,
+    key.offset: 3771,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3819,
+    key.offset: 3794,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3852,
+    key.offset: 3827,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3857,
+    key.offset: 3832,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3863,
+    key.offset: 3838,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3881,
+    key.offset: 3856,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3895,
+    key.offset: 3870,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3921,
+    key.offset: 3896,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3926,
+    key.offset: 3901,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3905,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3919,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 3930,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3944,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3955,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3960,
+    key.offset: 3935,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3939,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3953,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 3964,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3978,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3989,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3994,
+    key.offset: 3969,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3998,
+    key.offset: 3973,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4012,
+    key.offset: 3987,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4020,
+    key.offset: 3995,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4031,
+    key.offset: 4006,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4036,
+    key.offset: 4011,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4041,
+    key.offset: 4016,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4065,
+    key.offset: 4040,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4070,
+    key.offset: 4045,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4075,
+    key.offset: 4050,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4092,
+    key.offset: 4067,
     key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4069,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4072,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4084,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4089,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4094,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4097,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4109,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4114,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4119,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4136,
+    key.offset: 4111,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4138,
+    key.offset: 4113,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4141,
+    key.offset: 4116,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4148,
+    key.offset: 4123,
     key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4129,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4132,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4144,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4149,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4154,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4157,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4169,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4174,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4179,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4216,
+    key.offset: 4191,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4221,
+    key.offset: 4196,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4227,
+    key.offset: 4202,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4232,
+    key.offset: 4207,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4251,
+    key.offset: 4226,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4258,
+    key.offset: 4233,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4268,
+    key.offset: 4243,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4284,
+    key.offset: 4259,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4291,
+    key.offset: 4266,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4273,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4277,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4290,
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2366,24 +2370,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4305,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4312,
+    key.length: 3
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4302,
+    key.offset: 4316,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4315,
+    key.offset: 4329,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4323,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4330,
-    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2391,24 +2395,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4344,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4351,
+    key.length: 3
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4341,
+    key.offset: 4355,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4354,
+    key.offset: 4368,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4362,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4369,
-    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2416,124 +2420,124 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4383,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4390,
+    key.length: 3
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4380,
+    key.offset: 4394,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4393,
+    key.offset: 4407,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4416,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4423,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4430,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4434,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4447,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4456,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4463,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4470,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4474,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4487,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4503,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4510,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4517,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4521,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4534,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4550,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4557,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4564,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4568,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4581,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4401,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4408,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4415,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4419,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4432,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4441,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4448,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4455,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4459,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4472,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4481,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4488,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4495,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4499,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4512,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4528,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4535,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4542,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4546,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4559,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4575,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4582,
-    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2541,24 +2545,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4596,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4603,
+    key.length: 3
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4593,
+    key.offset: 4607,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4606,
+    key.offset: 4620,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4614,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4621,
-    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2566,874 +2570,874 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4632,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4645,
-    key.length: 5
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4635,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4653,
+    key.offset: 4642,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4646,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 4660,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4667,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4671,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4685,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4693,
+    key.offset: 4668,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4675,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4682,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4686,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 4700,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4707,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4711,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4725,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4731,
+    key.offset: 4706,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4738,
+    key.offset: 4713,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4745,
+    key.offset: 4720,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4749,
+    key.offset: 4724,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4763,
+    key.offset: 4738,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4771,
+    key.offset: 4746,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4778,
+    key.offset: 4753,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4785,
+    key.offset: 4760,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4789,
+    key.offset: 4764,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4804,
+    key.offset: 4779,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4812,
+    key.offset: 4787,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4819,
+    key.offset: 4794,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4826,
+    key.offset: 4801,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4830,
+    key.offset: 4805,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4850,
+    key.offset: 4825,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4859,
+    key.offset: 4834,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4866,
+    key.offset: 4841,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4873,
+    key.offset: 4848,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4877,
+    key.offset: 4852,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4895,
+    key.offset: 4870,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4904,
+    key.offset: 4879,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4911,
+    key.offset: 4886,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4918,
+    key.offset: 4893,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4922,
+    key.offset: 4897,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4941,
+    key.offset: 4916,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4949,
+    key.offset: 4924,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4956,
+    key.offset: 4931,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4963,
+    key.offset: 4938,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4967,
+    key.offset: 4942,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4986,
+    key.offset: 4961,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4994,
+    key.offset: 4969,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5001,
+    key.offset: 4976,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4983,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4988,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 5008,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5013,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5033,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5040,
+    key.offset: 5015,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5045,
+    key.offset: 5020,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5070,
+    key.offset: 5045,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5077,
+    key.offset: 5052,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5084,
+    key.offset: 5059,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5107,
+    key.offset: 5082,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5114,
+    key.offset: 5089,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5126,
+    key.offset: 5101,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5133,
+    key.offset: 5108,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5138,
+    key.offset: 5113,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5141,
+    key.offset: 5116,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5153,
+    key.offset: 5128,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5160,
+    key.offset: 5135,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5164,
+    key.offset: 5139,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5167,
+    key.offset: 5142,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5176,
+    key.offset: 5151,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5186,
+    key.offset: 5161,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5206,
+    key.offset: 5181,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5186,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5191,
+    key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5211,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5216,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5236,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5244,
+    key.offset: 5219,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5254,
+    key.offset: 5229,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5274,
+    key.offset: 5249,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5254,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5259,
+    key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5279,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5284,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5304,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5314,
+    key.offset: 5289,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5319,
+    key.offset: 5294,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5324,
+    key.offset: 5299,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5345,
+    key.offset: 5320,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5353,
+    key.offset: 5328,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5363,
+    key.offset: 5338,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5383,
+    key.offset: 5358,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5363,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5368,
+    key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5388,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5393,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5413,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5421,
+    key.offset: 5396,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5428,
+    key.offset: 5403,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5437,
+    key.offset: 5412,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5456,
+    key.offset: 5431,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5461,
+    key.offset: 5436,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5467,
+    key.offset: 5442,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5491,
+    key.offset: 5466,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5510,
+    key.offset: 5485,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5515,
+    key.offset: 5490,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5521,
+    key.offset: 5496,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5549,
+    key.offset: 5524,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5569,
+    key.offset: 5544,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5585,
+    key.offset: 5560,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5590,
+    key.offset: 5565,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5594,
+    key.offset: 5569,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5606,
+    key.offset: 5581,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5622,
+    key.offset: 5597,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5638,
+    key.offset: 5613,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5643,
+    key.offset: 5618,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5647,
+    key.offset: 5622,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5665,
+    key.offset: 5640,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5681,
+    key.offset: 5656,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5686,
+    key.offset: 5661,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5690,
+    key.offset: 5665,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5702,
+    key.offset: 5677,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5712,
+    key.offset: 5687,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5717,
+    key.offset: 5692,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5721,
+    key.offset: 5696,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5732,
+    key.offset: 5707,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5742,
+    key.offset: 5717,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5747,
+    key.offset: 5722,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5751,
+    key.offset: 5726,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5761,
+    key.offset: 5736,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5771,
+    key.offset: 5746,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5776,
+    key.offset: 5751,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5781,
+    key.offset: 5756,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5785,
+    key.offset: 5760,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5794,
+    key.offset: 5769,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5810,
+    key.offset: 5785,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5815,
+    key.offset: 5790,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5819,
+    key.offset: 5794,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5827,
+    key.offset: 5802,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5836,
+    key.offset: 5811,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5841,
+    key.offset: 5816,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5847,
+    key.offset: 5822,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5871,
+    key.offset: 5846,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5891,
+    key.offset: 5866,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5898,
+    key.offset: 5873,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5910,
+    key.offset: 5885,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5916,
+    key.offset: 5891,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5920,
+    key.offset: 5895,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5923,
+    key.offset: 5898,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5935,
+    key.offset: 5910,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 5946,
+    key.offset: 5921,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5949,
+    key.offset: 5924,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5961,
+    key.offset: 5936,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 5970,
+    key.offset: 5945,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5979,
+    key.offset: 5954,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5984,
+    key.offset: 5959,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5989,
+    key.offset: 5964,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6007,
+    key.offset: 5982,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6018,
+    key.offset: 5993,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6024,
+    key.offset: 5999,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6030,
+    key.offset: 6005,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6037,
+    key.offset: 6012,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6042,
+    key.offset: 6017,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6047,
+    key.offset: 6022,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6077,
+    key.offset: 6052,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6088,
+    key.offset: 6063,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6095,
+    key.offset: 6070,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6107,
+    key.offset: 6082,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6113,
+    key.offset: 6088,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6122,
+    key.offset: 6097,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6131,
+    key.offset: 6106,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6136,
+    key.offset: 6111,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6141,
+    key.offset: 6116,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6172,
+    key.offset: 6147,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6179,
+    key.offset: 6154,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6185,
+    key.offset: 6160,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6200,
+    key.offset: 6175,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6211,
+    key.offset: 6186,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6214,
+    key.offset: 6189,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6226,
+    key.offset: 6201,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6235,
+    key.offset: 6210,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6264,
+    key.offset: 6239,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6271,
+    key.offset: 6246,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6276,
+    key.offset: 6251,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6300,
+    key.offset: 6275,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6311,
+    key.offset: 6286,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6316,
+    key.offset: 6291,
     key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.number,
+    key.offset: 6307,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6314,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6319,
+    key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
@@ -3441,93 +3445,78 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6339,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6344,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6357,
-    key.length: 1
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6362,
+    key.offset: 6337,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6369,
+    key.offset: 6344,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6375,
+    key.offset: 6350,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6402,
+    key.offset: 6377,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6409,
+    key.offset: 6384,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6414,
+    key.offset: 6389,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6421,
+    key.offset: 6396,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6428,
+    key.offset: 6403,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6434,
+    key.offset: 6409,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6459,
+    key.offset: 6434,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6463,
+    key.offset: 6438,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6490,
+    key.offset: 6465,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6499,
+    key.offset: 6474,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6506,
+    key.offset: 6481,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6511,
+    key.offset: 6486,
     key.length: 1
   }
 ]
@@ -3548,634 +3537,628 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 9
   },
   {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 42,
-    key.length: 17,
-    key.is_system: 1
-  },
-  {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 112,
+    key.offset: 87,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 122,
+    key.offset: 97,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 133,
+    key.offset: 108,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 181,
+    key.offset: 156,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 216,
+    key.offset: 191,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 250,
+    key.offset: 225,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 309,
+    key.offset: 284,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 352,
+    key.offset: 327,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 362,
+    key.offset: 337,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 373,
+    key.offset: 348,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 421,
+    key.offset: 396,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 456,
+    key.offset: 431,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 490,
+    key.offset: 465,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 522,
+    key.offset: 497,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 562,
+    key.offset: 537,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 605,
+    key.offset: 580,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 615,
+    key.offset: 590,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 626,
+    key.offset: 601,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 674,
+    key.offset: 649,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 709,
+    key.offset: 684,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 743,
+    key.offset: 718,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 775,
+    key.offset: 750,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 815,
+    key.offset: 790,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 904,
+    key.offset: 879,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 1072,
+    key.offset: 1047,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1111,
+    key.offset: 1086,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1152,
+    key.offset: 1127,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1215,
+    key.offset: 1190,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1310,
+    key.offset: 1285,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1320,
+    key.offset: 1295,
     key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1322,
+    key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 1347,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1372,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1419,
+    key.offset: 1394,
     key.length: 20,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1440,
+    key.offset: 1415,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1519,
+    key.offset: 1494,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1529,
+    key.offset: 1504,
     key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1531,
+    key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 1556,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1581,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1628,
+    key.offset: 1603,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1713,
+    key.offset: 1688,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1723,
+    key.offset: 1698,
     key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1725,
+    key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 1750,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1775,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1845,
+    key.offset: 1820,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1901,
+    key.offset: 1876,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1960,
+    key.offset: 1935,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1970,
+    key.offset: 1945,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2015,
+    key.offset: 1990,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2025,
+    key.offset: 2000,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2058,
+    key.offset: 2033,
     key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2045,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2057,
+    key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 2070,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2082,
-    key.length: 6,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2095,
     key.length: 20,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2116,
+    key.offset: 2091,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2128,
+    key.offset: 2103,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2173,
+    key.offset: 2148,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2183,
+    key.offset: 2158,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2257,
+    key.offset: 2232,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2267,
+    key.offset: 2242,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2311,
+    key.offset: 2286,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2352,
+    key.offset: 2327,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2912,
+    key.offset: 2887,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2922,
+    key.offset: 2897,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3370,
+    key.offset: 3345,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3411,
+    key.offset: 3386,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3452,
+    key.offset: 3427,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3506,
+    key.offset: 3481,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3648,
+    key.offset: 3623,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3721,
+    key.offset: 3696,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3881,
+    key.offset: 3856,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3895,
+    key.offset: 3870,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3944,
+    key.offset: 3919,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3978,
+    key.offset: 3953,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4012,
+    key.offset: 3987,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4097,
+    key.offset: 4072,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4141,
+    key.offset: 4116,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4157,
+    key.offset: 4132,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4284,
+    key.offset: 4259,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4315,
+    key.offset: 4290,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4354,
+    key.offset: 4329,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4393,
+    key.offset: 4368,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4432,
+    key.offset: 4407,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4472,
+    key.offset: 4447,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4512,
+    key.offset: 4487,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4559,
+    key.offset: 4534,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4606,
+    key.offset: 4581,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4645,
+    key.offset: 4620,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4685,
+    key.offset: 4660,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4725,
+    key.offset: 4700,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4763,
+    key.offset: 4738,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4804,
+    key.offset: 4779,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4850,
+    key.offset: 4825,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4895,
+    key.offset: 4870,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4941,
+    key.offset: 4916,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4986,
+    key.offset: 4961,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5141,
+    key.offset: 5116,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5167,
+    key.offset: 5142,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5186,
+    key.offset: 5161,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5254,
+    key.offset: 5229,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5363,
+    key.offset: 5338,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5491,
+    key.offset: 5466,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5549,
+    key.offset: 5524,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5827,
+    key.offset: 5802,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5871,
+    key.offset: 5846,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5923,
+    key.offset: 5898,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6300,
+    key.offset: 6275,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 6459,
+    key.offset: 6434,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6463,
+    key.offset: 6438,
     key.length: 19
   }
 ]
@@ -4184,13 +4167,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1",
-    key.offset: 94,
+    key.offset: 69,
     key.length: 164,
-    key.nameoffset: 101,
+    key.nameoffset: 76,
     key.namelength: 8,
-    key.bodyoffset: 151,
+    key.bodyoffset: 126,
     key.bodylength: 106,
-    key.docoffset: 61,
+    key.docoffset: 36,
     key.doclength: 26,
     key.inheritedtypes: [
       {
@@ -4205,7 +4188,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 87,
+        key.offset: 62,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4213,17 +4196,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 112,
+        key.offset: 87,
         key.length: 8
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 122,
+        key.offset: 97,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 133,
+        key.offset: 108,
         key.length: 16
       }
     ],
@@ -4232,13 +4215,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 164,
+        key.offset: 139,
         key.length: 24,
-        key.nameoffset: 164,
+        key.nameoffset: 139,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 157,
+            key.offset: 132,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4247,7 +4230,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 169,
+            key.offset: 144,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4257,13 +4240,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 201,
+        key.offset: 176,
         key.length: 22,
-        key.nameoffset: 201,
+        key.nameoffset: 176,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 194,
+            key.offset: 169,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4272,10 +4255,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 206,
+            key.offset: 181,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 206,
+            key.nameoffset: 181,
             key.namelength: 8
           }
         ]
@@ -4285,14 +4268,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 236,
+        key.offset: 211,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 240,
+        key.nameoffset: 215,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 229,
+            key.offset: 204,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4304,18 +4287,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1X",
-    key.offset: 294,
+    key.offset: 269,
     key.length: 31,
     key.typename: "FooEnum1",
-    key.nameoffset: 298,
+    key.nameoffset: 273,
     key.namelength: 9,
-    key.bodyoffset: 319,
+    key.bodyoffset: 294,
     key.bodylength: 5,
-    key.docoffset: 260,
+    key.docoffset: 235,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 287,
+        key.offset: 262,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4325,11 +4308,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2",
-    key.offset: 334,
+    key.offset: 309,
     key.length: 164,
-    key.nameoffset: 341,
+    key.nameoffset: 316,
     key.namelength: 8,
-    key.bodyoffset: 391,
+    key.bodyoffset: 366,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4344,7 +4327,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 327,
+        key.offset: 302,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4352,17 +4335,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 352,
+        key.offset: 327,
         key.length: 8
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 362,
+        key.offset: 337,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 373,
+        key.offset: 348,
         key.length: 16
       }
     ],
@@ -4371,13 +4354,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 404,
+        key.offset: 379,
         key.length: 24,
-        key.nameoffset: 404,
+        key.nameoffset: 379,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 397,
+            key.offset: 372,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4386,7 +4369,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 409,
+            key.offset: 384,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4396,13 +4379,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 441,
+        key.offset: 416,
         key.length: 22,
-        key.nameoffset: 441,
+        key.nameoffset: 416,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 434,
+            key.offset: 409,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4411,10 +4394,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 446,
+            key.offset: 421,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 446,
+            key.nameoffset: 421,
             key.namelength: 8
           }
         ]
@@ -4424,14 +4407,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 476,
+        key.offset: 451,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 480,
+        key.nameoffset: 455,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 469,
+            key.offset: 444,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4443,16 +4426,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2X",
-    key.offset: 507,
+    key.offset: 482,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 511,
+    key.nameoffset: 486,
     key.namelength: 9,
-    key.bodyoffset: 532,
+    key.bodyoffset: 507,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 500,
+        key.offset: 475,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4462,16 +4445,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2Y",
-    key.offset: 547,
+    key.offset: 522,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 551,
+    key.nameoffset: 526,
     key.namelength: 9,
-    key.bodyoffset: 572,
+    key.bodyoffset: 547,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 540,
+        key.offset: 515,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4481,11 +4464,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3",
-    key.offset: 587,
+    key.offset: 562,
     key.length: 164,
-    key.nameoffset: 594,
+    key.nameoffset: 569,
     key.namelength: 8,
-    key.bodyoffset: 644,
+    key.bodyoffset: 619,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4500,7 +4483,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 580,
+        key.offset: 555,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4508,17 +4491,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 605,
+        key.offset: 580,
         key.length: 8
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 615,
+        key.offset: 590,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 626,
+        key.offset: 601,
         key.length: 16
       }
     ],
@@ -4527,13 +4510,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 657,
+        key.offset: 632,
         key.length: 24,
-        key.nameoffset: 657,
+        key.nameoffset: 632,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 650,
+            key.offset: 625,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4542,7 +4525,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 662,
+            key.offset: 637,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4552,13 +4535,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 694,
+        key.offset: 669,
         key.length: 22,
-        key.nameoffset: 694,
+        key.nameoffset: 669,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 687,
+            key.offset: 662,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4567,10 +4550,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 699,
+            key.offset: 674,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 699,
+            key.nameoffset: 674,
             key.namelength: 8
           }
         ]
@@ -4580,14 +4563,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 729,
+        key.offset: 704,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 733,
+        key.nameoffset: 708,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 722,
+            key.offset: 697,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4599,16 +4582,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3X",
-    key.offset: 760,
+    key.offset: 735,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 764,
+    key.nameoffset: 739,
     key.namelength: 9,
-    key.bodyoffset: 785,
+    key.bodyoffset: 760,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 753,
+        key.offset: 728,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4618,16 +4601,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3Y",
-    key.offset: 800,
+    key.offset: 775,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 804,
+    key.nameoffset: 779,
     key.namelength: 9,
-    key.bodyoffset: 825,
+    key.bodyoffset: 800,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 793,
+        key.offset: 768,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4637,13 +4620,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooComparisonResult",
-    key.offset: 877,
+    key.offset: 852,
     key.length: 124,
-    key.nameoffset: 882,
+    key.nameoffset: 857,
     key.namelength: 19,
-    key.bodyoffset: 909,
+    key.bodyoffset: 884,
     key.bodylength: 91,
-    key.docoffset: 833,
+    key.docoffset: 808,
     key.doclength: 37,
     key.inheritedtypes: [
       {
@@ -4652,7 +4635,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 870,
+        key.offset: 845,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4660,28 +4643,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 904,
+        key.offset: 879,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 915,
+        key.offset: 890,
         key.length: 26,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedAscending",
-            key.offset: 920,
+            key.offset: 895,
             key.length: 21,
-            key.nameoffset: 920,
+            key.nameoffset: 895,
             key.namelength: 16,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 939,
+                key.offset: 914,
                 key.length: 2
               }
             ]
@@ -4690,21 +4673,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 947,
+        key.offset: 922,
         key.length: 20,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedSame",
-            key.offset: 952,
+            key.offset: 927,
             key.length: 15,
-            key.nameoffset: 952,
+            key.nameoffset: 927,
             key.namelength: 11,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 966,
+                key.offset: 941,
                 key.length: 1
               }
             ]
@@ -4713,21 +4696,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 973,
+        key.offset: 948,
         key.length: 26,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedDescending",
-            key.offset: 978,
+            key.offset: 953,
             key.length: 21,
-            key.nameoffset: 978,
+            key.nameoffset: 953,
             key.namelength: 17,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 998,
+                key.offset: 973,
                 key.length: 1
               }
             ]
@@ -4740,13 +4723,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooRuncingOptions",
-    key.offset: 1045,
+    key.offset: 1020,
     key.length: 197,
-    key.nameoffset: 1052,
+    key.nameoffset: 1027,
     key.namelength: 17,
-    key.bodyoffset: 1083,
+    key.bodyoffset: 1058,
     key.bodylength: 158,
-    key.docoffset: 1003,
+    key.docoffset: 978,
     key.doclength: 35,
     key.inheritedtypes: [
       {
@@ -4755,7 +4738,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 1038,
+        key.offset: 1013,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4763,7 +4746,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1072,
+        key.offset: 1047,
         key.length: 9
       }
     ],
@@ -4772,13 +4755,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 1096,
+        key.offset: 1071,
         key.length: 19,
-        key.nameoffset: 1096,
+        key.nameoffset: 1071,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 1089,
+            key.offset: 1064,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4787,10 +4770,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 1101,
+            key.offset: 1076,
             key.length: 13,
             key.typename: "Int",
-            key.nameoffset: 1101,
+            key.nameoffset: 1076,
             key.namelength: 8
           }
         ]
@@ -4799,16 +4782,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableMince",
-        key.offset: 1128,
+        key.offset: 1103,
         key.length: 49,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1139,
+        key.nameoffset: 1114,
         key.namelength: 11,
-        key.bodyoffset: 1171,
+        key.bodyoffset: 1146,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1121,
+            key.offset: 1096,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4818,16 +4801,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableQuince",
-        key.offset: 1190,
+        key.offset: 1165,
         key.length: 50,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1201,
+        key.nameoffset: 1176,
         key.namelength: 12,
-        key.bodyoffset: 1234,
+        key.bodyoffset: 1209,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1183,
+            key.offset: 1158,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4839,15 +4822,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1",
-    key.offset: 1251,
+    key.offset: 1226,
     key.length: 129,
-    key.nameoffset: 1258,
+    key.nameoffset: 1233,
     key.namelength: 10,
-    key.bodyoffset: 1270,
+    key.bodyoffset: 1245,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1244,
+        key.offset: 1219,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4857,13 +4840,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1283,
+        key.offset: 1258,
         key.length: 6,
-        key.nameoffset: 1283,
+        key.nameoffset: 1258,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1276,
+            key.offset: 1251,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4873,13 +4856,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1302,
+        key.offset: 1277,
         key.length: 25,
-        key.nameoffset: 1302,
+        key.nameoffset: 1277,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1295,
+            key.offset: 1270,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4888,19 +4871,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1307,
+            key.offset: 1282,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1307,
+            key.nameoffset: 1282,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1317,
+            key.offset: 1292,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1317,
+            key.nameoffset: 1292,
             key.namelength: 1
           }
         ]
@@ -4910,14 +4893,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1340,
+        key.offset: 1315,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1344,
+        key.nameoffset: 1319,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1333,
+            key.offset: 1308,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4928,14 +4911,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1365,
+        key.offset: 1340,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1369,
+        key.nameoffset: 1344,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1358,
+            key.offset: 1333,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4947,13 +4930,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1Pointer",
-    key.offset: 1389,
+    key.offset: 1364,
     key.length: 62,
-    key.nameoffset: 1399,
+    key.nameoffset: 1374,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1382,
+        key.offset: 1357,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4963,15 +4946,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct2",
-    key.offset: 1460,
+    key.offset: 1435,
     key.length: 129,
-    key.nameoffset: 1467,
+    key.nameoffset: 1442,
     key.namelength: 10,
-    key.bodyoffset: 1479,
+    key.bodyoffset: 1454,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1453,
+        key.offset: 1428,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4981,13 +4964,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1492,
+        key.offset: 1467,
         key.length: 6,
-        key.nameoffset: 1492,
+        key.nameoffset: 1467,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1485,
+            key.offset: 1460,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4997,13 +4980,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1511,
+        key.offset: 1486,
         key.length: 25,
-        key.nameoffset: 1511,
+        key.nameoffset: 1486,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1504,
+            key.offset: 1479,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5012,19 +4995,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1516,
+            key.offset: 1491,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1516,
+            key.nameoffset: 1491,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1526,
+            key.offset: 1501,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1526,
+            key.nameoffset: 1501,
             key.namelength: 1
           }
         ]
@@ -5034,14 +5017,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1549,
+        key.offset: 1524,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1553,
+        key.nameoffset: 1528,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1542,
+            key.offset: 1517,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5052,14 +5035,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1574,
+        key.offset: 1549,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1578,
+        key.nameoffset: 1553,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1567,
+            key.offset: 1542,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5071,13 +5054,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef1",
-    key.offset: 1598,
+    key.offset: 1573,
     key.length: 40,
-    key.nameoffset: 1608,
+    key.nameoffset: 1583,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1591,
+        key.offset: 1566,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5087,15 +5070,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef2",
-    key.offset: 1647,
+    key.offset: 1622,
     key.length: 136,
-    key.nameoffset: 1654,
+    key.nameoffset: 1629,
     key.namelength: 17,
-    key.bodyoffset: 1673,
+    key.bodyoffset: 1648,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1640,
+        key.offset: 1615,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5105,13 +5088,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1686,
+        key.offset: 1661,
         key.length: 6,
-        key.nameoffset: 1686,
+        key.nameoffset: 1661,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1679,
+            key.offset: 1654,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5121,13 +5104,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1705,
+        key.offset: 1680,
         key.length: 25,
-        key.nameoffset: 1705,
+        key.nameoffset: 1680,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1698,
+            key.offset: 1673,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5136,19 +5119,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1710,
+            key.offset: 1685,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1710,
+            key.nameoffset: 1685,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1720,
+            key.offset: 1695,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1720,
+            key.nameoffset: 1695,
             key.namelength: 1
           }
         ]
@@ -5158,14 +5141,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1743,
+        key.offset: 1718,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1747,
+        key.nameoffset: 1722,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1736,
+            key.offset: 1711,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5176,14 +5159,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1768,
+        key.offset: 1743,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1772,
+        key.nameoffset: 1747,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1761,
+            key.offset: 1736,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5195,15 +5178,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooTypedef1",
-    key.offset: 1821,
+    key.offset: 1796,
     key.length: 29,
-    key.nameoffset: 1831,
+    key.nameoffset: 1806,
     key.namelength: 11,
-    key.docoffset: 1785,
+    key.docoffset: 1760,
     key.doclength: 29,
     key.attributes: [
       {
-        key.offset: 1814,
+        key.offset: 1789,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5214,16 +5197,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "fooIntVar",
-    key.offset: 1886,
+    key.offset: 1861,
     key.length: 20,
     key.typename: "Int32",
-    key.nameoffset: 1890,
+    key.nameoffset: 1865,
     key.namelength: 9,
-    key.docoffset: 1852,
+    key.docoffset: 1827,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 1879,
+        key.offset: 1854,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5233,16 +5216,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1(_:)",
-    key.offset: 1941,
+    key.offset: 1916,
     key.length: 34,
     key.typename: "Int32",
-    key.nameoffset: 1946,
+    key.nameoffset: 1921,
     key.namelength: 20,
-    key.docoffset: 1908,
+    key.docoffset: 1883,
     key.doclength: 26,
     key.attributes: [
       {
-        key.offset: 1934,
+        key.offset: 1909,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5251,7 +5234,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 1955,
+        key.offset: 1930,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -5261,14 +5244,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1AnonymousParam(_:)",
-    key.offset: 1984,
+    key.offset: 1959,
     key.length: 46,
     key.typename: "Int32",
-    key.nameoffset: 1989,
+    key.nameoffset: 1964,
     key.namelength: 32,
     key.attributes: [
       {
-        key.offset: 1977,
+        key.offset: 1952,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5276,7 +5259,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
-        key.offset: 2012,
+        key.offset: 1987,
         key.length: 8,
         key.typename: "Int32"
       }
@@ -5286,14 +5269,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc3(_:_:_:_:)",
-    key.offset: 2039,
+    key.offset: 2014,
     key.length: 94,
     key.typename: "Int32",
-    key.nameoffset: 2044,
+    key.nameoffset: 2019,
     key.namelength: 80,
     key.attributes: [
       {
-        key.offset: 2032,
+        key.offset: 2007,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5302,28 +5285,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2053,
+        key.offset: 2028,
         key.length: 10,
         key.typename: "Int32"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "b",
-        key.offset: 2065,
+        key.offset: 2040,
         key.length: 10,
         key.typename: "Float"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "c",
-        key.offset: 2077,
+        key.offset: 2052,
         key.length: 11,
         key.typename: "Double"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "d",
-        key.offset: 2090,
+        key.offset: 2065,
         key.length: 33,
         key.typename: "UnsafeMutablePointer<Int32>!"
       }
@@ -5333,13 +5316,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithBlock(_:)",
-    key.offset: 2142,
+    key.offset: 2117,
     key.length: 49,
-    key.nameoffset: 2147,
+    key.nameoffset: 2122,
     key.namelength: 44,
     key.attributes: [
       {
-        key.offset: 2135,
+        key.offset: 2110,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5348,7 +5331,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "blk",
-        key.offset: 2164,
+        key.offset: 2139,
         key.length: 26,
         key.typename: "((Float) -> Int32)!"
       }
@@ -5358,13 +5341,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithFunctionPointer(_:)",
-    key.offset: 2200,
+    key.offset: 2175,
     key.length: 75,
-    key.nameoffset: 2205,
+    key.nameoffset: 2180,
     key.namelength: 70,
     key.attributes: [
       {
-        key.offset: 2193,
+        key.offset: 2168,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5373,7 +5356,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "fptr",
-        key.offset: 2232,
+        key.offset: 2207,
         key.length: 42,
         key.typename: "(@convention(c) (Float) -> Int32)!"
       }
@@ -5383,14 +5366,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn1()",
-    key.offset: 2284,
+    key.offset: 2259,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2289,
+    key.nameoffset: 2264,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2277,
+        key.offset: 2252,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5400,14 +5383,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn2()",
-    key.offset: 2325,
+    key.offset: 2300,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2330,
+    key.nameoffset: 2305,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2318,
+        key.offset: 2293,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5417,15 +5400,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment1()",
-    key.offset: 2429,
+    key.offset: 2404,
     key.length: 26,
-    key.nameoffset: 2434,
+    key.nameoffset: 2409,
     key.namelength: 21,
-    key.docoffset: 2359,
+    key.docoffset: 2334,
     key.doclength: 62,
     key.attributes: [
       {
-        key.offset: 2422,
+        key.offset: 2397,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5435,15 +5418,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment2()",
-    key.offset: 2507,
+    key.offset: 2482,
     key.length: 26,
-    key.nameoffset: 2512,
+    key.nameoffset: 2487,
     key.namelength: 21,
-    key.docoffset: 2457,
+    key.docoffset: 2432,
     key.doclength: 42,
     key.attributes: [
       {
-        key.offset: 2500,
+        key.offset: 2475,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5453,15 +5436,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment3()",
-    key.offset: 2602,
+    key.offset: 2577,
     key.length: 26,
-    key.nameoffset: 2607,
+    key.nameoffset: 2582,
     key.namelength: 21,
-    key.docoffset: 2535,
+    key.docoffset: 2510,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 2595,
+        key.offset: 2570,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5471,15 +5454,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment4()",
-    key.offset: 2690,
+    key.offset: 2665,
     key.length: 26,
-    key.nameoffset: 2695,
+    key.nameoffset: 2670,
     key.namelength: 21,
-    key.docoffset: 2630,
+    key.docoffset: 2605,
     key.doclength: 53,
     key.attributes: [
       {
-        key.offset: 2683,
+        key.offset: 2658,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5489,15 +5472,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment5()",
-    key.offset: 2784,
+    key.offset: 2759,
     key.length: 26,
-    key.nameoffset: 2789,
+    key.nameoffset: 2764,
     key.namelength: 21,
-    key.docoffset: 2718,
+    key.docoffset: 2693,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 2777,
+        key.offset: 2752,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5507,16 +5490,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
-    key.offset: 2869,
+    key.offset: 2844,
     key.length: 58,
     key.typename: "Int32",
-    key.nameoffset: 2874,
+    key.nameoffset: 2849,
     key.namelength: 44,
-    key.docoffset: 2812,
+    key.docoffset: 2787,
     key.doclength: 50,
     key.attributes: [
       {
-        key.offset: 2862,
+        key.offset: 2837,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5525,7 +5508,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2907,
+        key.offset: 2882,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -5535,17 +5518,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolBase",
-    key.offset: 2969,
+    key.offset: 2944,
     key.length: 498,
-    key.nameoffset: 2978,
+    key.nameoffset: 2953,
     key.namelength: 15,
-    key.bodyoffset: 2995,
+    key.bodyoffset: 2970,
     key.bodylength: 471,
-    key.docoffset: 2929,
+    key.docoffset: 2904,
     key.doclength: 33,
     key.attributes: [
       {
-        key.offset: 2962,
+        key.offset: 2937,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5555,42 +5538,42 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFunc()",
-        key.offset: 3048,
+        key.offset: 3023,
         key.length: 19,
-        key.nameoffset: 3053,
+        key.nameoffset: 3028,
         key.namelength: 14,
-        key.docoffset: 3001,
+        key.docoffset: 2976,
         key.doclength: 43
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation1()",
-        key.offset: 3141,
+        key.offset: 3116,
         key.length: 40,
-        key.nameoffset: 3146,
+        key.nameoffset: 3121,
         key.namelength: 35,
-        key.docoffset: 3073,
+        key.docoffset: 3048,
         key.doclength: 64
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation2()",
-        key.offset: 3269,
+        key.offset: 3244,
         key.length: 40,
-        key.nameoffset: 3274,
+        key.nameoffset: 3249,
         key.namelength: 35,
-        key.docoffset: 3187,
+        key.docoffset: 3162,
         key.doclength: 77
       },
       {
         key.kind: source.lang.swift.decl.function.method.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoClassFunc()",
-        key.offset: 3315,
+        key.offset: 3290,
         key.length: 31,
-        key.nameoffset: 3327,
+        key.nameoffset: 3302,
         key.namelength: 19
       },
       {
@@ -5598,12 +5581,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 3352,
+        key.offset: 3327,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3356,
+        key.nameoffset: 3331,
         key.namelength: 12,
-        key.bodyoffset: 3377,
+        key.bodyoffset: 3352,
         key.bodylength: 9
       },
       {
@@ -5611,24 +5594,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 3393,
+        key.offset: 3368,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3397,
+        key.nameoffset: 3372,
         key.namelength: 12,
-        key.bodyoffset: 3418,
+        key.bodyoffset: 3393,
         key.bodylength: 9
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 3434,
+        key.offset: 3409,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 3438,
+        key.nameoffset: 3413,
         key.namelength: 12,
-        key.bodyoffset: 3459,
+        key.bodyoffset: 3434,
         key.bodylength: 5
       }
     ]
@@ -5637,11 +5620,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolDerived",
-    key.offset: 3476,
+    key.offset: 3451,
     key.length: 49,
-    key.nameoffset: 3485,
+    key.nameoffset: 3460,
     key.namelength: 18,
-    key.bodyoffset: 3523,
+    key.bodyoffset: 3498,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -5650,7 +5633,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 3469,
+        key.offset: 3444,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5658,7 +5641,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3506,
+        key.offset: 3481,
         key.length: 15
       }
     ]
@@ -5667,15 +5650,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassBase",
-    key.offset: 3532,
+    key.offset: 3507,
     key.length: 285,
-    key.nameoffset: 3538,
+    key.nameoffset: 3513,
     key.namelength: 12,
-    key.bodyoffset: 3552,
+    key.bodyoffset: 3527,
     key.bodylength: 264,
     key.attributes: [
       {
-        key.offset: 3527,
+        key.offset: 3502,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5685,13 +5668,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc0()",
-        key.offset: 3563,
+        key.offset: 3538,
         key.length: 27,
-        key.nameoffset: 3568,
+        key.nameoffset: 3543,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 3558,
+            key.offset: 3533,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5701,14 +5684,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc1(_:)",
-        key.offset: 3601,
+        key.offset: 3576,
         key.length: 60,
         key.typename: "FooClassBase!",
-        key.nameoffset: 3606,
+        key.nameoffset: 3581,
         key.namelength: 38,
         key.attributes: [
           {
-            key.offset: 3596,
+            key.offset: 3571,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5717,7 +5700,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "anObject",
-            key.offset: 3627,
+            key.offset: 3602,
             key.length: 16,
             key.typename: "Any!"
           }
@@ -5727,13 +5710,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 3674,
+        key.offset: 3649,
         key.length: 7,
-        key.nameoffset: 3674,
+        key.nameoffset: 3649,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3667,
+            key.offset: 3642,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5743,18 +5726,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(float:)",
-        key.offset: 3706,
+        key.offset: 3681,
         key.length: 21,
-        key.nameoffset: 3706,
+        key.nameoffset: 3681,
         key.namelength: 21,
         key.attributes: [
           {
-            key.offset: 3694,
+            key.offset: 3669,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 3687,
+            key.offset: 3662,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5763,10 +5746,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "f",
-            key.offset: 3712,
+            key.offset: 3687,
             key.length: 14,
             key.typename: "Float",
-            key.nameoffset: 3712,
+            key.nameoffset: 3687,
             key.namelength: 5
           }
         ]
@@ -5775,13 +5758,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 3738,
+        key.offset: 3713,
         key.length: 36,
-        key.nameoffset: 3743,
+        key.nameoffset: 3718,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 3733,
+            key.offset: 3708,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5791,13 +5774,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseClassFunc0()",
-        key.offset: 3785,
+        key.offset: 3760,
         key.length: 30,
-        key.nameoffset: 3796,
+        key.nameoffset: 3771,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 3780,
+            key.offset: 3755,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5809,13 +5792,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassDerived",
-    key.offset: 3857,
+    key.offset: 3832,
     key.length: 392,
-    key.nameoffset: 3863,
+    key.nameoffset: 3838,
     key.namelength: 15,
-    key.bodyoffset: 3915,
+    key.bodyoffset: 3890,
     key.bodylength: 333,
-    key.docoffset: 3819,
+    key.docoffset: 3794,
     key.doclength: 33,
     key.inheritedtypes: [
       {
@@ -5827,7 +5810,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 3852,
+        key.offset: 3827,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5835,12 +5818,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3881,
+        key.offset: 3856,
         key.length: 12
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3895,
+        key.offset: 3870,
         key.length: 18
       }
     ],
@@ -5850,14 +5833,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty1",
-        key.offset: 3926,
+        key.offset: 3901,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3930,
+        key.nameoffset: 3905,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 3921,
+            key.offset: 3896,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5868,14 +5851,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty2",
-        key.offset: 3960,
+        key.offset: 3935,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3964,
+        key.nameoffset: 3939,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 3955,
+            key.offset: 3930,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5885,16 +5868,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty3",
-        key.offset: 3994,
+        key.offset: 3969,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 3998,
+        key.nameoffset: 3973,
         key.namelength: 12,
-        key.bodyoffset: 4019,
+        key.bodyoffset: 3994,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 3989,
+            key.offset: 3964,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5904,13 +5887,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc0()",
-        key.offset: 4036,
+        key.offset: 4011,
         key.length: 23,
-        key.nameoffset: 4041,
+        key.nameoffset: 4016,
         key.namelength: 18,
         key.attributes: [
           {
-            key.offset: 4031,
+            key.offset: 4006,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5920,13 +5903,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc1(_:)",
-        key.offset: 4070,
+        key.offset: 4045,
         key.length: 33,
-        key.nameoffset: 4075,
+        key.nameoffset: 4050,
         key.namelength: 28,
         key.attributes: [
           {
-            key.offset: 4065,
+            key.offset: 4040,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5935,7 +5918,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4092,
+            key.offset: 4067,
             key.length: 10,
             key.typename: "Int32"
           }
@@ -5945,13 +5928,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc2(_:withB:)",
-        key.offset: 4114,
+        key.offset: 4089,
         key.length: 49,
-        key.nameoffset: 4119,
+        key.nameoffset: 4094,
         key.namelength: 44,
         key.attributes: [
           {
-            key.offset: 4109,
+            key.offset: 4084,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5960,17 +5943,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4136,
+            key.offset: 4111,
             key.length: 10,
             key.typename: "Int32"
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "b",
-            key.offset: 4148,
+            key.offset: 4123,
             key.length: 14,
             key.typename: "Int32",
-            key.nameoffset: 4148,
+            key.nameoffset: 4123,
             key.namelength: 5
           }
         ]
@@ -5979,13 +5962,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 4174,
+        key.offset: 4149,
         key.length: 36,
-        key.nameoffset: 4179,
+        key.nameoffset: 4154,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 4169,
+            key.offset: 4144,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5995,13 +5978,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooClassFunc0()",
-        key.offset: 4221,
+        key.offset: 4196,
         key.length: 26,
-        key.nameoffset: 4232,
+        key.nameoffset: 4207,
         key.namelength: 15,
         key.attributes: [
           {
-            key.offset: 4216,
+            key.offset: 4191,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6013,13 +5996,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "typedef_int_t",
-    key.offset: 4258,
+    key.offset: 4233,
     key.length: 31,
-    key.nameoffset: 4268,
+    key.nameoffset: 4243,
     key.namelength: 13,
     key.attributes: [
       {
-        key.offset: 4251,
+        key.offset: 4226,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6029,16 +6012,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_1",
-    key.offset: 4298,
+    key.offset: 4273,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4302,
+    key.nameoffset: 4277,
     key.namelength: 11,
-    key.bodyoffset: 4322,
+    key.bodyoffset: 4297,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4291,
+        key.offset: 4266,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6048,16 +6031,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_2",
-    key.offset: 4337,
+    key.offset: 4312,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4341,
+    key.nameoffset: 4316,
     key.namelength: 11,
-    key.bodyoffset: 4361,
+    key.bodyoffset: 4336,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4330,
+        key.offset: 4305,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6067,16 +6050,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_3",
-    key.offset: 4376,
+    key.offset: 4351,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4380,
+    key.nameoffset: 4355,
     key.namelength: 11,
-    key.bodyoffset: 4400,
+    key.bodyoffset: 4375,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4369,
+        key.offset: 4344,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6086,16 +6069,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_4",
-    key.offset: 4415,
+    key.offset: 4390,
     key.length: 31,
     key.typename: "UInt32",
-    key.nameoffset: 4419,
+    key.nameoffset: 4394,
     key.namelength: 11,
-    key.bodyoffset: 4440,
+    key.bodyoffset: 4415,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4408,
+        key.offset: 4383,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6105,16 +6088,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_5",
-    key.offset: 4455,
+    key.offset: 4430,
     key.length: 31,
     key.typename: "UInt64",
-    key.nameoffset: 4459,
+    key.nameoffset: 4434,
     key.namelength: 11,
-    key.bodyoffset: 4480,
+    key.bodyoffset: 4455,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4448,
+        key.offset: 4423,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6124,16 +6107,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_6",
-    key.offset: 4495,
+    key.offset: 4470,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4499,
+    key.nameoffset: 4474,
     key.namelength: 11,
-    key.bodyoffset: 4527,
+    key.bodyoffset: 4502,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4488,
+        key.offset: 4463,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6143,16 +6126,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_7",
-    key.offset: 4542,
+    key.offset: 4517,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4546,
+    key.nameoffset: 4521,
     key.namelength: 11,
-    key.bodyoffset: 4574,
+    key.bodyoffset: 4549,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4535,
+        key.offset: 4510,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6162,16 +6145,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_8",
-    key.offset: 4589,
+    key.offset: 4564,
     key.length: 30,
     key.typename: "CChar",
-    key.nameoffset: 4593,
+    key.nameoffset: 4568,
     key.namelength: 11,
-    key.bodyoffset: 4613,
+    key.bodyoffset: 4588,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4582,
+        key.offset: 4557,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6181,16 +6164,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_9",
-    key.offset: 4628,
+    key.offset: 4603,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4632,
+    key.nameoffset: 4607,
     key.namelength: 11,
-    key.bodyoffset: 4652,
+    key.bodyoffset: 4627,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4621,
+        key.offset: 4596,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6200,16 +6183,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_10",
-    key.offset: 4667,
+    key.offset: 4642,
     key.length: 31,
     key.typename: "Int16",
-    key.nameoffset: 4671,
+    key.nameoffset: 4646,
     key.namelength: 12,
-    key.bodyoffset: 4692,
+    key.bodyoffset: 4667,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4660,
+        key.offset: 4635,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6219,16 +6202,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_11",
-    key.offset: 4707,
+    key.offset: 4682,
     key.length: 29,
     key.typename: "Int",
-    key.nameoffset: 4711,
+    key.nameoffset: 4686,
     key.namelength: 12,
-    key.bodyoffset: 4730,
+    key.bodyoffset: 4705,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4700,
+        key.offset: 4675,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6238,16 +6221,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_OR",
-    key.offset: 4745,
+    key.offset: 4720,
     key.length: 31,
     key.typename: "Int32",
-    key.nameoffset: 4749,
+    key.nameoffset: 4724,
     key.namelength: 12,
-    key.bodyoffset: 4770,
+    key.bodyoffset: 4745,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4738,
+        key.offset: 4713,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6257,16 +6240,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_AND",
-    key.offset: 4785,
+    key.offset: 4760,
     key.length: 32,
     key.typename: "Int32",
-    key.nameoffset: 4789,
+    key.nameoffset: 4764,
     key.namelength: 13,
-    key.bodyoffset: 4811,
+    key.bodyoffset: 4786,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4778,
+        key.offset: 4753,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6276,16 +6259,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_BITWIDTH",
-    key.offset: 4826,
+    key.offset: 4801,
     key.length: 38,
     key.typename: "UInt64",
-    key.nameoffset: 4830,
+    key.nameoffset: 4805,
     key.namelength: 18,
-    key.bodyoffset: 4858,
+    key.bodyoffset: 4833,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4819,
+        key.offset: 4794,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6295,16 +6278,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_SIGNED",
-    key.offset: 4873,
+    key.offset: 4848,
     key.length: 36,
     key.typename: "UInt32",
-    key.nameoffset: 4877,
+    key.nameoffset: 4852,
     key.namelength: 16,
-    key.bodyoffset: 4903,
+    key.bodyoffset: 4878,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4866,
+        key.offset: 4841,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6314,16 +6297,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_1",
-    key.offset: 4918,
+    key.offset: 4893,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 4922,
+    key.nameoffset: 4897,
     key.namelength: 17,
-    key.bodyoffset: 4948,
+    key.bodyoffset: 4923,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4911,
+        key.offset: 4886,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6333,16 +6316,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_2",
-    key.offset: 4963,
+    key.offset: 4938,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 4967,
+    key.nameoffset: 4942,
     key.namelength: 17,
-    key.bodyoffset: 4993,
+    key.bodyoffset: 4968,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4956,
+        key.offset: 4931,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6352,13 +6335,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "theLastDeclInFoo()",
-    key.offset: 5008,
+    key.offset: 4983,
     key.length: 23,
-    key.nameoffset: 5013,
+    key.nameoffset: 4988,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 5001,
+        key.offset: 4976,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6368,13 +6351,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_internalTopLevelFunc()",
-    key.offset: 5040,
+    key.offset: 5015,
     key.length: 28,
-    key.nameoffset: 5045,
+    key.nameoffset: 5020,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 5033,
+        key.offset: 5008,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6384,15 +6367,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalStruct",
-    key.offset: 5077,
+    key.offset: 5052,
     key.length: 97,
-    key.nameoffset: 5084,
+    key.nameoffset: 5059,
     key.namelength: 15,
-    key.bodyoffset: 5101,
+    key.bodyoffset: 5076,
     key.bodylength: 72,
     key.attributes: [
       {
-        key.offset: 5070,
+        key.offset: 5045,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6402,13 +6385,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 5114,
+        key.offset: 5089,
         key.length: 6,
-        key.nameoffset: 5114,
+        key.nameoffset: 5089,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 5107,
+            key.offset: 5082,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6418,13 +6401,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:)",
-        key.offset: 5133,
+        key.offset: 5108,
         key.length: 14,
-        key.nameoffset: 5133,
+        key.nameoffset: 5108,
         key.namelength: 14,
         key.attributes: [
           {
-            key.offset: 5126,
+            key.offset: 5101,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6433,10 +6416,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 5138,
+            key.offset: 5113,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 5138,
+            key.nameoffset: 5113,
             key.namelength: 1
           }
         ]
@@ -6446,14 +6429,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 5160,
+        key.offset: 5135,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 5164,
+        key.nameoffset: 5139,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 5153,
+            key.offset: 5128,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6464,25 +6447,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5176,
+    key.offset: 5151,
     key.length: 66,
-    key.nameoffset: 5186,
+    key.nameoffset: 5161,
     key.namelength: 12,
-    key.bodyoffset: 5200,
+    key.bodyoffset: 5175,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth1()",
-        key.offset: 5211,
+        key.offset: 5186,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5216,
+        key.nameoffset: 5191,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5206,
+            key.offset: 5181,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6493,25 +6476,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5244,
+    key.offset: 5219,
     key.length: 107,
-    key.nameoffset: 5254,
+    key.nameoffset: 5229,
     key.namelength: 12,
-    key.bodyoffset: 5268,
+    key.bodyoffset: 5243,
     key.bodylength: 82,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth2()",
-        key.offset: 5279,
+        key.offset: 5254,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5284,
+        key.nameoffset: 5259,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5274,
+            key.offset: 5249,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6521,14 +6504,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "nonInternalMeth()",
-        key.offset: 5319,
+        key.offset: 5294,
         key.length: 30,
         key.typename: "Any!",
-        key.nameoffset: 5324,
+        key.nameoffset: 5299,
         key.namelength: 17,
         key.attributes: [
           {
-            key.offset: 5314,
+            key.offset: 5289,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6539,25 +6522,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5353,
+    key.offset: 5328,
     key.length: 66,
-    key.nameoffset: 5363,
+    key.nameoffset: 5338,
     key.namelength: 12,
-    key.bodyoffset: 5377,
+    key.bodyoffset: 5352,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth3()",
-        key.offset: 5388,
+        key.offset: 5363,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5393,
+        key.nameoffset: 5368,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5383,
+            key.offset: 5358,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6569,15 +6552,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalProt",
-    key.offset: 5428,
+    key.offset: 5403,
     key.length: 26,
-    key.nameoffset: 5437,
+    key.nameoffset: 5412,
     key.namelength: 13,
-    key.bodyoffset: 5452,
+    key.bodyoffset: 5427,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 5421,
+        key.offset: 5396,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6587,11 +6570,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "ClassWithInternalProt",
-    key.offset: 5461,
+    key.offset: 5436,
     key.length: 47,
-    key.nameoffset: 5467,
+    key.nameoffset: 5442,
     key.namelength: 21,
-    key.bodyoffset: 5506,
+    key.bodyoffset: 5481,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -6600,7 +6583,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5456,
+        key.offset: 5431,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6608,7 +6591,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5491,
+        key.offset: 5466,
         key.length: 13
       }
     ]
@@ -6617,11 +6600,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassPropertyOwnership",
-    key.offset: 5515,
+    key.offset: 5490,
     key.length: 319,
-    key.nameoffset: 5521,
+    key.nameoffset: 5496,
     key.namelength: 25,
-    key.bodyoffset: 5563,
+    key.bodyoffset: 5538,
     key.bodylength: 270,
     key.inheritedtypes: [
       {
@@ -6630,7 +6613,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5510,
+        key.offset: 5485,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6638,7 +6621,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5549,
+        key.offset: 5524,
         key.length: 12
       }
     ],
@@ -6648,19 +6631,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "assignable",
-        key.offset: 5590,
+        key.offset: 5565,
         key.length: 26,
         key.typename: "AnyObject!",
-        key.nameoffset: 5594,
+        key.nameoffset: 5569,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 5585,
+            key.offset: 5560,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5569,
+            key.offset: 5544,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6671,19 +6654,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "unsafeAssignable",
-        key.offset: 5643,
+        key.offset: 5618,
         key.length: 32,
         key.typename: "AnyObject!",
-        key.nameoffset: 5647,
+        key.nameoffset: 5622,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5638,
+            key.offset: 5613,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5622,
+            key.offset: 5597,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6694,14 +6677,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "retainable",
-        key.offset: 5686,
+        key.offset: 5661,
         key.length: 20,
         key.typename: "Any!",
-        key.nameoffset: 5690,
+        key.nameoffset: 5665,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 5681,
+            key.offset: 5656,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6712,14 +6695,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "strongRef",
-        key.offset: 5717,
+        key.offset: 5692,
         key.length: 19,
         key.typename: "Any!",
-        key.nameoffset: 5721,
+        key.nameoffset: 5696,
         key.namelength: 9,
         key.attributes: [
           {
-            key.offset: 5712,
+            key.offset: 5687,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6730,14 +6713,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "copyable",
-        key.offset: 5747,
+        key.offset: 5722,
         key.length: 18,
         key.typename: "Any!",
-        key.nameoffset: 5751,
+        key.nameoffset: 5726,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 5742,
+            key.offset: 5717,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6748,19 +6731,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "weakRef",
-        key.offset: 5781,
+        key.offset: 5756,
         key.length: 23,
         key.typename: "AnyObject!",
-        key.nameoffset: 5785,
+        key.nameoffset: 5760,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 5776,
+            key.offset: 5751,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5771,
+            key.offset: 5746,
             key.length: 4,
             key.attribute: source.decl.attribute.weak
           }
@@ -6771,14 +6754,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "scalar",
-        key.offset: 5815,
+        key.offset: 5790,
         key.length: 17,
         key.typename: "Int32",
-        key.nameoffset: 5819,
+        key.nameoffset: 5794,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 5810,
+            key.offset: 5785,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6790,11 +6773,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooUnavailableMembers",
-    key.offset: 5841,
+    key.offset: 5816,
     key.length: 329,
-    key.nameoffset: 5847,
+    key.nameoffset: 5822,
     key.namelength: 21,
-    key.bodyoffset: 5885,
+    key.bodyoffset: 5860,
     key.bodylength: 284,
     key.inheritedtypes: [
       {
@@ -6803,7 +6786,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5836,
+        key.offset: 5811,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6811,7 +6794,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5871,
+        key.offset: 5846,
         key.length: 12
       }
     ],
@@ -6820,18 +6803,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(int:)",
-        key.offset: 5910,
+        key.offset: 5885,
         key.length: 19,
-        key.nameoffset: 5910,
+        key.nameoffset: 5885,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 5898,
+            key.offset: 5873,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 5891,
+            key.offset: 5866,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6840,10 +6823,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "i",
-            key.offset: 5916,
+            key.offset: 5891,
             key.length: 12,
             key.typename: "Int32",
-            key.nameoffset: 5916,
+            key.nameoffset: 5891,
             key.namelength: 3
           }
         ]
@@ -6852,18 +6835,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "deprecated()",
-        key.offset: 5984,
+        key.offset: 5959,
         key.length: 17,
-        key.nameoffset: 5989,
+        key.nameoffset: 5964,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 5979,
+            key.offset: 5954,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5935,
+            key.offset: 5910,
             key.length: 39,
             key.attribute: source.decl.attribute.available
           }
@@ -6873,18 +6856,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroduced()",
-        key.offset: 6042,
+        key.offset: 6017,
         key.length: 29,
-        key.nameoffset: 6047,
+        key.nameoffset: 6022,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 6037,
+            key.offset: 6012,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6007,
+            key.offset: 5982,
             key.length: 25,
             key.attribute: source.decl.attribute.available
           }
@@ -6894,18 +6877,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroducedMsg()",
-        key.offset: 6136,
+        key.offset: 6111,
         key.length: 32,
-        key.nameoffset: 6141,
+        key.nameoffset: 6116,
         key.namelength: 27,
         key.attributes: [
           {
-            key.offset: 6131,
+            key.offset: 6106,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6077,
+            key.offset: 6052,
             key.length: 49,
             key.attribute: source.decl.attribute.available
           }
@@ -6917,15 +6900,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooCFType",
-    key.offset: 6179,
+    key.offset: 6154,
     key.length: 19,
-    key.nameoffset: 6185,
+    key.nameoffset: 6160,
     key.namelength: 9,
-    key.bodyoffset: 6196,
+    key.bodyoffset: 6171,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 6172,
+        key.offset: 6147,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6935,11 +6918,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "ABAuthorizationStatus",
-    key.offset: 6271,
+    key.offset: 6246,
     key.length: 89,
-    key.nameoffset: 6276,
+    key.nameoffset: 6251,
     key.namelength: 21,
-    key.bodyoffset: 6305,
+    key.bodyoffset: 6280,
     key.bodylength: 54,
     key.inheritedtypes: [
       {
@@ -6948,12 +6931,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6264,
+        key.offset: 6239,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       },
       {
-        key.offset: 6200,
+        key.offset: 6175,
         key.length: 63,
         key.attribute: source.decl.attribute.available
       }
@@ -6961,28 +6944,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6300,
+        key.offset: 6275,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6311,
+        key.offset: 6286,
         key.length: 22,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "notDetermined",
-            key.offset: 6316,
+            key.offset: 6291,
             key.length: 17,
-            key.nameoffset: 6316,
+            key.nameoffset: 6291,
             key.namelength: 13,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6332,
+                key.offset: 6307,
                 key.length: 1
               }
             ]
@@ -6991,21 +6974,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6339,
+        key.offset: 6314,
         key.length: 19,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "restricted",
-            key.offset: 6344,
+            key.offset: 6319,
             key.length: 14,
-            key.nameoffset: 6344,
+            key.nameoffset: 6319,
             key.namelength: 10,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6357,
+                key.offset: 6332,
                 key.length: 1
               }
             ]
@@ -7018,15 +7001,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 6369,
+    key.offset: 6344,
     key.length: 50,
-    key.nameoffset: 6375,
+    key.nameoffset: 6350,
     key.namelength: 19,
-    key.bodyoffset: 6396,
+    key.bodyoffset: 6371,
     key.bodylength: 22,
     key.attributes: [
       {
-        key.offset: 6362,
+        key.offset: 6337,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7036,13 +7019,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6409,
+        key.offset: 6384,
         key.length: 8,
-        key.nameoffset: 6414,
+        key.nameoffset: 6389,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 6402,
+            key.offset: 6377,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -7054,11 +7037,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 6428,
+    key.offset: 6403,
     key.length: 88,
-    key.nameoffset: 6434,
+    key.nameoffset: 6409,
     key.namelength: 22,
-    key.bodyoffset: 6484,
+    key.bodyoffset: 6459,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -7067,7 +7050,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6421,
+        key.offset: 6396,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7075,7 +7058,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6459,
+        key.offset: 6434,
         key.length: 23
       }
     ],
@@ -7084,18 +7067,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6506,
+        key.offset: 6481,
         key.length: 8,
-        key.nameoffset: 6511,
+        key.nameoffset: 6486,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 6499,
+            key.offset: 6474,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           },
           {
-            key.offset: 6490,
+            key.offset: 6465,
             key.length: 8,
             key.attribute: source.decl.attribute.override
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -1,4 +1,3 @@
-
 public func fooSubFunc1(_ a: Int32) -> Int32
 
 public struct FooSubEnum1 : Hashable, Equatable, RawRepresentable {
@@ -20,272 +19,272 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 13,
+    key.offset: 12,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 25,
+    key.offset: 24,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 27,
+    key.offset: 26,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 30,
+    key.offset: 29,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 40,
+    key.offset: 39,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 47,
+    key.offset: 46,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 54,
+    key.offset: 53,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 61,
+    key.offset: 60,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 75,
+    key.offset: 74,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 85,
+    key.offset: 84,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 96,
+    key.offset: 95,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 120,
+    key.offset: 119,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 127,
+    key.offset: 126,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 132,
+    key.offset: 131,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 134,
+    key.offset: 133,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 144,
+    key.offset: 143,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 157,
+    key.offset: 156,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 164,
+    key.offset: 163,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 169,
+    key.offset: 168,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 179,
+    key.offset: 178,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 192,
+    key.offset: 191,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 199,
+    key.offset: 198,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 203,
+    key.offset: 202,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 213,
+    key.offset: 212,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 223,
+    key.offset: 222,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 230,
+    key.offset: 229,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 234,
+    key.offset: 233,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 248,
+    key.offset: 247,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 262,
+    key.offset: 261,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 269,
+    key.offset: 268,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 276,
+    key.offset: 275,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 280,
+    key.offset: 279,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 294,
+    key.offset: 293,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 308,
+    key.offset: 307,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 315,
+    key.offset: 314,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 322,
+    key.offset: 321,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 326,
+    key.offset: 325,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 353,
+    key.offset: 352,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 359,
+    key.offset: 358,
     key.length: 3
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 30,
+    key.offset: 29,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 40,
+    key.offset: 39,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 75,
+    key.offset: 74,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 85,
+    key.offset: 84,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 96,
+    key.offset: 95,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 144,
+    key.offset: 143,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 179,
+    key.offset: 178,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 213,
+    key.offset: 212,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 248,
+    key.offset: 247,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 294,
+    key.offset: 293,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 353,
+    key.offset: 352,
     key.length: 3,
     key.is_system: 1
   }
@@ -295,14 +294,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooSubFunc1(_:)",
-    key.offset: 8,
+    key.offset: 7,
     key.length: 37,
     key.typename: "Int32",
-    key.nameoffset: 13,
+    key.nameoffset: 12,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 1,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -311,7 +310,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 25,
+        key.offset: 24,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -321,11 +320,11 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1",
-    key.offset: 54,
+    key.offset: 53,
     key.length: 167,
-    key.nameoffset: 61,
+    key.nameoffset: 60,
     key.namelength: 11,
-    key.bodyoffset: 114,
+    key.bodyoffset: 113,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -340,7 +339,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     ],
     key.attributes: [
       {
-        key.offset: 47,
+        key.offset: 46,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -348,17 +347,17 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 75,
+        key.offset: 74,
         key.length: 8
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 85,
+        key.offset: 84,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 96,
+        key.offset: 95,
         key.length: 16
       }
     ],
@@ -367,13 +366,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 127,
+        key.offset: 126,
         key.length: 24,
-        key.nameoffset: 127,
+        key.nameoffset: 126,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 120,
+            key.offset: 119,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -382,7 +381,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 132,
+            key.offset: 131,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -392,13 +391,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 164,
+        key.offset: 163,
         key.length: 22,
-        key.nameoffset: 164,
+        key.nameoffset: 163,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 157,
+            key.offset: 156,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -407,10 +406,10 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 169,
+            key.offset: 168,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 169,
+            key.nameoffset: 168,
             key.namelength: 8
           }
         ]
@@ -420,14 +419,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 199,
+        key.offset: 198,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 203,
+        key.nameoffset: 202,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 192,
+            key.offset: 191,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -439,16 +438,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1X",
-    key.offset: 230,
+    key.offset: 229,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 234,
+    key.nameoffset: 233,
     key.namelength: 12,
-    key.bodyoffset: 261,
+    key.bodyoffset: 260,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 223,
+        key.offset: 222,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -458,16 +457,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1Y",
-    key.offset: 276,
+    key.offset: 275,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 280,
+    key.nameoffset: 279,
     key.namelength: 12,
-    key.bodyoffset: 307,
+    key.bodyoffset: 306,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 269,
+        key.offset: 268,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -477,16 +476,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubUnnamedEnumeratorA1",
-    key.offset: 322,
+    key.offset: 321,
     key.length: 42,
     key.typename: "Int",
-    key.nameoffset: 326,
+    key.nameoffset: 325,
     key.namelength: 25,
-    key.bodyoffset: 358,
+    key.bodyoffset: 357,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 315,
+        key.offset: 314,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_public_module_name.swift
+++ b/test/SourceKit/InterfaceGen/gen_public_module_name.swift
@@ -1,0 +1,97 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+// RUN: %target-swift-frontend %t/common.swift -sdk %t/sdk \
+// RUN:   -module-name Common \
+// RUN:   -emit-module-path %t/sdk/Common.swiftmodule \
+// RUN:   -emit-module-interface-path %t/sdk/Common.swiftinterface \
+// RUN:   -enable-library-evolution -swift-version 6
+
+// RUN: %target-swift-frontend %t/subimpl.swift -sdk %t/sdk -I %t/sdk \
+// RUN:   -module-name SubImpl \
+// RUN:   -emit-module-path %t/sdk/SubImpl.swiftmodule \
+// RUN:   -emit-module-interface-path %t/sdk/SubImpl.swiftinterface \
+// RUN:   -enable-library-evolution -swift-version 6
+//
+// RUN: %target-swift-frontend %t/modimpl.swift -sdk %t/sdk -I %t/sdk \
+// RUN:   -module-name ModImpl \
+// RUN:   -emit-module-path %t/sdk/ModImpl.swiftmodule \
+// RUN:   -emit-module-interface-path %t/sdk/ModImpl.swiftinterface \
+// RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -public-module-name PubMod
+
+// RUN: %target-swift-frontend %t/mod.swift -sdk %t/sdk -I %t/sdk \
+// RUN:   -module-name PubMod \
+// RUN:   -emit-module-path %t/sdk/PubMod.swiftmodule \
+// RUN:   -emit-module-interface-path %t/sdk/PubMod.swiftinterface \
+// RUN:   -enable-library-evolution -swift-version 6
+
+// RUN: %sourcekitd-test -req=interface-gen -module PubMod -- -swift-version 6 -sdk %t/sdk -I %t/sdk -target %target-triple &> %t/PubMod.generatedinterface
+// RUN: %FileCheck -input-file=%t/PubMod.generatedinterface -check-prefix INTERFACE %s
+
+// Cursor info on the type of `ModTy.member2`, ie. `ImplTy` (see the generated `PubMod.generatedinterface`)
+// RUN: %sourcekitd-test -req=interface-gen-open -module PubMod -- -swift-version 6 -sdk %t/sdk -I %t/sdk -target %target-triple \
+// RUN:   == -req=cursor -pos=13:24 | %FileCheck %s --check-prefix=INTERFACE-DEF
+// INTERFACE-DEF: ImplTy
+// INTERFACE-DEF: PubMod
+
+
+//--- common.swift
+public struct CommonType {}
+
+
+//--- subimpl.swift
+public struct SubImplTy {}
+
+
+//--- modimpl.swift
+import struct Common.CommonType
+import SubImpl
+
+public struct ImplTy {
+  public let member: SubImplTy
+  public let member2: SubImpl.SubImplTy
+}
+
+public func fromModImpl(arg: ImplTy, arg2: ModImpl.ImplTy) {}
+
+
+//--- mod.swift
+@_exported import ModImpl
+import struct Common.CommonType
+
+public struct ModTy {
+  public let member: ImplTy
+  public let member2: ModImpl.ImplTy
+}
+
+public func fromMod(arg: ModTy, arg2: PubMod.ModTy) {}
+
+// INTERFACE-NOT: import ModImpl
+// INTERFACE: import struct Common.CommonType
+// INTERFACE: import SubImpl
+// INTERFACE-NOT: import
+// INTERFACE: struct ImplTy
+// INTERFACE:   let member: SubImplTy
+// INTERFACE:   let member2: SubImplTy
+// INTERFACE: struct ModTy
+// INTERFACE:   let member: ImplTy
+// INTERFACE:   let member2: ImplTy
+// INTERFACE: func fromMod(arg: ModTy, arg2: ModTy)
+// INTERFACE: func fromModImpl(arg: ImplTy, arg2: ImplTy)
+
+
+//--- use.swift
+import PubMod
+
+func test() {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):3 %t/use.swift -- -swift-version 6 -sdk %t/sdk -I %t/sdk -target %target-triple %t/use.swift | %FileCheck -check-prefix=MOD %s
+  fromMod()
+  // MOD: fromMod
+  // MOD: PubMod
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):3 %t/use.swift -- -swift-version 6 -sdk %t/sdk -I %t/sdk -target %target-triple %t/use.swift | %FileCheck -check-prefix=MODIMPL %s
+  fromModImpl()
+  // MODIMPL: fromModImpl
+  // MODIMPL: PubMod
+}

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.from_swiftinterface.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.from_swiftinterface.response
@@ -1,4 +1,3 @@
-
 public class MyClass {
 
     public func pub_method()
@@ -18,104 +17,104 @@ public func pub_function() -> Int
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8,
+    key.offset: 7,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 14,
+    key.offset: 13,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 29,
+    key.offset: 28,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 36,
+    key.offset: 35,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 41,
+    key.offset: 40,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 59,
+    key.offset: 58,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 69,
+    key.offset: 68,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 76,
+    key.offset: 75,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 85,
+    key.offset: 84,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 93,
+    key.offset: 92,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 107,
+    key.offset: 106,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 122,
+    key.offset: 121,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 131,
+    key.offset: 130,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 150,
+    key.offset: 149,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 157,
+    key.offset: 156,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 162,
+    key.offset: 161,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 180,
+    key.offset: 179,
     key.length: 3
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.associatedtype,
-    key.offset: 93,
+    key.offset: 92,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 180,
+    key.offset: 179,
     key.length: 3,
     key.is_system: 1
   }
@@ -125,15 +124,15 @@ public func pub_function() -> Int
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MyClass",
-    key.offset: 8,
+    key.offset: 7,
     key.length: 59,
-    key.nameoffset: 14,
+    key.nameoffset: 13,
     key.namelength: 7,
-    key.bodyoffset: 23,
+    key.bodyoffset: 22,
     key.bodylength: 43,
     key.attributes: [
       {
-        key.offset: 1,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -143,13 +142,13 @@ public func pub_function() -> Int
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "pub_method()",
-        key.offset: 36,
+        key.offset: 35,
         key.length: 17,
-        key.nameoffset: 41,
+        key.nameoffset: 40,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 29,
+            key.offset: 28,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -161,15 +160,15 @@ public func pub_function() -> Int
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MyProto",
-    key.offset: 76,
+    key.offset: 75,
     key.length: 53,
-    key.nameoffset: 85,
+    key.nameoffset: 84,
     key.namelength: 7,
-    key.bodyoffset: 101,
+    key.bodyoffset: 100,
     key.bodylength: 27,
     key.attributes: [
       {
-        key.offset: 69,
+        key.offset: 68,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -179,9 +178,9 @@ public func pub_function() -> Int
         key.kind: source.lang.swift.decl.associatedtype,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Assoc",
-        key.offset: 107,
+        key.offset: 106,
         key.length: 20,
-        key.nameoffset: 122,
+        key.nameoffset: 121,
         key.namelength: 5
       }
     ]
@@ -190,19 +189,19 @@ public func pub_function() -> Int
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "pub_function()",
-    key.offset: 157,
+    key.offset: 156,
     key.length: 26,
     key.typename: "Int",
-    key.nameoffset: 162,
+    key.nameoffset: 161,
     key.namelength: 14,
     key.attributes: [
       {
-        key.offset: 150,
+        key.offset: 149,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       },
       {
-        key.offset: 131,
+        key.offset: 130,
         key.length: 18,
         key.attribute: source.decl.attribute.discardableResult
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module.swift.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 public class MyClass {
 
     public func pub_method()
@@ -16,116 +14,100 @@ public func pub_function() -> Int
 
 [
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 0,
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 26,
-    key.length: 6
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 33,
+    key.offset: 7,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 39,
+    key.offset: 13,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 54,
+    key.offset: 28,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 61,
+    key.offset: 35,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 66,
+    key.offset: 40,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 82,
+    key.offset: 56,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 89,
+    key.offset: 63,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 98,
+    key.offset: 72,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 106,
+    key.offset: 80,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 120,
+    key.offset: 94,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 135,
+    key.offset: 109,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 144,
+    key.offset: 118,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 163,
+    key.offset: 137,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 170,
+    key.offset: 144,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 175,
+    key.offset: 149,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 193,
+    key.offset: 167,
     key.length: 3
   }
 ]
 [
   {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 7,
-    key.length: 17,
-    key.is_system: 1
-  },
-  {
     key.kind: source.lang.swift.ref.associatedtype,
-    key.offset: 106,
+    key.offset: 80,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 193,
+    key.offset: 167,
     key.length: 3,
     key.is_system: 1
   }
@@ -135,15 +117,15 @@ public func pub_function() -> Int
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MyClass",
-    key.offset: 33,
+    key.offset: 7,
     key.length: 47,
-    key.nameoffset: 39,
+    key.nameoffset: 13,
     key.namelength: 7,
-    key.bodyoffset: 48,
+    key.bodyoffset: 22,
     key.bodylength: 31,
     key.attributes: [
       {
-        key.offset: 26,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -153,13 +135,13 @@ public func pub_function() -> Int
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "pub_method()",
-        key.offset: 61,
+        key.offset: 35,
         key.length: 17,
-        key.nameoffset: 66,
+        key.nameoffset: 40,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 54,
+            key.offset: 28,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -171,15 +153,15 @@ public func pub_function() -> Int
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MyProto",
-    key.offset: 89,
+    key.offset: 63,
     key.length: 53,
-    key.nameoffset: 98,
+    key.nameoffset: 72,
     key.namelength: 7,
-    key.bodyoffset: 114,
+    key.bodyoffset: 88,
     key.bodylength: 27,
     key.attributes: [
       {
-        key.offset: 82,
+        key.offset: 56,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -189,9 +171,9 @@ public func pub_function() -> Int
         key.kind: source.lang.swift.decl.associatedtype,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Assoc",
-        key.offset: 120,
+        key.offset: 94,
         key.length: 20,
-        key.nameoffset: 135,
+        key.nameoffset: 109,
         key.namelength: 5
       }
     ]
@@ -200,19 +182,19 @@ public func pub_function() -> Int
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "pub_function()",
-    key.offset: 170,
+    key.offset: 144,
     key.length: 26,
     key.typename: "Int",
-    key.nameoffset: 175,
+    key.nameoffset: 149,
     key.namelength: 14,
     key.attributes: [
       {
-        key.offset: 163,
+        key.offset: 137,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       },
       {
-        key.offset: 144,
+        key.offset: 118,
         key.length: 18,
         key.attribute: source.decl.attribute.discardableResult
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift
@@ -9,7 +9,7 @@
 // Make sure cursor info within the generated interface of A on one of the
 // decls originally from a cross-import decls shows 'A' as the parent module.
 //
-// RUN: %sourcekitd-test -req=interface-gen-open -module A -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %S/../Inputs/CrossImport -module-cache-path %t.mod/mcp == -req=cursor -print-raw-response -pos=11:15 -- -I %S/../Inputs/CrossImport -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %sourcekitd-test -req=interface-gen-open -module A -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %S/../Inputs/CrossImport -module-cache-path %t.mod/mcp == -req=cursor -print-raw-response -pos=9:15 -- -I %S/../Inputs/CrossImport -Xfrontend -enable-cross-import-overlays > %t.response
 // RUN: %FileCheck --input-file %t.response %s
 //
 // CHECK: key.name: "From_ABAdditionsType"

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift.A.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift.A.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 public func fromA()
 
 
@@ -28,191 +26,175 @@ public func other(x: A.From_ABAdditionsType)
 
 [
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 0,
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 26,
-    key.length: 6
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 33,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 38,
+    key.offset: 12,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 48,
+    key.offset: 22,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 51,
+    key.offset: 25,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 72,
+    key.offset: 46,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 79,
+    key.offset: 53,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 82,
+    key.offset: 56,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 121,
+    key.offset: 95,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 128,
+    key.offset: 102,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 135,
+    key.offset: 109,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 161,
+    key.offset: 135,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 200,
+    key.offset: 174,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 207,
+    key.offset: 181,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 212,
+    key.offset: 186,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 233,
+    key.offset: 207,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 236,
+    key.offset: 210,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 263,
+    key.offset: 237,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 270,
+    key.offset: 244,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 273,
+    key.offset: 247,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 319,
+    key.offset: 293,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 326,
+    key.offset: 300,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 331,
+    key.offset: 305,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 362,
+    key.offset: 336,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 408,
+    key.offset: 382,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 415,
+    key.offset: 389,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 420,
+    key.offset: 394,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 426,
+    key.offset: 400,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 429,
+    key.offset: 403,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 431,
+    key.offset: 405,
     key.length: 20
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 7,
-    key.length: 17,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 79,
+    key.offset: 53,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 270,
+    key.offset: 244,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 429,
+    key.offset: 403,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 431,
+    key.offset: 405,
     key.length: 20
   }
 ]
@@ -221,13 +203,13 @@ public func other(x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromA()",
-    key.offset: 33,
+    key.offset: 7,
     key.length: 12,
-    key.nameoffset: 38,
+    key.nameoffset: 12,
     key.namelength: 7,
     key.attributes: [
       {
-        key.offset: 26,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -237,15 +219,15 @@ public func other(x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "From_ABAdditionsType",
-    key.offset: 128,
+    key.offset: 102,
     key.length: 31,
-    key.nameoffset: 135,
+    key.nameoffset: 109,
     key.namelength: 20,
-    key.bodyoffset: 157,
+    key.bodyoffset: 131,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 121,
+        key.offset: 95,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -255,13 +237,13 @@ public func other(x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "from_ABAdditions()",
-    key.offset: 207,
+    key.offset: 181,
     key.length: 23,
-    key.nameoffset: 212,
+    key.nameoffset: 186,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 200,
+        key.offset: 174,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -271,13 +253,13 @@ public func other(x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "from__ABAdditionsCAdditions()",
-    key.offset: 326,
+    key.offset: 300,
     key.length: 34,
-    key.nameoffset: 331,
+    key.nameoffset: 305,
     key.namelength: 29,
     key.attributes: [
       {
-        key.offset: 319,
+        key.offset: 293,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -287,13 +269,13 @@ public func other(x: A.From_ABAdditionsType)
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "other(x:)",
-    key.offset: 415,
+    key.offset: 389,
     key.length: 37,
-    key.nameoffset: 420,
+    key.nameoffset: 394,
     key.namelength: 32,
     key.attributes: [
       {
-        key.offset: 408,
+        key.offset: 382,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -302,10 +284,10 @@ public func other(x: A.From_ABAdditionsType)
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "x",
-        key.offset: 426,
+        key.offset: 400,
         key.length: 25,
         key.typename: "A.From_ABAdditionsType",
-        key.nameoffset: 426,
+        key.nameoffset: 400,
         key.namelength: 1
       }
     ]

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift.Other.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import.swift.Other.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 public func fromOther()
 
 
@@ -7,7 +5,6 @@ public func fromOther()
 
 import B
 import C
-import A
 
 // Available when C is imported with Other
 /// This has some interesting documentation that shouldn't be separated from
@@ -18,126 +15,95 @@ public func from_OtherCAdditions()
 
 [
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 0,
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 26,
-    key.length: 6
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 33,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 38,
+    key.offset: 12,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 52,
+    key.offset: 26,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 55,
+    key.offset: 29,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 76,
+    key.offset: 50,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 83,
+    key.offset: 57,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 85,
+    key.offset: 59,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 92,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 94,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 101,
+    key.offset: 66,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 104,
+    key.offset: 69,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 147,
+    key.offset: 112,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 224,
+    key.offset: 189,
     key.length: 80
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 304,
+    key.offset: 269,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 340,
+    key.offset: 305,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 347,
+    key.offset: 312,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 352,
+    key.offset: 317,
     key.length: 20
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 7,
-    key.length: 17,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 83,
+    key.offset: 57,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 92,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 101,
+    key.offset: 66,
     key.length: 1
   }
 ]
@@ -146,13 +112,13 @@ public func from_OtherCAdditions()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromOther()",
-    key.offset: 33,
+    key.offset: 7,
     key.length: 16,
-    key.nameoffset: 38,
+    key.nameoffset: 12,
     key.namelength: 11,
     key.attributes: [
       {
-        key.offset: 26,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -162,15 +128,15 @@ public func from_OtherCAdditions()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "from_OtherCAdditions()",
-    key.offset: 347,
+    key.offset: 312,
     key.length: 27,
-    key.nameoffset: 352,
+    key.nameoffset: 317,
     key.namelength: 22,
-    key.docoffset: 147,
+    key.docoffset: 112,
     key.doclength: 193,
     key.attributes: [
       {
-        key.offset: 340,
+        key.offset: 305,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
@@ -12,7 +12,7 @@
 // Make sure cursor info within the generated interface of SwiftFramework on one of the
 // decls originally from a cross-import decls shows 'SwiftFramework' as the parent module.
 //
-// RUN: %sourcekitd-test -req=interface-gen-open -module SwiftFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=9:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %sourcekitd-test -req=interface-gen-open -module SwiftFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=7:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
 // RUN: %FileCheck --input-file %t.response --check-prefix=CHECKSWIFT %s
 //
 // CHECKSWIFT: key.name: "fromSwiftFrameworkCrossImport()"
@@ -27,7 +27,7 @@
 // Make sure cursor info within the generated interface of ClangFramework on one of the
 // decls originally from a cross-import decls shows 'ClangFramework' as the parent module.
 //
-// RUN: %sourcekitd-test -req=interface-gen-open -module ClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=10:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %sourcekitd-test -req=interface-gen-open -module ClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=7:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
 // RUN: %FileCheck --input-file %t.response --check-prefix=CHECKCLANG %s
 //
 // CHECKCLANG: key.name: "fromClangFrameworkCrossImport()"
@@ -42,7 +42,7 @@
 // Make sure cursor info within the generated interface of OverlaidClangFramework on one of the
 // decls originally from a cross-import decls shows 'OverlaidClangFramework' as the parent module.
 //
-// RUN: %sourcekitd-test -req=interface-gen-open -module OverlaidClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=11:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %sourcekitd-test -req=interface-gen-open -module OverlaidClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=9:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
 // RUN: %FileCheck --input-file %t.response --check-prefix=CHECKOVERLAIDCLANG %s
 //
 // CHECKOVERLAIDCLANG: key.name: "fromOverlaidClangFrameworkCrossImport()"

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.ClangFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.ClangFramework.response
@@ -1,10 +1,7 @@
-
 public func fromClangFramework()
 
 
 // MARK: - BystandingLibrary Additions
-
-import SwiftOnoneSupport
 
 // Available when BystandingLibrary is imported with ClangFramework
 public func fromClangFrameworkCrossImport()
@@ -13,80 +10,63 @@ public func fromClangFrameworkCrossImport()
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 13,
+    key.offset: 12,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 36,
+    key.offset: 35,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 39,
+    key.offset: 38,
     key.length: 35
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 76,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 83,
-    key.length: 17
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 102,
+    key.offset: 75,
     key.length: 68
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 170,
+    key.offset: 143,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 177,
+    key.offset: 150,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 182,
+    key.offset: 155,
     key.length: 29
   }
 ]
-[
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 83,
-    key.length: 17,
-    key.is_system: 1
-  }
-]
+<<NULL>>
 [
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromClangFramework()",
-    key.offset: 8,
+    key.offset: 7,
     key.length: 25,
-    key.nameoffset: 13,
+    key.nameoffset: 12,
     key.namelength: 20,
     key.attributes: [
       {
-        key.offset: 1,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -96,13 +76,13 @@ public func fromClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromClangFrameworkCrossImport()",
-    key.offset: 177,
+    key.offset: 150,
     key.length: 36,
-    key.nameoffset: 182,
+    key.nameoffset: 155,
     key.namelength: 31,
     key.attributes: [
       {
-        key.offset: 170,
+        key.offset: 143,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.OverlaidClangFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.OverlaidClangFramework.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 public func fromOverlaidClangFramework()
 
 public func fromOverlaidClangFrameworkOverlay()
@@ -13,96 +11,79 @@ public func fromOverlaidClangFrameworkCrossImport()
 
 [
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 0,
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 26,
-    key.length: 6
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 33,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 38,
+    key.offset: 12,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 68,
+    key.offset: 42,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 75,
+    key.offset: 49,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 80,
+    key.offset: 54,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 118,
+    key.offset: 92,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 121,
+    key.offset: 95,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 158,
+    key.offset: 132,
     key.length: 76
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 234,
+    key.offset: 208,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 241,
+    key.offset: 215,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 246,
+    key.offset: 220,
     key.length: 37
   }
 ]
-[
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 7,
-    key.length: 17,
-    key.is_system: 1
-  }
-]
+<<NULL>>
 [
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromOverlaidClangFramework()",
-    key.offset: 33,
+    key.offset: 7,
     key.length: 33,
-    key.nameoffset: 38,
+    key.nameoffset: 12,
     key.namelength: 28,
     key.attributes: [
       {
-        key.offset: 26,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -112,13 +93,13 @@ public func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromOverlaidClangFrameworkOverlay()",
-    key.offset: 75,
+    key.offset: 49,
     key.length: 40,
-    key.nameoffset: 80,
+    key.nameoffset: 54,
     key.namelength: 35,
     key.attributes: [
       {
-        key.offset: 68,
+        key.offset: 42,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -128,13 +109,13 @@ public func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromOverlaidClangFrameworkCrossImport()",
-    key.offset: 241,
+    key.offset: 215,
     key.length: 44,
-    key.nameoffset: 246,
+    key.nameoffset: 220,
     key.namelength: 39,
     key.attributes: [
       {
-        key.offset: 234,
+        key.offset: 208,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.SwiftFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.SwiftFramework.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 public func fromSwiftFramework()
 
 
@@ -11,81 +9,64 @@ public func fromSwiftFrameworkCrossImport()
 
 [
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 0,
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 26,
-    key.length: 6
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 33,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 38,
+    key.offset: 12,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 61,
+    key.offset: 35,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 64,
+    key.offset: 38,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 101,
+    key.offset: 75,
     key.length: 68
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 169,
+    key.offset: 143,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 176,
+    key.offset: 150,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 181,
+    key.offset: 155,
     key.length: 29
   }
 ]
-[
-  {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 7,
-    key.length: 17,
-    key.is_system: 1
-  }
-]
+<<NULL>>
 [
   {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromSwiftFramework()",
-    key.offset: 33,
+    key.offset: 7,
     key.length: 25,
-    key.nameoffset: 38,
+    key.nameoffset: 12,
     key.namelength: 20,
     key.attributes: [
       {
-        key.offset: 26,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -95,13 +76,13 @@ public func fromSwiftFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromSwiftFrameworkCrossImport()",
-    key.offset: 176,
+    key.offset: 150,
     key.length: 36,
-    key.nameoffset: 181,
+    key.nameoffset: 155,
     key.namelength: 31,
     key.attributes: [
       {
-        key.offset: 169,
+        key.offset: 143,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swiftonly_systemmodule.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swiftonly_systemmodule.swift.response
@@ -1,5 +1,3 @@
-import SwiftOnoneSupport
-
 public class PublicClass {
 }
 
@@ -17,148 +15,132 @@ public func publicFunc()
 
 [
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 0,
     key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 26,
-    key.length: 6
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 33,
+    key.offset: 7,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 39,
+    key.offset: 13,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 56,
+    key.offset: 30,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 63,
+    key.offset: 37,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 70,
+    key.offset: 44,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 87,
+    key.offset: 61,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 94,
+    key.offset: 68,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 98,
+    key.offset: 72,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 111,
+    key.offset: 85,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 117,
+    key.offset: 91,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 128,
+    key.offset: 102,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 135,
+    key.offset: 109,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 140,
+    key.offset: 114,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 158,
+    key.offset: 132,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 167,
+    key.offset: 141,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 174,
+    key.offset: 148,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 179,
+    key.offset: 153,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 187,
+    key.offset: 161,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 195,
+    key.offset: 169,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 202,
+    key.offset: 176,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 207,
+    key.offset: 181,
     key.length: 10
   }
 ]
 [
   {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 7,
-    key.length: 17,
-    key.is_system: 1
-  },
-  {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 111,
+    key.offset: 85,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 158,
+    key.offset: 132,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 187,
+    key.offset: 161,
     key.length: 3,
     key.is_system: 1
   }
@@ -168,15 +150,15 @@ public func publicFunc()
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "PublicClass",
-    key.offset: 33,
+    key.offset: 7,
     key.length: 21,
-    key.nameoffset: 39,
+    key.nameoffset: 13,
     key.namelength: 11,
-    key.bodyoffset: 52,
+    key.bodyoffset: 26,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 26,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -186,15 +168,15 @@ public func publicFunc()
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "SomeValue",
-    key.offset: 63,
+    key.offset: 37,
     key.length: 130,
-    key.nameoffset: 70,
+    key.nameoffset: 44,
     key.namelength: 9,
-    key.bodyoffset: 81,
+    key.bodyoffset: 55,
     key.bodylength: 111,
     key.attributes: [
       {
-        key.offset: 56,
+        key.offset: 30,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -204,16 +186,16 @@ public func publicFunc()
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "publicValue",
-        key.offset: 94,
+        key.offset: 68,
         key.length: 28,
         key.typename: "Int",
-        key.nameoffset: 98,
+        key.nameoffset: 72,
         key.namelength: 11,
-        key.bodyoffset: 116,
+        key.bodyoffset: 90,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 87,
+            key.offset: 61,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -223,14 +205,14 @@ public func publicFunc()
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "publicMethod()",
-        key.offset: 135,
+        key.offset: 109,
         key.length: 26,
         key.typename: "Int",
-        key.nameoffset: 140,
+        key.nameoffset: 114,
         key.namelength: 14,
         key.attributes: [
           {
-            key.offset: 128,
+            key.offset: 102,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -240,13 +222,13 @@ public func publicFunc()
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(public:)",
-        key.offset: 174,
+        key.offset: 148,
         key.length: 17,
-        key.nameoffset: 174,
+        key.nameoffset: 148,
         key.namelength: 17,
         key.attributes: [
           {
-            key.offset: 167,
+            key.offset: 141,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -255,10 +237,10 @@ public func publicFunc()
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "public",
-            key.offset: 179,
+            key.offset: 153,
             key.length: 11,
             key.typename: "Int",
-            key.nameoffset: 179,
+            key.nameoffset: 153,
             key.namelength: 6
           }
         ]
@@ -269,13 +251,13 @@ public func publicFunc()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "publicFunc()",
-    key.offset: 202,
+    key.offset: 176,
     key.length: 17,
-    key.nameoffset: 207,
+    key.nameoffset: 181,
     key.namelength: 12,
     key.attributes: [
       {
-        key.offset: 195,
+        key.offset: 169,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -387,8 +387,11 @@ static bool getModuleInterfaceInfo(
       Options.SkipInlineCXXNamespace = true;
     }
   }
+  // Skip submodules but include any exported modules that have the same public
+  // module name as this module.
   ModuleTraversalOptions TraversalOptions =
-      std::nullopt; // Don't print submodules.
+      ModuleTraversal::VisitMatchingExported;
+
   SmallString<128> Text;
   llvm::raw_svector_ostream OS(Text);
   AnnotatingPrinter Printer(Info, OS);

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -764,7 +764,8 @@ static StringRef getModuleName(const ValueDecl *VD,
   // overlay's declaring module as the owning module.
   if (ModuleDecl *Declaring = MD->getDeclaringModuleIfCrossImportOverlay())
     MD = Declaring;
-  return MD->getNameStr();
+
+  return MD->getPublicModuleName(/*onlyIfImported=*/false).str();
 }
 
 struct DeclInfo {


### PR DESCRIPTION
  - **Explanation**:
If a module has the same `public-module-name` as the module being generated and its import is exported, merge it into the same generated interface. Use the public module name for any module names being returned from SourceKit requests (eg. in cursor info and documentation). Also fixes various always-imported modules from being printed.

(cherry picked from commit ddddc667c8be2c162550797f431f98d4b8aa013e)
  - **Scope**: SourceKit generated interface and cursor info
  - **Issues**: rdar://137887712
  - **Original PRs**: https://github.com/swiftlang/swift/pull/80958
  - **Risk**: For the compiler, none. For SourceKit the main risk is for duplicate imports in the generated interface, which while weird, doesn't prevent the feature from working.
  - **Testing**: Large number of existing tests in this area (hence all the updates for `SwiftOnoneSupport` removal). Also added a test case for `public-module-name` specifically.
  - **Reviewers**: @rintaro 