### PR TITLE
[Caching] Reduce the number of cas ID passed on frontend commandline

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -534,6 +534,7 @@ ERROR(error_cache_key_creation, none, "cannot create cache key for compilation %
 ERROR(error_cas_file_ref, none, "cannot load file %0 from CAS filesystem", (StringRef))
 ERROR(error_cas_conflict_options, none, "cannot setup CAS due to conflicting '-cas-*' options", ())
 ERROR(error_cas_initialization, none, "CAS cannot be initialized from the specified '-cas-*' options: %0", (StringRef))
+ERROR(error_cas_malformed_input, none, "CAS input '%0' is malformed: %1", (StringRef, StringRef))
 WARNING(cache_replay_failed, none, "cache replay failed: %0", (StringRef))
 
 ERROR(error_failed_cached_diag, none, "failed to serialize cached diagnostics: %0", (StringRef))

--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -41,10 +41,10 @@ public:
   std::vector<std::string> CASFSRootIDs;
 
   /// Clang Include Trees.
-  std::vector<std::string> ClangIncludeTrees;
+  std::string ClangIncludeTree;
 
   /// Clang Include Tree FileList.
-  std::vector<std::string> ClangIncludeTreeFileList;
+  std::string ClangIncludeTreeFileList;
 
   /// CacheKey for input file.
   std::string InputFileKey;
@@ -62,7 +62,7 @@ public:
   /// Check to see if a CASFileSystem is required.
   bool requireCASFS() const {
     return EnableCaching &&
-           (!CASFSRootIDs.empty() || !ClangIncludeTrees.empty() ||
+           (!CASFSRootIDs.empty() || !ClangIncludeTree.empty() ||
             !ClangIncludeTreeFileList.empty() || !InputFileKey.empty() ||
             !BridgingHeaderPCHCacheKey.empty());
   }

--- a/include/swift/Frontend/CachingUtils.h
+++ b/include/swift/Frontend/CachingUtils.h
@@ -71,8 +71,8 @@ std::unique_ptr<llvm::MemoryBuffer> loadCachedCompileResultFromCacheKey(
 
 llvm::Expected<llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>>
 createCASFileSystem(llvm::cas::ObjectStore &CAS, ArrayRef<std::string> FSRoots,
-                    ArrayRef<std::string> IncludeTreeRoots,
-                    ArrayRef<std::string> IncludeTreeFileList);
+                    const std::string &IncludeTreeRoot,
+                    const std::string &IncludeTreeFileList);
 
 std::vector<std::string> remapPathsFromCommandLine(
     ArrayRef<std::string> Args,

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -64,9 +64,9 @@ static StringRef pluginModuleNameStringFromPath(StringRef path) {
 
 static llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem>
 getPluginLoadingFS(ASTContext &Ctx) {
-  // If there is a clang include tree FS, using real file system to load plugin
+  // If there is an immutable file system, using real file system to load plugin
   // as the FS in SourceMgr doesn't support directory iterator.
-  if (Ctx.ClangImporterOpts.HasClangIncludeTreeRoot)
+  if (Ctx.CASOpts.HasImmutableFileSystem)
     return llvm::vfs::getRealFileSystem();
   return Ctx.SourceMgr.getFileSystem();
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1187,8 +1187,7 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
            CI->getFrontendOpts().ProgramAction ==
                clang::frontend::ActionKind::GeneratePCH) &&
           ctx.ClangImporterOpts.HasClangIncludeTreeRoot) {
-        CI->getFrontendOpts().CASIncludeTreeID =
-            ctx.CASOpts.ClangIncludeTrees.back();
+        CI->getFrontendOpts().CASIncludeTreeID = ctx.CASOpts.ClangIncludeTree;
         CI->getFrontendOpts().Inputs.clear();
       }
     }
@@ -1247,7 +1246,7 @@ std::optional<std::vector<std::string>> ClangImporter::getClangCC1Arguments(
 
   std::vector<std::string> FilteredModuleMapFiles;
   for (auto ModuleMapFile : CI->getFrontendOpts().ModuleMapFiles) {
-    if (ctx.ClangImporterOpts.HasClangIncludeTreeRoot) {
+    if (ctx.ClangImporterOpts.UseClangIncludeTree) {
       // There is no need to add any module map file here. Issue a warning and
       // drop the option.
       Impl.diagnose(SourceLoc(), diag::module_map_ignored, ModuleMapFile);
@@ -1327,7 +1326,7 @@ ClangImporter::create(ASTContext &ctx,
       fileMapping.requiresBuiltinHeadersInSystemModules;
 
   // Avoid creating indirect file system when using include tree.
-  if (!ctx.ClangImporterOpts.HasClangIncludeTreeRoot) {
+  if (!ctx.CASOpts.HasImmutableFileSystem) {
     // Wrap Swift's FS to allow Clang to override the working directory
     VFS = llvm::vfs::RedirectingFileSystem::create(
         fileMapping.redirectedFiles, true, *ctx.SourceMgr.getFileSystem());

--- a/lib/Frontend/CachingUtils.cpp
+++ b/lib/Frontend/CachingUtils.cpp
@@ -472,16 +472,10 @@ static Expected<ObjectRef> mergeCASFileSystem(ObjectStore &CAS,
 
 Expected<IntrusiveRefCntPtr<vfs::FileSystem>>
 createCASFileSystem(ObjectStore &CAS, ArrayRef<std::string> FSRoots,
-                    ArrayRef<std::string> IncludeTrees,
-                    ArrayRef<std::string> IncludeTreeFileList) {
-  assert(!FSRoots.empty() || !IncludeTrees.empty() ||
+                    const std::string &IncludeTree,
+                    const std::string &IncludeTreeFileList) {
+  assert(!FSRoots.empty() || !IncludeTree.empty() ||
          !IncludeTreeFileList.empty() && "no root ID provided");
-  if (FSRoots.size() == 1 && IncludeTrees.empty()) {
-    auto ID = CAS.parseID(FSRoots.front());
-    if (!ID)
-      return ID.takeError();
-    return createCASFileSystem(CAS, *ID);
-  }
 
   auto NewRoot = mergeCASFileSystem(CAS, FSRoots);
   if (!NewRoot)
@@ -492,10 +486,9 @@ createCASFileSystem(ObjectStore &CAS, ArrayRef<std::string> FSRoots,
     return FS.takeError();
 
   auto CASFS = makeIntrusiveRefCnt<vfs::OverlayFileSystem>(std::move(*FS));
-  std::vector<clang::cas::IncludeTree::FileList::FileEntry> Files;
-  // Push all Include File System onto overlay.
-  for (auto &Tree : IncludeTrees) {
-    auto ID = CAS.parseID(Tree);
+
+  if (!IncludeTree.empty()) {
+    auto ID = CAS.parseID(IncludeTree);
     if (!ID)
       return ID.takeError();
 
@@ -510,45 +503,31 @@ createCASFileSystem(ObjectStore &CAS, ArrayRef<std::string> FSRoots,
     if (!ITF)
       return ITF.takeError();
 
-    auto Err = ITF->forEachFile(
-        [&](clang::cas::IncludeTree::File File,
-            clang::cas::IncludeTree::FileList::FileSizeTy Size) -> llvm::Error {
-          Files.push_back({File.getRef(), Size});
-          return llvm::Error::success();
-        });
+    auto ITFS = clang::cas::createIncludeTreeFileSystem(*ITF);
+    if (!ITFS)
+      return ITFS.takeError();
 
-    if (Err)
-      return std::move(Err);
+    CASFS->pushOverlay(*ITFS);
   }
 
-  for (auto &List: IncludeTreeFileList) {
-    auto ID = CAS.parseID(List);
+  if (!IncludeTreeFileList.empty()) {
+    auto ID = CAS.parseID(IncludeTreeFileList);
     if (!ID)
       return ID.takeError();
 
     auto Ref = CAS.getReference(*ID);
     if (!Ref)
       return createCASObjectNotFoundError(*ID);
-    auto IT = clang::cas::IncludeTree::FileList::get(CAS, *Ref);
-    if (!IT)
-      return IT.takeError();
+    auto ITF = clang::cas::IncludeTree::FileList::get(CAS, *Ref);
+    if (!ITF)
+      return ITF.takeError();
 
-    auto Err = IT->forEachFile(
-        [&](clang::cas::IncludeTree::File File,
-            clang::cas::IncludeTree::FileList::FileSizeTy Size) -> llvm::Error {
-          Files.push_back({File.getRef(), Size});
-          return llvm::Error::success();
-        });
+    auto ITFS = clang::cas::createIncludeTreeFileSystem(*ITF);
+    if (!ITFS)
+      return ITFS.takeError();
 
-    if (Err)
-      return std::move(Err);
+    CASFS->pushOverlay(std::move(*ITFS));
   }
-
-  auto ITFS = clang::cas::createIncludeTreeFileSystem(CAS, Files);
-  if (!ITFS)
-    return ITFS.takeError();
-
-  CASFS->pushOverlay(std::move(*ITFS));
 
   return CASFS;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -763,10 +763,10 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
 
   for (const auto &A : Args.getAllArgValues(OPT_cas_fs))
     Opts.CASFSRootIDs.emplace_back(A);
-  for (const auto &A : Args.getAllArgValues(OPT_clang_include_tree_root))
-    Opts.ClangIncludeTrees.emplace_back(A);
-  for (const auto &A : Args.getAllArgValues(OPT_clang_include_tree_filelist))
-    Opts.ClangIncludeTreeFileList.emplace_back(A);
+  if (auto *A = Args.getLastArg(OPT_clang_include_tree_root))
+    Opts.ClangIncludeTree = A->getValue();
+  if (auto *A = Args.getLastArg(OPT_clang_include_tree_filelist))
+    Opts.ClangIncludeTreeFileList = A->getValue();
 
   if (const Arg *A = Args.getLastArg(OPT_input_file_key))
     Opts.InputFileKey = A->getValue();
@@ -774,7 +774,7 @@ static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
   if (const Arg*A = Args.getLastArg(OPT_bridging_header_pch_key))
     Opts.BridgingHeaderPCHCacheKey = A->getValue();
 
-  if (!Opts.CASFSRootIDs.empty() || !Opts.ClangIncludeTrees.empty() ||
+  if (!Opts.CASFSRootIDs.empty() || !Opts.ClangIncludeTree.empty() ||
       !Opts.ClangIncludeTreeFileList.empty())
     Opts.HasImmutableFileSystem = true;
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -630,11 +630,11 @@ bool CompilerInstance::setUpVirtualFileSystemOverlays() {
   }
 
   if (Invocation.getCASOptions().requireCASFS()) {
-    if (!CASOpts.CASFSRootIDs.empty() || !CASOpts.ClangIncludeTrees.empty() ||
+    if (!CASOpts.CASFSRootIDs.empty() || !CASOpts.ClangIncludeTree.empty() ||
         !CASOpts.ClangIncludeTreeFileList.empty()) {
       // Set up CASFS as BaseFS.
       auto FS = createCASFileSystem(*CAS, CASOpts.CASFSRootIDs,
-                                    CASOpts.ClangIncludeTrees,
+                                    CASOpts.ClangIncludeTree,
                                     CASOpts.ClangIncludeTreeFileList);
       if (!FS) {
         Diagnostics.diagnose(SourceLoc(), diag::error_cas_fs_creation,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -282,7 +282,7 @@ initializePlugin(ASTContext &ctx, CompilerPlugin *plugin, StringRef libraryPath,
   if (!libraryPath.empty()) {
 #if SWIFT_BUILD_SWIFT_SYNTAX
     llvm::SmallString<128> resolvedLibraryPath;
-    auto fs = ctx.ClangImporterOpts.HasClangIncludeTreeRoot
+    auto fs = ctx.CASOpts.HasImmutableFileSystem
                   ? llvm::vfs::getRealFileSystem()
                   : ctx.SourceMgr.getFileSystem();
     if (auto err = fs->getRealPath(libraryPath, resolvedLibraryPath)) {

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -41,7 +41,6 @@
 // INCLUDE_TREE_F-NEXT: CHeaders/F.h
 
 // MAIN_CMD: -direct-clang-cc1-module-build
-// MAIN_CMD: -clang-include-tree-root
 // MAIN_CMD: -clang-include-tree-filelist
 
 import C


### PR DESCRIPTION
Using IncludeTree::FileList to concat the include tree file systems that are passed on the command-line. This significantly reduce the command-line size, and also makes the cache key computation a lot faster.

rdar://148752988

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
