### PR TITLE
[Swiftify] Don't use count from Span inside withUnsafeBufferPointer call

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -778,6 +778,13 @@ struct CountedOrSizedPointerThunkBuilder: ParamBoundsThunkBuilder, PointerBounds
     let argExpr = ExprSyntax("\(unwrappedName).baseAddress")
     assert(args[index] == nil)
     args[index] = try castPointerToOpaquePointer(unwrapIfNonnullable(argExpr))
+    if skipTrivialCount {
+      if let countVar = countExpr.as(DeclReferenceExprSyntax.self) {
+        let i = try getParameterIndexForDeclRef(signature.parameterClause.parameters, countVar)
+        args[i] = castIntToTargetType(
+          expr: "\(unwrappedName).count", type: getParam(signature, i).type)
+      }
+    }
     let call = try base.buildFunctionCall(args)
     let ptrRef = unwrapIfNullable(ExprSyntax(DeclReferenceExprSyntax(baseName: name)))
 

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -545,7 +545,7 @@ struct CxxSpanReturnThunkBuilder: SpanBoundsThunkBuilder {
       } else {
         "MutableSpan"
       }
-    return "unsafe _cxxOverrideLifetime(\(raw: cast)(_unsafeCxxSpan: \(call)), copying: ())"
+    return "unsafe _swiftifyOverrideLifetime(\(raw: cast)(_unsafeCxxSpan: \(call)), copying: ())"
   }
 }
 
@@ -701,10 +701,15 @@ struct CountedOrSizedReturnPointerThunkBuilder: PointerBoundsThunkBuilder {
       }()
       """
     }
-    return
+    var expr = ExprSyntax(
       """
-      unsafe \(raw: cast)(\(raw: startLabel): \(call), count: Int(\(countExpr)))
+      \(raw: cast)(\(raw: startLabel): \(call), count: Int(\(countExpr)))
       """
+    )
+    if generateSpan {
+      expr = "_swiftifyOverrideLifetime(\(expr), copying: ())"
+    }
+    return "unsafe \(expr)"
   }
 }
 

--- a/stdlib/public/core/SwiftifyImport.swift
+++ b/stdlib/public/core/SwiftifyImport.swift
@@ -63,3 +63,43 @@ public enum _SwiftifyInfo {
 public macro _SwiftifyImport(_ paramInfo: _SwiftifyInfo..., typeMappings: [String: String] = [:]) =
     #externalMacro(module: "SwiftMacros", type: "SwiftifyImportMacro")
 #endif
+
+/// Unsafely discard any lifetime dependency on the `dependent` argument. Return
+/// a value identical to `dependent` with a lifetime dependency on the caller's
+/// borrow scope of the `source` argument.
+///
+/// This mimics the stdlib definition. It is public for use with import macros.
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(borrow source)
+public func _swiftifyOverrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, borrowing source: borrowing U
+) -> T {
+  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
+  // should be expressed by a builtin that is hidden within the function body.
+  dependent
+}
+
+/// Unsafely discard any lifetime dependency on the `dependent` argument. Return
+/// a value identical to `dependent` that inherits all lifetime dependencies from
+/// the `source` argument.
+///
+/// This mimics the stdlib definition. It is public for use with import macros.
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(copy source)
+public func _swiftifyOverrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, copying source: borrowing U
+) -> T {
+  // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence
+  // should be expressed by a builtin that is hidden within the function body.
+  dependent
+}

--- a/test/Interop/C/swiftify-import/Inputs/counted-by-noescape.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by-noescape.h
@@ -17,7 +17,7 @@ void nullUnspecified(int len, int * __counted_by(len) _Null_unspecified __noesca
 
 void nonnull(int len, int * __counted_by(len) _Nonnull __noescape p);
 
-//void nullable(int len, int * __counted_by(len) _Nullable p);
+void nullable(int len, int * __counted_by(len) _Nullable p __noescape);
 
 int * __counted_by(len) __noescape returnPointer(int len);
 

--- a/test/Interop/C/swiftify-import/Inputs/sized-by-noescape.h
+++ b/test/Interop/C/swiftify-import/Inputs/sized-by-noescape.h
@@ -16,8 +16,7 @@ void nullUnspecified(int len, const void * __sized_by(len) __noescape _Null_unsp
 
 void nonnull(int len, const void * __sized_by(len) __noescape _Nonnull p);
 
-// Nullable ~Escapable types not supported yet
-//void nullable(int len, const void * __sized_by(len) __noescape _Nullable p);
+void nullable(int len, const void * __sized_by(len) __noescape _Nullable p);
 
 const void * __sized_by(len) __noescape _Nonnull returnPointer(int len);
 

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -6,7 +6,6 @@
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence %s
-// XFAIL: *
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by __noescape parameters.
 

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -5,7 +5,8 @@
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence %s
+// XFAIL: *
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by __noescape parameters.
 
@@ -17,6 +18,8 @@ import CountedByNoEscapeClang
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_ p: inout MutableSpan<Int32>)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_ p: inout MutableSpan<Int32>)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_ p: inout MutableSpan<Int32>?)
 // CHECK-NEXT: @lifetime(copy p)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func returnLifetimeBound(_ len1: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
@@ -29,9 +32,57 @@ import CountedByNoEscapeClang
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_ p: inout MutableSpan<Int32>)
 
+@lifetime(p: copy p)
+@inlinable
+public func callComplexExpr(_ p: inout MutableSpan<CInt>) {
+  complexExpr(CInt(p.count), 1, &p)
+}
+
+@lifetime(p: copy p)
+@inlinable
+public func callNonnull(_ p: inout MutableSpan<CInt>) {
+  nonnull(&p)
+}
+
+@lifetime(p: copy p)
+@inlinable
+public func callNullUnspecified(_ p: inout MutableSpan<CInt>) {
+  nullUnspecified(&p)
+}
+
+@lifetime(p: copy p)
+@inlinable
+public func callNullable(_ p: inout MutableSpan<CInt>?) {
+  nullable(&p)
+}
+
+@lifetime(p: copy p)
+@inlinable
+public func callReturnLifetimeBound(_ p: inout MutableSpan<CInt>) {
+  let a: MutableSpan<CInt> = returnLifetimeBound(2, &p)
+}
+
 @inlinable
 public func callReturnPointer() {
   let a: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
   let b: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
 }
 
+@lifetime(p: copy p)
+@lifetime(p2: copy p2)
+@inlinable
+public func callShared(_ p: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {
+  shared(CInt(p.count), &p, &p2)
+}
+
+@lifetime(p: copy p)
+@inlinable
+public func callSimple(_ p: inout MutableSpan<CInt>) {
+  simple(&p)
+}
+
+@lifetime(p: copy p)
+@inlinable
+public func callSwiftAttr(_ p: inout MutableSpan<CInt>) {
+  swiftAttr(&p)
+}

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -20,7 +20,42 @@ import CountedByClang
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 
 @inlinable
+public func callComplexExpr(_ p: UnsafeMutableBufferPointer<CInt>) {
+  complexExpr(CInt(p.count), 1, p)
+}
+
+@inlinable
+public func callNonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
+  nonnull(p)
+}
+
+@inlinable
+public func callNullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
+  nullUnspecified(p)
+}
+
+@inlinable
+public func callNullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
+  nullable(p)
+}
+
+@inlinable
 public func callReturnPointer() {
   let a: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
   let b: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
+}
+
+@inlinable
+public func callShared(_ p: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
+  shared(CInt(p.count), p, p2)
+}
+
+@inlinable
+public func callSimple(_ p: UnsafeMutableBufferPointer<CInt>) {
+  simple(p)
+}
+
+@inlinable
+public func callSwiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
+  swiftAttr(p)
 }

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -12,8 +12,50 @@ import SizedByNoEscapeClang
 // CHECK:      @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: RawSpan)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_ p: RawSpan)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_  p: RawSpan)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_  p: RawSpan?)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func opaque(_  p: RawSpan)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int{{.*}}) -> UnsafeRawBufferPointer
 // CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int{{.*}}, _ p1: RawSpan, _ p2: RawSpan)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: RawSpan)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: RawSpan)
+
+@inlinable
+public func callComplexExpr(_ p: RawSpan) {
+  complexExpr(CInt(p.byteCount), 1, p)
+}
+
+@inlinable
+public func callNonnull(_ p: RawSpan) {
+  nonnull(p)
+}
+
+@inlinable
+public func callNullUnspecified(_ p: RawSpan) {
+  nullUnspecified(p)
+}
+
+@inlinable
+public func callNullable(_ p: RawSpan?) {
+  nullable(p)
+}
+
+@inlinable
+public func callReturnPointer() {
+  let a: UnsafeRawBufferPointer? = returnPointer(4) // call wrapper
+  let b: UnsafeRawPointer? = returnPointer(4) // call unsafe interop
+}
+
+@inlinable
+public func callShared(_ p: RawSpan, _ p2: RawSpan) {
+  shared(CInt(p.byteCount), p, p2)
+}
+
+@inlinable
+public func callSimple(_ p: RawSpan) {
+  simple(p)
+}
+
+@inlinable
+public func callSwiftAttr(_ p: RawSpan) {
+  swiftAttr(p)
+}

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -19,3 +19,48 @@ import SizedByClang
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: UnsafeMutableRawBufferPointer)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: UnsafeMutableRawBufferPointer)
 
+@inlinable
+public func callComplexExpr(_ p: UnsafeMutableRawBufferPointer) {
+  complexExpr(CInt(p.count), 1, p)
+}
+
+@inlinable
+public func callNonnull(_ p: UnsafeMutableRawBufferPointer) {
+  nonnull(p)
+}
+
+@inlinable
+public func callNullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
+  nullUnspecified(p)
+}
+
+@inlinable
+public func callNullable(_ p: UnsafeMutableRawBufferPointer?) {
+  nullable(p)
+}
+
+@inlinable
+public func callOpaque(_ p: UnsafeRawBufferPointer) {
+  opaque(p)
+}
+
+@inlinable
+public func callReturnPointer() {
+  let a: UnsafeMutableRawBufferPointer? = returnPointer(4) // call wrapper
+  let b: UnsafeMutableRawPointer? = returnPointer(4) // call unsafe interop
+}
+
+@inlinable
+public func callShared(_ p: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
+  shared(CInt(p.count), p, p2)
+}
+
+@inlinable
+public func callSimple(_ p: UnsafeMutableRawBufferPointer) {
+  simple(p)
+}
+
+@inlinable
+public func callSwiftAttr(_ p: UnsafeMutableRawBufferPointer) {
+  swiftAttr(p)
+}

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -10,6 +10,6 @@ func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr)
 // CHECK-NEXT: func myFunc(_ ptr: inout MutableSpan<CInt>) {
 // CHECK-NEXT:     return unsafe   ptr.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -30,7 +30,7 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 // CHECK-NEXT:             unsafe myFunc2(nil, CInt(exactly: ptr?.count ?? 0)!)
 // CHECK-NEXT:         } else {
 // CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                 return unsafe myFunc2(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:                 return unsafe myFunc2(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }()
@@ -45,7 +45,7 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 // CHECK-NEXT:                     unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
 // CHECK-NEXT:                 } else {
 // CHECK-NEXT:                     unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                         return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                         return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }()
@@ -53,10 +53,10 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 // CHECK-NEXT:             unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
 // CHECK-NEXT:                 return { () in
 // CHECK-NEXT:                     return if ptr == nil {
-// CHECK-NEXT:                         unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                         unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: _ptr2Ptr.count)!)
 // CHECK-NEXT:                     } else {
 // CHECK-NEXT:                         unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                             return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: ptr?.count ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                             return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!, _ptr2Ptr.baseAddress, CInt(exactly: _ptr2Ptr.count)!)
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }()

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -31,7 +31,7 @@ func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy p)
 // CHECK-NEXT: func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
 // CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart:   unsafe p.withUnsafeBufferPointer { _pPtr in
-// CHECK-NEXT:         return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: p.count)!, len2)
+// CHECK-NEXT:         return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: _pPtr.count)!, len2)
 // CHECK-NEXT:       }, count: Int(len2))
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -30,13 +30,13 @@ func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy p)
 // CHECK-NEXT: func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart:   unsafe p.withUnsafeBufferPointer { _pPtr in
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart:   unsafe p.withUnsafeBufferPointer { _pPtr in
 // CHECK-NEXT:         return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: _pPtr.count)!, len2)
-// CHECK-NEXT:       }, count: Int(len2))
+// CHECK-NEXT:       }, count: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p)
 // CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2))
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2)), copying: ())
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
@@ -10,6 +10,6 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: Span<CInt>) {
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
@@ -10,6 +10,6 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: Span<CInt>) -> CInt {
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -11,7 +11,7 @@ func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePointer<CIn
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
 // CHECK-NEXT:     return unsafe ptr1.withUnsafeBufferPointer { _ptr1Ptr in
-// CHECK-NEXT:         return unsafe myFunc(_ptr1Ptr.baseAddress!, CInt(exactly: ptr1.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
+// CHECK-NEXT:         return unsafe myFunc(_ptr1Ptr.baseAddress!, CInt(exactly: _ptr1Ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -59,27 +59,27 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span)
 // CHECK-NEXT: func myFunc(_ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc(SpanOfInt(span))), copying: ())
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc(SpanOfInt(span))), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ vec: borrowing VecOfInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc2(vec)), copying: ())
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc2(vec)), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span1, copy span2)
 // CHECK-NEXT: func myFunc3(_ span1: Span<CInt>, _ span2: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc3(SpanOfInt(span1), SpanOfInt(span2))), copying: ())
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc3(SpanOfInt(span1), SpanOfInt(span2))), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec, copy span)
 // CHECK-NEXT: func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc4(vec, SpanOfInt(span))), copying: ())
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc4(vec, SpanOfInt(span))), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow self) @_disfavoredOverload
 // CHECK-NEXT: func myFunc5() -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc5()), copying: ())
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc5()), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span)
@@ -88,7 +88,7 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
 // CHECK-NEXT:         return unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
 // CHECK-NEXT:     }), copying: ())
 // CHECK-NEXT: }
@@ -99,7 +99,7 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
 // CHECK-NEXT:         return unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
 // CHECK-NEXT:     }), copying: ())
 // CHECK-NEXT: }
@@ -110,14 +110,14 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
 // CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
 // CHECK-NEXT:         return unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)
 // CHECK-NEXT:     }), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @lifetime(span: copy span)
 // CHECK-NEXT: func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
-// CHECK-NEXT:     return unsafe _cxxOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
 // CHECK-NEXT:         return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
 // CHECK-NEXT:    }), copying: ())
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -10,6 +10,6 @@ func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr)
 // CHECK-NEXT: func myFunc(_ ptr: inout MutableRawSpan) {
 // CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -44,7 +44,7 @@ func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func nonnullSpan(_ ptr: RawSpan) {
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:         return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
@@ -55,7 +55,7 @@ func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 // CHECK-NEXT:             unsafe nullableSpan(nil, CInt(exactly: ptr?.byteCount ?? 0)!)
 // CHECK-NEXT:         } else {
 // CHECK-NEXT:             unsafe ptr!.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:                 return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), CInt(exactly: ptr?.byteCount ?? 0)!)
+// CHECK-NEXT:                 return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }()
@@ -64,7 +64,7 @@ func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func impNullableSpan(_ ptr: RawSpan) {
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:         return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
@@ -10,6 +10,6 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: RawSpan) {
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
@@ -10,6 +10,6 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 // CHECK:      @_alwaysEmitIntoClient
 // CHECK-NEXT: func myFunc(_ ptr: RawSpan) -> CInt {
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: ptr.byteCount)!)
+// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }


### PR DESCRIPTION
Given a call like: `ptr.withUnsafeBufferPointer { _ptrPtr in ... }` `ptr.count` and `_ptrPtr.count` both contain the same value, but when `ptr` is a `MutableSpan` we get an error when referring to `ptr` inside a call to `withUnsafeMutableBufferPointer`, so we should use `_ptrPtr.count` instead.

rdar://150551109
