### PR TITLE
[6.2][Parse] Parse operator function with value generics

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -8737,12 +8737,12 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
   SourceLoc NameLoc;
   if (Tok.isAnyOperator() || Tok.isAny(tok::exclaim_postfix, tok::amp_prefix)) {
     // If the name is an operator token that ends in '<' and the following token
-    // is an identifier, split the '<' off as a separate token. This allows
-    // things like 'func ==<T>(x:T, y:T) {}' to parse as '==' with generic type
-    // variable '<T>' as expected.
+    // is an identifier or 'let', split the '<' off as a separate token. This
+    // allows things like 'func ==<T>(x:T, y:T) {}' to parse as '==' with
+    // generic type variable '<T>' as expected.
     auto NameStr = Tok.getText();
     if (NameStr.size() > 1 && NameStr.back() == '<' &&
-        peekToken().is(tok::identifier)) {
+        peekToken().isAny(tok::identifier, tok::kw_let)) {
       NameStr = NameStr.slice(0, NameStr.size() - 1);
     }
     SimpleName = Context.getIdentifier(NameStr);

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -51,6 +51,8 @@ func c<let M: Int>(with a: A<M>) {} // OK
 func d<T>(with a: A<T>) {} // expected-error {{cannot pass type 'T' as a value for generic value 'N'}}
 func e(with a: A<Int>) {} // expected-error {{cannot pass type 'Int' as a value for generic value 'N'}}
 
+func *<let X: Int, let Y: Int>(l: A<X>, r: A<Y>) -> Int { l.int * r.int }
+
 struct Generic<T: ~Copyable & ~Escapable> {}
 struct GenericWithIntParam<T: ~Copyable & ~Escapable, let N: Int> {}
 


### PR DESCRIPTION
Cherry-pick #81265 into `release/6.2`

* **Explanation**:  Operator function parsing has a heuristics to determine if `<` a part of the operator name or the generic parameter clause. Previously if `<` was followed by an identifier it considered `<` was a start of the generic parameter clause. However, since value generics was introduced, generic parameter clause can start with `< let` which was not handled.
* **Scope**: Parse
* **Risk**: Low, the change is trivial.
* **Testing**: Added an regression test case
* **Issue**: rdar://149556573
* **Reviewer**: Ben Barham (@bnbarham)