### PR TITLE
[6.2] Fix LifetimeDependence type inference for setters.

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1132,8 +1132,8 @@ protected:
       // The 'newValue' dependence kind must match the getter's dependence kind
       // because generated the implementation '_modify' accessor composes the
       // getter's result with the setter's 'newValue'. In particular, if the
-      // result type is non-Escapable then the setter must not depend on
-      // 'newValue'.
+      // result type is Escapable then the getter does not have any lifetime
+      // dependency, so the setter cannot depend on 'newValue'.
       if (!paramTypeInContext->isEscapable()) {
         targetDeps = std::move(targetDeps)
           .add(newValIdx, LifetimeDependenceKind::Inherit);

--- a/test/SILOptimizer/lifetime_dependence/Inputs/lifetime_depend_diagnose.swiftinterface
+++ b/test/SILOptimizer/lifetime_dependence/Inputs/lifetime_depend_diagnose.swiftinterface
@@ -24,4 +24,24 @@ extension NE {
     return NE(pointer: _pointer)
   }
 }
+
+public struct NCNE<Element>: ~Swift.Copyable & ~Swift.Escapable {
+  var e: Element
+}
+
+extension NCNE where Element : Swift.BitwiseCopyable {
+  // Ensure that lifetime dependence diagnostics accessp the generated _modify accessor:
+  // the getter dependency must match the setter's mewValue dependence.
+  // In this case, the getter has no dependency because the result is BitwiseCopyable. The setter cannot, therefore,
+  // have a borrow dependency no 'newValue' which is produced by the getter.
+  public subscript() -> Element {
+    get {
+      return e
+    }
+    //@lifetime(self: copy self, self: copy newValue)
+    set {
+      e = newValue
+    }
+  }
+}
 #endif


### PR DESCRIPTION
A setter on a non-Escapable type may have a dependency on both it's incoming
'self' and 'newValue'. If the 'newValue' dependency does not match the getter's
dependency, then lifetime diagnostics will not accept the generated '_modify'
accessor:

error: lifetime-dependent value returned by generated accessor '_modify'

To fix this, make sure that we don't (conservatively) infer a borrow
dependency on 'newValue'.

Fixes rdar://150444400

(cherry picked from commit 88bbc18730ee82e81a34fd05bd84162ffc033dd5)

main PR: https://github.com/swiftlang/swift/pull/81270
