### PR TITLE
[6.2][Sema]: ban @isolated(any) conversions to synchronous function types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5024,6 +5024,10 @@ ERROR(capture_across_type_decl,none,
       "%0 declaration cannot close over value %1 defined in outer scope",
       (DescriptiveDeclKind, Identifier))
 
+ERROR(isolated_any_conversion_to_synchronous_func,none,
+      "converting @isolated(any) function of type %0 to synchronous function type %1 is not allowed",
+      (Type, Type))
+
 ERROR(reference_to_invalid_decl,none,
       "cannot reference invalid declaration %0", (const ValueDecl *))
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2710,6 +2710,18 @@ namespace {
             }
           }
 
+          // @isolated(any) functions (async or not) cannot be converted to
+          // synchronous, non-@isolated(any) functions.
+          if (fromIsolation.isErased() && !toIsolation.isErased() &&
+              !toFnType->isAsync()) {
+            ctx.Diags
+                .diagnose(funcConv->getLoc(),
+                          diag::isolated_any_conversion_to_synchronous_func,
+                          fromFnType, toFnType)
+                .warnUntilFutureSwiftVersion();
+            return;
+          }
+
           // Conversions from non-Sendable types are handled by
           // region-based isolation.
           // Function conversions are used to inject concurrency attributes

--- a/test/Concurrency/isolated_any.swift
+++ b/test/Concurrency/isolated_any.swift
@@ -64,9 +64,21 @@ func testEraseFromIsolatedArgument() {
   requireIsolatedAnyWithActorArgument(hasIsolatedArgument)
 }
 
-func requireSendableNonIsolated(_ fn: @Sendable () -> ()) {}
+func requireSendableNonIsolated(_ fn: @Sendable () async -> ()) {}
 func testConvertIsolatedAnyToNonIsolated(fn: @Sendable @isolated(any) () -> ()) {
   requireSendableNonIsolated(fn)
+}
+
+func requireSendableNonIsolated_sync(_ fn: @Sendable () -> ()) {}
+func testConvertIsolatedAnyToNonIsolated_sync(fn: @Sendable @isolated(any) () -> ()) {
+  // expected-warning @+1 {{converting @isolated(any) function of type '@isolated(any) @Sendable () -> ()' to synchronous function type '@Sendable () -> ()' is not allowed; this will be an error in a future Swift language mode}}
+  requireSendableNonIsolated_sync(fn)
+}
+
+func requireNonSendableNonIsolated_sync(_ fn: () -> ()) {}
+func testConvertIsolatedAnyToNonSendableNonIsolated_sync(fn: @isolated(any) () -> ()) {
+  // expected-warning @+1 {{converting @isolated(any) function of type '@isolated(any) () -> ()' to synchronous function type '() -> ()' is not allowed; this will be an error in a future Swift language mode}}
+  requireNonSendableNonIsolated_sync(fn)
 }
 
 func requireSendableGlobalActor(_ fn: @Sendable @MainActor () -> ()) {}
@@ -125,8 +137,22 @@ func testFunctionIsolationExprTuple(
   return (fn1?.isolation, fn2?.isolation)
 }
 
-func nonSendableIsolatedAny(
+func nonSendableIsolatedAnySyncToSendableSync(
   _ fn: @escaping @isolated(any) () -> Void // expected-note {{parameter 'fn' is implicitly non-sendable}}
 ) {
   let _: @Sendable () -> Void = fn  // expected-warning {{using non-sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
+  // expected-warning @-1 {{converting @isolated(any) function of type '@isolated(any) () -> Void' to synchronous function type '@Sendable () -> Void' is not allowed; this will be an error in a future Swift language mode}}
+}
+
+func nonSendableIsolatedAnyAsyncToSendableSync(
+  _ fn: @escaping @isolated(any) () async -> Void // expected-note {{parameter 'fn' is implicitly non-sendable}}
+) {
+  let _: @Sendable () -> Void = fn  // expected-warning {{using non-sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
+  // expected-error @-1 {{invalid conversion from 'async' function of type '@isolated(any) () async -> Void' to synchronous function type '@Sendable () -> Void'}}
+}
+
+func nonSendableIsolatedAnyAsyncToSendableAsync(
+  _ fn: @escaping @isolated(any) () async -> Void // expected-note {{parameter 'fn' is implicitly non-sendable}}
+) {
+  let _: @Sendable () async -> Void = fn  // expected-warning {{using non-sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
 }


### PR DESCRIPTION
  - **Explanation**:
    per SE-0431, function conversions from an `@isolated(any)` function to a synchronous, non-`@isolated(any)` function type should not be allowed. this adds a warning during type checking to enforce this, which will be an error in a future major language mode.
    
    (cherry picked from commit 629e20897054aaa5b154b83cd6f59e805d1c3f5a)

  - **Scope**: adds a new typechecking diagnostic error that is downgraded to a warning until a future major language mode so should have minimal impact to existing code
  - **Issues**: resolves https://github.com/swiftlang/swift/issues/80823
  - **Original PRs**: https://github.com/swiftlang/swift/pull/80812
  - **Risk**: minimal. new diagnostic is a warning until a future major language mode
  - **Testing**: added new unit tests
  - **Reviewers**: @hborla 
