### PR TITLE
[6.2 🍒]: Add platform executor module for FreeBSD

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(swift_Concurrency
   PartialAsyncTask.swift
   PlatformExecutorDarwin.swift
   PlatformExecutorLinux.swift
+  PlatformExecutorFreeBSD.swift
   PlatformExecutorWindows.swift
   PriorityQueue.swift
   SourceCompatibilityShims.swift

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -164,6 +164,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
   PlatformExecutorDarwin.swift
   PlatformExecutorLinux.swift
   PlatformExecutorWindows.swift
+  PlatformExecutorFreeBSD.swift
 )
 
 set(SWIFT_RUNTIME_CONCURRENCY_NONEMBEDDED_C_SOURCES

--- a/stdlib/public/Concurrency/PlatformExecutorFreeBSD.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorFreeBSD.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if !$Embedded && os(FreeBSD)
+
+import Swift
+
+// The default executors for now are Dispatch-based
+@available(SwiftStdlib 6.2, *)
+public struct PlatformExecutorFactory: ExecutorFactory {
+  public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
+  public static let defaultExecutor: any TaskExecutor
+    = DispatchGlobalTaskExecutor()
+}
+
+#endif // os(FreeBSD)


### PR DESCRIPTION
Cherry-Pick: https://github.com/swiftlang/swift/pull/81227

Swift concurrency defines a default platform executor. This was not defined for FreeBSD resulting in build failures. Defining it to use the Dispatch executor.

Scope: This only impacts FreeBSD.
Risk: Low. This change only affects FreeBSD.
Reviewers: @compnerd, @ktoso, @al45tair
Testing: Local testing to ensure Concurrency builds on FreeBSD.
Fixes: rdar://150643436

(cherry picked from commit 4a41e507307c1df3b499d674355d7ace3855c0fa)
