### PR TITLE
[presets] Escalate C++ "unused" warnings in macOS smoke test

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -671,6 +671,10 @@ skip-test-llbuild
 
 enable-new-runtime-build
 
+# Escalate certain C++ warnings to errors for Swift.
+extra-swift-cmake-options=
+   -DCMAKE_CXX_FLAGS="-Werror=unused"
+
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
 build-subdir=buildbot_incremental


### PR DESCRIPTION
This is a modest attempt to make our builds more warning-free. Over time, we can add more warning groups and extrapolate this to Swift sources.