### PR TITLE
[6.2] Define SwiftBuild_Dir when building SwiftPM in build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2821,6 +2821,7 @@ function Build-PackageManager([Hashtable] $Platform) {
       LLBuild_DIR = (Get-ProjectCMakeModules $Platform LLBuild);
       ArgumentParser_DIR = (Get-ProjectCMakeModules $Platform ArgumentParser);
       SwiftDriver_DIR = (Get-ProjectCMakeModules $Platform Driver);
+      SwiftBuild_DIR = (Get-ProjectCMakeModules $Platform Build);
       SwiftCrypto_DIR = (Get-ProjectCMakeModules $Platform Crypto);
       SwiftCollections_DIR = (Get-ProjectCMakeModules $Platform Collections);
       SwiftASN1_DIR = (Get-ProjectCMakeModules $Platform ASN1);
@@ -2945,6 +2946,7 @@ function Build-SourceKitLSP([Hashtable] $Platform) {
       ArgumentParser_DIR = (Get-ProjectCMakeModules $Platform ArgumentParser);
       SwiftCrypto_DIR = (Get-ProjectCMakeModules $Platform Crypto);
       SwiftCollections_DIR = (Get-ProjectCMakeModules $Platform Collections);
+      SwiftBuild_DIR = (Get-ProjectCMakeModules $Platform Build);
       SwiftPM_DIR = (Get-ProjectCMakeModules $Platform PackageManager);
       LMDB_DIR = (Get-ProjectCMakeModules $Platform LMDB);
       IndexStoreDB_DIR = (Get-ProjectCMakeModules $Platform IndexStoreDB);


### PR DESCRIPTION
 - **Explanation**:
Cherrypick https://github.com/swiftlang/swift/pull/80703 to 6.2 branch.
Define SwiftBuild_Dir when building SwiftPM in build.ps1 in preparation for updating the Cmake build of SwiftPM to depend on Swift Build
  - **Scope**:
 Affects Windows build configuration
  - **Original PRs**:
    https://github.com/swiftlang/swift/pull/80703
  - **Risk**:
    Low. This change has very little impact on its own and has been building on main for about a week. It's not expected to have any runtime impact.
  - **Testing**:
   Windows PR testing in CI
  - **Reviewers**:
   @compnerd 