### PR TITLE
[6.2] embedded: avoid false error "Deinit of non-copyable type not visible in the current module" in SourceKit

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -137,11 +137,17 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
       // We need to de-virtualize deinits of non-copyable types to be able to specialize the deinitializers.
       case let destroyValue as DestroyValueInst:
         if !devirtualizeDeinits(of: destroyValue, simplifyCtxt) {
-          context.diagnosticEngine.diagnose(destroyValue.location.sourceLoc, .deinit_not_visible)
+          // If invoked from SourceKit avoid reporting false positives when WMO is turned off for indexing purposes.
+          if moduleContext.enableWMORequiredDiagnostics {
+            context.diagnosticEngine.diagnose(destroyValue.location.sourceLoc, .deinit_not_visible)
+          }
         }
       case let destroyAddr as DestroyAddrInst:
         if !devirtualizeDeinits(of: destroyAddr, simplifyCtxt) {
-          context.diagnosticEngine.diagnose(destroyAddr.location.sourceLoc, .deinit_not_visible)
+          // If invoked from SourceKit avoid reporting false positives when WMO is turned off for indexing purposes.
+          if moduleContext.enableWMORequiredDiagnostics {
+            context.diagnosticEngine.diagnose(destroyAddr.location.sourceLoc, .deinit_not_visible)
+          }
         }
 
       case let iem as InitExistentialMetatypeInst:

--- a/test/SourceKit/Diagnostics/embedded_non_wmo.swift
+++ b/test/SourceKit/Diagnostics/embedded_non_wmo.swift
@@ -16,6 +16,11 @@ func foo() {
     bar(Int.self)
 }
 
+func testNonCopyable() {
+  let nc = NonCopyable()
+  nc.doSomething()
+}
+
 @main
 struct Main {
     var someClass = SomeClass()
@@ -30,6 +35,11 @@ struct Main {
 final class SomeClass {}
 
 func bar<T>(_ T: T.Type) {}
+
+struct NonCopyable : ~Copyable {
+  func doSomething() {}
+  deinit {}
+}
 
 // CHECK:      {
 // CHECK-NEXT:   key.diagnostics: [


### PR DESCRIPTION
* **Explanation**: As SourceKit explicitly disables WMO, silence the diagnostic in SourceKit.
* **Risk**: low: It only affects SourceKit and disables a false error there.
* **Testing**: Tested by lit tests
* **Issue**: rdar://150596807
* **Reviewer**:  @bnbarham
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/81285
