### PR TITLE
[6.2 🍒][Dependency Scanning] Always use a locking diagnostic consumer

### DIFF
--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -40,6 +40,7 @@ private:
     std::optional<ScannerImportStatementInfo::ImportDiagnosticLocationInfo> ImportLocation;
   };
   std::vector<ScannerDiagnosticInfo> Diagnostics;
+  llvm::sys::SmartMutex<true> ScanningDiagnosticConsumerStateLock;
 
   void handleDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) override;
 
@@ -53,19 +54,6 @@ public:
   const std::vector<ScannerDiagnosticInfo> &getDiagnostics() const {
     return Diagnostics;
   }
-};
-
-/// Locking variant of the above diagnostic collector that guards accesses to
-/// its state with a lock.
-class LockingDependencyScanDiagnosticCollector
-    : public DependencyScanDiagnosticCollector {
-private:
-  void addDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) override;
-  llvm::sys::SmartMutex<true> ScanningDiagnosticConsumerStateLock;
-
-public:
-  friend DependencyScanningTool;
-  LockingDependencyScanDiagnosticCollector() {}
 };
 
 /// Given a set of arguments to a print-target-info frontend tool query, produce the
@@ -118,7 +106,7 @@ private:
   llvm::sys::SmartMutex<true> DependencyScanningToolStateLock;
 
   /// A shared consumer that accumulates encountered diagnostics.
-  LockingDependencyScanDiagnosticCollector CDC;
+  DependencyScanDiagnosticCollector CDC;
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver;
 };

--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -85,11 +85,6 @@ public:
   llvm::ErrorOr<swiftscan_import_set_t>
   getImports(ArrayRef<const char *> Command, StringRef WorkingDirectory);
 
-  /// Query diagnostics consumed so far.
-  std::vector<DependencyScanDiagnosticCollector::ScannerDiagnosticInfo> getDiagnostics();
-  /// Discared the collection of diagnostics encountered so far.
-  void resetDiagnostics();
-
   /// Using the specified invocation command, instantiate a CompilerInstance
   /// that will be used for this scan.
   llvm::ErrorOr<ScanQueryInstance>
@@ -104,9 +99,6 @@ private:
 
   /// Shared state mutual-exclusivity lock
   llvm::sys::SmartMutex<true> DependencyScanningToolStateLock;
-
-  /// A shared consumer that accumulates encountered diagnostics.
-  DependencyScanDiagnosticCollector CDC;
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver;
 };

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -259,7 +259,7 @@ static swiftscan_import_set_t generateHollowDiagnosticOutputImportSet(
 
 DependencyScanningTool::DependencyScanningTool()
     : ScanningService(std::make_unique<SwiftDependencyScanningService>()),
-      CDC(), Alloc(), Saver(Alloc) {}
+      Alloc(), Saver(Alloc) {}
 
 llvm::ErrorOr<swiftscan_dependency_graph_t>
 DependencyScanningTool::getDependencies(
@@ -326,18 +326,6 @@ DependencyScanningTool::getImports(ArrayRef<const char *> Command,
   return std::move(*DependenciesOrErr);
 }
 
-std::vector<
-    DependencyScanDiagnosticCollector::ScannerDiagnosticInfo>
-DependencyScanningTool::getDiagnostics() {
-  llvm::sys::SmartScopedLock<true> Lock(DependencyScanningToolStateLock);
-  return CDC.Diagnostics;
-}
-
-void DependencyScanningTool::resetDiagnostics() {
-  llvm::sys::SmartScopedLock<true> Lock(DependencyScanningToolStateLock);
-  CDC.reset();
-}
-
 llvm::ErrorOr<ScanQueryInstance>
 DependencyScanningTool::initCompilerInstanceForScan(
     ArrayRef<const char *> CommandArgs,
@@ -353,10 +341,6 @@ DependencyScanningTool::initCompilerInstanceForScan(
 
   // State unique to an individual scan
   auto Instance = std::make_unique<CompilerInstance>();
-
-  // FIXME: The shared CDC must be deprecated once all clients have switched
-  // to using per-scan diagnostic output embedded in the `swiftscan_dependency_graph_s`
-  Instance->addDiagnosticConsumer(&CDC);
   Instance->addDiagnosticConsumer(scannerDiagnosticsCollector.get());
 
   // Basic error checking on the arguments

--- a/lib/Tooling/libSwiftScan/libSwiftScan.cpp
+++ b/lib/Tooling/libSwiftScan/libSwiftScan.cpp
@@ -589,45 +589,15 @@ swiftscan_compiler_supported_features_query() {
 //=== Scanner Diagnostics -------------------------------------------------===//
 swiftscan_diagnostic_set_t*
 swiftscan_scanner_diagnostics_query(swiftscan_scanner_t scanner) {
-  DependencyScanningTool *ScanningTool = unwrap(scanner);
-  auto Diagnostics = ScanningTool->getDiagnostics();
-  auto NumDiagnostics = Diagnostics.size();
-
-  swiftscan_diagnostic_set_t *Result = new swiftscan_diagnostic_set_t;
-  Result->count = NumDiagnostics;
-  Result->diagnostics = new swiftscan_diagnostic_info_t[NumDiagnostics];
-
-  for (size_t i = 0; i < NumDiagnostics; ++i) {
-    const auto &Diagnostic = Diagnostics[i];
-    swiftscan_diagnostic_info_s *DiagnosticInfo = new swiftscan_diagnostic_info_s;
-    DiagnosticInfo->message = swift::c_string_utils::create_clone(Diagnostic.Message.c_str());
-    switch (Diagnostic.Severity) {
-    case llvm::SourceMgr::DK_Error:
-      DiagnosticInfo->severity = SWIFTSCAN_DIAGNOSTIC_SEVERITY_ERROR;
-      break;
-    case llvm::SourceMgr::DK_Warning:
-      DiagnosticInfo->severity = SWIFTSCAN_DIAGNOSTIC_SEVERITY_WARNING;
-      break;
-    case llvm::SourceMgr::DK_Note:
-      DiagnosticInfo->severity = SWIFTSCAN_DIAGNOSTIC_SEVERITY_NOTE;
-      break;
-    case llvm::SourceMgr::DK_Remark:
-      DiagnosticInfo->severity = SWIFTSCAN_DIAGNOSTIC_SEVERITY_REMARK;
-      break;
-    }
-    // swiftscan_scanner_diagnostics_query is deprecated,
-    // so it does not support source locations.
-    DiagnosticInfo->source_location = nullptr;
-    Result->diagnostics[i] = DiagnosticInfo;
-  }
-
-  return Result;
+  // This method is deprecated
+  swiftscan_diagnostic_set_t *set = new swiftscan_diagnostic_set_t;
+  set->count = 0;
+  return set;
 }
 
 void
 swiftscan_scanner_diagnostics_reset(swiftscan_scanner_t scanner) {
-  DependencyScanningTool *ScanningTool = unwrap(scanner);
-  ScanningTool->resetDiagnostics();
+  // This method is deprecated
 }
 
 swiftscan_string_ref_t


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/81262
-------------------------
- **Explanation**: Since we enabled parallel dependency scanning by-default, each individual scan needs a diagnostic consumer that is safe to use across many threads. Deprecate the 'Locking' sub-class, making its behavior the default in the base class. This ensures that parallel scanning will not encounter a race when multiple worker threads are registering new diagnostics. 

- **Scope**: All clients of parallel (default) dependency scanning

- **Risk**: Low, replaces the use of a base diagnostic collector data-structure with one that simply causes its functionality to form a critical section without changing the semantics otherwise. 

- **Issue**: rdar://150286558

- **Original PR**: https://github.com/swiftlang/swift/pull/81262

