### PR TITLE
[6.2] Fix newly introduced warnings in LifetimeDependenceScopeFixup

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -194,19 +194,7 @@ private func createEndCOWMutationIfNeeded(lifetimeDep: LifetimeDependence, _ con
       }
       scoped = beginApply
     // None of the below cases can generate a mutable address.
-    case let .owned:
-      fallthrough
-    case let .borrowed:
-      fallthrough
-    case let .local:
-      fallthrough
-    case let .initialized:
-      fallthrough
-    case let .caller:
-      fallthrough
-    case let .global:
-      fallthrough
-    case let .unknown:
+    case .owned, .borrowed, .local, .initialized, .caller, .global, .unknown:
       return
   }
 

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -575,6 +575,7 @@ public struct Builder {
     return notifyNew(endMutation.getAs(EndCOWMutationInst.self))
   }
 
+  @discardableResult
   public func createEndCOWMutationAddr(address: Value) -> EndCOWMutationAddrInst {
     let endMutation = bridged.createEndCOWMutationAddr(address.bridged)
     return notifyNew(endMutation.getAs(EndCOWMutationAddrInst.self))


### PR DESCRIPTION
Explanation:  Fix newly introduced warnings in LifetimeDependenceScopeFixup in https://github.com/swiftlang/swift/pull/81216 
Risk: None
