### PR TITLE
🍒[6.2 Concurrency] An implementation of system epochs for continuous and suspending clocks (#80409)

### DIFF
--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -141,6 +141,14 @@ extension ContinuousClock: Clock {
 
 @available(SwiftStdlib 5.7, *)
 @_unavailableInEmbedded
+extension ContinuousClock {
+  @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
+  public var systemEpoch: Instant { unsafeBitCast(Duration.seconds(0), to: Instant.self) }
+}
+
+@available(SwiftStdlib 5.7, *)
+@_unavailableInEmbedded
 extension ContinuousClock.Instant: InstantProtocol {
   public static var now: ContinuousClock.Instant { ContinuousClock.now }
 

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -129,6 +129,14 @@ extension SuspendingClock: Clock {
 
 @available(SwiftStdlib 5.7, *)
 @_unavailableInEmbedded
+extension SuspendingClock {
+  @available(SwiftStdlib 5.7, *)
+  @_alwaysEmitIntoClient
+  public var systemEpoch: Instant { unsafeBitCast(Duration.seconds(0), to: Instant.self) }
+}
+
+@available(SwiftStdlib 5.7, *)
+@_unavailableInEmbedded
 extension SuspendingClock.Instant: InstantProtocol {
   @available(SwiftStdlib 5.7, *)
   public static var now: SuspendingClock.Instant { SuspendingClock().now }

--- a/test/Concurrency/Runtime/clock.swift
+++ b/test/Concurrency/Runtime/clock.swift
@@ -158,6 +158,13 @@ import StdlibUnittest
       }
     }
 
+    tests.test("Ensure abi layout size of Instant") {
+      // If this test fails it means the ABI of ContinuousClock.Instant has been broken!
+      // it MUST be the same laoyut of that of Duration
+      expectEqual(MemoryLayout<ContinuousClock.Instant>.size, MemoryLayout<Duration>.size)
+      expectEqual(MemoryLayout<SuspendingClock.Instant>.size, MemoryLayout<Duration>.size)
+    }
+
     await runAllTestsAsync()
   }
 }

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -415,6 +415,10 @@ Added: _swift_task_dealloc_through
 // SwiftSettings
 Added: _$ss12SwiftSettingVsE16defaultIsolationyABScA_pXpSgFZ
 
+// Clock systemEpochs
+Added: _$ss15ContinuousClockV11systemEpochAB7InstantVvpMV
+Added: _$ss15SuspendingClockV11systemEpochAB7InstantVvpMV
+
 // Hashable for (Throwing)AsyncStream
 Added: _$sScS12ContinuationV7storageScS8_StorageCyx_Gvg
 Added: _$sScS12ContinuationV7storageScS8_StorageCyx_GvpMV

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -415,6 +415,10 @@ Added: _swift_task_dealloc_through
 // SwiftSettings
 Added: _$ss12SwiftSettingVsE16defaultIsolationyABScA_pXpSgFZ
 
+// Clock systemEpochs
+Added: _$ss15ContinuousClockV11systemEpochAB7InstantVvpMV
+Added: _$ss15SuspendingClockV11systemEpochAB7InstantVvpMV
+
 // Hashable for (Throwing)AsyncStream
 Added: _$sScS12ContinuationV7storageScS8_StorageCyx_Gvg
 Added: _$sScS12ContinuationV7storageScS8_StorageCyx_GvpMV


### PR DESCRIPTION
  - **Explanation**:
This implements
[SE-0473](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0473-clock-epochs.md)
 - **Scope**:
This feature is limited to new adoptions of the systemEpoch property with no language or runtime changes.
  - **Issues**:
None
  - **Original PRs**:
https://github.com/swiftlang/swift/pull/80409
  - **Risk**:
Low - this is an additive change with no compiler or runtime changes.
  - **Testing**:
Validation was added to ensure the property is the correct ABI layout (since it can be back deployed as always emit into client).