### PR TITLE
Sema: Disallow SE-0361 with variadic generic types for now

### DIFF
--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -870,7 +870,7 @@ InferredGenericSignatureRequest::evaluate(
   // inferred same-type requirements when building the generic signature of
   // an extension whose extended type is a generic typealias.
   for (const auto &req : addedRequirements)
-    requirements.push_back({req, SourceLoc()});
+    requirements.push_back({req, loc});
 
   desugarRequirements(requirements, inverses, errors);
 

--- a/test/Generics/variadic_generic_types.swift
+++ b/test/Generics/variadic_generic_types.swift
@@ -116,3 +116,16 @@ func packExpansionInScalarArgument<each T>(_: repeat each T) {
   typealias A<U> = U
   typealias One = A<repeat each T> // expected-error {{pack expansion 'repeat each T' can only appear in a function parameter list, tuple element, or generic argument of a variadic type}}
 }
+
+// Make sure we diagnose instead of silently dropping the same-type requirement
+// https://github.com/apple/swift/issues/70432
+
+struct WithPack<each T> {}
+
+// FIXME: The diagnostics are misleading.
+
+extension WithPack<Int, Int> {}
+// expected-error@-1 {{same-element requirements are not yet supported}}
+
+extension WithPack where (repeat each T) == (Int, Int) {}
+// expected-error@-1 {{generic signature requires types '(repeat each T)' and '(Int, Int)' to be the same}}


### PR DESCRIPTION
`extension G<Int>` introduces a same-type requirement, and this isn't supported for variadic generic types yet.

Make sure we pass a valid source location here to diagnose instead of dropping the error.

- Fixes https://github.com/apple/swift/issues/70432
- Fixes rdar://119613080