### PR TITLE
[test] Fix checking C and C++ headers for cross-compilation by explicitly adding the sysroot and target triple

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2742,6 +2742,8 @@ extraCheckWarningFlags = (
 # Verifies that a C++ file can be compiled without warnings except for some exceptions.
 config.substitutions.insert(0, ('%check-c-header-in-clang',
   '%clang -fsyntax-only -x c-header ' + extraCheckWarningFlags +
+  ' --sysroot %r ' % config.variant_sdk +
+  '-target %r ' % config.variant_triple +
   # Use standard header/framework search paths.
   '-F %%clang-importer-sdk-path/frameworks '
   '-I %%clang-include-dir '
@@ -2751,6 +2753,7 @@ config.substitutions.insert(0, ('%check-c-header-in-clang',
 config.substitutions.insert(0, ('%check-cxx-header-in-clang',
   '%clangxx -fsyntax-only -x c++-header ' + extraCheckWarningFlags +
   ' --sysroot %r ' % config.variant_sdk +
+  '-target %r ' % config.variant_triple +
   # Use standard header/framework search paths.
   '-F %%clang-importer-sdk-path/frameworks '
   '-I %%clang-include-dir %%cxx-stdlib-include '


### PR DESCRIPTION
@weliveindetail noticed that these header checks when cross-compiling are incorrectly checked against the host C and C++ headers and target, so he added the cross-compilation sysroot for the C++ header check alone more than a month ago in #79185. However, that broke several C++ Interop tests when running the compiler validation suite for Android on both [the Windows toolchain CI](https://ci-external.swift.org/job/swift-main-windows-toolchain/) and [the community Android CI on a linux host](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-24.04-android-arm64/):
```
FAIL: Swift(android-x86_64) :: Interop/SwiftToCxx/class/nested-classes-in-cxx.swift (4495 of 18856)
******************** TEST 'Swift(android-x86_64) :: Interop/SwiftToCxx/class/nested-classes-in-cxx.swift' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
# RUN: at line 1
rm -rf "T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp" && mkdir -p "T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp"
# executed command: rm -rf 'T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp'
# executed command: mkdir -p 'T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp'
# RUN: at line 2
t:\5\bin\swift-frontend.exe -target x86_64-unknown-linux-android -sdk T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot -resource-dir T:/x86_64-unknown-linux-android28/Runtime/./lib/swift -module-cache-path T:\x86_64-unknown-linux-android28\Runtime\swift-test-results\x86_64-unknown-linux-android\clang-module-cache -swift-version 4  -define-availability 'SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999' -define-availability 'SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2' -define-availability 'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' -define-availability 'SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4' -define-availability 'SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0' -define-availability 'SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5' -define-availability 'SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0' -define-availability 'SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4' -define-availability 'SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0' -define-availability 'SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4' -define-availability 'SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0' -define-availability 'SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1' -define-availability 'SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0' -define-availability 'SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4' -define-availability 'SwiftStdlib 6.2:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999' -define-availability 'SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1' -define-availability 'SwiftCompatibilitySpan 6.2:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0' -typo-correction-limit 10  C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain\swift\test\Interop\SwiftToCxx\class\nested-classes-in-cxx.swift -enable-library-evolution -typecheck -module-name Classes -clang-header-expose-decls=all-public -emit-clang-header-path T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp/classes.h
# executed command: 't:\5\bin\swift-frontend.exe' -target x86_64-unknown-linux-android -sdk T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot -resource-dir T:/x86_64-unknown-linux-android28/Runtime/./lib/swift -module-cache-path 'T:\x86_64-unknown-linux-android28\Runtime\swift-test-results\x86_64-unknown-linux-android\clang-module-cache' -swift-version 4 -define-availability 'SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999' -define-availability 'SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2' -define-availability 'SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0' -define-availability 'SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4' -define-availability 'SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0' -define-availability 'SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5' -define-availability 'SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0' -define-availability 'SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4' -define-availability 'SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0' -define-availability 'SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4' -define-availability 'SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0' -define-availability 'SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, visionOS 1.1' -define-availability 'SwiftStdlib 6.0:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0' -define-availability 'SwiftStdlib 6.1:macOS 15.4, iOS 18.4, watchOS 11.4, tvOS 18.4, visionOS 2.4' -define-availability 'SwiftStdlib 6.2:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999' -define-availability 'SwiftCompatibilitySpan 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2, visionOS 1.1' -define-availability 'SwiftCompatibilitySpan 6.2:macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0' -typo-correction-limit 10 'C:\Users\swift-ci\jenkins\workspace\swift-main-windows-toolchain\swift\test\Interop\SwiftToCxx\class\nested-classes-in-cxx.swift' -enable-library-evolution -typecheck -module-name Classes -clang-header-expose-decls=all-public -emit-clang-header-path 'T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp/classes.h'
# RUN: at line 3
't:\\5\\bin\\clang++.exe' -fmodules-cache-path='T:\\x86_64-unknown-linux-android28\\Runtime\\swift-test-results\\x86_64-unknown-linux-android\\clang-module-cache' -fsyntax-only -x c++-header -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -Wno-auto-import -Wno-variadic-macros -Wno-c++98-compat-pedantic -Wno-poison-system-directories -Wno-unused-command-line-argument -Wno-nullability-extension  --sysroot 'T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot' -F 'C:\\Users\\swift-ci\\jenkins\\workspace\\swift-main-windows-toolchain\\swift\\test\\Inputs\\clang-importer-sdk'/frameworks -I T:\x86_64-unknown-linux-android28\LLVM\include  -isysroot 'C:/Users/swift-ci/jenkins/workspace/swift-main-windows-toolchain/swift\\test'/Inputs/clang-importer-sdk -std=c++14 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB -IT:/x86_64-unknown-linux-android28/Runtime/./lib/swift T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp/classes.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17 && 't:\\5\\bin\\clang++.exe' -fmodules-cache-path='T:\\x86_64-unknown-linux-android28\\Runtime\\swift-test-results\\x86_64-unknown-linux-android\\clang-module-cache' -fsyntax-only -x c++-header -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -Wno-auto-import -Wno-variadic-macros -Wno-c++98-compat-pedantic -Wno-poison-system-directories -Wno-unused-command-line-argument -Wno-nullability-extension  --sysroot 'T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot' -F 'C:\\Users\\swift-ci\\jenkins\\workspace\\swift-main-windows-toolchain\\swift\\test\\Inputs\\clang-importer-sdk'/frameworks -I T:\x86_64-unknown-linux-android28\LLVM\include  -isysroot 'C:/Users/swift-ci/jenkins/workspace/swift-main-windows-toolchain/swift\\test'/Inputs/clang-importer-sdk -std=c++17 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB -IT:/x86_64-unknown-linux-android28/Runtime/./lib/swift T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp/classes.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17 && 't:\\5\\bin\\clang++.exe' -fmodules-cache-path='T:\\x86_64-unknown-linux-android28\\Runtime\\swift-test-results\\x86_64-unknown-linux-android\\clang-module-cache' -fsyntax-only -x c++-header -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -Wno-auto-import -Wno-variadic-macros -Wno-c++98-compat-pedantic -Wno-poison-system-directories -Wno-unused-command-line-argument -Wno-nullability-extension  --sysroot 'T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot' -F 'C:\\Users\\swift-ci\\jenkins\\workspace\\swift-main-windows-toolchain\\swift\\test\\Inputs\\clang-importer-sdk'/frameworks -I T:\x86_64-unknown-linux-android28\LLVM\include  -isysroot 'C:/Users/swift-ci/jenkins/workspace/swift-main-windows-toolchain/swift\\test'/Inputs/clang-importer-sdk -std=c++20 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB -IT:/x86_64-unknown-linux-android28/Runtime/./lib/swift T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp/classes.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17
# executed command: 't:\\5\\bin\\clang++.exe' '-fmodules-cache-path=T:\\x86_64-unknown-linux-android28\\Runtime\\swift-test-results\\x86_64-unknown-linux-android\\clang-module-cache' -fsyntax-only -x c++-header -Weverything -Werror -Wno-unused-macros -Wno-incomplete-module -Wno-auto-import -Wno-variadic-macros -Wno-c++98-compat-pedantic -Wno-poison-system-directories -Wno-unused-command-line-argument -Wno-nullability-extension --sysroot T:/android-ndk-r27c/toolchains/llvm/prebuilt/windows-x86_64/sysroot -F 'C:\\Users\\swift-ci\\jenkins\\workspace\\swift-main-windows-toolchain\\swift\\test\\Inputs\\clang-importer-sdk/frameworks' -I 'T:\x86_64-unknown-linux-android28\LLVM\include' -isysroot 'C:/Users/swift-ci/jenkins/workspace/swift-main-windows-toolchain/swift\\test/Inputs/clang-importer-sdk' -std=c++14 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB -IT:/x86_64-unknown-linux-android28/Runtime/./lib/swift 'T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp/classes.h' -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -std=c++17
# .---command stderr------------
# | T:\x86_64-unknown-linux-android28\Runtime\test-android-x86_64\Interop\SwiftToCxx\class\Output\nested-classes-in-cxx.swift.tmp/classes.h:29:10: fatal error: 'cstdint' file not found
# |    29 | #include <cstdint>
# |       |          ^~~~~~~~~
# | 1 error generated.
# `-----------------------------
# error: command failed with exit status: 1
```
I experimented a bit and found that explicitly passing in the target triple fixed these tests, so this pull does that for C++ and also corrects the C header check.