### PR TITLE
[Concurrency] Make initial executor construction fully thread safe.

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -594,6 +594,14 @@ public func _createExecutors<F: ExecutorFactory>(factory: F.Type) {
   Task._defaultExecutor = factory.defaultExecutor
 }
 
+@available(SwiftStdlib 6.2, *)
+@_silgen_name("swift_createDefaultExecutors")
+func _createDefaultExecutors() {
+  if Task._defaultExecutor == nil {
+    _createExecutors(factory: DefaultExecutorFactory.self)
+  }
+}
+
 #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 extension MainActor {
   @available(SwiftStdlib 6.2, *)
@@ -606,9 +614,8 @@ extension MainActor {
   /// executor is a fatal error.
   @available(SwiftStdlib 6.2, *)
   public static var executor: any MainExecutor {
-    if _executor == nil {
-      _executor = DefaultExecutorFactory.mainExecutor
-    }
+    // It would be good if there was a Swift way to do this
+    _createDefaultExecutorsOnce()
     return _executor!
   }
 }
@@ -625,9 +632,8 @@ extension Task where Success == Never, Failure == Never {
   /// executor is a fatal error.
   @available(SwiftStdlib 6.2, *)
   public static var defaultExecutor: any TaskExecutor {
-    if _defaultExecutor == nil {
-      _defaultExecutor = DefaultExecutorFactory.defaultExecutor
-    }
+    // It would be good if there was a Swift way to do this
+    _createDefaultExecutorsOnce()
     return _defaultExecutor!
   }
 }

--- a/stdlib/public/Concurrency/ExecutorBridge.cpp
+++ b/stdlib/public/Concurrency/ExecutorBridge.cpp
@@ -14,6 +14,8 @@
 #include <dispatch/dispatch.h>
 #endif
 
+#include "swift/Threading/Once.h"
+
 #include "Error.h"
 #include "ExecutorBridge.h"
 #include "TaskPrivate.h"
@@ -26,6 +28,13 @@ using namespace swift;
 extern "C" SWIFT_CC(swift)
 void _swift_exit(int result) {
   exit(result);
+}
+
+extern "C" SWIFT_CC(swift)
+void swift_createDefaultExecutorsOnce() {
+  static swift::once_t createExecutorsOnce;
+
+  swift::once(createExecutorsOnce, swift_createDefaultExecutors);
 }
 
 #if SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY

--- a/stdlib/public/Concurrency/ExecutorBridge.h
+++ b/stdlib/public/Concurrency/ExecutorBridge.h
@@ -33,9 +33,15 @@ void swift_destroyDispatchEventC(void *event);
 extern "C" SWIFT_CC(swift)
 void swift_signalDispatchEvent(void *event);
 #endif // !SWIFT_CONCURRENCY_EMBEDDED
- 
+
 extern "C" SWIFT_CC(swift) __attribute__((noreturn))
 void swift_dispatchMain();
+
+extern "C" SWIFT_CC(swift)
+void swift_createDefaultExecutors();
+
+extern "C" SWIFT_CC(swift)
+void swift_createDefaultExecutorsOnce();
 
 #pragma clang diagnostic pop
 

--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -132,3 +132,6 @@ internal func _dispatchAssertMainQueue()
 internal func _getDispatchQueueForExecutor(
   _ executor: UnownedSerialExecutor
 ) -> OpaquePointer?
+
+@_silgen_name("swift_createDefaultExecutorsOnce")
+func _createDefaultExecutorsOnce()


### PR DESCRIPTION
I had originally thought that we'd get away without this because the executor construction generally happens in the async `main` function, but of course if a program doesn't already use Swift Concurrency, and someone uses it from a plug-in or library it loads, there's a risk that we might have a race condition.

rdar://150753884
