### PR TITLE
[IRGen] Emit llvm fneg operation for Builtin.fneg_*

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -588,9 +588,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
   }
   
   if (Builtin.ID == BuiltinValueKind::FNeg) {
-    llvm::Value *rhs = args.claimNext();
-    llvm::Value *lhs = llvm::ConstantFP::get(rhs->getType(), "-0.0");
-    llvm::Value *v = IGF.Builder.CreateFSub(lhs, rhs);
+    llvm::Value *v = IGF.Builder.CreateFNeg(args.claimNext());
     return out.add(v);
   }
   if (Builtin.ID == BuiltinValueKind::AssumeTrue) {

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -329,9 +329,9 @@ func fneg_test(_ half: Builtin.FPIEEE16,
                double: Builtin.FPIEEE64)
   -> (Builtin.FPIEEE16, Builtin.FPIEEE32, Builtin.FPIEEE64)
 {
-  // CHECK: fsub half 0xH8000, {{%.*}}
-  // CHECK: fsub float -0.000000e+00, {{%.*}}
-  // CHECK: fsub double -0.000000e+00, {{%.*}}
+  // CHECK: fneg half
+  // CHECK: fneg float
+  // CHECK: fneg double
   return (Builtin.fneg_FPIEEE16(half),
           Builtin.fneg_FPIEEE32(single),
           Builtin.fneg_FPIEEE64(double))


### PR DESCRIPTION
rdar://150722907

The original handling was a workaround before LLVM added the fneg operation. Now that it has it, we should use it.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
