### PR TITLE
SILCombine: handle `mark_dependence` in some closure optimizations

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -1520,8 +1520,14 @@ SILInstruction *SILCombiner::legacyVisitApplyInst(ApplyInst *AI) {
     return nullptr;
 
   SILValue callee = AI->getCallee();
-  if (auto *cee = dyn_cast<ConvertEscapeToNoEscapeInst>(callee)) {
-    callee = cee->getOperand();
+  for (;;) {
+    if (auto *cee = dyn_cast<ConvertEscapeToNoEscapeInst>(callee)) {
+      callee = cee->getOperand();
+    } else if (auto *mdi = dyn_cast<MarkDependenceInst>(callee)) {
+      callee = mdi->getValue();
+    } else {
+      break;
+    }
   }
   if (auto *CFI = dyn_cast<ConvertFunctionInst>(callee))
     return optimizeApplyOfConvertFunctionInst(AI, CFI);

--- a/test/SILOptimizer/sil_combine1.swift
+++ b/test/SILOptimizer/sil_combine1.swift
@@ -36,3 +36,9 @@ public func test_compose_closure() -> Int32 {
   return gs
 }
 
+// CHECK-LABEL: sil @$s12sil_combine122remove_partial_applies_3key5valueySDySSSiGSgz_SSSitF :
+// CHECK-NOT:     partial_apply
+// CHECK:       } // end sil function '$s12sil_combine122remove_partial_applies_3key5valueySDySSSiGSgz_SSSitF'
+public func remove_partial_applies(_ dict: inout [String: Int]?, key: String, value: Int) {
+  dict?[key, default: value] = value 
+}

--- a/test/SILOptimizer/sil_combine_apply_ossa.sil
+++ b/test/SILOptimizer/sil_combine_apply_ossa.sil
@@ -1188,6 +1188,21 @@ bb0(%0 : $Int):
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_dead_closure_with_mark_dependence :
+// CHECK-NOT:     partial_apply
+// CHECK-LABEL: } // end sil function 'test_dead_closure_with_mark_dependence'
+sil [ossa] @test_dead_closure_with_mark_dependence : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %3 = function_ref @closure2 : $@convention(thin) (Int) -> ()
+  %4 = partial_apply %3(%0) : $@convention(thin) (Int) -> ()
+  %6 = convert_escape_to_noescape %4 to $@noescape @callee_owned () -> ()
+  %7 = mark_dependence %6 on %4
+  destroy_value %4
+  destroy_value %7
+  %r = tuple ()
+  return %r : $()
+}
+
 sil [ossa] @closure2 : $@convention(thin) (Int) -> ()
 
 sil [ossa] @yield1 : $@yield_once(Float) -> (@yields Float) {

--- a/test/SILOptimizer/sil_combine_apply_ossa.sil
+++ b/test/SILOptimizer/sil_combine_apply_ossa.sil
@@ -1172,6 +1172,22 @@ bb0(%0 : $Int):
   return %r : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_mark_dependence_of_closure :
+// CHECK-NOT:     partial_apply
+// CHECK-LABEL: } // end sil function 'test_mark_dependence_of_closure'
+sil [ossa] @test_mark_dependence_of_closure : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %3 = function_ref @closure2 : $@convention(thin) (Int) -> ()
+  %4 = partial_apply %3(%0) : $@convention(thin) (Int) -> ()
+  %5 = convert_function %4 to $@callee_owned () -> ()
+  %6 = convert_escape_to_noescape %5 to $@noescape @callee_owned () -> ()
+  %7 = mark_dependence %6 on %5
+  apply %7() : $@noescape @callee_owned () -> ()
+  destroy_value %5
+  %r = tuple ()
+  return %r : $()
+}
+
 sil [ossa] @closure2 : $@convention(thin) (Int) -> ()
 
 sil [ossa] @yield1 : $@yield_once(Float) -> (@yields Float) {


### PR DESCRIPTION
This enables `apply`-of-`partial_apply` simplification and dead-closure elimination if the closure (= the `partial_apply`) has a `mark_dependence` user.

rdar://150686370