### PR TITLE
[6.2] Infer nonisolated conformances from witnesses

### DIFF
--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -276,9 +276,7 @@ public:
            typename std::enable_if<Request::hasSplitCache>::type* = nullptr>
   void cacheNonEmptyOutput(const Request &request,
                            typename Request::OutputType &&output) {
-    bool inserted = cache.insert<Request>(request, std::move(output));
-    assert(inserted && "Request result was already cached");
-    (void) inserted;
+    (void)cache.insert<Request>(request, std::move(output));
   }
 
   /// Consults the request evaluator's cache for a split-cached request.

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -131,6 +131,8 @@ class alignas(1 << DeclAlignInBits) ProtocolConformance
   /// conformance definition.
   Type ConformingType;
 
+  friend class ConformanceIsolationRequest;
+
 protected:
   // clang-format off
   //
@@ -139,9 +141,13 @@ protected:
   union { uint64_t OpaqueBits;
 
     SWIFT_INLINE_BITFIELD_BASE(ProtocolConformance,
+                               1+
                                bitmax(NumProtocolConformanceKindBits, 8),
       /// The kind of protocol conformance.
-      Kind : bitmax(NumProtocolConformanceKindBits, 8)
+      Kind : bitmax(NumProtocolConformanceKindBits, 8),
+
+      /// Whether the computed actor isolation is nonisolated.
+      IsComputedNonisolated : 1
     );
 
     SWIFT_INLINE_BITFIELD_EMPTY(RootProtocolConformance, ProtocolConformance);
@@ -160,9 +166,6 @@ protected:
       /// Whether the preconcurrency attribute is effectful (not redundant) for
       /// this conformance.
       IsPreconcurrencyEffectful : 1,
-
-      /// Whether the computed actor isolation is nonisolated.
-      IsComputedNonisolated : 1,
 
       /// Whether there is an explicit global actor specified for this
       /// conformance.
@@ -198,6 +201,15 @@ protected:
   ProtocolConformance(ProtocolConformanceKind kind, Type conformingType)
     : ConformingType(conformingType) {
     Bits.ProtocolConformance.Kind = unsigned(kind);
+    Bits.ProtocolConformance.IsComputedNonisolated = false;
+  }
+
+  bool isComputedNonisolated() const {
+    return Bits.ProtocolConformance.IsComputedNonisolated;
+  }
+
+  void setComputedNonnisolated(bool value = true) {
+    Bits.ProtocolConformance.IsComputedNonisolated = value;
   }
 
 public:
@@ -591,14 +603,6 @@ class NormalProtocolConformance : public RootProtocolConformance,
   // Record the explicitly-specified global actor isolation.
   void setExplicitGlobalActorIsolation(TypeExpr *typeExpr);
 
-  bool isComputedNonisolated() const {
-    return Bits.NormalProtocolConformance.IsComputedNonisolated;
-  }
-
-  void setComputedNonnisolated(bool value = true) {
-    Bits.NormalProtocolConformance.IsComputedNonisolated = value;
-  }
-
 public:
   NormalProtocolConformance(Type conformingType, ProtocolDecl *protocol,
                             SourceLoc loc, DeclContext *dc,
@@ -622,7 +626,6 @@ public:
     Bits.NormalProtocolConformance.HasComputedAssociatedConformances = false;
     Bits.NormalProtocolConformance.SourceKind =
         unsigned(ConformanceEntryKind::Explicit);
-    Bits.NormalProtocolConformance.IsComputedNonisolated = false;
     Bits.NormalProtocolConformance.HasExplicitGlobalActor = false;
     setExplicitGlobalActorIsolation(options.getGlobalActorIsolationType());
   }

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -717,6 +717,9 @@ public:
     return ExplicitSafety::Unspecified;
   }
 
+  /// Whether this conformance has explicitly-specified global actor isolation.
+  bool hasExplicitGlobalActorIsolation() const;
+
   /// Determine whether we've lazily computed the associated conformance array
   /// already.
   bool hasComputedAssociatedConformances() const {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -515,6 +515,10 @@ TypeExpr *NormalProtocolConformance::getExplicitGlobalActorIsolation() const {
   return ctx.getGlobalCache().conformanceExplicitGlobalActorIsolation[this];
 }
 
+bool NormalProtocolConformance::hasExplicitGlobalActorIsolation() const {
+  return Bits.NormalProtocolConformance.HasExplicitGlobalActor;
+}
+
 void
 NormalProtocolConformance::setExplicitGlobalActorIsolation(TypeExpr *typeExpr) {
   if (!typeExpr) {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1378,31 +1378,25 @@ ConformanceIsolationRequest::getCachedResult() const {
   // everything else, which is nearly every conformance, this request quickly
   // returns "nonisolated" so there is no point in caching it.
   auto conformance = std::get<0>(getStorage());
-  auto rootNormal =
-      dyn_cast<NormalProtocolConformance>(conformance->getRootConformance());
-  if (!rootNormal)
-    return ActorIsolation::forNonisolated(false);
 
   // Was actor isolation non-isolated?
-  if (rootNormal->isComputedNonisolated())
+  if (conformance->isComputedNonisolated())
     return ActorIsolation::forNonisolated(false);
 
-  ASTContext &ctx = rootNormal->getDeclContext()->getASTContext();
+  ASTContext &ctx = conformance->getDeclContext()->getASTContext();
   return ctx.evaluator.getCachedNonEmptyOutput(*this);
 }
 
 void ConformanceIsolationRequest::cacheResult(ActorIsolation result) const {
   auto conformance = std::get<0>(getStorage());
-  auto rootNormal =
-      cast<NormalProtocolConformance>(conformance->getRootConformance());
 
   // Common case: conformance is nonisolated.
   if (result.isNonisolated()) {
-    rootNormal->setComputedNonnisolated();
+    conformance->setComputedNonnisolated();
     return;
   }
 
-  ASTContext &ctx = rootNormal->getDeclContext()->getASTContext();
+  ASTContext &ctx = conformance->getDeclContext()->getASTContext();
   ctx.evaluator.cacheNonEmptyOutput(*this, std::move(result));
 }
 

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1728,12 +1728,52 @@ bool swift::hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   });
 }
 
+/// Determine whether a synth
+static bool synthesizedRequirementIsNonIsolated(
+    const NormalProtocolConformance *conformance) {
+  // @preconcurrency suppresses this.
+  if (conformance->isPreconcurrency())
+    return false;
+
+  // Explicit global actor isolation suppresses this.
+  if (conformance->hasExplicitGlobalActorIsolation())
+    return false;
+
+  // Explicit nonisolated forces this.
+  if (conformance->getOptions()
+          .contains(ProtocolConformanceFlags::Nonisolated))
+    return true;
+
+  // When we are inferring conformance isolation, only add nonisolated if
+  // either
+  //   (1) the protocol inherits from SendableMetatype, or
+  //   (2) the conforming type is nonisolated.
+  ASTContext &ctx = conformance->getDeclContext()->getASTContext();
+  if (!ctx.LangOpts.hasFeature(Feature::InferIsolatedConformances))
+    return true;
+
+  // Check inheritance from SendableMetatype, which implies that the conformance
+  // will be nonisolated.
+  auto sendableMetatypeProto =
+      ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+  if (sendableMetatypeProto &&
+      conformance->getProtocol()->inheritsFrom(sendableMetatypeProto))
+    return true;
+
+  auto nominalType = conformance->getType()->getAnyNominal();
+  if (!nominalType)
+    return true;
+
+  return !getActorIsolation(nominalType).isMainActor();
+}
+
 bool swift::addNonIsolatedToSynthesized(DerivedConformance &derived,
                                         ValueDecl *value) {
   if (auto *conformance = derived.Conformance) {
-    if (conformance && conformance->isPreconcurrency())
+    if (!synthesizedRequirementIsNonIsolated(conformance))
       return false;
   }
+
   return addNonIsolatedToSynthesized(derived.Nominal, value);
 }
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -155,6 +155,16 @@ addImplicitCodingKeys(NominalTypeDecl *target,
   enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);
 
+  switch (C.LangOpts.DefaultIsolationBehavior) {
+  case DefaultIsolation::MainActor:
+    enumDecl->getAttrs().add(NonisolatedAttr::createImplicit(C));
+    break;
+
+  case DefaultIsolation::Nonisolated:
+    // Nothing to do.
+    break;
+  }
+
   // For classes which inherit from something Encodable or Decodable, we
   // provide case `super` as the first key (to be used in encoding super).
   auto *classDecl = dyn_cast<ClassDecl>(target);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7988,15 +7988,23 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
 
   auto dc = rootNormal->getDeclContext();
   ASTContext &ctx = dc->getASTContext();
+  auto proto = rootNormal->getProtocol();
 
   // If the protocol itself is isolated, don't infer isolation for the
   // conformance.
-  if (getActorIsolation(rootNormal->getProtocol()).isActorIsolated())
+  if (getActorIsolation(proto).isActorIsolated())
+    return ActorIsolation::forNonisolated(false);
+
+  // SendableMetatype disables isolation inference.
+  auto sendableMetatypeProto =
+      ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+  if (sendableMetatypeProto && proto->inheritsFrom(sendableMetatypeProto))
     return ActorIsolation::forNonisolated(false);
 
   // @preconcurrency disables isolation inference.
   if (rootNormal->isPreconcurrency())
     return ActorIsolation::forNonisolated(false);
+
 
   // Isolation inference rules follow. If we aren't inferring isolated conformances,
   // we're done.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7991,17 +7991,51 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
   if (getActorIsolation(rootNormal->getProtocol()).isActorIsolated())
     return ActorIsolation::forNonisolated(false);
 
-  // If we are inferring isolated conformances and the conforming type is
-  // isolated to a global actor, use the conforming type's isolation.
+  // Isolation inference rules follow. If we aren't inferring isolated conformances,
+  // we're done.
+  if (!ctx.LangOpts.hasFeature(Feature::InferIsolatedConformances))
+    return ActorIsolation::forNonisolated(false);
+
   auto nominal = dc->getSelfNominalTypeDecl();
-  if (ctx.LangOpts.hasFeature(Feature::InferIsolatedConformances) &&
-      nominal) {
-    auto nominalIsolation = getActorIsolation(nominal);
-    if (nominalIsolation.isGlobalActor())
-      return nominalIsolation;
+  if (!nominal) {
+    return ActorIsolation::forNonisolated(false);
   }
 
-  return ActorIsolation::forNonisolated(false);
+  // If we are inferring isolated conformances and the conforming type is
+  // isolated to a global actor, we may use the conforming type's isolation.
+  auto nominalIsolation = getActorIsolation(nominal);
+  if (!nominalIsolation.isGlobalActor()) {
+    return ActorIsolation::forNonisolated(false);
+  }
+
+  // If all of the value witnesses are nonisolated, then we should not infer
+  // global actor isolation.
+  bool anyIsolatedWitness = false;
+  auto protocol = conformance->getProtocol();
+  for (auto requirement : protocol->getMembers()) {
+    if (isa<TypeDecl>(requirement))
+      continue;
+
+    auto valueReq = dyn_cast<ValueDecl>(requirement);
+    if (!valueReq)
+      continue;
+
+    auto witness = conformance->getWitnessDecl(valueReq);
+    if (!witness)
+      continue;
+
+    auto witnessIsolation = getActorIsolation(witness);
+    if (witnessIsolation.isActorIsolated()) {
+      anyIsolatedWitness = true;
+      break;
+    }
+  }
+
+  if (!anyIsolatedWitness) {
+    return ActorIsolation::forNonisolated(false);
+  }
+
+  return nominalIsolation;
 }
 
 namespace {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7954,6 +7954,9 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
   if (!rootNormal)
     return ActorIsolation::forNonisolated(false);
 
+  if (conformance != rootNormal)
+    return rootNormal->getIsolation();
+
   // If the conformance is explicitly non-isolated, report that.
   if (rootNormal->getOptions().contains(ProtocolConformanceFlags::Nonisolated))
     return ActorIsolation::forNonisolated(false);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7994,6 +7994,10 @@ ConformanceIsolationRequest::evaluate(Evaluator &evaluator, ProtocolConformance 
   if (getActorIsolation(rootNormal->getProtocol()).isActorIsolated())
     return ActorIsolation::forNonisolated(false);
 
+  // @preconcurrency disables isolation inference.
+  if (rootNormal->isPreconcurrency())
+    return ActorIsolation::forNonisolated(false);
+
   // Isolation inference rules follow. If we aren't inferring isolated conformances,
   // we're done.
   if (!ctx.LangOpts.hasFeature(Feature::InferIsolatedConformances))

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -42,6 +42,24 @@ nonisolated class CNonIsolated: P {
   @MainActor func f() { } // expected-note{{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
 }
 
+// Synthesized conformances
+struct EquatableStruct: Equatable {
+  var state: Int = 0
+}
+
+struct HashableStruct: Hashable {
+  var state: Int = 0
+}
+
+enum RawRepresentableEnum: Int {
+case one
+case two
+}
+
+class CodableClass: Codable {
+  var state: Int = 0
+}
+
 func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }
 func acceptSendableQMeta<T: Sendable & Q>(_: T.Type) { }
 
@@ -55,4 +73,10 @@ nonisolated func testConformancesFromNonisolated() {
   // Okay, these are nonisolated conformances.
   let _: any Q = CExplicitMainActor()
   let _: any Q = CImplicitMainActor()
+
+  // Error, these are main-actor-isolated conformances
+  let _: any Equatable.Type = EquatableStruct.self // expected-error{{main actor-isolated conformance of 'EquatableStruct' to 'Equatable' cannot be used in nonisolated context}}
+  let _: any Hashable.Type = HashableStruct.self // expected-error{{main actor-isolated conformance of 'HashableStruct' to 'Hashable' cannot be used in nonisolated context}}
+  let _: any RawRepresentable.Type = RawRepresentableEnum.self
+  let _: any Encodable.Type = CodableClass.self // expected-error{{main actor-isolated conformance of 'CodableClass' to 'Encodable' cannot be used in nonisolated context}}
 }

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -46,8 +46,8 @@ func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }
 func acceptSendableQMeta<T: Sendable & Q>(_: T.Type) { }
 
 nonisolated func testConformancesFromNonisolated() {
-  let _: any P = CExplicitMainActor() // expected-error{{main actor-isolated conformance of 'CExplicitMainActor' to 'P' cannot be used in nonisolated context}}
-  let _: any P = CImplicitMainActor() // expected-error{{main actor-isolated conformance of 'CImplicitMainActor' to 'P' cannot be used in nonisolated context}}
+  let _: any P = CExplicitMainActor() // okay
+  let _: any P = CImplicitMainActor() // okay
 
   let _: any P = CNonIsolated()
   let _: any P = CImplicitMainActorNonisolatedConformance()

--- a/test/Concurrency/isolated_conformance_inference.swift
+++ b/test/Concurrency/isolated_conformance_inference.swift
@@ -47,7 +47,21 @@ nonisolated class CNonIsolated: P {
 func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }
 func acceptSendableQMeta<T: Sendable & Q>(_: T.Type) { }
 
-nonisolated func testConformancesFromNonisolated() {
+// @preconcurrency suppresses actor isolation inference
+struct NotSendable: Equatable, Hashable {
+}
+
+@available(*, unavailable)
+extension NotSendable: Sendable {}
+
+extension NotSendable : Codable {}
+
+@MainActor
+struct TestDerivedCodable : @preconcurrency Codable {
+  var x: NotSendable
+}
+
+nonisolated func testConformancesFromNonisolated(tdc: TestDerivedCodable) {
   let _: any P = CExplicit() // expected-error{{global actor 'SomeGlobalActor'-isolated conformance of 'CExplicit' to 'P' cannot be used in nonisolated context}}
 
   let _: any P = CNonIsolated()
@@ -56,4 +70,6 @@ nonisolated func testConformancesFromNonisolated() {
   let _: any Q = CExplicit()
 
   let _: any P = CViaNonisolatedWitness()
+
+  let _: any Codable = tdc
 }

--- a/test/Concurrency/isolated_conformance_inference.swift
+++ b/test/Concurrency/isolated_conformance_inference.swift
@@ -32,6 +32,11 @@ extension CExplicit: Q {
   func g() { }
 }
 
+@SomeGlobalActor
+class CViaNonisolatedWitness: P {
+  nonisolated func f() { } // okay! conformance above is nonisolated via this witness
+}
+
 // expected-error@+3{{conformance of 'CNonIsolated' to protocol 'P' crosses into global actor 'SomeGlobalActor'-isolated code and can cause data races}}
 // expected-note@+2{{turn data races into runtime errors with '@preconcurrency'}}
 // expected-note@+1{{isolate this conformance to the global actor 'SomeGlobalActor' with '@SomeGlobalActor'}}{{33-33=@SomeGlobalActor }}
@@ -49,4 +54,6 @@ nonisolated func testConformancesFromNonisolated() {
 
   // Okay, these are nonisolated conformances.
   let _: any Q = CExplicit()
+
+  let _: any P = CViaNonisolatedWitness()
 }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2881,6 +2881,58 @@ public struct HangingMacro: PeerMacro {
   }
 }
 
+public struct PWithNonisolatedFuncMacro: ExtensionMacro {
+  public static var inferNonisolatedConformances: Bool { false }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    if (protocols.isEmpty) {
+      return []
+    }
+
+    let decl: DeclSyntax =
+      """
+      extension \(raw: type.trimmedDescription): P {
+        nonisolated static func requirement() { }
+      }
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
+public struct NonisolatedPWithNonisolatedFuncMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    if (protocols.isEmpty) {
+      return []
+    }
+
+    let decl: DeclSyntax =
+      """
+      extension \(raw: type.trimmedDescription): P {
+        nonisolated static func requirement() { }
+      }
+      """
+
+    return [
+      decl.cast(ExtensionDeclSyntax.self)
+    ]
+  }
+}
+
 public struct BigEndianAccessorMacro: AccessorMacro {
     public static func expansion(
         of node: AttributeSyntax,

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -283,3 +283,15 @@ struct HasNestedType {
 // extensions of nested types when the outer type has an
 // attached macro that can add other nested types.
 extension HasNestedType.Inner {}
+
+@attached(extension, conformances: P, names: named(requirement))
+macro AddPWithNonisolated() = #externalMacro(module: "MacroDefinition", type: "PWithNonisolatedFuncMacro")
+
+@attached(extension, conformances: P, names: named(requirement))
+macro AddNonisolatedPWithNonisolated() = #externalMacro(module: "MacroDefinition", type: "NonisolatedPWithNonisolatedFuncMacro")
+
+@AddNonisolatedPWithNonisolated
+struct MakeMeNonisolated { }
+
+@AddPWithNonisolated
+struct KeepMeIsolated { }


### PR DESCRIPTION
  - **Explanation**: If all of the witnesses to a conformance are nonisolated, then infer that conformance as nonisolated rather than global-actor-isolated. This is only relevant when `InferIsolatedConformances` is enabled, and prevents that inference to help maintain source compatibility. Related to this, don't force members introduced for compiler-synthesized conformances (`Equatable`, `Hashable`, `Codable`, etc.) to be `nonisolated` when inferring conditional conformances. This makes main-actor-by-default mode work with synthesized conformances so you can make a main-actor type `Codable` and it'll correctly turn that into a main-actor-isolated conformance.
  - **Scope**: Limited to inference of isolation on conformances and synthesized members under the upcoming feature `InferIsolatedConformance` or when defaulting to the main actor.
  - **Issues**: rdar://150691429
  - **Original PRs**: https://github.com/swiftlang/swift/pull/81296, https://github.com/swiftlang/swift/pull/81420
  - **Risk**: Low, due to narrow scope of the change.
  - **Testing**: CI.
