### PR TITLE
[Macros] Don't include attr range when checking macro definition

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -136,7 +136,7 @@ MacroDefinition MacroDefinitionRequest::evaluate(
       SM.getEntireTextForBuffer(sourceFile->getBufferID());
   StringRef macroDeclText =
       SM.extractText(Lexer::getCharSourceRangeFromSourceRange(
-          SM, macro->getSourceRangeIncludingAttrs()));
+          SM, macro->getSourceRange()));
 
   auto checkResult = swift_Macros_checkMacroDefinition(
       &ctx.Diags, sourceFileText, macroDeclText, &externalMacroName,

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -234,3 +234,10 @@ func someGlobalNext(
 ) async throws {
   fatalError()
 }
+
+// This is testing if the definition is actually checked. The error means the '#externalMacro' was correctly parsed and checked.
+#if true
+@available(*, unavailable)
+#endif
+@freestanding(expression) public macro MacroWithIfConfigAttr() = #externalMacro(module: "ThisMacroModuleDoesNotExist", type: "ThisMacroTypeDoesNotExist")
+// expected-warning@-1{{external macro implementation type 'ThisMacroModuleDoesNotExist.ThisMacroTypeDoesNotExist'}}


### PR DESCRIPTION
For macro definition checking, we use the range of the `macro` declaration and re-parse it with `SwiftParser`. Previously it uses the range including the attributes, but that can result invalid code because the attribute can be in a `#if ... #endif` region.

Since we don't use attributes for checking the definition, just use the range without the attributes instead.

rdar://150805795



NOTE: Previously it silently failed here https://github.com/swiftlang/swift/blob/aee6a52bcf88fdf220ada6c2f0a89e3669dd38a7/lib/ASTGen/Sources/MacroEvaluation/Macros.swift#L218-L221
This should only happen if there's a compiler bug (like this). But we should emit an error here. I'll do it in follow-ups.