### PR TITLE
IRGen: Disable ASan for the auto dynamic replacement array

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1991,6 +1991,7 @@ void IRGenerator::emitDynamicReplacements() {
       "\x01l_auto_dynamic_replacements", IGM.getPointerAlignment(),
       /*isConstant*/ true, llvm::GlobalValue::PrivateLinkage);
   autoReplVar->setSection(getDynamicReplacementSection(IGM));
+  disableAddressSanitizer(IGM, autoReplVar);
   IGM.addUsedGlobal(autoReplVar);
 
   if (origFuncTypes.empty())

--- a/test/IRGen/dynamic_replaceable.sil
+++ b/test/IRGen/dynamic_replaceable.sil
@@ -24,7 +24,7 @@
 // CHECK: @"\01l_auto_dynamic_replacements" = private constant { i32, i32, [2 x i32] }
 // CHECK-SAME: { i32 0, i32 1,
 // CHECK-SAME: [2 x i32] [{{.*}}@"\01l_unnamed_dynamic_replacements"{{.*}}, i32 0]
-// CHECK-SAME: }, section "__TEXT, __swift5_replace, regular, no_dead_strip"
+// CHECK-SAME: }, section "__TEXT, __swift5_replace, regular, no_dead_strip", no_sanitize_address
 
 // CHECK-LABEL: define swiftcc void @test_dynamically_replaceable()
 // CHECK-NEXT: entry:


### PR DESCRIPTION
As well as other `swift5_` metadata sections, the dynamic replacement global data is accessed assuming all data are contiguous but ASan inserts some poisoned space before/after the data, so we need to disable ASan for them.

This allows us to test swift-foundation with ASan.