### PR TITLE
[Swiftify] Skip swiftify during symbolic import

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9091,6 +9091,8 @@ private:
 void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
   if (!SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers))
     return;
+  if (importSymbolicCXXDecls)
+    return;
   auto ClangDecl =
       dyn_cast_or_null<clang::FunctionDecl>(MappedDecl->getClangDecl());
   if (!ClangDecl)


### PR DESCRIPTION
 - **Explanation**:
    Swiftify does not, and can not, work in the symbolic import mode. This skips swiftify when that mode is enabled.
  - **Scope**:
    This should not affect compilation. It doesn't seem like symbolic imports are really used. They have been removed in main in https://github.com/swiftlang/swift/pull/81257, but this is a smaller change to fix a specific issue that should carry less risk to the release.
  - **Issues**:
    rdar://149953125
  - **Original PRs**:
    Not really applicable since importSymbolicCXXDecls is no longer a thing in main, but https://github.com/swiftlang/swift/pull/81257 would be the closes thing.
  - **Risk**:
    Low
  - **Testing**:
    User testing in Xcode
  - **Reviewers**:
    No original change, see above
