### PR TITLE
Add SwiftASN1 to sourcekit-lsp dependencies for Windows.

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2934,6 +2934,7 @@ function Build-SourceKitLSP([Hashtable] $Platform) {
       TSC_DIR = (Get-ProjectCMakeModules $Platform ToolsSupportCore);
       LLBuild_DIR = (Get-ProjectCMakeModules $Platform LLBuild);
       ArgumentParser_DIR = (Get-ProjectCMakeModules $Platform ArgumentParser);
+      SwiftASN1_DIR = (Get-ProjectCMakeModules $Platform ASN1);
       SwiftCrypto_DIR = (Get-ProjectCMakeModules $Platform Crypto);
       SwiftCollections_DIR = (Get-ProjectCMakeModules $Platform Collections);
       SwiftBuild_DIR = (Get-ProjectCMakeModules $Platform Build);


### PR DESCRIPTION
Updates the build.ps1 script to add the SwiftASN1 package support to it's CMake build. This was caused by this dependency being added to a module in SwiftPM that sourcekit-lsp imports.

Links to the PRs that will use this addition:
https://github.com/swiftlang/sourcekit-lsp/pull/2139
https://github.com/swiftlang/swift-package-manager/pull/8610
