### PR TITLE
Fallback to legacy way to build compiler-rt in some Linux bots

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -935,6 +935,9 @@ mixin-preset=
 
 skip-test-swiftdocc
 
+# to allow to build under aarch64
+llvm-build-compiler-rt-with-use-runtime=0
+
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux
 


### PR DESCRIPTION
In particular, this ensures we are able to build Linux packages for aarch64.

Addresses rdar://150423995