### PR TITLE
[6.2][Macros] Don't include attr range when checking macro definition

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -136,7 +136,7 @@ MacroDefinition MacroDefinitionRequest::evaluate(
       SM.getEntireTextForBuffer(sourceFile->getBufferID());
   StringRef macroDeclText =
       SM.extractText(Lexer::getCharSourceRangeFromSourceRange(
-          SM, macro->getSourceRangeIncludingAttrs()));
+          SM, macro->getSourceRange()));
 
   auto checkResult = swift_Macros_checkMacroDefinition(
       &ctx.Diags, sourceFileText, macroDeclText, &externalMacroName,

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -234,3 +234,10 @@ func someGlobalNext(
 ) async throws {
   fatalError()
 }
+
+// This is testing if the definition is actually checked. The error means the '#externalMacro' was correctly parsed and checked.
+#if true
+@available(*, unavailable)
+#endif
+@freestanding(expression) public macro MacroWithIfConfigAttr() = #externalMacro(module: "ThisMacroModuleDoesNotExist", type: "ThisMacroTypeDoesNotExist")
+// expected-warning@-1{{external macro implementation type 'ThisMacroModuleDoesNotExist.ThisMacroTypeDoesNotExist'}}


### PR DESCRIPTION
Cherry-pick #81346 into `release/6.2`

* **Explanation**: For macro definition checking, we use the range of the `macro` declaration and re-parse it with `SwiftParser`. Previously it uses the range including the attributes, but that can result invalid code because the attribute can be in a `#if ... #endif` region. Since we don't use attributes for checking the definition, just use the range without the attributes instead.
* **Scope**: Macros
* **Risk**: Low. The change is simple enough 
* **Testing**: Added a regression test case
* **Issues**: rdar://150805795
* **Reviewer**: Stuart Montgomery (@stmontgomery)