### PR TITLE
[ClangImporter] Import 'swift_attr("sending")' As a Type Attribute

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -217,6 +217,10 @@ enum class ImportTypeAttr : uint8_t {
   ///
   /// This ensures that the parameter is not marked as Unmanaged.
   CFUnretainedOutParameter = 1 << 5,
+
+  /// Type should be imported as though declaration was marked with
+  /// \c __attribute__((swift_attr("sending"))) .
+  Sending = 1 << 6,
 };
 
 /// Find and iterate over swift attributes embedded in the type

--- a/test/ClangImporter/Inputs/sending.h
+++ b/test/ClangImporter/Inputs/sending.h
@@ -43,4 +43,7 @@ sendUserDefinedFromGlobalFunction(NonSendableCStruct other) SWIFT_SENDING;
 void sendUserDefinedIntoGlobalFunction(
     NonSendableCStruct arg SWIFT_SENDING);
 
+void sendingWithCompletionHandler(void (^completion)(SWIFT_SENDING NonSendableCStruct arg));
+SWIFT_SENDING NonSendableCStruct sendingWithLazyReturn(SWIFT_SENDING NonSendableCStruct (^makeLazily)(void));
+
 #pragma clang assume_nonnull end


### PR DESCRIPTION
Previously, `__attribute__((swift_attr("sending")))` would only be resolved when attached to declarations. This patch expands it to be a type attribute as well, which enables it to occur in the result and parameter positions for blocks, function pointers, and lambdas.

Resolves rdar://148435359