### PR TITLE
Remove disabled asserts in LifetimeDependence

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -220,16 +220,9 @@ public:
         targetIndex(targetIndex) {
     assert(this->isImmortal() || inheritLifetimeParamIndices ||
            scopeLifetimeParamIndices);
-    // FIXME: These asserts can trigger when Optional/Result support ~Escapable use (rdar://147765187)
-    // assert(!inheritLifetimeParamIndices ||
-    //        !inheritLifetimeParamIndices->isEmpty());
-    // assert(!scopeLifetimeParamIndices || !scopeLifetimeParamIndices->isEmpty());
-    if (inheritLifetimeParamIndices && inheritLifetimeParamIndices->isEmpty()) {
-      inheritLifetimeParamIndices = nullptr;
-    }
-    if (scopeLifetimeParamIndices && scopeLifetimeParamIndices->isEmpty()) {
-      scopeLifetimeParamIndices = nullptr;
-    }
+    ASSERT(!inheritLifetimeParamIndices ||
+           !inheritLifetimeParamIndices->isEmpty());
+    ASSERT(!scopeLifetimeParamIndices || !scopeLifetimeParamIndices->isEmpty());
     assert((!addressableParamIndices
             || !conditionallyAddressableParamIndices
             || conditionallyAddressableParamIndices->isDisjointWith(


### PR DESCRIPTION
Asserts in LifetimeDependence was previously disabled during the bringup of ~Escapable Optional because they were firing on AsyncNinja. I am enabling it back because I cannot reproduce it. Also turning it into `ASSERT` which will fire in no-asserts build in case this turns out to be an intermittent failure.