### PR TITLE
[Build-Script]: Extend Swift cmake options

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3138,20 +3138,20 @@ build-swift-examples=0
 build-runtime-with-host-compiler=0
 build-swift-libexec=0
 build-swift-remote-mirror=0
+build-swift-static-sdk-overlay=0
+build-swift-static-stdlib=0
+enable-experimental-concurrency=1
+enable-experimental-distributed=0
+enable-experimental-observation=0
+enable-experimental-differentiable-programming=0
 
-extra-cmake-options=
+extra-llvm-cmake-options=
   -DLLVM_TARGETS_TO_BUILD=AArch64;X86
 
-swift-cmake-options=
-  -DSWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY:BOOL=YES
-  -DSWIFT_ENABLE_EXPERIMENTAL_OBSERVATION:BOOL=NO
-  -DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED:BOOL=NO
-  -DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING:BOOL=NO
+extra-swift-cmake-options=
   -DSWIFT_ENABLE_SWIFT_IN_SWIFT:BOOL=NO
   -DSWIFT_INCLUDE_DOCS:BOOL=NO
   -DSWIFT_BUILD_EXAMPLES:BOOL=OFF
-  -DSWIFT_BUILD_STATIC_SDK_OVERLAY:BOOL=NO
-  -DSWIFT_BUILD_STATIC_STDLIB:BOOL=NO
 
 build-subdir=%(build_subdir)s
 install-destdir=%(install_destdir)s

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -592,6 +592,12 @@ def create_argument_parser():
                 'will get little benefit from it (e.g. tools for '
                 'bootstrapping or debugging Swift)')
 
+    option('--extra-swift-cmake-options', append,
+           type=argparse.ShellSplitType(),
+           help='Pass additional CMake options to the Swift build. '
+                'Can be passed multiple times to add multiple options.',
+           default=[])
+
     option('--dsymutil-jobs', store_int,
            default=defaults.DSYMUTIL_JOBS,
            metavar='COUNT',
@@ -1403,6 +1409,13 @@ def create_argument_parser():
            help='CMake options used for llvm in the form of comma '
                 'separated options "-DCMAKE_VAR1=YES,-DCMAKE_VAR2=/tmp". Can '
                 'be called multiple times to add multiple such options.')
+    option('--extra-llvm-cmake-options', append,
+           type=argparse.ShellSplitType(),
+           help='Pass additional CMake options to the LLVM build. '
+                'Can be passed multiple times to add multiple options. '
+                'These are the last arguments passed to CMake and can override '
+                'existing options.',
+           default=[])
 
     option('--llvm-build-compiler-rt-with-use-runtimes', toggle_true, default=True,
            help='Switch to LLVM_ENABLE_RUNTIMES as the mechanism to build compiler-rt'

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -197,7 +197,9 @@ EXPECTED_DEFAULTS = {
     'enable_ubsan': False,
     'export_compile_commands': False,
     'extra_cmake_options': [],
+    'extra_llvm_cmake_options': [],
     'extra_swift_args': [],
+    'extra_swift_cmake_options': [],
     'swift_debuginfo_non_lto_args': None,
     'force_optimized_typechecker': False,
     'foundation_build_variant': 'Debug',
@@ -803,6 +805,7 @@ EXPECTED_OPTIONS = [
     StrOption('--swift-darwin-module-archs'),
     StrOption('--swift-darwin-supported-archs'),
     SetTrueOption('--swift-freestanding-is-darwin'),
+    AppendOption('--extra-swift-cmake-options'),
 
     StrOption('--linux-archs'),
     StrOption('--linux-static-archs'),
@@ -853,6 +856,7 @@ EXPECTED_OPTIONS = [
     AppendOption('--llvm-ninja-targets'),
     AppendOption('--llvm-ninja-targets-for-cross-compile-hosts'),
     AppendOption('--llvm-cmake-options'),
+    AppendOption('--extra-llvm-cmake-options'),
     EnableOption('--llvm-build-compiler-rt-with-use-runtimes'),
     AppendOption('--darwin-symroot-path-filters'),
 

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -453,6 +453,7 @@ class LLVM(cmake_product.CMakeProduct):
 
         self.cmake_options.extend(host_config.cmake_options)
         self.cmake_options.extend(llvm_cmake_options)
+        self.cmake_options.extend_raw(self.args.extra_llvm_cmake_options)
 
         self._handle_cxx_headers(host_target, platform)
 

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -104,6 +104,8 @@ class Swift(product.Product):
         self.cmake_options.extend(
             self._enable_new_runtime_build)
 
+        self.cmake_options.extend_raw(self.args.extra_swift_cmake_options)
+
     @classmethod
     def product_source_name(cls):
         """product_source_name() -> str

--- a/utils/swift_build_support/tests/products/test_swift.py
+++ b/utils/swift_build_support/tests/products/test_swift.py
@@ -52,6 +52,7 @@ class SwiftTestCase(unittest.TestCase):
             benchmark_num_o_iterations=3,
             disable_guaranteed_normal_arguments=True,
             force_optimized_typechecker=False,
+            extra_swift_cmake_options=["-DHELLO=YES"],
             enable_stdlibcore_exclusivity_checking=False,
             enable_experimental_differentiable_programming=False,
             enable_experimental_concurrency=False,
@@ -125,6 +126,7 @@ class SwiftTestCase(unittest.TestCase):
             '-USWIFT_DEBUGINFO_NON_LTO_ARGS',
             '-DSWIFT_STDLIB_BUILD_SYMBOL_GRAPHS:BOOL=FALSE',
             '-DSWIFT_ENABLE_NEW_RUNTIME_BUILD:BOOL=FALSE',
+            '-DHELLO=YES',
         ]
         self.assertEqual(set(swift.cmake_options), set(expected))
 
@@ -161,6 +163,7 @@ class SwiftTestCase(unittest.TestCase):
             '-USWIFT_DEBUGINFO_NON_LTO_ARGS',
             '-DSWIFT_STDLIB_BUILD_SYMBOL_GRAPHS:BOOL=FALSE',
             '-DSWIFT_ENABLE_NEW_RUNTIME_BUILD:BOOL=FALSE',
+            '-DHELLO=YES',
         ]
         self.assertEqual(set(swift.cmake_options), set(flags_set))
 


### PR DESCRIPTION
The existing `swift-cmake-options` flag overwrites all flags computed by build-script. Sometimes it is useful to be able to append additional CMake flags without overwriting the existing flags. This patch adds `--extra-swift-cmake-options` that adds the specified flags to the Swift CMake configuration instead of overwriting them.

This also adds a similar `--extra-llvm-cmake-options`, which adds the new flags to the end, allowing one to replace and overwrite CMake flags that build-script computed.
Due to the parameter passing mechanisms in build-script-impl, while this behavior would be useful for Swift, it is not immediately apparent how one would best implement this at this time.