### PR TITLE
[AST & Runtime] Correctly mangle extended existentials with inverse requirements

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2352,12 +2352,7 @@ public:
   }
   
   bool isCopyable() const {
-    if (!hasGeneralizationSignature()) {
-      return true;
-    }
-    auto *reqts = getGenSigRequirements();
-    for (unsigned i = 0, e = getNumGenSigRequirements(); i < e; ++i) {
-      auto &reqt = reqts[i];
+    for (auto &reqt : getRequirementSignature().getRequirements()) {
       if (reqt.getKind() != GenericRequirementKind::InvertedProtocols) {
         continue;
       }

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -117,9 +117,20 @@ struct ExistentialLayout {
 
   LayoutConstraint getLayoutConstraint() const;
 
+  /// Whether this layout has any inverses within its signature.
+  bool hasInverses() const {
+    return !inverses.empty();
+  }
+
+  /// Whether this existential needs to have an extended existential shape. This
+  /// is relevant for the mangler to mangle as a symbolic link where possible
+  /// and for IRGen directly emitting some existentials.
+  bool needsExtendedShape() const;
+
 private:
   SmallVector<ProtocolDecl *, 4> protocols;
   SmallVector<ParameterizedProtocolType *, 4> parameterized;
+  InvertibleProtocolSet inverses;
 };
 
 }

--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -125,7 +125,11 @@ struct ExistentialLayout {
   /// Whether this existential needs to have an extended existential shape. This
   /// is relevant for the mangler to mangle as a symbolic link where possible
   /// and for IRGen directly emitting some existentials.
-  bool needsExtendedShape() const;
+  ///
+  /// If 'allowInverses' is false, then regardless of if this existential layout
+  /// has inverse requirements those will not influence the need for having a
+  /// shape.
+  bool needsExtendedShape(bool allowInverses = true) const;
 
 private:
   SmallVector<ProtocolDecl *, 4> protocols;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1613,7 +1613,7 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
       // ExtendedExistentialTypeShapes consider existential metatypes to
       // be part of the existential, so if we're symbolically referencing
       // shapes, we need to handle that at this level.
-      if (EMT->hasParameterizedExistential()) {
+      if (EMT->getExistentialLayout().needsExtendedShape()) {
         auto referent = SymbolicReferent::forExtendedExistentialTypeShape(EMT);
         if (canSymbolicReference(referent)) {
           appendSymbolicExtendedExistentialType(referent, EMT, sig, forDecl);
@@ -1693,7 +1693,7 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
 
     case TypeKind::Existential: {
       auto *ET = cast<ExistentialType>(tybase);
-      if (ET->hasParameterizedExistential()) {
+      if (ET->getExistentialLayout().needsExtendedShape()) {
         auto referent = SymbolicReferent::forExtendedExistentialTypeShape(ET);
         if (canSymbolicReference(referent)) {
           appendSymbolicExtendedExistentialType(referent, ET, sig, forDecl);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1619,11 +1619,13 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
           appendSymbolicExtendedExistentialType(referent, EMT, sig, forDecl);
           return;
         }
-
-        appendConstrainedExistential(EMT->getInstanceType(), sig, forDecl);
-      } else {
-        appendType(EMT->getInstanceType(), sig, forDecl);
       }
+
+      if (EMT->getInstanceType()->isExistentialType() &&
+          EMT->getExistentialLayout().needsExtendedShape(AllowInverses))
+        appendConstrainedExistential(EMT->getInstanceType(), sig, forDecl);
+      else
+        appendType(EMT->getInstanceType(), sig, forDecl);
 
       if (EMT->hasRepresentation()) {
         appendOperator("Xm",

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -435,11 +435,11 @@ Type ExistentialLayout::getSuperclass() const {
   return Type();
 }
 
-bool ExistentialLayout::needsExtendedShape() const {
+bool ExistentialLayout::needsExtendedShape(bool allowInverses) const {
   if (!getParameterizedProtocols().empty())
     return true;
 
-  if (hasInverses())
+  if (allowInverses && hasInverses())
     return true;
 
   return false;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -320,6 +320,8 @@ ExistentialLayout::ExistentialLayout(CanProtocolType type) {
                            !protoDecl->isMarkerProtocol());
   representsAnyObject = false;
 
+  inverses = InvertibleProtocolSet();
+
   protocols.push_back(protoDecl);
   expandDefaults(protocols, InvertibleProtocolSet(), type->getASTContext());
 }
@@ -353,7 +355,7 @@ ExistentialLayout::ExistentialLayout(CanProtocolCompositionType type) {
     protocols.push_back(protoDecl);
   }
 
-  auto inverses = type->getInverses();
+  inverses = type->getInverses();
   expandDefaults(protocols, inverses, type->getASTContext());
 
   representsAnyObject = [&]() {
@@ -431,6 +433,16 @@ Type ExistentialLayout::getSuperclass() const {
   }
 
   return Type();
+}
+
+bool ExistentialLayout::needsExtendedShape() const {
+  if (!getParameterizedProtocols().empty())
+    return true;
+
+  if (hasInverses())
+    return true;
+
+  return false;
 }
 
 bool TypeBase::isObjCExistentialType() {

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -7852,8 +7852,10 @@ irgen::emitExtendedExistentialTypeShape(IRGenModule &IGM,
 
     // You can have a superclass with a generic parameter pack in a composition,
     // like `C<each T> & P<Int>`
-    assert(genHeader->GenericPackArguments.empty() &&
+    if (genSig) {
+      assert(genHeader->GenericPackArguments.empty() &&
            "Generic parameter packs not supported here yet");
+    }
 
     return b.finishAndCreateFuture();
   }, [&](llvm::GlobalVariable *var) {

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -465,6 +465,69 @@ _buildDemanglingForNominalType(const Metadata *type, Demangle::Demangler &Dem) {
   return _buildDemanglingForContext(description, demangledGenerics, Dem);
 }
 
+static Demangle::NodePointer
+_replaceGeneralizationArg(Demangle::NodePointer type,
+                          SubstGenericParametersFromMetadata substitutions,
+                          Demangle::Demangler &Dem) {
+  assert(type->getKind() == Node::Kind::Type);
+  auto genericParam = type->getChild(0);
+
+  if (genericParam->getKind() != Node::Kind::DependentGenericParamType)
+    return type;
+
+  auto depth = genericParam->getChild(0)->getIndex();
+  auto index = genericParam->getChild(1)->getIndex();
+
+  auto arg = substitutions.getMetadata(depth, index);
+  assert(arg.isMetadata());
+  return _swift_buildDemanglingForMetadata(arg.getMetadata(), Dem);
+}
+
+static Demangle::NodePointer
+_buildDemanglingForExtendedExistential(const Metadata *type,
+                                       Demangle::Demangler &Dem) {
+  auto ee = cast<ExtendedExistentialTypeMetadata>(type);
+
+  auto demangledExistential = Dem.demangleType(ee->Shape->ExistentialType.get(),
+                                               ResolveToDemanglingForContext(Dem));
+
+  if (!ee->Shape->hasGeneralizationSignature())
+    return demangledExistential;
+
+  SubstGenericParametersFromMetadata substitutions(ee->Shape,
+                                              ee->getGeneralizationArguments());
+
+  // Dig out the requirement list.
+  auto constrainedExistential = demangledExistential->getChild(0);
+  assert(constrainedExistential->getKind() == Node::Kind::ConstrainedExistential);
+  auto reqList = constrainedExistential->getChild(1);
+  assert(reqList->getKind() == Node::Kind::ConstrainedExistentialRequirementList);
+
+  auto newReqList = Dem.createNode(Node::Kind::ConstrainedExistentialRequirementList);
+
+  for (auto req : *reqList) {
+    // Currently, the only requirements that can create generalization arguments
+    // are same types.
+    if (req->getKind() != Node::Kind::DependentGenericSameTypeRequirement) {
+      newReqList->addChild(req, Dem);
+      continue;
+    }
+
+    auto lhs = _replaceGeneralizationArg(req->getChild(0), substitutions, Dem);
+    auto rhs = _replaceGeneralizationArg(req->getChild(1), substitutions, Dem);
+
+    auto newReq = Dem.createNode(Node::Kind::DependentGenericSameTypeRequirement);
+    newReq->addChild(lhs, Dem);
+    newReq->addChild(rhs, Dem);
+
+    newReqList->addChild(newReq, Dem);
+  }
+
+  constrainedExistential->replaceChild(1, newReqList);
+
+  return demangledExistential;
+}
+
 // Build a demangled type tree for a type.
 //
 // FIXME: This should use MetadataReader.h.
@@ -596,13 +659,7 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
     return proto_list;
   }
   case MetadataKind::ExtendedExistential: {
-    // FIXME: Implement this by demangling the extended existential and
-    // substituting the generalization arguments into the demangle tree.
-    // For now, unconditional casts will report '<<< invalid type >>>' when
-    // they fail.
-    // TODO: for clients that need to guarantee round-tripping, demangle
-    // to a SymbolicExtendedExistentialType.
-    return nullptr;
+    return _buildDemanglingForExtendedExistential(type, Dem);
   }
   case MetadataKind::ExistentialMetatype: {
     auto metatype = static_cast<const ExistentialMetatypeMetadata *>(type);

--- a/test/Interpreter/extended_existential.swift
+++ b/test/Interpreter/extended_existential.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -O -target arm64-apple-macos15.0 %s -o %t/a.out
+// RUN: %target-build-swift -O -target %target-cpu-apple-macos15.0 %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/Interpreter/extended_existential.swift
+++ b/test/Interpreter/extended_existential.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -O -target arm64-apple-macos15.0 %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: executable_test
+
+protocol A<B>: ~Copyable {
+  associatedtype B
+}
+
+protocol B: ~Copyable {}
+
+let a: Any = (any ~Copyable).self
+// CHECK: any Any<Self: ~Swift.Copyable>
+print(a)
+
+let b: Any = (any ~Escapable).self
+// CHECK: any Any<Self: ~Swift.Escapable>
+print(b)
+
+let c: Any = (any ~Copyable & ~Escapable).self
+// CHECK: any Any<Self: ~Swift.Copyable, Self: ~Swift.Escapable>
+print(c)
+
+let d: Any = (any A).self
+// CHECK: A
+print(d)
+
+let e: Any = (any B).self
+// CHECK: B
+print(e)
+
+let f: Any = (any A & B).self
+// CHECK: A & B
+print(f)
+
+let g: Any = (any A & ~Copyable).self
+// CHECK: any A<Self: ~Swift.Copyable>
+print(g)
+
+let h: Any = (any B & ~Copyable).self
+// CHECK: any B<Self: ~Swift.Copyable>
+print(h)
+
+let i: Any = (any A & B & ~Copyable).self
+// CHECK: any A & B<Self: ~Swift.Copyable>
+print(i)

--- a/test/Interpreter/moveonly_existentials.swift
+++ b/test/Interpreter/moveonly_existentials.swift
@@ -28,3 +28,19 @@ func mutate(_ b: inout any Boopable & ~Copyable) {
 borrow(S())
 var s = S() as any Boopable & ~Copyable
 mutate(&s)
+
+let a: Any = (any ~Copyable).self
+// CHECK: << invalid type >>
+print(a)
+
+let b: Any = (any ~Escapable).self
+// CHECK: << invalid type >>
+print(b)
+
+let c: Any = (any ~Copyable & ~Escapable).self
+// CHECK: << invalid type >>
+print(c)
+
+let d: Any = (any Boopable & ~Copyable).self
+// CHECK: << invalid type >>
+print(d)

--- a/test/Interpreter/moveonly_existentials.swift
+++ b/test/Interpreter/moveonly_existentials.swift
@@ -28,19 +28,3 @@ func mutate(_ b: inout any Boopable & ~Copyable) {
 borrow(S())
 var s = S() as any Boopable & ~Copyable
 mutate(&s)
-
-let a: Any = (any ~Copyable).self
-// CHECK: << invalid type >>
-print(a)
-
-let b: Any = (any ~Escapable).self
-// CHECK: << invalid type >>
-print(b)
-
-let c: Any = (any ~Copyable & ~Escapable).self
-// CHECK: << invalid type >>
-print(c)
-
-let d: Any = (any Boopable & ~Copyable).self
-// CHECK: << invalid type >>
-print(d)


### PR DESCRIPTION
Currently, the ASTMangler has 2 ways of emitting an extended existential mangling: 1. if the extended existential is parameterized, it will eagerly try to symbolically reference the extended shape or 2. just as a flat string. For extended existentials that have inverses, it was taking the 2nd option. The runtime does not currently have the capabilities to decode an extended existential without a shape referenced in the type mangling, so when attempting to create metadata for something like `any ~Copyable` it would fail spectacularly.

Add a method on existential layouts called `needsExtendedShape` which should be single point of truth whether or not the compiler should emit a shape into binaries for such existentials.

Also, while we're at it, since we have access to extended existential metadata for these things now, we should implement printing of these metadata. So also included in this patch is the runtime building of the demangling tree from the metadata which includes generalization argument substitution.

Resolves: rdar://150219645