### PR TITLE
[FreeBSD]: Optional observation pthread primitives

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/Locking.swift
+++ b/stdlib/public/Observation/Sources/Observation/Locking.swift
@@ -34,7 +34,15 @@ internal struct Lock {
   #if canImport(Darwin)
   typealias Primitive = os_unfair_lock
   #elseif canImport(Glibc) || canImport(Musl) || canImport(Bionic)
+  #if os(FreeBSD) || os(OpenBSD)
+  // BSD libc does not annotate the nullability of pthread APIs.
+  // We should replace this with the appropriate API note in the platform
+  // overlay.
+  // https://github.com/swiftlang/swift/issues/81407
+  typealias Primitive = pthread_mutex_t?
+  #else
   typealias Primitive = pthread_mutex_t
+  #endif
   #elseif canImport(WinSDK)
   typealias Primitive = SRWLOCK
   #elseif arch(wasm32)


### PR DESCRIPTION
The pthread APIs on FreeBSD do not include nullability APIs so the pthread mutex APIs are imported as pointers to optional values. Other platforms include nullability APIs and import the pthread APIs as pointers to the mutex. Splitting the locking primitive type based on the OS.

Fixes: rdar://150880976