### PR TITLE
[6.2] RemoteInspection: Support for parameter packs

### DIFF
--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -238,10 +238,6 @@ public:
   const TypeRef *subst(TypeRefBuilder &Builder,
                        const GenericArgumentMap &Subs) const;
 
-  const TypeRef *subst(TypeRefBuilder &Builder,
-                       const GenericArgumentMap &Subs,
-                       bool &DidSubstitute) const;
-
   std::optional<GenericArgumentMap> getSubstMap() const;
 
   virtual ~TypeRef() = default;

--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -416,6 +416,65 @@ public:
   }
 };
 
+class PackTypeRef final : public TypeRef {
+protected:
+  std::vector<const TypeRef *> Elements;
+
+  static TypeRefID Profile(const std::vector<const TypeRef *> &Elements) {
+    TypeRefID ID;
+    for (auto Element : Elements)
+      ID.addPointer(Element);
+    return ID;
+  }
+
+public:
+  PackTypeRef(std::vector<const TypeRef *> Elements)
+      : TypeRef(TypeRefKind::Pack), Elements(std::move(Elements)) {}
+
+  template <typename Allocator>
+  static const PackTypeRef *create(Allocator &A,
+                                    std::vector<const TypeRef *> Elements) {
+    FIND_OR_CREATE_TYPEREF(A, PackTypeRef, Elements);
+  }
+
+  const std::vector<const TypeRef *> &getElements() const { return Elements; };
+
+  static bool classof(const TypeRef *TR) {
+    return TR->getKind() == TypeRefKind::Pack;
+  }
+};
+
+class PackExpansionTypeRef final : public TypeRef {
+protected:
+  const TypeRef *Pattern;
+  const TypeRef *Count;
+
+  static TypeRefID Profile(const TypeRef *Pattern, const TypeRef *Count) {
+    TypeRefID ID;
+    ID.addPointer(Pattern);
+    ID.addPointer(Count);
+    return ID;
+  }
+
+public:
+  PackExpansionTypeRef( const TypeRef *Pattern, const TypeRef *Count)
+      : TypeRef(TypeRefKind::PackExpansion), Pattern(Pattern), Count(Count) {}
+
+  template <typename Allocator>
+  static const PackExpansionTypeRef *create(Allocator &A,
+                                 const TypeRef *Pattern, const TypeRef *Count) {
+    FIND_OR_CREATE_TYPEREF(A, PackExpansionTypeRef, Pattern, Count);
+  }
+
+  const TypeRef *getPattern() const { return Pattern; }
+
+  const TypeRef *getCount() const { return Count; }
+
+  static bool classof(const TypeRef *TR) {
+    return TR->getKind() == TypeRefKind::PackExpansion;
+  }
+};
+
 class OpaqueArchetypeTypeRef final : public TypeRef {
   std::string ID;
   std::string Description;

--- a/include/swift/RemoteInspection/TypeRefs.def
+++ b/include/swift/RemoteInspection/TypeRefs.def
@@ -39,5 +39,7 @@ TYPEREF(SILBox, TypeRef)
 TYPEREF(SILBoxTypeWithLayout, TypeRef)
 TYPEREF(Integer, TypeRef)
 TYPEREF(BuiltinFixedArray, TypeRef)
+TYPEREF(Pack, TypeRef)
+TYPEREF(PackExpansion, TypeRef)
 
 #undef TYPEREF

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1744,6 +1744,15 @@ public:
     return true;
   }
 
+  bool visitPackTypeRef(const PackTypeRef *P) {
+    return false;
+  }
+
+  bool visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
+    DEBUG_LOG(fprintf(stderr, "Cannot have pack expansion type here: "); PE->dump());
+    return false;
+  }
+
   bool visitFunctionTypeRef(const FunctionTypeRef *F) {
     return true;
   }
@@ -1876,6 +1885,20 @@ public:
     auto result = MetatypeRepresentation::Thin;
     for (auto Element : T->getElements())
       result = combineRepresentations(result, visit(Element));
+    return result;
+  }
+
+  MetatypeRepresentation visitPackTypeRef(const PackTypeRef *P) {
+    auto result = MetatypeRepresentation::Thin;
+    for (auto Element : P->getElements())
+      result = combineRepresentations(result, visit(Element));
+    return result;
+  }
+
+  MetatypeRepresentation visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
+    auto result = MetatypeRepresentation::Thin;
+    result = combineRepresentations(result, visit(PE->getPattern()));
+    result = combineRepresentations(result, visit(PE->getCount()));
     return result;
   }
 
@@ -2419,6 +2442,16 @@ public:
       // The label is not going to be relevant/harmful for looking up type info.
       builder.addField("", Element, ExternalTypeInfo);
     return builder.build();
+  }
+
+  const TypeInfo *visitPackTypeRef(const PackTypeRef *P) {
+    DEBUG_LOG(fprintf(stderr, "Cannot have pack type here: "); P->dump());
+    return nullptr;
+  }
+
+  const TypeInfo *visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
+    DEBUG_LOG(fprintf(stderr, "Cannot have pack expansion type here: "); PE->dump());
+    return nullptr;
   }
 
   const TypeInfo *visitFunctionTypeRef(const FunctionTypeRef *F) {

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -1350,15 +1350,12 @@ class TypeRefSubstitution
   : public TypeRefVisitor<TypeRefSubstitution, const TypeRef *> {
   TypeRefBuilder &Builder;
   GenericArgumentMap Substitutions;
-  // Set true iff the Substitution map was actually used
-  bool DidSubstitute;
+
 public:
   using TypeRefVisitor<TypeRefSubstitution, const TypeRef *>::visit;
 
   TypeRefSubstitution(TypeRefBuilder &Builder, GenericArgumentMap Substitutions)
-      : Builder(Builder), Substitutions(Substitutions), DidSubstitute(false) {}
-
-  bool didSubstitute() const { return DidSubstitute; }
+      : Builder(Builder), Substitutions(Substitutions) {}
 
   const TypeRef *visitBuiltinTypeRef(const BuiltinTypeRef *B) {
     return B;
@@ -1488,7 +1485,6 @@ public:
     if (found == Substitutions.end())
       return GTP;
     assert(found->second->isConcrete());
-    DidSubstitute = true; // We actually used the Substitutions
 
     // When substituting a concrete type containing a metatype into a
     // type parameter, (eg: T, T := C.Type), we must also represent
@@ -1607,15 +1603,6 @@ public:
 const TypeRef *TypeRef::subst(TypeRefBuilder &Builder,
                               const GenericArgumentMap &Subs) const {
   return TypeRefSubstitution(Builder, Subs).visit(this);
-}
-
-const TypeRef *TypeRef::subst(TypeRefBuilder &Builder,
-                              const GenericArgumentMap &Subs,
-			      bool &DidSubstitute) const {
-  auto subst = TypeRefSubstitution(Builder, Subs);
-  auto TR = subst.visit(this);
-  DidSubstitute = subst.didSubstitute();
-  return TR;
 }
 
 bool TypeRef::deriveSubstitutions(GenericArgumentMap &Subs,

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -26,6 +26,12 @@
 using namespace swift;
 using namespace reflection;
 
+#ifdef DEBUG_TYPE_LOWERING
+  #define DEBUG_LOG(expr) expr;
+#else
+  #define DEBUG_LOG(expr)
+#endif
+
 class PrintTypeRef : public TypeRefVisitor<PrintTypeRef, void> {
   std::ostream &stream;
   unsigned Indent;
@@ -120,6 +126,31 @@ public:
       printRec(std::get<1>(NameElement));
     }
     stream << ")";
+  }
+
+  void visitPackTypeRef(const PackTypeRef *P) {
+    printHeader("pack");
+
+    for (auto Element : P->getElements()) {
+      printRec(Element);
+    }
+    stream << ")";
+  }
+
+  void visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
+    printHeader("pack_expansion");
+
+    Indent += 2;
+    stream << "\n";
+    printHeader("pattern");
+    printRec(PE->getPattern());
+
+    stream << "\n";
+    printHeader("count");
+    printRec(PE->getCount());
+
+    stream << ")";
+    Indent -= 2;
   }
 
   void visitFunctionTypeRef(const FunctionTypeRef *F) {
@@ -447,6 +478,18 @@ struct TypeRefIsConcrete
     return true;
   }
 
+  bool visitPackTypeRef(const PackTypeRef *P) {
+    for (auto Element : P->getElements()) {
+      if (!visit(Element))
+        return false;
+    }
+    return true;
+  }
+
+  bool visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
+    return false;
+  }
+
   bool visitFunctionTypeRef(const FunctionTypeRef *F) {
     for (const auto &Param : F->getParameters())
       if (!visit(Param.getType()))
@@ -672,6 +715,20 @@ public:
       tuple->addChild(tupleElt, Dem);
     }
     return tuple;
+  }
+
+  Demangle::NodePointer visitPackTypeRef(const PackTypeRef *P) {
+    auto pack = Dem.createNode(Node::Kind::Pack);
+    for (auto Element : P->getElements())
+      pack->addChild(visit(Element), Dem);
+    return pack;
+  }
+
+  Demangle::NodePointer visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
+    auto expansion = Dem.createNode(Node::Kind::PackExpansion);
+    expansion->addChild(visit(PE->getPattern()), Dem);
+    expansion->addChild(visit(PE->getCount()), Dem);
+    return expansion;
   }
 
   Demangle::NodePointer visitFunctionTypeRef(const FunctionTypeRef *F) {
@@ -1239,6 +1296,19 @@ public:
     return TupleTypeRef::create(Builder, Elements, Labels);
   }
 
+  const TypeRef *visitPackTypeRef(const PackTypeRef *P) {
+    std::vector<const TypeRef *> Elements;
+    for (auto Element : P->getElements())
+      Elements.push_back(visit(Element));
+    return PackTypeRef::create(Builder, Elements);
+  }
+
+  const TypeRef *visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
+    auto *Pattern = visit(PE->getPattern());
+    auto *Count = visit(PE->getCount());
+    return PackExpansionTypeRef::create(Builder, Pattern, Count);
+  }
+
   const TypeRef *visitFunctionTypeRef(const FunctionTypeRef *F) {
     std::vector<remote::FunctionParam<const TypeRef *>> SubstitutedParams;
     for (const auto &Param : F->getParameters()) {
@@ -1351,6 +1421,43 @@ class TypeRefSubstitution
   TypeRefBuilder &Builder;
   GenericArgumentMap Substitutions;
 
+  std::vector<unsigned> ActivePackExpansions;
+
+  /// Simplified variant of InFlightSubstitution::expandPackExpansionShape()
+  /// that only implements the case where the replacement packs are concrete,
+  /// that is, they do not contain more pack expansions. This will always be
+  /// true here, because even more generally, our "substitution maps" do not
+  /// contain type parameters.
+  template<typename Fn>
+  bool expandPackExpansion(const PackExpansionTypeRef *origExpansion,
+                           Fn handleComponent) {
+    // Substitute the shape using the baseline substitutions, not the
+    // current elementwise projections.
+    auto *substShape = origExpansion->getCount()->subst(Builder, Substitutions);
+
+    auto *substPackShape = dyn_cast<PackTypeRef>(substShape);
+    if (!substPackShape) {
+      DEBUG_LOG(fprintf(stderr, "Replacement for pack must be another pack"));
+      return false;
+    }
+
+    ActivePackExpansions.push_back(0);
+    for (auto *substShapeElt : substPackShape->getElements()) {
+      if (isa<PackExpansionTypeRef>(substShapeElt)) {
+        DEBUG_LOG(fprintf(stderr, "Replacement pack cannot contain further expansions"));
+        return false;
+      }
+
+      auto *origPattern = origExpansion->getPattern();
+      auto *substElt = visit(origPattern);
+      handleComponent(substElt);
+
+      ++ActivePackExpansions.back();
+    }
+    ActivePackExpansions.pop_back();
+    return true;
+  }
+
 public:
   using TypeRefVisitor<TypeRefSubstitution, const TypeRef *>::visit;
 
@@ -1380,18 +1487,66 @@ public:
   }
 
   const TypeRef *visitTupleTypeRef(const TupleTypeRef *T) {
+    std::vector<std::string> Labels;
     std::vector<const TypeRef *> Elements;
-    for (auto Element : T->getElements())
-      Elements.push_back(visit(Element));
-    auto Labels = T->getLabels();
+    for (auto NameElement : llvm::zip_first(T->getLabels(), T->getElements())) {
+      auto *Element = std::get<1>(NameElement);
+      if (auto *PE = dyn_cast<PackExpansionTypeRef>(Element)) {
+        bool result = expandPackExpansion(PE, [&](const TypeRef *substElt) {
+          Labels.push_back(std::get<0>(NameElement));
+          Elements.push_back(substElt);
+        });
+        if (!result)
+          return T;
+      } else {
+        Labels.push_back(std::get<0>(NameElement));
+        Elements.push_back(visit(Element));
+      }
+    }
+
+    // Unwrap one-element tuples.
+    if (Elements.size() == 1 && Labels[0].empty() &&
+        !isa<PackExpansionTypeRef>(Elements[0])) {
+      return Elements[0];
+    }
+
     return TupleTypeRef::create(Builder, Elements, Labels);
+  }
+
+  const TypeRef *visitPackTypeRef(const PackTypeRef *P) {
+    std::vector<const TypeRef *> Elements;
+    for (auto Element : P->getElements()) {
+      if (auto *PE = dyn_cast<PackExpansionTypeRef>(Element)) {
+        bool result = expandPackExpansion(PE, [&](const TypeRef *substElt) {
+          Elements.push_back(substElt);
+        });
+        if (!result)
+          return P;
+      } else {
+        Elements.push_back(visit(Element));
+      }
+    }
+    return PackTypeRef::create(Builder, Elements);
+  }
+
+  const TypeRef *visitPackExpansionTypeRef(const PackExpansionTypeRef *PE) {
+    DEBUG_LOG(fprintf(stderr, "Cannot have pack expansion type here: "); PE->dump());
+    return nullptr;
   }
 
   const TypeRef *visitFunctionTypeRef(const FunctionTypeRef *F) {
     std::vector<remote::FunctionParam<const TypeRef *>> SubstitutedParams;
     for (const auto &Param : F->getParameters()) {
-      auto typeRef = Param.getType();
-      SubstitutedParams.push_back(Param.withType(visit(typeRef)));
+      auto *TR = Param.getType();
+      if (auto *PE = dyn_cast<PackExpansionTypeRef>(TR)) {
+        bool result = expandPackExpansion(PE, [&](const TypeRef *substElt) {
+          SubstitutedParams.push_back(Param.withType(visit(substElt)));
+        });
+        if (!result)
+          return F;
+      } else {
+        SubstitutedParams.push_back(Param.withType(visit(TR)));
+      }
     }
 
     auto SubstitutedResult = visit(F->getResult());
@@ -1484,12 +1639,30 @@ public:
     auto found = Substitutions.find({GTP->getDepth(), GTP->getIndex()});
     if (found == Substitutions.end())
       return GTP;
-    assert(found->second->isConcrete());
+
+    auto substType = found->second;
+    assert(substType->isConcrete());
+
+    if (!ActivePackExpansions.empty()) {
+      auto *P = dyn_cast<PackTypeRef>(substType);
+      if (!P) {
+        DEBUG_LOG(fprintf(stderr, "Replacement for pack is not a pack: "); P->dump());
+        return nullptr;
+      }
+
+      unsigned index = ActivePackExpansions.back();
+      if (index >= P->getElements().size()) {
+        DEBUG_LOG(fprintf(stderr, "Packs with wrong shape: "); P->dump());
+        return nullptr;
+      }
+
+      substType = P->getElements()[index];
+    }
 
     // When substituting a concrete type containing a metatype into a
     // type parameter, (eg: T, T := C.Type), we must also represent
     // the metatype as a value.
-    return thickenMetatypes(Builder, found->second);
+    return thickenMetatypes(Builder, substType);
   }
 
   const TypeRef *visitDependentMemberTypeRef(const DependentMemberTypeRef *DM) {

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -538,8 +538,9 @@ bool TypeRefBuilder::getFieldTypeRefs(
     // We need this for enums; an enum case "is generic" if any generic type
     // parameter substitutions occurred on the payload.  E.g.,
     // `case a([T?])` is generic, but `case a([Int?])` is not.
-    bool IsGeneric = false;
-    auto Substituted = Unsubstituted->subst(*this, *Subs, IsGeneric);
+    bool IsGeneric = !Unsubstituted->isConcrete();
+    auto Substituted = (IsGeneric ? Unsubstituted->subst(*this, *Subs)
+                                  : Unsubstituted);
     bool IsIndirect = FD.isEnum() && Field->IsIndirectCase;
 
     auto FieldTI = FieldTypeInfo(FieldName.str(), FieldValue, Substituted,

--- a/test/Reflection/Inputs/Packs.swift
+++ b/test/Reflection/Inputs/Packs.swift
@@ -1,0 +1,51 @@
+
+public typealias Second<T, U> = U
+
+public struct Packed<each T, U> {
+  public var tuple1: (repeat each T)
+  public var tuple2: (repeat (each T) -> ())
+  public var tuple3: (repeat Scalar<each T>)
+  public var tuple4: (repeat Second<each T, Int>)
+
+  public var func1: (repeat each T) -> ()
+  public var func2: (repeat Scalar<each T>) -> ()
+  public var func3: (repeat Second<each T, Int>) -> ()
+
+  public var nominal1: AlsoPacked<repeat each T>
+  public var nominal2: AlsoPacked<repeat Scalar<each T>>
+  public var nominal3: AlsoPacked<repeat Second<each T, Int>>
+}
+
+public struct AlsoPacked<each T> {
+  public var t: (repeat each T)
+}
+
+public struct Scalar<T> {
+  public var t: T
+}
+
+public protocol P {
+  associatedtype A
+  var t: A { get }
+}
+
+extension AlsoPacked: P {}
+
+public struct NestedPacked<each T> {
+  public struct Inner<each U> {
+    var t: (repeat Packed<repeat each U, each T>)
+    var u: (repeat AlsoPacked<repeat each U, each T>)
+  }
+}
+
+public struct Simple {
+  var x1: AlsoPacked<Float>
+  var x2: AlsoPacked<Int, Float>
+  var x3: AlsoPacked<Int, String, Float>
+}
+
+public struct Complex {
+  var x1: Packed<Float>
+  var x2: Packed<Int, Float>
+  var x3: Packed<Int, String, Float>
+}

--- a/test/Reflection/typeref_decoding_packs.swift
+++ b/test/Reflection/typeref_decoding_packs.swift
@@ -1,0 +1,175 @@
+// REQUIRES: no_asan
+//
+// LC_DYLD_CHAINED_FIXUPS decode not currently supported (default on visionOS)
+// UNSUPPORTED: OS=xros
+//
+// rdar://100805115
+// UNSUPPORTED: CPU=arm64e
+
+// RUN: %empty-directory(%t)
+
+// FIXME: rdar://127796117
+// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+
+// RUN: %target-build-swift -target %target-swift-5.9-abi-triple %S/Inputs/Packs.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -target %target-swift-5.9-abi-triple %S/Inputs/Packs.swift -emit-module -emit-executable %no-fixup-chains -module-name TypesToReflect -o %t/TypesToReflect
+
+// RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s
+// RUN: %target-swift-reflection-dump %t/TypesToReflect | %FileCheck %s
+
+// CHECK: FIELDS:
+// CHECK: =======
+// CHECK: TypesToReflect.Packed
+// CHECK: ---------------------
+// CHECK: tuple1: (repeat A)
+// CHECK: (tuple
+// CHECK:   (pack_expansion
+// CHECK:     (pattern
+// CHECK:       (generic_type_parameter depth=0 index=0)
+// CHECK:     (count
+// CHECK:       (generic_type_parameter depth=0 index=0)))
+
+// CHECK: tuple2: (repeat (A) -> ())
+// CHECK: (tuple
+// CHECK:   (pack_expansion
+// CHECK:     (pattern
+// CHECK:       (function
+// CHECK:         (parameters
+// CHECK:           (generic_type_parameter depth=0 index=0)
+// CHECK:         (result
+// CHECK:           (tuple))
+// CHECK:     (count
+// CHECK:       (generic_type_parameter depth=0 index=0)))
+
+// CHECK: tuple3: (repeat TypesToReflect.Scalar<A>)
+// CHECK: (tuple
+// CHECK:   (pack_expansion
+// CHECK:     (pattern
+// CHECK:       (bound_generic_struct TypesToReflect.Scalar
+// CHECK:         (generic_type_parameter depth=0 index=0))
+// CHECK:     (count
+// CHECK:       (generic_type_parameter depth=0 index=0)))
+
+// CHECK: tuple4: (repeat Swift.Int)
+// CHECK: (tuple
+// CHECK:   (pack_expansion
+// CHECK:     (pattern
+// CHECK:       (struct Swift.Int)
+// CHECK:     (count
+// CHECK:       (generic_type_parameter depth=0 index=0)))
+
+// CHECK: func1: (repeat A) -> ()
+// CHECK: (function
+// CHECK:   (parameters
+// CHECK:     (pack_expansion
+// CHECK:       (pattern
+// CHECK:         (generic_type_parameter depth=0 index=0)
+// CHECK:       (count
+// CHECK:         (generic_type_parameter depth=0 index=0))
+// CHECK:   (result
+// CHECK:     (tuple))
+
+// CHECK: func2: (repeat TypesToReflect.Scalar<A>) -> ()
+// CHECK: (function
+// CHECK:   (parameters
+// CHECK:     (pack_expansion
+// CHECK:       (pattern
+// CHECK:         (bound_generic_struct TypesToReflect.Scalar
+// CHECK:           (generic_type_parameter depth=0 index=0))
+// CHECK:       (count
+// CHECK:         (generic_type_parameter depth=0 index=0))
+// CHECK:   (result
+// CHECK:     (tuple))
+
+// CHECK: func3: (repeat Swift.Int) -> ()
+// CHECK: (function
+// CHECK:   (parameters
+// CHECK:     (pack_expansion
+// CHECK:       (pattern
+// CHECK:         (struct Swift.Int)
+// CHECK:       (count
+// CHECK:         (generic_type_parameter depth=0 index=0))
+// CHECK:   (result
+// CHECK:     (tuple))
+
+// CHECK: nominal1: TypesToReflect.AlsoPacked<Pack{repeat A}>
+// CHECK: (bound_generic_struct TypesToReflect.AlsoPacked
+// CHECK:   (pack
+// CHECK:     (pack_expansion
+// CHECK:       (pattern
+// CHECK:         (generic_type_parameter depth=0 index=0)
+// CHECK:       (count
+// CHECK:         (generic_type_parameter depth=0 index=0))))
+
+// CHECK: nominal2: TypesToReflect.AlsoPacked<Pack{repeat TypesToReflect.Scalar<A>}>
+// CHECK: (bound_generic_struct TypesToReflect.AlsoPacked
+// CHECK:   (pack
+// CHECK:     (pack_expansion
+// CHECK:       (pattern
+// CHECK:         (bound_generic_struct TypesToReflect.Scalar
+// CHECK:           (generic_type_parameter depth=0 index=0))
+// CHECK:       (count
+// CHECK:         (generic_type_parameter depth=0 index=0))))
+
+// CHECK: nominal3: TypesToReflect.AlsoPacked<Pack{repeat Swift.Int}>
+// CHECK: (bound_generic_struct TypesToReflect.AlsoPacked
+// CHECK:   (pack
+// CHECK:     (pack_expansion
+// CHECK:       (pattern
+// CHECK:         (struct Swift.Int)
+// CHECK:       (count
+// CHECK:         (generic_type_parameter depth=0 index=0))))
+
+// CHECK: TypesToReflect.AlsoPacked
+// CHECK: -------------------------
+// CHECK: t: (repeat A)
+// CHECK: (tuple
+// CHECK:   (pack_expansion
+// CHECK:     (pattern
+// CHECK:       (generic_type_parameter depth=0 index=0)
+// CHECK:     (count
+// CHECK:       (generic_type_parameter depth=0 index=0)))
+
+// CHECK: TypesToReflect.NestedPacked
+// CHECK: ---------------------------
+// CHECK: t: (repeat TypesToReflect.Packed<Pack{repeat A1}, A>)
+// CHECK: (tuple
+// CHECK:   (pack_expansion
+// CHECK:     (pattern
+// CHECK:       (bound_generic_struct TypesToReflect.Packed
+// CHECK:         (pack
+// CHECK:           (pack_expansion
+// CHECK:             (pattern
+// CHECK:               (generic_type_parameter depth=1 index=0)
+// CHECK:             (count
+// CHECK:               (generic_type_parameter depth=1 index=0)))
+// CHECK:         (generic_type_parameter depth=0 index=0))
+// CHECK:     (count
+// CHECK:       (generic_type_parameter depth=0 index=0)))
+
+// CHECK: u: (repeat TypesToReflect.AlsoPacked<Pack{repeat A1, A}>)
+// CHECK: (tuple
+// CHECK:   (pack_expansion
+// CHECK:     (pattern
+// CHECK:       (bound_generic_struct TypesToReflect.AlsoPacked
+// CHECK:         (pack
+// CHECK:           (pack_expansion
+// CHECK:             (pattern
+// CHECK:               (generic_type_parameter depth=1 index=0)
+// CHECK:             (count
+// CHECK:               (generic_type_parameter depth=1 index=0))
+// CHECK:           (generic_type_parameter depth=0 index=0)))
+// CHECK:     (count
+// CHECK:       (generic_type_parameter depth=0 index=0)))
+
+// CHECK: ASSOCIATED TYPES:
+// CHECK: =================
+// CHECK: - TypesToReflect.AlsoPacked : TypesToReflect.P
+// CHECK: typealias A = (repeat A)
+// CHECK: (repeat A)
+// CHECK: (tuple
+// CHECK:   (pack_expansion
+// CHECK:     (pattern
+// CHECK:       (generic_type_parameter depth=0 index=0)
+// CHECK:     (count
+// CHECK:       (generic_type_parameter depth=0 index=0)))

--- a/test/Reflection/typeref_lowering_packs.swift
+++ b/test/Reflection/typeref_lowering_packs.swift
@@ -1,0 +1,309 @@
+// REQUIRES: no_asan
+//
+// LC_DYLD_CHAINED_FIXUPS decode not currently supported (default on visionOS)
+// UNSUPPORTED: OS=xros
+//
+// RUN: %empty-directory(%t)
+
+// rdar://100558042
+// UNSUPPORTED: CPU=arm64e
+
+// RUN: %target-build-swift -target %target-swift-5.9-abi-triple %S/Inputs/Packs.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -target %target-swift-5.9-abi-triple %S/Inputs/Packs.swift %S/Inputs/main.swift -emit-module -emit-executable %no-fixup-chains -module-name TypeLowering -o %t/TypesToReflect
+
+// RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s
+// RUN: %target-swift-reflection-dump %t/TypesToReflect %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s
+
+// REQUIRES: PTRSIZE=64
+
+12TypeLowering6SimpleV
+
+// CHECK: (struct TypeLowering.Simple)
+// CHECK: (struct size=52 alignment=8 stride=56 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:   (field name=x1 offset=0
+// CHECK:     (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:       (field name=t offset=0
+// CHECK:         (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=_value offset=0
+// CHECK:             (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK:   (field name=x2 offset=8
+// CHECK:     (struct size=12 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:       (field name=t offset=0
+// CHECK:         (tuple size=12 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:           (field offset=8
+// CHECK:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK:   (field name=x3 offset=24
+// CHECK:     (struct size=28 alignment=8 stride=32 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:       (field name=t offset=0
+// CHECK:         (tuple size=28 alignment=8 stride=32 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:           (field offset=8
+// CHECK:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:               (field name=_guts offset=0
+// CHECK:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                   (field name=_object offset=0
+// CHECK:                     (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                       (field name=_countAndFlagsBits offset=0
+// CHECK:                         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                           (field name=_value offset=0
+// CHECK:                             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:                       (field name=_object offset=8
+// CHECK:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))))))))
+// CHECK:           (field offset=24
+// CHECK:             (struct size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=4 alignment=4 stride=4 num_extra_inhabitants=0 bitwise_takable=1)))))))))
+
+12TypeLowering7ComplexV
+
+// CHECK: (struct TypeLowering.Complex)
+// CHECK: (struct size=368 alignment=8 stride=368 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:   (field name=x1 offset=0
+// CHECK:     (struct size=48 alignment=8 stride=48 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:       (field name=tuple1 offset=0
+// CHECK:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK:       (field name=tuple2 offset=0
+// CHECK:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK:       (field name=tuple3 offset=0
+// CHECK:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK:       (field name=tuple4 offset=0
+// CHECK:         (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))
+// CHECK:       (field name=func1 offset=0
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=func2 offset=16
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=func3 offset=32
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=nominal1 offset=48
+// CHECK:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:       (field name=nominal2 offset=48
+// CHECK:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:       (field name=nominal3 offset=48
+// CHECK:         (struct size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (tuple size=0 alignment=1 stride=1 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK:   (field name=x2 offset=48
+// CHECK:     (struct size=112 alignment=8 stride=112 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:       (field name=tuple1 offset=0
+// CHECK:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=_value offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:       (field name=tuple2 offset=8
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=tuple3 offset=24
+// CHECK:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK:       (field name=tuple4 offset=32
+// CHECK:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=_value offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:       (field name=func1 offset=40
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=func2 offset=56
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=func3 offset=72
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=nominal1 offset=88
+// CHECK:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK:       (field name=nominal2 offset=96
+// CHECK:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=t offset=0
+// CHECK:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                   (field name=_value offset=0
+// CHECK:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK:       (field name=nominal3 offset=104
+// CHECK:         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))))
+// CHECK:   (field name=x3 offset=160
+// CHECK:     (struct size=208 alignment=8 stride=208 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:       (field name=tuple1 offset=0
+// CHECK:         (tuple size=24 alignment=8 stride=24 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:           (field offset=8
+// CHECK:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:               (field name=_guts offset=0
+// CHECK:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                   (field name=_object offset=0
+// CHECK:                     (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                       (field name=_countAndFlagsBits offset=0
+// CHECK:                         (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                           (field name=_value offset=0
+// CHECK:                             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:                       (field name=_object offset=8
+// CHECK:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))))))))))
+// CHECK:       (field name=tuple2 offset=24
+// CHECK:         (tuple size=32 alignment=8 stride=32 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field offset=0
+// CHECK:             (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:               (field name=function offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:               (field name=context offset=8
+// CHECK:                 (reference kind=strong refcounting=native))))
+// CHECK:           (field offset=16
+// CHECK:             (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:               (field name=function offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:               (field name=context offset=8
+// CHECK:                 (reference kind=strong refcounting=native))))))
+// CHECK:       (field name=tuple3 offset=56
+// CHECK:         (tuple size=24 alignment=8 stride=24 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=t offset=0
+// CHECK:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                   (field name=_value offset=0
+// CHECK:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK:           (field offset=8
+// CHECK:             (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:               (field name=t offset=0
+// CHECK:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                   (field name=_guts offset=0
+// CHECK:                     (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                       (field name=_object offset=0
+// CHECK:                         (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                           (field name=_countAndFlagsBits offset=0
+// CHECK:                             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                               (field name=_value offset=0
+// CHECK:                                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:                           (field name=_object offset=8
+// CHECK:                             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))))))))))))
+// CHECK:       (field name=tuple4 offset=80
+// CHECK:         (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field offset=0
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:           (field offset=8
+// CHECK:             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field name=_value offset=0
+// CHECK:                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK:       (field name=func1 offset=96
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=func2 offset=112
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=func3 offset=128
+// CHECK:         (thick_function size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=function offset=0
+// CHECK:             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))
+// CHECK:           (field name=context offset=8
+// CHECK:             (reference kind=strong refcounting=native))))
+// CHECK:       (field name=nominal1 offset=144
+// CHECK:         (struct size=24 alignment=8 stride=24 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (tuple size=24 alignment=8 stride=24 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:               (field offset=0
+// CHECK:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                   (field name=_value offset=0
+// CHECK:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:               (field offset=8
+// CHECK:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                   (field name=_guts offset=0
+// CHECK:                     (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                       (field name=_object offset=0
+// CHECK:                         (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                           (field name=_countAndFlagsBits offset=0
+// CHECK:                             (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                               (field name=_value offset=0
+// CHECK:                                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:                           (field name=_object offset=8
+// CHECK:                             (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))))))))))))
+// CHECK:       (field name=nominal2 offset=168
+// CHECK:         (struct size=24 alignment=8 stride=24 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (tuple size=24 alignment=8 stride=24 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:               (field offset=0
+// CHECK:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                   (field name=t offset=0
+// CHECK:                     (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                       (field name=_value offset=0
+// CHECK:                         (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))))
+// CHECK:               (field offset=8
+// CHECK:                 (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                   (field name=t offset=0
+// CHECK:                     (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                       (field name=_guts offset=0
+// CHECK:                         (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                           (field name=_object offset=0
+// CHECK:                             (struct size=16 alignment=8 stride=16 num_extra_inhabitants={{.*}} bitwise_takable=1
+// CHECK:                               (field name=_countAndFlagsBits offset=0
+// CHECK:                                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                                   (field name=_value offset=0
+// CHECK:                                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:                               (field name=_object offset=8
+// CHECK:                                 (builtin size=8 alignment=8 stride=8 num_extra_inhabitants={{.*}} bitwise_takable=1))))))))))))))
+// CHECK:       (field name=nominal3 offset=192
+// CHECK:         (struct size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:           (field name=t offset=0
+// CHECK:             (tuple size=16 alignment=8 stride=16 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:               (field offset=0
+// CHECK:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                   (field name=_value offset=0
+// CHECK:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1))))
+// CHECK:               (field offset=8
+// CHECK:                 (struct size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1
+// CHECK:                   (field name=_value offset=0
+// CHECK:                     (builtin size=8 alignment=8 stride=8 num_extra_inhabitants=0 bitwise_takable=1)))))))))))

--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -270,6 +270,7 @@
 // RUN:             -e _ZNSt6vectorISsSaISsEE17_M_realloc_insertIJSsEEEvN9__gnu_cxx17__normal_iteratorIPSsS1_EEDpOT_ \
 // RUN:             -e _ZNSt6vectorISt10unique_ptrIKvSt8functionIFvPS1_EEESaIS6_EE19_M_emplace_back_auxIJS6_EEEvDpOT_ \
 // RUN:             -e _ZNSt6vectorISt10unique_ptrIKvSt8functionIFvPS1_EEESaIS6_EE17_M_realloc_insertIJS6_EEEvN9__gnu_cxx17__normal_iteratorIPS6_S8_EEDpOT_ \
+// RUN:             -e _ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EE17_M_realloc_insertIJRKS5_EEEvN9__gnu_cxx17__normal_iteratorIPS5_S7_EEDpOT_ \
 // RUN:             -e _ZNSt10_HashtableImSt4pairIKmSt10unique_ptrIKvSt8functionIFvPS3_EEEESaIS9_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSB_18_Mod_range_hashingENSB_20_Default_ranged_hashENSB_20_Prime_rehash_policyENSB_17_Hashtable_traitsILb0ELb0ELb1EEEE10_M_emplaceIJS0_ImS8_EEEES0_INSB_14_Node_iteratorIS9_Lb0ELb0EEEbESt17integral_constantIbLb1EEDpOT_ \
 // RUN:             -e _ZNSt10_HashtableImSt4pairIKmSt10unique_ptrIKvSt8functionIFvPS3_EEEESaIS9_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSB_18_Mod_range_hashingENSB_20_Default_ranged_hashENSB_20_Prime_rehash_policyENSB_17_Hashtable_traitsILb0ELb0ELb1EEEE13_M_rehash_auxEmSt17integral_constantIbLb1EE \
 // RUN:             -e _ZNSt10_HashtableImSt4pairIKmSt10unique_ptrIKvSt8functionIFvPS3_EEEESaIS9_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSB_18_Mod_range_hashingENSB_20_Default_ranged_hashENSB_20_Prime_rehash_policyENSB_17_Hashtable_traitsILb0ELb0ELb1EEEED2Ev \


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/81299.

* **Description:** Remote mirrors did not support types containing parameter packs. Add that support.

* **Scope of the issue:** This meant that parameter packs defeat lldb's remote mirrors-based code path, forcing the ASTContext to be loaded. This should no longer be necessary.

* **Risk:** There is a bunch of new code, and it might have bugs in it. However this doesn't change behavior of existing code.

* **Reviewed by:** @adrian-prantl 