### PR TITLE
[6.2][IRGen] Emit llvm fneg operation for Builtin.fneg_*

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -588,9 +588,7 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
   }
   
   if (Builtin.ID == BuiltinValueKind::FNeg) {
-    llvm::Value *rhs = args.claimNext();
-    llvm::Value *lhs = llvm::ConstantFP::get(rhs->getType(), "-0.0");
-    llvm::Value *v = IGF.Builder.CreateFSub(lhs, rhs);
+    llvm::Value *v = IGF.Builder.CreateFNeg(args.claimNext());
     return out.add(v);
   }
   if (Builtin.ID == BuiltinValueKind::AssumeTrue) {

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -329,9 +329,9 @@ func fneg_test(_ half: Builtin.FPIEEE16,
                double: Builtin.FPIEEE64)
   -> (Builtin.FPIEEE16, Builtin.FPIEEE32, Builtin.FPIEEE64)
 {
-  // CHECK: fsub half 0xH8000, {{%.*}}
-  // CHECK: fsub float -0.000000e+00, {{%.*}}
-  // CHECK: fsub double -0.000000e+00, {{%.*}}
+  // CHECK: fneg half
+  // CHECK: fneg float
+  // CHECK: fneg double
   return (Builtin.fneg_FPIEEE16(half),
           Builtin.fneg_FPIEEE32(single),
           Builtin.fneg_FPIEEE64(double))


### PR DESCRIPTION
- **Explanation**: The original handling was a workaround before LLVM added the fneg operation. Now that it has it, we should use it.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: IRGen for FNeg builtin
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://150722907
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/81339
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Replaces an approximation of an instruction with the instruction itself
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Adjusted existing tests to use the new instruction
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @rjmccall @stephentyrone 
