### PR TITLE
[6.2][Concurrency] Use reinterpret_cast for function_cast when ptrauth is on.

### DIFF
--- a/include/swift/Basic/Casting.h
+++ b/include/swift/Basic/Casting.h
@@ -41,9 +41,17 @@ Destination function_cast(Source source) {
   static_assert(std::is_trivially_copyable_v<Destination>,
                 "The destination type must be trivially constructible");
 
+#if __has_feature(ptrauth_calls)
+  // Use reinterpret_cast here so we perform any necessary auth-and-sign.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
+  return reinterpret_cast<Destination>(source);
+#pragma clang diagnostic pop
+#else
   Destination destination;
   memcpy(&destination, &source, sizeof(source));
   return destination;
+#endif
 }
 
 }


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/81380 to `release/6.2`.

We need to use reinterpret_cast when ptrauth is enabled to ensure that any necessary auth-and-sign operations are performed.

rdar://150747009