### PR TITLE
[Swiftify] Handle anonymous parameters

### DIFF
--- a/test/Interop/C/swiftify-import/Inputs/counted-by-noescape.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by-noescape.h
@@ -22,3 +22,5 @@ void nullable(int len, int * __counted_by(len) _Nullable p __noescape);
 int * __counted_by(len) __noescape returnPointer(int len);
 
 int * __counted_by(len1) returnLifetimeBound(int len1, int len2, int * __counted_by(len2) p __lifetimebound);
+
+void anonymous(int len, int * __counted_by(len) _Nullable __noescape);

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -12,6 +12,9 @@
 import CountedByNoEscapeClang
 
 // CHECK:      @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(_param1: copy _param1)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func anonymous(_ _param1: inout MutableSpan<Int32>?)
+// CHECK-NEXT:  @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>)
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -101,4 +104,10 @@ public func callSimple(_ p: inout MutableSpan<CInt>) {
 @inlinable
 public func callSwiftAttr(_ p: inout MutableSpan<CInt>) {
   swiftAttr(&p)
+}
+
+@lifetime(p: copy p)
+@inlinable
+public func callAnonymous(_ p: inout MutableSpan<CInt>?) {
+  anonymous(&p)
 }

--- a/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
@@ -1,0 +1,43 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
+public func myFunc(_: UnsafePointer<CInt>, _ len: CInt) {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"))
+public func myFunc2(_ p: UnsafePointer<CInt>, _ len: CInt, _: CInt) {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
+public func myFunc3(_: UnsafePointer<CInt>, _ len: CInt) {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)))
+public func myFunc4(_: UnsafeMutablePointer<CInt>, _ len: CInt) {
+}
+
+// CHECK:      @_alwaysEmitIntoClient
+// CHECK-NEXT: public func myFunc(_ _param0: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     return unsafe myFunc(_param0.baseAddress!, CInt(exactly: _param0.count)!)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient
+// CHECK-NEXT: public func myFunc2(_ p: UnsafeBufferPointer<CInt>, _ _param2: CInt) {
+// CHECK-NEXT:     return unsafe myFunc2(p.baseAddress!, CInt(exactly: p.count)!, _param2)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient
+// CHECK-NEXT: public func myFunc3(_ _param0: Span<CInt>) {
+// CHECK-NEXT:     return unsafe _param0.withUnsafeBufferPointer { __param0Ptr in
+// CHECK-NEXT:         return unsafe myFunc3(__param0Ptr.baseAddress!, CInt(exactly: __param0Ptr.count)!)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(_param0: copy _param0)
+// CHECK-NEXT: public func myFunc4(_ _param0: inout MutableSpan<CInt>) {
+// CHECK-NEXT:     return unsafe _param0.withUnsafeMutableBufferPointer { __param0Ptr in
+// CHECK-NEXT:         return unsafe myFunc4(__param0Ptr.baseAddress!, CInt(exactly: __param0Ptr.count)!)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }


### PR DESCRIPTION
_SwiftifyImport would expand with syntax errors if applied to a function with anonymous parameters, because it would try to refer to parameters using the name `_`. Detect these cases and create names for unnamed parameters.

rdar://150955944
