### PR TITLE
Reenable build of compiler-rt with LLVM_ENABLE_RUNTIMES in Linux bots...

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -936,9 +936,6 @@ mixin-preset=
 
 skip-test-swiftdocc
 
-# to allow to build under aarch64
-llvm-build-compiler-rt-with-use-runtime=0
-
 [preset: buildbot_linux,release_foundation_tests]
 mixin-preset=buildbot_linux
 

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -389,7 +389,7 @@ class Product(object):
         sysroot_arch, vendor, abi = self.get_linux_target_components(arch)
         return '{}-{}-linux-{}'.format(sysroot_arch, vendor, abi)
 
-    def generate_linux_toolchain_file(self, platform, arch):
+    def generate_linux_toolchain_file(self, platform, arch, crosscompiling=True):
         """
         Generates a new CMake tolchain file that specifies Linux as a target
         platform.
@@ -402,8 +402,9 @@ class Product(object):
 
         toolchain_args = {}
 
-        toolchain_args['CMAKE_SYSTEM_NAME'] = 'Linux'
-        toolchain_args['CMAKE_SYSTEM_PROCESSOR'] = arch
+        if crosscompiling:
+            toolchain_args['CMAKE_SYSTEM_NAME'] = 'Linux'
+            toolchain_args['CMAKE_SYSTEM_PROCESSOR'] = arch
 
         # We only set the actual sysroot if we are actually cross
         # compiling. This is important since otherwise cmake seems to change the


### PR DESCRIPTION
...we disabled in #81354

This requires a couple of supporting changes
    
* under Linux, do not cross compile LLVM when building for the host
architecture -- that will ensure that the compiler-rt build will use
the just built compiler and not the system one (which may not be
new enough for this purpose);
* provide sanitizer flags depending on the linker the just built compiler
will use -- this detection is brittle, so print a message advising the
user how to override this.
    
Addresses rdar://150849329