### PR TITLE
[wasm] Remove workaround for wasi-libc's check-symbols target

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -58,20 +58,11 @@ class WASILibc(product.Product):
 
         sysroot_build_dir = WASILibc.sysroot_build_path(
             build_root, host_target, target_triple)
-        # FIXME: Manually create an empty dir that is usually created during
-        # check-symbols. The directory is required during sysroot installation step.
-        os.makedirs(os.path.join(sysroot_build_dir, "share"), exist_ok=True)
 
         sysroot_install_path = WASILibc.sysroot_install_path(build_root, target_triple)
         shell.call([
             'make', 'install',
             '-j', str(build_jobs),
-            # FIXME: wasi-libc's pre-defined macro list does not expect
-            # `__FPCLASS_XXX`, which is introduced by the LLVM 17, yet.
-            # So skip the symbol check step by treating the phony target
-            # as very old file.
-            # https://github.com/llvm/llvm-project/commit/7dd387d2971d7759cadfffeb2082439f6c7ddd49
-            '--old-file=check-symbols',
             '-C', self.source_dir,
             'OBJDIR=' + os.path.join(self.build_dir, 'obj-' + thread_model),
             'SYSROOT=' + sysroot_build_dir,


### PR DESCRIPTION
The expected LLVM version in wasi-libc is enough new for us, so we no longer need to workaround the `__FPCLASS_XXX` macro issue in wasi-libc's check-symbols target.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
