### PR TITLE
[Caching] Remove capture clang extra files

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -474,11 +474,6 @@ public:
   /// Reads the original source file name from PCH.
   std::string getOriginalSourceFile(StringRef PCHFilename);
 
-  /// Add clang dependency file names.
-  ///
-  /// \param files The list of file to append dependencies to.
-  void addClangInvovcationDependencies(std::vector<std::string> &files);
-
   /// Makes a temporary replica of the ClangImporter's CompilerInstance, reads a
   /// module map into the replica and emits a PCM file for one of the modules it
   /// declares. Delegates to clang for everything except construction of the

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1038,27 +1038,6 @@ std::string ClangImporter::getOriginalSourceFile(StringRef PCHFilename) {
       Impl.Instance->getPCHContainerReader(), Impl.Instance->getDiagnostics());
 }
 
-void ClangImporter::addClangInvovcationDependencies(
-    std::vector<std::string> &files) {
-  auto addFiles = [&files](const auto &F) {
-    files.insert(files.end(), F.begin(), F.end());
-  };
-  auto &invocation = *Impl.Invocation;
-  // FIXME: Add file dependencies that are not accounted. The long term solution
-  // is to do a dependency scanning for clang importer and use that directly.
-  SmallVector<std::string, 4> HeaderMapFileNames;
-  Impl.Instance->getPreprocessor().getHeaderSearchInfo().getHeaderMapFileNames(
-      HeaderMapFileNames);
-  addFiles(HeaderMapFileNames);
-  addFiles(invocation.getHeaderSearchOpts().VFSOverlayFiles);
-  // FIXME: Should not depend on working directory. Build system/swift driver
-  // should not pass working directory here but if that option is passed,
-  // repect that and add that into CASFS.
-  auto CWD = invocation.getFileSystemOpts().WorkingDir;
-  if (!CWD.empty())
-    files.push_back(CWD);
-}
-
 std::optional<std::string>
 ClangImporter::getPCHFilename(const ClangImporterOptions &ImporterOptions,
                               StringRef SwiftPCHHash, bool &isExplicit) {

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -388,14 +388,6 @@ ModuleDependencyScanner::getMainModuleDependencyInfo(ModuleDecl *mainModule) {
   auto mainDependencies = ModuleDependencyInfo::forSwiftSourceModule(
        {}, buildCommands, {}, {}, {});
 
-  if (ScanASTContext.CASOpts.EnableCaching) {
-    std::vector<std::string> clangDependencyFiles;
-    clangImporter->addClangInvovcationDependencies(clangDependencyFiles);
-    llvm::for_each(clangDependencyFiles, [&](std::string &file) {
-      mainDependencies.addAuxiliaryFile(file);
-    });
-  }
-
   llvm::StringSet<> alreadyAddedModules;
   // Compute Implicit dependencies of the main module
   {

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -243,16 +243,6 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
             InPath, compiledCandidatesRefs, ArgsRefs, {}, {}, linkLibraries,
             isFramework, isStatic, {}, /*module-cache-key*/ "", UserModVer);
 
-        if (Ctx.CASOpts.EnableCaching) {
-          std::vector<std::string> clangDependencyFiles;
-          auto clangImporter =
-              static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
-          clangImporter->addClangInvovcationDependencies(clangDependencyFiles);
-          llvm::for_each(clangDependencyFiles, [&](std::string &file) {
-            Result->addAuxiliaryFile(file);
-          });
-        }
-
         // Walk the source file to find the import declarations.
         llvm::StringSet<> alreadyAddedModules;
         Result->addModuleImports(*sourceFile, alreadyAddedModules,

--- a/test/CAS/module_deps_clang_extras.swift
+++ b/test/CAS/module_deps_clang_extras.swift
@@ -4,46 +4,99 @@
 // RUN: mkdir -p %t/clang-module-cache
 // RUN: mkdir -p %t/cas
 // RUN: split-file %s %t
-// RUN: %hmaptool write %t/hmap.json %t/empty.hmap
+// RUN: sed "s|DIR|%/t|g" %t/hmap.json.template > %t/hmap.json
+// RUN: sed "s|DIR|%/t|g" %t/test.yaml.template > %t/test.yaml
+// RUN: %hmaptool write %t/hmap.json %t/test.hmap
 
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache \
-// RUN:   %t/Test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas \
-// RUN:   -Xcc -fmodule-map-file=%t/module.modulemap -Xcc -ivfsoverlay -Xcc %t/empty.yaml \
-// RUN:   -Xcc -I%t/empty.hmap
+// RUN:   %t/Test.swift -module-name Test -o %t/deps.json -cache-compile-job -cas-path %t/cas \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -Xcc -fmodule-map-file=%t/include/module.modulemap -Xcc -ivfsoverlay -Xcc %t/test.yaml \
+// RUN:   -Xcc -I%t/test.hmap -module-load-mode prefer-serialized -scanner-output-dir %t \
+// RUN:   -import-objc-header %t/Bridge.h -auto-bridging-header-chaining
 // RUN: %validate-json %t/deps.json &>/dev/null
 
-// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps casFSRootID > %t/fs.casid
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Test casFSRootID > %t/fs.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s -DDIR=%basename_t -check-prefix FS_ROOT
-// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:Dummy clangIncludeTree > %t/tree.casid
-// RUN: clang-cas-test --cas %t/cas --print-include-tree @%t/tree.casid | %FileCheck %s -DDIR=%basename_t -check-prefix INCLUDE_TREE
 
-// FS_ROOT: [[DIR]].tmp/empty.hmap
-// FS_ROOT: [[DIR]].tmp/empty.yaml
+// FS_ROOT: [[DIR]].tmp/hidden/Dummy.h
+// FS_ROOT: [[DIR]].tmp/hidden/a.h
+// FS_ROOT: [[DIR]].tmp/hidden/b.h
 
-// INCLUDE_TREE: [[DIR]].tmp/Dummy.h
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
+// RUN: %swift_frontend_plain @%t/shim.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:Dummy > %t/dummy.cmd
+// RUN: %swift_frontend_plain @%t/dummy.cmd
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
+// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
+// RUN: echo "\"%t/objc.pch\"" >> %t/MyApp.cmd
+// RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
+// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
+
+// RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %t/Test.swift \
+// RUN:   -emit-module -o %t/test.swiftmodule
 
 //--- Test.swift
 import Dummy
 func test() {}
 
-//--- module.modulemap
+//--- Bridge.h
+#include "b.h"
+
+//--- hidden/module.modulemap
 module Dummy {
  umbrella header "Dummy.h"
 }
 
-//--- Dummy.h
+//--- hidden/Dummy.h
+#include "a.h"
 void dummy(void);
 
-//--- hmap.json
+//--- hidden/a.h
+/* empty file */
+
+//--- hidden/b.h
+/* empty file */
+
+//--- hmap.json.template
 {
-  "mappings": {} 
+  "mappings": {
+    "a.h": "DIR/hidden/a.h",
+    "b.h": "DIR/hidden/b.h"
+  }
 }
 
-//--- empty.yaml
+//--- test.yaml.template
 {
   "version": 0,
   "case-sensitive": "false",
   "use-external-names": true,
-  "roots": []
+  "roots": [
+    {
+      "type": "file",
+      "name": "DIR/include/module.modulemap",
+      "external-contents": "DIR/hidden/module.modulemap"
+    },
+    {
+      "type": "file",
+      "name": "DIR/include/Dummy.h",
+      "external-contents": "DIR/hidden/Dummy.h"
+    },
+  ]
 }
 


### PR DESCRIPTION
After removing the CASFS implementation for clang modules, there is no need to capture clang extra file that sets up the VFS for the clang modules since all content imported by ClangImporter is dependency scanned and available via include-tree.

Update the test to check that clang content found via `-Xcc` VFS options can currently work without capture the headermaps and vfs overlays.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
