### PR TITLE
Add ASN1 module to SourceKit-LSP Test

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2976,6 +2976,9 @@ function Test-SourceKitLSP {
     "-Xswiftc", "-I$(Get-ProjectBinaryCache $BuildPlatform Crypto)\swift",
     "-Xlinker", "-L$(Get-ProjectBinaryCache $BuildPlatform Crypto)\lib",
     "-Xlinker", "$(Get-ProjectBinaryCache $BuildPlatform Crypto)\lib\CCryptoBoringSSL.lib",
+    # swift-asn1
+    "-Xswiftc", "-I$(Get-ProjectBinaryCache $BuildPlatform ASN1)\swift",
+    "-Xlinker", "-L$(Get-ProjectBinaryCache $BuildPlatform ASN1)\lib",
     # swift-package-manager
     "-Xswiftc", "-I$(Get-ProjectBinaryCache $BuildPlatform PackageManager)\swift",
     "-Xlinker", "-L$(Get-ProjectBinaryCache $BuildPlatform PackageManager)\lib",


### PR DESCRIPTION
Super surprised to see the build for swift test of sourcekit-lsp hardcoded in the build.ps1 script instead of in the sourcekit-lsp repo. At any rate, looks like I need to add the dependency on ASN1 here too.

This is to support changes in SwiftPM that add the dependency which translates through to sourcekit-lsp.

https://github.com/swiftlang/swift-package-manager/pull/8610
