### PR TITLE
[6.2][Distributed] pointer auth protocol pointers as we use conformsToProtocol

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -26,6 +26,7 @@
 #include "GenDecl.h"
 #include "GenMeta.h"
 #include "GenOpaque.h"
+#include "GenPointerAuth.h"
 #include "GenProto.h"
 #include "GenType.h"
 #include "IRGenDebugInfo.h"
@@ -589,9 +590,26 @@ static llvm::Value *lookupWitnessTable(IRGenFunction &IGF, llvm::Value *witness,
   assert(Lowering::TypeConverter::protocolRequiresWitnessTable(protocol));
 
   auto &IGM = IGF.IGM;
-  auto *protocolDescriptor = IGM.getAddrOfProtocolDescriptor(protocol);
+  llvm::Value *protocolDescriptor = IGM.getAddrOfProtocolDescriptor(protocol);
+
+  bool signedProtocolDescriptor = IGM.getAvailabilityRange().isContainedIn(
+    IGM.Context.getSignedConformsToProtocolAvailability());
+
+  auto conformsToProtocolFunctionPointer = signedProtocolDescriptor ?
+    IGM.getConformsToProtocol2FunctionPointer() :
+    IGM.getConformsToProtocolFunctionPointer();
+
+  // Sign the protocol descriptor.
+  auto schema = IGF.IGM.getOptions().PointerAuth.ProtocolDescriptorsAsArguments;
+  if (schema && signedProtocolDescriptor) {
+    auto authInfo = PointerAuthInfo::emit(
+        IGF, schema, nullptr,
+        PointerAuthEntity::Special::ProtocolDescriptorAsArgument);
+    protocolDescriptor = emitPointerAuthSign(IGF, protocolDescriptor, authInfo);
+  }
+
   auto *witnessTable = IGF.Builder.CreateCall(
-      IGM.getConformsToProtocolFunctionPointer(), {witness, protocolDescriptor});
+      conformsToProtocolFunctionPointer, {witness, protocolDescriptor});
 
   auto failBB = IGF.createBasicBlock("missing-witness");
   auto contBB = IGF.createBasicBlock("");


### PR DESCRIPTION
**Description:** We should be signing metadata pointers in the distributed runtime in order to avoid any future potential signing issues, and improve security of this lookup.
**Scope/Impact:** Low
**Risk:** Low, the identical pattern is done elsewhere.
**Testing:** Manually verified on arm64e
**Reviewed by:** @xedin @aschwaighofer who did similar changes around the codebase and knows the impact.

**Original PR:** https://github.com/swiftlang/swift/pull/81372
**Radar:** rdar://150976815