### PR TITLE
🍒  [6.2] [Swiftify] Do not swiftify non-Swift-like counted_by exprs

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -60,7 +60,9 @@
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjCCommon.h"
+#include "clang/AST/Expr.h"
 #include "clang/AST/PrettyPrinter.h"
+#include "clang/AST/StmtVisitor.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Specifiers.h"
@@ -9094,6 +9096,47 @@ private:
 };
 } // namespace
 
+namespace {
+  /// Look for any side effects within a Stmt.
+  struct CATExprValidator : clang::ConstStmtVisitor<CATExprValidator, bool> {
+    bool VisitDeclRefExpr(const clang::DeclRefExpr *e) { return true; }
+    bool VisitIntegerLiteral(const clang::IntegerLiteral *) { return true; }
+    bool VisitImplicitCastExpr(const clang::ImplicitCastExpr *c) { return this->Visit(c->getSubExpr()); }
+    bool VisitParenExpr(const clang::ParenExpr *p) { return this->Visit(p->getSubExpr()); }
+
+#define SUPPORTED_UNOP(UNOP) \
+    bool VisitUnary ## UNOP(const clang::UnaryOperator *unop) { \
+      return this->Visit(unop->getSubExpr()); \
+    }
+    SUPPORTED_UNOP(Plus)
+    SUPPORTED_UNOP(Minus)
+    SUPPORTED_UNOP(Not)
+#undef SUPPORTED_UNOP
+
+#define SUPPORTED_BINOP(BINOP) \
+    bool VisitBin ## BINOP(const clang::BinaryOperator *binop) { \
+      return this->Visit(binop->getLHS()) && this->Visit(binop->getRHS()); \
+    }
+    SUPPORTED_BINOP(Add)
+    SUPPORTED_BINOP(Sub)
+    SUPPORTED_BINOP(Div)
+    SUPPORTED_BINOP(Mul)
+    SUPPORTED_BINOP(Rem)
+    SUPPORTED_BINOP(Shl)
+    SUPPORTED_BINOP(Shr)
+    SUPPORTED_BINOP(And)
+    SUPPORTED_BINOP(Xor)
+    SUPPORTED_BINOP(Or)
+#undef SUPPORTED_BINOP
+
+    bool VisitStmt(const clang::Stmt *) { return false; }
+  };
+} // namespace
+
+static bool SwiftifiableCAT(const clang::CountAttributedType *CAT) {
+  return CAT && CATExprValidator().Visit(CAT->getCountExpr());
+}
+
 void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
   if (!SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers))
     return;
@@ -9131,8 +9174,8 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
     SwiftifyInfoPrinter printer(getClangASTContext(), out);
     bool returnIsStdSpan = registerStdSpanTypeMapping(
         MappedDecl->getResultInterfaceType(), ClangDecl->getReturnType());
-    if (auto CAT =
-            ClangDecl->getReturnType()->getAs<clang::CountAttributedType>()) {
+    auto *CAT = ClangDecl->getReturnType()->getAs<clang::CountAttributedType>();
+    if (SwiftifiableCAT(CAT)) {
       printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
       attachMacro = true;
     }
@@ -9147,7 +9190,8 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
       auto clangParamTy = clangParam->getType();
       auto swiftParam = MappedDecl->getParameters()->get(index);
       bool paramHasBoundsInfo = false;
-      if (auto CAT = clangParamTy->getAs<clang::CountAttributedType>()) {
+      auto *CAT = clangParamTy->getAs<clang::CountAttributedType>();
+      if (SwiftifiableCAT(CAT)) {
         printer.printCountedBy(CAT, index);
         attachMacro = paramHasBoundsInfo = true;
       }

--- a/test/Interop/C/swiftify-import/Inputs/counted-by.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by.h
@@ -4,6 +4,8 @@
 
 void simple(int len, int * __counted_by(len) p);
 
+void simpleFlipped(int * __counted_by(len) p, int len);
+
 void swiftAttr(int len, int *p) __attribute__((
     swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(2), count: \"len\"))")));
 
@@ -18,3 +20,35 @@ void nonnull(int len, int * __counted_by(len) _Nonnull p);
 void nullable(int len, int * __counted_by(len) _Nullable p);
 
 int * __counted_by(len) returnPointer(int len);
+
+void offByOne(int len, int * __counted_by(len + 1) p);
+
+void offBySome(int len, int offset, int * __counted_by(len + (1 + offset)) p);
+
+void scalar(int m, int n, int * __counted_by(m * n) p);
+
+void bitwise(int m, int n, int o, int * __counted_by(m & n | ~o) p);
+
+void bitshift(int m, int n, int o, int * __counted_by(m << (n >> o)) p);
+
+void constInt(int * __counted_by(42 * 10) p);
+
+void constFloatCastedToInt(int * __counted_by((int) (4.2 / 12)) p);
+
+void sizeofType(int * __counted_by(sizeof(int *)) p);
+
+void sizeofParam(int * __counted_by(sizeof(p)) p);
+
+void derefLen(int * len, int * __counted_by(*len) p);
+
+void lNot(int len, int * __counted_by(!len) p);
+
+void lAnd(int len, int * __counted_by(len && len) p);
+
+void lOr(int len, int * __counted_by(len || len) p);
+
+void floatCastToInt(float meters, int * __counted_by((int) meters) p);
+
+void pointerCastToInt(int *square, int * __counted_by((int) square) p);
+
+void nanAsInt(int * __counted_by((int) (0 / 0)) p);

--- a/test/Interop/C/swiftify-import/counted-by-no-swiftify.swift
+++ b/test/Interop/C/swiftify-import/counted-by-no-swiftify.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// These functions use __counted_by annotations that are not syntactically valid
+// in Swift, so they should not be Swiftified
+
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} derefLen
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} lNot
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} lAnd
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} lOr
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} floatCastToInt
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} pointerCastToInt
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} nanAsInt

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -10,18 +10,33 @@
 
 import CountedByClang
 
-// CHECK:      @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: UnsafeMutableBufferPointer<Int{{.*}}>)
+// CHECK:      @_alwaysEmitIntoClient public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func bitwise(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: UnsafeMutableBufferPointer<Int{{.*}}>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func constInt(_ p: UnsafeMutableBufferPointer<Int32>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_  p: UnsafeMutableBufferPointer<Int{{.*}}>?)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_  len: Int{{.*}}) -> UnsafeMutableBufferPointer<Int{{.*}}>
+// CHECK-NEXT: @_alwaysEmitIntoClient public func scalar(_ m: Int32, _ n: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int{{.*}}, _ p1: UnsafeMutableBufferPointer<Int{{.*}}>, _ p2: UnsafeMutableBufferPointer<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func simpleFlipped(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func sizeofParam(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func sizeofType(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 
 @inlinable
 public func callComplexExpr(_ p: UnsafeMutableBufferPointer<CInt>) {
   complexExpr(CInt(p.count), 1, p)
+}
+
+@inlinable
+public func callConstInt(_ p: UnsafeMutableBufferPointer<CInt>) {
+  constInt(p)
 }
 
 @inlinable
@@ -40,9 +55,19 @@ public func callNullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
 }
 
 @inlinable
+public func callOffByOne(_ p: UnsafeMutableBufferPointer<CInt>) {
+  offByOne(0, p)
+}
+
+@inlinable
 public func callReturnPointer() {
   let a: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
   let b: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
+}
+
+@inlinable
+public func callScalar(_ p: UnsafeMutableBufferPointer<CInt>) {
+  scalar(4, 2, p)
 }
 
 @inlinable
@@ -53,6 +78,11 @@ public func callShared(_ p: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutabl
 @inlinable
 public func callSimple(_ p: UnsafeMutableBufferPointer<CInt>) {
   simple(p)
+}
+
+@inlinable
+public func callSimpleFlipped(_ p: UnsafeMutableBufferPointer<CInt>) {
+  simpleFlipped(p)
 }
 
 @inlinable


### PR DESCRIPTION
Explanation: This patch adds a check to ensure we only attach the Swiftify macro to `__counted_by` and `__sized_by` expressions that are also syntactically valid in Swift.

**Issue**: rdar://150956352
**Risk**: low
**Testing**: added tests
**Original PRs**: https://github.com/swiftlang/swift/pull/81395
**Reviewer**: @hnrklssn