### PR TITLE
preset: treat swift testing the same as xctest

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -424,6 +424,8 @@ mixin-preset=buildbot_incremental_base
 # on Foundation, so that is built as well. On OS X, Foundation is built as part
 # of the XCTest Xcode project.
 xctest
+swift-testing
+swift-testing-macros
 
 build-swift-stdlib-unittest-extra
 
@@ -441,6 +443,8 @@ skip-test-foundation
 release
 assertions
 xctest
+swift-testing
+swift-testing-macros
 test
 
 skip-test-cmark
@@ -625,6 +629,8 @@ swiftformat
 swift-driver
 indexstore-db
 sourcekit-lsp
+swift-testing
+swift-testing-macros
 # Failing to build in CI: rdar://78408440
 # swift-inspect
 install-llvm
@@ -635,6 +641,8 @@ install-swiftpm
 install-swiftsyntax
 install-swift-driver
 install-swiftformat
+install-swift-testing
+install-swift-testing-macros
 
 # We need to build the unittest extras so we can test
 build-swift-stdlib-unittest-extra
@@ -1134,6 +1142,8 @@ lldb
 foundation
 swiftpm
 swift-driver
+swift-testing
+swift-testing-macros
 xctest
 
 build-subdir=buildbot_linux
@@ -1147,6 +1157,8 @@ install-foundation
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
+install-swift-testing
+install-swift-testing-macros
 install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;libexec;stdlib;swift-remote-mirror;sdk-overlay;dev
@@ -3030,8 +3042,12 @@ build-subdir=compat_linux
 foundation
 libdispatch
 xctest
+swift-testing
+swift-testing-macros
 install-foundation
 install-libdispatch
+install-swift-testing
+install-swift-testing-macros
 install-xctest
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
 
@@ -3224,6 +3240,8 @@ skip-early-swift-driver
 
 llbuild
 xctest
+swift-testing
+swift-testing-macros
 swiftpm
 
 swift-include-tests=0
@@ -3248,4 +3266,6 @@ install-foundation
 install-libdispatch
 install-llbuild
 install-swiftpm
+install-swift-testing
+install-swift-testing-macros
 install-xctest


### PR DESCRIPTION
Whenever XCtest is build and installed, do the same for swift-testing and swift-testing macros so projects can use whichever testing framework. 

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
