### PR TITLE
Supplemental: add installation rules for StringProcessing

### DIFF
--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -22,7 +22,16 @@ set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
 
 find_package(SwiftCore)
 
+include(GNUInstallDirs)
+
 include(AvailabilityMacros)
+include(EmitSwiftInterface)
+include(PlatformInfo)
+include(ResourceEmbedding)
+
+option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
+set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${PROJECT_NAME}_INSTALL_NESTED_SUBDIR>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>")
+set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${PROJECT_NAME}_INSTALL_NESTED_SUBDIR>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}>")
 
 add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>

--- a/Runtimes/Supplemental/StringProcessing/RegexBuilder/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/RegexBuilder/CMakeLists.txt
@@ -13,3 +13,12 @@ target_link_libraries(swiftRegexBuilder PRIVATE
   swift_RegexParser
   swift_StringProcessing
   swiftCore)
+
+install(TARGETS swiftRegexBuilder
+  ARCHIVE DESTINATION "${SwiftStringProcessing_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${SwiftStringProcessing_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+emit_swift_interface(swiftRegexBuilder)
+install_swift_interface(swiftRegexBuilder)
+
+embed_manifest(swiftRegexBuilder)

--- a/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
@@ -35,3 +35,12 @@ target_link_libraries(swift_RegexParser PRIVATE swiftCore)
 
 set_target_properties(swift_RegexParser PROPERTIES
   Swift_MODULE_NAME _RegexParser)
+
+install(TARGETS swift_RegexParser
+  ARCHIVE DESTINATION "${SwiftStringProcessing_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${SwiftStringProcessing_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+emit_swift_interface(swift_RegexParser)
+install_swift_interface(swift_RegexParser)
+
+embed_manifest(swift_RegexParser)

--- a/Runtimes/Supplemental/StringProcessing/_StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/_StringProcessing/CMakeLists.txt
@@ -78,3 +78,12 @@ set_target_properties(swift_StringProcessing PROPERTIES
 target_link_libraries(swift_StringProcessing PRIVATE
     swift_RegexParser
     swiftCore)
+
+install(TARGETS swift_StringProcessing
+  ARCHIVE DESTINATION "${SwiftStringProcessing_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${SwiftStringProcessing_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+emit_swift_interface(swift_StringProcessing)
+install_swift_interface(swift_StringProcessing)
+
+embed_manifest(swift_StringProcessing)


### PR DESCRIPTION
Introduce install targets for the StringProcessing module. This is a prerequisite for building a static variant of the standard library to enable the statically linked early swift driver for Windows to bootstrap.