### PR TITLE
[Dependency Scanning][C++Interop] Do not query `CxxStdlib` Swift overlay for textual modules which were not built with c++interop

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -689,7 +689,7 @@ public:
     storage->importedSwiftModules.assign(dependencyIDs.begin(),
                                          dependencyIDs.end());
   }
-  const ArrayRef<ModuleDependencyID> getImportedSwiftDependencies() const {
+  ArrayRef<ModuleDependencyID> getImportedSwiftDependencies() const {
     return storage->importedSwiftModules;
   }
 
@@ -698,7 +698,7 @@ public:
     storage->importedClangModules.assign(dependencyIDs.begin(),
                                          dependencyIDs.end());
   }
-  const ArrayRef<ModuleDependencyID> getImportedClangDependencies() const {
+  ArrayRef<ModuleDependencyID> getImportedClangDependencies() const {
     return storage->importedClangModules;
   }
 
@@ -732,7 +732,7 @@ public:
     }
     }
   }
-  const ArrayRef<ModuleDependencyID> getHeaderClangDependencies() const {
+  ArrayRef<ModuleDependencyID> getHeaderClangDependencies() const {
     switch (getKind()) {
     case swift::ModuleDependencyKind::SwiftInterface: {
       auto swiftInterfaceStorage =
@@ -760,7 +760,7 @@ public:
     storage->swiftOverlayDependencies.assign(dependencyIDs.begin(),
                                              dependencyIDs.end());
   }
-  const ArrayRef<ModuleDependencyID> getSwiftOverlayDependencies() const {
+  ArrayRef<ModuleDependencyID> getSwiftOverlayDependencies() const {
     return storage->swiftOverlayDependencies;
   }
 
@@ -770,11 +770,11 @@ public:
     storage->crossImportOverlayModules.assign(dependencyIDs.begin(),
                                               dependencyIDs.end());
   }
-  const ArrayRef<ModuleDependencyID> getCrossImportOverlayDependencies() const {
+  ArrayRef<ModuleDependencyID> getCrossImportOverlayDependencies() const {
     return storage->crossImportOverlayModules;
   }
 
-  const ArrayRef<LinkLibrary> getLinkLibraries() const {
+  ArrayRef<LinkLibrary> getLinkLibraries() const {
     return storage->linkLibraries;
   }
 
@@ -783,7 +783,7 @@ public:
     storage->linkLibraries.assign(linkLibraries.begin(), linkLibraries.end());
   }
 
-  const ArrayRef<std::string> getAuxiliaryFiles() const {
+  ArrayRef<std::string> getAuxiliaryFiles() const {
     return storage->auxiliaryFiles;
   }
 
@@ -795,7 +795,7 @@ public:
     return false;
   }
 
-  const ArrayRef<std::string> getHeaderInputSourceFiles() const {
+  ArrayRef<std::string> getHeaderInputSourceFiles() const {
     if (auto *detail = getAsSwiftInterfaceModule())
       return detail->textualModuleDetails.bridgingSourceFiles;
     if (auto *detail = getAsSwiftSourceModule())
@@ -805,7 +805,7 @@ public:
     return {};
   }
 
-  std::vector<std::string> getCommandline() const {
+  ArrayRef<std::string> getCommandline() const {
     if (auto *detail = getAsClangModule())
       return detail->buildCommandLine;
     if (auto *detail = getAsSwiftInterfaceModule())
@@ -828,7 +828,7 @@ public:
     llvm_unreachable("Unexpected type");
   }
 
-  std::vector<std::string> getBridgingHeaderCommandline() const {
+  ArrayRef<std::string> getBridgingHeaderCommandline() const {
     if (auto *detail = getAsSwiftSourceModule())
       return detail->bridgingHeaderBuildCommandLine;
     return {};

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -468,7 +468,7 @@ ModuleDependencyScanner::getMainModuleDependencyInfo(ModuleDecl *mainModule) {
     // build command to main module to ensure frontend gets the same result.
     // This needs to happen after visiting all the top-level decls from all
     // SourceFiles.
-    auto buildArgs = mainDependencies.getCommandline();
+    std::vector<std::string> buildArgs = mainDependencies.getCommandline();
     mainModule->getASTContext().forEachCanImportVersionCheck(
         [&](StringRef moduleName, const llvm::VersionTuple &Version,
             const llvm::VersionTuple &UnderlyingVersion) {
@@ -1328,25 +1328,33 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
     recordResult(clangDep);
 
   // C++ Interop requires additional handling
-  if (ScanCompilerInvocation.getLangOptions().EnableCXXInterop) {
-    for (const auto &clangDepName : allClangDependencies) {
-      // If this Clang module is a part of the C++ stdlib, and we haven't loaded
-      // the overlay for it so far, it is a split libc++ module (e.g.
-      // std_vector). Load the CxxStdlib overlay explicitly.
-      const auto &clangDepInfo =
-          cache.findDependency(clangDepName, ModuleDependencyKind::Clang)
-              .value()
-              ->getAsClangModule();
-      if (importer::isCxxStdModule(clangDepName, clangDepInfo->IsSystem) &&
-          !swiftOverlayDependencies.contains(
-              {clangDepName, ModuleDependencyKind::SwiftInterface}) &&
-          !swiftOverlayDependencies.contains(
-              {clangDepName, ModuleDependencyKind::SwiftBinary})) {
-        ScanningThreadPool.async(
-            scanForSwiftDependency,
-            getModuleImportIdentifier(ScanASTContext.Id_CxxStdlib.str()));
-        ScanningThreadPool.wait();
-        recordResult(ScanASTContext.Id_CxxStdlib.str().str());
+  if (ScanCompilerInvocation.getLangOptions().EnableCXXInterop &&
+      moduleID.Kind == ModuleDependencyKind::SwiftInterface) {
+    const auto &moduleInfo = cache.findKnownDependency(moduleID);
+    const auto commandLine = moduleInfo.getCommandline();
+
+    // If the textual interface was built without C++ interop, do not query
+    // the C++ Standard Library Swift overlay for its compilation.
+    if (llvm::find(commandLine, "-formal-cxx-interoperability-mode=off") ==
+        commandLine.end()) {
+      for (const auto &clangDepName : allClangDependencies) {
+        // If this Clang module is a part of the C++ stdlib, and we haven't
+        // loaded the overlay for it so far, it is a split libc++ module (e.g.
+        // std_vector). Load the CxxStdlib overlay explicitly.
+        const auto &clangDepInfo =
+            cache.findDependency(clangDepName, ModuleDependencyKind::Clang)
+                .value()
+                ->getAsClangModule();
+        if (importer::isCxxStdModule(clangDepName, clangDepInfo->IsSystem) &&
+            !swiftOverlayDependencies.contains(
+                {clangDepName, ModuleDependencyKind::SwiftInterface}) &&
+            !swiftOverlayDependencies.contains(
+                {clangDepName, ModuleDependencyKind::SwiftBinary})) {
+          scanForSwiftDependency(
+              getModuleImportIdentifier(ScanASTContext.Id_CxxStdlib.str()));
+          recordResult(ScanASTContext.Id_CxxStdlib.str().str());
+          break;
+        }
       }
     }
   }
@@ -1401,7 +1409,7 @@ void ModuleDependencyScanner::resolveCrossImportOverlayDependencies(
   // Update the command-line on the main module to
   // disable implicit cross-import overlay search.
   auto mainDep = cache.findKnownDependency(actualMainID);
-  auto cmdCopy = mainDep.getCommandline();
+  std::vector<std::string> cmdCopy = mainDep.getCommandline();
   cmdCopy.push_back("-disable-cross-import-overlay-search");
   for (auto &entry : overlayFiles) {
     mainDep.addAuxiliaryFile(entry.second);

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -933,7 +933,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
     moduleInfo->details = getModuleDetails();
 
     // Create a link libraries set for this module
-    auto &linkLibraries = moduleDependencyInfo.getLinkLibraries();
+    auto linkLibraries = moduleDependencyInfo.getLinkLibraries();
     swiftscan_link_library_set_t *linkLibrarySet =
         new swiftscan_link_library_set_t;
     linkLibrarySet->count = linkLibraries.size();

--- a/test/ScanDependencies/no-cxx-overlay-for-non-interop-interface.swift
+++ b/test/ScanDependencies/no-cxx-overlay-for-non-interop-interface.swift
@@ -1,0 +1,78 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/deps)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %t/clientWithInteropDep.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -verify
+// RUN: cat %t/deps.json | %FileCheck %s -check-prefix=ENABLE-CHECK
+
+// RUN: %target-swift-frontend -scan-dependencies -o %t/deps_no_interop_dep.json %t/clientNoInteropDep.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -verify
+// RUN: cat %t/deps_no_interop_dep.json | %FileCheck %s -check-prefix=DISABLE-CHECK
+
+//--- deps/bar.h
+void bar(void);
+
+//--- deps/module.modulemap
+module std_Bar [system] {
+  header "bar.h"
+  export *
+}
+
+//--- deps/Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo -enable-library-evolution
+import std_Bar
+public struct Foo1 {}
+
+//--- deps/FooNoInterop.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name FooNoInterop -enable-library-evolution
+// swift-module-flags-ignorable: -formal-cxx-interoperability-mode=off
+import std_Bar
+public struct Foo2 {}
+
+//--- clientWithInteropDep.swift
+import Foo
+
+//--- clientNoInteropDep.swift
+import FooNoInterop
+
+// Ensure that when the 'Foo' dependency was built with C++ interop enabled,
+// it gets the C++ standard library overlay for its 'std_*' dependency
+//
+// 'Foo' as it appears in direct deps
+// ENABLE-CHECK: "swift": "Foo"
+// 'Foo' as it appears in source-import deps
+// ENABLE-CHECK: "swift": "Foo"
+// Actual dependency info node
+// ENABLE-CHECK: "swift": "Foo"
+// ENABLE-CHECK:      "directDependencies": [
+// ENABLE-CHECK:        {
+// ENABLE-CHECK:          "swift": "SwiftOnoneSupport"
+// ENABLE-CHECK:        },
+// ENABLE-CHECK:        {
+// ENABLE-CHECK:          "swift": "CxxStdlib"
+// ENABLE-CHECK:        },
+// ENABLE-CHECK:        {
+// ENABLE-CHECK:          "clang": "std_Bar"
+// ENABLE-CHECK:        }
+// ENABLE-CHECK:      ],
+
+// Ensure that when the 'Foo' dependency was *not* built with C++ interop enabled,
+// it does not get the C++ standard library overlay for its 'std_*' dependency
+//
+// 'Foo' as it appears in direct deps
+// DISABLE-CHECK: "swift": "FooNoInterop"
+// 'Foo' as it appears in source-import deps
+// DISABLE-CHECK: "swift": "FooNoInterop"
+// Actual dependency info node
+// DISABLE-CHECK: "swift": "FooNoInterop"
+// DISABLE-CHECK:      "directDependencies": [
+// DISABLE-CHECK:        {
+// DISABLE-CHECK:          "swift": "SwiftOnoneSupport"
+// DISABLE-CHECK:        },
+// DISABLE-CHECK:        {
+// DISABLE-CHECK:          "clang": "std_Bar"
+// DISABLE-CHECK:        }
+// DISABLE-CHECK:      ],
+
+


### PR DESCRIPTION
When we discover a textual module dependency which is a module which was not originally built from source using C++ interop (specifying '-formal-cxx-interoperability-mode=off'), avoid looking up the C++ standard library Swift overlay for it. This is required for the case of the 'Darwin' module, for example, which includes headers which map to C++ stdlib headers when the compiler is operating in C++ interop mode, but the C++ standard library Swift overlay module itself depends on 'Darwin', which results in a cycle. To resolve such situations, we can rely on the fact that Swift textual interfaces of modules which were not built with C++ interop must be able to build without importing the C++ standard library Swift overlay, so we avoid specifying it as a dependency for such modules.

The primary source module, as well as Swift textual module dependencies which *were* built with C++ interop will continue getting a direct depedency of the 'CxxStdlib' Swift module.

Resolves rdar://150222155
