### PR TITLE
[6.2] [Frontend] Avoid storing StringRef values in `ModuleAliasMap`

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -620,7 +620,7 @@ public:
   /// For example, if '-module-alias Foo=X -module-alias Bar=Y' input is passed in, the aliases Foo and Bar are
   /// the names of the imported or referenced modules in source files in the main module, and X and Y
   /// are the real (physical) module names on disk.
-  void setModuleAliases(const llvm::StringMap<StringRef> &aliasMap);
+  void setModuleAliases(const llvm::StringMap<std::string> &aliasMap);
 
   /// Adds a given alias to the map of Identifiers between module aliases and
   /// their actual names.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -58,7 +58,7 @@ public:
   std::string ImplicitObjCPCHPath;
 
   /// The map of aliases and real names of imported or referenced modules.
-  llvm::StringMap<StringRef> ModuleAliasMap;
+  llvm::StringMap<std::string> ModuleAliasMap;
 
   /// The name of the module that the frontend is building.
   std::string ModuleName;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2151,15 +2151,14 @@ void ASTContext::addModuleInterfaceChecker(
   getImpl().InterfaceChecker = std::move(checker);
 }
 
-void ASTContext::setModuleAliases(const llvm::StringMap<StringRef> &aliasMap) {
+void ASTContext::setModuleAliases(
+    const llvm::StringMap<std::string> &aliasMap) {
   // This setter should be called only once after ASTContext has been initialized
   assert(ModuleAliasMap.empty());
-  
-  for (auto k: aliasMap.keys()) {
-    auto v = aliasMap.lookup(k);
-    if (!v.empty()) {
-      addModuleAlias(k, v);
-    }
+
+  for (auto &entry : aliasMap) {
+    if (!entry.getValue().empty())
+      addModuleAlias(entry.getKey(), entry.getValue());
   }
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -980,13 +980,12 @@ bool ModuleAliasesConverter::computeModuleAliases(std::vector<std::string> args,
 
       // First, add the real name as a key to prevent it from being
       // used as an alias
-      if (!options.ModuleAliasMap.insert({rhs, StringRef()}).second) {
+      if (!options.ModuleAliasMap.insert({rhs, ""}).second) {
         diags.diagnose(SourceLoc(), diag::error_module_alias_duplicate, rhs);
         return false;
       }
       // Next, add the alias as a key and the real name as a value to the map
-      auto underlyingName = options.ModuleAliasMap.find(rhs)->first();
-      if (!options.ModuleAliasMap.insert({lhs, underlyingName}).second) {
+      if (!options.ModuleAliasMap.insert({lhs, rhs.str()}).second) {
         diags.diagnose(SourceLoc(), diag::error_module_alias_duplicate, lhs);
         return false;
       }

--- a/test/SourceKit/Misc/rdar148130166.swift
+++ b/test/SourceKit/Misc/rdar148130166.swift
@@ -1,0 +1,5 @@
+// RUN: env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib %sourcekitd-test -req=active-regions %s -- %s -module-name B -module-alias A=B
+// Make sure we don't crash.
+
+// guardmalloc is incompatible with ASAN
+// REQUIRES: no_asan


### PR DESCRIPTION
*6.2 cherry-pick of #81414*

- Explanation: Fixes a SourceKit crash that could occur with `-module-alias`
- Scope: Affects `-module-alias` with SourceKit
- Issue: rdar://148130166
- Risk: Low, the fix is straightforward
- Testing: Added tests to test suite
- Reviewer: Artem Chikin, Ben Barham