### PR TITLE
[SE-0470] Fix synthesized conformances with default main actor isolation

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -713,6 +713,9 @@ public:
     return ExplicitSafety::Unspecified;
   }
 
+  /// Whether this conformance has explicitly-specified global actor isolation.
+  bool hasExplicitGlobalActorIsolation() const;
+
   /// Determine whether we've lazily computed the associated conformance array
   /// already.
   bool hasComputedAssociatedConformances() const {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -515,6 +515,10 @@ TypeExpr *NormalProtocolConformance::getExplicitGlobalActorIsolation() const {
   return ctx.getGlobalCache().conformanceExplicitGlobalActorIsolation[this];
 }
 
+bool NormalProtocolConformance::hasExplicitGlobalActorIsolation() const {
+  return Bits.NormalProtocolConformance.HasExplicitGlobalActor;
+}
+
 void
 NormalProtocolConformance::setExplicitGlobalActorIsolation(TypeExpr *typeExpr) {
   if (!typeExpr) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1723,12 +1723,52 @@ bool swift::hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   });
 }
 
+/// Determine whether a synth
+static bool synthesizedRequirementIsNonIsolated(
+    const NormalProtocolConformance *conformance) {
+  // @preconcurrency suppresses this.
+  if (conformance->isPreconcurrency())
+    return false;
+
+  // Explicit global actor isolation suppresses this.
+  if (conformance->hasExplicitGlobalActorIsolation())
+    return false;
+
+  // Explicit nonisolated forces this.
+  if (conformance->getOptions()
+          .contains(ProtocolConformanceFlags::Nonisolated))
+    return true;
+
+  // When we are inferring conformance isolation, only add nonisolated if
+  // either
+  //   (1) the protocol inherits from SendableMetatype, or
+  //   (2) the conforming type is nonisolated.
+  ASTContext &ctx = conformance->getDeclContext()->getASTContext();
+  if (!ctx.LangOpts.hasFeature(Feature::InferIsolatedConformances))
+    return true;
+
+  // Check inheritance from SendableMetatype, which implies that the conformance
+  // will be nonisolated.
+  auto sendableMetatypeProto =
+      ctx.getProtocol(KnownProtocolKind::SendableMetatype);
+  if (sendableMetatypeProto &&
+      conformance->getProtocol()->inheritsFrom(sendableMetatypeProto))
+    return true;
+
+  auto nominalType = conformance->getType()->getAnyNominal();
+  if (!nominalType)
+    return true;
+
+  return !getActorIsolation(nominalType).isMainActor();
+}
+
 bool swift::addNonIsolatedToSynthesized(DerivedConformance &derived,
                                         ValueDecl *value) {
   if (auto *conformance = derived.Conformance) {
-    if (conformance && conformance->isPreconcurrency())
+    if (!synthesizedRequirementIsNonIsolated(conformance))
       return false;
   }
+
   return addNonIsolatedToSynthesized(derived.Nominal, value);
 }
 

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -155,6 +155,16 @@ addImplicitCodingKeys(NominalTypeDecl *target,
   enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);
 
+  switch (C.LangOpts.DefaultIsolationBehavior) {
+  case DefaultIsolation::MainActor:
+    enumDecl->getAttrs().add(NonisolatedAttr::createImplicit(C));
+    break;
+
+  case DefaultIsolation::Nonisolated:
+    // Nothing to do.
+    break;
+  }
+
   // For classes which inherit from something Encodable or Decodable, we
   // provide case `super` as the first key (to be used in encoding super).
   auto *classDecl = dyn_cast<ClassDecl>(target);

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -42,6 +42,24 @@ nonisolated class CNonIsolated: P {
   @MainActor func f() { } // expected-note{{main actor-isolated instance method 'f()' cannot satisfy nonisolated requirement}}
 }
 
+// Synthesized conformances
+struct EquatableStruct: Equatable {
+  var state: Int = 0
+}
+
+struct HashableStruct: Hashable {
+  var state: Int = 0
+}
+
+enum RawRepresentableEnum: Int {
+case one
+case two
+}
+
+class CodableClass: Codable {
+  var state: Int = 0
+}
+
 func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }
 func acceptSendableQMeta<T: Sendable & Q>(_: T.Type) { }
 
@@ -55,4 +73,10 @@ nonisolated func testConformancesFromNonisolated() {
   // Okay, these are nonisolated conformances.
   let _: any Q = CExplicitMainActor()
   let _: any Q = CImplicitMainActor()
+
+  // Error, these are main-actor-isolated conformances
+  let _: any Equatable.Type = EquatableStruct.self // expected-error{{main actor-isolated conformance of 'EquatableStruct' to 'Equatable' cannot be used in nonisolated context}}
+  let _: any Hashable.Type = HashableStruct.self // expected-error{{main actor-isolated conformance of 'HashableStruct' to 'Hashable' cannot be used in nonisolated context}}
+  let _: any RawRepresentable.Type = RawRepresentableEnum.self
+  let _: any Encodable.Type = CodableClass.self // expected-error{{main actor-isolated conformance of 'CodableClass' to 'Encodable' cannot be used in nonisolated context}}
 }


### PR DESCRIPTION
When defaulting to main-actor isolation, types that have synthesized conformances (e.g., for Equatable, Hashable, Codable) were getting nonisolated members by default. That would cause compiler errors because the conformances themselves defaulted to main-actor isolation when their types were.

Be careful to only mark these members as 'nonisolated' when it makes sense, and leave them to get the isolation of their enclosing type when the conformance might have isolation. This ensures that one can use synthesis of these protocols along with default main-actor mode.

There is a one-off trick here to force the synthesized CodingKeys to be nonisolated, because the CodingKey protocol requires Sendable. We'll separately consider whether to generalize this rule.

More of rdar://150691429.