### PR TITLE
Fix `@_implements` type resolution diagnostics

### DIFF
--- a/test/attr/attr_implements_bad_types.swift
+++ b/test/attr/attr_implements_bad_types.swift
@@ -21,5 +21,9 @@ struct S0 : NeedsF0 {  // expected-error {{type 'S0' does not conform to protoco
   @_implements(Equatable, ==(_:_:)) // expected-error {{containing type 'S0' does not conform to protocol 'Equatable'}}
   static func gg2(x:S0, y:S0) -> Bool {
   }
+
+  @_implements(NonexistentType, ff3()) // expected-error {{cannot find type 'NonexistentType' in scope}}
+  func gg3() {
+  }
 }
 


### PR DESCRIPTION
If a type in an `@_implements` attribute failed to resolve, Sema would assume it was because the type existed but wasn’t a protocol, even if there was another reason for the problem (such as the type not existing). Explicitly resolve the TypeRepr again through a path that will produce diagnostics.

Extracted from (an unpushed rebase of) #34556.