### PR TITLE
[Parse]Check if unsafe is used as the condition operand in a ternary operator

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -421,8 +421,9 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 
   if (Tok.isContextualKeyword("unsafe") &&
       !(peekToken().isAtStartOfLine() ||
-        peekToken().isAny(tok::r_paren, tok::r_brace, tok::r_square,
-                          tok::equal, tok::colon, tok::comma, tok::eof) ||
+        peekToken().isAny(tok::r_paren, tok::r_brace, tok::r_square, tok::equal,
+                          tok::colon, tok::comma, tok::eof,
+                          tok::question_infix) ||
         (isExprBasic && peekToken().is(tok::l_brace)) ||
         peekToken().is(tok::period) ||
         (peekToken().isAny(tok::l_paren, tok::l_square) &&

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -422,12 +422,13 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
   if (Tok.isContextualKeyword("unsafe") &&
       !(peekToken().isAtStartOfLine() ||
         peekToken().isAny(tok::r_paren, tok::r_brace, tok::r_square, tok::equal,
-                          tok::colon, tok::comma, tok::eof,
-                          tok::question_infix) ||
+                          tok::colon, tok::comma, tok::eof) ||
         (isExprBasic && peekToken().is(tok::l_brace)) ||
         peekToken().is(tok::period) ||
         (peekToken().isAny(tok::l_paren, tok::l_square) &&
-         peekToken().getRange().getStart() == Tok.getRange().getEnd()))) {
+         peekToken().getRange().getStart() == Tok.getRange().getEnd()) ||
+        peekToken().isBinaryOperatorLike() ||
+        peekToken().isPostfixOperatorLike())) {
     Tok.setKind(tok::contextual_keyword);
     SourceLoc unsafeLoc = consumeToken();
     ParserResult<Expr> sub =

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -200,6 +200,8 @@ func unsafeFun() {
   _ = color
 
   if unsafe { }
+
+  _ = unsafe ? 1 : 0
 }
 
 func moreUnsafeFunc(unsafe: [Int]) {

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -220,6 +220,10 @@ func yetMoreUnsafeFunc(unsafe: () -> Void) {
   // expected-warning@-1{{no unsafe operations occur within 'unsafe' expression}}
 }
 
+func yetMoreMoreUnsafeFunc(unsafe: Int?) {
+  _ = unsafe! + 1
+}
+
 // @safe suppresses unsafe-type-related diagnostics on an entity
 struct MyArray<Element> {
   @safe func withUnsafeBufferPointer<R, E>(

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -221,7 +221,10 @@ func yetMoreUnsafeFunc(unsafe: () -> Void) {
 }
 
 func yetMoreMoreUnsafeFunc(unsafe: Int?) {
-  _ = unsafe! + 1
+  _ = unsafe!
+  if let unsafe {
+    _ = unsafe + 1
+  }
 }
 
 // @safe suppresses unsafe-type-related diagnostics on an entity


### PR DESCRIPTION
Resolves #81323 

It appears we forgot to check whether `unsafe` is used as the condition in a ternary operator.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
