### PR TITLE
[embedded] Fix `memmove` for testing

### DIFF
--- a/utils/embedded-test-support/libc.c
+++ b/utils/embedded-test-support/libc.c
@@ -81,7 +81,7 @@ int memcmp(const void *s1, const void *s2, size_t n) {
 
 __attribute__((used))
 void *memmove(void *dst, const void *src, size_t n) {
-  if ((uintptr_t)dst > (uintptr_t)src) {
+  if ((uintptr_t)dst < (uintptr_t)src) {
     for (int i = 0; i < n; i++) {
       ((char *)dst)[i] = ((char *)src)[i];
     }


### PR DESCRIPTION
`memmove` in `utils/embedded-test-support/libc.c` is obviously wrong. It appears that the conditional branch has been inverted.

refs: https://git.musl-libc.org/cgit/musl/tree/src/string/memmove.c