### PR TITLE
utils: indicate that the old driver is in effect

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1348,6 +1348,7 @@ function Build-CMakeProject {
       } else {
         Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER (Join-Path -Path (Get-PinnedToolchainToolsDir) -ChildPath  "swiftc.exe")
       }
+      Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_USE_OLD_DRIVER "YES"
       if (-not ($Platform.OS -eq [OS]::Windows)) {
         Add-KeyValueIfNew $Defines CMAKE_Swift_COMPILER_WORKS = "YES"
       }


### PR DESCRIPTION
We currently cannot boostrap the toolchain with an early swift-driver. Mark that we are using the old driver. Once the new experimental SDK is packaged, we should be able to start building the early swift-driver with static linking to use the bootstrapped driver.