### PR TITLE
[6.2] build.ps1 updates for new SwiftASN1 dependency

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2986,6 +2986,9 @@ function Test-SourceKitLSP {
     "-Xswiftc", "-I$(Get-ProjectBinaryCache $BuildPlatform Crypto)\swift",
     "-Xlinker", "-L$(Get-ProjectBinaryCache $BuildPlatform Crypto)\lib",
     "-Xlinker", "$(Get-ProjectBinaryCache $BuildPlatform Crypto)\lib\CCryptoBoringSSL.lib",
+    # swift-asn1
+    "-Xswiftc", "-I$(Get-ProjectBinaryCache $BuildPlatform ASN1)\swift",
+    "-Xlinker", "-L$(Get-ProjectBinaryCache $BuildPlatform ASN1)\lib",
     # swift-package-manager
     "-Xswiftc", "-I$(Get-ProjectBinaryCache $BuildPlatform PackageManager)\swift",
     "-Xlinker", "-L$(Get-ProjectBinaryCache $BuildPlatform PackageManager)\lib",

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2944,6 +2944,7 @@ function Build-SourceKitLSP([Hashtable] $Platform) {
       TSC_DIR = (Get-ProjectCMakeModules $Platform ToolsSupportCore);
       LLBuild_DIR = (Get-ProjectCMakeModules $Platform LLBuild);
       ArgumentParser_DIR = (Get-ProjectCMakeModules $Platform ArgumentParser);
+      SwiftASN1_DIR = (Get-ProjectCMakeModules $Platform ASN1);
       SwiftCrypto_DIR = (Get-ProjectCMakeModules $Platform Crypto);
       SwiftCollections_DIR = (Get-ProjectCMakeModules $Platform Collections);
       SwiftBuild_DIR = (Get-ProjectCMakeModules $Platform Build);


### PR DESCRIPTION
- **Explanation**: Updates the Windows SourceKit-LSP build to pass through a new ASN1 dependency that was added in SwiftPM.
- **Scope**: Windows SourceKit-LSP
- **Risk**: None as long as the build passes
- **Reviewed By**: @compnerd @ahoppen 
- **Original PR**: https://github.com/swiftlang/swift/pull/81353 and https://github.com/swiftlang/swift/pull/81391

