### PR TITLE
Assert diagnostic location is valid in `EmbeddedSwiftDiagnostics.swift`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/EmbeddedSwiftDiagnostics.swift
@@ -220,6 +220,7 @@ private struct FunctionChecker {
       return
     }
     if !conformance.protocol.requiresClass {
+      assert(location.hasValidLineNumber)
       throw Diagnostic(.embedded_swift_existential_protocol, conformance.protocol.name, at: location)
     }
 


### PR DESCRIPTION
`assert(location.hasValidLineNumber)` before throwing `embedded_swift_existential_protocol` should help with debugging cases where diagnostic location is missing.