### PR TITLE
[SE-0470] Include isolated conformance checks for default value expressions

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1723,7 +1723,8 @@ bool swift::hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   });
 }
 
-/// Determine whether a synth
+/// Determine whether a synthesized requirement for the given conformance
+/// should be explicitly marked as 'nonisolated'.
 static bool synthesizedRequirementIsNonIsolated(
     const NormalProtocolConformance *conformance) {
   // @preconcurrency suppresses this.

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -734,12 +734,22 @@ void introduceUnsafeInheritExecutorReplacements(
 void introduceUnsafeInheritExecutorReplacements(
     const DeclContext *dc, Type base, SourceLoc loc, LookupResult &result);
 
+/// Function that attempts to handle all of the "bad" conformance isolation
+/// found somewhere, and returns true if it handled them. If not, returns
+/// false so that the conformances can be diagnose.
+using HandleConformanceIsolationFn =
+  llvm::function_ref<bool(ArrayRef<ActorIsolation>)>;
+
+/// Function used as a default HandleConformanceIsolationFn.
+bool doNotDiagnoseConformanceIsolation(ArrayRef<ActorIsolation>);
+
 /// Check for correct use of isolated conformances in the given reference.
 ///
 /// This checks that any isolated conformances that occur in the given
 /// declaration reference match the isolated of the context.
 bool checkIsolatedConformancesInContext(
-    ConcreteDeclRef declRef, SourceLoc loc, const DeclContext *dc);
+    ConcreteDeclRef declRef, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
 /// Check for correct use of isolated conformances in the set given set of
 /// protocol conformances.
@@ -748,7 +758,8 @@ bool checkIsolatedConformancesInContext(
 /// declaration reference match the isolated of the context.
 bool checkIsolatedConformancesInContext(
     ArrayRef<ProtocolConformanceRef> conformances, SourceLoc loc,
-    const DeclContext *dc);
+    const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
 /// Check for correct use of isolated conformances in the given substitution
 /// map.
@@ -756,14 +767,16 @@ bool checkIsolatedConformancesInContext(
 /// This checks that any isolated conformances that occur in the given
 /// substitution map match the isolated of the context.
 bool checkIsolatedConformancesInContext(
-    SubstitutionMap subs, SourceLoc loc, const DeclContext *dc);
+    SubstitutionMap subs, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
 /// Check for correct use of isolated conformances in the given type.
 ///
 /// This checks that any isolated conformances that occur in the given
 /// type match the isolated of the context.
 bool checkIsolatedConformancesInContext(
-    Type type, SourceLoc loc, const DeclContext *dc);
+    Type type, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
 } // end namespace swift
 

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -60,6 +60,10 @@ class CodableClass: Codable {
   var state: Int = 0
 }
 
+class OtherClass {
+  var otherState: any Encodable.Type = CodableClass.self
+}
+
 func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }
 func acceptSendableQMeta<T: Sendable & Q>(_: T.Type) { }
 

--- a/test/Concurrency/isolated_conformance_inference.swift
+++ b/test/Concurrency/isolated_conformance_inference.swift
@@ -73,3 +73,22 @@ nonisolated func testConformancesFromNonisolated(tdc: TestDerivedCodable) {
 
   let _: any Codable = tdc
 }
+
+protocol P2 {
+  func g()
+}
+
+struct DifferingConformances: @MainActor P {
+  @MainActor func f() { }
+}
+
+extension DifferingConformances: @SomeGlobalActor P2 {
+  @SomeGlobalActor func g() { }
+}
+
+@MainActor
+class InferMeDefaults {
+  var mainState: any P.Type = DifferingConformances.self
+  var someGlobalActorState: any P2.Type = DifferingConformances.self // expected-error{{global actor 'SomeGlobalActor'-isolated default value in a main actor-isolated context}}
+  var bothState: any (P & P2).Type = DifferingConformances.self // expected-error{{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+}


### PR DESCRIPTION
Per SE-0411, we compute the isolation of a default value expression based on what isolation it requires. Include isolated conformance checks in this computation, rather than always emitting diagnostics, so that the combination of isolated default values + isolated conformances works as expected.

Fixes rdar://150691429.