### PR TITLE
[SE-0470] Include isolated conformance checks for default value expressions

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1728,7 +1728,8 @@ bool swift::hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   });
 }
 
-/// Determine whether a synth
+/// Determine whether a synthesized requirement for the given conformance
+/// should be explicitly marked as 'nonisolated'.
 static bool synthesizedRequirementIsNonIsolated(
     const NormalProtocolConformance *conformance) {
   // @preconcurrency suppresses this.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2839,6 +2839,29 @@ namespace {
       }
     }
 
+    /// Function object that refines isolation for each actor isolation it is
+    /// given, returning true if all of the provided isolations have been
+    /// accounted for, or false if the caller should handle them.
+    class RefineConformances {
+      ActorIsolationChecker &self;
+
+    public:
+      RefineConformances(ActorIsolationChecker &self) : self(self) { }
+
+      bool operator()(ArrayRef<ActorIsolation> isolations) const {
+        bool anyRefined = false;
+        bool anyUnrefined = false;
+        for (const auto &isolation : isolations) {
+          if (self.refineRequiredIsolation(isolation))
+            anyRefined = true;
+          else
+            anyUnrefined = true;
+        }
+
+        return anyRefined && !anyUnrefined;
+      }
+    };
+
     bool refineRequiredIsolation(ActorIsolation refinedIsolation) {
       if (requiredIsolationLoc.isInvalid())
         return false;
@@ -3348,13 +3371,13 @@ namespace {
       if (auto erasureExpr = dyn_cast<ErasureExpr>(expr)) {
         checkIsolatedConformancesInContext(
             erasureExpr->getConformances(), erasureExpr->getLoc(),
-            getDeclContext());
+            getDeclContext(), RefineConformances{*this});
       }
 
       if (auto *underlyingToOpaque = dyn_cast<UnderlyingToOpaqueExpr>(expr)) {
         checkIsolatedConformancesInContext(
             underlyingToOpaque->substitutions, underlyingToOpaque->getLoc(),
-            getDeclContext());
+            getDeclContext(), RefineConformances{*this});
       }
 
       return Action::Continue(expr);
@@ -4463,7 +4486,8 @@ namespace {
         return false;
 
       // Make sure isolated conformances are formed in the right context.
-      checkIsolatedConformancesInContext(declRef, loc, getDeclContext());
+      checkIsolatedConformancesInContext(declRef, loc, getDeclContext(),
+                                         RefineConformances{*this});
 
       auto *const decl = declRef.getDecl();
 
@@ -8039,11 +8063,14 @@ namespace {
   class MismatchedIsolatedConformances {
     llvm::TinyPtrVector<ProtocolConformance *> badIsolatedConformances;
     DeclContext *fromDC;
+    HandleConformanceIsolationFn handleBad;
     mutable std::optional<ActorIsolation> fromIsolation;
 
   public:
-    MismatchedIsolatedConformances(const DeclContext *fromDC)
-      : fromDC(const_cast<DeclContext *>(fromDC)) { }
+    MismatchedIsolatedConformances(const DeclContext *fromDC,
+                                   HandleConformanceIsolationFn handleBad)
+      : fromDC(const_cast<DeclContext *>(fromDC)),
+        handleBad(handleBad) { }
 
     ActorIsolation getContextIsolation() const {
       if (!fromIsolation)
@@ -8083,6 +8110,16 @@ namespace {
       if (badIsolatedConformances.empty())
         return false;
 
+      if (handleBad) {
+        // Capture all of the actor isolations from the conformances.
+        std::vector<ActorIsolation> badIsolations;
+        for (auto conformance : badIsolatedConformances)
+          badIsolations.push_back(conformance->getIsolation());
+
+        if (handleBad(badIsolations))
+          return false;
+      }
+
       ASTContext &ctx = fromDC->getASTContext();
       auto firstConformance = badIsolatedConformances.front();
       ctx.Diags.diagnose(
@@ -8098,32 +8135,40 @@ namespace {
 
 }
 
+bool swift::doNotDiagnoseConformanceIsolation(ArrayRef<ActorIsolation>) {
+  return false;
+}
+
 bool swift::checkIsolatedConformancesInContext(
-    ConcreteDeclRef declRef, SourceLoc loc, const DeclContext *dc) {
-  MismatchedIsolatedConformances mismatched(dc);
+    ConcreteDeclRef declRef, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad) {
+  MismatchedIsolatedConformances mismatched(dc, handleBad);
   forEachConformance(declRef, mismatched);
   return mismatched.diagnose(loc);
 }
 
 bool swift::checkIsolatedConformancesInContext(
     ArrayRef<ProtocolConformanceRef> conformances, SourceLoc loc,
-    const DeclContext *dc) {
-  MismatchedIsolatedConformances mismatched(dc);
+    const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad) {
+  MismatchedIsolatedConformances mismatched(dc, handleBad);
   for (auto conformance: conformances)
     forEachConformance(conformance, mismatched);
   return mismatched.diagnose(loc);
 }
 
 bool swift::checkIsolatedConformancesInContext(
-    SubstitutionMap subs, SourceLoc loc, const DeclContext *dc) {
-  MismatchedIsolatedConformances mismatched(dc);
+    SubstitutionMap subs, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad) {
+  MismatchedIsolatedConformances mismatched(dc, handleBad);
   forEachConformance(subs, mismatched);
   return mismatched.diagnose(loc);
 }
 
 bool swift::checkIsolatedConformancesInContext(
-    Type type, SourceLoc loc, const DeclContext *dc) {
-  MismatchedIsolatedConformances mismatched(dc);
+    Type type, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad) {
+  MismatchedIsolatedConformances mismatched(dc, handleBad);
   forEachConformance(type, mismatched);
   return mismatched.diagnose(loc);
 }

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -702,12 +702,22 @@ void introduceUnsafeInheritExecutorReplacements(
 void introduceUnsafeInheritExecutorReplacements(
     const DeclContext *dc, Type base, SourceLoc loc, LookupResult &result);
 
+/// Function that attempts to handle all of the "bad" conformance isolation
+/// found somewhere, and returns true if it handled them. If not, returns
+/// false so that the conformances can be diagnose.
+using HandleConformanceIsolationFn =
+  llvm::function_ref<bool(ArrayRef<ActorIsolation>)>;
+
+/// Function used as a default HandleConformanceIsolationFn.
+bool doNotDiagnoseConformanceIsolation(ArrayRef<ActorIsolation>);
+
 /// Check for correct use of isolated conformances in the given reference.
 ///
 /// This checks that any isolated conformances that occur in the given
 /// declaration reference match the isolated of the context.
 bool checkIsolatedConformancesInContext(
-    ConcreteDeclRef declRef, SourceLoc loc, const DeclContext *dc);
+    ConcreteDeclRef declRef, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
 /// Check for correct use of isolated conformances in the set given set of
 /// protocol conformances.
@@ -716,7 +726,8 @@ bool checkIsolatedConformancesInContext(
 /// declaration reference match the isolated of the context.
 bool checkIsolatedConformancesInContext(
     ArrayRef<ProtocolConformanceRef> conformances, SourceLoc loc,
-    const DeclContext *dc);
+    const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
 /// Check for correct use of isolated conformances in the given substitution
 /// map.
@@ -724,14 +735,16 @@ bool checkIsolatedConformancesInContext(
 /// This checks that any isolated conformances that occur in the given
 /// substitution map match the isolated of the context.
 bool checkIsolatedConformancesInContext(
-    SubstitutionMap subs, SourceLoc loc, const DeclContext *dc);
+    SubstitutionMap subs, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
 /// Check for correct use of isolated conformances in the given type.
 ///
 /// This checks that any isolated conformances that occur in the given
 /// type match the isolated of the context.
 bool checkIsolatedConformancesInContext(
-    Type type, SourceLoc loc, const DeclContext *dc);
+    Type type, SourceLoc loc, const DeclContext *dc,
+    HandleConformanceIsolationFn handleBad = doNotDiagnoseConformanceIsolation);
 
 } // end namespace swift
 

--- a/test/Concurrency/isolated_conformance_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_default_actor.swift
@@ -60,6 +60,10 @@ class CodableClass: Codable {
   var state: Int = 0
 }
 
+class OtherClass {
+  var otherState: any Encodable.Type = CodableClass.self
+}
+
 func acceptSendablePMeta<T: Sendable & P>(_: T.Type) { }
 func acceptSendableQMeta<T: Sendable & Q>(_: T.Type) { }
 

--- a/test/Concurrency/isolated_conformance_inference.swift
+++ b/test/Concurrency/isolated_conformance_inference.swift
@@ -73,3 +73,22 @@ nonisolated func testConformancesFromNonisolated(tdc: TestDerivedCodable) {
 
   let _: any Codable = tdc
 }
+
+protocol P2 {
+  func g()
+}
+
+struct DifferingConformances: @MainActor P {
+  @MainActor func f() { }
+}
+
+extension DifferingConformances: @SomeGlobalActor P2 {
+  @SomeGlobalActor func g() { }
+}
+
+@MainActor
+class InferMeDefaults {
+  var mainState: any P.Type = DifferingConformances.self
+  var someGlobalActorState: any P2.Type = DifferingConformances.self // expected-error{{global actor 'SomeGlobalActor'-isolated default value in a main actor-isolated context}}
+  var bothState: any (P & P2).Type = DifferingConformances.self // expected-error{{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+}


### PR DESCRIPTION
- **Explanation**: Include the checks for isolated conformances (SE-0470) when determining the isolation of a default value expression (SE-0411), rather than always emitting isolated-conformance diagnostics. This means that isolated conformances contribute to the isolation computed for a default value, which is especially important in default-main-actor mode, where more types (and therefore their conformances) are on the main actor. 
- **Scope**: Limited to the actor isolation checker, and only has any user-visible effect when isolated conformances are used either directly (e.g., `@MainActor Codable`) or through inference (`InferIsolatedConformances` or default main actor).
- **Issues**:  rdar://150691429
- **Original PRs**: https://github.com/swiftlang/swift/pull/81450
- **Risk**: Low due to the narrow scope, and fact that it depends on other new features to change behavior.
- **Testing**: CI, side projects with default main-actor mode
- **Reviewers**: (not yet)