### PR TITLE
[6.2 🍒][Dependency Scanning][Refactor] Reduce the number of ClangImporter instances used by the scanner

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -374,7 +374,7 @@ public:
   getModuleDependencies(Identifier moduleName,
                         StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
-                        clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
+                        const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
                         InterfaceSubContextDelegate &delegate,
                         llvm::PrefixMapper *mapper = nullptr,
                         bool isTestableImport = false) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -64,6 +64,7 @@ namespace tooling {
 namespace dependencies {
   struct ModuleDeps;
   struct TranslationUnitDeps;
+  enum class ModuleOutputKind;
   using ModuleDepsGraph = std::vector<ModuleDeps>;
 }
 }
@@ -209,8 +210,7 @@ public:
                        bool ignoreClangTarget = false);
 
   std::vector<std::string>
-  getClangDepScanningInvocationArguments(ASTContext &ctx,
-      std::optional<StringRef> sourceFileName = std::nullopt);
+  getClangDepScanningInvocationArguments(ASTContext &ctx);
 
   static std::unique_ptr<clang::CompilerInvocation>
   createClangInvocation(ClangImporter *importer,
@@ -497,53 +497,31 @@ public:
   void verifyAllModules() override;
 
   using RemapPathCallback = llvm::function_ref<std::string(StringRef)>;
-  llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
+  using LookupModuleOutputCallback =
+      llvm::function_ref<std::string(const clang::tooling::dependencies::ModuleDeps &,
+                                     clang::tooling::dependencies::ModuleOutputKind)>;
+  
+  static llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
   bridgeClangModuleDependencies(
+      const ASTContext &ctx,
       clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
       clang::tooling::dependencies::ModuleDepsGraph &clangDependencies,
       StringRef moduleOutputPath, StringRef stableModuleOutputPath,
+      LookupModuleOutputCallback LookupModuleOutput,
       RemapPathCallback remapPath = nullptr);
 
   llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
   getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
-                        clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
+                        const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
                         InterfaceSubContextDelegate &delegate,
                         llvm::PrefixMapper *mapper,
                         bool isTestableImport = false) override;
 
-  void recordBridgingHeaderOptions(
-      ModuleDependencyInfo &MDI,
-      const clang::tooling::dependencies::TranslationUnitDeps &deps);
-
-  void getBridgingHeaderOptions(
+  static void getBridgingHeaderOptions(
+      const ASTContext &ctx,
       const clang::tooling::dependencies::TranslationUnitDeps &deps,
       std::vector<std::string> &swiftArgs);
-
-  /// Query dependency information for header dependencies
-  /// of a binary Swift module.
-  ///
-  /// \param moduleID the name of the Swift module whose dependency
-  /// information will be augmented with information about the given
-  /// textual header inputs.
-  ///
-  /// \param headerPath the path to the header to be scanned.
-  ///
-  /// \param clangScanningTool The clang dependency scanner.
-  ///
-  /// \param cache The module dependencies cache to update, with information
-  /// about new Clang modules discovered along the way.
-  ///
-  /// \returns \c true if an error occurred, \c false otherwise
-  bool getHeaderDependencies(
-      ModuleDependencyID moduleID, std::optional<StringRef> headerPath,
-      std::optional<llvm::MemoryBufferRef> sourceBuffer,
-      clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
-      ModuleDependenciesCache &cache,
-      ModuleDependencyIDSetVector &headerClangModuleDependencies,
-      std::vector<std::string> &headerFileInputs,
-      std::vector<std::string> &bridgingHeaderCommandLine,
-      std::optional<std::string> &includeTreeID);
 
   clang::TargetInfo &getModuleAvailabilityTarget() const override;
   clang::ASTContext &getClangASTContext() const override;

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -50,6 +50,32 @@ private:
       StringRef sdkModuleOutputPath, llvm::PrefixMapper *prefixMapper,
       bool isTestableImport = false);
 
+  /// Query dependency information for header dependencies
+  /// of a binary Swift module.
+  ///
+  /// \param moduleID the name of the Swift module whose dependency
+  /// information will be augmented with information about the given
+  /// textual header inputs.
+  ///
+  /// \param headerPath the path to the header to be scanned.
+  ///
+  /// \param clangScanningTool The clang dependency scanner.
+  ///
+  /// \param cache The module dependencies cache to update, with information
+  /// about new Clang modules discovered along the way.
+  ///
+  /// \returns \c true if an error occurred, \c false otherwise
+  bool scanHeaderDependenciesOfSwiftModule(
+      const ASTContext &ctx,
+      ModuleDependencyID moduleID, std::optional<StringRef> headerPath,
+      std::optional<llvm::MemoryBufferRef> sourceBuffer,
+      ModuleDependenciesCache &cache,
+      ModuleDependencyIDSetVector &headerClangModuleDependencies,
+      std::vector<std::string> &headerFileInputs,
+      std::vector<std::string> &bridgingHeaderCommandLine,
+      std::optional<std::string> &includeTreeID);
+
+
   /// Store cache entry for include tree.
   llvm::Error
   createCacheKeyForEmbeddedHeader(std::string embeddedHeaderIncludeTree,
@@ -65,7 +91,17 @@ private:
   clang::tooling::dependencies::DependencyScanningTool clangScanningTool;
   // Swift and Clang module loaders acting as scanners.
   std::unique_ptr<ModuleInterfaceLoader> swiftScannerModuleLoader;
-  std::unique_ptr<ClangImporter> clangScannerModuleLoader;
+
+  // Base command line invocation for clang scanner queries (both module and header)
+  std::vector<std::string> clangScanningBaseCommandLineArgs;
+  // Command line invocation for clang by-name module lookups
+  std::vector<std::string> clangScanningModuleCommandLineArgs;
+  // Clang-specific (-Xcc) command-line flags to include on
+  // Swift module compilation commands
+  std::vector<std::string> swiftModuleClangCC1CommandLineArgs;
+  // Working directory for clang module lookup queries
+  std::string clangScanningWorkingDirectoryPath;
+
   // CAS instance.
   std::shared_ptr<llvm::cas::ObjectStore> CAS;
   std::shared_ptr<llvm::cas::ActionCache> ActionCache;

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -101,7 +101,7 @@ public:
   llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
   getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
-                        clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
+                        const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
                         InterfaceSubContextDelegate &delegate,
                         llvm::PrefixMapper *mapper,
                         bool isTestableImport) override;

--- a/include/swift/Serialization/ScanningLoaders.h
+++ b/include/swift/Serialization/ScanningLoaders.h
@@ -43,6 +43,9 @@ private:
   std::string moduleOutputPath;
   /// Location where pre-built SDK modules are to be built into.
   std::string sdkModuleOutputPath;
+  /// Clang-specific (-Xcc) command-line flags to include on
+  /// Swift module compilation commands
+  std::vector<std::string> swiftModuleClangCC1CommandLineArgs;
 
 public:
   std::optional<ModuleDependencyInfo> dependencies;
@@ -51,12 +54,14 @@ public:
                      Identifier moduleName,
                      InterfaceSubContextDelegate &astDelegate,
                      StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
+                     std::vector<std::string> swiftModuleClangCC1CommandLineArgs,
                      ScannerKind kind = MDS_plain)
       : SerializedModuleLoaderBase(ctx, nullptr, LoadMode,
                                    /*IgnoreSwiftSourceInfoFile=*/true),
         kind(kind), moduleName(moduleName), astDelegate(astDelegate),
         moduleOutputPath(moduleOutputPath),
-        sdkModuleOutputPath(sdkModuleOutputPath) {}
+        sdkModuleOutputPath(sdkModuleOutputPath),
+        swiftModuleClangCC1CommandLineArgs(swiftModuleClangCC1CommandLineArgs)  {}
 
   std::error_code findModuleFilesInDirectory(
       ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
@@ -100,9 +105,8 @@ public:
                                 StringRef moduleOutputPath,
                                 StringRef sdkModuleOutputPath)
       : SwiftModuleScanner(ctx, LoadMode, moduleName, astDelegate,
-                           moduleOutputPath, sdkModuleOutputPath,
+                           moduleOutputPath, sdkModuleOutputPath, {},
                            MDS_placeholder) {
-
     // FIXME: Find a better place for this map to live, to avoid
     // doing the parsing on every module.
     if (!PlaceholderDependencyModuleMap.empty()) {

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -266,7 +266,7 @@ public:
   virtual llvm::SmallVector<std::pair<ModuleDependencyID, ModuleDependencyInfo>, 1>
   getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
-                        clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
+                        const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
                         InterfaceSubContextDelegate &delegate,
                         llvm::PrefixMapper *mapper,
                         bool isTestableImport) override;

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -37,45 +37,6 @@ using namespace swift;
 using namespace clang::tooling;
 using namespace clang::tooling::dependencies;
 
-static std::string
-moduleCacheRelativeLookupModuleOutput(const ModuleDeps &MD, ModuleOutputKind MOK,
-                                      const StringRef moduleCachePath,
-                                      const StringRef stableModuleCachePath,
-                                      const StringRef runtimeResourcePath) {
-  llvm::SmallString<128> outputPath(moduleCachePath);
-  if (MD.IsInStableDirectories)
-    outputPath = stableModuleCachePath;
-
-  // FIXME: This is a hack to treat Clang modules defined in the compiler's
-  // own resource directory as stable, when they are not reported as such
-  // by the Clang scanner.
-  if (!runtimeResourcePath.empty() &&
-      hasPrefix(llvm::sys::path::begin(MD.ClangModuleMapFile),
-                llvm::sys::path::end(MD.ClangModuleMapFile),
-                llvm::sys::path::begin(runtimeResourcePath),
-                llvm::sys::path::end(runtimeResourcePath)))
-    outputPath = stableModuleCachePath;
-
-  llvm::sys::path::append(outputPath, MD.ID.ModuleName + "-" + MD.ID.ContextHash);
-  switch (MOK) {
-  case ModuleOutputKind::ModuleFile:
-    llvm::sys::path::replace_extension(
-        outputPath, getExtension(swift::file_types::TY_ClangModuleFile));
-    break;
-  case ModuleOutputKind::DependencyFile:
-    llvm::sys::path::replace_extension(
-        outputPath, getExtension(swift::file_types::TY_Dependencies));
-    break;
-  case ModuleOutputKind::DependencyTargets:
-    return MD.ID.ModuleName + "-" + MD.ID.ContextHash;
-  case ModuleOutputKind::DiagnosticSerializationFile:
-    llvm::sys::path::replace_extension(
-        outputPath, getExtension(swift::file_types::TY_SerializedDiagnostics));
-    break;
-  }
-  return outputPath.str().str();
-}
-
 static void addScannerPrefixMapperInvocationArguments(
     std::vector<std::string> &invocationArgStrs, ASTContext &ctx) {
   for (const auto &arg : ctx.SearchPathOpts.ScannerPrefixMapper) {
@@ -86,18 +47,9 @@ static void addScannerPrefixMapperInvocationArguments(
 
 /// Create the command line for Clang dependency scanning.
 std::vector<std::string> ClangImporter::getClangDepScanningInvocationArguments(
-    ASTContext &ctx, std::optional<StringRef> sourceFileName) {
+    ASTContext &ctx) {
   std::vector<std::string> commandLineArgs = getClangDriverArguments(ctx);
   addScannerPrefixMapperInvocationArguments(commandLineArgs, ctx);
-
-  auto sourceFilePos = std::find(
-      commandLineArgs.begin(), commandLineArgs.end(),
-      "<swift-imported-modules>");
-  assert(sourceFilePos != commandLineArgs.end());
-  if (sourceFileName.has_value())
-    *sourceFilePos = sourceFileName->str();
-  else
-    commandLineArgs.erase(sourceFilePos);
 
   // HACK! Drop the -fmodule-format= argument and the one that
   // precedes it.
@@ -149,11 +101,12 @@ getClangPrefixMapper(DependencyScanningTool &clangScanningTool,
 }
 
 ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
+    const ASTContext &ctx,
     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
     clang::tooling::dependencies::ModuleDepsGraph &clangDependencies,
     StringRef moduleOutputPath, StringRef stableModuleOutputPath,
+    LookupModuleOutputCallback lookupModuleOutput,
     RemapPathCallback callback) {
-  const auto &ctx = Impl.SwiftContext;
   ModuleDependencyVector result;
 
   auto remapPath = [&](StringRef path) {
@@ -182,9 +135,8 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
     swiftArgs.push_back("-module-name");
     swiftArgs.push_back(clangModuleDep.ID.ModuleName);
 
-    auto pcmPath = moduleCacheRelativeLookupModuleOutput(
-        clangModuleDep, ModuleOutputKind::ModuleFile, moduleOutputPath,
-        stableModuleOutputPath, ctx.SearchPathOpts.RuntimeResourcePath);
+    auto pcmPath = lookupModuleOutput(clangModuleDep,
+                                      ModuleOutputKind::ModuleFile);
     swiftArgs.push_back("-o");
     swiftArgs.push_back(pcmPath);
 
@@ -312,19 +264,10 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
   return result;
 }
 
-void ClangImporter::recordBridgingHeaderOptions(
-    ModuleDependencyInfo &MDI,
-    const clang::tooling::dependencies::TranslationUnitDeps &deps) {
-  std::vector<std::string> swiftArgs;
-  getBridgingHeaderOptions(deps, swiftArgs);
-  MDI.updateBridgingHeaderCommandLine(swiftArgs);
-}
-
 void ClangImporter::getBridgingHeaderOptions(
+    const ASTContext &ctx,
     const clang::tooling::dependencies::TranslationUnitDeps &deps,
     std::vector<std::string> &swiftArgs) {
-  auto &ctx = Impl.SwiftContext;
-
   auto addClangArg = [&](Twine arg) {
     swiftArgs.push_back("-Xcc");
     swiftArgs.push_back(arg.str());
@@ -390,165 +333,14 @@ void ClangImporter::getBridgingHeaderOptions(
   }
 }
 
-// The Swift compiler does not have a concept of a working directory.
-// It is instead handled by the Swift driver by resolving relative paths
-// according to the driver's notion of a working directory. On the other hand,
-// Clang does have a concept working directory which may be specified on this
-// Clang invocation with '-working-directory'. If so, it is crucial that we
-// use this directory as an argument to the Clang scanner invocation below.
-static std::optional<std::string>
-computeClangWorkingDirectory(const std::vector<std::string> &commandLineArgs,
-                             const ASTContext &ctx) {
-  std::string workingDir;
-  auto clangWorkingDirPos = std::find(
-      commandLineArgs.rbegin(), commandLineArgs.rend(), "-working-directory");
-  if (clangWorkingDirPos == commandLineArgs.rend())
-    workingDir =
-        ctx.SourceMgr.getFileSystem()->getCurrentWorkingDirectory().get();
-  else {
-    if (clangWorkingDirPos - 1 == commandLineArgs.rend()) {
-      ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
-                         "Missing '-working-directory' argument");
-      return std::nullopt;
-    }
-    workingDir = *(clangWorkingDirPos - 1);
-  }
-  return workingDir;
-}
-
 ModuleDependencyVector
 ClangImporter::getModuleDependencies(Identifier moduleName,
                                      StringRef moduleOutputPath,
                                      StringRef sdkModuleOutputPath,
                                      const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
-                                     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
+                                     const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
                                      InterfaceSubContextDelegate &delegate,
                                      llvm::PrefixMapper *mapper,
                                      bool isTestableImport) {
-  auto &ctx = Impl.SwiftContext;
-  // Determine the command-line arguments for dependency scanning.
-  std::vector<std::string> commandLineArgs =
-      getClangDepScanningInvocationArguments(ctx);
-  auto optionalWorkingDir = computeClangWorkingDirectory(commandLineArgs, ctx);
-  if (!optionalWorkingDir) {
-    ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
-                       "Missing '-working-directory' argument");
-    return {};
-  }
-  std::string workingDir = *optionalWorkingDir;
-  auto lookupModuleOutput =
-      [moduleOutputPath, sdkModuleOutputPath, &ctx]
-      (const ModuleDeps &MD, ModuleOutputKind MOK) -> std::string {
-    return moduleCacheRelativeLookupModuleOutput(MD, MOK, moduleOutputPath,
-                                                 sdkModuleOutputPath,
-                                                 ctx.SearchPathOpts.RuntimeResourcePath);
-  };
-
-  auto clangModuleDependencies =
-      clangScanningTool.getModuleDependencies(
-          moduleName.str(), commandLineArgs, workingDir,
-          alreadySeenClangModules, lookupModuleOutput);
-  if (!clangModuleDependencies) {
-    auto errorStr = toString(clangModuleDependencies.takeError());
-    // We ignore the "module 'foo' not found" error, the Swift dependency
-    // scanner will report such an error only if all of the module loaders
-    // fail as well.
-    if (errorStr.find("fatal error: module '" + moduleName.str().str() +
-                      "' not found") == std::string::npos)
-      ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
-                         errorStr);
-    return {};
-  }
-
-  return bridgeClangModuleDependencies(clangScanningTool,
-                                       *clangModuleDependencies,
-                                       moduleOutputPath, sdkModuleOutputPath,
-                                       [&](StringRef path) {
-                                         if (mapper)
-                                           return mapper->mapToString(path);
-                                         return path.str();
-                                       });
-}
-
-bool ClangImporter::getHeaderDependencies(
-    ModuleDependencyID moduleID, std::optional<StringRef> headerPath,
-    std::optional<llvm::MemoryBufferRef> sourceBuffer,
-    clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
-    ModuleDependenciesCache &cache,
-    ModuleDependencyIDSetVector &headerClangModuleDependencies,
-    std::vector<std::string> &headerFileInputs,
-    std::vector<std::string> &bridgingHeaderCommandLine,
-    std::optional<std::string> &includeTreeID) {
-  // Scan the specified textual header file and collect its dependencies
-  auto scanHeaderDependencies = [&]() -> llvm::Expected<TranslationUnitDeps> {
-    auto &ctx = Impl.SwiftContext;
-    std::vector<std::string> commandLineArgs =
-        getClangDepScanningInvocationArguments(ctx, headerPath);
-    auto optionalWorkingDir =
-        computeClangWorkingDirectory(commandLineArgs, ctx);
-    if (!optionalWorkingDir) {
-      ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
-                         "Missing '-working-directory' argument");
-      return llvm::errorCodeToError(
-          std::error_code(errno, std::generic_category()));
-    }
-    std::string workingDir = *optionalWorkingDir;
-    auto moduleOutputPath = cache.getModuleOutputPath();
-    auto sdkModuleOutputPath = cache.getSDKModuleOutputPath();
-    auto lookupModuleOutput =
-        [moduleOutputPath, sdkModuleOutputPath, &ctx]
-        (const ModuleDeps &MD, ModuleOutputKind MOK) -> std::string {
-      return moduleCacheRelativeLookupModuleOutput(MD, MOK,
-                                                   moduleOutputPath,
-                                                   sdkModuleOutputPath,
-                                                   ctx.SearchPathOpts.RuntimeResourcePath);
-    };
-    auto dependencies = clangScanningTool.getTranslationUnitDependencies(
-        commandLineArgs, workingDir, cache.getAlreadySeenClangModules(),
-        lookupModuleOutput, sourceBuffer);
-    if (!dependencies)
-      return dependencies.takeError();
-
-    // Record module dependencies for each new module we found.
-    auto bridgedDeps = bridgeClangModuleDependencies(
-        clangScanningTool, dependencies->ModuleGraph,
-        moduleOutputPath, sdkModuleOutputPath,
-        [&cache](StringRef path) {
-          return cache.getScanService().remapPath(path);
-        });
-    cache.recordDependencies(bridgedDeps, Impl.SwiftContext.Diags);
-
-    llvm::copy(dependencies->FileDeps, std::back_inserter(headerFileInputs));
-    auto bridgedDependencyIDs =
-        llvm::map_range(dependencies->ClangModuleDeps, [](auto &input) {
-          return ModuleDependencyID{input.ModuleName, ModuleDependencyKind::Clang};
-        });
-    headerClangModuleDependencies.insert(bridgedDependencyIDs.begin(),
-                                         bridgedDependencyIDs.end());
-    return dependencies;
-  };
-
-  // - If a generated header is provided, scan the generated header.
-  // - Textual module dependencies require us to process their bridging header.
-  // - Binary module dependnecies may have arbitrary header inputs.
-  auto clangModuleDependencies = scanHeaderDependencies();
-  if (!clangModuleDependencies) {
-    // FIXME: Route this to a normal diagnostic.
-    llvm::logAllUnhandledErrors(clangModuleDependencies.takeError(),
-                                llvm::errs());
-    Impl.SwiftContext.Diags.diagnose(
-        SourceLoc(), diag::clang_dependency_scan_error,
-        "failed to scan bridging header dependencies");
-    return true;
-  }
-
-  auto targetModuleInfo = cache.findKnownDependency(moduleID);
-  if (!targetModuleInfo.isTextualSwiftModule())
-    return false;
-
-  if (auto TreeID = clangModuleDependencies->IncludeTreeID)
-    includeTreeID = TreeID;
-  getBridgingHeaderOptions(*clangModuleDependencies, bridgingHeaderCommandLine);
-
-  return false;
+  return {};
 }

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -179,13 +179,96 @@ static bool isSwiftDependencyKind(ModuleDependencyKind Kind) {
          Kind == ModuleDependencyKind::SwiftPlaceholder;
 }
 
+// The Swift compiler does not have a concept of a working directory.
+// It is instead handled by the Swift driver by resolving relative paths
+// according to the driver's notion of a working directory. On the other hand,
+// Clang does have a concept working directory which may be specified on a
+// Clang invocation with '-working-directory'. If so, it is crucial that we
+// use this directory as an argument to the Clang scanner invocation below.
+static std::string
+computeClangWorkingDirectory(const std::vector<std::string> &commandLineArgs,
+                             const ASTContext &ctx) {
+  std::string workingDir;
+  auto clangWorkingDirPos = std::find(
+      commandLineArgs.rbegin(), commandLineArgs.rend(), "-working-directory");
+  if (clangWorkingDirPos == commandLineArgs.rend())
+    workingDir =
+        ctx.SourceMgr.getFileSystem()->getCurrentWorkingDirectory().get();
+  else {
+    if (clangWorkingDirPos - 1 == commandLineArgs.rend()) {
+      ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
+                         "Missing '-working-directory' argument");
+      workingDir =
+          ctx.SourceMgr.getFileSystem()->getCurrentWorkingDirectory().get();
+    } else
+      workingDir = *(clangWorkingDirPos - 1);
+  }
+  return workingDir;
+}
+
+static std::string
+moduleCacheRelativeLookupModuleOutput(const clang::tooling::dependencies::ModuleDeps &MD,
+                                      clang::tooling::dependencies::ModuleOutputKind MOK,
+                                      const StringRef moduleCachePath,
+                                      const StringRef stableModuleCachePath,
+                                      const StringRef runtimeResourcePath) {
+  llvm::SmallString<128> outputPath(moduleCachePath);
+  if (MD.IsInStableDirectories)
+    outputPath = stableModuleCachePath;
+
+  // FIXME: This is a hack to treat Clang modules defined in the compiler's
+  // own resource directory as stable, when they are not reported as such
+  // by the Clang scanner.
+  if (!runtimeResourcePath.empty() &&
+      hasPrefix(llvm::sys::path::begin(MD.ClangModuleMapFile),
+                llvm::sys::path::end(MD.ClangModuleMapFile),
+                llvm::sys::path::begin(runtimeResourcePath),
+                llvm::sys::path::end(runtimeResourcePath)))
+    outputPath = stableModuleCachePath;
+
+  llvm::sys::path::append(outputPath, MD.ID.ModuleName + "-" + MD.ID.ContextHash);
+  switch (MOK) {
+  case clang::tooling::dependencies::ModuleOutputKind::ModuleFile:
+    llvm::sys::path::replace_extension(
+        outputPath, getExtension(swift::file_types::TY_ClangModuleFile));
+    break;
+  case clang::tooling::dependencies::ModuleOutputKind::DependencyFile:
+    llvm::sys::path::replace_extension(
+        outputPath, getExtension(swift::file_types::TY_Dependencies));
+    break;
+  case clang::tooling::dependencies::ModuleOutputKind::DependencyTargets:
+    return MD.ID.ModuleName + "-" + MD.ID.ContextHash;
+  case clang::tooling::dependencies::ModuleOutputKind::DiagnosticSerializationFile:
+    llvm::sys::path::replace_extension(
+        outputPath, getExtension(swift::file_types::TY_SerializedDiagnostics));
+    break;
+  }
+  return outputPath.str().str();
+}
+
+static std::vector<std::string> inputSpecificClangScannerCommand(
+    const std::vector<std::string> &baseCommandLineArgs,
+    std::optional<StringRef> sourceFileName) {
+  std::vector<std::string> result(baseCommandLineArgs.begin(),
+                                  baseCommandLineArgs.end());
+  auto sourceFilePos =
+      std::find(result.begin(), result.end(), "<swift-imported-modules>");
+  assert(sourceFilePos != result.end());
+  if (sourceFileName.has_value())
+    *sourceFilePos = sourceFileName->str();
+  else
+    result.erase(sourceFilePos);
+  return result;
+}
+
 ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     SwiftDependencyScanningService &globalScanningService,
     const CompilerInvocation &ScanCompilerInvocation,
     const SILOptions &SILOptions, ASTContext &ScanASTContext,
     swift::DependencyTracker &DependencyTracker, DiagnosticEngine &Diagnostics)
     : clangScanningTool(*globalScanningService.ClangScanningService,
-                        globalScanningService.getClangScanningFS()) {
+                        globalScanningService.getClangScanningFS()),
+      swiftModuleClangCC1CommandLineArgs() {
   // Create a scanner-specific Invocation and ASTContext.
   workerCompilerInvocation =
       std::make_unique<CompilerInvocation>(ScanCompilerInvocation);
@@ -222,12 +305,33 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
   CAS = globalScanningService.CAS;
   ActionCache = globalScanningService.ActionCache;
 
-  // Set up the ClangImporter.
-  clangScannerModuleLoader = ClangImporter::create(
-      *workerASTContext, workerCompilerInvocation->getPCHHash(),
-      &DependencyTracker);
-  if (!clangScannerModuleLoader)
-    Diagnostics.diagnose(SourceLoc(), diag::error_clang_importer_create_fail);
+  // Set up the required command-line arguments and working directory
+  // configuration required for clang dependency scanner queries
+  auto scanClangImporter =
+      static_cast<ClangImporter *>(ScanASTContext.getClangModuleLoader());
+  clangScanningBaseCommandLineArgs =
+      scanClangImporter->getClangDepScanningInvocationArguments(ScanASTContext);
+  clangScanningModuleCommandLineArgs = inputSpecificClangScannerCommand(
+      clangScanningBaseCommandLineArgs, std::nullopt);
+  clangScanningWorkingDirectoryPath = computeClangWorkingDirectory(
+      clangScanningBaseCommandLineArgs, ScanASTContext);
+
+  // Handle clang arguments. For caching build, all arguments are passed
+  // with `-direct-clang-cc1-module-build`.
+  if (ScanASTContext.ClangImporterOpts.ClangImporterDirectCC1Scan) {
+    swiftModuleClangCC1CommandLineArgs.push_back("-direct-clang-cc1-module-build");
+    auto *importer =
+        static_cast<ClangImporter *>(ScanASTContext.getClangModuleLoader());
+    for (auto &Arg : importer->getSwiftExplicitModuleDirectCC1Args()) {
+      swiftModuleClangCC1CommandLineArgs.push_back("-Xcc");
+      swiftModuleClangCC1CommandLineArgs.push_back(Arg);
+    }
+  } else {
+    swiftModuleClangCC1CommandLineArgs.push_back("-Xcc");
+    swiftModuleClangCC1CommandLineArgs.push_back("-fno-implicit-modules");
+    swiftModuleClangCC1CommandLineArgs.push_back("-Xcc");
+    swiftModuleClangCC1CommandLineArgs.push_back("-fno-implicit-module-maps");
+  }
 
   // Set up the Swift interface loader for Swift scanning.
   swiftScannerModuleLoader = ModuleInterfaceLoader::create(
@@ -245,7 +349,7 @@ ModuleDependencyScanningWorker::scanFilesystemForSwiftModuleDependency(
     bool isTestableImport) {
   return swiftScannerModuleLoader->getModuleDependencies(
       moduleName, moduleOutputPath, sdkModuleOutputPath,
-      {}, clangScanningTool, *scanningASTDelegate,
+      {}, swiftModuleClangCC1CommandLineArgs, *scanningASTDelegate,
       prefixMapper, isTestableImport);
 }
 
@@ -253,12 +357,118 @@ ModuleDependencyVector
 ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
     Identifier moduleName, StringRef moduleOutputPath,
     StringRef sdkModuleOutputPath,
-    const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenModules,
+    const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
+        &alreadySeenModules,
     llvm::PrefixMapper *prefixMapper) {
-  return clangScannerModuleLoader->getModuleDependencies(
-      moduleName, moduleOutputPath, sdkModuleOutputPath,
-      alreadySeenModules, clangScanningTool,
-      *scanningASTDelegate, prefixMapper, false);
+  auto lookupModuleOutput =
+      [this, moduleOutputPath, sdkModuleOutputPath](
+          const clang::tooling::dependencies::ModuleDeps &MD,
+          const clang::tooling::dependencies::ModuleOutputKind MOK)
+      -> std::string {
+    return moduleCacheRelativeLookupModuleOutput(
+        MD, MOK, moduleOutputPath, sdkModuleOutputPath,
+        workerASTContext->SearchPathOpts.RuntimeResourcePath);
+  };
+
+  auto clangModuleDependencies = clangScanningTool.getModuleDependencies(
+      moduleName.str(), clangScanningModuleCommandLineArgs,
+      clangScanningWorkingDirectoryPath,
+      alreadySeenModules,
+      lookupModuleOutput);
+  if (!clangModuleDependencies) {
+    auto errorStr = toString(clangModuleDependencies.takeError());
+    // We ignore the "module 'foo' not found" error, the Swift dependency
+    // scanner will report such an error only if all of the module loaders
+    // fail as well.
+    if (errorStr.find("fatal error: module '" + moduleName.str().str() +
+                      "' not found") == std::string::npos)
+      workerASTContext->Diags.diagnose(
+          SourceLoc(), diag::clang_dependency_scan_error, errorStr);
+    return {};
+  }
+
+  return ClangImporter::bridgeClangModuleDependencies(
+      *workerASTContext, clangScanningTool, *clangModuleDependencies,
+      moduleOutputPath, sdkModuleOutputPath, lookupModuleOutput,
+      [&](StringRef path) {
+        if (prefixMapper)
+          return prefixMapper->mapToString(path);
+        return path.str();
+      });
+}
+
+bool ModuleDependencyScanningWorker::scanHeaderDependenciesOfSwiftModule(
+    const ASTContext &ctx,
+    ModuleDependencyID moduleID, std::optional<StringRef> headerPath,
+    std::optional<llvm::MemoryBufferRef> sourceBuffer,
+    ModuleDependenciesCache &cache,
+    ModuleDependencyIDSetVector &headerClangModuleDependencies,
+    std::vector<std::string> &headerFileInputs,
+    std::vector<std::string> &bridgingHeaderCommandLine,
+    std::optional<std::string> &includeTreeID) {
+  // Scan the specified textual header file and collect its dependencies
+  auto scanHeaderDependencies = [&]()
+      -> llvm::Expected<clang::tooling::dependencies::TranslationUnitDeps> {
+    auto moduleOutputPath = cache.getModuleOutputPath();
+    auto sdkModuleOutputPath = cache.getSDKModuleOutputPath();
+    auto lookupModuleOutput =
+        [moduleOutputPath, sdkModuleOutputPath,
+         &ctx](const clang::tooling::dependencies::ModuleDeps &MD,
+               const clang::tooling::dependencies::ModuleOutputKind MOK)
+        -> std::string {
+      return moduleCacheRelativeLookupModuleOutput(
+          MD, MOK, moduleOutputPath, sdkModuleOutputPath,
+          ctx.SearchPathOpts.RuntimeResourcePath);
+    };
+
+    auto dependencies = clangScanningTool.getTranslationUnitDependencies(
+        /*ACTODO:*/ inputSpecificClangScannerCommand(clangScanningBaseCommandLineArgs, headerPath),
+        clangScanningWorkingDirectoryPath,
+        cache.getAlreadySeenClangModules(), lookupModuleOutput, sourceBuffer);
+    if (!dependencies)
+      return dependencies.takeError();
+
+    // Record module dependencies for each new module we found.
+    auto bridgedDeps = ClangImporter::bridgeClangModuleDependencies(
+        ctx, clangScanningTool, dependencies->ModuleGraph, moduleOutputPath,
+        sdkModuleOutputPath, lookupModuleOutput, [&cache](StringRef path) {
+          return cache.getScanService().remapPath(path);
+        });
+    cache.recordDependencies(bridgedDeps, ctx.Diags);
+
+    llvm::copy(dependencies->FileDeps, std::back_inserter(headerFileInputs));
+    auto bridgedDependencyIDs =
+        llvm::map_range(dependencies->ClangModuleDeps, [](auto &input) {
+          return ModuleDependencyID{input.ModuleName,
+                                    ModuleDependencyKind::Clang};
+        });
+    headerClangModuleDependencies.insert(bridgedDependencyIDs.begin(),
+                                         bridgedDependencyIDs.end());
+    return dependencies;
+  };
+
+  // - If a generated header is provided, scan the generated header.
+  // - Textual module dependencies require us to process their bridging header.
+  // - Binary module dependnecies may have arbitrary header inputs.
+  auto clangModuleDependencies = scanHeaderDependencies();
+  if (!clangModuleDependencies) {
+    // FIXME: Route this to a normal diagnostic.
+    llvm::logAllUnhandledErrors(clangModuleDependencies.takeError(),
+                                llvm::errs());
+    ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
+                       "failed to scan header dependencies");
+    return true;
+  }
+
+  auto targetModuleInfo = cache.findKnownDependency(moduleID);
+  if (!targetModuleInfo.isTextualSwiftModule())
+    return false;
+
+  if (auto TreeID = clangModuleDependencies->IncludeTreeID)
+    includeTreeID = TreeID;
+  ClangImporter::getBridgingHeaderOptions(ctx, *clangModuleDependencies,
+                                          bridgingHeaderCommandLine);
+  return false;
 }
 
 template <typename Function, typename... Args>
@@ -831,8 +1041,7 @@ ModuleDependencyScanner::resolveSwiftModuleDependencies(
   return;
 }
 
-void
-ModuleDependencyScanner::resolveAllClangModuleDependencies(
+void ModuleDependencyScanner::resolveAllClangModuleDependencies(
     ArrayRef<ModuleDependencyID> swiftModuleDependents,
     ModuleDependenciesCache &cache,
     ModuleDependencyIDSetVector &allDiscoveredClangModules) {
@@ -840,13 +1049,23 @@ ModuleDependencyScanner::resolveAllClangModuleDependencies(
   // Clang modules (since no Swift module for them was found).
   llvm::StringSet<> unresolvedImportIdentifiers;
   llvm::StringSet<> unresolvedOptionalImportIdentifiers;
-  std::unordered_map<ModuleDependencyID, std::vector<ScannerImportStatementInfo>> unresolvedImportsMap;
-  std::unordered_map<ModuleDependencyID, std::vector<ScannerImportStatementInfo>> unresolvedOptionalImportsMap;
+  std::unordered_map<ModuleDependencyID,
+                     std::vector<ScannerImportStatementInfo>>
+      unresolvedImportsMap;
+  std::unordered_map<ModuleDependencyID,
+                     std::vector<ScannerImportStatementInfo>>
+      unresolvedOptionalImportsMap;
 
   for (const auto &moduleID : swiftModuleDependents) {
     auto moduleDependencyInfo = cache.findKnownDependency(moduleID);
-    auto unresolvedImports = &unresolvedImportsMap.emplace(moduleID, std::vector<ScannerImportStatementInfo>()).first->second;
-    auto unresolvedOptionalImports = &unresolvedOptionalImportsMap.emplace(moduleID, std::vector<ScannerImportStatementInfo>()).first->second;
+    auto unresolvedImports =
+        &unresolvedImportsMap
+             .emplace(moduleID, std::vector<ScannerImportStatementInfo>())
+             .first->second;
+    auto unresolvedOptionalImports =
+        &unresolvedOptionalImportsMap
+             .emplace(moduleID, std::vector<ScannerImportStatementInfo>())
+             .first->second;
 
     // If we have already resolved Clang dependencies for this module,
     // then we have the entire dependency sub-graph already computed for
@@ -1226,15 +1445,13 @@ void ModuleDependencyScanner::resolveHeaderDependenciesForModule(
 
   withDependencyScanningWorker(
       [&](ModuleDependencyScanningWorker *ScanningWorker) {
-        auto clangImporter = static_cast<ClangImporter *>(
-            ScanningWorker->clangScannerModuleLoader.get());
-
         std::vector<std::string> headerFileInputs;
         std::optional<std::string> includeTreeID;
         std::vector<std::string> bridgingHeaderCommandLine;
-        auto headerScan = clangImporter->getHeaderDependencies(
+        auto headerScan = ScanningWorker->scanHeaderDependenciesOfSwiftModule(
+            *ScanningWorker->workerASTContext,
             moduleID, headerPath, sourceBufferRef,
-            ScanningWorker->clangScanningTool, cache,
+            cache,
             headerClangModuleDependencies, headerFileInputs,
             bridgingHeaderCommandLine, includeTreeID);
         if (!headerScan) {
@@ -1502,14 +1719,12 @@ llvm::Error ModuleDependencyScanner::performBridgingHeaderChaining(
   std::optional<std::string> includeTreeID;
   auto err = withDependencyScanningWorker(
       [&](ModuleDependencyScanningWorker *ScanningWorker) -> llvm::Error {
-        auto clangImporter = static_cast<ClangImporter *>(
-            ScanningWorker->clangScannerModuleLoader.get());
         std::vector<std::string> headerFileInputs;
         std::vector<std::string> bridgingHeaderCommandLine;
-        if (clangImporter->getHeaderDependencies(
+        if (ScanningWorker->scanHeaderDependenciesOfSwiftModule(
+                *ScanningWorker->workerASTContext,
                 rootModuleID, /*headerPath=*/std::nullopt,
-                sourceBuffer->getMemBufferRef(),
-                ScanningWorker->clangScanningTool, cache,
+                sourceBuffer->getMemBufferRef(), cache,
                 headerClangModuleDependencies, headerFileInputs,
                 bridgingHeaderCommandLine, includeTreeID))
           return llvm::createStringError(

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -267,8 +267,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     const SILOptions &SILOptions, ASTContext &ScanASTContext,
     swift::DependencyTracker &DependencyTracker, DiagnosticEngine &Diagnostics)
     : clangScanningTool(*globalScanningService.ClangScanningService,
-                        globalScanningService.getClangScanningFS()),
-      swiftModuleClangCC1CommandLineArgs() {
+                        globalScanningService.getClangScanningFS()) {
   // Create a scanner-specific Invocation and ASTContext.
   workerCompilerInvocation =
       std::make_unique<CompilerInvocation>(ScanCompilerInvocation);
@@ -320,9 +319,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
   // with `-direct-clang-cc1-module-build`.
   if (ScanASTContext.ClangImporterOpts.ClangImporterDirectCC1Scan) {
     swiftModuleClangCC1CommandLineArgs.push_back("-direct-clang-cc1-module-build");
-    auto *importer =
-        static_cast<ClangImporter *>(ScanASTContext.getClangModuleLoader());
-    for (auto &Arg : importer->getSwiftExplicitModuleDirectCC1Args()) {
+    for (auto &Arg : scanClangImporter->getSwiftExplicitModuleDirectCC1Args()) {
       swiftModuleClangCC1CommandLineArgs.push_back("-Xcc");
       swiftModuleClangCC1CommandLineArgs.push_back(Arg);
     }

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -158,10 +158,9 @@ ModuleDependencyVector
 SourceLoader::getModuleDependencies(Identifier moduleName,
                                     StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                                     const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
-                                    clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
+                                    const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
                                     InterfaceSubContextDelegate &delegate,
                                     llvm::PrefixMapper* mapper,
                                     bool isTestableImport) {
-  // FIXME: Implement?
   return {};
 }

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -187,20 +187,9 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
 
         // Handle clang arguments. For caching build, all arguments are passed
         // with `-direct-clang-cc1-module-build`.
-        if (Ctx.ClangImporterOpts.ClangImporterDirectCC1Scan) {
-          Args.push_back("-direct-clang-cc1-module-build");
-          auto *importer =
-              static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
-          for (auto &Arg : importer->getSwiftExplicitModuleDirectCC1Args()) {
-            Args.push_back("-Xcc");
-            Args.push_back(Arg);
-          }
-        } else {
-          Args.push_back("-Xcc");
-          Args.push_back("-fno-implicit-modules");
-          Args.push_back("-Xcc");
-          Args.push_back("-fno-implicit-module-maps");
-        }
+        for (const auto &arg : swiftModuleClangCC1CommandLineArgs)
+          Args.push_back(arg);
+
         for (const auto &candidate : compiledCandidates) {
           Args.push_back("-candidate-module-file");
           Args.push_back(candidate);
@@ -310,7 +299,7 @@ ModuleDependencyVector SerializedModuleLoaderBase::getModuleDependencies(
     StringRef sdkModuleOutputPath,
     const llvm::DenseSet<clang::tooling::dependencies::ModuleID>
         &alreadySeenClangModules,
-    clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
+    const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
     InterfaceSubContextDelegate &delegate, llvm::PrefixMapper *mapper,
     bool isTestableDependencyLookup) {
   ImportPath::Module::Builder builder(moduleName);
@@ -329,6 +318,7 @@ ModuleDependencyVector SerializedModuleLoaderBase::getModuleDependencies(
       delegate, moduleOutputPath, sdkModuleOutputPath));
   scanners.push_back(std::make_unique<SwiftModuleScanner>(
       Ctx, LoadMode, moduleId, delegate, moduleOutputPath, sdkModuleOutputPath,
+      swiftModuleClangCC1CommandLineArgs,
       SwiftModuleScanner::MDS_plain));
 
   // Check whether there is a module with this name that we can import.

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -187,8 +187,7 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
 
         // Handle clang arguments. For caching build, all arguments are passed
         // with `-direct-clang-cc1-module-build`.
-        for (const auto &arg : swiftModuleClangCC1CommandLineArgs)
-          Args.push_back(arg);
+        llvm::append_range(Args, swiftModuleClangCC1CommandLineArgs);
 
         for (const auto &candidate : compiledCandidates) {
           Args.push_back("-candidate-module-file");

--- a/test/ScanDependencies/clang_scan_error.swift
+++ b/test/ScanDependencies/clang_scan_error.swift
@@ -6,7 +6,7 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -o %t/deps.json -I %t -swift-version 5 2>&1 | %FileCheck %s
 
-// CHECK: error: Clang dependency scanner failure: failed to scan bridging header dependencies
+// CHECK: error: Clang dependency scanner failure: failed to scan header dependencies
 
 //--- bridging.h
 #include "do-not-exist.h"


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/81361
-----------------------------------------
- **Explanation**: This is a refactoring PR that includes two changes meant to reduce the overall number of times that `ClangImporter` is instantiated during a given dependency scanning action:
    - **Remove 'ClangImporter' instance from dependency scanning worker**
This change moves `getModuleDependency` and `getHeaderDependency` functionality from `ClangImporter` directly into Swift's `ModuleDependencyScanningWorker` using the `clangScanningTool` it already has, removing the need to instantiate an instance of `ClangImporter` per-worker. 

    - **Reduce number of module loaders instantiated for textual interface scanning sub-instance**
When creating a compilation sub-instance for scanning a textual Swift module interface for dependencies, in `setupModuleLoaders` only configure the strictly-necessary module loaders, skipping `ClangImporter` in particular. 

  On a large benchmark scan (e.g. importing every Swift module in the macOS SDK yielding ~270 Swift modules and ~530 Clang modules) this change results in a ~5% speedup. 


- **Scope**: All projects building with explicitly-built modules which perform a module dependency scan

- **Risk**: Low, in expectation this change does not alter any functionality of the dependency scanner. 

- **Reviewed By**: @cachemeifyoucan

- **Original PR**: https://github.com/swiftlang/swift/pull/81361
