### PR TITLE
[6.2][CSApply] Don't attempt to mark autoclosures as non-implicit

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8669,7 +8669,10 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
                                  AccessSemantics::Ordinary);
   if (!declRef)
     return nullptr;
-  declRef->setImplicit(apply->isImplicit());
+
+  if (!isa<AutoClosureExpr>(declRef))
+    declRef->setImplicit(apply->isImplicit());
+
   apply->setFn(declRef);
 
   // Tail-recur to actually call the constructor.

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -272,3 +272,22 @@ do {
   }
 }
 
+// The compiler used to mark autoclosure in `MyThing` reference as "non-implicit"
+// which caused a crash in migration mode because it assumes that autoclosures
+// are always implicit.
+do {
+  struct Other {
+    init(test: Int) {}
+  }
+
+  struct S<T> {
+    typealias MyThing = Other
+    var value: T
+  }
+
+  func test(c: S<Int?>) {
+    _ = c.value.map {
+      type(of: c).MyThing(test: $0) // Ok (used to crash due to autoclosure use)
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/81422

---

- Explanation:

  While building an initializer call the declaration reference should have the same implicitness as the call when it doesn't require thunking, otherwise don't attempt to mark autoclosures as non-implicit because it could break assumptions elsewhere.

- Main Branch PR: https://github.com/swiftlang/swift/pull/81422

- Risk: Low (This is a narrow fix which could only be currently found by migration code).

- Reviewed By: @AnthonyLatsis  

- Resolves: rdar://151157725

- Testing: Added new tests to the test suite.

(cherry picked from commit 37e2f374aac9916f2dbabc9ab2e04b83bc18e14a)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
