### PR TITLE
[swift-inspect] Fix corpse leaks when target doesn't have libswiftCore loaded.

### DIFF
--- a/tools/swift-inspect/Sources/swift-inspect/Cleanup.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Cleanup.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A helper struct that manages the cleanup of some external resource.
+/// The value is stored as an Optional, but presented as a non-optional.
+/// Accessing the value before one has been set is a runtime error. The cleanup
+/// function is called on the value if one has been set, when setting a new
+/// value or when the struct is destroyed.
+struct Cleanup<T>: ~Copyable {
+  /// The underlying Optional storage for the value.
+  private var _value: T?
+
+  /// The wrapped value. A value must be set before any value is read here.
+  var value: T {
+    get {
+      _value!
+    }
+    set {
+      if let _value {
+        cleanup(_value)
+      }
+      _value = newValue
+    }
+  }
+
+  /// The function used to clean up the resource held by this struct.
+  let cleanup: (T) -> Void
+
+  init(cleanup: @escaping (T) -> Void) {
+    self._value = nil
+    self.cleanup = cleanup
+  }
+
+  deinit {
+    if let _value {
+      cleanup(_value)
+    }
+  }
+}

--- a/tools/swift-inspect/Sources/swift-inspect/Process.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Process.swift
@@ -80,7 +80,7 @@ internal func getAllProcesses(options: UniversalOptions) -> [ProcessIdentifier]?
   }
   let newCount = bufferSize / kinfo_stride
   if count > newCount {
-    buffer.dropLast(count - newCount)
+    buffer.removeLast(count - newCount)
   }
   let sorted = buffer.sorted { first, second in
     first.kp_proc.p_pid > second.kp_proc.p_pid


### PR DESCRIPTION
In DarwinRemoteProcess's early return when libswiftCore.dylib isn't loaded in the process, we hadn't initialized all stored properties yet, which means our deinit didn't run. This leaked the task. This is especially bad when forking a corpse, as the system has a very limited number of corpses available.

Add a Cleanup helper to manage resources that need explicit cleanup. This is a noncopyable struct which takes a cleanup function and calls it whenever a new value is set or when the struct is destroyed. Use this for the DarwinRemoteProcess properties that need explicit cleanup. This allows us to remove DarwinRemoteProcess's deinit and always run these cleanups regardless of how we exit the initializer.

While we're here, fix the truncations of buffer in getAllProcesses.

rdar://151170155