### PR TITLE
[stdlib] Mark `contains` methods on `Range/ClosedRange` transparent

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -357,7 +357,6 @@ where Bound: Strideable, Bound.Stride: SignedInteger
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
-  @_transparent
   public func contains(_ other: Range<Bound>) -> Bool {
     if other.isEmpty { return true }
     let otherInclusiveUpper = other.upperBound.advanced(by: -1)

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -128,7 +128,8 @@ extension ClosedRange: RangeExpression {
   /// - Parameter element: The element to check for containment.
   /// - Returns: `true` if `element` is contained in the range; otherwise,
   ///   `false`.
-  @_transparent
+  @inlinable
+  @inline(__always)
   public func contains(_ element: Bound) -> Bool {
     return element >= self.lowerBound && element <= self.upperBound
   }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -128,7 +128,7 @@ extension ClosedRange: RangeExpression {
   /// - Parameter element: The element to check for containment.
   /// - Returns: `true` if `element` is contained in the range; otherwise,
   ///   `false`.
-  @inlinable
+  @_transparent
   public func contains(_ element: Bound) -> Bool {
     return element >= self.lowerBound && element <= self.upperBound
   }
@@ -357,6 +357,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public func contains(_ other: Range<Bound>) -> Bool {
     if other.isEmpty { return true }
     let otherInclusiveUpper = other.upperBound.advanced(by: -1)
@@ -383,6 +384,7 @@ extension ClosedRange {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public func contains(_ other: ClosedRange<Bound>) -> Bool {
     lowerBound <= other.lowerBound && upperBound >= other.upperBound
   }

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -1080,7 +1080,7 @@ extension Range {
     other.isEmpty ||
       (lowerBound <= other.lowerBound && upperBound >= other.upperBound)
   }
-  
+
   /// Returns a Boolean value indicating whether the given closed range is
   /// contained within this range.
   ///

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -682,7 +682,7 @@ extension PartialRangeFrom: RangeExpression {
   ) -> Range<Bound> where C.Index == Bound {
     return self.lowerBound..<collection.endIndex
   }
-  @inlinable // trivial-implementation
+  @_transparent
   public func contains(_ element: Bound) -> Bool {
     return lowerBound <= element
   }

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -194,7 +194,7 @@ public struct Range<Bound: Comparable> {
   /// - Parameter element: The element to check for containment.
   /// - Returns: `true` if `element` is contained in the range; otherwise,
   ///   `false`.
-  @inlinable
+  @_transparent
   public func contains(_ element: Bound) -> Bool {
     return lowerBound <= element && element < upperBound
   }
@@ -1074,6 +1074,7 @@ extension Range {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public func contains(_ other: Range<Bound>) -> Bool {
     other.isEmpty ||
       (lowerBound <= other.lowerBound && upperBound >= other.upperBound)
@@ -1101,6 +1102,7 @@ extension Range {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public func contains(_ other: ClosedRange<Bound>) -> Bool {
     lowerBound <= other.lowerBound && upperBound > other.upperBound
   }

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -96,7 +96,35 @@ extension RangeExpression {
   @inlinable
   public static func ~= (pattern: Self, value: Bound) -> Bool {
     return pattern.contains(value)
-  }  
+  }
+}
+
+extension Range {
+  /// Returns a Boolean value indicating whether a value is included in a
+  /// range.
+  ///
+  /// You can use the pattern-matching operator (`~=`) to test whether a value
+  /// is included in a range. The pattern-matching operator is used
+  /// internally in `case` statements for pattern matching. The following
+  /// example uses the `~=` operator to test whether an integer is included in
+  /// a range of single-digit numbers:
+  ///
+  ///     let chosenNumber = 3
+  ///     if 0..<10 ~= chosenNumber {
+  ///         print("\(chosenNumber) is a single digit.")
+  ///     }
+  ///     // Prints "3 is a single digit."
+  ///
+  /// - Parameters:
+  ///   - pattern: A range.
+  ///   - bound: A value to match against `pattern`.
+  @_transparent
+  public static func ~= (pattern: Self, value: Bound) -> Bool {
+    // Note: `Range.~=` is used particularly frequently to implement bounds
+    // checks. This more specific variant of the generic `=~` is intended to
+    // help improve unoptimized performance of these cases.
+    pattern.contains(value)
+  }
 }
 
 /// A half-open interval from a lower bound up to, but not including, an upper

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -94,36 +94,9 @@ extension RangeExpression {
   ///   - pattern: A range.
   ///   - bound: A value to match against `pattern`.
   @inlinable
+  @inline(__always)
   public static func ~= (pattern: Self, value: Bound) -> Bool {
     return pattern.contains(value)
-  }
-}
-
-extension Range {
-  /// Returns a Boolean value indicating whether a value is included in a
-  /// range.
-  ///
-  /// You can use the pattern-matching operator (`~=`) to test whether a value
-  /// is included in a range. The pattern-matching operator is used
-  /// internally in `case` statements for pattern matching. The following
-  /// example uses the `~=` operator to test whether an integer is included in
-  /// a range of single-digit numbers:
-  ///
-  ///     let chosenNumber = 3
-  ///     if 0..<10 ~= chosenNumber {
-  ///         print("\(chosenNumber) is a single digit.")
-  ///     }
-  ///     // Prints "3 is a single digit."
-  ///
-  /// - Parameters:
-  ///   - pattern: A range.
-  ///   - bound: A value to match against `pattern`.
-  @_transparent
-  public static func ~= (pattern: Self, value: Bound) -> Bool {
-    // Note: `Range.~=` is used particularly frequently to implement bounds
-    // checks. This more specific variant of the generic `=~` is intended to
-    // help improve unoptimized performance of these cases.
-    pattern.contains(value)
   }
 }
 

--- a/test/stdlib/RangeContainsInlining.swift
+++ b/test/stdlib/RangeContainsInlining.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-emit-ir -primary-file %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-emit-ir -primary-file %s -O 2>&1 | %FileCheck %s
+// RUN: %target-swift-emit-ir -primary-file %s -Osize 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: define hidden swiftcc i1 @"$s17RangeContainsPerf08halfOpenB0ySbSnySiG_SitF"
+// CHECK-NOT: call swiftcc
+// CHECK: icmp
+// CHECK-NOT: call swiftcc
+// CHECK-LABEL: }
+func halfOpenContains(_ r: Range<Int>, _ i: Int) -> Bool {
+  r.contains(i)
+}
+
+// CHECK-LABEL: define hidden swiftcc i1 @"$s17RangeContainsPerf06closedB0ySbSNySiG_SitF"
+// CHECK-NOT: call swiftcc
+// CHECK: icmp
+// CHECK-NOT: call swiftcc
+// CHECK-LABEL: }
+func closedContains(_ r: ClosedRange<Int>, _ i: Int) -> Bool {
+  r.contains(i)
+}
+
+// CHECK-LABEL: define hidden swiftcc i1 @"$s17RangeContainsPerf20halfOpenPatternMatchySbSnySiG_SitF"
+// CHECK-NOT: call swiftcc
+// CHECK: icmp
+// CHECK-NOT: call swiftcc
+// CHECK-LABEL: }
+func halfOpenPatternMatch(_ r: Range<Int>, _ i: Int) -> Bool {
+  r ~= i
+}
+
+// CHECK-LABEL: define hidden swiftcc i1 @"$s17RangeContainsPerf18closedPatternMatchySbSNySiG_SitF"
+// CHECK-NOT: call swiftcc
+// CHECK: icmp
+// CHECK-NOT: call swiftcc
+// CHECK-LABEL: }
+func closedPatternMatch(_ r: ClosedRange<Int>, _ i: Int) -> Bool {
+  r ~= i
+}

--- a/test/stdlib/RangeContainsInlining.swift
+++ b/test/stdlib/RangeContainsInlining.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-emit-ir -primary-file %s 2>&1 | %FileCheck %s
-// RUN: %target-swift-emit-ir -primary-file %s -O 2>&1 | %FileCheck %s
-// RUN: %target-swift-emit-ir -primary-file %s -Osize 2>&1 | %FileCheck %s
+// RUN: %target-swift-emit-ir -primary-file %s -O 2>&1 | %FileCheck --check-prefixes CHECK,CHECK-OPTIMIZED %s
+// RUN: %target-swift-emit-ir -primary-file %s -Osize 2>&1 | %FileCheck --check-prefixes CHECK,CHECK-OPTIMIZED %s
 
-// We expect calls to `Range.contains`, `ClosedRange.contains` and `~=` over a
+// We expect calls to `Range.contains`, `ClosedRange.contains` over a
 // `Range` instance to result in direct bound comparisons in all compilation
 // modes, including unoptimized builds. (These are often used to implement
 // bounds checking.)
@@ -10,7 +10,7 @@
 // The sample functions below use bounds of different integer types to avoid
 // them tail-calling each other.
 
-// CHECK-LABEL: define swiftcc i1 @"$s21RangeContainsInlining08halfOpenB0ySbSnys4Int8VG_ADtF"
+// CHECK-LABEL: define {{.*}} i1 @"$s21RangeContainsInlining08halfOpenB0ySbSnys4Int8VG_ADtF"
 // CHECK-NOT: call swiftcc
 // CHECK: icmp
 // CHECK-NOT: call swiftcc
@@ -19,7 +19,7 @@ public func halfOpenContains(_ r: Range<Int8>, _ i: Int8) -> Bool {
   r.contains(i)
 }
 
-// CHECK-LABEL: define swiftcc i1 @"$s21RangeContainsInlining06closedB0ySbSNys5Int16VG_ADtF"
+// CHECK-LABEL: define  {{.*}} i1 @"$s21RangeContainsInlining06closedB0ySbSNys5Int16VG_ADtF"
 // CHECK-NOT: call swiftcc
 // CHECK: icmp
 // CHECK-NOT: call swiftcc
@@ -28,11 +28,14 @@ public func closedContains(_ r: ClosedRange<Int16>, _ i: Int16) -> Bool {
   r.contains(i)
 }
 
-// CHECK-LABEL: define swiftcc i1 @"$s21RangeContainsInlining20halfOpenPatternMatchySbSnys5Int32VG_ADtF"
-// CHECK-NOT: call swiftcc
-// CHECK: icmp
-// CHECK-NOT: call swiftcc
-// CHECK-LABEL: {{^}}}
+// `Range.~=` is only marked `@inline(__always)`; unfortunately it doesn't get
+// inlined in deug builds.
+
+// CHECK-OPTIMIZED-LABEL: define {{.*}} i1 @"$s21RangeContainsInlining20halfOpenPatternMatchySbSnys5Int32VG_ADtF"
+// CHECK-OPTIMIZED-NOT: call swiftcc
+// CHECK-OPTIMIZED: icmp
+// CHECK-OPTIMIZED-NOT: call swiftcc
+// CHECK-OPTIMIZED-LABEL: {{^}}}
 public func halfOpenPatternMatch(_ r: Range<Int32>, _ i: Int32) -> Bool {
   r ~= i
 }

--- a/test/stdlib/RangeContainsInlining.swift
+++ b/test/stdlib/RangeContainsInlining.swift
@@ -2,38 +2,37 @@
 // RUN: %target-swift-emit-ir -primary-file %s -O 2>&1 | %FileCheck %s
 // RUN: %target-swift-emit-ir -primary-file %s -Osize 2>&1 | %FileCheck %s
 
-// CHECK-LABEL: define hidden swiftcc i1 @"$s17RangeContainsPerf08halfOpenB0ySbSnySiG_SitF"
+// We expect calls to `Range.contains`, `ClosedRange.contains` and `~=` over a
+// `Range` instance to result in direct bound comparisons in all compilation
+// modes, including unoptimized builds. (These are often used to implement
+// bounds checking.)
+//
+// The sample functions below use bounds of different integer types to avoid
+// them tail-calling each other.
+
+// CHECK-LABEL: define swiftcc i1 @"$s21RangeContainsInlining08halfOpenB0ySbSnys4Int8VG_ADtF"
 // CHECK-NOT: call swiftcc
 // CHECK: icmp
 // CHECK-NOT: call swiftcc
-// CHECK-LABEL: }
-func halfOpenContains(_ r: Range<Int>, _ i: Int) -> Bool {
+// CHECK-LABEL: {{^}}}
+public func halfOpenContains(_ r: Range<Int8>, _ i: Int8) -> Bool {
   r.contains(i)
 }
 
-// CHECK-LABEL: define hidden swiftcc i1 @"$s17RangeContainsPerf06closedB0ySbSNySiG_SitF"
+// CHECK-LABEL: define swiftcc i1 @"$s21RangeContainsInlining06closedB0ySbSNys5Int16VG_ADtF"
 // CHECK-NOT: call swiftcc
 // CHECK: icmp
 // CHECK-NOT: call swiftcc
-// CHECK-LABEL: }
-func closedContains(_ r: ClosedRange<Int>, _ i: Int) -> Bool {
+// CHECK-LABEL: {{^}}}
+public func closedContains(_ r: ClosedRange<Int16>, _ i: Int16) -> Bool {
   r.contains(i)
 }
 
-// CHECK-LABEL: define hidden swiftcc i1 @"$s17RangeContainsPerf20halfOpenPatternMatchySbSnySiG_SitF"
+// CHECK-LABEL: define swiftcc i1 @"$s21RangeContainsInlining20halfOpenPatternMatchySbSnys5Int32VG_ADtF"
 // CHECK-NOT: call swiftcc
 // CHECK: icmp
 // CHECK-NOT: call swiftcc
-// CHECK-LABEL: }
-func halfOpenPatternMatch(_ r: Range<Int>, _ i: Int) -> Bool {
-  r ~= i
-}
-
-// CHECK-LABEL: define hidden swiftcc i1 @"$s17RangeContainsPerf18closedPatternMatchySbSNySiG_SitF"
-// CHECK-NOT: call swiftcc
-// CHECK: icmp
-// CHECK-NOT: call swiftcc
-// CHECK-LABEL: }
-func closedPatternMatch(_ r: ClosedRange<Int>, _ i: Int) -> Bool {
+// CHECK-LABEL: {{^}}}
+public func halfOpenPatternMatch(_ r: Range<Int32>, _ i: Int32) -> Bool {
   r ~= i
 }

--- a/test/stdlib/RangeContainsInlining.swift
+++ b/test/stdlib/RangeContainsInlining.swift
@@ -2,10 +2,9 @@
 // RUN: %target-swift-emit-ir -primary-file %s -O 2>&1 | %FileCheck --check-prefixes CHECK,CHECK-OPTIMIZED %s
 // RUN: %target-swift-emit-ir -primary-file %s -Osize 2>&1 | %FileCheck --check-prefixes CHECK,CHECK-OPTIMIZED %s
 
-// We expect calls to `Range.contains`, `ClosedRange.contains` over a
-// `Range` instance to result in direct bound comparisons in all compilation
-// modes, including unoptimized builds. (These are often used to implement
-// bounds checking.)
+// We expect calls to `Range.contains` to result in direct bound comparisons in
+// all compilation modes, including unoptimized builds. (These are often used to
+// implement bounds checking.)
 //
 // The sample functions below use bounds of different integer types to avoid
 // them tail-calling each other.
@@ -19,11 +18,14 @@ public func halfOpenContains(_ r: Range<Int8>, _ i: Int8) -> Bool {
   r.contains(i)
 }
 
-// CHECK-LABEL: define  {{.*}} i1 @"$s21RangeContainsInlining06closedB0ySbSNys5Int16VG_ADtF"
-// CHECK-NOT: call swiftcc
-// CHECK: icmp
-// CHECK-NOT: call swiftcc
-// CHECK-LABEL: {{^}}}
+// `ClosedRange.contains is only marked `@inline(__always)`; unfortunately it
+// doesn't get inlined in deug builds.
+
+// CHECK-OPTIMIZED-LABEL: define  {{.*}} i1 @"$s21RangeContainsInlining06closedB0ySbSNys5Int16VG_ADtF"
+// CHECK-OPTIMIZED-NOT: call swiftcc
+// CHECK-OPTIMIZED: icmp
+// CHECK-OPTIMIZED-NOT: call swiftcc
+// CHECK-OPTIMIZED-LABEL: {{^}}}
 public func closedContains(_ r: ClosedRange<Int16>, _ i: Int16) -> Bool {
   r.contains(i)
 }


### PR DESCRIPTION
These are really popular shorthands for implementing bounds checks, but currently they aren’t even marked `@inline(__always)`, so in larger functions they tend to remain outlined, defeating optimizations that would otherwise happen.

The corresponding variants on the partial range types are `@_transparent`; that helps unoptimized performance, so let’s apply the same attribute here.

rdar://151177326
