### PR TITLE
[6.2][stdlib] Mark contains methods on Range/ClosedRange transparent

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -128,7 +128,7 @@ extension ClosedRange: RangeExpression {
   /// - Parameter element: The element to check for containment.
   /// - Returns: `true` if `element` is contained in the range; otherwise,
   ///   `false`.
-  @inlinable
+  @_transparent
   public func contains(_ element: Bound) -> Bool {
     return element >= self.lowerBound && element <= self.upperBound
   }
@@ -357,6 +357,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public func contains(_ other: Range<Bound>) -> Bool {
     if other.isEmpty { return true }
     let otherInclusiveUpper = other.upperBound.advanced(by: -1)
@@ -383,6 +384,7 @@ extension ClosedRange {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public func contains(_ other: ClosedRange<Bound>) -> Bool {
     lowerBound <= other.lowerBound && upperBound >= other.upperBound
   }

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -194,7 +194,7 @@ public struct Range<Bound: Comparable> {
   /// - Parameter element: The element to check for containment.
   /// - Returns: `true` if `element` is contained in the range; otherwise,
   ///   `false`.
-  @inlinable
+  @_transparent
   public func contains(_ element: Bound) -> Bool {
     return lowerBound <= element && element < upperBound
   }
@@ -1074,6 +1074,7 @@ extension Range {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public func contains(_ other: Range<Bound>) -> Bool {
     other.isEmpty ||
       (lowerBound <= other.lowerBound && upperBound >= other.upperBound)
@@ -1101,6 +1102,7 @@ extension Range {
   ///
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
+  @_transparent
   public func contains(_ other: ClosedRange<Bound>) -> Bool {
     lowerBound <= other.lowerBound && upperBound > other.upperBound
   }


### PR DESCRIPTION
(Cherry picked from #81458)

These are really popular shorthands for implementing bounds checks, but currently they aren’t even marked `@inline(__always)`, so in larger functions they tend to remain outlined, defeating optimizations that would otherwise happen.

The corresponding variants on the partial range types are `@_transparent`; that helps unoptimized performance, so let’s apply the same attribute here.

rdar://151177326
