### PR TITLE
Set debug location to Coroutine call expression

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5023,6 +5023,8 @@ static void emitRetconCoroutineEntry(
   for (auto *arg : finalArguments) {
     arguments.push_back(arg);
   }
+  ArtificialLocation Loc(IGF.getDebugScope(), IGF.IGM.DebugInfo.get(),
+                         IGF.Builder);
   llvm::Value *id = IGF.Builder.CreateIntrinsicCall(idIntrinsic, arguments);
 
   // Call 'llvm.coro.begin', just for consistency with the normal pattern.
@@ -5127,7 +5129,6 @@ void irgen::emitYieldOnceCoroutineEntry(
     allocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getMallocFn());
   }
 
-  ArtificialLocation Loc(IGF.getDebugScope(), IGF.IGM.DebugInfo.get(), IGF.Builder);
   emitRetconCoroutineEntry(IGF, fnType, buffer,
                            llvm::Intrinsic::coro_id_retcon_once,
                            getYieldOnceCoroutineBufferSize(IGF.IGM),

--- a/test/IRGen/CoroutineAccessorsDebugLoc.swift
+++ b/test/IRGen/CoroutineAccessorsDebugLoc.swift
@@ -1,0 +1,19 @@
+// REQUIRES: swift_feature_CoroutineAccessors
+// RUN: %target-swift-frontend %s -g -c -O -o - -emit-irgen -enable-experimental-feature CoroutineAccessors | %FileCheck %s
+
+// This test checks to made sure that the ReadAccessor s26CoroutineAccessorsDebugLoc1SV3irmSivr that has a call to @llvm.coro.id.retcon.once, also has a debug location set.
+
+// CHECK-LABEL: @"$s26CoroutineAccessorsDebugLoc1SV3irmSivr"
+// CHECK: %{{.*}} = call token ({{.*}}) @llvm.coro.id.retcon.once({{.*}}), !dbg ![[DBGLOC:[0-9]+]]
+// CHECK-NEXT: %{{.*}} = call ptr @llvm.coro.begin({{.*}}), !dbg ![[DBGLOC]]
+
+public struct S {
+public var o: any AnyObject
+public var _i: Int = 0
+
+public var irm: Int {
+  _read {
+    yield _i
+  }
+} // public var irm
+}


### PR DESCRIPTION
If debug info generation is enabled, set debug location to the coroutine call instruction to make sure there are no issues with invalid debug information in LTO.

This happens because in LTO, if a call to a function doesn't contain a debug location, we see the warning:

inlinable function call in a function with debug info must have a !dbg location

ld: warning: Invalid debug info found, debug info will be stripped

Which then strips the debug info from the entire .o file linked into the dylib.