### PR TITLE
[rebranch] SIL: Restore old behavior in `llvm::APInt` ctor call

### DIFF
--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1145,7 +1145,9 @@ IntegerLiteralInst *IntegerLiteralInst::create(SILDebugLocation Loc,
 static APInt getAPInt(AnyBuiltinIntegerType *anyIntTy, intmax_t value) {
   // If we're forming a fixed-width type, build using the greatest width.
   if (auto intTy = dyn_cast<BuiltinIntegerType>(anyIntTy))
-    return APInt(intTy->getGreatestWidth(), value);
+    // TODO: Avoid implicit trunc?
+    return APInt(intTy->getGreatestWidth(), value, /*isSigned=*/false,
+                 /*implicitTrunc=*/true);
 
   // Otherwise, build using the size of the type and then truncate to the
   // minimum width necessary.

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1995,11 +1995,12 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
             emitOSVersionRangeCheck(loc, versionRange.value(), isMacCatalyst);
         if (availability->isUnavailability()) {
           // If this is an unavailability check, invert the result
-          // by emitting a call to Builtin.xor_Int1(lhs, 1).
+          // by emitting a call to Builtin.xor_Int1(lhs, -1).
           SILType i1 = SILType::getBuiltinIntegerType(1, getASTContext());
-          SILValue one = B.createIntegerLiteral(loc, i1, 1);
-          booleanTestValue = B.createBuiltinBinaryFunction(
-              loc, "xor", i1, i1, {booleanTestValue, one});
+          SILValue minusOne = B.createIntegerLiteral(loc, i1, -1);
+          booleanTestValue =
+            B.createBuiltinBinaryFunction(loc, "xor", i1, i1,
+                                          {booleanTestValue, minusOne});
         }
       }
       break;

--- a/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
+++ b/lib/SILOptimizer/LoopTransforms/BoundsCheckOpts.cpp
@@ -558,7 +558,7 @@ static SILValue getSub(SILLocation Loc, SILValue Val, unsigned SubVal,
   SmallVector<SILValue, 4> Args(1, Val);
   Args.push_back(B.createIntegerLiteral(Loc, Val->getType(), SubVal));
   Args.push_back(B.createIntegerLiteral(
-      Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), 1));
+      Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), -1));
 
   auto *AI = B.createBuiltinBinaryFunctionWithOverflow(
       Loc, "ssub_with_overflow", Args);
@@ -570,7 +570,7 @@ static SILValue getAdd(SILLocation Loc, SILValue Val, unsigned AddVal,
   SmallVector<SILValue, 4> Args(1, Val);
   Args.push_back(B.createIntegerLiteral(Loc, Val->getType(), AddVal));
   Args.push_back(B.createIntegerLiteral(
-      Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), 1));
+      Loc, SILType::getBuiltinIntegerType(1, B.getASTContext()), -1));
 
   auto *AI = B.createBuiltinBinaryFunctionWithOverflow(
       Loc, "sadd_with_overflow", Args);
@@ -1342,7 +1342,7 @@ BoundsCheckOpts::findAndOptimizeInductionVariables(SILLoop *loop) {
           if (isComparisonKnownTrue(builtin, *ivar)) {
             if (!trueVal)
               trueVal = builder.createIntegerLiteral(builtin->getLoc(),
-                                                     builtin->getType(), 1);
+                                                     builtin->getType(), -1);
             builtin->replaceAllUsesWith(trueVal);
             changed = true;
             continue;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2976,7 +2976,7 @@ static SILValue testAllControlVariableBits(SILLocation Loc,
   if (IVType->getFixedWidth() == 1)
     return CondVal;
 
-  SILValue AllBitsSet = B.createIntegerLiteral(Loc, CondVal->getType(), 1);
+  SILValue AllBitsSet = B.createIntegerLiteral(Loc, CondVal->getType(), -1);
   if (!CmpEqFn.get())
     CmpEqFn = getBinaryFunction("cmp_eq", CondVal->getType(),
                                 B.getASTContext());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -304,7 +304,7 @@ static SILValue createValueForEdge(SILInstruction *UserInst,
 
   if (auto *CBI = dyn_cast<CondBranchInst>(DominatingTerminator))
     return Builder.createIntegerLiteral(
-        CBI->getLoc(), CBI->getCondition()->getType(), EdgeIdx == 0 ? 1 : 0);
+        CBI->getLoc(), CBI->getCondition()->getType(), EdgeIdx == 0 ? -1 : 0);
 
   auto *SEI = cast<SwitchEnumInst>(DominatingTerminator);
   auto *DstBlock = SEI->getSuccessors()[EdgeIdx].getBB();
@@ -1480,7 +1480,7 @@ static SILValue invertExpectAndApplyTo(SILBuilder &Builder,
   if (!IL)
     return V;
   SILValue NegatedExpectedValue = Builder.createIntegerLiteral(
-      IL->getLoc(), Args[1]->getType(), IL->getValue() == 0 ? 1 : 0);
+      IL->getLoc(), Args[1]->getType(), IL->getValue() == 0 ? -1 : 0);
   return Builder.createBuiltin(BI->getLoc(), BI->getName(), BI->getType(), {},
                                {V, NegatedExpectedValue});
 }


### PR DESCRIPTION
See https://github.com/llvm/llvm-project/pull/114539.

The approach taken in the reverted commit is causing tests to fail, and I am not positive that all instances of the -1 to 1 switch are correct. Restore the old behavior by tweaking the ctor call instead.