### PR TITLE
[Strict memory safety] Squash warning about unsafety in "@objc enum" synthesized code

### DIFF
--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -105,7 +105,9 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
 
     auto *argList = ArgumentList::forImplicitCallTo(functionRef->getName(),
                                                     {selfRef, typeExpr}, C);
-    auto call = CallExpr::createImplicit(C, functionRef, argList);
+    Expr *call = CallExpr::createImplicit(C, functionRef, argList);
+    if (C.LangOpts.hasFeature(Feature::StrictMemorySafety))
+      call = UnsafeExpr::createImplicit(C, SourceLoc(), call);
     auto *returnStmt = ReturnStmt::createImplicit(C, call);
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
                                   SourceLoc());


### PR DESCRIPTION
There's a synthesized call to unsafeBitCast(_:to:), which is obvious unsafe, and is being diagnosed as such. The compiler generates this call, so have the compiler also generate the `unsafe` around it to suppress these warnings.

Fixes rdar://151199011.