### PR TITLE
[6.2] [Strict memory safety] Squash warning about unsafety in "@objc enum" synthesized code

### DIFF
--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -105,7 +105,9 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
 
     auto *argList = ArgumentList::forImplicitCallTo(functionRef->getName(),
                                                     {selfRef, typeExpr}, C);
-    auto call = CallExpr::createImplicit(C, functionRef, argList);
+    Expr *call = CallExpr::createImplicit(C, functionRef, argList);
+    if (C.LangOpts.hasFeature(Feature::StrictMemorySafety))
+      call = UnsafeExpr::createImplicit(C, SourceLoc(), call);
     auto *returnStmt = ReturnStmt::createImplicit(C, call);
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),
                                   SourceLoc());


### PR DESCRIPTION
- **Explanation**: For `@objc enum`, there's a synthesized call to `unsafeBitCast(_:to:)`, which is obviously unsafe, and is being diagnosed as such by the strict memory safety mode. The compiler generates this call, so have the compiler also generate the `unsafe` around it to suppress these warnings.
- **Scope**: Limited to synthesized code for `@objc enum`.
- **Issues**: rdar://151199011
- **Original PRs**: https://github.com/swiftlang/swift/pull/81466
- **Risk**: Very low. The introduced `unsafe` expression has no semantic effect other than squashing a warning.
- **Testing**: CI
