### PR TITLE
TempRValueElimination: handle `store` instructions to the temporary stack location

### DIFF
--- a/include/swift/SIL/SILInstructionWorklist.h
+++ b/include/swift/SIL/SILInstructionWorklist.h
@@ -302,9 +302,12 @@ public:
   // method to delete the given instruction.
   void eraseInstFromFunction(SILInstruction &instruction,
                              SILBasicBlock::iterator &iterator,
-                             bool addOperandsToWorklist = true) {
-    // Try to salvage debug info first.
-    swift::salvageDebugInfo(&instruction);
+                             bool addOperandsToWorklist = true,
+                             bool salvageDebugInfo = true) {
+    if (salvageDebugInfo) {
+      // Try to salvage debug info first.
+      swift::salvageDebugInfo(&instruction);
+    }
     // Then delete old debug users.
     for (auto result : instruction.getResults()) {
       while (!result->use_empty()) {
@@ -323,9 +326,11 @@ public:
   }
 
   void eraseInstFromFunction(SILInstruction &instruction,
-                             bool addOperandsToWorklist = true) {
+                             bool addOperandsToWorklist = true,
+                             bool salvageDebugInfo = true) {
     SILBasicBlock::iterator nullIter;
-    return eraseInstFromFunction(instruction, nullIter, addOperandsToWorklist);
+    return eraseInstFromFunction(instruction, nullIter, addOperandsToWorklist,
+                                 salvageDebugInfo);
   }
 
   void eraseSingleInstFromFunction(SILInstruction &instruction,

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -234,7 +234,7 @@ struct BridgedPassContext {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock splitBlockAfter(BridgedInstruction bridgedInst) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock createBlockAfter(BridgedBasicBlock bridgedBlock) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock appendBlock(BridgedFunction bridgedFunction) const;
-  BRIDGED_INLINE void eraseInstruction(BridgedInstruction inst) const;
+  BRIDGED_INLINE void eraseInstruction(BridgedInstruction inst, bool salvageDebugInfo) const;
   BRIDGED_INLINE void eraseBlock(BridgedBasicBlock block) const;
   static BRIDGED_INLINE void moveInstructionBefore(BridgedInstruction inst, BridgedInstruction beforeInst);
   bool tryOptimizeApplyOfPartialApply(BridgedInstruction closure) const;

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -27,6 +27,7 @@
 #include "swift/SILOptimizer/OptimizerBridging.h"
 #include "swift/SILOptimizer/PassManager/PassManager.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
+#include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
@@ -253,8 +254,8 @@ BridgedBasicBlock BridgedPassContext::appendBlock(BridgedFunction bridgedFunctio
   return {bridgedFunction.getFunction()->createBasicBlock()};
 }
 
-void BridgedPassContext::eraseInstruction(BridgedInstruction inst) const {
-  invocation->eraseInstruction(inst.unbridged());
+void BridgedPassContext::eraseInstruction(BridgedInstruction inst, bool salvageDebugInfo) const {
+  invocation->eraseInstruction(inst.unbridged(), salvageDebugInfo);
 }
 
 void BridgedPassContext::eraseBlock(BridgedBasicBlock block) const {

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -138,7 +138,7 @@ public:
   void freeOperandSet(OperandSet *set);
 
   /// The top-level API to erase an instruction, called from the Swift pass.
-  void eraseInstruction(SILInstruction *inst);
+  void eraseInstruction(SILInstruction *inst, bool salvageDebugInfo);
 
   /// Called by the pass when changes are made to the SIL.
   void notifyChanges(SILAnalysis::InvalidationKind invalidationKind);

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -694,11 +694,13 @@ SILTransform *swift::createSILCombine() {
 //                          SwiftFunctionPassContext
 //===----------------------------------------------------------------------===//
 
-void SwiftPassInvocation::eraseInstruction(SILInstruction *inst) {
+void SwiftPassInvocation::eraseInstruction(SILInstruction *inst, bool salvageDebugInfo) {
   if (silCombiner) {
-    silCombiner->eraseInstFromFunction(*inst);
+    silCombiner->eraseInstFromFunction(*inst, /*addOperandsToWorklist=*/ true, salvageDebugInfo);
   } else {
-    swift::salvageDebugInfo(inst);
+    if (salvageDebugInfo) {
+      swift::salvageDebugInfo(inst);
+    }
     if (inst->isStaticInitializerInst()) {
       inst->getParent()->erase(inst, *getPassManager()->getModule());
     } else {

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -220,8 +220,10 @@ public:
   // by this method.
   SILInstruction *eraseInstFromFunction(SILInstruction &I,
                                         SILBasicBlock::iterator &InstIter,
-                                        bool AddOperandsToWorklist = true) {
-    Worklist.eraseInstFromFunction(I, InstIter, AddOperandsToWorklist);
+                                        bool AddOperandsToWorklist = true,
+                                        bool salvageDebugInfo = true) {
+    Worklist.eraseInstFromFunction(I, InstIter, AddOperandsToWorklist,
+                                   salvageDebugInfo);
     MadeChange = true;
     // Dummy return, so the caller doesn't need to explicitly return nullptr.
     return nullptr;
@@ -232,9 +234,10 @@ public:
   void eraseInstIncludingUsers(SILInstruction *inst);
 
   SILInstruction *eraseInstFromFunction(SILInstruction &I,
-                                        bool AddOperandsToWorklist = true) {
+                                        bool AddOperandsToWorklist = true,
+                                        bool salvageDebugInfo = true) {
     SILBasicBlock::iterator nullIter;
-    return eraseInstFromFunction(I, nullIter, AddOperandsToWorklist);
+    return eraseInstFromFunction(I, nullIter, AddOperandsToWorklist, salvageDebugInfo);
   }
 
   void addInitialGroup(ArrayRef<SILInstruction *> List) {

--- a/test/SILOptimizer/globalopt_resilience.swift
+++ b/test/SILOptimizer/globalopt_resilience.swift
@@ -37,13 +37,9 @@ public func cannotConvertToValueUse() {
 }
 
 // CHECK-LABEL: sil @$s4test23cannotConvertToValueUseyyF : $@convention(thin) () -> ()
-// CHECK: [[INT:%.*]] = integer_literal $Builtin.Int{{32|64}}, 27
-// CHECK: [[S1:%.*]] = struct $Int ([[INT]] : $Builtin.Int{{32|64}})
-// CHECK: [[S2:%.*]] = struct $ResilientStruct ([[S1]] : $Int)
-// CHECK: [[TMP:%.*]] = alloc_stack $ResilientStruct
-// CHECK: store [[S2]] to [[TMP]] : $*ResilientStruct
+// CHECK: [[GA:%.*]] = global_addr @$s4test15ResilientStructV9staticValACvpZ
 // CHECK: [[METHOD:%.*]] = function_ref @$s4test15ResilientStructV6methodyyF : $@convention(method) (@in_guaranteed ResilientStruct) -> ()
-// CHECK: apply [[METHOD]]([[TMP]]) : $@convention(method) (@in_guaranteed ResilientStruct) -> ()
+// CHECK: apply [[METHOD]]([[GA]]) : $@convention(method) (@in_guaranteed ResilientStruct) -> ()
 // CHECK: [[RESULT:%.*]] = tuple ()
 // CHECK: return [[RESULT]] : $()
 

--- a/test/SILOptimizer/inline_arrays.swift
+++ b/test/SILOptimizer/inline_arrays.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend  -primary-file %s -O -disable-availability-checking -module-name=test -emit-sil | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
+
+// CHECK-LABEL: sil @$s4test0A9Subscriptys5UInt8Vs11InlineArrayVy$255_ADGz_SitF :
+// CHECK:          [[S:%.*]] = struct_element_addr %0, #InlineArray._storage
+// CHECK:          [[BA:%.*]] = vector_base_addr [[S]]
+// CHECK:          [[EA:%.*]] = index_addr [stack_protection] [[BA]],
+// CHECK:          [[E:%.*]] = load [[EA]]
+// CHECK:          return [[E]]
+// CHECK:       } // end sil function '$s4test0A9Subscriptys5UInt8Vs11InlineArrayVy$255_ADGz_SitF'
+public func testSubscript(_ a: inout InlineArray<256, UInt8>, _ i: Int) -> UInt8 {
+  return a[i]
+}
+
+public final class C {
+  let a: InlineArray<256, UInt8>
+
+  init(_ a: InlineArray<256, UInt8>) {
+    self.a = a
+  }
+
+  // CHECK-LABEL: sil @$s4test1CC0A9Subscriptys5UInt8VSiF :
+  // CHECK:          [[CA:%.*]] = ref_element_addr [immutable] %1, #C.a
+  // CHECK:          [[S:%.*]] = struct_element_addr [[CA]], #InlineArray._storage
+  // CHECK:          [[BA:%.*]] = vector_base_addr [[S]]
+  // CHECK:          [[EA:%.*]] = index_addr [stack_protection] [[BA]],
+  // CHECK:          [[E:%.*]] = load [[EA]]
+  // CHECK:          return [[E]]
+  // CHECK:       } // end sil function '$s4test1CC0A9Subscriptys5UInt8VSiF'
+  public func testSubscript(_ i: Int) -> UInt8 {
+    return a[i]
+  }
+}
+

--- a/test/SILOptimizer/pre_specialize_layouts.swift
+++ b/test/SILOptimizer/pre_specialize_layouts.swift
@@ -189,7 +189,6 @@ public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, 
 // OPT:   [[A1:%.*]] = unchecked_ref_cast [[P1]] : $SomeClass to $AnyObject
 // OPT:   [[R3:%.*]] = apply [[F1]]([[A1]]) : $@convention(thin) (@guaranteed AnyObject) -> @owned AnyObject
 // OPT:   store [[R3]] to [[R2]] : $*AnyObject
-// OPT:   [[A2:%.*]] = load [[R1]] : $*SomeClass
 // OPT:   [[F2:%.*]] = function_ref @$s22pre_specialize_layouts7consumeyyxlF0a20_specialized_module_C09SomeClassC_Ttg5 : $@convention(thin) () -> ()
 // OPT:   apply [[F2]]() : $@convention(thin) () -> ()
 // OPT:   dealloc_stack [[R1]] : $*SomeClass

--- a/test/SILOptimizer/specialize_opaque_type_archetypes.swift
+++ b/test/SILOptimizer/specialize_opaque_type_archetypes.swift
@@ -421,12 +421,12 @@ struct PAEM : P4EM {
 // CHECK:   apply [[F]]([[V]])
 
 // CHECK-64-LABEL: sil hidden @$s1A2PAV4testyyF : $@convention(method) (PA) -> ()
-// CHECK-64:   [[V:%.*]] = integer_literal $Builtin.Int64, 5
-// CHECK-64:   [[I:%.*]] = struct $Int64 ([[V]] : $Builtin.Int64)
-// CHECK-64:   [[F:%.*]] = function_ref @$s1A4usePyyxAA1PRzlFs5Int64V_Tg5
-// CHECK-64:   apply [[F]]([[I]]) : $@convention(thin) (Int64) -> ()
-// CHECK-64:   apply [[F]]([[I]]) : $@convention(thin) (Int64) -> ()
-
+// CHECK-64:         [[V:%.*]] = integer_literal $Builtin.Int64, 5
+// CHECK-64-DAG:     [[I:%.*]] = struct $Int64 ([[V]] : $Builtin.Int64)
+// CHECK-64-DAG:     [[F:%.*]] = function_ref @$s1A4usePyyxAA1PRzlFs5Int64V_Tg5
+// CHECK-64:         apply [[F]]([[I]]) : $@convention(thin) (Int64) -> ()
+// CHECK-64:         apply [[F]]([[I]]) : $@convention(thin) (Int64) -> ()
+// CHECK-64:       } // end sil function '$s1A2PAV4testyyF'
 @inline(never)
 func testIt<T>(cl: (Int64) throws -> T) {
  do {

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -827,3 +827,18 @@ bb0:
   return %12
 }
 
+// CHECK-LABEL: sil @store_to_temp :
+// CHECK:         %1 = load %0
+// CHECK-NEXT:    return %1
+// CHECK-LABEL: } // end sil function 'store_to_temp'
+sil @store_to_temp : $@convention(thin) (@in_guaranteed Klass) -> @owned Klass {
+bb0(%0 : $*Klass):
+  %1 = load %0
+  %2 = alloc_stack $Klass
+  store %1 to %2
+  %4 = load %2
+  destroy_addr %2
+  dealloc_stack %2
+  return %4
+}
+

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -1472,3 +1472,119 @@ bb0(%0 : $*P):
   %15 = tuple ()
   return %15
 }
+
+// CHECK-LABEL: sil [ossa] @store_to_temp :
+// CHECK:         %1 = load [copy] %0
+// CHECK-NEXT:    return %1
+// CHECK-LABEL: } // end sil function 'store_to_temp'
+sil [ossa] @store_to_temp : $@convention(thin) (@in_guaranteed Klass) -> @owned Klass {
+bb0(%0 : $*Klass):
+  %1 = load [copy] %0
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2
+  %4 = load [copy] %2
+  destroy_addr %2
+  dealloc_stack %2
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_to_temp_take :
+// CHECK:         %1 = load [copy] %0
+// CHECK-NEXT:    destroy_addr %0
+// CHECK-NEXT:    return %1
+// CHECK-LABEL: } // end sil function 'store_to_temp_take'
+sil [ossa] @store_to_temp_take : $@convention(thin) (@in Klass) -> @owned Klass {
+bb0(%0 : $*Klass):
+  %1 = load [take] %0
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2
+  %4 = load [copy] %2
+  destroy_addr %2
+  dealloc_stack %2
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_to_temp_trivial :
+// CHECK:         %1 = load [trivial] %0
+// CHECK-NEXT:    return %1
+// CHECK-LABEL: } // end sil function 'store_to_temp_trivial'
+sil [ossa] @store_to_temp_trivial : $@convention(thin) (@in_guaranteed Int) -> @owned Int {
+bb0(%0 : $*Int):
+  %1 = load [trivial] %0
+  %2 = alloc_stack $Int
+  store %1 to [trivial] %2
+  %4 = load [trivial] %2
+  destroy_addr %2
+  dealloc_stack %2
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_with_early_destroy_of_src :
+// CHECK:         alloc_stack
+// CHECK-NEXT:    store %1
+// CHECK-LABEL: } // end sil function 'store_with_early_destroy_of_src'
+sil [ossa] @store_with_early_destroy_of_src : $@convention(thin) (@in Klass) -> @owned Klass {
+bb0(%0 : $*Klass):
+  %1 = load [copy] %0
+  fix_lifetime %0
+  destroy_addr %0
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2
+  %4 = load [copy] %2
+  destroy_addr %2
+  dealloc_stack %2
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_with_load_in_different_block :
+// CHECK:         alloc_stack
+// CHECK-NEXT:    store %1
+// CHECK-LABEL: } // end sil function 'store_with_load_in_different_block'
+sil [ossa] @store_with_load_in_different_block : $@convention(thin) (@in Klass) -> @owned Klass {
+bb0(%0 : $*Klass):
+  %1 = load [copy] %0
+  br bb1
+bb1:
+  fix_lifetime %0
+  destroy_addr %0
+  br bb2
+bb2:
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2
+  %4 = load [copy] %2
+  destroy_addr %2
+  dealloc_stack %2
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_with_load_with_multiple_uses :
+// CHECK:         fix_lifetime
+// CHECK:         alloc_stack
+// CHECK-NEXT:    store %1
+// CHECK-LABEL: } // end sil function 'store_with_load_with_multiple_uses'
+sil [ossa] @store_with_load_with_multiple_uses : $@convention(thin) (@in_guaranteed Klass) -> @owned Klass {
+bb0(%0 : $*Klass):
+  %1 = load [copy] %0
+  fix_lifetime %1
+  %2 = alloc_stack $Klass
+  store %1 to [init] %2
+  %4 = load [copy] %2
+  destroy_addr %2
+  dealloc_stack %2
+  return %4
+}
+
+// CHECK-LABEL: sil [ossa] @store_without_load :
+// CHECK:         alloc_stack
+// CHECK-NEXT:    store %0
+// CHECK-LABEL: } // end sil function 'store_without_load'
+sil [ossa] @store_without_load : $@convention(thin) (@owned Klass) -> @owned Klass {
+bb0(%0 : @owned $Klass):
+  %2 = alloc_stack $Klass
+  store %0 to [init] %2
+  %4 = load [copy] %2
+  destroy_addr %2
+  dealloc_stack %2
+  return %4
+}
+


### PR DESCRIPTION
Treat `load`-`store` pairs as if they were `copy_addr` instructions.
This can catch more cases. For example it can eliminate unnecessary copies of InlineArray when subscripting it.

rdar://149250346