### PR TITLE
Concurrency: silence warning on Windows

### DIFF
--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -654,8 +654,13 @@ void AsyncTask::pushInitialTaskName(const char* _taskName) {
   auto taskNameLen = strlen(_taskName);
   char* taskNameCopy = reinterpret_cast<char*>(
       _swift_task_alloc_specific(this, taskNameLen + 1/*null terminator*/));
+#if defined(_WIN32)
+  static_cast<void>(strncpy_s(taskNameCopy, taskNameLen + 1,
+                              _taskName, _TRUNCATE));
+#else
   (void) strncpy(/*dst=*/taskNameCopy, /*src=*/_taskName, taskNameLen);
   taskNameCopy[taskNameLen] = '\0'; // make sure we null-terminate
+#endif
 
   auto record =
       ::new (allocation) TaskNameStatusRecord(taskNameCopy);


### PR DESCRIPTION
Prefer `strncpy_s` over `strncpy` which triggers a warning. This function ensures that the copied string is null-terminated if the string fits or simply returns an empty string (`\0`) if the string does not fit. Prefer to use `_TRUNCATE` to copy as much of the name as fits and ensure that it is null-terminated.