### PR TITLE
CommandLineSupport: prefer `_strdup` over `strdup`

### DIFF
--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -135,7 +135,11 @@ char **_swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
       }
     }
 
+#if defined(_WIN32)
+    argv[argc] = _strdup(arg);
+#else
     argv[argc] = strdup(arg);
+#endif
     argc += 1;
   });
 


### PR DESCRIPTION
This silences a warning on Windows as `strdup` is considered deprecated in favour of the POSIX compliant `_strdup` spelling.