### PR TITLE
[6.2, cmake] LifetimeDependenceMutableAccessors should be enabled

### DIFF
--- a/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake
@@ -4,6 +4,7 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature MemberImportVisibility>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature TypedThrows>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Macros>"


### PR DESCRIPTION
This enables the LifetimeDependenceMutableAccessors flag (added in https://github.com/swiftlang/swift/pull/80831) in the new build system.

This is a cherry-pick of https://github.com/swiftlang/swift/pull/81465, reviewed by @compnerd

Addresses rdar://151179266
