### PR TITLE
[6.2] [Parse] Avoid parsing `unsafe` expression before binary or postfix op

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -421,12 +421,14 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 
   if (Tok.isContextualKeyword("unsafe") &&
       !(peekToken().isAtStartOfLine() ||
-        peekToken().isAny(tok::r_paren, tok::r_brace, tok::r_square,
-                          tok::equal, tok::colon, tok::comma, tok::eof) ||
+        peekToken().isAny(tok::r_paren, tok::r_brace, tok::r_square, tok::equal,
+                          tok::colon, tok::comma, tok::eof) ||
         (isExprBasic && peekToken().is(tok::l_brace)) ||
         peekToken().is(tok::period) ||
         (peekToken().isAny(tok::l_paren, tok::l_square) &&
-         peekToken().getRange().getStart() == Tok.getRange().getEnd()))) {
+         peekToken().getRange().getStart() == Tok.getRange().getEnd()) ||
+        peekToken().isBinaryOperatorLike() ||
+        peekToken().isPostfixOperatorLike())) {
     Tok.setKind(tok::contextual_keyword);
     SourceLoc unsafeLoc = consumeToken();
     ParserResult<Expr> sub =

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -200,6 +200,8 @@ func unsafeFun() {
   _ = color
 
   if unsafe { }
+
+  _ = unsafe ? 1 : 0
 }
 
 func moreUnsafeFunc(unsafe: [Int]) {
@@ -216,6 +218,13 @@ func yetMoreUnsafeFunc(unsafe: () -> Void) {
 
   _ = unsafe ()
   // expected-warning@-1{{no unsafe operations occur within 'unsafe' expression}}
+}
+
+func yetMoreMoreUnsafeFunc(unsafe: Int?) {
+  _ = unsafe!
+  if let unsafe {
+    _ = unsafe + 1
+  }
 }
 
 // @safe suppresses unsafe-type-related diagnostics on an entity


### PR DESCRIPTION
*6.2 cherry-pick of #81429*

- Explanation: Avoids parsing an `unsafe` expression if followed by a binary or postfix operator.
- Scope: Affects parsing of `unsafe`.
- Issue: https://github.com/swiftlang/swift/issues/81323, rdar://150751248
- Risk: Low, avoids parsing `unsafe` expression in cases that would be invalid, adjusts logic to more closely align with the swift-syntax parser logic.
- Testing: Added tests to test suite
- Reviewer: Hamish Knight