### PR TITLE
[ClangImporter][Serialization] Produce more remarks about details of module loading under -Rmodule-loading

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1240,6 +1240,18 @@ REMARK(module_loaded,none,
        "; source: '%2', loaded: '%3'",
        (Identifier, unsigned, StringRef, StringRef))
 
+REMARK(module_loading_swift_attempt,none,
+       "attempting to load Swift module '%0' from %1", (StringRef, StringRef))
+REMARK(module_loading_swift_failed,none,
+       "Swift module '%0' failed to load", (StringRef))
+       
+REMARK(module_loading_clang_attempt,none,
+       "attempting to load Clang module '%0'", (StringRef))
+REMARK(module_loading_clang_finished,none,
+       "loaded Clang module '%0' from %1", (StringRef, StringRef))
+REMARK(module_loading_clang_also_imported,none,
+       "load of Clang module '%0' also imported modules: %1", (StringRef, StringRef))
+
 REMARK(module_api_import,none,
        "%select{|implicitly used }4"
        "%kind0 is imported via %1"

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2398,6 +2398,12 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
     return result;
   };
 
+  if (path.size() == 1) {
+    if (SwiftContext.LangOpts.EnableModuleLoadingRemarks)
+      SwiftContext.Diags.diagnose(SourceLoc(), diag::module_loading_clang_attempt,
+                                  clangPath.front().first->getName());
+  }
+
   // Now load the top-level module, so that we can check if the submodule
   // exists without triggering a fatal error.
   auto clangModule = loadModule(clangPath.front(), clang::Module::AllVisible);
@@ -2407,6 +2413,12 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
   // If we're asked to import the top-level module then we're done here.
   auto *topSwiftModule = finishLoadingClangModule(clangModule, importLoc);
   if (path.size() == 1) {
+    if (SwiftContext.LangOpts.EnableModuleLoadingRemarks)
+      SwiftContext.Diags.diagnose(SourceLoc(),
+                                  diag::module_loading_clang_finished,
+                                  (*clangModule).getFullModuleName(),
+                                  (*clangModule).getASTFile()->getName());
+
     return topSwiftModule;
   }
 
@@ -4552,6 +4564,17 @@ void ClangModuleUnit::getImportedModulesForLookup(
   if (imported.empty()) {
     importedModulesForLookup = ArrayRef<ImportedModule>();
     return;
+  }
+
+  if (owner.SwiftContext.LangOpts.EnableModuleLoadingRemarks) {
+    std::string importedModulesList;
+    for (auto &m : imported) {
+      importedModulesList += m->getFullModuleName();
+      importedModulesList += " ";
+    }
+    owner.SwiftContext.Diags.diagnose(
+        SourceLoc(), diag::module_loading_clang_also_imported,
+        clangModule->getFullModuleName(), importedModulesList);
   }
 
   SmallPtrSet<clang::Module *, 32> seen{imported.begin(), imported.end()};

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1703,6 +1703,11 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
 
   assert(moduleInputBuffer);
 
+  if (Ctx.LangOpts.EnableModuleLoadingRemarks)
+    Ctx.Diags.diagnose(SourceLoc(), diag::module_loading_swift_attempt,
+                       moduleID.Item.str(),
+                       moduleInputBuffer->getBufferIdentifier());
+
   LoadedFile *file = nullptr;
   auto *M = ModuleDecl::create(moduleID.Item, Ctx,
                                [&](ModuleDecl *M, auto addFile) {
@@ -1735,6 +1740,13 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
       }
     }
   }
+
+  if (Ctx.LangOpts.EnableModuleLoadingRemarks) {
+    if (!M || M->failedToLoad())
+      Ctx.Diags.diagnose(importLoc, diag::module_loading_swift_failed,
+                         moduleID.Item.str());
+  }
+
   return M;
 }
 


### PR DESCRIPTION
Remarks from `-Rmodule-loading` are incredibly useful in certain situations, but they don't show enough details about Clang modules, module dependencies from Clang modules, and about load failures. Let's add more remarks into that mode.