### PR TITLE
Runtimes: correct CommandLineSupport build on Windows

### DIFF
--- a/Runtimes/Core/CommandLineSupport/CMakeLists.txt
+++ b/Runtimes/Core/CommandLineSupport/CMakeLists.txt
@@ -5,6 +5,8 @@ if(SwiftCore_ENABLE_COMMANDLINE_SUPPORT)
     "${PROJECT_BINARY_DIR}/include")
   target_compile_definitions(swiftCommandLineSupport PUBLIC
     -DSWIFT_STDLIB_HAS_COMMANDLINE)
+  target_compile_definitions(swiftCommandLineSupport PRIVATE
+    $<$<BOOL:${BUILD_SHARED_LIBS}>:-DswiftCore_EXPORTS>)
 
   target_link_libraries(swiftCommandLineSupport PRIVATE
     swiftShims)


### PR DESCRIPTION
We would fail to build the runtime with the new build with command line support and a shared runtime. The reason for this was that CommandLineSupport did not properly build against the headers and attempted to import a locally defined symbol. Correct the build by indicating that this library is compacted into the runtime.