### PR TITLE
[ClangImporter] Fix enum conversion type when importing global values (unwrap if needed)

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4630,9 +4630,14 @@ namespace {
             auto convertKind = ConstantConvertKind::None;
             // Request conversions on enums, and swift_wrapper((enum/struct))
             // types
-            if (decl->getType()->isEnumeralType())
-              convertKind = ConstantConvertKind::Construction;
-            else if (findSwiftNewtype(decl, Impl.getClangSema(),
+            if (decl->getType()->isEnumeralType()) {
+              if (type->getEnumOrBoundGenericEnum()) {
+                // When importing as an enum, also apply implicit force unwrap
+                convertKind = ConstantConvertKind::ConstructionWithUnwrap;
+              } else {
+                convertKind = ConstantConvertKind::Construction;
+              }
+            } else if (findSwiftNewtype(decl, Impl.getClangSema(),
                                       Impl.CurrentVersion))
               convertKind = ConstantConvertKind::Construction;
 

--- a/test/ClangImporter/const_values_apinotes.swift
+++ b/test/ClangImporter/const_values_apinotes.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %t/src/main.swift \
+// RUN:   -module-name main -I %t/src -emit-sil -sil-verify-all | %FileCheck %s
+
+//--- test.h
+
+typedef long NSInteger;
+typedef enum XCTestErrorCode: NSInteger {
+    XCTestErrorCodeTimeoutWhileWaiting,
+    XCTestErrorCodeFailureWhileWaiting,
+} XCTestErrorCode;
+
+static XCTestErrorCode const XCTestErrorUnsupported = (XCTestErrorCode)109;
+
+//--- Framework.apinotes
+---
+Name: Framework
+Tags:
+- Name: XCTestErrorCode
+  NSErrorDomain: XCTestErrorDomain
+
+//--- module.modulemap
+module Framework {
+  header "test.h"
+}
+
+//--- main.swift
+import Framework
+func foo() {
+  print(XCTestError.timeoutWhileWaiting)
+  print(XCTestErrorUnsupported)
+}
+
+
+// CHECK: // XCTestErrorUnsupported.getter
+// CHECK: sil shared [transparent] @$sSo22XCTestErrorUnsupportedSo0aB4CodeVvg : $@convention(thin) () -> XCTestError {


### PR DESCRIPTION
This fixes a bug in the (recently added) ClangImporter logic that imports global/static integer+enum+float values on top of their declarations. See the attached testcase that triggers a compiler crash:

```
SIL verification failed: return value type does not match return type of function
  $XCTestError.Code
  $Optional<XCTestError.Code>
Verifying instruction:
     %6 = apply %5(%4, %0) : $@convention(method) (Int, @thin XCTestError.Code.Type) -> Optional<XCTestError.Code> // user: %7
->   return %6 : $Optional<XCTestError.Code>      // id: %7
In function:
// XCTestErrorUnsupported.getter
// Isolation: nonisolated
sil shared [transparent] [serialized] [ossa] @$sSo22XCTestErrorUnsupportedSo0aB4CodeVvg : $@convention(thin) () -> XCTestError.Code {
bb0:
  %0 = metatype $@thin XCTestError.Code.Type      // user: %6
  %1 = integer_literal $Builtin.IntLiteral, 109   // user: %4
  %2 = metatype $@thin Int.Type                   // user: %4
  // function_ref Int.init(_builtinIntegerLiteral:)
  %3 = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %4
  %4 = apply %3(%1, %2) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int // user: %6
  // function_ref XCTestErrorCode.init(rawValue:)
  %5 = function_ref @$sSo15XCTestErrorCodeV8rawValueABSgSi_tcfC : $@convention(method) (Int, @thin XCTestError.Code.Type) -> Optional<XCTestError.Code> // user: %6
  %6 = apply %5(%4, %0) : $@convention(method) (Int, @thin XCTestError.Code.Type) -> Optional<XCTestError.Code> // user: %7
  return %6                                       // id: %7
} // end sil function '$sSo22XCTestErrorUnsupportedSo0aB4CodeVvg'
```

If a C enum is imported as a Swift enum with a failable initializer, we need to unwrap the value after we call the initializer in the getter.

rdar://151174264
