### PR TITLE
Set debug location to Coroutine call expression

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5019,6 +5019,8 @@ static void emitRetconCoroutineEntry(
   for (auto *arg : finalArguments) {
     arguments.push_back(arg);
   }
+  ArtificialLocation Loc(IGF.getDebugScope(), IGF.IGM.DebugInfo.get(),
+                         IGF.Builder);
   llvm::Value *id = IGF.Builder.CreateIntrinsicCall(idIntrinsic, arguments);
 
   // Call 'llvm.coro.begin', just for consistency with the normal pattern.
@@ -5125,7 +5127,6 @@ void irgen::emitYieldOnceCoroutineEntry(
     allocFn = IGF.IGM.getOpaquePtr(IGF.IGM.getMallocFn());
   }
 
-  ArtificialLocation Loc(IGF.getDebugScope(), IGF.IGM.DebugInfo.get(), IGF.Builder);
   emitRetconCoroutineEntry(IGF, fnType, buffer,
                            llvm::Intrinsic::coro_id_retcon_once,
                            getYieldOnceCoroutineBufferSize(IGF.IGM),

--- a/test/IRGen/CoroutineAccessorsDebugLoc.swift
+++ b/test/IRGen/CoroutineAccessorsDebugLoc.swift
@@ -1,0 +1,19 @@
+// REQUIRES: swift_feature_CoroutineAccessors
+// RUN: %target-swift-frontend %s -g -c -O -o - -emit-irgen -enable-experimental-feature CoroutineAccessors | %FileCheck %s
+
+// This test checks to made sure that the ReadAccessor s26CoroutineAccessorsDebugLoc1SV3irmSivr that has a call to @llvm.coro.id.retcon.once, also has a debug location set.
+
+// CHECK-LABEL: @"$s26CoroutineAccessorsDebugLoc1SV3irmSivr"
+// CHECK: %{{.*}} = call token ({{.*}}) @llvm.coro.id.retcon.once({{.*}}), !dbg ![[DBGLOC:[0-9]+]]
+// CHECK-NEXT: %{{.*}} = call ptr @llvm.coro.begin({{.*}}), !dbg ![[DBGLOC]]
+
+public struct S {
+public var o: any AnyObject
+public var _i: Int = 0
+
+public var irm: Int {
+  _read {
+    yield _i
+  }
+} // public var irm
+}


### PR DESCRIPTION
cherry picked from commit 17e756ba81106afa1a368ea61b123e6cac78bd87 https://github.com/swiftlang/swift/pull/81463

Explanation: This change makes sure that a debug location is attached to a coroutine call instruction to make sure there are no issues with invalid debug information in LTO. If LTO detects any invalid debug info, such as an instruction without a debug location, when compiled with debug info, the debug info for that translation unit will be stripped.

Scope: limited to swift.org toolchains

Risk: low, the change is additive and doesn't impact anything else

Testing: automated testing via github.com/swiftlang/swift-integration-tests

Issue: rdar://149574283

Reviewer: @adrian-prantl 

