### PR TITLE
[AST/Sema/SIL] Implement `@_inheritActorContext(always)`

### DIFF
--- a/docs/ReferenceGuides/UnderscoredAttributes.md
+++ b/docs/ReferenceGuides/UnderscoredAttributes.md
@@ -600,6 +600,43 @@ inherit the actor context (i.e. what actor it should be run on) based on the
 declaration site of the closure rather than be non-Sendable. This does not do
 anything if the closure is synchronous.
 
+This works with global actors as expected:
+
+```swift 
+@MainActor
+func test() {
+  Task { /* main actor isolated */ }
+}
+```
+
+However, for the inference to work with instance actors (i.e. `isolated` parameters),
+the closure must capture the isolated parameter explicitly:
+
+```swift 
+func test(actor: isolated (any Actor)) {
+  Task { /* non isolated */ } // !!!
+}
+
+func test(actor: isolated (any Actor)) {
+  Task { // @_inheritActorContext
+    _ = actor // 'actor'-isolated 
+  }
+}
+```
+
+The attribute takes an optional modifier '`always`', which changes this behavior 
+and *always* captures the enclosing isolated context, rather than forcing developers
+to perform the explicit capture themselfes:
+
+```swift
+func test(actor: isolated (any Actor)) {
+  Task.immediate { // @_inheritActorContext(always)
+    // 'actor'-isolated!
+    // (without having to capture 'actor explicitly')
+  }
+}
+```
+
 DISCUSSION: The reason why this does nothing when the closure is synchronous is
 since it does not have the ability to hop to the appropriate executor before it
 is run, so we may create concurrency errors.

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1254,6 +1254,18 @@ BridgedNonisolatedAttr_createParsed(BridgedASTContext cContext,
                                     BridgedSourceRange cRange,
                                     BridgedNonIsolatedModifier modifier);
 
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedInheritActorContextModifier {
+  BridgedInheritActorContextModifierNone,
+  BridgedInheritActorContextModifierAlways,
+};
+
+SWIFT_NAME("BridgedInheritActorContextAttr.createParsed(_:atLoc:range:modifier:)")
+BridgedInheritActorContextAttr
+BridgedInheritActorContextAttr_createParsed(BridgedASTContext cContext,
+                                            BridgedSourceLoc cAtLoc,
+                                            BridgedSourceRange cRange,
+                                            BridgedInheritActorContextModifier modifier);
+
 SWIFT_NAME("BridgedObjCAttr.createParsedUnnamed(_:atLoc:attrNameLoc:)")
 BridgedObjCAttr
 BridgedObjCAttr_createParsedUnnamed(BridgedASTContext cContext,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -230,6 +230,10 @@ protected:
       Modifier : NumNonIsolatedModifierBits
     );
 
+    SWIFT_INLINE_BITFIELD(InheritActorContextAttr, DeclAttribute, NumInheritActorContextKindBits,
+      Modifier : NumInheritActorContextKindBits
+    );
+
     SWIFT_INLINE_BITFIELD_FULL(AllowFeatureSuppressionAttr, DeclAttribute, 1+31,
       : NumPadBits,
       Inverted : 1,
@@ -3007,6 +3011,50 @@ public:
   }
 
   bool isEquivalent(const NonisolatedAttr *other, Decl *attachedTo) const {
+    return getModifier() == other->getModifier();
+  }
+};
+
+/// Represents @_inheritActorContext modifier.
+class InheritActorContextAttr final : public DeclAttribute {
+public:
+  InheritActorContextAttr(SourceLoc atLoc, SourceRange range,
+                          InheritActorContextModifier modifier, bool implicit)
+      : DeclAttribute(DeclAttrKind::InheritActorContext, atLoc, range,
+                      implicit) {
+    Bits.InheritActorContextAttr.Modifier = static_cast<unsigned>(modifier);
+    assert((getModifier() == modifier) && "not enough bits for modifier");
+  }
+
+  InheritActorContextModifier getModifier() const {
+    return static_cast<InheritActorContextModifier>(
+        Bits.InheritActorContextAttr.Modifier);
+  }
+
+  bool isAlways() const {
+    return getModifier() == InheritActorContextModifier::Always;
+  }
+
+  static InheritActorContextAttr *
+  createImplicit(ASTContext &ctx, InheritActorContextModifier modifier =
+                                      InheritActorContextModifier::None) {
+    return new (ctx)
+        InheritActorContextAttr(/*atLoc*/ {}, /*range*/ {}, modifier,
+                                /*implicit=*/true);
+  }
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DeclAttrKind::InheritActorContext;
+  }
+
+  /// Create a copy of this attribute.
+  InheritActorContextAttr *clone(ASTContext &ctx) const {
+    return new (ctx)
+        InheritActorContextAttr(AtLoc, Range, getModifier(), isImplicit());
+  }
+
+  bool isEquivalent(const InheritActorContextAttr *other,
+                    Decl *attachedTo) const {
     return getModifier() == other->getModifier();
   }
 };

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -142,6 +142,22 @@ enum : unsigned {
       static_cast<unsigned>(NonIsolatedModifier::Last_NonIsolatedModifier))
 };
 
+enum class InheritActorContextModifier : uint8_t {
+  /// Inherit the actor execution context if the isolated parameter was
+  /// captured by the closure, context is nonisolated or isolated to a
+  /// global actor.
+  None = 0,
+  /// Always inherit the actor context, even when the isolated parameter
+  /// for the context is not closed over explicitly.
+  Always,
+  Last_InheritActorContextKind = Always
+};
+
+enum : unsigned {
+  NumInheritActorContextKindBits = countBitsUsed(static_cast<unsigned>(
+      InheritActorContextModifier::Last_InheritActorContextKind))
+};
+
 enum class DeclAttrKind : unsigned {
 #define DECL_ATTR(_, CLASS, ...) CLASS,
 #define LAST_DECL_ATTR(CLASS) Last_DeclAttr = CLASS,

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -620,9 +620,10 @@ SIMPLE_DECL_ATTR(_implicitSelfCapture, ImplicitSelfCapture,
   UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIBreakingToRemove | ForbiddenInABIAttr,
   115)
 
-SIMPLE_DECL_ATTR(_inheritActorContext, InheritActorContext,
+DECL_ATTR(_inheritActorContext, InheritActorContext,
   OnParam,
-  UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIBreakingToRemove | ForbiddenInABIAttr,
+  // since the _inheritActorContext(always) forces an actor capture, it changes ABI of the closure this applies to
+  UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIBreakingToRemove | UnconstrainedInABIAttr,
   116)
 
 SIMPLE_DECL_ATTR(_eagerMove, EagerMove,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8602,6 +8602,16 @@ ERROR(inherit_actor_context_only_on_func_types,none,
       "%0 only applies to parameters with function types (got: %1)",
       (DeclAttribute, Type))
 
+ERROR(inherit_actor_context_only_on_sending_or_Sendable_params,none,
+      "%0 only applies to 'sending' parameters or parameters with "
+      "'@Sendable' function types",
+      (DeclAttribute))
+
+ERROR(inherit_actor_context_only_on_async_or_isolation_erased_params,none,
+      "%0 only applies to '@isolated(any)' parameters or parameters with "
+      "asynchronous function types",
+      (DeclAttribute))
+
 //===----------------------------------------------------------------------===//
 // MARK: @concurrent and nonisolated(nonsending) attributes
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8596,6 +8596,13 @@ GROUPED_ERROR(isolated_conformance_wrong_domain,IsolatedConformances,none,
       (ActorIsolation, Type, DeclName, ActorIsolation))
 
 //===----------------------------------------------------------------------===//
+// MARK: @_inheritActorContext
+//===----------------------------------------------------------------------===//
+ERROR(inherit_actor_context_only_on_func_types,none,
+      "%0 only applies to parameters with function types (got: %1)",
+      (DeclAttribute, Type))
+
+//===----------------------------------------------------------------------===//
 // MARK: @concurrent and nonisolated(nonsending) attributes
 //===----------------------------------------------------------------------===//
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -267,7 +267,7 @@ protected:
     Kind : 2
   );
 
-  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ClosureExpr, AbstractClosureExpr, 1+1+1+1+1+1+1+1+1,
     /// True if closure parameters were synthesized from anonymous closure
     /// variables.
     HasAnonymousClosureVars : 1,
@@ -276,9 +276,11 @@ protected:
     /// on each member reference.
     ImplicitSelfCapture : 1,
 
-    /// True if this @Sendable async closure parameter should implicitly
-    /// inherit the actor context from where it was formed.
+    /// True if this closure parameter should implicitly inherit the actor
+    /// context from where it was formed.
     InheritActorContext : 1,
+    /// The kind for inheritance - none or always at the moment.
+    InheritActorContextKind : 1,
 
     /// True if this closure's actor isolation behavior was determined by an
     /// \c \@preconcurrency declaration.
@@ -4318,6 +4320,7 @@ public:
     Bits.ClosureExpr.HasAnonymousClosureVars = false;
     Bits.ClosureExpr.ImplicitSelfCapture = false;
     Bits.ClosureExpr.InheritActorContext = false;
+    Bits.ClosureExpr.InheritActorContextKind = 0;
     Bits.ClosureExpr.IsPassedToSendingParameter = false;
     Bits.ClosureExpr.NoGlobalActorAttribute = false;
     Bits.ClosureExpr.RequiresDynamicIsolationChecking = false;
@@ -4366,8 +4369,29 @@ public:
     return Bits.ClosureExpr.InheritActorContext;
   }
 
-  void setInheritsActorContext(bool value = true) {
+  /// Whether this closure should _always_ implicitly inherit the actor context
+  /// regardless of whether the isolation parameter is captured or not.
+  bool alwaysInheritsActorContext() const {
+    if (!inheritsActorContext())
+      return false;
+    return getInheritActorIsolationModifier() ==
+           InheritActorContextModifier::Always;
+  }
+
+  void setInheritsActorContext(bool value = true,
+                               InheritActorContextModifier modifier =
+                                   InheritActorContextModifier::None) {
     Bits.ClosureExpr.InheritActorContext = value;
+    Bits.ClosureExpr.InheritActorContextKind = uint8_t(modifier);
+    assert((static_cast<InheritActorContextModifier>(
+                Bits.ClosureExpr.InheritActorContextKind) == modifier) &&
+           "not enough bits for modifier");
+  }
+
+  InheritActorContextModifier getInheritActorIsolationModifier() const {
+    assert(inheritsActorContext());
+    return static_cast<InheritActorContextModifier>(
+        Bits.ClosureExpr.InheritActorContextKind);
   }
 
   /// Whether the closure's concurrency behavior was determined by an

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -325,6 +325,7 @@ IDENTIFIER(SerializationRequirement)
 IDENTIFIER_WITH_NAME(builderSelf, "$builderSelf")
 
 // Attribute options
+IDENTIFIER(always)
 IDENTIFIER_(_always)
 IDENTIFIER_(assumed)
 IDENTIFIER(checked)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4049,6 +4049,7 @@ struct ParameterListInfo {
   SmallBitVector propertyWrappers;
   SmallBitVector implicitSelfCapture;
   SmallBitVector inheritActorContext;
+  SmallBitVector alwaysInheritActorContext;
   SmallBitVector variadicGenerics;
   SmallBitVector sendingParameters;
 
@@ -4075,7 +4076,8 @@ public:
 
   /// Whether the given parameter is a closure that should inherit the
   /// actor context from the context in which it was created.
-  bool inheritsActorContext(unsigned paramIdx) const;
+  std::pair<bool, InheritActorContextModifier>
+  inheritsActorContext(unsigned paramIdx) const;
 
   bool isVariadicGenericParameter(unsigned paramIdx) const;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -259,6 +259,7 @@ LANGUAGE_FEATURE(IsolatedConformances, 407, "Global-actor isolated conformances"
 LANGUAGE_FEATURE(ValueGenericsNameLookup, 452, "Value generics appearing as static members for namelookup")
 LANGUAGE_FEATURE(GeneralizedIsSameMetaTypeBuiltin, 465, "Builtin.is_same_metatype with support for noncopyable/nonescapable types")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ABIAttributeSE0479, 479, "@abi attribute on functions, initializers, properties, and subscripts")
+LANGUAGE_FEATURE(AlwaysInheritActorContext, 472, "@_inheritActorContext(always)")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -39,7 +39,8 @@ enum class ParameterizedDeclAttributeKind {
   Available,
   FreestandingMacro,
   AttachedMacro,
-  StorageRestrictions
+  StorageRestrictions,
+  InheritActorContext
 };
 
 /// A bit of a hack. When completing inside the '@storageRestrictions'

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -4976,7 +4976,6 @@ public:
   TRIVIAL_ATTR_PRINTER(ImplicitSelfCapture, implicit_self_capture)
   TRIVIAL_ATTR_PRINTER(Indirect, indirect)
   TRIVIAL_ATTR_PRINTER(Infix, infix)
-  TRIVIAL_ATTR_PRINTER(InheritActorContext, inherit_actor_context)
   TRIVIAL_ATTR_PRINTER(InheritsConvenienceInitializers,
                        inherits_convenience_initializers)
   TRIVIAL_ATTR_PRINTER(Inlinable, inlinable)
@@ -5299,6 +5298,12 @@ public:
     printCommon(Attr, "nonisolated_attr", label);
     printFlag(Attr->isUnsafe(), "unsafe");
     printFlag(Attr->isNonSending(), "nonsending");
+    printFoot();
+  }
+  void visitInheritActorContextAttr(InheritActorContextAttr *Attr,
+                                    Label label) {
+    printCommon(Attr, "inherit_actor_context_attr", label);
+    printFlag(Attr->isAlways(), "always");
     printFoot();
   }
   void visitObjCAttr(ObjCAttr *Attr, Label label) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1531,6 +1531,18 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DeclAttrKind::InheritActorContext: {
+    Printer.printAttrName("@_inheritActorContext");
+    switch (cast<InheritActorContextAttr>(this)->getModifier()) {
+    case InheritActorContextModifier::None:
+      break;
+    case InheritActorContextModifier::Always:
+      Printer << "(always)";
+      break;
+    }
+    break;
+  }
+
   case DeclAttrKind::MacroRole: {
     auto Attr = cast<MacroRoleAttr>(this);
 
@@ -1914,6 +1926,13 @@ StringRef DeclAttribute::getAttrName() const {
       return "nonisolated(unsafe)";
     case NonIsolatedModifier::NonSending:
       return "nonisolated(nonsending)";
+    }
+  case DeclAttrKind::InheritActorContext:
+    switch (cast<InheritActorContextAttr>(this)->getModifier()) {
+    case InheritActorContextModifier::None:
+      return "_inheritActorContext";
+    case InheritActorContextModifier::Always:
+      return "_inheritActorContext(always)";
     }
   case DeclAttrKind::MacroRole:
     switch (cast<MacroRoleAttr>(this)->getMacroSyntax()) {

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -649,6 +649,25 @@ BridgedNonisolatedAttr_createParsed(BridgedASTContext cContext,
       /*implicit=*/false);
 }
 
+static InheritActorContextModifier
+unbridged(BridgedInheritActorContextModifier modifier) {
+  switch (modifier) {
+  case BridgedInheritActorContextModifierNone:
+    return InheritActorContextModifier::None;
+  case BridgedInheritActorContextModifierAlways:
+    return InheritActorContextModifier::Always;
+  }
+  llvm_unreachable("unhandled enum value");
+}
+
+BridgedInheritActorContextAttr BridgedInheritActorContextAttr_createParsed(
+    BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
+    BridgedSourceRange cRange, BridgedInheritActorContextModifier modifier) {
+  return new (cContext.unbridged()) InheritActorContextAttr(
+      cAtLoc.unbridged(), cRange.unbridged(), unbridged(modifier),
+      /*implicit=*/false);
+}
+
 BridgedObjCAttr
 BridgedObjCAttr_createParsedUnnamed(BridgedASTContext cContext,
                                     BridgedSourceLoc cAtLoc,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -624,6 +624,21 @@ static bool usesFeatureExtensibleAttribute(Decl *decl) {
   return decl->getAttrs().hasAttribute<ExtensibleAttr>();
 }
 
+static bool usesFeatureAlwaysInheritActorContext(Decl *decl) {
+  auto *VD = dyn_cast<ValueDecl>(decl);
+  if (!VD)
+    return false;
+
+  if (auto *PL = VD->getParameterList()) {
+    return llvm::any_of(*PL, [&](const ParamDecl *P) {
+      auto *attr = P->getAttrs().getAttribute<InheritActorContextAttr>();
+      return attr && attr->isAlways();
+    });
+  }
+
+  return false;
+}
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1378,6 +1378,7 @@ ParameterListInfo::ParameterListInfo(
   propertyWrappers.resize(params.size());
   implicitSelfCapture.resize(params.size());
   inheritActorContext.resize(params.size());
+  alwaysInheritActorContext.resize(params.size());
   variadicGenerics.resize(params.size());
   sendingParameters.resize(params.size());
 
@@ -1434,8 +1435,13 @@ ParameterListInfo::ParameterListInfo(
       implicitSelfCapture.set(i);
     }
 
-    if (param->getAttrs().hasAttribute<InheritActorContextAttr>()) {
-      inheritActorContext.set(i);
+    if (auto *attr =
+            param->getAttrs().getAttribute<InheritActorContextAttr>()) {
+      if (attr->isAlways()) {
+        alwaysInheritActorContext.set(i);
+      } else {
+        inheritActorContext.set(i);
+      }
     }
 
     if (param->getInterfaceType()->is<PackExpansionType>()) {
@@ -1469,10 +1475,18 @@ bool ParameterListInfo::isImplicitSelfCapture(unsigned paramIdx) const {
       : false;
 }
 
-bool ParameterListInfo::inheritsActorContext(unsigned paramIdx) const {
-  return paramIdx < inheritActorContext.size()
-      ? inheritActorContext[paramIdx]
-      : false;
+std::pair<bool, InheritActorContextModifier>
+ParameterListInfo::inheritsActorContext(unsigned paramIdx) const {
+  if (paramIdx >= inheritActorContext.size())
+    return std::make_pair(false, InheritActorContextModifier::None);
+
+  if (inheritActorContext[paramIdx])
+    return std::make_pair(true, InheritActorContextModifier::None);
+
+  if (alwaysInheritActorContext[paramIdx])
+    return std::make_pair(true, InheritActorContextModifier::Always);
+
+  return std::make_pair(false, InheritActorContextModifier::None);
 }
 
 bool ParameterListInfo::isVariadicGenericParameter(unsigned paramIdx) const {

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -249,7 +249,6 @@ extension ASTGenVisitor {
         .ibSegueAction,
         .implementationOnly,
         .implicitSelfCapture,
-        .inheritActorContext,
         .inheritsConvenienceInitializers,
         .inlinable,
         .isolated,
@@ -312,6 +311,9 @@ extension ASTGenVisitor {
       case .referenceOwnership:
         // TODO: Diagnose.
         return handle(self.generateReferenceOwnershipAttr(attribute: node, attrName: attrName)?.asDeclAttribute)
+      case .inheritActorContext:
+        return handle(self.generateInheritActorContextAttr(attribute: node)?.asDeclAttribute)
+
       case .async,
         .consuming,
         .borrowing,
@@ -1399,6 +1401,28 @@ extension ASTGenVisitor {
         }
       },
       valueIfOmitted: BridgedNonIsolatedModifier.none
+    )
+    guard let modifier else {
+      return nil
+    }
+    return .createParsed(
+      self.ctx,
+      atLoc: self.generateSourceLoc(node.atSign),
+      range: self.generateAttrSourceRange(node),
+      modifier: modifier
+    )
+  }
+
+  func generateInheritActorContextAttr(attribute node: AttributeSyntax) -> BridgedInheritActorContextAttr? {
+    let modifier: BridgedInheritActorContextModifier? = self.generateSingleAttrOption(
+      attribute: node,
+      {
+        switch $0.rawText {
+        case "always": return .always
+        default: return nil
+        }
+      },
+      valueIfOmitted: BridgedInheritActorContextModifier.none
     )
     guard let modifier else {
       return nil

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3141,6 +3141,9 @@ void CompletionLookup::getAttributeDeclParamCompletions(
     addDeclAttrParamKeyword("unsafe", /*Parameters=*/{}, "", false);
     addDeclAttrParamKeyword("nonsending", /*Parameters=*/{}, "", false);
     break;
+  case ParameterizedDeclAttributeKind::InheritActorContext:
+    addDeclAttrParamKeyword("always", /*Parameters=*/{}, "", false);
+    break;
   case ParameterizedDeclAttributeKind::AccessControl:
     addDeclAttrParamKeyword("set", /*Parameters=*/{}, "", false);
     break;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3773,6 +3773,25 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
     break;
   }
+  case DeclAttrKind::InheritActorContext: {
+    AttrRange = Loc;
+    std::optional<InheritActorContextModifier> Modifier(
+        InheritActorContextModifier::None);
+    Modifier = parseSingleAttrOption<InheritActorContextModifier>(
+        *this, Loc, AttrRange, AttrName, DK,
+        {{Context.Id_always, InheritActorContextModifier::Always}}, *Modifier,
+        ParameterizedDeclAttributeKind::InheritActorContext);
+    if (!Modifier) {
+      return makeParserSuccess();
+    }
+
+    if (!DiscardAttribute) {
+      Attributes.add(new (Context) InheritActorContextAttr(
+          AtLoc, AttrRange, *Modifier, /*implicit=*/false));
+    }
+
+    break;
+  }
   case DeclAttrKind::MacroRole: {
     auto syntax = (AttrName == "freestanding" ? MacroSyntax::Freestanding
                                               : MacroSyntax::Attached);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -184,7 +184,6 @@ public:
   IGNORED_ATTR(AtRethrows)
   IGNORED_ATTR(AtReasync)
   IGNORED_ATTR(ImplicitSelfCapture)
-  IGNORED_ATTR(InheritActorContext)
   IGNORED_ATTR(Preconcurrency)
   IGNORED_ATTR(BackDeployed)
   IGNORED_ATTR(Documentation)
@@ -442,8 +441,10 @@ public:
   void visitNonisolatedAttr(NonisolatedAttr *attr);
   void visitIsolatedAttr(IsolatedAttr *attr);
 
+  void visitInheritActorContextAttr(InheritActorContextAttr *attr);
+
   void visitNoImplicitCopyAttr(NoImplicitCopyAttr *attr);
-  
+
   void visitAlwaysEmitConformanceMetadataAttr(AlwaysEmitConformanceMetadataAttr *attr);
 
   void visitExtractConstantsFromMembersAttr(ExtractConstantsFromMembersAttr *attr);
@@ -7843,6 +7844,22 @@ void AttributeChecker::visitAsyncAttr(AsyncAttr *attr) {
       attr->setInvalid();
       return;
     }
+  }
+}
+
+void AttributeChecker::visitInheritActorContextAttr(
+    InheritActorContextAttr *attr) {
+  auto *P = dyn_cast<ParamDecl>(D);
+  if (!P)
+    return;
+
+  auto paramTy = P->getInterfaceType();
+  auto *funcTy =
+      paramTy->lookThroughAllOptionalTypes()->getAs<AnyFunctionType>();
+  if (!funcTy) {
+    diagnoseAndRemoveAttr(attr, diag::inherit_actor_context_only_on_func_types,
+                          attr, paramTy);
+    return;
   }
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7861,6 +7861,24 @@ void AttributeChecker::visitInheritActorContextAttr(
                           attr, paramTy);
     return;
   }
+
+  // The type has to be either `@Sendable` or `sending` _and_
+  // `async` or `@isolated(any)`.
+  if (!(funcTy->isSendable() || P->isSending())) {
+    diagnose(attr->getLocation(),
+             diag::inherit_actor_context_only_on_sending_or_Sendable_params,
+             attr)
+        .warnUntilFutureSwiftVersion();
+  }
+
+  // Eiether `async` or `@isolated(any)`.
+  if (!(funcTy->isAsync() || funcTy->getIsolation().isErased())) {
+    diagnose(
+        attr->getLocation(),
+        diag::inherit_actor_context_only_on_async_or_isolation_erased_params,
+        attr)
+        .warnUntilFutureSwiftVersion();
+  }
 }
 
 void AttributeChecker::visitMarkerAttr(MarkerAttr *attr) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4774,6 +4774,11 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
 
     case ActorIsolation::ActorInstance: {
       if (checkIsolatedCapture) {
+        auto *explicitClosure = dyn_cast<ClosureExpr>(closure);
+        // @_inheritActorContext(always) forces the isolation capture.
+        if (explicitClosure && explicitClosure->alwaysInheritsActorContext())
+          return parentIsolation;
+
         if (auto param = closure->getCaptureInfo().getIsolatedParamCapture())
           return ActorIsolation::forActorInstanceCapture(param);
       } else {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6544,6 +6544,17 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::InheritActorContext_DECL_ATTR: {
+        unsigned modifier;
+        bool isImplicit{};
+        serialization::decls_block::InheritActorContextDeclAttrLayout::
+            readRecord(scratch, modifier, isImplicit);
+        Attr = new (ctx) InheritActorContextAttr(
+            {}, {}, static_cast<InheritActorContextModifier>(modifier),
+            isImplicit);
+        break;
+      }
+
       case decls_block::MacroRole_DECL_ATTR: {
         bool isImplicit;
         uint8_t rawMacroSyntax;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 950; // DeclNameRef module selectors
+const uint16_t SWIFTMODULE_VERSION_MINOR = 951; // add modifier to @_inheritActorContext
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2553,6 +2553,12 @@ namespace decls_block {
   using NonisolatedDeclAttrLayout =
       BCRecordLayout<Nonisolated_DECL_ATTR,
                      BCFixed<2>, // the modifier (unsafe, nonsending)
+                     BCFixed<1>  // implicit flag
+                     >;
+
+  using InheritActorContextDeclAttrLayout =
+       BCRecordLayout<InheritActorContext_DECL_ATTR,
+                     BCFixed<1>, // the modifier (none = 0, always = 1)
                      BCFixed<1>  // implicit flag
                      >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3451,6 +3451,16 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DeclAttrKind::InheritActorContext: {
+      auto *theAttr = cast<InheritActorContextAttr>(DA);
+      auto abbrCode =
+          S.DeclTypeAbbrCodes[InheritActorContextDeclAttrLayout::Code];
+      InheritActorContextDeclAttrLayout::emitRecord(
+          S.Out, S.ScratchRecord, abbrCode,
+          static_cast<uint8_t>(theAttr->getModifier()), theAttr->isImplicit());
+      return;
+    }
+
     case DeclAttrKind::MacroRole: {
       auto *theAttr = cast<MacroRoleAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[MacroRoleDeclAttrLayout::Code];

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -257,5 +257,5 @@ struct AnyEraser: EraserProto {
   init<T: EraserProto>(erasing: T) {}
 }
 
-func takeNone(@_inheritActorContext param: () async -> ()) { }
-func takeAlways(@_inheritActorContext(always) param: () async -> ()) { }
+func takeNone(@_inheritActorContext param: @Sendable () async -> ()) { }
+func takeAlways(@_inheritActorContext(always) param: sending @isolated(any) () -> ()) { }

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -256,3 +256,6 @@ struct LayoutOuter {
 struct AnyEraser: EraserProto {
   init<T: EraserProto>(erasing: T) {}
 }
+
+func takeNone(@_inheritActorContext param: () async -> ()) { }
+func takeAlways(@_inheritActorContext(always) param: () async -> ()) { }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1210,6 +1210,8 @@ actor MyServer : Server {
 func acceptAsyncSendableClosure<T>(_: @Sendable () async -> T) { }
 @available(SwiftStdlib 5.1, *)
 func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable () async -> T) { }
+@available(SwiftStdlib 5.1, *)
+func acceptAsyncSendableClosureInheritingAlways<T>(@_inheritActorContext(always) _: @Sendable () async -> T) { }
 
 @available(SwiftStdlib 5.1, *)
 extension MyActor {
@@ -1237,6 +1239,10 @@ extension MyActor {
       _ = await synchronous() // expected-warning{{no 'async' operations occur within 'await' expression}}
       counter += 1 // okay
     }
+
+    acceptAsyncSendableClosureInheritingAlways {
+      counter += 1 // Ok
+    }
   }
 }
 
@@ -1256,6 +1262,32 @@ func testGlobalActorInheritance() {
 
   acceptAsyncSendableClosureInheriting {
     counter += 1 // ok
+  }
+
+  acceptAsyncSendableClosureInheritingAlways {
+    counter += 1 // ok
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func testIsolatedParameter1(_: isolated any Actor, v: inout Int) {
+  acceptAsyncSendableClosureInheriting {
+    v += 1 // expected-warning {{mutable capture of 'inout' parameter 'v' is not allowed in concurrently-executing code}}
+  }
+
+  acceptAsyncSendableClosureInheritingAlways {
+    v += 1 // Ok
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func testIsolatedParameter2(_: isolated (any Actor)? = #isolation, v: inout Int) {
+  acceptAsyncSendableClosureInheriting {
+    v += 1 // expected-warning {{mutable capture of 'inout' parameter 'v' is not allowed in concurrently-executing code}}
+  }
+
+  acceptAsyncSendableClosureInheritingAlways {
+    v += 1 // Ok
   }
 }
 

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -24,10 +24,6 @@ func normalAcceptsClosure(_ x: () -> ()) {}
 func normalAcceptsSendingClosure(_ x: sending () -> ()) {}
 func normalAcceptsSendableClosure(_ x: @Sendable () -> ()) {}
 
-func inheritActorContextAcceptsClosure(@_inheritActorContext _ x: () -> ()) { }
-func inheritActorContextAcceptsSendingClosure(@_inheritActorContext _ x: sending () -> ()) { }
-func inheritActorContextAcceptsSendableClosure(@_inheritActorContext _ x: @Sendable () -> ()) { }
-
 @MainActor
 func normalGlobalActorAcceptsClosure(_ x: () -> ()) { }
 @MainActor
@@ -35,18 +31,10 @@ func normalGlobalActorAcceptsSendingClosure(_ x: sending () -> ()) { }
 @MainActor
 func normalGlobalActorAcceptsSendableClosure(_ x: @Sendable () -> ()) { }
 
-@MainActor
-func inheritActorContextGlobalActorAcceptsClosure(@_inheritActorContext _ x: () -> ()) { }
-@MainActor
-func inheritActorContextGlobalActorAcceptsSendingClosure(@_inheritActorContext _ x: sending () -> ()) { }
-@MainActor
-func inheritActorContextGlobalActorAcceptsSendableClosure(@_inheritActorContext _ x: @Sendable () -> ()) { }
-
 func normalAcceptsAsyncClosure(_ x: () async -> ()) {}
 func normalAcceptsSendingAsyncClosure(_ x: sending () async -> ()) {}
 func normalAcceptsSendableAsyncClosure(_ x: @Sendable () async -> ()) {}
 
-func inheritActorContextAcceptsAsyncClosure(@_inheritActorContext _ x: () async -> ()) { }
 func inheritActorContextAcceptsSendingAsyncClosure(@_inheritActorContext _ x: sending () async -> ()) { }
 func inheritActorContextAcceptsSendableAsyncClosure(@_inheritActorContext _ x: @Sendable () async -> ()) { }
 
@@ -58,8 +46,6 @@ func normalGlobalActorAcceptsSendingAsyncClosure(_ x: sending () async -> ()) { 
 func normalGlobalActorAcceptsSendableAsyncClosure(_ x: @Sendable () async -> ()) { }
 
 @MainActor
-func inheritActorContextGlobalActorAcceptsAsyncClosure(@_inheritActorContext _ x: () async -> ()) { }
-@MainActor
 func inheritActorContextGlobalActorAcceptsSendingAsyncClosure(@_inheritActorContext _ x: sending () async -> ()) { }
 @MainActor
 func inheritActorContextGlobalActorAcceptsSendableAsyncClosure(@_inheritActorContext _ x: @Sendable () async -> ()) { }
@@ -68,10 +54,6 @@ func asyncNormalAcceptsClosure(_ x: () -> ()) async {}
 func asyncNormalAcceptsSendingClosure(_ x: sending () -> ()) async {}
 func asyncNormalAcceptsSendableClosure(_ x: @Sendable () -> ()) async {}
 
-func asyncInheritActorContextAcceptsClosure(@_inheritActorContext _ x: () -> ()) async {}
-func asyncInheritActorContextAcceptsSendingClosure(@_inheritActorContext _ x: sending () -> ()) async {}
-func asyncInheritActorContextAcceptsSendableClosure(@_inheritActorContext _ x: @Sendable () -> ()) async {}
-
 @MainActor
 func asyncNormalGlobalActorAcceptsClosure(_ x: () -> ()) async {}
 @MainActor
@@ -79,18 +61,10 @@ func asyncNormalGlobalActorAcceptsSendingClosure(_ x: sending () -> ()) async {}
 @MainActor
 func asyncNormalGlobalActorAcceptsSendableClosure(_ x: @Sendable () -> ()) async {}
 
-@MainActor
-func asyncInheritActorContextGlobalActorAcceptsClosure(@_inheritActorContext _ x: () -> ()) async {}
-@MainActor
-func asyncInheritActorContextGlobalActorAcceptsSendingClosure(@_inheritActorContext _ x: sending () -> ()) async {}
-@MainActor
-func asyncInheritActorContextGlobalActorAcceptsSendableClosure(@_inheritActorContext _ x: @Sendable () -> ()) async {}
-
 func asyncNormalAcceptsAsyncClosure(_ x: () async -> ()) async {}
 func asyncNormalAcceptsSendingAsyncClosure(_ x: sending () async -> ()) async {}
 func asyncNormalAcceptsSendableAsyncClosure(_ x: @Sendable () async -> ()) async {}
 
-func asyncInheritActorContextAcceptsAsyncClosure(@_inheritActorContext _ x: () async -> ()) async {}
 func asyncInheritActorContextAcceptsSendingAsyncClosure(@_inheritActorContext _ x: sending () async -> ()) async {}
 func asyncInheritActorContextAcceptsSendableAsyncClosure(@_inheritActorContext _ x: @Sendable () async -> ()) async {}
 
@@ -101,8 +75,6 @@ func asyncNormalGlobalActorAcceptsSendingAsyncClosure(_ x: sending () async -> (
 @MainActor
 func asyncNormalGlobalActorAcceptsSendableAsyncClosure(_ x: @Sendable () async -> ()) async {}
 
-@MainActor
-func asyncInheritActorContextGlobalActorAcceptsAsyncClosure(@_inheritActorContext _ x: () async -> ()) async {}
 @MainActor
 func asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure(@_inheritActorContext _ x: sending () async -> ()) async {}
 @MainActor
@@ -139,26 +111,6 @@ func test_CallerSyncNormal_CalleeSyncNonIsolated() async {
 }
 
 @CustomActor
-func test_CallerSyncInheritsActorContext_CalleeSyncNonisolated() {
-    // CHECK: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference042test_CallerSyncInheritsActorContext_CalleeF11NonisolatedyyF'
-
-    // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    inheritActorContextAcceptsClosure { }
-
-    // This is a synchronous closure, so we error here.
-    //
-    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    inheritActorContextAcceptsSendingClosure { } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    //  expected-note @-1 {{Passing global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' as a 'sending' parameter to global function 'inheritActorContextAcceptsSendingClosure' risks causing races inbetween global actor 'CustomActor'-isolated uses and uses reachable from 'inheritActorContextAcceptsSendingClosure'}}
-
-    // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    inheritActorContextAcceptsSendableClosure { }
-}
-
-@CustomActor
 func test_CallerSyncNormal_CalleeSyncMainActorIsolated() async {
     // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference028test_CallerSyncNormal_CalleeF17MainActorIsolatedyyYaF'
 
@@ -174,27 +126,6 @@ func test_CallerSyncNormal_CalleeSyncMainActorIsolated() async {
     // CHECK-LABEL: // closure #3 in test_CallerSyncNormal_CalleeSyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: nonisolated
     await normalGlobalActorAcceptsSendableClosure { }
-}
-
-@CustomActor
-func test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
-    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference042test_CallerSyncInheritsActorContext_Calleef4MainH8IsolatedyyYaF'
-
-    // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await inheritActorContextGlobalActorAcceptsClosure { } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' to main actor-isolated global function 'inheritActorContextGlobalActorAcceptsClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
-
-    // This is a synchronous closure, so we error here.
-    //
-    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await inheritActorContextGlobalActorAcceptsSendingClosure { } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{Passing global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' as a 'sending' parameter to global function 'inheritActorContextGlobalActorAcceptsSendingClosure' risks causing races inbetween global actor 'CustomActor'-isolated uses and uses reachable from 'inheritActorContextGlobalActorAcceptsSendingClosure'}}
-
-    // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await inheritActorContextGlobalActorAcceptsSendableClosure { }
 }
 
 ////////////////////////////////////////////////
@@ -223,13 +154,9 @@ func test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated() {
 
     // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    inheritActorContextAcceptsAsyncClosure { }
-
-    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     inheritActorContextAcceptsSendingAsyncClosure { }
 
-    // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     inheritActorContextAcceptsSendableAsyncClosure { }
 }
@@ -258,13 +185,9 @@ func test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
 
     // CHECK-LABEL: // closure #1 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await inheritActorContextGlobalActorAcceptsAsyncClosure { }
-
-    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await inheritActorContextGlobalActorAcceptsSendingAsyncClosure { }
 
-    // CHECK-LABEL: // closure #3 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-LABEL: // closure #2 in test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await inheritActorContextGlobalActorAcceptsSendableAsyncClosure { }
 }
@@ -294,27 +217,6 @@ func test_CallerAsyncNormal_CalleeSyncNonIsolated() async {
 }
 
 @CustomActor
-func test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated() async {
-    // CHECK: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference58test_CallerAsyncInheritsActorContext_CalleeSyncNonisolatedyyYaF'
-
-    // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsClosure { } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' to nonisolated global function 'asyncInheritActorContextAcceptsClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
-
-    // This is a synchronous closure, so we error here.
-    //
-    // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsSendingClosure { } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{Passing global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' as a 'sending' parameter to global function 'asyncInheritActorContextAcceptsSendingClosure' risks causing races inbetween global actor 'CustomActor'-isolated uses and uses reachable from 'asyncInheritActorContextAcceptsSendingClosure'}}
-
-    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsSendableClosure { }
-}
-
-@CustomActor
 func test_CallerAsyncNormal_CalleeSyncMainActorIsolated() async {
     // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference50test_CallerAsyncNormal_CalleeSyncMainActorIsolatedyyYaF'
 
@@ -330,27 +232,6 @@ func test_CallerAsyncNormal_CalleeSyncMainActorIsolated() async {
     // CHECK-LABEL: // closure #3 in test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: nonisolated
     await asyncNormalGlobalActorAcceptsSendableClosure { }
-}
-
-@CustomActor
-func test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
-    // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference051test_CallerAsyncInheritsActorContext_CalleeSyncMainH8IsolatedyyYaF'
-
-    // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextGlobalActorAcceptsClosure { } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' to main actor-isolated global function 'asyncInheritActorContextGlobalActorAcceptsClosure' risks causing races in between global actor 'CustomActor'-isolated and main actor-isolated uses}}
-
-    // This is a synchronous closure, so we error here.
-    //
-    // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextGlobalActorAcceptsSendingClosure { } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{Passing global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' as a 'sending' parameter to global function 'asyncInheritActorContextGlobalActorAcceptsSendingClosure' risks causing races inbetween global actor 'CustomActor'-isolated uses and uses reachable from 'asyncInheritActorContextGlobalActorAcceptsSendingClosure'}}
-
-    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextGlobalActorAcceptsSendableClosure { }
 }
 
 /////////////////////////////////////////////////
@@ -381,21 +262,17 @@ func test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated() async {
 
     // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsAsyncClosure { }
+    await asyncInheritActorContextAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextAcceptsSendingAsyncClosure { }
-
-    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await asyncInheritActorContextAcceptsSendingAsyncClosure { @CustomActor in }
 
-    // CHECK-LABEL: // closure #4 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: MainActor
     await asyncInheritActorContextAcceptsSendingAsyncClosure { @MainActor in }
 
-    // CHECK-LABEL: // closure #5 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+    // CHECK-LABEL: // closure #4 in test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await asyncInheritActorContextAcceptsSendableAsyncClosure { }
 }
@@ -424,21 +301,17 @@ func test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated() async {
 
     // CHECK-LABEL: // closure #1 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextGlobalActorAcceptsAsyncClosure { }
+    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { }
 
     // CHECK-LABEL: // closure #2 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
-    await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { }
-
-    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
-    // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @CustomActor in }
 
-    // CHECK-LABEL: // closure #4 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-LABEL: // closure #3 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: MainActor
     await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @MainActor in }
 
-    // CHECK-LABEL: // closure #5 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+    // CHECK-LABEL: // closure #4 in test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
     // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
     await asyncInheritActorContextGlobalActorAcceptsSendableAsyncClosure { }
 }
@@ -464,26 +337,6 @@ extension MyActor {
         normalAcceptsSendableClosure { print(self) }
     }
 
-    func test_CallerSyncInheritsActorContext_CalleeSyncNonisolated() {
-        // CHECK: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC023test_CallerSyncInheritse14Context_CalleeH11NonisolatedyyF'
-
-        // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        inheritActorContextAcceptsClosure { print(self) }
-
-        // This is a synchronous closure, so we error here.
-        //
-        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        inheritActorContextAcceptsSendingClosure { // expected-error {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
-            print(self) // expected-note {{closure captures 'self'}}
-        }
-
-        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncNonisolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        inheritActorContextAcceptsSendableClosure { print(self) }
-    }
-
     func test_CallerSyncNormal_CalleeSyncMainActorIsolated() async {
         // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC028test_CallerSyncNormal_Calleeh4MainE8IsolatedyyYaF'
 
@@ -499,27 +352,6 @@ extension MyActor {
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncNormal_CalleeSyncMainActorIsolated()
         // CHECK-NEXT: // Isolation: nonisolated
         await normalGlobalActorAcceptsSendableClosure { print(self) }
-    }
-
-    func test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
-        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC023test_CallerSyncInheritse14Context_Calleeh4MainE8IsolatedyyYaF'
-
-        // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await inheritActorContextGlobalActorAcceptsClosure { print(self) } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-        // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() -> ()' to main actor-isolated global function 'inheritActorContextGlobalActorAcceptsClosure' risks causing races in between 'self'-isolated and main actor-isolated uses}}
-
-        // This is a synchronous closure, so we error here.
-        //
-        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await inheritActorContextGlobalActorAcceptsSendingClosure { // expected-error {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
-            print(self) // expected-note {{closure captures 'self'}}
-        }
-
-        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncInheritsActorContext_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await inheritActorContextGlobalActorAcceptsSendableClosure { print(self) }
     }
 }
 
@@ -550,13 +382,9 @@ extension MyActor {
 
         // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
         // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        inheritActorContextAcceptsAsyncClosure { print(self) }
-
-        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
         inheritActorContextAcceptsSendingAsyncClosure { print(self) }
 
-        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncNonisolated()
         // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
         inheritActorContextAcceptsSendableAsyncClosure { print(self) }
     }
@@ -583,13 +411,9 @@ extension MyActor {
 
         // CHECK-LABEL: // closure #1 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
         // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await inheritActorContextGlobalActorAcceptsAsyncClosure { print(self) }
-
-        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
         await inheritActorContextGlobalActorAcceptsSendingAsyncClosure { print(self) }
 
-        // CHECK-LABEL: // closure #3 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerSyncInheritsActorContext_CalleeAsyncMainActorIsolated()
         // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
         await inheritActorContextGlobalActorAcceptsSendableAsyncClosure { print(self) }
     }
@@ -620,27 +444,6 @@ extension MyActor {
         await asyncNormalAcceptsSendableClosure { print(self) }
     }
 
-    func test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated() async {
-        // CHECK: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC024test_CallerAsyncInheritsE29Context_CalleeSyncNonisolatedyyYaF'
-
-        // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await asyncInheritActorContextAcceptsClosure { print(self) } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-        // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() -> ()' to nonisolated global function 'asyncInheritActorContextAcceptsClosure' risks causing races in between 'self'-isolated and nonisolated uses}}
-
-        // This is a synchronous closure, so we error here.
-        //
-        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await asyncInheritActorContextAcceptsSendingClosure { // expected-error {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
-            print(self) // expected-note {{closure captures 'self'}}
-        }
-
-        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncNonisolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await asyncInheritActorContextAcceptsSendableClosure { print(self) }
-    }
-
     func test_CallerAsyncNormal_CalleeSyncMainActorIsolated() async {
         // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC037test_CallerAsyncNormal_CalleeSyncMainE8IsolatedyyYaF'
 
@@ -656,27 +459,6 @@ extension MyActor {
         // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncNormal_CalleeSyncMainActorIsolated()
         // CHECK-NEXT: // Isolation: nonisolated
         await asyncNormalGlobalActorAcceptsSendableClosure { print(self) }
-    }
-
-    func test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated() async {
-        // CHECK-LABEL: } // end sil function '$s54transfernonsendable_closureliterals_isolationinference7MyActorC024test_CallerAsyncInheritse22Context_CalleeSyncMainE8IsolatedyyYaF'
-
-        // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await asyncInheritActorContextGlobalActorAcceptsClosure { print(self) } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-        // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() -> ()' to main actor-isolated global function 'asyncInheritActorContextGlobalActorAcceptsClosure' risks causing races in between 'self'-isolated and main actor-isolated uses}}
-
-        // This is a synchronous function, so we error.
-        //
-        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await asyncInheritActorContextGlobalActorAcceptsSendingClosure { // expected-error {{passing closure as a 'sending' parameter risks causing data races between 'self'-isolated code and concurrent execution of the closure}}
-            print(self) // expected-note {{closure captures 'self'}}
-        }
-
-        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeSyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await asyncInheritActorContextGlobalActorAcceptsSendableClosure { print(self) }
     }
 }
 
@@ -708,21 +490,17 @@ extension MyActor {
 
         // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
         // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await asyncInheritActorContextAcceptsAsyncClosure { print(self) }
-
-        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
         await asyncInheritActorContextAcceptsSendingAsyncClosure { print(self) }
 
-        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
         // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
         await asyncInheritActorContextAcceptsSendingAsyncClosure { @CustomActor in print(self) }
 
-        // CHECK-LABEL: // closure #4 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
         // CHECK-NEXT: // Isolation: global_actor. type: MainActor
         await asyncInheritActorContextAcceptsSendingAsyncClosure { @MainActor in print(self) }
 
-        // CHECK-LABEL: // closure #5 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
+        // CHECK-LABEL: // closure #4 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncNonisolated()
         // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
         await asyncInheritActorContextAcceptsSendableAsyncClosure { print(self) }
     }
@@ -749,21 +527,17 @@ extension MyActor {
 
         // CHECK-LABEL: // closure #1 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
         // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
-        await asyncInheritActorContextGlobalActorAcceptsAsyncClosure { print(self) }
-
-        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
-        // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
         await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { print(self) }
 
-        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-LABEL: // closure #2 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
         // CHECK-NEXT: // Isolation: global_actor. type: CustomActor
         await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @CustomActor in print(self) }
 
-        // CHECK-LABEL: // closure #4 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-LABEL: // closure #3 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
         // CHECK-NEXT: // Isolation: global_actor. type: MainActor
         await asyncInheritActorContextGlobalActorAcceptsSendingAsyncClosure { @MainActor in print(self) }
 
-        // CHECK-LABEL: // closure #5 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
+        // CHECK-LABEL: // closure #4 in MyActor.test_CallerAsyncInheritsActorContext_CalleeAsyncMainActorIsolated()
         // CHECK-NEXT: // Isolation: actor_instance. name: 'self'
         await asyncInheritActorContextGlobalActorAcceptsSendableAsyncClosure { print(self) }
     }

--- a/test/ModuleInterface/inheritActorContext_attr.swift
+++ b/test/ModuleInterface/inheritActorContext_attr.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// CHECK-NOT: #if compiler(>=5.3) && $AlwaysInheritActorContext
+// CHECK: public func globalTest(@_inheritActorContext _: @Sendable () async -> Swift.Void)
+// CHECK-NOT: #endif
+public func globalTest(@_inheritActorContext _: @Sendable () async -> Void) {}
+
+// CHECK: #if compiler(>=5.3) && $AlwaysInheritActorContext
+// CHECK-NEXT: public func globalTestAlways(@_inheritActorContext(always) _: @Sendable () async -> Swift.Void)
+// CHECK-NEXT: #endif
+public func globalTestAlways(@_inheritActorContext(always) _: @Sendable () async -> Void) {}
+
+public struct Test {
+  // CHECK-NOT: #if compiler(>=5.3) && $AlwaysInheritActorContext
+  // CHECK: public init(@_inheritActorContext x: @Sendable () async -> Swift.Int)
+  // CHECK-NOT: #endif
+  public init(@_inheritActorContext x: @Sendable () async -> Int) {}
+
+  // CHECK: #if compiler(>=5.3) && $AlwaysInheritActorContext
+  // CHECK-NEXT: #if compiler(>=5.3) && $SendingArgsAndResults
+  // CHECK-NEXT: public init(@_inheritActorContext(always) y: sending () async -> Swift.Void)
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: public init(@_inheritActorContext(always) y: () async -> Swift.Void)
+  // CHECK-NEXT: #endif
+  // CHECK-NEXT: #endif
+  public init(@_inheritActorContext(always) y: sending () async -> Void) {}
+
+  // CHECK-NOT: #if compiler(>=5.3) && $AlwaysInheritActorContext
+  // CHECK: public subscript(@_inheritActorContext _: @Sendable () async -> Swift.Void) -> Swift.Bool {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+  // CHECK-NOT: #endif
+  public subscript(@_inheritActorContext _: @Sendable () async -> Void) -> Bool { false }
+
+  // CHECK: #if compiler(>=5.3) && $AlwaysInheritActorContext
+  // CHECK-NEXT: public subscript(@_inheritActorContext(always) _: @Sendable (Swift.Int) async -> Swift.Void) -> Swift.Bool {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+  public subscript(@_inheritActorContext(always) _: @Sendable (Int) async -> Void) -> Bool { false }
+}

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1406,15 +1406,18 @@ func nonEphemeral2(_: UnsafeRawPointer) {}
 @abi(func disfavoredOverload3(_: UnsafeRawPointer))
 func nonEphemeral3(@_nonEphemeral _: UnsafeRawPointer) {}
 
-// @_inheritActorContext -- banned in @abi
-@abi(func inheritActorContext1(@_inheritActorContext fn: @Sendable @escaping () async -> Void)) // expected-error {{unused '_inheritActorContext' attribute in '@abi'}} {{32-53=}}
+// @_inheritActorContext
+@abi(func inheritActorContext1(@_inheritActorContext fn: @Sendable @escaping () async -> Void))
 func inheritActorContext1(@_inheritActorContext fn: @Sendable @escaping () async -> Void) {}
 
-@abi(func inheritActorContext2(@_inheritActorContext fn: @Sendable @escaping () async -> Void)) // expected-error {{unused '_inheritActorContext' attribute in '@abi'}} {{32-53=}}
+@abi(func inheritActorContext2(@_inheritActorContext fn: @Sendable @escaping () async -> Void))
 func inheritActorContext2(fn: @Sendable @escaping () async -> Void) {}
 
 @abi(func inheritActorContext3(fn: @Sendable @escaping () async -> Void))
 func inheritActorContext3(@_inheritActorContext fn: @Sendable @escaping () async -> Void) {}
+
+@abi(func inheritActorContext4(@_inheritActorContext(always) fn: @Sendable @escaping () async -> Void))
+func inheritActorContext4(fn: @Sendable @escaping () async -> Void) {}
 
 // @excusivity(checked/unchecked) -- banned in @abi
 class Exclusivity {

--- a/test/attr/attr_inheritActorContext.swift
+++ b/test/attr/attr_inheritActorContext.swift
@@ -3,13 +3,17 @@
 func test1(@_inheritActorContext _: @Sendable () async -> Void) {} // Ok
 func test2(@_inheritActorContext(always) _: sending () async -> Void) {} // Ok
 
-func test3(@_inheritActorContext _: () -> Void) {}
+func test3(@_inheritActorContext _: () async -> Void) {}
+// expected-warning@-1 {{@_inheritActorContext only applies to 'sending' parameters or parameters with '@Sendable' function types}}
+func test3(@_inheritActorContext _: @Sendable () -> Void) {}
+// expected-warning@-1 {{@_inheritActorContext only applies to '@isolated(any)' parameters or parameters with asynchronous function types}}
 
 func test4(@_inheritActorContext _: Int) {}
 // expected-error@-1 {{@_inheritActorContext only applies to parameters with function types (got: 'Int')}}
 
-func test5(@_inheritActorContext _: Optional<() async -> Int>) {} // Ok
-func test6(@_inheritActorContext _: (Optional<() async -> Int>)?) {} // Ok
+func test5(@_inheritActorContext _: sending Optional<() async -> Int>) {} // Ok
+func test6(@_inheritActorContext _: (Optional<@Sendable () async -> Int>)?) {} // Ok
+func test6(@_inheritActorContext _: (Optional<@Sendable @isolated(any) () -> Int>)?) {} // Ok
 
 func test7(@_inheritActorContext _: Int?) {} // Ok
 // expected-error@-1 {{@_inheritActorContext only applies to parameters with function types (got: 'Int?')}}
@@ -24,12 +28,11 @@ struct S {
   subscript(@_inheritActorContext _: @Sendable () async -> Void) -> Bool { false } // Ok
   subscript(@_inheritActorContext(always) _: @Sendable (Int) async -> Void) -> Bool { false } // Ok
 
-  subscript(@_inheritActorContext _: (String) -> Void) -> Bool { false }
-  subscript(x: Int, @_inheritActorContext(always) _: (Int, Int) -> Void) -> Bool { false }
+  subscript(@_inheritActorContext _: sending (String) async -> Void) -> Bool { false }
+  subscript(x: Int, @_inheritActorContext(always) _: @Sendable (Int, Int) async -> Void) -> Bool { false }
 
   func testClosure() {
     _ = { @_inheritActorContext in // expected-error {{attribute @_inheritActorContext is not supported on a closure}}
     }
   }
 }
-

--- a/test/attr/attr_inheritActorContext.swift
+++ b/test/attr/attr_inheritActorContext.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift
+
+func test1(@_inheritActorContext _: @Sendable () async -> Void) {} // Ok
+func test2(@_inheritActorContext(always) _: sending () async -> Void) {} // Ok
+
+func test3(@_inheritActorContext _: () -> Void) {}
+
+func test4(@_inheritActorContext _: Int) {}
+// expected-error@-1 {{@_inheritActorContext only applies to parameters with function types (got: 'Int')}}
+
+func test5(@_inheritActorContext _: Optional<() async -> Int>) {} // Ok
+func test6(@_inheritActorContext _: (Optional<() async -> Int>)?) {} // Ok
+
+func test7(@_inheritActorContext _: Int?) {} // Ok
+// expected-error@-1 {{@_inheritActorContext only applies to parameters with function types (got: 'Int?')}}
+
+struct S {
+  init(@_inheritActorContext(always) _: @escaping @Sendable () async -> Void) {} // Ok
+
+  var test: @_inheritActorContext () async -> Void { // expected-error {{attribute can only be applied to declarations, not types}}
+    { }
+  }
+
+  subscript(@_inheritActorContext _: @Sendable () async -> Void) -> Bool { false } // Ok
+  subscript(@_inheritActorContext(always) _: @Sendable (Int) async -> Void) -> Bool { false } // Ok
+
+  subscript(@_inheritActorContext _: (String) -> Void) -> Bool { false }
+  subscript(x: Int, @_inheritActorContext(always) _: (Int, Int) -> Void) -> Bool { false }
+
+  func testClosure() {
+    _ = { @_inheritActorContext in // expected-error {{attribute @_inheritActorContext is not supported on a closure}}
+    }
+  }
+}
+


### PR DESCRIPTION
- Extend `@_inheritActorContext` attribute to support optional `always` modifier. The new modifier will make closure context isolated even if the parameter is not captured by the closure.
- Implementation `@_inheritActorContext` attribute validation - it could only be used on parameter that have `@Sendable` or `sending` and `@isolated(any)` or `async` function type (downgraded to a warning until future major Swift mode to avoid source compatibility issues).
- Add a new language feature that guards use of `@_inheritActorContext(always)` in swift interface files
- Update `getLoweredLocalCaptures` to add an entry for isolation parameter implicitly captured by `@_inheritActorContext(always)`
- Update serialization code to store `always` modifier

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
