### PR TITLE
6.2: Fixed no copying IsIsolated flag when cloning subscript params

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7000,6 +7000,10 @@ public:
   /// Create a an identical copy of this ParamDecl.
   static ParamDecl *clone(const ASTContext &Ctx, ParamDecl *PD);
 
+  static ParamDecl *cloneAccessor(const ASTContext &Ctx,
+                                  ParamDecl const *subscriptParam,
+                                  DeclContext *Parent);
+
   static ParamDecl *
   createImplicit(ASTContext &Context, SourceLoc specifierLoc,
                  SourceLoc argumentNameLoc, Identifier argumentName,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11134,16 +11134,16 @@ AccessorDecl *AccessorDecl::createParsed(
           subscriptParam->getArgumentNameLoc(),
           subscriptParam->getArgumentName(), subscriptParam->getNameLoc(),
           subscriptParam->getName(), /*declContext*/ accessor);
-      param->setAutoClosure(subscriptParam->isAutoClosure());
 
       // The cloned parameter is implicit.
       param->setImplicit();
 
-      if (subscriptParam->isSending())
-        param->setSending();
-
-      if (subscriptParam->isCallerIsolated())
-        param->setCallerIsolated();
+      // TODO: Check why IsVariadic is not copied.
+      param->setAutoClosure(subscriptParam->isAutoClosure());
+      param->setIsolated(subscriptParam->isIsolated());
+      // TODO: Check why IsAddressable is not copied.
+      param->setSending(subscriptParam->isSending());
+      param->setCallerIsolated(subscriptParam->isCallerIsolated());
 
       newParams.push_back(param);
     }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8918,6 +8918,21 @@ ParamDecl *ParamDecl::clone(const ASTContext &Ctx, ParamDecl *PD) {
   return Clone;
 }
 
+ParamDecl *ParamDecl::cloneAccessor(const ASTContext &Ctx,
+                                    ParamDecl const *subscriptParam,
+                                    DeclContext *Parent) {
+  auto *param = new (Ctx) ParamDecl(
+      subscriptParam->getSpecifierLoc(), subscriptParam->getArgumentNameLoc(),
+      subscriptParam->getArgumentName(), subscriptParam->getNameLoc(),
+      subscriptParam->getName(), /*declContext*/ Parent);
+  param->setOptions(subscriptParam->getOptions());
+
+  // The cloned parameter is implicit.
+  param->setImplicit();
+
+  return param;
+}
+
 ParamDecl *
 ParamDecl::createImplicit(ASTContext &Context, SourceLoc specifierLoc,
                           SourceLoc argumentNameLoc, Identifier argumentName,
@@ -11128,23 +11143,7 @@ AccessorDecl *AccessorDecl::createParsed(
       paramsEnd = indices->getEndLoc();
     }
     for (auto *subscriptParam : *indices) {
-      // Clone the parameter.
-      auto *param = new (ctx) ParamDecl(
-          subscriptParam->getSpecifierLoc(),
-          subscriptParam->getArgumentNameLoc(),
-          subscriptParam->getArgumentName(), subscriptParam->getNameLoc(),
-          subscriptParam->getName(), /*declContext*/ accessor);
-
-      // The cloned parameter is implicit.
-      param->setImplicit();
-
-      // TODO: Check why IsVariadic is not copied.
-      param->setAutoClosure(subscriptParam->isAutoClosure());
-      param->setIsolated(subscriptParam->isIsolated());
-      // TODO: Check why IsAddressable is not copied.
-      param->setSending(subscriptParam->isSending());
-      param->setCallerIsolated(subscriptParam->isCallerIsolated());
-
+      auto param = ParamDecl::cloneAccessor(ctx, subscriptParam, accessor);
       newParams.push_back(param);
     }
 


### PR DESCRIPTION
- **Explanation**: Fixes some parameter flags (`IsIsolated`, `IsVariadic`, `IsAddressable`) not copied when cloning subscript params into individual accessors, with a bit of refactoring to ensure that any flags added in the future will be copied as well.
- **Scope**: Unlikely to break any existing code. Code existing code relying on these attributes was pretty much unusable.
- **Issues**: https://github.com/swiftlang/swift/issues/80992
- **Original PRs**: https://github.com/swiftlang/swift/pull/81022
- **Risk**: Low, this is a localised bugfix
- **Testing**: MR includes update of the unit tests
- **Reviewers**: @hborla, @slavapestov 
