### PR TITLE
[Concurrency] Lower the availability of task inits with names

### DIFF
--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -226,9 +226,9 @@ extension Task where Failure == Never {
   /// - SeeAlso: ``withTaskExecutorPreference(_:operation:)``
   @discardableResult
   @_alwaysEmitIntoClient
-  public init(
+  public init( // Task.init where Failure == Never (TaskExecutor)
     name: String? = nil,
-    executorPreference taskExecutor: consuming (any TaskExecutor)? = nil,
+    executorPreference taskExecutor: consuming (any TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: sending @escaping () async -> Success
   ) {
@@ -315,7 +315,7 @@ extension Task where Failure == Error {
   /// - SeeAlso: ``withTaskExecutorPreference(_:operation:)``
   @discardableResult
   @_alwaysEmitIntoClient
-  public init(
+  public init( // Task.init where Failure == Error (TaskExecutor)
     name: String? = nil,
     executorPreference taskExecutor: consuming (any TaskExecutor)?,
     priority: TaskPriority? = nil,

--- a/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
+++ b/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
@@ -31,13 +31,33 @@ import Swift
 %          'ThrowingDiscardingTaskGroup'
 %        ],
 %        [
-%          '@available(SwiftStdlib 6.2, *)',
+%          '@available(SwiftStdlib 6.0, *)', # because task executor
 %          '@_unavailableInEmbedded', # since TaskExecutor is not available on embedded
 %        ],
 %        ['addTask', 'addTaskUnlessCancelled'],
 %        [
 %          'name: String?',
 %          'executorPreference taskExecutor: (any TaskExecutor)? = nil',
+%          'priority: TaskPriority? = nil',
+%          # throws and ChildTaskResult will be adjusted per task group type
+%          'operation: sending @escaping @isolated(any) () async throws -> ChildTaskResult'
+%        ],
+%      ),
+%      (
+%        '', # no #if condition
+%        [
+%          'TaskGroup',
+%          'ThrowingTaskGroup',
+%          'DiscardingTaskGroup',
+%          'ThrowingDiscardingTaskGroup'
+%        ],
+%        [
+%          # use availability of task group we're declaring within since decl is @AEIC
+%          '@_unavailableInEmbedded', # since TaskExecutor is not available on embedded
+%        ],
+%        ['addTask', 'addTaskUnlessCancelled'],
+%        [
+%          'name: String?',
 %          'priority: TaskPriority? = nil',
 %          # throws and ChildTaskResult will be adjusted per task group type
 %          'operation: sending @escaping @isolated(any) () async throws -> ChildTaskResult'
@@ -266,7 +286,9 @@ extension ${TYPE} {
             flags: flags,
             initialSerialExecutor: builtinSerialExecutor,
             taskGroup: _group,
+            % if HAS_TASK_EXECUTOR:
             initialTaskExecutorConsuming: taskExecutor,
+            % end
             taskName: nameBytes.baseAddress!._rawValue,
             operation: operation).0
         }
@@ -282,7 +304,9 @@ extension ${TYPE} {
         flags: flags,
         initialSerialExecutor: builtinSerialExecutor,
         taskGroup: _group,
+        % if HAS_TASK_EXECUTOR:
         initialTaskExecutorConsuming: taskExecutor,
+        % end
         operation: operation).0
       #else
       // legacy branch for the non-consuming task executor

--- a/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
+++ b/stdlib/public/Concurrency/TaskGroup+addTask.swift.gyb
@@ -191,10 +191,9 @@ extension ${TYPE} {
   ///
   /// - Parameters:
   % if HAS_TASK_NAME:
-  ///   - name: Human readable name of this task.
+  ///   - name: Human readable name of this task. Some runtime versions may not support naming tasks, and this parameter will be ignored.
   % end
   % if HAS_TASK_EXECUTOR:
-  ///   - taskExecutor:
   ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///      Explicitly passing `nil` as the executor preference is equivalent to
   ///      calling the `${METHOD_NAME}` method without a preference, and effectively

--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -111,7 +111,7 @@
 /// In a context that expects a sendable closure,
 /// a closure that satisfies the requirements
 /// implicitly conforms to `Sendable` ---
-/// for example, in a call to `Task.detached(priority:operation:)`.
+/// for example, in a call to `Task.detached(name:priority:operation:)`.
 ///
 /// You can explicitly mark a closure as sendable
 /// by writing `@Sendable` as part of a type annotation,

--- a/test/Concurrency/Runtime/task_naming_availability.swift
+++ b/test/Concurrency/Runtime/task_naming_availability.swift
@@ -1,0 +1,74 @@
+// RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -verify %s
+
+
+
+ struct Boom: Error {}
+
+ @available(SwiftStdlib 6.2, *)
+ func testName() {
+   _ = Task.name
+ }
+
+ @available(SwiftStdlib 6.0, *)
+ func taskExecutor() async {
+   Task(name: "name", executorPreference: nil) { }
+   Task(name: "name", executorPreference: nil) { throw Boom() }
+
+   Task.detached(name: "name", executorPreference: nil) { throw Boom() }
+
+   await withTaskGroup(of: Void.self) { group in
+     group.addTask(name: "name", executorPreference: nil) {
+       ()
+     }
+   }
+   await withThrowingTaskGroup(of: Void.self) { group in
+     group.addTask(name: "name", executorPreference: nil) {
+       ()
+     }
+   }
+
+   await withDiscardingTaskGroup { group in
+     group.addTask(name: "name", executorPreference: nil) {
+       ()
+     }
+   }
+   try! await withThrowingDiscardingTaskGroup { group in
+     group.addTask(name: "name", executorPreference: nil) {
+       ()
+     }
+   }
+ }
+
+ @available(SwiftStdlib 5.1, *)
+ func backDeployedNames() async {
+   Task(name: "name") { }
+   Task(name: "name") { throw Boom() }
+
+   Task.detached(name: "name") { }
+   Task.detached(name: "name") { throw Boom() }
+
+   await withTaskGroup(of: Void.self) { group in
+     group.addTask(name: "name") {
+       ()
+     }
+   }
+   await withThrowingTaskGroup(of: Void.self) { group in
+     group.addTask(name: "name") {
+       ()
+     }
+   }
+ }
+
+ @available(SwiftStdlib 5.9, *)
+ func backDeployedDiscarding() async {
+   await withDiscardingTaskGroup { group in
+     group.addTask(name: "name") {
+       ()
+     }
+   }
+   try! await withThrowingDiscardingTaskGroup { group in
+     group.addTask(name: "name") {
+       ()
+     }
+   }
+ }

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -debug-constraints
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -debug-constraints -strict-concurrency=targeted
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -debug-constraints -strict-concurrency=complete
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -debug-constraints -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=targeted
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -enable-actor-data-race-checks -o - %s | %FileCheck %s
 

--- a/test/Concurrency/actor_defer.swift
+++ b/test/Concurrency/actor_defer.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=targeted
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -debug-constraints
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -debug-constraints -strict-concurrency=targeted
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -debug-constraints -strict-concurrency=complete
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -DNEGATIVES -verify %s -debug-constraints -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // RUN: %target-swift-frontend -parse-as-library -emit-sil -enable-actor-data-race-checks -o - %s | %FileCheck %s
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1767,7 +1767,7 @@ extension MyActor {
         _ = sc
 
         Task { // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-          // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(priority:operation:)' risks causing races in between local and caller code}}
+          // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
           _ = sc
         }
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1767,7 +1767,7 @@ extension MyActor {
         _ = sc
 
         Task { // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-          // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+          // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(priority:operation:)' risks causing races in between local and caller code}}
           _ = sc
         }
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1767,7 +1767,7 @@ extension MyActor {
         _ = sc
 
         Task { // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-          // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(priority:operation:)' risks causing races in between local and caller code}}
+          // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
           _ = sc
         }
 
@@ -1975,7 +1975,7 @@ func mutableLocalCaptureDataRace() async {
   _ = x
 
   Task.detached { x = 1 } // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-  // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(priority:operation:)' risks causing races in between local and caller code}}
+  // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
 
   x = 2 // expected-tns-note {{access can happen concurrently}}
 }
@@ -1985,7 +1985,7 @@ func mutableLocalCaptureDataRace2() async {
   x = 0
 
   Task.detached { x = 1 } // expected-tns-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-  // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(priority:operation:)' risks causing races in between local and caller code}}
+  // expected-tns-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
 
   print(x) // expected-tns-note {{access can happen concurrently}}
 }

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -1008,7 +1008,7 @@ func closureTests() async {
   func testWithTaskDetached() async {
     let x1 = NonSendableKlass()
     Task.detached { _ = x1 } // expected-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-    // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(priority:operation:)' risks causing races in between local and caller code}}
+    // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
     Task.detached { _ = x1 } // expected-note {{access can happen concurrently}}
 
     nonisolated(unsafe) let x2 = NonSendableKlass()
@@ -1023,7 +1023,7 @@ func closureTests() async {
     nonisolated(unsafe) let x4a = NonSendableKlass()
     let x4b = NonSendableKlass()
     Task.detached { _ = x4a; _ = x4b } // expected-warning {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-    // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(priority:operation:)' risks causing races in between local and caller code}}
+    // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(name:priority:operation:)' risks causing races in between local and caller code}}
     Task.detached { _ = x4a; _ = x4b } // expected-note {{access can happen concurrently}}
   }
 }

--- a/test/Concurrency/transfernonsendable_typed_errors.swift
+++ b/test/Concurrency/transfernonsendable_typed_errors.swift
@@ -60,7 +60,7 @@ extension MyActor {
         _ = sc
 
         Task { // expected-error {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-          // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(priority:operation:)' risks causing races in between local and caller code}}
+          // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
           _ = sc
         }
 

--- a/test/Concurrency/transfernonsendable_typed_errors.swift
+++ b/test/Concurrency/transfernonsendable_typed_errors.swift
@@ -60,7 +60,7 @@ extension MyActor {
         _ = sc
 
         Task { // expected-error {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-          // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(name:priority:operation:)' risks causing races in between local and caller code}}
+          // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to initializer 'init(priority:operation:)' risks causing races in between local and caller code}}
           _ = sc
         }
 


### PR DESCRIPTION
This lowers the availability of all task creation APIs which use the new task names - as approved by SE evolution.

Originally the PR https://github.com/swiftlang/swift/pull/80984 was meant to do this while moving all these APIs to gyb, but landing that change proved difficult so let's do it manually for now, and remove the duplication later.

