### PR TITLE
6.2: Copy WasmKit to `host_install_destdir`

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1345,6 +1345,7 @@ playgroundsupport
 indexstore-db
 sourcekit-lsp
 swiftdocc
+wasmkit
 
 # Build with debug info, this allows us to symbolicate crashes from
 # production builds.

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -672,6 +672,14 @@ class BuildScriptInvocation(object):
                             is_enabled=self.args.build_wasmstdlib)
         builder.add_product(products.WasmThreadsLLVMRuntimeLibs,
                             is_enabled=self.args.build_wasmstdlib)
+
+        builder.add_product(products.SwiftTestingMacros,
+                            is_enabled=self.args.build_swift_testing_macros)
+        builder.add_product(products.SwiftTesting,
+                            is_enabled=self.args.build_swift_testing)
+        builder.add_product(products.SwiftPM,
+                            is_enabled=self.args.build_swiftpm)
+
         builder.add_product(products.WasmKit,
                             is_enabled=self.args.build_wasmkit)
         builder.add_product(products.WasmStdlib,
@@ -681,12 +689,6 @@ class BuildScriptInvocation(object):
         builder.add_product(products.WasmSwiftSDK,
                             is_enabled=self.args.build_wasmstdlib)
 
-        builder.add_product(products.SwiftTestingMacros,
-                            is_enabled=self.args.build_swift_testing_macros)
-        builder.add_product(products.SwiftTesting,
-                            is_enabled=self.args.build_swift_testing)
-        builder.add_product(products.SwiftPM,
-                            is_enabled=self.args.build_swiftpm)
         builder.add_product(products.SwiftFoundationTests,
                             is_enabled=self.args.build_foundation)
         builder.add_product(products.FoundationTests,

--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -47,19 +47,24 @@ class WasmKit(product.Product):
 
     def should_install(self, host_target):
         # Currently, it's only used for testing stdlib.
-        return False
+        return True
 
     def install(self, host_target):
-        pass
+        """
+        Install WasmKit to the target location
+        """
+        install_destdir = self.host_install_destdir(host_target)
+        build_toolchain_path = install_destdir + self.args.install_prefix + '/bin'
+        shutil.copy(self.bin_path, build_toolchain_path)
 
     def build(self, host_target):
-        bin_path = run_swift_build(host_target, self, 'wasmkit-cli')
-        print("Built wasmkit-cli at: " + bin_path)
+        self.bin_path = run_swift_build(host_target, self, 'wasmkit-cli')
+        print("Built wasmkit-cli at: " + self.bin_path)
         # Copy the built binary to ./bin
         dest_bin_path = self.__class__.cli_file_path(self.build_dir)
         print("Copying wasmkit-cli to: " + dest_bin_path)
         os.makedirs(os.path.dirname(dest_bin_path), exist_ok=True)
-        shutil.copy(bin_path, dest_bin_path)
+        shutil.copy(self.bin_path, dest_bin_path)
 
     @classmethod
     def cli_file_path(cls, build_dir):

--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -56,33 +56,44 @@ class WasmKit(product.Product):
         """
         install_destdir = self.host_install_destdir(host_target)
         build_toolchain_path = install_destdir + self.args.install_prefix + '/bin'
-        shutil.copy(self.bin_path, build_toolchain_path + '/wasmkit')
+        bin_path = run_swift_build(host_target, self, 'wasmkit-cli', set_installation_rpath=True)
+        shutil.copy(bin_path, build_toolchain_path + '/wasmkit')
 
     def build(self, host_target):
-        self.bin_path = run_swift_build(host_target, self, 'wasmkit-cli')
-        print("Built wasmkit-cli at: " + self.bin_path)
+        bin_path = run_swift_build(host_target, self, 'wasmkit-cli')
+        print("Built wasmkit-cli at: " + bin_path)
         # Copy the built binary to ./bin
         dest_bin_path = self.__class__.cli_file_path(self.build_dir)
         print("Copying wasmkit-cli to: " + dest_bin_path)
         os.makedirs(os.path.dirname(dest_bin_path), exist_ok=True)
-        shutil.copy(self.bin_path, dest_bin_path)
+        shutil.copy(bin_path, dest_bin_path)
 
     @classmethod
     def cli_file_path(cls, build_dir):
         return os.path.join(build_dir, 'bin', 'wasmkit-cli')
 
 
-def run_swift_build(host_target, product, swpft_package_product_name):
+def run_swift_build(host_target, product, swiftpm_package_product_name, set_installation_rpath=False):
     # Building with the freshly-built SwiftPM
     swift_build = os.path.join(product.install_toolchain_path(host_target), "bin", "swift-build")
 
+    build_os = host_target.split('-')[0]
+    if set_installation_rpath and not host_target.startswith('macos'):
+        # Library rpath for swift, dispatch, Foundation, etc. when installing
+        rpath_args = [
+            '--disable-local-rpath', '-Xswiftc', '-no-toolchain-stdlib-rpath',
+            '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/' + build_os
+        ]
+    else:
+        rpath_args = []
+
     build_args = [
         swift_build,
-        '--product', swpft_package_product_name,
+        '--product', swiftpm_package_product_name,
         '--package-path', os.path.join(product.source_dir),
         '--build-path', product.build_dir,
         '--configuration', 'release',
-    ]
+    ] + rpath_args
 
     if product.args.verbose_build:
         build_args.append('--verbose')
@@ -94,4 +105,4 @@ def run_swift_build(host_target, product, swpft_package_product_name):
 
     bin_dir_path = shell.capture(
         build_args + ['--show-bin-path'], dry_run=False, echo=False).rstrip()
-    return os.path.join(bin_dir_path, swpft_package_product_name)
+    return os.path.join(bin_dir_path, swiftpm_package_product_name)

--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -14,6 +14,7 @@ import os
 import shutil
 
 from . import product
+from . import swiftpm
 from .. import shell
 
 
@@ -37,7 +38,7 @@ class WasmKit(product.Product):
 
     @classmethod
     def get_dependencies(cls):
-        return []
+        return [swiftpm.SwiftPM]
 
     def should_build(self, host_target):
         return self.args.build_wasmkit
@@ -72,10 +73,8 @@ class WasmKit(product.Product):
 
 
 def run_swift_build(host_target, product, swpft_package_product_name):
-    # Building with the host toolchain's SwiftPM
-    swiftc_path = os.path.abspath(product.toolchain.swiftc)
-    toolchain_path = os.path.dirname(os.path.dirname(swiftc_path))
-    swift_build = os.path.join(toolchain_path, 'bin', 'swift-build')
+    # Building with the freshly-built SwiftPM
+    swift_build = os.path.join(product.install_toolchain_path(host_target), "bin", "swift-build")
 
     build_args = [
         swift_build,

--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -55,7 +55,7 @@ class WasmKit(product.Product):
         """
         install_destdir = self.host_install_destdir(host_target)
         build_toolchain_path = install_destdir + self.args.install_prefix + '/bin'
-        shutil.copy(self.bin_path, build_toolchain_path)
+        shutil.copy(self.bin_path, build_toolchain_path + '/wasmkit')
 
     def build(self, host_target):
         self.bin_path = run_swift_build(host_target, self, 'wasmkit-cli')


### PR DESCRIPTION
Cherry-pick of #81178, merged as eac419b8ca2dc36925f678b24d1077c61910cf09

**Explanation**: This enables `swift run` and `swift test` to use WasmKit when cross-compiling to Wasm with Swift SDKs that have toolsets pointing to WasmKit.
**Scope**: limited to swift.org toolchains and a single WasmKit product. No other build products are changed.
**Risk**: low, the change is additive and doesn't impact anything other than this single product.
**Testing**: automated testing via github.com/swiftlang/swift-integration-tests
**Issue**: rdar://150382758
**Reviewer**: @bnbarham 
