### PR TITLE
[6.2] preset: treat swift testing the same as xctest

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -424,6 +424,8 @@ mixin-preset=buildbot_incremental_base
 # on Foundation, so that is built as well. On OS X, Foundation is built as part
 # of the XCTest Xcode project.
 xctest
+swift-testing
+swift-testing-macros
 
 build-swift-stdlib-unittest-extra
 
@@ -441,6 +443,8 @@ skip-test-foundation
 release
 assertions
 xctest
+swift-testing
+swift-testing-macros
 test
 
 skip-test-cmark
@@ -625,6 +629,8 @@ swiftformat
 swift-driver
 indexstore-db
 sourcekit-lsp
+swift-testing
+swift-testing-macros
 # Failing to build in CI: rdar://78408440
 # swift-inspect
 install-llvm
@@ -635,6 +641,8 @@ install-swiftpm
 install-swiftsyntax
 install-swift-driver
 install-swiftformat
+install-swift-testing
+install-swift-testing-macros
 
 # We need to build the unittest extras so we can test
 build-swift-stdlib-unittest-extra
@@ -1123,6 +1131,8 @@ lldb
 foundation
 swiftpm
 swift-driver
+swift-testing
+swift-testing-macros
 xctest
 
 build-subdir=buildbot_linux
@@ -1136,6 +1146,8 @@ install-foundation
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
+install-swift-testing
+install-swift-testing-macros
 install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;libexec;stdlib;swift-remote-mirror;sdk-overlay;dev
@@ -3014,8 +3026,12 @@ build-subdir=compat_linux
 foundation
 libdispatch
 xctest
+swift-testing
+swift-testing-macros
 install-foundation
 install-libdispatch
+install-swift-testing
+install-swift-testing-macros
 install-xctest
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
 
@@ -3208,6 +3224,8 @@ skip-early-swift-driver
 
 llbuild
 xctest
+swift-testing
+swift-testing-macros
 swiftpm
 
 swift-include-tests=0
@@ -3232,4 +3250,6 @@ install-foundation
 install-libdispatch
 install-llbuild
 install-swiftpm
+install-swift-testing
+install-swift-testing-macros
 install-xctest


### PR DESCRIPTION
Whenever XCtest is build and installed, do the same for swift-testing and swift-testing macros.

(cherry picked from commit 2962ea2b31bba2ed35a28afc73a11414759ef35b)

Based on #81401 

**Explanation**:
The SwiftPM repository added Swift Testing helpers in a non-test target, so we can re-used common helpers (e.g.: custom traits, custom tags, etc...).  As part of the toolchain build, SwiftPM builds a baseline of itself using Cmake, then build the `Package.swift` using the Cmake artifact.  During the "second" stage SwiftPM build, this non-test target (which is meant to only be used by tests), will be complied, and would cause a "Testing module not found error".
    
The ideal solution would be to have a SwiftPM feature that would allow the specifying targets to only be made available for test target.  Converting this target to a test targets causes `swift build` and `swift test` to succeed, but  Xcode package resolution fails.

The path to least resistance was to treat Swift Testing, and Swift Testing Macros the same as XCTest in the build presets.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
**Scope**:
This will likely cause longe build times since additional "projects" may be built.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
**Issues**:
N/A
  <!--
  References to issues the changes resolve, if any.
  -->
**Original PRs**:
#81401, to allow https://github.com/swiftlang/swift-package-manager/pull/8495 and https://github.com/swiftlang/swift-package-manager/pull/8663, and other changes to https://github.com/swiftlang/swift-package-manager Swift Testing tests.
 <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
**Risk**:
this is low risk as the change build extra "projects", but toolchain builds will likely fail if this is merged after the next [SwiftPM `main` to `release/6.2` merge](https://github.com/swiftlang/swift-package-manager/pull/8608) 
  <!--
  The (specific) risk to the release for taking the changes.
  -->
**Testing**:
If we can get a toolchain successfully built, this would yield positive results. and prefer have this merged before the next [SwiftPM `main` to `release/6.2` merge](https://github.com/swiftlang/swift-package-manager/pull/8608)  to avoid toolchain build failures.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
**Reviewers**:
 @etcwilde 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->


<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
