### PR TITLE
IRGen: Fix out-of-order task_dealloc with parameter pack metadata

### DIFF
--- a/include/swift/AST/TypeTransform.h
+++ b/include/swift/AST/TypeTransform.h
@@ -1176,6 +1176,12 @@ case TypeKind::Id:
     if (transformedPack.getPointer() == element->getPackType().getPointer())
       return element;
 
+    if (!transformedPack->isParameterPack() &&
+        !transformedPack->is<PackArchetypeType>() &&
+        !transformedPack->isTypeVariableOrMember()) {
+      return transformedPack;
+    }
+
     return PackElementType::get(transformedPack, element->getLevel());
   }
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3879,7 +3879,7 @@ PackElementType::PackElementType(Type packType, unsigned level,
     packType(packType), level(level) {
   assert(packType->isParameterPack() ||
          packType->is<PackArchetypeType>() ||
-         packType->is<TypeVariableType>());
+         packType->isTypeVariableOrMember());
   assert(level > 0);
 }
 

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -307,8 +307,6 @@ static CanPackType getReducedShapeOfPack(const ASTContext &ctx,
     }
 
     // Use () as a placeholder for scalar shape.
-    assert(!elt->template is<PackArchetypeType>() &&
-           "Pack archetype outside of a pack expansion");
     elts.push_back(ctx.TheEmptyTupleType);
   }
 

--- a/test/Concurrency/Runtime/async_parameter_pack.swift
+++ b/test/Concurrency/Runtime/async_parameter_pack.swift
@@ -1,0 +1,21 @@
+// RUN: %target-run-simple-swift( -target %target-swift-5.9-abi-triple)
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+protocol P {
+  associatedtype A
+  var a: A { get }
+}
+
+func f<each T: P>(_ t: repeat each T) async -> (repeat (each T).A) {
+  let x = (repeat (each t).a)
+  return x
+}
+
+struct S: P {
+  var a: String { "" }
+}
+
+_ = await f()
+_ = await f(S())
+_ = await f(S(), S())

--- a/test/IRGen/pack_metadata_dealloc.swift
+++ b/test/IRGen/pack_metadata_dealloc.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple | %FileCheck %s
+
+protocol P {
+  associatedtype A
+  var a: A { get }
+}
+
+func f<each T: P>(_ t: repeat each T) -> (repeat (each T).A) {
+  let data = (repeat (each t).a)
+  return data
+}
+
+// CHECK-LABEL: define {{.*}} void @"$s21pack_metadata_dealloc1fy1AQzxQp_txxQpRvzAA1PRzlF"
+// CHECK: [[SPSAVE:%.*]] = call ptr @llvm.stacksave.p0()
+// CHECK: call void @llvm.stackrestore.p0(ptr [[SPSAVE]])
+// CHECK: [[SPSAVE1:%.*]] = call ptr @llvm.stacksave.p0()
+// CHECK: [[SPSAVE2:%.*]] = call ptr @llvm.stacksave.p0()
+// CHECK-NOT: call ptr llvm.stacksave.p0()
+// CHECK:  call void @llvm.stackrestore.p0(ptr [[SPSAVE2]])
+// CHECK:  call void @llvm.stackrestore.p0(ptr [[SPSAVE1]])
+// CHECK:  ret void

--- a/test/IRGen/pack_metadata_dealloc.swift
+++ b/test/IRGen/pack_metadata_dealloc.swift
@@ -19,3 +19,12 @@ func f<each T: P>(_ t: repeat each T) -> (repeat (each T).A) {
 // CHECK:  call void @llvm.stackrestore.p0(ptr [[SPSAVE2]])
 // CHECK:  call void @llvm.stackrestore.p0(ptr [[SPSAVE1]])
 // CHECK:  ret void
+
+struct G<each T> {
+  init(_: repeat each T) {}
+}
+
+func f2<each T: P, each U>(t: repeat each T, u: repeat each U) async -> (repeat G<(each T).A, repeat each U>) {
+  let x = (repeat G((each t).a, repeat each u))
+  return x
+}


### PR DESCRIPTION
We deallocate an instruction's packs at points where no further control flow path uses the value. In the case of an `alloc_stack`, this will be right after the `dealloc_stack`. Thus, if `alloc_stack` allocates some packs to build type metadata for a tuple type that contains a pack, and then proceeds to allocate a value large enough to hold the tuple, we will free the second allocation first, before we free the pack, as expected.

However, after stack allocating the value, `alloc_stack` does some further work to emit debug info. This could result in
emission of additional metadata packs.

Split up the debug info emission into two parts; the first we do before we perform the stack allocation, the rest we do after.

- Fixes https://github.com/swiftlang/swift/issues/67702.
- Fixes rdar://problem/141363236.