### PR TITLE
[Macros] Mitigate plugin process 'wait' failure 

### DIFF
--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -213,6 +213,7 @@ LoadedExecutablePlugin::PluginProcess::~PluginProcess() {
 #else
   close(input);
   close(output);
+  kill(process.Pid, SIGTERM);
 #endif
 
   // Set `SecondsToWait` non-zero so it waits for the timeout and kill it after

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -219,8 +219,10 @@ LoadedExecutablePlugin::PluginProcess::~PluginProcess() {
   // that. Usually when the pipe is closed above, the plugin detects the EOF in
   // the stdin and exits immediately, so this usually doesn't wait for the
   // timeout. Note that we can't use '0' because it performs a non-blocking
-  // wait, which make the plugin a zombie if it hasn't exited.
-  llvm::sys::Wait(process, /*SecondsToWait=*/1);
+  // wait, which make the plugin a zombie if it hasn't exited. We don't use
+  // a small number like '1' because the timeout alarm(3) can fire before the
+  // wait4(2).
+  llvm::sys::Wait(process, /*SecondsToWait=*/10);
 }
 
 ssize_t LoadedExecutablePlugin::PluginProcess::read(void *buf,


### PR DESCRIPTION
Previously, the compiler waited the plugin process with `llvm::sys::Wait(process, /*SecondsToWait=*/1)`. But in the `Wait` implementation, it sets the `alarm(SecondsToWait)`, then `wait4(process.Pid, ..)` so if the alarm fires before the `wait4` call, it may miss the timeout and can wait indefinitely. To mitigate that risk, use **`10`** for the timeout value.

And terminate the plugin process, then `wait` to reap it, instead of expecting the plugin read `EOF` and `exit` itself.

Also, close all the pipe file descriptors in the child process after duping them to the standard I/O. This is not necessary but it's a good thing to do anyway.

rdar://150474701