### PR TITLE
[6.2][Frontend] Add a way to print features supported by the compiler

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -59,9 +59,9 @@ GROUPED_WARNING(cannot_disable_feature_with_mode, StrictLanguageFeatures, none,
                 "'%0' argument '%1' cannot specify a mode",
                 (StringRef, StringRef))
 
-GROUPED_WARNING(feature_does_not_support_adoption_mode, StrictLanguageFeatures,
+GROUPED_WARNING(feature_does_not_support_migration_mode, StrictLanguageFeatures,
                 none,
-                "feature '%0' does not support adoption mode",
+                "feature '%0' does not support migration mode",
                 (StringRef))
 
 ERROR(error_unknown_library_level, none,

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -57,8 +57,8 @@ struct Feature {
   /// Determine the in-source name of the given feature.
   llvm::StringRef getName() const;
 
-  /// Determine whether the given feature supports adoption mode.
-  bool isAdoptable() const;
+  /// Determine whether the given feature supports migration mode.
+  bool isMigratable() const;
 
   /// Determine whether this feature should be included in the
   /// module interface

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -10,8 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_BASIC_FEATURES_H
-#define SWIFT_BASIC_FEATURES_H
+#ifndef SWIFT_BASIC_FEATURE_H
+#define SWIFT_BASIC_FEATURE_H
+
+#include "swift/Basic/LLVM.h"
 
 #include "llvm/ADT/StringRef.h"
 #include <optional>
@@ -21,53 +23,72 @@ namespace swift {
 class LangOptions;
 
 /// Enumeration describing all of the named features.
-enum class Feature : uint16_t {
+struct Feature {
+  enum class InnerKind : uint16_t {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description) FeatureName,
 #include "swift/Basic/Features.def"
+  };
+
+  InnerKind kind;
+
+  constexpr Feature(InnerKind kind) : kind(kind) {}
+  constexpr Feature(unsigned inputKind) : kind(InnerKind(inputKind)) {}
+
+  constexpr operator InnerKind() const { return kind; }
+  constexpr explicit operator unsigned() const { return unsigned(kind); }
+  constexpr explicit operator size_t() const { return size_t(kind); }
+
+  static constexpr unsigned getNumFeatures() {
+    enum Features {
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description) FeatureName,
+#include "swift/Basic/Features.def"
+      NumFeatures
+    };
+    return NumFeatures;
+  }
+
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
+  static const Feature FeatureName;
+#include "swift/Basic/Features.def"
+
+  /// Check whether the given feature is available in production compilers.
+  bool isAvailableInProduction() const;
+
+  /// Determine the in-source name of the given feature.
+  llvm::StringRef getName() const;
+
+  /// Determine whether the given feature supports adoption mode.
+  bool isAdoptable() const;
+
+  /// Determine whether this feature should be included in the
+  /// module interface
+  bool includeInModuleInterface() const;
+
+  /// Determine whether the first feature is more recent (and thus implies
+  /// the existence of) the second feature.  Only meaningful for suppressible
+  /// features.
+  constexpr bool featureImpliesFeature(Feature implied) const {
+    // Suppressible features are expected to be listed in order of
+    // addition in Features.def.
+    return (unsigned)kind < (unsigned)implied.kind;
+  }
+
+  /// Get the feature corresponding to this "future" feature, if there is one.
+  static std::optional<Feature> getUpcomingFeature(StringRef name);
+
+  /// Get the feature corresponding to this "experimental" feature, if there is
+  /// one.
+  static std::optional<Feature> getExperimentalFeature(StringRef name);
+
+  /// Get the major language version in which this feature was introduced, or
+  /// \c None if it does not have such a version.
+  std::optional<unsigned> getLanguageVersion() const;
 };
 
-constexpr unsigned numFeatures() {
-  enum Features {
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Description) FeatureName,
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
+  constexpr inline Feature Feature::FeatureName =                              \
+      Feature::InnerKind::FeatureName;
 #include "swift/Basic/Features.def"
-    NumFeatures
-  };
-  return NumFeatures;
-}
-
-/// Check whether the given feature is available in production compilers.
-bool isFeatureAvailableInProduction(Feature feature);
-
-/// Determine the in-source name of the given feature.
-llvm::StringRef getFeatureName(Feature feature);
-
-/// Determine whether the first feature is more recent (and thus implies
-/// the existence of) the second feature.  Only meaningful for suppressible
-/// features.
-inline bool featureImpliesFeature(Feature feature, Feature implied) {
-  // Suppressible features are expected to be listed in order of
-  // addition in Features.def.
-  return (unsigned) feature < (unsigned) implied;
-}
-
-/// Get the feature corresponding to this "future" feature, if there is one.
-std::optional<Feature> getUpcomingFeature(llvm::StringRef name);
-
-/// Get the feature corresponding to this "experimental" feature, if there is
-/// one.
-std::optional<Feature> getExperimentalFeature(llvm::StringRef name);
-
-/// Get the major language version in which this feature was introduced, or
-/// \c None if it does not have such a version.
-std::optional<unsigned> getFeatureLanguageVersion(Feature feature);
-
-/// Determine whether the given feature supports adoption mode.
-bool isFeatureAdoptable(Feature feature);
-
-/// Determine whether this feature should be included in the
-/// module interface
-bool includeInModuleInterface(Feature feature);
-
 }
 
 #endif // SWIFT_BASIC_FEATURES_H

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -121,36 +121,36 @@
     LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #endif
 
-// An upcoming feature that supports adoption mode.
+// An upcoming feature that supports migration mode.
 //
 // If the feature is source-breaking and provides for a
-// mechanical code migration, it should implement adoption mode.
+// mechanical code migration, it should implement migration mode.
 //
-// Adoption mode is a feature-oriented code migration mechanism: a mode
+// Migration mode is a feature-oriented code migration mechanism: a mode
 // of operation that should produce compiler warnings with attached
 // fix-its that can be applied to preserve the behavior of the code once
 // the upcoming feature is enacted.
 // These warnings must belong to a diagnostic group named after the
-// feature. Adoption mode itself *and* the fix-its it produces must be
+// feature. Migration mode itself *and* the fix-its it produces must be
 // source and binary compatible with how the code is compiled when the
 // feature is disabled.
-#ifndef ADOPTABLE_UPCOMING_FEATURE
+#ifndef MIGRATABLE_UPCOMING_FEATURE
   #if defined(UPCOMING_FEATURE)
-    #define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
+    #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
       UPCOMING_FEATURE(FeatureName, SENumber, Version)
   #else
-    #define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
+    #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)         \
       LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName)
   #endif
 #endif
 
-// See `ADOPTABLE_UPCOMING_FEATURE`.
-#ifndef ADOPTABLE_EXPERIMENTAL_FEATURE
+// See `MIGRATABLE_UPCOMING_FEATURE`.
+#ifndef MIGRATABLE_EXPERIMENTAL_FEATURE
   #if defined(EXPERIMENTAL_FEATURE)
-    #define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)       \
+    #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)       \
       EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
   #else
-    #define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)       \
+    #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)       \
       LANGUAGE_FEATURE(FeatureName, 0, #FeatureName)
   #endif
 #endif
@@ -278,11 +278,11 @@ UPCOMING_FEATURE(NonfrozenEnumExhaustivity, 192, 6)
 UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
 
 // Swift 7
-ADOPTABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
+MIGRATABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
 UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
 UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
-ADOPTABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
+MIGRATABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
 
 // Optional language features / modes
 
@@ -518,8 +518,8 @@ EXPERIMENTAL_FEATURE(CopyBlockOptimization, true)
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
-#undef ADOPTABLE_UPCOMING_FEATURE
-#undef ADOPTABLE_EXPERIMENTAL_FEATURE
+#undef MIGRATABLE_UPCOMING_FEATURE
+#undef MIGRATABLE_EXPERIMENTAL_FEATURE
 #undef BASELINE_LANGUAGE_FEATURE
 #undef OPTIONAL_LANGUAGE_FEATURE
 #undef CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE

--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -78,8 +78,8 @@ TYPE("fine-module-trace",   FineModuleTrace,           "",                "")
 // Complete dependency information for the given Swift files as JSON.
 TYPE("json-dependencies",   JSONDependencies,          "dependencies.json",      "")
 
-// Complete feature information for the given Swift compiler.
-TYPE("json-features",       JSONFeatures,              "features.json",   "")
+// Complete supported argument information for the given Swift compiler.
+TYPE("json-arguments",      JSONArguments,            "arguments.json",   "")
 
 // Gathered compile-time-known value information for the given Swift input file as JSON.
 TYPE("const-values",       ConstValues,              "swiftconstvalues",   "")

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -830,7 +830,7 @@ namespace swift {
 
     /// A wrapper around the feature state enumeration.
     struct FeatureState {
-      enum class Kind : uint8_t { Off, EnabledForAdoption, Enabled };
+      enum class Kind : uint8_t { Off, EnabledForMigration, Enabled };
 
     private:
       Feature feature;
@@ -843,9 +843,9 @@ namespace swift {
       /// Returns whether the feature is enabled.
       bool isEnabled() const;
 
-      /// Returns whether the feature is enabled in adoption mode. Should only
+      /// Returns whether the feature is enabled in migration mode. Should only
       /// be called if the feature is known to support this mode.
-      bool isEnabledForAdoption() const;
+      bool isEnabledForMigration() const;
 
       operator Kind() const { return state; }
     };
@@ -878,9 +878,9 @@ namespace swift {
     /// `false` if a feature by this name is not known.
     bool hasFeature(llvm::StringRef featureName) const;
 
-    /// Enables the given feature (enables in adoption mode if `forAdoption` is
-    /// `true`).
-    void enableFeature(Feature feature, bool forAdoption = false);
+    /// Enables the given feature (enables in migration mode if `forMigration`
+    /// is `true`).
+    void enableFeature(Feature feature, bool forMigration = false);
 
     /// Disables the given feature.
     void disableFeature(Feature feature);

--- a/include/swift/Basic/SupportedFeatures.h
+++ b/include/swift/Basic/SupportedFeatures.h
@@ -1,0 +1,28 @@
+//===--- SupportedFeatures.h - Supported Features Output --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides a high-level API for supported features info
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SUPPORTEDFEATURES_H
+#define SWIFT_SUPPORTEDFEATURES_H
+
+#include "swift/Basic/LLVM.h"
+
+namespace swift {
+namespace features {
+void printSupportedFeatures(llvm::raw_ostream &out);
+} // namespace features
+} // namespace swift
+
+#endif

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -201,7 +201,7 @@ public:
 
     ScanDependencies, ///< Scan dependencies of Swift source files
     PrintVersion,     ///< Print version information.
-    PrintFeature,     ///< Print supported feature of this compiler
+    PrintArguments,   ///< Print supported arguments of this compiler
   };
 
   /// Indicates the action the user requested that the frontend perform.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -314,6 +314,10 @@ public:
   /// exit.
   bool PrintTargetInfo = false;
 
+  /// Indicates that the frontend should print the supported features and then
+  /// exit.
+  bool PrintSupportedFeatures = false;
+
   /// See the \ref SILOptions.EmitVerboseSIL flag.
   bool EmitVerboseSIL = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1530,6 +1530,10 @@ def print_target_info : Flag<["-"], "print-target-info">,
     Flags<[FrontendOption]>,
     HelpText<"Print target information for the given target <triple>, such as x86_64-apple-macos10.9">, MetaVarName<"<triple>">;
 
+def print_supported_features : Flag<["-"], "print-supported-features">,
+    Flags<[FrontendOption]>,
+    HelpText<"Print information about features supported by the compiler">;
+
 def target_cpu : Separate<["-"], "target-cpu">, Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Generate code for a particular CPU variant">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1650,9 +1650,13 @@ def scan_dependencies : Flag<["-"], "scan-dependencies">,
   HelpText<"Scan dependencies of the given Swift sources">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 
-def emit_supported_features : Flag<["-"], "emit-supported-features">,
-  HelpText<"Emit a JSON file including all supported compiler features">, ModeOpt,
+def emit_supported_arguments : Flag<["-"], "emit-supported-arguments">,
+  HelpText<"Emit a JSON file including all supported compiler arguments">, ModeOpt,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
+def emit_supported_features : Flag<["-"], "emit-supported-features">,
+  HelpText<"This is a compatibility alias for '-emit-supported-arguments'">, ModeOpt,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild, HelpHidden]>,
+  Alias<emit_supported_arguments>;
 
 def enable_incremental_imports :
   Flag<["-"], "enable-incremental-imports">,

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -560,7 +560,7 @@ bool BridgedPassContext::enableMergeableTraps() const {
 
 bool BridgedPassContext::hasFeature(BridgedFeature feature) const {
   swift::SILModule *mod = invocation->getPassManager()->getModule();
-  return mod->getASTContext().LangOpts.hasFeature((swift::Feature)feature);
+  return mod->getASTContext().LangOpts.hasFeature(swift::Feature(feature));
 }
 
 bool BridgedPassContext::enableMoveInoutStackProtection() const {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3338,7 +3338,7 @@ static void printCompatibilityCheckIf(ASTPrinter &printer, bool isElseIf,
     } else {
       first = false;
     }
-    printer << "$" << getFeatureName(feature);
+    printer << "$" << Feature(feature).getName();
   }
 
 #ifndef NDEBUG

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -626,7 +626,7 @@ void FeatureSet::collectRequiredFeature(Feature feature,
 
 void FeatureSet::collectSuppressibleFeature(Feature feature,
                                             InsertOrRemove operation) {
-  suppressible.insertOrRemove(numFeatures() - size_t(feature),
+  suppressible.insertOrRemove(Feature::getNumFeatures() - size_t(feature),
                               operation == Insert);
 }
 

--- a/lib/AST/FeatureSet.h
+++ b/lib/AST/FeatureSet.h
@@ -19,7 +19,8 @@
 
 namespace swift {
 
-using BasicFeatureSet = FixedBitSet<numFeatures(), Feature>;
+using BasicFeatureSet =
+    FixedBitSet<Feature::getNumFeatures(), Feature::InnerKind>;
 
 class FeatureSet {
   BasicFeatureSet required;
@@ -30,7 +31,7 @@ class FeatureSet {
   // This is the easiest way of letting us iterate from largest to
   // smallest, i.e. from the newest to the oldest feature, which is
   // the order in which we need to emit #if clauses.
-  using SuppressibleFeatureSet = FixedBitSet<numFeatures(), size_t>;
+  using SuppressibleFeatureSet = FixedBitSet<Feature::getNumFeatures(), size_t>;
   SuppressibleFeatureSet suppressible;
 
 public:
@@ -42,7 +43,7 @@ public:
 
   public:
     bool empty() const { return i == e; }
-    Feature next() { return Feature(numFeatures() - *i++); }
+    Feature next() { return Feature(Feature::getNumFeatures() - *i++); }
   };
 
   bool empty() const { return required.empty() && suppressible.empty(); }

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -75,6 +75,7 @@ add_swift_host_library(swiftBasic STATIC
   StableHasher.cpp
   Statistic.cpp
   StringExtras.cpp
+  SupportedFeatures.cpp
   TargetInfo.cpp
   TaskQueue.cpp
   ThreadSafeRefCounted.cpp

--- a/lib/Basic/Feature.cpp
+++ b/lib/Basic/Feature.cpp
@@ -16,8 +16,8 @@
 
 using namespace swift;
 
-bool swift::isFeatureAvailableInProduction(Feature feature) {
-  switch (feature) {
+bool Feature::isAvailableInProduction() const {
+  switch (kind) {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
   case Feature::FeatureName:                                                   \
     return true;
@@ -29,8 +29,8 @@ bool swift::isFeatureAvailableInProduction(Feature feature) {
   llvm_unreachable("covered switch");
 }
 
-llvm::StringRef swift::getFeatureName(Feature feature) {
-  switch (feature) {
+llvm::StringRef Feature::getName() const {
+  switch (kind) {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
   case Feature::FeatureName:                                                   \
     return #FeatureName;
@@ -39,7 +39,7 @@ llvm::StringRef swift::getFeatureName(Feature feature) {
   llvm_unreachable("covered switch");
 }
 
-std::optional<Feature> swift::getUpcomingFeature(llvm::StringRef name) {
+std::optional<Feature> Feature::getUpcomingFeature(llvm::StringRef name) {
   return llvm::StringSwitch<std::optional<Feature>>(name)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #define UPCOMING_FEATURE(FeatureName, SENumber, Version)                       \
@@ -48,7 +48,7 @@ std::optional<Feature> swift::getUpcomingFeature(llvm::StringRef name) {
       .Default(std::nullopt);
 }
 
-std::optional<Feature> swift::getExperimentalFeature(llvm::StringRef name) {
+std::optional<Feature> Feature::getExperimentalFeature(llvm::StringRef name) {
   return llvm::StringSwitch<std::optional<Feature>>(name)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)                     \
@@ -57,8 +57,8 @@ std::optional<Feature> swift::getExperimentalFeature(llvm::StringRef name) {
       .Default(std::nullopt);
 }
 
-std::optional<unsigned> swift::getFeatureLanguageVersion(Feature feature) {
-  switch (feature) {
+std::optional<unsigned> Feature::getLanguageVersion() const {
+  switch (kind) {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #define UPCOMING_FEATURE(FeatureName, SENumber, Version)                       \
   case Feature::FeatureName:                                                   \
@@ -69,8 +69,8 @@ std::optional<unsigned> swift::getFeatureLanguageVersion(Feature feature) {
   }
 }
 
-bool swift::isFeatureAdoptable(Feature feature) {
-  switch (feature) {
+bool Feature::isAdoptable() const {
+  switch (kind) {
 #define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
 #define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
@@ -87,8 +87,8 @@ bool swift::isFeatureAdoptable(Feature feature) {
   }
 }
 
-bool swift::includeInModuleInterface(Feature feature) {
-  switch (feature) {
+bool Feature::includeInModuleInterface() const {
+  switch (kind) {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
   case Feature::FeatureName:                                                   \
     return true;

--- a/lib/Basic/Feature.cpp
+++ b/lib/Basic/Feature.cpp
@@ -69,7 +69,7 @@ std::optional<unsigned> Feature::getLanguageVersion() const {
   }
 }
 
-bool Feature::isAdoptable() const {
+bool Feature::isMigratable() const {
   switch (kind) {
 #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
 #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)

--- a/lib/Basic/Feature.cpp
+++ b/lib/Basic/Feature.cpp
@@ -71,16 +71,16 @@ std::optional<unsigned> Feature::getLanguageVersion() const {
 
 bool Feature::isAdoptable() const {
   switch (kind) {
-#define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
-#define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
+#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
+#define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
   case Feature::FeatureName:
 #include "swift/Basic/Features.def"
     return false;
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
-#define ADOPTABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)             \
+#define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)            \
   case Feature::FeatureName:
-#define ADOPTABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)           \
+#define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)          \
   case Feature::FeatureName:
 #include "swift/Basic/Features.def"
     return true;

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -112,7 +112,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_PackageSwiftModuleInterfaceFile:
   case file_types::TY_SwiftOverlayFile:
   case file_types::TY_JSONDependencies:
-  case file_types::TY_JSONFeatures:
+  case file_types::TY_JSONArguments:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:
   case file_types::TY_ConstValues:
@@ -195,7 +195,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_PrivateSwiftModuleInterfaceFile:
   case file_types::TY_PackageSwiftModuleInterfaceFile:
   case file_types::TY_JSONDependencies:
-  case file_types::TY_JSONFeatures:
+  case file_types::TY_JSONArguments:
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:
@@ -257,7 +257,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:
-  case file_types::TY_JSONFeatures:
+  case file_types::TY_JSONArguments:
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:
@@ -321,7 +321,7 @@ bool file_types::isProducedFromDiagnostics(ID Id) {
   case file_types::TY_YAMLOptRecord:
   case file_types::TY_BitstreamOptRecord:
   case file_types::TY_JSONDependencies:
-  case file_types::TY_JSONFeatures:
+  case file_types::TY_JSONArguments:
   case file_types::TY_IndexUnitOutputPath:
   case file_types::TY_SwiftABIDescriptor:
   case file_types::TY_SwiftAPIDescriptor:

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -298,10 +298,10 @@ bool LangOptions::FeatureState::isEnabled() const {
   return state == FeatureState::Kind::Enabled;
 }
 
-bool LangOptions::FeatureState::isEnabledForAdoption() const {
-  ASSERT(feature.isAdoptable() && "You forgot to make the feature adoptable!");
+bool LangOptions::FeatureState::isEnabledForMigration() const {
+  ASSERT(feature.isMigratable() && "You forgot to make the feature migratable!");
 
-  return state == FeatureState::Kind::EnabledForAdoption;
+  return state == FeatureState::Kind::EnabledForMigration;
 }
 
 LangOptions::FeatureStateStorage::FeatureStateStorage()
@@ -357,10 +357,10 @@ bool LangOptions::hasFeature(llvm::StringRef featureName) const {
   return false;
 }
 
-void LangOptions::enableFeature(Feature feature, bool forAdoption) {
-  if (forAdoption) {
-    ASSERT(feature.isAdoptable());
-    featureStates.setState(feature, FeatureState::Kind::EnabledForAdoption);
+void LangOptions::enableFeature(Feature feature, bool forMigration) {
+  if (forMigration) {
+    ASSERT(feature.isMigratable());
+    featureStates.setState(feature, FeatureState::Kind::EnabledForMigration);
     return;
   }
 

--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -1,0 +1,74 @@
+//===--- SupportedFeatures.cpp - Supported features printing --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include <array>
+#include <vector>
+
+#include "swift/Basic/Feature.h"
+#include "swift/Frontend/Frontend.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift;
+
+namespace swift {
+namespace features {
+/// Print information about what features upcoming/experimental are
+/// supported by the compiler.
+/// The information includes whether a feature is adoptable and for
+/// upcoming features - what is the first mode it's introduced.
+void printSupportedFeatures(llvm::raw_ostream &out) {
+  std::array upcoming{
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
+#define UPCOMING_FEATURE(FeatureName, SENumber, Version) Feature::FeatureName,
+#include "swift/Basic/Features.def"
+  };
+
+  std::vector<swift::Feature> experimental{{
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
+#define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd) Feature::FeatureName,
+#include "swift/Basic/Features.def"
+  }};
+
+  // Include only experimental features that are available in production.
+  llvm::erase_if(experimental, [](auto &feature) {
+    return feature.isAvailableInProduction();
+  });
+
+  out << "{\n";
+  auto printFeature = [&out](const Feature &feature) {
+    out << "      ";
+    out << "{ \"name\": \"" << feature.getName() << "\"";
+    if (feature.isAdoptable()) {
+      out << ", \"migratable\": true";
+    }
+    if (auto version = feature.getLanguageVersion()) {
+      out << ", \"enabled_in\": " << *version;
+    }
+    out << " }";
+  };
+
+  out << "  \"features\": {\n";
+  out << "    \"upcoming\": [\n";
+  llvm::interleave(upcoming, printFeature, [&out] { out << ",\n"; });
+  out << "\n    ],\n";
+
+  out << "    \"experimental\": [\n";
+  llvm::interleave(experimental, printFeature, [&out] { out << ",\n"; });
+  out << "\n    ]\n";
+
+  out << "  }\n";
+  out << "}\n";
+}
+
+} // end namespace features
+} // end namespace swift

--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -48,7 +48,7 @@ void printSupportedFeatures(llvm::raw_ostream &out) {
   auto printFeature = [&out](const Feature &feature) {
     out << "      ";
     out << "{ \"name\": \"" << feature.getName() << "\"";
-    if (feature.isAdoptable()) {
+    if (feature.isMigratable()) {
       out << ", \"migratable\": true";
     }
     if (auto version = feature.getLanguageVersion()) {

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2049,6 +2049,28 @@ bool Driver::handleImmediateArgs(const ArgList &Args, const ToolChain &TC) {
     return false;
   }
 
+  if (Args.hasArg(options::OPT_print_supported_features)) {
+    SmallVector<const char *, 5> commandLine;
+    commandLine.push_back("-frontend");
+    commandLine.push_back("-print-supported-features");
+
+    std::string executable = getSwiftProgramPath();
+
+    // FIXME(https://github.com/apple/swift/issues/54554): This bypasses
+    // mechanisms like -v and -###.
+    sys::TaskQueue queue;
+    queue.addTask(executable.c_str(), commandLine);
+    queue.execute(nullptr,
+                  [](sys::ProcessId PID, int returnCode, StringRef output,
+                     StringRef errors, sys::TaskProcessInformation ProcInfo,
+                     void *unused) -> sys::TaskFinishedResponse {
+                    llvm::outs() << output;
+                    llvm::errs() << errors;
+                    return sys::TaskFinishedResponse::ContinueExecution;
+                  });
+    return false;
+  }
+
   return true;
 }
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1708,7 +1708,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
       case file_types::TY_SwiftCrossImportDir:
       case file_types::TY_SwiftOverlayFile:
       case file_types::TY_JSONDependencies:
-      case file_types::TY_JSONFeatures:
+      case file_types::TY_JSONArguments:
       case file_types::TY_SwiftABIDescriptor:
       case file_types::TY_SwiftAPIDescriptor:
       case file_types::TY_ConstValues:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -754,8 +754,8 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
     return "-emit-imported-modules";
   case file_types::TY_JSONDependencies:
     return "-scan-dependencies";
-  case file_types::TY_JSONFeatures:
-    return "-emit-supported-features";
+  case file_types::TY_JSONArguments:
+    return "-emit-supported-arguments";
   case file_types::TY_IndexData:
     return "-typecheck";
   case file_types::TY_Remapping:
@@ -1041,7 +1041,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_ClangModuleFile:
     case file_types::TY_IndexData:
     case file_types::TY_JSONDependencies:
-    case file_types::TY_JSONFeatures:
+    case file_types::TY_JSONArguments:
       llvm_unreachable("Cannot be output from backend job");
     case file_types::TY_Swift:
     case file_types::TY_dSYM:

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -763,14 +763,14 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   }
 
   for (auto &featureName : options.UpcomingFeatures) {
-    auto feature = getUpcomingFeature(featureName);
+    auto feature = Feature::getUpcomingFeature(featureName);
     if (!feature) {
       llvm::errs() << "error: unknown upcoming feature "
                    << QuotedString(featureName) << "\n";
       exit(-1);
     }
 
-    if (auto firstVersion = getFeatureLanguageVersion(*feature)) {
+    if (auto firstVersion = feature->getLanguageVersion()) {
       if (Invocation.getLangOptions().isSwiftVersionAtLeast(*firstVersion)) {
         llvm::errs() << "error: upcoming feature " << QuotedString(featureName)
                      << " is already enabled as of Swift version "
@@ -782,7 +782,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   }
 
   for (auto &featureName : options.ExperimentalFeatures) {
-    if (auto feature = getExperimentalFeature(featureName)) {
+    if (auto feature = Feature::getExperimentalFeature(featureName)) {
       Invocation.getLangOptions().enableFeature(*feature);
     } else {
       llvm::errs() << "error: unknown experimental feature "

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -682,8 +682,8 @@ ArgsToFrontendOptionsConverter::determineRequestedAction(const ArgList &args) {
     return FrontendOptions::ActionType::CompileModuleFromInterface;
   if (Opt.matches(OPT_typecheck_module_from_interface))
     return FrontendOptions::ActionType::TypecheckModuleFromInterface;
-  if (Opt.matches(OPT_emit_supported_features))
-    return FrontendOptions::ActionType::PrintFeature;
+  if (Opt.matches(OPT_emit_supported_arguments))
+    return FrontendOptions::ActionType::PrintArguments;
   llvm_unreachable("Unhandled mode option");
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -206,6 +206,10 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.PrintTargetInfo = true;
   }
 
+  if (Args.hasArg(OPT_print_supported_features)) {
+    Opts.PrintSupportedFeatures = true;
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_verify_generic_signatures)) {
     Opts.VerifyGenericSignaturesInModule = A->getValue();
   }

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -448,7 +448,7 @@ static bool shouldEmitFineModuleTrace(FrontendOptions::ActionType action) {
   case swift::FrontendOptions::ActionType::DumpPCM:
   case swift::FrontendOptions::ActionType::ScanDependencies:
   case swift::FrontendOptions::ActionType::PrintVersion:
-  case swift::FrontendOptions::ActionType::PrintFeature:
+  case swift::FrontendOptions::ActionType::PrintArguments:
     return false;
   }
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -872,7 +872,7 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
 
     if (featureMode) {
       if (isEnableFeatureFlag) {
-        const auto isAdoptable = feature->isAdoptable();
+        const auto isMigratable = feature->isMigratable();
 
         // Diagnose an invalid mode.
         StringRef validModeName = "adoption";
@@ -880,13 +880,13 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
           Diags.diagnose(SourceLoc(), diag::invalid_feature_mode, *featureMode,
                          featureName,
                          /*didYouMean=*/validModeName,
-                         /*showDidYouMean=*/isAdoptable);
+                         /*showDidYouMean=*/isMigratable);
           continue;
         }
 
-        if (!isAdoptable) {
+        if (!isMigratable) {
           Diags.diagnose(SourceLoc(),
-                         diag::feature_does_not_support_adoption_mode,
+                         diag::feature_does_not_support_migration_mode,
                          featureName);
           continue;
         }
@@ -904,7 +904,7 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
 
     // Enable the feature if requested.
     if (isEnableFeatureFlag)
-      Opts.enableFeature(*feature, /*forAdoption=*/featureMode.has_value());
+      Opts.enableFeature(*feature, /*forMigration=*/featureMode.has_value());
   }
 
   // Since pseudo-features don't have a boolean on/off state, process them in

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -816,7 +816,7 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
       continue;
     }
 
-    // For all other features, the argument format is `<name>[:adoption]`.
+    // For all other features, the argument format is `<name>[:migrate]`.
     StringRef featureName;
     std::optional<StringRef> featureMode;
     std::tie(featureName, featureMode) = argValue.rsplit(':');
@@ -875,7 +875,7 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
         const auto isMigratable = feature->isMigratable();
 
         // Diagnose an invalid mode.
-        StringRef validModeName = "adoption";
+        StringRef validModeName = "migrate";
         if (*featureMode != validModeName) {
           Diags.diagnose(SourceLoc(), diag::invalid_feature_mode, *featureMode,
                          featureName,

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -58,7 +58,7 @@ bool FrontendOptions::needsProperModuleName(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::EmitAssembly:
   case ActionType::EmitIRGen:
@@ -82,7 +82,7 @@ bool FrontendOptions::shouldActionOnlyParse(ActionType action) {
   case ActionType::EmitImportedModules:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return true;
   default:
     return false;
@@ -103,7 +103,7 @@ bool FrontendOptions::doesActionRequireSwiftStandardLibrary(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::CompileModuleFromInterface:
   case ActionType::TypecheckModuleFromInterface:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -138,7 +138,7 @@ bool FrontendOptions::doesActionRequireInputs(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::REPL:
   case ActionType::Parse:
@@ -181,7 +181,7 @@ bool FrontendOptions::doesActionPerformEndOfPipelineActions(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
   case ActionType::EmitPCH:
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
@@ -226,7 +226,7 @@ bool FrontendOptions::supportCompilationCaching(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
   case ActionType::DumpPCM:
   case ActionType::REPL:
   case ActionType::Parse:
@@ -362,8 +362,8 @@ FrontendOptions::formatForPrincipalOutputFileForAction(ActionType action) {
 
   case ActionType::ScanDependencies:
     return TY_JSONDependencies;
-  case ActionType::PrintFeature:
-    return TY_JSONFeatures;
+  case ActionType::PrintArguments:
+    return TY_JSONArguments;
   }
   llvm_unreachable("unhandled action");
 }
@@ -386,7 +386,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   case ActionType::REPL:
   case ActionType::DumpPCM:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -432,7 +432,7 @@ bool FrontendOptions::canActionEmitReferenceDependencies(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -482,7 +482,7 @@ bool FrontendOptions::canActionEmitModuleSummary(ActionType action) {
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
@@ -519,7 +519,7 @@ bool FrontendOptions::canActionEmitClangHeader(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -560,7 +560,7 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -610,7 +610,7 @@ bool FrontendOptions::canActionEmitModuleSemanticInfo(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
   case ActionType::EmitSIL:
   case ActionType::EmitLoweredSIL:
   case ActionType::EmitSIBGen:
@@ -653,7 +653,7 @@ bool FrontendOptions::canActionEmitConstValues(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::Typecheck:
   case ActionType::MergeModules:
@@ -698,7 +698,7 @@ bool FrontendOptions::canActionEmitModule(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::MergeModules:
   case ActionType::EmitModuleOnly:
@@ -744,7 +744,7 @@ bool FrontendOptions::canActionEmitInterface(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -787,7 +787,7 @@ bool FrontendOptions::canActionEmitAPIDescriptor(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::ResolveImports:
   case ActionType::Typecheck:
@@ -838,7 +838,7 @@ bool FrontendOptions::doesActionProduceOutput(ActionType action) {
   case ActionType::EmitPCM:
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return true;
 
   case ActionType::TypecheckModuleFromInterface:
@@ -889,7 +889,7 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return true;
   }
   llvm_unreachable("unhandled action");
@@ -916,7 +916,7 @@ bool FrontendOptions::doesActionGenerateSIL(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::EmitSILGen:
   case ActionType::EmitSIBGen:
@@ -967,7 +967,7 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
     return false;
   case ActionType::Immediate:
   case ActionType::REPL:
@@ -1011,7 +1011,7 @@ bool FrontendOptions::doesActionBuildModuleFromInterface(ActionType action) {
   case ActionType::DumpPCM:
   case ActionType::ScanDependencies:
   case ActionType::PrintVersion:
-  case ActionType::PrintFeature:
+  case ActionType::PrintArguments:
   case ActionType::Immediate:
   case ActionType::REPL:
   case ActionType::EmitIRGen:

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -46,6 +46,7 @@
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/Basic/SupportedFeatures.h"
 #include "swift/Basic/TargetInfo.h"
 #include "swift/Basic/UUID.h"
 #include "swift/Basic/Version.h"
@@ -2060,6 +2061,11 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   if (Invocation.getFrontendOptions().PrintTargetInfo) {
     swift::targetinfo::printTargetInfo(Invocation, llvm::outs());
+    return finishDiagProcessing(0, /*verifierEnabled*/ false);
+  }
+
+  if (Invocation.getFrontendOptions().PrintSupportedFeatures) {
+    swift::features::printSupportedFeatures(llvm::outs());
     return finishDiagProcessing(0, /*verifierEnabled*/ false);
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1131,7 +1131,7 @@ static void printSingleFrontendOpt(llvm::opt::OptTable &table, options::ID id,
   }
 }
 
-static bool printSwiftFeature(CompilerInstance &instance) {
+static bool printSwiftArguments(CompilerInstance &instance) {
   ASTContext &context = instance.getASTContext();
   const CompilerInvocation &invocation = instance.getInvocation();
   const FrontendOptions &opts = invocation.getFrontendOptions();
@@ -1227,8 +1227,8 @@ static bool performAction(CompilerInstance &Instance,
     return Instance.getASTContext().hadError();
   case FrontendOptions::ActionType::PrintVersion:
     return printSwiftVersion(Instance.getInvocation());
-  case FrontendOptions::ActionType::PrintFeature:
-    return printSwiftFeature(Instance);
+  case FrontendOptions::ActionType::PrintArguments:
+    return printSwiftArguments(Instance);
   case FrontendOptions::ActionType::REPL:
     llvm::report_fatal_error("Compiler-internal integrated REPL has been "
                              "removed; use the LLDB-enhanced REPL instead.");

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2570,7 +2570,7 @@ ParserResult<LifetimeAttr> Parser::parseLifetimeAttribute(SourceLoc atLoc,
   if (!Context.LangOpts.hasFeature(Feature::LifetimeDependence) &&
       !Context.SourceMgr.isImportMacroGeneratedLoc(atLoc)) {
     diagnose(loc, diag::requires_experimental_feature, "@lifetime", false,
-             getFeatureName(Feature::LifetimeDependence));
+             Feature::LifetimeDependence.getName());
     status.setIsParseError();
     return status;
   }
@@ -5314,7 +5314,7 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
     if (Tok.isContextualKeyword("sending")) {
       if (!P.Context.LangOpts.hasFeature(Feature::SendingArgsAndResults)) {
         P.diagnose(Tok, diag::requires_experimental_feature, Tok.getRawText(),
-                   false, getFeatureName(Feature::SendingArgsAndResults));
+                   false, Feature::SendingArgsAndResults.getName());
       }
 
       // Only allow for 'sending' to be written once.
@@ -5338,7 +5338,7 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
       if (!P.Context.LangOpts.hasFeature(Feature::LifetimeDependence)) {
         P.diagnose(Tok, diag::requires_experimental_feature,
                    "lifetime dependence specifier", false,
-                   getFeatureName(Feature::LifetimeDependence));
+                   Feature::LifetimeDependence.getName());
       }
       P.consumeToken(); // consume '@'
       auto loc = P.consumeToken(); // consume 'lifetime'

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1856,8 +1856,7 @@ shouldEmitPartialMutationError(UseState &useState, PartialMutation::Kind kind,
   if (feature &&
       !fn->getModule().getASTContext().LangOpts.hasFeature(*feature) &&
       !isa<DropDeinitInst>(user)) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "    " << getFeatureName(*feature) << " disabled!\n");
+    LLVM_DEBUG(llvm::dbgs() << "    " << feature->getName() << " disabled!\n");
     // If the types equal, just bail early.
     // Emit the error.
     return {PartialMutationError::featureDisabled(iterType, kind)};

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -60,7 +60,7 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
   const auto feature = Feature::NonisolatedNonsendingByDefault;
 
   ASSERT(node);
-  ASSERT(ctx.LangOpts.getFeatureState(feature).isEnabledForAdoption());
+  ASSERT(ctx.LangOpts.getFeatureState(feature).isEnabledForMigration());
 
   ValueDecl *decl = nullptr;
   ClosureExpr *closure = nullptr;

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -150,7 +150,7 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
 
   const ConcurrentAttr attr(/*implicit=*/true);
 
-  const auto featureName = getFeatureName(feature);
+  const auto featureName = feature.getName();
   if (decl) {
     // Diagnose the function, but slap the attribute on the storage declaration
     // instead if the function is an accessor.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1656,7 +1656,7 @@ static bool hasObjCImplementationFeature(Decl *D, ObjCImplementationAttr *attr,
   // syntax, or you're using Feature::CImplementation. Either way, no go.
   ctx.Diags.diagnose(attr->getLocation(), diag::requires_experimental_feature,
                      attr->getAttrName(), attr->isDeclModifier(),
-                     getFeatureName(requiredFeature));
+                     requiredFeature.getName());
   return false;
 }
 
@@ -1868,7 +1868,7 @@ void TypeChecker::checkDeclAttributes(Decl *D) {
             && !D->getASTContext().LangOpts.hasFeature(*feature)) {
         Checker.diagnoseAndRemoveAttr(attr, diag::requires_experimental_feature,
                                       attr->getAttrName(), false,
-                                      getFeatureName(*feature));
+                                      feature->getName());
         continue;
       }
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4810,7 +4810,7 @@ ActorIsolation ActorIsolationChecker::determineClosureIsolation(
   isolation = isolation.withPreconcurrency(preconcurrency);
 
   if (ctx.LangOpts.getFeatureState(Feature::NonisolatedNonsendingByDefault)
-          .isEnabledForAdoption()) {
+          .isEnabledForMigration()) {
     warnAboutNewNonisolatedAsyncExecutionBehavior(ctx, closure, isolation);
   }
 
@@ -6296,7 +6296,7 @@ InferredActorIsolation ActorIsolationRequest::evaluate(Evaluator &evaluator,
 
   auto &ctx = value->getASTContext();
   if (ctx.LangOpts.getFeatureState(Feature::NonisolatedNonsendingByDefault)
-          .isEnabledForAdoption()) {
+          .isEnabledForMigration()) {
     warnAboutNewNonisolatedAsyncExecutionBehavior(ctx, value,
                                                   inferredIsolation.isolation);
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4252,7 +4252,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
       isolation = FunctionTypeIsolation::forNonIsolated();
   } else {
     if (ctx.LangOpts.getFeatureState(Feature::NonisolatedNonsendingByDefault)
-            .isEnabledForAdoption()) {
+            .isEnabledForMigration()) {
       // Diagnose only in the interface stage, which is run once.
       if (inStage(TypeResolutionStage::Interface)) {
         warnAboutNewNonisolatedAsyncExecutionBehavior(ctx, repr, isolation);
@@ -6578,7 +6578,7 @@ private:
     // A missing `any` or `some` is always diagnosed if this feature not
     // disabled.
     auto featureState = ctx.LangOpts.getFeatureState(Feature::ExistentialAny);
-    if (featureState.isEnabled() || featureState.isEnabledForAdoption()) {
+    if (featureState.isEnabled() || featureState.isEnabledForMigration()) {
       return true;
     }
 
@@ -6671,10 +6671,10 @@ private:
                                       /*isAlias=*/isa<TypeAliasDecl>(decl)));
     }
 
-    // If `ExistentialAny` is enabled in adoption mode, warn unconditionally.
+    // If `ExistentialAny` is enabled in migration mode, warn unconditionally.
     // Otherwise, warn until the feature's coming-of-age language mode.
     const auto feature = Feature::ExistentialAny;
-    if (Ctx.LangOpts.getFeatureState(feature).isEnabledForAdoption()) {
+    if (Ctx.LangOpts.getFeatureState(feature).isEnabledForMigration()) {
       diag->limitBehavior(DiagnosticBehavior::Warning);
     } else {
       diag->warnUntilSwiftVersion(feature.getLanguageVersion().value());

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6677,7 +6677,7 @@ private:
     if (Ctx.LangOpts.getFeatureState(feature).isEnabledForAdoption()) {
       diag->limitBehavior(DiagnosticBehavior::Warning);
     } else {
-      diag->warnUntilSwiftVersion(getFeatureLanguageVersion(feature).value());
+      diag->warnUntilSwiftVersion(feature.getLanguageVersion().value());
     }
 
     emitInsertAnyFixit(*diag, T);

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -enable-upcoming-feature NonisolatedNonsendingByDefault:adoption
-// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault:adoption
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 5 -enable-upcoming-feature NonisolatedNonsendingByDefault:migrate
+// RUN: %target-typecheck-verify-swift -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault:migrate
 
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 

--- a/test/Frontend/emit-supported-features.swift
+++ b/test/Frontend/emit-supported-features.swift
@@ -1,8 +1,0 @@
-// RUN: %target-swift-frontend -emit-supported-features %s | %FileCheck %s
-
-// CHECK: "SupportedArguments"
-// CHECK: "abi"
-// CHECK: "emit-module"
-// CHECK: "LastOption"
-// CHECK: "SupportedFeatures"
-// CHECK: "LastFeature"

--- a/test/Frontend/features/adoption_mode.swift
+++ b/test/Frontend/features/adoption_mode.swift
@@ -4,29 +4,29 @@
 // RUN: %target-swift-frontend -parse -swift-version 5                         \
 // RUN:   -enable-upcoming-feature      DynamicActorIsolation:invalid1         \
 // RUN:   -enable-upcoming-feature      DynamicActorIsolation:invalid2         \
-// RUN:   -enable-upcoming-feature      DynamicActorIsolation:adoption         \
-// RUN:   -enable-upcoming-feature      DynamicActorIsolation:adoption         \
+// RUN:   -enable-upcoming-feature      DynamicActorIsolation:migrate         \
+// RUN:   -enable-upcoming-feature      DynamicActorIsolation:migrate         \
 // RUN:   -enable-experimental-feature  DynamicActorIsolation:invalid3         \
 // RUN:   -enable-experimental-feature  DynamicActorIsolation:invalid4         \
-// RUN:   -enable-experimental-feature  DynamicActorIsolation:adoption         \
-// RUN:   -enable-experimental-feature  DynamicActorIsolation:adoption         \
+// RUN:   -enable-experimental-feature  DynamicActorIsolation:migrate         \
+// RUN:   -enable-experimental-feature  DynamicActorIsolation:migrate         \
 // RUN:   -disable-upcoming-feature     DynamicActorIsolation:invalid5         \
 // RUN:   -disable-upcoming-feature     DynamicActorIsolation:invalid6         \
-// RUN:   -disable-upcoming-feature     DynamicActorIsolation:adoption         \
+// RUN:   -disable-upcoming-feature     DynamicActorIsolation:migrate         \
 // RUN:   -disable-experimental-feature DynamicActorIsolation:invalid7         \
 // RUN:   -disable-experimental-feature DynamicActorIsolation:invalid8         \
-// RUN:   -disable-experimental-feature DynamicActorIsolation:adoption         \
+// RUN:   -disable-experimental-feature DynamicActorIsolation:migrate         \
 // RUN:   %s 2>&1 | %FileCheck %s --check-prefix=CHECK-SWIFT-5
 
 // RUN: %target-swift-frontend -parse -swift-version 6                         \
 // RUN:   -enable-upcoming-feature      DynamicActorIsolation:invalid1         \
-// RUN:   -enable-upcoming-feature      DynamicActorIsolation:adoption         \
+// RUN:   -enable-upcoming-feature      DynamicActorIsolation:migrate         \
 // RUN:   -enable-experimental-feature  DynamicActorIsolation:invalid2         \
-// RUN:   -enable-experimental-feature  DynamicActorIsolation:adoption         \
+// RUN:   -enable-experimental-feature  DynamicActorIsolation:migrate         \
 // RUN:   -disable-upcoming-feature     DynamicActorIsolation:invalid3         \
-// RUN:   -disable-upcoming-feature     DynamicActorIsolation:adoption         \
+// RUN:   -disable-upcoming-feature     DynamicActorIsolation:migrate         \
 // RUN:   -disable-experimental-feature DynamicActorIsolation:invalid4         \
-// RUN:   -disable-experimental-feature DynamicActorIsolation:adoption         \
+// RUN:   -disable-experimental-feature DynamicActorIsolation:migrate         \
 // RUN:   %s 2>&1 | %FileCheck %s --check-prefix=CHECK-SWIFT-6
 
 // REQUIRES: swift_feature_DynamicActorIsolation
@@ -34,18 +34,18 @@
 // CHECK-NOT: error:
 
 // CHECK-SWIFT-5-NOT: warning:
-// CHECK-SWIFT-5: warning: '-disable-experimental-feature' argument 'DynamicActorIsolation:adoption' cannot specify a mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5: warning: '-disable-experimental-feature' argument 'DynamicActorIsolation:migrate' cannot specify a mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: '-disable-experimental-feature' argument 'DynamicActorIsolation:invalid8' cannot specify a mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: '-disable-experimental-feature' argument 'DynamicActorIsolation:invalid7' cannot specify a mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'DynamicActorIsolation:adoption' cannot specify a mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'DynamicActorIsolation:migrate' cannot specify a mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'DynamicActorIsolation:invalid6' cannot specify a mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'DynamicActorIsolation:invalid5' cannot specify a mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support adoption mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support adoption mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support migration mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support migration mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: 'invalid4' is not a recognized mode for feature 'DynamicActorIsolation' [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: 'invalid3' is not a recognized mode for feature 'DynamicActorIsolation' [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support adoption mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support adoption mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support migration mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: feature 'DynamicActorIsolation' does not support migration mode [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: 'invalid2' is not a recognized mode for feature 'DynamicActorIsolation' [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NEXT: warning: 'invalid1' is not a recognized mode for feature 'DynamicActorIsolation' [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NOT: warning:

--- a/test/Frontend/features/adoption_mode_adoptable_feature.swift
+++ b/test/Frontend/features/adoption_mode_adoptable_feature.swift
@@ -3,20 +3,20 @@
 
 // RUN: %target-swift-frontend -parse -swift-version 6                         \
 // RUN:   -enable-upcoming-feature      ExistentialAny:invalid1                \
-// RUN:   -enable-upcoming-feature      ExistentialAny:adoption                \
+// RUN:   -enable-upcoming-feature      ExistentialAny:migrate                \
 // RUN:   -enable-experimental-feature  ExistentialAny:invalid2                \
-// RUN:   -enable-experimental-feature  ExistentialAny:adoption                \
-// RUN:   -disable-upcoming-feature     ExistentialAny:adoption                \
-// RUN:   -disable-experimental-feature ExistentialAny:adoption                \
+// RUN:   -enable-experimental-feature  ExistentialAny:migrate                \
+// RUN:   -disable-upcoming-feature     ExistentialAny:migrate                \
+// RUN:   -disable-experimental-feature ExistentialAny:migrate                \
 // RUN:   %s 2>&1 | %FileCheck %s --check-prefix=CHECK-SWIFT-5
 
 // RUN: %target-swift-frontend -parse -swift-version 7                         \
 // RUN:   -enable-upcoming-feature      ExistentialAny:invalid1                \
-// RUN:   -enable-upcoming-feature      ExistentialAny:adoption                \
+// RUN:   -enable-upcoming-feature      ExistentialAny:migrate                \
 // RUN:   -enable-experimental-feature  ExistentialAny:invalid2                \
-// RUN:   -enable-experimental-feature  ExistentialAny:adoption                \
-// RUN:   -disable-upcoming-feature     ExistentialAny:adoption                \
-// RUN:   -disable-experimental-feature ExistentialAny:adoption                \
+// RUN:   -enable-experimental-feature  ExistentialAny:migrate                \
+// RUN:   -disable-upcoming-feature     ExistentialAny:migrate                \
+// RUN:   -disable-experimental-feature ExistentialAny:migrate                \
 // RUN:   %s 2>&1 | %FileCheck %s --check-prefix=CHECK-SWIFT-7
 
 // REQUIRES: swift_feature_ExistentialAny
@@ -25,10 +25,10 @@
 // CHECK-NOT: error:
 
 // CHECK-SWIFT-5-NOT: warning:
-// CHECK-SWIFT-5: warning: '-disable-experimental-feature' argument 'ExistentialAny:adoption' cannot specify a mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'ExistentialAny:adoption' cannot specify a mode [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: 'invalid2' is not a recognized mode for feature 'ExistentialAny'; did you mean 'adoption'? [#StrictLanguageFeatures]{{$}}
-// CHECK-SWIFT-5-NEXT: warning: 'invalid1' is not a recognized mode for feature 'ExistentialAny'; did you mean 'adoption'? [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5: warning: '-disable-experimental-feature' argument 'ExistentialAny:migrate' cannot specify a mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: '-disable-upcoming-feature' argument 'ExistentialAny:migrate' cannot specify a mode [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: 'invalid2' is not a recognized mode for feature 'ExistentialAny'; did you mean 'migrate'? [#StrictLanguageFeatures]{{$}}
+// CHECK-SWIFT-5-NEXT: warning: 'invalid1' is not a recognized mode for feature 'ExistentialAny'; did you mean 'migrate'? [#StrictLanguageFeatures]{{$}}
 // CHECK-SWIFT-5-NOT: warning:
 
 // CHECK-SWIFT-7-NOT: warning:

--- a/test/Frontend/print-supported-features.swift
+++ b/test/Frontend/print-supported-features.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -print-supported-features | %FileCheck %s
+
+// CHECK: "features": {
+// CHECK-NEXT:   "upcoming": [
+// CHECK:     { "name": "{{.*}}"{{, "migratable": true}}, "enabled_in": {{[0-9]+}} }
+// CHECK:   ],
+// CHECK-NEXT:   "experimental": [
+// CHECK:     { "name": "{{.*}}" }
+// CHECK:   ]
+// CHECK: }

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -8,7 +8,7 @@
 // RUN:   -verify-additional-prefix default-swift-mode- \
 // RUN:   -verify-additional-prefix explicit-any-
 
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature ExistentialAny:adoption \
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature ExistentialAny:migrate \
 //        To verify that the message is not followed by
 //        "; this will be an error ...".
 // RUN:   -verify-additional-prefix default-swift-mode- \

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4388,13 +4388,13 @@ int main(int argc, char *argv[]) {
     InitInvok.getFrontendOptions().InputsAndOutputs.addInputFile(File);
 
   for (const auto &featureArg : options::EnableExperimentalFeatures) {
-    if (auto feature = getExperimentalFeature(featureArg)) {
+    if (auto feature = Feature::getExperimentalFeature(featureArg)) {
       InitInvok.getLangOptions().enableFeature(*feature);
     }
   }
 
   for (const auto &featureArg : options::EnableUpcomingFeatures) {
-    if (auto feature = getUpcomingFeature(featureArg)) {
+    if (auto feature = Feature::getUpcomingFeature(featureArg)) {
       InitInvok.getLangOptions().enableFeature(*feature);
     }
   }

--- a/unittests/Frontend/FeatureParsingTest.cpp
+++ b/unittests/Frontend/FeatureParsingTest.cpp
@@ -51,8 +51,8 @@ void swift::PrintTo(const LangOptions::FeatureState::Kind &value,
   case LangOptions::FeatureState::Kind::Off:
     *os << "Off";
     break;
-  case LangOptions::FeatureState::Kind::EnabledForAdoption:
-    *os << "EnabledForAdoption";
+  case LangOptions::FeatureState::Kind::EnabledForMigration:
+    *os << "EnabledForMigration";
     break;
   case LangOptions::FeatureState::Kind::Enabled:
     *os << "Enabled";

--- a/unittests/Frontend/FeatureParsingTest.cpp
+++ b/unittests/Frontend/FeatureParsingTest.cpp
@@ -20,9 +20,8 @@ FeatureParsingTest::FeatureParsingTest() : ArgParsingTest() {
   this->langMode = defaultLangMode;
 }
 
-FeatureWrapper::FeatureWrapper(Feature id)
-    : id(id), name(getFeatureName(id).data()) {
-  auto langMode = getFeatureLanguageVersion(id);
+FeatureWrapper::FeatureWrapper(Feature id) : id(id), name(id.getName().data()) {
+  auto langMode = id.getLanguageVersion();
   if (langMode) {
     this->langMode = std::to_string(*langMode);
   }

--- a/unittests/Frontend/IsFeatureEnabledTests.cpp
+++ b/unittests/Frontend/IsFeatureEnabledTests.cpp
@@ -36,29 +36,29 @@ class IsFeatureEnabledTest
 TEST_F(IsFeatureEnabledTest, VerifyTestedFeatures) {
   auto feature = baselineF;
   {
-    ASSERT_FALSE(getUpcomingFeature(feature.name));
-    ASSERT_FALSE(getExperimentalFeature(feature.name));
-    ASSERT_FALSE(isFeatureAdoptable(feature));
+    ASSERT_FALSE(Feature::getUpcomingFeature(feature.name));
+    ASSERT_FALSE(Feature::getExperimentalFeature(feature.name));
+    ASSERT_FALSE(feature.id.isAdoptable());
   }
 
   feature = upcomingF;
   {
-    ASSERT_TRUE(getUpcomingFeature(feature.name));
-    ASSERT_FALSE(isFeatureAdoptable(feature));
+    ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
+    ASSERT_FALSE(feature.id.isAdoptable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
   feature = adoptableUpcomingF;
   {
-    ASSERT_TRUE(getUpcomingFeature(feature.name));
-    ASSERT_TRUE(isFeatureAdoptable(feature));
+    ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
+    ASSERT_TRUE(feature.id.isAdoptable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
   feature = strictConcurrencyF;
   {
-    ASSERT_TRUE(getUpcomingFeature(feature.name));
-    ASSERT_FALSE(isFeatureAdoptable(feature));
+    ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
+    ASSERT_FALSE(feature.id.isAdoptable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
@@ -66,9 +66,9 @@ TEST_F(IsFeatureEnabledTest, VerifyTestedFeatures) {
   {
     // If these tests start failing because `experimentalF` was promoted, swap
     // it for another experimental feature one that is available in production.
-    ASSERT_TRUE(isFeatureAvailableInProduction(feature));
-    ASSERT_TRUE(getExperimentalFeature(feature.name));
-    ASSERT_FALSE(isFeatureAdoptable(feature));
+    ASSERT_TRUE(feature.id.isAvailableInProduction());
+    ASSERT_TRUE(Feature::getExperimentalFeature(feature.name));
+    ASSERT_FALSE(feature.id.isAdoptable());
   }
 }
 
@@ -81,7 +81,7 @@ TEST_P(IsFeatureEnabledTest, ) {
     auto actualState = getLangOptions().getFeatureState(feature);
     auto expectedState = pair.second;
     ASSERT_EQ(actualState, expectedState)
-        << "Feature: " + getFeatureName(feature).str();
+        << "Feature: " + feature.getName().str();
   }
 }
 

--- a/unittests/Frontend/IsFeatureEnabledTests.cpp
+++ b/unittests/Frontend/IsFeatureEnabledTests.cpp
@@ -119,7 +119,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", baselineF.name + ":undef"},
       {{baselineF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", baselineF.name + ":adoption"},
+      {"-enable-upcoming-feature", baselineF.name + ":migrate"},
       {{baselineF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", baselineF.name},
@@ -128,7 +128,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", baselineF.name + ":undef"},
       {{baselineF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", baselineF.name + ":adoption"},
+      {"-enable-experimental-feature", baselineF.name + ":migrate"},
       {{baselineF, FeatureState::Enabled}}),
 
   IsFeatureEnabledTestCase(
@@ -138,7 +138,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", upcomingF.name + ":undef"},
       {{upcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", upcomingF.name + ":adoption"},
+      {"-enable-upcoming-feature", upcomingF.name + ":migrate"},
       {{upcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", upcomingF.name},
@@ -147,7 +147,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", upcomingF.name + ":undef"},
       {{upcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", upcomingF.name + ":adoption"},
+      {"-enable-experimental-feature", upcomingF.name + ":migrate"},
       {{upcomingF, FeatureState::Off}}),
 
   IsFeatureEnabledTestCase(
@@ -157,14 +157,14 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", adoptableUpcomingF.name + ":undef"},
       {{adoptableUpcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption"},
+      {"-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate"},
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 // Swift 7 is asserts-only.
 #ifndef NDEBUG
-  // Requesting adoption mode in target language mode has no effect.
+  // Requesting migration mode in target language mode has no effect.
   IsFeatureEnabledTestCase({
         "-swift-version", adoptableUpcomingF.langMode,
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
 #endif
@@ -175,14 +175,14 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", adoptableUpcomingF.name + ":undef"},
       {{adoptableUpcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", adoptableUpcomingF.name + ":adoption"},
+      {"-enable-experimental-feature", adoptableUpcomingF.name + ":migrate"},
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 // Swift 7 is asserts-only.
 #ifndef NDEBUG
-  // Requesting adoption mode in target language mode has no effect.
+  // Requesting migration mode in target language mode has no effect.
   IsFeatureEnabledTestCase({
         "-swift-version", adoptableUpcomingF.langMode,
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
 #endif
@@ -193,7 +193,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", strictConcurrencyF.name + ":undef"},
       {{strictConcurrencyF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", strictConcurrencyF.name + ":adoption"},
+      {"-enable-upcoming-feature", strictConcurrencyF.name + ":migrate"},
       {{strictConcurrencyF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", strictConcurrencyF.name},
@@ -202,7 +202,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", strictConcurrencyF.name + ":undef"},
       {{strictConcurrencyF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", strictConcurrencyF.name + ":adoption"},
+      {"-enable-experimental-feature", strictConcurrencyF.name + ":migrate"},
       {{strictConcurrencyF, FeatureState::Off}}),
 
   IsFeatureEnabledTestCase(
@@ -212,7 +212,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-upcoming-feature", experimentalF.name + ":undef"},
       {{experimentalF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-upcoming-feature", experimentalF.name + ":adoption"},
+      {"-enable-upcoming-feature", experimentalF.name + ":migrate"},
       {{experimentalF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", experimentalF.name},
@@ -221,7 +221,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {"-enable-experimental-feature", experimentalF.name + ":undef"},
       {{experimentalF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
-      {"-enable-experimental-feature", experimentalF.name + ":adoption"},
+      {"-enable-experimental-feature", experimentalF.name + ":migrate"},
       {{experimentalF, FeatureState::Off}}),
 };
 // clang-format on
@@ -300,7 +300,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-upcoming-feature", upcomingF.name + ":adoption",
+        "-enable-upcoming-feature", upcomingF.name + ":migrate",
         "-enable-upcoming-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -311,7 +311,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", upcomingF.name,
-        "-enable-upcoming-feature", upcomingF.name + ":adoption",
+        "-enable-upcoming-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -320,7 +320,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-upcoming-feature", upcomingF.name + ":adoption",
+        "-enable-upcoming-feature", upcomingF.name + ":migrate",
         "-enable-experimental-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -331,7 +331,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", upcomingF.name,
-        "-enable-experimental-feature", upcomingF.name + ":adoption",
+        "-enable-experimental-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -340,7 +340,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", upcomingF.name + ":adoption",
+        "-enable-experimental-feature", upcomingF.name + ":migrate",
         "-enable-upcoming-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -351,7 +351,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", upcomingF.name,
-        "-enable-upcoming-feature", upcomingF.name + ":adoption",
+        "-enable-upcoming-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -360,7 +360,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", upcomingF.name + ":adoption",
+        "-enable-experimental-feature", upcomingF.name + ":migrate",
         "-enable-experimental-feature", upcomingF.name,
       },
       {{upcomingF, FeatureState::Enabled}}),
@@ -371,7 +371,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", upcomingF.name,
-        "-enable-experimental-feature", upcomingF.name + ":adoption",
+        "-enable-experimental-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
 
@@ -383,7 +383,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
         "-enable-upcoming-feature", adoptableUpcomingF.name,
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -394,7 +394,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", adoptableUpcomingF.name,
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
@@ -403,7 +403,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
         "-enable-experimental-feature", adoptableUpcomingF.name,
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -414,7 +414,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", adoptableUpcomingF.name,
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
@@ -423,7 +423,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
         "-enable-upcoming-feature", adoptableUpcomingF.name,
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -434,7 +434,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", adoptableUpcomingF.name,
-        "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-upcoming-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
@@ -443,7 +443,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
         "-enable-experimental-feature", adoptableUpcomingF.name,
       },
       {{adoptableUpcomingF, FeatureState::Enabled}}),
@@ -454,7 +454,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", adoptableUpcomingF.name,
-        "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
+        "-enable-experimental-feature", adoptableUpcomingF.name + ":migrate",
       },
       {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 
@@ -466,7 +466,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       },
       {{experimentalF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
-        "-enable-experimental-feature", experimentalF.name + ":adoption",
+        "-enable-experimental-feature", experimentalF.name + ":migrate",
         "-enable-experimental-feature", experimentalF.name,
       },
       {{experimentalF, FeatureState::Enabled}}),
@@ -477,7 +477,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
       {{experimentalF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", experimentalF.name,
-        "-enable-experimental-feature", experimentalF.name + ":adoption",
+        "-enable-experimental-feature", experimentalF.name + ":migrate",
       },
       {{experimentalF, FeatureState::Enabled}}),
 };
@@ -501,7 +501,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", upcomingF.name,
-        "-disable-upcoming-feature", upcomingF.name + ":adoption",
+        "-disable-upcoming-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -521,7 +521,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", upcomingF.name,
-        "-disable-upcoming-feature", upcomingF.name + ":adoption",
+        "-disable-upcoming-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -541,7 +541,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", upcomingF.name,
-        "-disable-experimental-feature", upcomingF.name + ":adoption",
+        "-disable-experimental-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -561,7 +561,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", upcomingF.name,
-        "-disable-experimental-feature", upcomingF.name + ":adoption",
+        "-disable-experimental-feature", upcomingF.name + ":migrate",
       },
       {{upcomingF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
@@ -581,7 +581,7 @@ static const IsFeatureEnabledTestCase enableDisableTestCases[] = {
       {{experimentalF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", experimentalF.name,
-        "-disable-experimental-feature", experimentalF.name + ":adoption",
+        "-disable-experimental-feature", experimentalF.name + ":migrate",
       },
       {{experimentalF, FeatureState::Enabled}}),
   IsFeatureEnabledTestCase({

--- a/unittests/Frontend/IsFeatureEnabledTests.cpp
+++ b/unittests/Frontend/IsFeatureEnabledTests.cpp
@@ -38,27 +38,27 @@ TEST_F(IsFeatureEnabledTest, VerifyTestedFeatures) {
   {
     ASSERT_FALSE(Feature::getUpcomingFeature(feature.name));
     ASSERT_FALSE(Feature::getExperimentalFeature(feature.name));
-    ASSERT_FALSE(feature.id.isAdoptable());
+    ASSERT_FALSE(feature.id.isMigratable());
   }
 
   feature = upcomingF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_FALSE(feature.id.isAdoptable());
+    ASSERT_FALSE(feature.id.isMigratable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
   feature = adoptableUpcomingF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_TRUE(feature.id.isAdoptable());
+    ASSERT_TRUE(feature.id.isMigratable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
   feature = strictConcurrencyF;
   {
     ASSERT_TRUE(Feature::getUpcomingFeature(feature.name));
-    ASSERT_FALSE(feature.id.isAdoptable());
+    ASSERT_FALSE(feature.id.isMigratable());
     ASSERT_LT(defaultLangMode, feature.langMode);
   }
 
@@ -68,7 +68,7 @@ TEST_F(IsFeatureEnabledTest, VerifyTestedFeatures) {
     // it for another experimental feature one that is available in production.
     ASSERT_TRUE(feature.id.isAvailableInProduction());
     ASSERT_TRUE(Feature::getExperimentalFeature(feature.name));
-    ASSERT_FALSE(feature.id.isAdoptable());
+    ASSERT_FALSE(feature.id.isMigratable());
   }
 }
 
@@ -158,7 +158,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption"},
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 // Swift 7 is asserts-only.
 #ifndef NDEBUG
   // Requesting adoption mode in target language mode has no effect.
@@ -176,7 +176,7 @@ static const IsFeatureEnabledTestCase singleEnableTestCases[] = {
       {{adoptableUpcomingF, FeatureState::Off}}),
   IsFeatureEnabledTestCase(
       {"-enable-experimental-feature", adoptableUpcomingF.name + ":adoption"},
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 // Swift 7 is asserts-only.
 #ifndef NDEBUG
   // Requesting adoption mode in target language mode has no effect.
@@ -396,7 +396,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
         "-enable-upcoming-feature", adoptableUpcomingF.name,
         "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
       },
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
         "-enable-upcoming-feature", adoptableUpcomingF.name + ":undef",
         "-enable-experimental-feature", adoptableUpcomingF.name,
@@ -416,7 +416,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
         "-enable-upcoming-feature", adoptableUpcomingF.name,
         "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
       },
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", adoptableUpcomingF.name + ":undef",
         "-enable-upcoming-feature", adoptableUpcomingF.name,
@@ -436,7 +436,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
         "-enable-experimental-feature", adoptableUpcomingF.name,
         "-enable-upcoming-feature", adoptableUpcomingF.name + ":adoption",
       },
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
   IsFeatureEnabledTestCase({
         "-enable-experimental-feature", adoptableUpcomingF.name + ":undef",
         "-enable-experimental-feature", adoptableUpcomingF.name,
@@ -456,7 +456,7 @@ static const IsFeatureEnabledTestCase doubleEnableTestCases[] = {
         "-enable-experimental-feature", adoptableUpcomingF.name,
         "-enable-experimental-feature", adoptableUpcomingF.name + ":adoption",
       },
-      {{adoptableUpcomingF, FeatureState::EnabledForAdoption}}),
+      {{adoptableUpcomingF, FeatureState::EnabledForMigration}}),
 
   // MARK: Experimental
 

--- a/unittests/Frontend/StrictConcurrencyTests.cpp
+++ b/unittests/Frontend/StrictConcurrencyTests.cpp
@@ -42,13 +42,13 @@ static const StrictConcurrencyTestCase strictConcurrencyTestCases[] = {
       {"-enable-upcoming-feature", strictConcurrencyF.name},
       StrictConcurrency::Complete),
   StrictConcurrencyTestCase(
-      {"-enable-upcoming-feature", strictConcurrencyF.name + ":adoption"},
+      {"-enable-upcoming-feature", strictConcurrencyF.name + ":migrate"},
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(
       {"-enable-experimental-feature", strictConcurrencyF.name},
       StrictConcurrency::Complete),
   StrictConcurrencyTestCase(
-      {"-enable-experimental-feature", strictConcurrencyF.name + ":adoption"},
+      {"-enable-experimental-feature", strictConcurrencyF.name + ":migrate"},
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(
       {"-disable-upcoming-feature", strictConcurrencyF.name},
@@ -73,7 +73,7 @@ static const StrictConcurrencyTestCase strictConcurrencyTestCases[] = {
       StrictConcurrency::Targeted),
   StrictConcurrencyTestCase({
         "-enable-upcoming-feature",
-        strictConcurrencyF.name + "=targeted:adoption",
+        strictConcurrencyF.name + "=targeted:migrate",
       },
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(
@@ -81,7 +81,7 @@ static const StrictConcurrencyTestCase strictConcurrencyTestCases[] = {
       StrictConcurrency::Targeted),
   StrictConcurrencyTestCase({
         "-enable-experimental-feature",
-        strictConcurrencyF.name + "=targeted:adoption",
+        strictConcurrencyF.name + "=targeted:migrate",
       },
       StrictConcurrency::Minimal),
   StrictConcurrencyTestCase(


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/80833

---

- Explanation:
 
  This is required to support `swift package migrate` command.

  - Replace `-emit-supported-features` with `-emit-supported-arguments` mode because "features" part was never implemented.
  - Introduce `-print-supported-features` option that prints supported upcoming/experimental features and their metadata.
  -  Rename `Feature` APIs from `adoption` to `migration` (update feature suffix from `:adoption` to `:migrate`)

- Main Branch PR:  https://github.com/swiftlang/swift/pull/80833

- Risk: Low (Adds a new `-print-supported-features` compiler flag).

- Reviewed By: @artemcm 

- Resolves: rdar://148124973

- Testing: Added new tests to the suite.



<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
