### PR TITLE
[6.2] Add a new semantics attribute to disable SIL verification on a function

### DIFF
--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -165,5 +165,7 @@ SEMANTICS_ATTR(USE_FRAME_POINTER, "use_frame_pointer")
 SEMANTICS_ATTR(FIXED_STORAGE_CHECK_INDEX, "fixed_storage.check_index")
 SEMANTICS_ATTR(FIXED_STORAGE_GET_COUNT, "fixed_storage.get_count")
 
+SEMANTICS_ATTR(NO_SIL_VERIFICATION, "sil.verify_none")
+
 #undef SEMANTICS_ATTR
 

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -20,6 +20,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Range.h"
@@ -856,6 +857,14 @@ void SILInstruction::verifyOperandOwnership(
   if (!getModule().getOptions().VerifyAll)
     return;
 #endif
+
+  if (getModule().getOptions().VerifyNone) {
+    return;
+  }
+
+  if (getFunction()->hasSemanticsAttr(semantics::NO_SIL_VERIFICATION)) {
+    return;
+  }
 
   // If SILOwnership is not enabled, do not perform verification.
   if (!getModule().getOptions().VerifySILOwnership)

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7419,6 +7419,10 @@ void SILFunction::verify(CalleeCache *calleeCache,
   if (!verificationEnabled(getModule()))
     return;
 
+  if (hasSemanticsAttr(semantics::NO_SIL_VERIFICATION)) {
+    return;
+  }
+
   // Please put all checks in visitSILFunction in SILVerifier, not here. This
   // ensures that the pretty stack trace in the verifier is included with the
   // back trace when the verifier crashes.

--- a/lib/SILOptimizer/Utils/OptimizerBridging.cpp
+++ b/lib/SILOptimizer/Utils/OptimizerBridging.cpp
@@ -11,7 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SILOptimizer/OptimizerBridging.h"
+#include "../../IRGen/IRGenModule.h"
+#include "swift/AST/SemanticAttrs.h"
+#include "swift/SIL/DynamicCasts.h"
+#include "swift/SIL/OSSALifetimeCompletion.h"
+#include "swift/SIL/SILCloner.h"
 #include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/IPO/ClosureSpecializer.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/ConstantFolding.h"
 #include "swift/SILOptimizer/Utils/Devirtualize.h"
@@ -21,11 +27,6 @@
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
 #include "swift/SILOptimizer/Utils/SpecializationMangler.h"
 #include "swift/SILOptimizer/Utils/StackNesting.h"
-#include "swift/SILOptimizer/IPO/ClosureSpecializer.h"
-#include "swift/SIL/DynamicCasts.h"
-#include "swift/SIL/OSSALifetimeCompletion.h"
-#include "swift/SIL/SILCloner.h"
-#include "../../IRGen/IRGenModule.h"
 
 using namespace swift;
 
@@ -62,6 +63,10 @@ void SILPassManager::runSwiftFunctionVerification(SILFunction *f) {
 
   if (DisableSwiftVerification)
     return;
+
+  if (f->hasSemanticsAttr(semantics::NO_SIL_VERIFICATION)) {
+    return;
+  }
 
   getSwiftPassInvocation()->beginVerifyFunction(f);
   verifyFunctionFunction({getSwiftPassInvocation()}, {f});

--- a/test/SIL/verifier_nofail.sil
+++ b/test/SIL/verifier_nofail.sil
@@ -23,3 +23,13 @@ bb0(%0 : $*P):
   %9999 = tuple()
   return %9999 : $()
 }
+
+
+class Klass {}
+
+sil [ossa] [_semantics "sil.verify_none"] @foo : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  destroy_value %0
+  %t = tuple()
+  return %t
+}


### PR DESCRIPTION
Explanation: Provide a per-function way to disable SIL verification. We have module level flags which are not an ideal workaround for compiler bugs that introduce SIL errors. 

Risk: None

Reviewer: @nate-chandler 

Main PR: https://github.com/swiftlang/swift/pull/81520 
