### PR TITLE
AST: Fix two bugs with SelfProtocolConformance

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -918,9 +918,7 @@ public:
   }
 
   ProtocolConformanceRef getAssociatedConformance(Type assocType,
-                                                  ProtocolDecl *protocol) const{
-    llvm_unreachable("self-conformances never have associated types");
-  }
+                                                  ProtocolDecl *protocol) const;
 
   bool hasWitness(ValueDecl *requirement) const {
     return true;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -739,6 +739,13 @@ NormalProtocolConformance::getWitnessUncached(ValueDecl *requirement) const {
   return entry->second;
 }
 
+ProtocolConformanceRef
+SelfProtocolConformance::getAssociatedConformance(Type assocType,
+                                                  ProtocolDecl *protocol) const {
+  ASSERT(assocType->isEqual(protocol->getSelfInterfaceType()));
+  return lookupConformance(getType(), protocol);
+}
+
 Witness SelfProtocolConformance::getWitness(ValueDecl *requirement) const {
   return Witness(requirement, SubstitutionMap(), nullptr, SubstitutionMap(),
                  GenericSignature(), std::nullopt);

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -285,12 +285,12 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
     // anything but still end up with an ErrorType in the AST.
     if (conformance.isConcrete()) {
       auto concrete = conformance.getConcrete();
-      auto normal = concrete->getRootNormalConformance();
-
-      if (!normal->hasComputedAssociatedConformances()) {
-        if (proto->getASTContext().evaluator.hasActiveRequest(
-              ResolveTypeWitnessesRequest{normal})) {
-          return ProtocolConformanceRef::forInvalid();
+      if (auto normal = dyn_cast<NormalProtocolConformance>(concrete->getRootConformance())) {
+        if (!normal->hasComputedAssociatedConformances()) {
+          if (proto->getASTContext().evaluator.hasActiveRequest(
+                ResolveTypeWitnessesRequest{normal})) {
+            return ProtocolConformanceRef::forInvalid();
+          }
         }
       }
     }

--- a/test/SILOptimizer/specialize_self_conforming.swift
+++ b/test/SILOptimizer/specialize_self_conforming.swift
@@ -5,14 +5,26 @@
 
 import Foundation
 
-@objc protocol P {}
+@objc protocol P: Q {
+  func foo()
+}
+
+@objc protocol Q {
+  func bar()
+}
 
 @_optimize(none)
-func takesP<T : P>(_: T) {}
+func takesP<T : P>(_ t: T) {}
+
+@_optimize(none)
+func takesQ<T : Q>(_ t: T) {}
 
 @inline(__always)
 func callsTakesP<T : P>(_ t: T) {
   takesP(t)
+  takesQ(t)
+  t.foo()
+  t.bar()
 }
 
 // CHECK-LABEL: sil hidden @$s26specialize_self_conforming16callsTakesPWithPyyAA1P_pF : $@convention(thin) (@guaranteed any P) -> () {


### PR DESCRIPTION
There were two problems that have been there for years:

- SubstitutionMap::lookupConformance() assumes that every concrete conformance in the path has a root normal conformance. But calling getRootNormalConformance() on a self conformance would assert.

- SelfProtocolConformance::getAssociatedConformance() was not implemented. While self-conforming protocols do not have associated types, they can inherit from other protocols, and we model this with an associated conformance requirement having a subject type of `Self`.

Both problems were hidden by the fact that ProtocolConformanceRef::subst() directly handled self-conforming existentials without calling into the substitution map. But that is the wrong place for other reasons. The refactoring in a209ff88696188f9b0e66ff85174aeb57ba2d95e exposed both of the above issues.

Fixes rdar://problem/151162470.