### PR TITLE
[6.2][Macros] Mitigate plugin process 'wait' failure

### DIFF
--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -213,6 +213,7 @@ LoadedExecutablePlugin::PluginProcess::~PluginProcess() {
 #else
   close(input);
   close(output);
+  kill(process.Pid, SIGTERM);
 #endif
 
   // Set `SecondsToWait` non-zero so it waits for the timeout and kill it after


### PR DESCRIPTION
Cherry-pick #81517 (and #81547) into `release/6.2`

* **Explanation**: We observed some cases where the compiler were waiting for macro plugins to exit for long time. To mitigate those issues, proactively terminate (`SIGTERM`) the plugin process, in addition to close the pipe and expecting the plugin exit itself. ~~Also adjust the `llvm::sys::Wait` timeout from 1 to 10 seconds, because in the `Wait` implementation, it sets the `alarm(SecondsToWait)`, then `wait4(pid, ..)` so the alarm can go off before the `wait4` call.~~ Also, make sure to `close` all the pipe file descriptor after duping them to stdio, which is not necessary, but it's a good thing to do.
* **Risk**: Low. Although this terminates the plugins ungracefully, but since the plugins can't access filesystems, the risk is not high.
* **Testing**: Passes the current test suite. No test added because we haven't been able to reproduce the hang.
* **Issues**: rdar://150474701
* **Reviewer**: Ben Barham (@bnbarham)