### PR TITLE
6.2: [MoveOnly] Fix consume of addr with mutated field.

### DIFF
--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -1340,10 +1340,8 @@ bool GatherLexicalLifetimeUseVisitor::visitUse(Operand *op,
     return true;
   }
 
-  // Then see if we have a inout_aliasable full apply site use. In that case, we
-  // are going to try and extend move checking into the partial apply using
-  // cloning to eliminate destroys or reinits.
   if (auto fas = FullApplySite::isa(op->getUser())) {
+    // Bail on apply uses of fields.
     if (stripAccessMarkers(op->get()) != useState.address) {
       LLVM_DEBUG(
           llvm::dbgs()
@@ -1352,6 +1350,9 @@ bool GatherLexicalLifetimeUseVisitor::visitUse(Operand *op,
       return false;
     }
 
+    // Then see if we have an inout_aliasable full apply site use. In that case,
+    // we are going to try and extend move checking into the partial apply
+    // using cloning to eliminate destroys or reinits.
     if (fas.getCaptureConvention(*op) ==
         SILArgumentConvention::Indirect_InoutAliasable) {
       // If we don't find the function, we can't handle this, so bail.

--- a/validation-test/SILOptimizer/rdar139666145.swift
+++ b/validation-test/SILOptimizer/rdar139666145.swift
@@ -1,0 +1,11 @@
+// RUN: %target-build-swift %s
+
+struct Box<T> { var value: T }
+
+func modify(_ string: inout String) {}
+
+func tryConsume() {
+    var box = Box(value: "")
+    modify(&box.value)
+    print(consume box)
+}


### PR DESCRIPTION
**Explanation**: Don't emit diagnostic when consuming an address whose field is passed inout.

The checker bails out when seeing an apply use of a field.  That doesn't make sense when the apply takes the field inout.  Narrow the condition under which it bails out to exclude inout operands.
**Scope**: Affects consume checking.
**Issue**: rdar://139666145
**Original PR**: https://github.com/swiftlang/swift/pull/81541
**Risk**: Low.
**Testing**: Added test.
**Reviewer**: Andrew Trick ( @atrick )
