### PR TITLE
[Macros] Revert the 'wait' timeout update back to 1 second

### DIFF
--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -220,10 +220,8 @@ LoadedExecutablePlugin::PluginProcess::~PluginProcess() {
   // that. Usually when the pipe is closed above, the plugin detects the EOF in
   // the stdin and exits immediately, so this usually doesn't wait for the
   // timeout. Note that we can't use '0' because it performs a non-blocking
-  // wait, which make the plugin a zombie if it hasn't exited. We don't use
-  // a small number like '1' because the timeout alarm(3) can fire before the
-  // wait4(2).
-  llvm::sys::Wait(process, /*SecondsToWait=*/10);
+  // wait, which make the plugin a zombie if it hasn't exited.
+  llvm::sys::Wait(process, /*SecondsToWait=*/1);
 }
 
 ssize_t LoadedExecutablePlugin::PluginProcess::read(void *buf,


### PR DESCRIPTION
This reverts commit be25ea2584997b45144d9e4facd8c7531fe0b393.

It turned out that the timeout not working was caused by a sandbox disallowing  a system call used by `alarm`. Assuming `SIGTERM` in #81517  would work, 10 seconds of timeout would be only a risk. So set it back to 1 second.