### PR TITLE
[Swiftify] Escape param decl refs

### DIFF
--- a/test/Interop/C/swiftify-import/Inputs/counted-by-noescape.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by-noescape.h
@@ -24,3 +24,58 @@ int * __counted_by(len) __noescape returnPointer(int len);
 int * __counted_by(len1) returnLifetimeBound(int len1, int len2, int * __counted_by(len2) p __lifetimebound);
 
 void anonymous(int len, int * __counted_by(len) _Nullable __noescape);
+
+void keyword(int len, int * __counted_by(len) _Nullable func __noescape,
+    int extension,
+    int init,
+    int open,
+    int var,
+    int is,
+    int as,
+    int in,
+    int guard,
+    int where
+);
+
+void pointerName(int len, int * __counted_by(len) _Nullable pointerName __noescape);
+
+void lenName(int lenName, int size, int * __counted_by(lenName * size) _Nullable p __noescape);
+
+void func(int len, int * __counted_by(len) _Nullable func __noescape);
+
+void *funcRenameKeyword(int len, int * __counted_by(len) _Nullable func __noescape,
+    int extension __lifetimebound,
+    int init,
+    int open,
+    int var,
+    int is,
+    int as,
+    int in,
+    int guard,
+    int where) __attribute__((swift_name("funcRenamed(len:func:extension:init:open:var:is:as:in:guard:where:)")));
+
+void *funcRenameKeywordAnonymous(int len, int * __counted_by(len) _Nullable __noescape,
+    int __lifetimebound,
+    int,
+    int,
+    int,
+    int,
+    int,
+    int,
+    int,
+    int) __attribute__((swift_name("funcRenamedAnon(len:func:extension:init:open:var:is:as:in:guard:where:)")));
+
+void funcRenameClash(int len, int * __counted_by(len) _Nullable func __noescape, int where)
+    __attribute__((swift_name("clash(len:func:clash:)")));
+
+void funcRenameClashKeyword(int len, int * __counted_by(len) _Nullable func __noescape, int where)
+    __attribute__((swift_name("open(len:func:open:)")));
+
+void funcRenameClashAnonymous(int len, int * __counted_by(len) _Nullable func __noescape, int)
+    __attribute__((swift_name("clash2(len:func:clash2:)")));
+
+void funcRenameClashKeywordAnonymous(int len, int * __counted_by(len) _Nullable func __noescape, int)
+    __attribute__((swift_name("in(len:func:in:)")));
+
+typedef struct actor_ *actor;
+actor _Nonnull keywordType(int len, actor * __counted_by(len) __noescape p, actor _Nonnull p2);

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -13,13 +13,60 @@ import CountedByNoEscapeClang
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(_param1: copy _param1)
-// CHECK-NEXT: @_alwaysEmitIntoClient public func anonymous(_ _param1: inout MutableSpan<Int32>?)
+// CHECK-NEXT: @lifetime(_anonymous_param1: copy _anonymous_param1)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func anonymous(_ _anonymous_param1: inout MutableSpan<Int32>?)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(func: copy func)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func clash(func: inout MutableSpan<Int32>?, clash where: Int32)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(_clash2_param1: copy _clash2_param1)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func clash2(func _clash2_param1: inout MutableSpan<Int32>?, clash2 _clash2_param2: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(_func_param1: copy _func_param1)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func `func`(_ _func_param1: inout MutableSpan<Int32>?)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(borrow extension)
+// CHECK-NEXT: @lifetime(func: copy func)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func funcRenamed(func: inout MutableSpan<Int32>?, extension: Int32, init: Int32, open: Int32, var: Int32, is: Int32, as: Int32, in: Int32, guard: Int32, where: Int32) -> UnsafeMutableRawPointer!
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(borrow _funcRenamedAnon_param2)
+// CHECK-NEXT: @lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func funcRenamedAnon(func _funcRenamedAnon_param1: inout MutableSpan<Int32>?, extension _funcRenamedAnon_param2: Int32, init _funcRenamedAnon_param3: Int32, open _funcRenamedAnon_param4: Int32, var _funcRenamedAnon_param5: Int32, is _funcRenamedAnon_param6: Int32, as _funcRenamedAnon_param7: Int32, in _funcRenamedAnon_param8: Int32, guard _funcRenamedAnon_param9: Int32, where _funcRenamedAnon_param10: Int32) -> UnsafeMutableRawPointer!
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(_in_param1: copy _in_param1)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func `in`(func _in_param1: inout MutableSpan<Int32>?, in _in_param2: Int32)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(func: copy func)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func keyword(_ func: inout MutableSpan<Int32>?, _ extension: Int32, _ init: Int32, _ open: Int32, _ var: Int32, _ is: Int32, _ as: Int32, _ in: Int32, _ guard: Int32, _ where: Int32)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func keywordType(_ p: inout MutableSpan<actor?>, _ p2: actor) -> actor
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(_lenName_param2: copy _lenName_param2)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func lenName(_ _lenName_param0: Int32, _ _lenName_param1: Int32, _ _lenName_param2: inout MutableSpan<Int32>?)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -35,6 +82,16 @@ import CountedByNoEscapeClang
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_ p: inout MutableSpan<Int32>?)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(func: copy func)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func open(func: inout MutableSpan<Int32>?, open where: Int32)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(_pointerName_param1: copy _pointerName_param1)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func pointerName(_ _pointerName_param1: inout MutableSpan<Int32>?)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -125,8 +182,65 @@ public func callSwiftAttr(_ p: inout MutableSpan<CInt>) {
   swiftAttr(&p)
 }
 
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @lifetime(p: copy p)
 @inlinable
 public func callAnonymous(_ p: inout MutableSpan<CInt>?) {
   anonymous(&p)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@lifetime(p: copy p)
+@inlinable
+public func callKeyword(_ p: inout MutableSpan<CInt>?) {
+  keyword(&p, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@lifetime(p: copy p)
+@inlinable
+public func callFunc(_ p: inout MutableSpan<CInt>?) {
+  `func`(&p)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@lifetime(p: copy p)
+@inlinable
+public func callFuncRenameKeyword(_ p: inout MutableSpan<CInt>?) {
+  funcRenamed(func: &p, extension: 1, init: 2, open: 3, var: 4, is: 5, as: 6, in: 7, guard: 8, where: 9)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@lifetime(p: copy p)
+@inlinable
+public func callFuncRenameClash(_ p: inout MutableSpan<CInt>?) {
+  clash(func: &p, clash: 1)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@lifetime(p: copy p)
+@inlinable
+public func callFuncRenameClashKeyword(_ p: inout MutableSpan<CInt>?) {
+  `open`(func: &p, open: 1)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@lifetime(p: copy p)
+@inlinable
+public func callFuncRenameClashKeywordAnon(_ p: inout MutableSpan<CInt>?) {
+  `in`(func: &p, in: 1)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@lifetime(p: copy p)
+@inlinable
+public func callPointerName(_ p: inout MutableSpan<CInt>?) {
+  pointerName(&p)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@lifetime(p: copy p)
+@inlinable
+public func callLenName(_ p: inout MutableSpan<CInt>?) {
+  lenName(CInt(p?.count ?? 0), 2, &p)
 }

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -170,4 +170,7 @@ struct SpanWithoutTypeAlias {
   void foo(std::span<const int> s [[clang::noescape]]);
 };
 
+inline void func(ConstSpanOfInt copy [[clang::noescape]]) {}
+inline void mutableKeyword(SpanOfInt copy [[clang::noescape]]) {}
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -94,8 +94,11 @@ import CxxStdlib
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper7(_ p: UnsafeMutableBufferPointer<Int32>) -> SpanOfInt
 
-
 // CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func `func`(_ copy: Span<CInt>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper(_ s: Span<CInt>)
 
@@ -136,6 +139,11 @@ import CxxStdlib
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper7(_ p: UnsafeBufferPointer<Int32>) -> ConstSpanOfInt
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(copy: copy copy)
+// CHECK-NEXT: @_alwaysEmitIntoClient public func mutableKeyword(_ copy: inout MutableSpan<CInt>)
 
 func callMethodWithSafeWrapper(_ x: inout X, s: Span<CInt>) {
     x.methodWithSafeWrapper(s)
@@ -228,4 +236,9 @@ func callMixedFuncWithSafeWrapper6(_ s: ConstSpanOfInt, _ p: UnsafeMutableBuffer
 
 func callMixedFuncWithSafeWrapper7(_ p: UnsafeBufferPointer<CInt>) {
     let _: ConstSpanOfInt = unsafe mixedFuncWithSafeWrapper7(p)
+}
+
+@lifetime(span: copy span)
+func callMutableKeyword(_ span: inout MutableSpan<CInt>) {
+    mutableKeyword(&span)
 }

--- a/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
@@ -19,25 +19,25 @@ public func myFunc4(_: UnsafeMutablePointer<CInt>, _ len: CInt) {
 }
 
 // CHECK:      @_alwaysEmitIntoClient
-// CHECK-NEXT: public func myFunc(_ _param0: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe myFunc(_param0.baseAddress!, CInt(exactly: _param0.count)!)
+// CHECK-NEXT: public func myFunc(_ _myFunc_param0: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     return unsafe myFunc(_myFunc_param0.baseAddress!, CInt(exactly: _myFunc_param0.count)!)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
-// CHECK-NEXT: public func myFunc2(_ p: UnsafeBufferPointer<CInt>, _ _param2: CInt) {
-// CHECK-NEXT:     return unsafe myFunc2(p.baseAddress!, CInt(exactly: p.count)!, _param2)
+// CHECK-NEXT: public func myFunc2(_ _myFunc2_param0: UnsafeBufferPointer<CInt>, _ _myFunc2_param2: CInt) {
+// CHECK-NEXT:     return unsafe myFunc2(_myFunc2_param0.baseAddress!, CInt(exactly: _myFunc2_param0.count)!, _myFunc2_param2)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient
-// CHECK-NEXT: public func myFunc3(_ _param0: Span<CInt>) {
-// CHECK-NEXT:     return unsafe _param0.withUnsafeBufferPointer { __param0Ptr in
-// CHECK-NEXT:         return unsafe myFunc3(__param0Ptr.baseAddress!, CInt(exactly: __param0Ptr.count)!)
-// CHECK-NEXT:     }
+// CHECK-NEXT: public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
+// CHECK-NEXT:     return   unsafe _myFunc3_param0.withUnsafeBufferPointer { __myFunc3_param0Ptr in
+// CHECK-NEXT:         return unsafe myFunc3(__myFunc3_param0Ptr.baseAddress!, CInt(exactly: __myFunc3_param0Ptr.count)!)
+// CHECK-NEXT:       }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(_param0: copy _param0)
-// CHECK-NEXT: public func myFunc4(_ _param0: inout MutableSpan<CInt>) {
-// CHECK-NEXT:     return unsafe _param0.withUnsafeMutableBufferPointer { __param0Ptr in
-// CHECK-NEXT:         return unsafe myFunc4(__param0Ptr.baseAddress!, CInt(exactly: __param0Ptr.count)!)
-// CHECK-NEXT:     }
+// CHECK:      @_alwaysEmitIntoClient @lifetime(_myFunc4_param0: copy _myFunc4_param0)
+// CHECK-NEXT: public func myFunc4(_ _myFunc4_param0: inout MutableSpan<CInt>) {
+// CHECK-NEXT:     return   unsafe _myFunc4_param0.withUnsafeMutableBufferPointer { __myFunc4_param0Ptr in
+// CHECK-NEXT:         return unsafe myFunc4(__myFunc4_param0Ptr.baseAddress!, CInt(exactly: __myFunc4_param0Ptr.count)!)
+// CHECK-NEXT:       }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
@@ -14,4 +14,3 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ size: CInt, _ count: CInt) {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, count)
 // CHECK-NEXT: }
-

--- a/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
@@ -10,4 +10,3 @@ func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableBufferPointer<CInt>) {
 // CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
-

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -9,7 +9,7 @@ func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr)
 // CHECK-NEXT: func myFunc(_ ptr: inout MutableSpan<CInt>) {
-// CHECK-NEXT:     return unsafe   ptr.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in
 // CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
@@ -55,4 +55,3 @@ func allNamedOther(buf ptr: UnsafePointer<CInt>, count len: CInt) {
 // CHECK-NEXT: func allNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
 // CHECK-NEXT:     return unsafe allNamedOther(buf: ptr.baseAddress!, count: CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
-

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -39,4 +39,3 @@ func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _
 // CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2)), copying: ())
 // CHECK-NEXT: }
-

--- a/test/Macros/SwiftifyImport/CountedBy/QualifiedTypes.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/QualifiedTypes.swift
@@ -19,5 +19,3 @@ func bar(_ ptr: Swift.UnsafePointer<Swift.CInt>, _ len: Swift.Int) -> () {
 // CHECK-NEXT: func bar(_ ptr: Swift.UnsafeBufferPointer<Swift.CInt>) -> () {
 // CHECK-NEXT:     return unsafe bar(ptr.baseAddress!, ptr.count)
 // CHECK-NEXT: }
-
-

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -14,4 +14,3 @@ func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePointer<CIn
 // CHECK-NEXT:         return unsafe myFunc(_ptr1Ptr.baseAddress!, CInt(exactly: _ptr1Ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
-

--- a/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
@@ -10,4 +10,3 @@ func myFunc(_ ptr: UnsafePointer<CInt>!, _ len: CInt) {
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
 // CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
-

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -57,6 +57,10 @@ func myFunc8(_ ptr: UnsafeRawPointer, _ span: SpanOfInt, _ count: CInt, _ size: 
 func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 }
 
+@_SwiftifyImport(.lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), typeMappings: ["MutableSpanOfInt" : "std.span<CInt>"])
+func myFunc10(_ self: MutableSpanOfInt) -> MutableSpanOfInt {
+}
+
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span)
 // CHECK-NEXT: func myFunc(_ span: Span<CInt>) -> Span<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc(SpanOfInt(span))), copying: ())
@@ -119,5 +123,12 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT: func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
 // CHECK-NEXT:         return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
+// CHECK-NEXT:    }), copying: ())
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy `self`) @lifetime(`self`: copy `self`)
+// CHECK-NEXT: func myFunc10(_ `self`: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe `self`.withUnsafeMutableBufferPointer { _selfPtr in
+// CHECK-NEXT:         return unsafe myFunc10(MutableSpanOfInt(_selfPtr))
 // CHECK-NEXT:    }), copying: ())
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -67,4 +67,3 @@ func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 // CHECK-NEXT:         return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: _ptrPtr.count)!)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
-

--- a/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
@@ -10,4 +10,3 @@ func myFunc(_ ptr: UnsafeRawPointer!, _ len: CInt) {
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) {
 // CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
 // CHECK-NEXT: }
-


### PR DESCRIPTION
Parameters can be named with keywords without escaping, because it's unambiguous in the grammar that they are parameters. They still need to escaped when referred to inside the function body however. This escapes all references to parameters using backticks.

Parameter names are also checked for clashes with the function name - in such cases the parameter is renamed in the same way as unnamed parameters.

rdar://151024645