### PR TITLE
Improve LifetimeDependenceDefUseWalker: consult DestructorAnalysis.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/CMakeLists.txt
@@ -10,5 +10,6 @@ swift_compiler_sources(Optimizer
   AliasAnalysis.swift
   CalleeAnalysis.swift
   DeadEndBlocksAnalysis.swift
+  DestructorAnalysis.swift
   DominatorTree.swift
   PostDominatorTree.swift)

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/DestructorAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/DestructorAnalysis.swift
@@ -1,0 +1,26 @@
+//===--- DestructorAnalysis.swift - the dead-end blocks analysis ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import OptimizerBridging
+import SIL
+
+struct DestructorAnalysis {
+  let bridged: BridgedDestructorAnalysis
+
+  // TODO: swift::isDestructorSideEffectFree() also  handles other cases, such as Arrays and closures.
+  func deinitMayHaveEffects(type: Type, in function: Function) -> Bool {
+    if type.isBox {
+      return type.getBoxFields(in: function).contains(where: { deinitMayHaveEffects(type: $0, in: function) })
+    }
+    return bridged.mayStoreToMemoryOnDestruction(type.bridged)
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -449,14 +449,17 @@ extension DependentAddressUseDefWalker: AddressUseDefWalker {
 /// TODO: handle stores to singly initialized temporaries like copies using a standard reaching-def analysis.
 private struct DiagnoseDependenceWalker {
   let context: Context
+  let destructorAnalysis: DestructorAnalysis
+
   var diagnostics: DiagnoseDependence
   let localReachabilityCache = LocalVariableReachabilityCache()
   var visitedValues: ValueSet
 
-  var function: Function { diagnostics.function }
+  var function: Function { get { diagnostics.function } }
   
-  init(_ diagnostics: DiagnoseDependence, _ context: Context) {
+  init(_ diagnostics: DiagnoseDependence, _ context: FunctionPassContext) {
     self.context = context
+    self.destructorAnalysis = context.destructorAnalysis
     self.diagnostics = diagnostics
     self.visitedValues = ValueSet(context)
   }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -1012,8 +1012,10 @@ private extension BeginApplyInst {
 ///
 /// Set 'dependsOnCaller' if a use escapes the function.
 private struct LifetimeDependentUseWalker : LifetimeDependenceDefUseWalker {
-  let function: Function
   let context: Context
+  let function: Function
+  let destructorAnalysis: DestructorAnalysis
+
   let visitor: (Operand) -> WalkResult
   let localReachabilityCache: LocalVariableReachabilityCache
   var visitedValues: ValueSet
@@ -1021,10 +1023,11 @@ private struct LifetimeDependentUseWalker : LifetimeDependenceDefUseWalker {
   /// Set to true if the dependence is returned from the current function.
   var dependsOnCaller = false
 
-  init(_ function: Function, _ localReachabilityCache: LocalVariableReachabilityCache, _ context: Context,
+  init(_ function: Function, _ localReachabilityCache: LocalVariableReachabilityCache, _ context: FunctionPassContext,
        visitor: @escaping (Operand) -> WalkResult) {
-    self.function = function
     self.context = context
+    self.function = function
+    self.destructorAnalysis = context.destructorAnalysis
     self.visitor = visitor
     self.localReachabilityCache = localReachabilityCache
     self.visitedValues = ValueSet(context)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -329,7 +329,7 @@ private struct ScopeExtension {
 // violation, and that subsequent optimizations do not shrink the inner access `%a1`.
 extension ScopeExtension {
   mutating func extendScopes(dependence: LifetimeDependence) -> Bool {
-    log("Scope fixup for lifetime dependent instructions: \(dependence)")
+    log("Scope fixup for lifetime dependent instructions:\n\(dependence)")
 
     gatherExtensions(dependence: dependence)
 

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -317,6 +317,11 @@ struct FunctionPassContext : MutatingContext {
     return DeadEndBlocksAnalysis(bridged: bridgeDEA)
   }
 
+  var destructorAnalysis: DestructorAnalysis {
+    let bridgeAnalysis = _bridged.getDestructorAnalysis()
+    return DestructorAnalysis(bridged: bridgeAnalysis)
+  }
+
   var dominatorTree: DominatorTree {
     let bridgedDT = _bridged.getDomTree()
     return DominatorTree(bridged: bridgedDT)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -543,6 +543,8 @@ protocol LifetimeDependenceDefUseWalker : ForwardingDefUseWalker,
                                           AddressUseVisitor {
   var function: Function { get }
 
+  var destructorAnalysis: DestructorAnalysis { get }
+
   /// Dependence tracking through local variables.
   var localReachabilityCache: LocalVariableReachabilityCache { get }
 
@@ -1028,12 +1030,15 @@ let lifetimeDependenceScopeTest = FunctionTest("lifetime_dependence_scope") {
 private struct LifetimeDependenceUsePrinter : LifetimeDependenceDefUseWalker {
   let context: Context
   let function: Function
+  let destructorAnalysis: DestructorAnalysis
+
   let localReachabilityCache = LocalVariableReachabilityCache()
   var visitedValues: ValueSet
   
-  init(function: Function, _ context: Context) {
+  init(function: Function, _ context: FunctionPassContext) {
     self.context = context
     self.function = function
+    self.destructorAnalysis = context.destructorAnalysis
     self.visitedValues = ValueSet(context)
   }
   

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -43,6 +43,7 @@ class AliasAnalysis;
 class BasicCalleeAnalysis;
 class CalleeList;
 class DeadEndBlocks;
+class DestructorAnalysis;
 class DominanceInfo;
 class PostDominanceInfo;
 class BasicBlockSet;
@@ -114,6 +115,12 @@ struct BridgedDeadEndBlocksAnalysis {
   swift::DeadEndBlocks * _Nonnull deb;
 
   BRIDGED_INLINE bool isDeadEnd(BridgedBasicBlock block) const;
+};
+
+struct BridgedDestructorAnalysis {
+  swift::DestructorAnalysis * _Nonnull analysis;
+
+  BRIDGED_INLINE bool mayStoreToMemoryOnDestruction(BridgedType type) const;
 };
 
 struct BridgedDomTree {
@@ -213,6 +220,7 @@ struct BridgedPassContext {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedAliasAnalysis getAliasAnalysis() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCalleeAnalysis getCalleeAnalysis() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeadEndBlocksAnalysis getDeadEndBlocksAnalysis() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDestructorAnalysis getDestructorAnalysis() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDomTree getDomTree() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedPostDomTree getPostDomTree() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedDeclObj getSwiftArrayDecl() const;

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -23,6 +23,7 @@
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
+#include "swift/SILOptimizer/Analysis/DestructorAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/OptimizerBridging.h"
 #include "swift/SILOptimizer/PassManager/PassManager.h"
@@ -72,6 +73,14 @@ BridgedFunction BridgedCalleeAnalysis::CalleeList::getCallee(SwiftInt index) con
 
 bool BridgedDeadEndBlocksAnalysis::isDeadEnd(BridgedBasicBlock block) const {
   return deb->isDeadEnd(block.unbridged());
+}
+
+//===----------------------------------------------------------------------===//
+//                          BridgedDestructorAnalysis
+//===----------------------------------------------------------------------===//
+
+bool BridgedDestructorAnalysis::mayStoreToMemoryOnDestruction(BridgedType type) const {
+  return analysis->mayStoreToMemoryOnDestruction(type.unbridged());
 }
 
 //===----------------------------------------------------------------------===//
@@ -203,6 +212,10 @@ BridgedCalleeAnalysis BridgedPassContext::getCalleeAnalysis() const {
 BridgedDeadEndBlocksAnalysis BridgedPassContext::getDeadEndBlocksAnalysis() const {
   auto *dba = invocation->getPassManager()->getAnalysis<swift::DeadEndBlocksAnalysis>();
   return {dba->get(invocation->getFunction())};
+}
+
+BridgedDestructorAnalysis BridgedPassContext::getDestructorAnalysis() const {
+  return {invocation->getPassManager()->getAnalysis<swift::DestructorAnalysis>()};
 }
 
 BridgedDomTree BridgedPassContext::getDomTree() const {

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -357,9 +357,10 @@ func testScopedOfInheritedWithLet(_ arg: [Int] ) {
   // TODO: should be // ✅ Safe: 'copySpan' result should be borrowed over `result`
   // rdar://128821299 ([nonescaping] extend borrowed arguments that are the source of a scoped dependence)
   let result = reborrowSpan(copySpan(span)) // expected-error {{lifetime-dependent variable 'result' escapes its scope}}
-  // expected-note @-1{{it depends on the lifetime of this parent value}}  
+  // expected-note @-1{{it depends on the lifetime of this parent value}}
+  // expected-note @-2{{this use of the lifetime-dependent value is out of scope}}
   _ = result
-} // expected-note {{this use of the lifetime-dependent value is out of scope}}
+}
 
 // Test a scoped dependence on an inherited inout argument.
 //
@@ -454,6 +455,14 @@ func testInoutBorrow(a: inout [Int]) -> Span<Int> {
 @lifetime(&a)
 func testInoutMutableBorrow(a: inout [Int]) -> MutableSpan<Int> {
   a.mutableSpan()
+}
+
+func testInoutTemporaryBorrow(a: inout [Int]) {
+  let span = a.span()
+  parse(span)
+  // 'read' access ends here even though span is still alive
+  // because span has no user-defined deinit.
+  a.append(10)
 }
 
 // =============================================================================


### PR DESCRIPTION
- **Fix DestructorAnalysis: handle enum, FixedArray, and generic types.**
  This checks the members of a value type to determine whether its synthesized
  deinitializer can have side effects.
  
  Add support for enum and fixed array.
  
  Add support for generic types. The old code was inexplicably failing to apply
  the aggregate's type substitutions to the members.
  

- **SwiftCompilerSources: bridge DestructorAnalysis.**
  

- **Add DestructorAnalysis to LifetimeDependenceDefUseWalker.**
  

- **[NFC] LifetimeDependence: fix internal debug output**
  

- **Improve LifetimeDependenceDefUseWalker: consult DestructorAnalysis.**
  Fixes rdar://150828355 (Overlapping access error after the last use
  of a lifetime-dependent span variable)
  