### PR TITLE
[6.2] [Sema] Continue type-checking `for` body when preamble fails

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1434,8 +1434,7 @@ public:
   }
   
   Stmt *visitForEachStmt(ForEachStmt *S) {
-    if (TypeChecker::typeCheckForEachPreamble(DC, S))
-      return nullptr;
+    TypeChecker::typeCheckForEachPreamble(DC, S);
 
     // Type-check the body of the loop.
     auto sourceFile = DC->getParentSourceFile();

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -210,8 +210,10 @@ func missingControllingExprInForEach() {
 // The #if block is used to provide a scope for the for stmt to force it to end
 // where necessary to provoke the crash.
 #if true  // <rdar://problem/21679557> compiler crashes on "for{{"
-  // expected-error @+2 {{expected pattern}}
-  // expected-error @+1 {{expected Sequence expression for for-each loop}}
+  // expected-error @+4 {{expected pattern}}
+  // expected-error @+3 {{expected Sequence expression for for-each loop}}
+  // expected-error @+2 {{closure expression is unused}}
+  // expected-note @+1 {{did you mean to use a 'do' statement?}}
   for{{ // expected-note 2 {{to match this opening '{'}}
 #endif  // expected-error {{expected '}' at end of closure}} expected-error {{expected '}' at end of brace statement}}
 

--- a/test/stmt/c_style_for.swift
+++ b/test/stmt/c_style_for.swift
@@ -32,9 +32,9 @@ for ; other<count; other+=1 { // expected-error {{C-style for statement was remo
 }
 
 for (var number : Int8 = start; number < count; number+=1) { // expected-error {{C-style for statement was removed in Swift 3}} {{none}}
-  print(number)
+  print(number) // expected-error {{cannot find 'number' in scope}}
 }
 
 for (var m : Int8 = start; m < count; m+=1) { // expected-error {{C-style for statement was removed in Swift 3}} {{none}}
-  m += 3
+  m += 3 // expected-error {{cannot find 'm' in scope}}
 }

--- a/test/stmt/foreach.swift
+++ b/test/stmt/foreach.swift
@@ -351,3 +351,16 @@ do {
     }
   }
 }
+
+// Make sure the bodies still type-check okay if the preamble is invalid.
+func testInvalidPreamble() {
+  func takesAutoclosure(_ x: @autoclosure () -> Int) -> Int { 0 }
+
+  for _ in undefined { // expected-error {{cannot find 'undefined' in scope}}
+    let a = takesAutoclosure(0) // Fine
+  }
+  for x in undefined { // expected-error {{cannot find 'undefined' in scope}}
+    let b: Int = x  // No type error, `x` is invalid.
+    _ = "" as Int // expected-error {{cannot convert value of type 'String' to type 'Int' in coercion}}
+  }
+}


### PR DESCRIPTION
*6.2 cherry-pick of #81540*

- Explanation: Fixes a crash that could occur when forming an autoclosure in a variable binding in the body of an invalid `for` loop
- Scope: Affects `for` loop type-checking
- Issue: rdar://136500008
- Risk: Medium - This does change a pretty fundamental part of how `for` loops are type-checked, but I don't actually think the risk is too bad since:
  - It only affects invalid code
  - We were already doing some amount of downstream type-checking through request evaluation for e.g pattern bindings
  - The situation today is already pretty bad since it can be triggered by something as simple as `let x = foo && bar` in the body of an invalid loop
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich