### PR TITLE
[Driver] Avoid using response files for SourceKit

### DIFF
--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -72,6 +72,11 @@ std::optional<Job::ResponseFileInfo>
 ToolChain::getResponseFileInfo(const Compilation &C, const char *executablePath,
                                const ToolChain::InvocationInfo &invocationInfo,
                                const ToolChain::JobContext &context) const {
+  // Never use a response file if this is a dummy driver for SourceKit, we
+  // just want the frontend arguments.
+  if (getDriver().isDummyDriverForFrontendInvocation())
+    return std::nullopt;
+
   const bool forceResponseFiles =
       C.getArgs().hasArg(options::OPT_driver_force_response_files);
   assert((invocationInfo.allowsResponseFiles || !forceResponseFiles) &&

--- a/test/SourceKit/Misc/rdar98880399.swift
+++ b/test/SourceKit/Misc/rdar98880399.swift
@@ -1,0 +1,4 @@
+// Make sure we don't create any temporary files.
+// RUN: %empty-directory(%t)
+// RUN: env TMP=%t TMPDIR=%t %sourcekitd-test -req=open %s -- %s -driver-force-response-files
+// RUN: not ls %t/* >/dev/null 2>&1


### PR DESCRIPTION
We only care about the frontend arguments here, creating a response file is unnecessary.

rdar://98880399
