### PR TITLE
Runtimes: adjust the synchronization module build

### DIFF
--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -1,13 +1,19 @@
 cmake_minimum_required(VERSION 3.29)
 
+if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
+  cmake_policy(SET CMP0157 OLD)
+endif()
+
 if($ENV{BUILD_NUMBER})
   math(EXPR BUILD_NUMBER "$ENV{BUILD_NUMBER} % 65535")
   set(BUILD_NUMBER ".${BUILD_NUMBER}")
 endif()
-
 project(SwiftSynchronization
   LANGUAGES Swift
   VERSION 6.1.0${BUILD_NUMBER})
+# FIXME(compnerd) this is a workaround for `GNUInstallDirs` which cannot be used
+# with a pure Swift project.
+enable_language(C)
 
 if(NOT PROJECT_IS_TOP_LEVEL)
   message(SEND_ERROR "Swift Synchronization must build as a standalone project")
@@ -17,23 +23,32 @@ set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake/modules")
 
-set(CMAKE_Swift_LANGUAGE_VERSION 5)
-
-include(GNUInstallDirs)
-
 set(${PROJECT_NAME}_SWIFTC_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/../../../"
   CACHE FILEPATH "Path to the root source directory of the Swift compiler")
 
+# Hook point for vendor-specific extensions to the build system
+# Allowed extension points:
+#   - DefaultSettings.cmake
+#   - Settings.cmake
 set(${PROJECT_NAME}_VENDOR_MODULE_DIR "${CMAKE_SOURCE_DIR}/../cmake/modules/vendor"
   CACHE FILEPATH "Location for private build system extension")
 
-find_package(SwiftCore QUIET REQUIRED)
+find_package(SwiftCore REQUIRED)
 
+include(GNUInstallDirs)
+
+include(AvailabilityMacros)
+include(EmitSwiftInterface)
+include(InstallSwiftInterface)
+include(PlatformInfo)
 include(gyb)
 include(ResourceEmbedding)
-include(AvailabilityMacros)
-include(PlatformInfo)
+include(CatalystSupport)
+
+option(${PROJECT_NAME}_INSTALL_NESTED_SUBDIR "Install libraries under a platform and architecture subdirectory" ON)
+set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}/${${PROJECT_NAME}_ARCH_SUBDIR}>" CACHE STRING "")
+set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${${PROJECT_NAME}_INSTALL_NESTED_SUBDIR}>:/${${PROJECT_NAME}_PLATFORM_SUBDIR}>" CACHE STRING "")
 
 include("${${PROJECT_NAME}_VENDOR_MODULE_DIR}/Settings.cmake" OPTIONAL)
 
@@ -43,20 +58,16 @@ option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime 
 option(${PROJECT_NAME}_ENABLE_PRESPECIALIZATION "Enable generic metadata prespecialization"
   ${SwiftCore_ENABLE_PRESPECIALIZATION})
 
-include(CatalystSupport)
-include(EmitSwiftInterface)
-include(InstallSwiftInterface)
-
 add_compile_options(
-  "$<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>"
-  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
-  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>"
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
+  $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
   $<$<COMPILE_LANGUAGE:Swift>:-enable-builtin-module>
   $<$<COMPILE_LANGUAGE:Swift>:-strict-memory-safety>
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature RawLayout>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature StaticExclusiveOnly>"
-  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Extern>")
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Extern>"
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
+  "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")
 
 gyb_expand(Atomics/AtomicIntegers.swift.gyb Atomics/AtomicIntegers.swift)
 gyb_expand(Atomics/AtomicStorage.swift.gyb Atomics/AtomicStorage.swift)
@@ -78,18 +89,14 @@ add_library(swiftSynchronization
   $<$<PLATFORM_ID:Darwin>:Mutex/DarwinImpl.swift>
   $<$<PLATFORM_ID:Linux>:Mutex/LinuxImpl.swift>
   $<$<PLATFORM_ID:WASI>:Mutex/SpinLoopHint.swift>
-  $<$<PLATFORM_ID:WINDOWS>:Mutex/WindowsImpl.swift>)
+  $<$<PLATFORM_ID:Windows>:Mutex/WindowsImpl.swift>)
 
 set_target_properties(swiftSynchronization PROPERTIES
   Swift_MODULE_NAME Synchronization)
 
-target_link_libraries(swiftSynchronization
-  PRIVATE
-    swiftCore
-    $<$<PLATFORM_ID:Darwin>:swiftDarwin>)
-
-set(${PROJECT_NAME}_INSTALL_LIBDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${Supplemental_INSTALL_NESTED_SUBDIR}>:/${Supplemental_PLATFORM_SUBDIR}/${Supplemental_ARCH_SUBDIR}>" CACHE STRING "")
-set(${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR "${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>$<$<BOOL:${Supplemental_INSTALL_NESTED_SUBDIR}>:/${Supplemental_PLATFORM_SUBDIR}>" CACHE STRING "")
+target_link_libraries(swiftSynchronization PRIVATE
+  swiftCore
+  $<$<PLATFORM_ID:Darwin>:swiftDarwin>)
 
 install(TARGETS swiftSynchronization
   EXPORT SwiftSynchronizationTargets


### PR DESCRIPTION
Disable CMP0157 with the old driver as this breaks on Windows. Adjust the Windows platform ID spelling to repair the Windows build. Take the opportunity to re-order some of the structure so that it is similar to the other modules.