### PR TITLE
Set the Compilation directory when generating the Skeleton CU

### DIFF
--- a/test/DebugInfo/comp-dir.swift
+++ b/test/DebugInfo/comp-dir.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
+// RUN: %target-swift-frontend -c -I %t -primary-file %s -g -parse-as-library -emit-module -emit-object -module-cache-path "./mc" -file-compilation-dir "." -debug-prefix-map "$(pwd)=." -o %t/test.o
+// RUN: %llvm-dwarfdump %t/test.o | %FileCheck %s
+
+// CHECK: DW_TAG_compile_unit
+
+// CHECK: DW_TAG_compile_unit
+// CHECK-NOT: NULL
+// CHECK: DW_AT_comp_dir	(".")
+// CHECK-NOT: NULL


### PR DESCRIPTION
When creating a skeleton Compile Unit, the DIFile passed in, it always uses the include path. This leads to the DW_AT_comp_dir being wrong, if the -file-compilation-dir option is passed, we need to use the remapped compilation dir passed in to the DIFile instead.

This patch fixes that problem.
