### PR TITLE
[6.2] IRGen: Fix miscompile when a generic parameter is fixed to a tuple containing a pack

### DIFF
--- a/lib/IRGen/Fulfillment.h
+++ b/lib/IRGen/Fulfillment.h
@@ -102,6 +102,14 @@ public:
                           unsigned sourceIndex, MetadataPath &&path,
                           const InterestingKeysCallback &interestingKeys);
 
+  /// Metadata fulfillment in tuple conformance witness thunks.
+  ///
+  /// \return true if any fulfillments were added by this search.
+  bool searchTupleTypeMetadata(IRGenModule &IGM, CanTupleType type, IsExact_t isExact,
+                               MetadataState metadataState,
+                               unsigned sourceIndex, MetadataPath &&path,
+                               const InterestingKeysCallback &interestingKeys);
+
   /// Search the given type metadata pack for useful fulfillments.
   ///
   /// \return true if any fulfillments were added by this search.

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -735,11 +735,20 @@ void LocalTypeDataCache::addAbstractForTypeMetadata(IRGenFunction &IGF,
   // Look for anything at all that's fulfilled by this.  If we don't find
   // anything, stop.
   FulfillmentMap fulfillments;
-  if (!fulfillments.searchTypeMetadata(IGF.IGM, type, isExact,
-                                       metadata.getStaticLowerBoundOnState(),
-                                       /*source*/ 0, MetadataPath(),
-                                       callbacks)) {
-    return;
+  if (auto tupleType = dyn_cast<TupleType>(type)) {
+    if (!fulfillments.searchTupleTypeMetadata(IGF.IGM, tupleType, isExact,
+                                              metadata.getStaticLowerBoundOnState(),
+                                              /*source*/ 0, MetadataPath(),
+                                              callbacks)) {
+      return;
+    }
+  } else {
+    if (!fulfillments.searchTypeMetadata(IGF.IGM, type, isExact,
+                                         metadata.getStaticLowerBoundOnState(),
+                                         /*source*/ 0, MetadataPath(),
+                                         callbacks)) {
+      return;
+    }
   }
 
   addAbstractForFulfillments(IGF, std::move(fulfillments),

--- a/test/IRGen/variadic_generic_fulfillment_tuple.swift
+++ b/test/IRGen/variadic_generic_fulfillment_tuple.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-ir %s -target %target-swift-5.9-abi-triple | %FileCheck %s
+
+struct G<T> {
+  var t: T
+
+  // Make sure we *don't* try to fulfill the pack from the tuple, because we cannot
+  // distinguish the one-element case that way.
+
+  // CHECK-LABEL: define {{.*}} void @"$s34variadic_generic_fulfillment_tuple1GV20fixOuterGenericParamyACyqd__qd__Qp_tGqd__qd__Qp_t_tRvd__qd__qd__Qp_tRszlF"(ptr noalias sret(%swift.opaque) %0, ptr noalias %1, {{i32|i64}} %2, ptr %"each U", ptr noalias swiftself %3)
+  func fixOuterGenericParam<each U>(_ t: T) -> G<T> where T == (repeat each U) {
+    return G<T>(t: t)
+  }
+}

--- a/test/Interpreter/variadic_generic_tuples.swift
+++ b/test/Interpreter/variadic_generic_tuples.swift
@@ -85,5 +85,19 @@ tuples.test("labels") {
   expectEqual("(label: Swift.Int, Swift.String)", _typeName(oneElementLabeledTuple(t: String.self)))
 }
 
+// https://github.com/swiftlang/swift/issues/78191
+tuples.test("fulfillment") {
+  struct S<T> {
+    let t: T
+
+    func f<each A, each B>(_ b: S<(repeat each B)>) -> S<(repeat each A, repeat each B)>
+        where T == (repeat each A) {
+      return S<(repeat each A, repeat each B)>(t: (repeat each t, repeat each b.t))
+    }
+  }
+
+  let s = S(t: "hello")
+  expectEqual("S<(String, Int, Int)>(t: (\"hello\", 1, 2))", String(describing: s.f(S(t: (1, 2)))))
+}
 
 runAllTests()


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/68130.

* **Description:** Fixes a miscompile if you fix a generic parameter of a nominal type to a tuple containing a pack expansion:

      struct G<T> {
        func f<each U>(_: repeat each U) where T == (repeat each U) {}
      }

  If you then call f() with a one-element pack, we would crash at runtime.

* **Origination:** Regression was introduced with this change in Swift 5.10: https://github.com/swiftlang/swift/pull/68130

* **Risk:** Low. This does change the calling convention, but not the mangling, in this specific scenario where the old calling convention passed the wrong information. This change reverts to the Swift 5.9 calling convention, since the specific pattern was only intended to kick in with tuple conformance witness thunks.

* **Reviewed by:** TBD

- Fixes https://github.com/swiftlang/swift/issues/78191.
- Fixes rdar://problem/135325886.
