### PR TITLE
[MoveOnlyChecker] Don't complete phis.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -122,14 +122,14 @@ void MoveOnlyChecker::checkObjects() {
 
 void MoveOnlyChecker::completeObjectLifetimes(
     ArrayRef<MarkUnresolvedNonCopyableValueInst *> insts) {
-// TODO: Delete once OSSALifetimeCompletion is run as part of SILGenCleanup.
-OSSALifetimeCompletion completion(fn, domTree, *deba->get(fn));
+  // TODO: Delete once OSSALifetimeCompletion is run as part of SILGenCleanup.
+  OSSALifetimeCompletion completion(fn, domTree, *deba->get(fn));
 
-// Collect all values derived from each mark_unresolved_non_copyable_value
-// instruction via ownership instructions and phis.
-ValueWorklist transitiveValues(fn);
-for (auto *inst : insts) {
-  transitiveValues.push(inst);
+  // Collect all values derived from each mark_unresolved_non_copyable_value
+  // instruction via ownership instructions and phis.
+  ValueWorklist transitiveValues(fn);
+  for (auto *inst : insts) {
+    transitiveValues.push(inst);
   }
   while (auto value = transitiveValues.pop()) {
     for (auto *use : value->getUses()) {

--- a/validation-test/SILOptimizer/gh81515.swift
+++ b/validation-test/SILOptimizer/gh81515.swift
@@ -1,0 +1,36 @@
+// RUN: %target-build-swift %s
+
+typealias LeagueDayOfWeek = UInt8
+
+let settings = LeagueSettings(divisions: [.init(id: 0, dayOfWeek: 0), .init(id: 1, dayOfWeek: 0)])
+let dummy = Dummy()
+dummy.dummy(settings: settings)
+
+struct LeagueSettings: Codable, Sendable {
+    let divisions:ContiguousArray<LeagueDivision>
+}
+struct LeagueEntry: Codable, Sendable {
+    typealias IDValue = Int
+}
+struct LeagueDivision: Codable, Hashable, Sendable {
+    typealias IDValue = Int
+    let id:IDValue
+    let dayOfWeek:LeagueDayOfWeek
+}
+struct Dummy: ~Copyable {
+}
+extension Dummy {
+    func dummy(settings: LeagueSettings) {
+        var divisionEntries:ContiguousArray<Set<LeagueEntry.IDValue>> = .init(repeating: Set(), count: settings.divisions.count)
+        var grouped:[LeagueDayOfWeek:Set<LeagueEntry.IDValue>] = [:]
+        for division in settings.divisions {
+            /* // OK
+            if grouped[division.dayOfWeek] == nil {
+                grouped[division.dayOfWeek] = divisionEntries[division.id]
+            } else {
+                grouped[division.dayOfWeek]!.formUnion(divisionEntries[division.id])
+            }*/
+            grouped[division.dayOfWeek, default: []].formUnion(divisionEntries[division.id]) // crashes
+        }
+    }
+}


### PR DESCRIPTION
Apply the `MoveOnlyAddressChecker` change from https://github.com/swiftlang/swift/pull/73358 to the `MoveOnly[Value]Checker`.

After 7713eef8174216bb170461e7b7ba8a1f9574109a, before running value checking, all lifetimes in the function are completed.  That doesn't quite work because lifetime completion expects not to encounter reborrows or their adjacent phis.

rdar://151325025
