### PR TITLE
SILGen: insert an `end_lifetime` in the throw-branch of a `Builtin.emplace`

### DIFF
--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2188,6 +2188,13 @@ static ManagedValue emitBuiltinEmplace(SILGenFunction &SGF,
     {
       SGF.B.emitBlock(errorBB);
 
+      // When the closure throws an error, it needs to clean up the buffer. This
+      // means that the buffer is uninitialized at this point.
+      // We need an `end_lifetime` so that the move-only checker doesn't insert
+      // a wrong `destroy_addr` because it thinks that the buffer is initialized
+      // here.
+      SGF.B.createEndLifetime(loc, buffer);
+
       SGF.Cleanups.emitCleanupsForReturn(CleanupLocation(loc), IsForUnwind);
 
       SGF.B.createThrowAddr(loc);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -297,6 +297,7 @@ bool noncopyable::memInstMustConsume(Operand *memOper) {
            (CAI->getDest() == address && !CAI->isInitializationOfDest());
   }
   case SILInstructionKind::DestroyAddrInst:
+  case SILInstructionKind::EndLifetimeInst:
     return true;
   case SILInstructionKind::DropDeinitInst:
     assert(memOper->get()->getType().isValueTypeWithDeinit());

--- a/test/stdlib/InlineArray.swift
+++ b/test/stdlib/InlineArray.swift
@@ -24,6 +24,8 @@
 import StdlibUnittest
 import Synchronization
 
+protocol P {}
+
 @available(SwiftStdlib 6.2, *)
 @main
 enum InlineArrayTests {
@@ -171,6 +173,9 @@ enum InlineArrayTests {
       }
       _expectThrows {
         let _ = try InlineArray<1, String> { _ in throw error }
+      }
+      _expectThrows {
+        let _ = try InlineArray<1, any P> { _ in throw error }
       }
       _expectThrows {
         let _ = try InlineArray<2, String> { index in


### PR DESCRIPTION
When the called closure throws an error, it needs to clean up the buffer. This means that the buffer is uninitialized at this point.

We need an `end_lifetime` so that the move-only checker doesn't insert a wrong `destroy_addr` because it thinks that the buffer is initialized.

Fixes a mis-compile.

rdar://151461109
