### PR TITLE
Sema: Fix UB in `NonisolatedNonsendingByDefault` migration diagnosis

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8698,23 +8698,23 @@ GROUPED_WARNING(
     attr_execution_nonisolated_behavior_will_change_decl, NonisolatedNonsendingByDefault,
     none,
     "feature '%0' will cause nonisolated async %kindbase1 to run on the "
-    "caller's actor; use %2 to preserve behavior",
-    (StringRef, const AbstractFunctionDecl *, DeclAttribute))
+    "caller's actor; use '@concurrent' to preserve behavior",
+    (StringRef, const AbstractFunctionDecl *))
 
 GROUPED_WARNING(
     attr_execution_nonisolated_behavior_will_change_closure,
     NonisolatedNonsendingByDefault, none,
     "feature '%0' will cause nonisolated async closure to run on the caller's "
-    "actor; use %1 to preserve behavior",
-    (StringRef, DeclAttribute))
+    "actor; use '@concurrent' to preserve behavior",
+    (StringRef))
 
 GROUPED_WARNING(
     attr_execution_nonisolated_behavior_will_change_typerepr,
     NonisolatedNonsendingByDefault, none,
     "feature '%0' will cause nonisolated async function type to be treated as "
-    "specified to run on the caller's actor; use %1 to preserve "
+    "specified to run on the caller's actor; use '@concurrent' to preserve "
     "behavior",
-    (StringRef, DeclAttribute))
+    (StringRef))
 
 //===----------------------------------------------------------------------===//
 // MARK: @extensible and @preEnumExtensibility Attributes

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -168,21 +168,21 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
     ctx.Diags
         .diagnose(functionDecl->getLoc(),
                   diag::attr_execution_nonisolated_behavior_will_change_decl,
-                  featureName, functionDecl, &attr)
+                  featureName, functionDecl)
         .fixItInsertAttribute(
             decl->getAttributeInsertionLoc(/*forModifier=*/false), &attr);
   } else if (closure) {
     ctx.Diags
         .diagnose(closure->getLoc(),
                   diag::attr_execution_nonisolated_behavior_will_change_closure,
-                  featureName, &attr)
+                  featureName)
         .fixItAddAttribute(&attr, closure);
   } else {
     ctx.Diags
         .diagnose(
             functionRepr->getStartLoc(),
             diag::attr_execution_nonisolated_behavior_will_change_typerepr,
-            featureName, &attr)
+            featureName)
         .fixItInsertAttribute(functionRepr->getStartLoc(), &attr);
   }
 }

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -19,7 +19,7 @@ do {
     isolation: isolated (any Actor)? = #isolation
   ) async {}
 
-  // expected-warning@+1:20 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async local function 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:20 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async local function 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{3-3=@concurrent }}{{none}}
   nonisolated func asyncF() async {}
 
   struct S {
@@ -27,14 +27,14 @@ do {
     @concurrent init(concurrentAsync: ()) async {}
     nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async {}
     @MainActor init(mainActorAsync: ()) async {}
-    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     init(async: ()) async {}
 
     func syncF() {}
     @concurrent func concurrentAsyncF() async {}
     nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async {}
     @MainActor func mainActorAsyncF() async {}
-    // expected-warning@+2:17 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:17 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     nonisolated
     public func asyncF() async {}
   }
@@ -44,14 +44,14 @@ do {
     @concurrent init(concurrentAsync: ()) async
     nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async
     @MainActor init(mainActorAsync: ()) async
-    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     init(async: ()) async
 
     func syncF()
     @concurrent func concurrentAsyncF() async
     nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async
     @MainActor func mainActorAsyncF() async
-    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     func asyncF() async
   }
 }
@@ -61,14 +61,14 @@ extension Functions {
   @concurrent init(concurrentAsync: ()) async {}
   nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async {}
   @MainActor init(mainActorAsync: ()) async {}
-  // expected-warning@+1:3 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:3 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{3-3=@concurrent }}{{none}}
   init(async: ()) async {}
 
   func syncF() {}
   @concurrent func concurrentAsyncF() async {}
   nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async {}
   @MainActor func mainActorAsyncF() async {}
-  // expected-warning@+1:8 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:8 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{3-3=@concurrent }}{{none}}
   func asyncF() async {}
 }
 
@@ -90,11 +90,11 @@ do {
     @MainActor var mainActorAsyncS: Int { get async {} }
     @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async {} }
 
-    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     var asyncS: Int {
       get async {}
     }
-    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     subscript(asyncS _: Int) -> Int {
       get async throws {}
     }
@@ -113,9 +113,9 @@ do {
     @MainActor var mainActorAsyncS: Int { get async }
     @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async }
 
-    // expected-warning@+1:23 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:23 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     var asyncS: Int { get async }
-    // expected-warning@+1:39 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:39 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     subscript(asyncS _: Int) -> Int { get async }
   }
 }
@@ -133,11 +133,11 @@ extension Storage {
   @MainActor var mainActorAsyncS: Int { get async {} }
   @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async {} }
 
-  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
+  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
   var asyncS: Int {
     get async {}
   }
-  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
+  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
   subscript(asyncS _: Int) -> Int {
     get async throws {}
   }
@@ -152,9 +152,9 @@ do {
       concurrentAsync: @concurrent () async -> Void,
       nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
       mainActorAsync: @MainActor () async -> Void,
-      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14=@concurrent }}{{none}}
       async: () async -> Void,
-      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{26-26=@concurrent }}{{none}}
       structuralAsync: G<() async -> Void>
     )
   }
@@ -165,9 +165,9 @@ do {
       concurrentAsync: @concurrent () async -> Void,
       nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
       mainActorAsync: @MainActor () async -> Void,
-      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14=@concurrent }}{{none}}
       async: () async -> Void,
-      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{26-26=@concurrent }}{{none}}
       structuralAsync: G<() async -> Void>
     ) -> Int {
       0
@@ -179,9 +179,9 @@ do {
     concurrentAsync: @concurrent () async -> Void,
     nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
     mainActorAsync: @MainActor () async -> Void,
-    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{12-12=@concurrent }}{{none}}
     async: () async -> Void,
-    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{24-24=@concurrent }}{{none}}
     structuralAsync: G<() async -> Void>
   ) {}
 
@@ -190,9 +190,9 @@ do {
     concurrentAsync: @concurrent () async -> Void,
     nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
     mainActorAsync: @MainActor () async -> Void,
-    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{12-12=@concurrent }}{{none}}
     async: () async -> Void,
-    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{24-24=@concurrent }}{{none}}
     structuralAsync: G<() async -> Void>
   ) in
   }
@@ -205,9 +205,9 @@ do {
     struct ConcurrentAsync where T == @concurrent () async -> Void {}
     struct NonisolatedNonsendingAsync where T == nonisolated(nonsending) () async -> Void {}
     struct MainActorAsync where T == @MainActor () async -> Void {}
-    // expected-warning@+1:29 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{29-29=@concurrent }}{{none}}
+    // expected-warning@+1:29 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{29-29=@concurrent }}{{none}}
     struct Async where T == () async -> Void {}
-    // expected-warning@+1:41 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{41-41=@concurrent }}{{none}}
+    // expected-warning@+1:41 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{41-41=@concurrent }}{{none}}
     struct StructuralAsync where T == G<() async -> Void> {}
   }
 }
@@ -218,9 +218,9 @@ do {
   let _: @concurrent () async -> Void
   let _: nonisolated(nonsending) () async -> Void
   let _: @MainActor () async -> Void
-  // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{10-10=@concurrent }}{{none}}
+  // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{10-10=@concurrent }}{{none}}
   let _: () async -> Void
-  // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+  // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{12-12=@concurrent }}{{none}}
   let _: G<() async -> Void>
 }
 
@@ -232,9 +232,9 @@ do {
   let _ = anything as? @concurrent () async -> Void
   let _ = anything as? nonisolated(nonsending) () async -> Void
   let _ = anything as? @MainActor () async -> Void
-  // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+  // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{24-24=@concurrent }}{{none}}
   let _ = anything as? () async -> Void
-  // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+  // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{26-26=@concurrent }}{{none}}
   let _ = anything as? G<() async -> Void>
 }
 
@@ -249,56 +249,56 @@ do {
     let _ = { @concurrent () async -> Void in }
     let _ = { @MainActor () async -> Void in }
 
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{15-15=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{15-15=@concurrent }}{{none}}
     let _ = { () async -> Void in }
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{15-15=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{15-15=@concurrent }}{{none}}
     let _ = { [x] () async -> Void in _ = x }
 
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {await globalAsyncF()}
-      // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+      // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14=@concurrent }}{{none}}
     let _ = {[x] in await globalAsyncF(); _ = x}
 
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {
       await globalAsyncF()
     }
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {
       await globalAsyncF()
       func takesInts(_: Int...) {}
       takesInts($0, $1, $2)
     }
 
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{25-25=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{25-25=@concurrent }}{{none}}
     let _ = { @Sendable in
       await globalAsyncF()
     }
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{25-25=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{25-25=@concurrent }}{{none}}
     let _ = { @Sendable [x] in
       _ = x
       await globalAsyncF()
     }
 
-    // expected-warning@+2:18 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{18-18=@concurrent }}{{none}}
-    // expected-warning@+1:45 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{47-47=@concurrent }}{{none}}
+    // expected-warning@+2:18 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{18-18=@concurrent }}{{none}}
+    // expected-warning@+1:45 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{47-47=@concurrent }}{{none}}
     var closure: (Int, Int) async -> Void = { a, b in
       await globalAsyncF()
     }
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{17-17=@concurrent }}{{none}}
     closure = { [x] a, b in _ = x }
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
     closure = {
       a, b async in ()
     }
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
     closure = {
       [x] a, b async in _ = x
     }
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{17-17=@concurrent }}{{none}}
     closure = { (a, b) in () }
 
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{17-17=@concurrent }}{{none}}
     closure = { [x] (a, b) in _ = x }
 
     let _ = closure


### PR DESCRIPTION
The diagnostic can outlive the locally constructed attribute, which was passed by pointer, if there is an active `DiagnosticTransaction`.
