### PR TITLE
[6.2] AST, Sema: Cherry-pick 4 `NonisolatedNonsendingByDefault` bug fixes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8634,23 +8634,23 @@ GROUPED_WARNING(
     attr_execution_nonisolated_behavior_will_change_decl, NonisolatedNonsendingByDefault,
     none,
     "feature '%0' will cause nonisolated async %kindbase1 to run on the "
-    "caller's actor; use %2 to preserve behavior",
-    (StringRef, const AbstractFunctionDecl *, DeclAttribute))
+    "caller's actor; use '@concurrent' to preserve behavior",
+    (StringRef, const AbstractFunctionDecl *))
 
 GROUPED_WARNING(
     attr_execution_nonisolated_behavior_will_change_closure,
     NonisolatedNonsendingByDefault, none,
     "feature '%0' will cause nonisolated async closure to run on the caller's "
-    "actor; use %1 to preserve behavior",
-    (StringRef, DeclAttribute))
+    "actor; use '@concurrent' to preserve behavior",
+    (StringRef))
 
 GROUPED_WARNING(
     attr_execution_nonisolated_behavior_will_change_typerepr,
     NonisolatedNonsendingByDefault, none,
     "feature '%0' will cause nonisolated async function type to be treated as "
-    "specified to run on the caller's actor; use %1 to preserve "
+    "specified to run on the caller's actor; use '@concurrent' to preserve "
     "behavior",
-    (StringRef, DeclAttribute))
+    (StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -393,15 +393,17 @@ InFlightDiagnostic::fixItAddAttribute(const DeclAttribute *Attr,
                                       const ClosureExpr *E) {
   ASSERT(!E->isImplicit());
 
-  SourceLoc insertionLoc;
+  SourceLoc insertionLoc = E->getBracketRange().Start;
 
-  if (auto *paramList = E->getParameters()) {
-    // HACK: Don't set insertion loc to param list start loc if it's equal to
-    // closure start loc (meaning it's implicit).
-    // FIXME: Don't set the start loc of an implicit param list, or put an
-    // isImplicit bit on ParameterList.
-    if (paramList->getStartLoc() != E->getStartLoc()) {
-      insertionLoc = paramList->getStartLoc();
+  if (insertionLoc.isInvalid()) {
+    if (auto *paramList = E->getParameters()) {
+      // HACK: Don't set insertion loc to param list start loc if it's equal to
+      // closure start loc (meaning it's implicit).
+      // FIXME: Don't set the start loc of an implicit param list, or put an
+      // isImplicit bit on ParameterList.
+      if (paramList->getStartLoc() != E->getStartLoc()) {
+        insertionLoc = paramList->getStartLoc();
+      }
     }
   }
 

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -168,21 +168,21 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
     ctx.Diags
         .diagnose(functionDecl->getLoc(),
                   diag::attr_execution_nonisolated_behavior_will_change_decl,
-                  featureName, functionDecl, &attr)
+                  featureName, functionDecl)
         .fixItInsertAttribute(
             decl->getAttributeInsertionLoc(/*forModifier=*/false), &attr);
   } else if (closure) {
     ctx.Diags
         .diagnose(closure->getLoc(),
                   diag::attr_execution_nonisolated_behavior_will_change_closure,
-                  featureName, &attr)
+                  featureName)
         .fixItAddAttribute(&attr, closure);
   } else {
     ctx.Diags
         .diagnose(
             functionRepr->getStartLoc(),
             diag::attr_execution_nonisolated_behavior_will_change_typerepr,
-            featureName, &attr)
+            featureName)
         .fixItInsertAttribute(functionRepr->getStartLoc(), &attr);
   }
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2418,6 +2418,11 @@ namespace {
   class TypeAttrSet {
     const ASTContext &ctx;
 
+    /// FIXME:
+    ///  `nonisolated(nonsending)` is modeled as a separate `TypeRepr`, but
+    ///  needs to be considered together with subsequent attributes.
+    CallerIsolatedTypeRepr *nonisolatedNonsendingAttr;
+
     llvm::TinyPtrVector<CustomAttr*> customAttrs;
     EnumMap<TypeAttrKind, TypeAttribute *> typeAttrs;
 
@@ -2429,7 +2434,9 @@ namespace {
 #endif
 
   public:
-    TypeAttrSet(const ASTContext &ctx) : ctx(ctx) {}
+    TypeAttrSet(const ASTContext &ctx,
+                CallerIsolatedTypeRepr *nonisolatedNonsendingAttr = nullptr)
+        : ctx(ctx), nonisolatedNonsendingAttr(nonisolatedNonsendingAttr) {}
 
     TypeAttrSet(const TypeAttrSet &) = delete;
     TypeAttrSet &operator=(const TypeAttrSet &) = delete;
@@ -2447,6 +2454,10 @@ namespace {
     /// Accumulate attributes from the given array.  Duplicate attributes
     /// will be diagnosed.
     void accumulate(ArrayRef<TypeOrCustomAttr> attrs);
+
+    CallerIsolatedTypeRepr *getNonisolatedNonsendingAttr() const {
+      return nonisolatedNonsendingAttr;
+    }
 
     /// Return all of the custom attributes.
     ArrayRef<CustomAttr*> getCustomAttrs() const {
@@ -2547,8 +2558,16 @@ namespace {
   }
 
   template <class AttrClass>
-  AttrClass *getWithoutClaiming(TypeAttrSet *attrs) {
+  std::enable_if_t<std::is_base_of_v<TypeAttribute, AttrClass>, AttrClass *>
+  getWithoutClaiming(TypeAttrSet *attrs) {
     return (attrs ? getWithoutClaiming<AttrClass>(*attrs) : nullptr);
+  }
+
+  template <class AttrClass>
+  std::enable_if_t<std::is_same_v<AttrClass, CallerIsolatedTypeRepr>,
+                   CallerIsolatedTypeRepr *>
+  getWithoutClaiming(TypeAttrSet *attrs) {
+    return attrs ? attrs->getNonisolatedNonsendingAttr() : nullptr;
   }
 } // end anonymous namespace
 
@@ -4247,10 +4266,19 @@ NeverNullType TypeResolver::resolveASTFunctionType(
   };
 
   if (auto concurrentAttr = claim<ConcurrentTypeAttr>(attrs)) {
+    if (auto *nonisolatedNonsendingAttr =
+            getWithoutClaiming<CallerIsolatedTypeRepr>(attrs)) {
+      diagnoseInvalid(
+          nonisolatedNonsendingAttr, nonisolatedNonsendingAttr->getStartLoc(),
+          diag::cannot_use_nonisolated_nonsending_together_with_concurrent,
+          nonisolatedNonsendingAttr);
+    }
+
     checkExecutionBehaviorAttribute(concurrentAttr);
+
     if (!repr->isInvalid())
       isolation = FunctionTypeIsolation::forNonIsolated();
-  } else {
+  } else if (!getWithoutClaiming<CallerIsolatedTypeRepr>(attrs)) {
     if (ctx.LangOpts.getFeatureState(Feature::NonisolatedNonsendingByDefault)
             .isEnabledForMigration()) {
       // Diagnose only in the interface stage, which is run once.
@@ -5281,7 +5309,20 @@ TypeResolver::resolveSendingTypeRepr(SendingTypeRepr *repr,
 NeverNullType
 TypeResolver::resolveCallerIsolatedTypeRepr(CallerIsolatedTypeRepr *repr,
                                             TypeResolutionOptions options) {
-  Type type = resolveType(repr->getBase(), options);
+  Type type;
+  {
+    TypeAttrSet attrs(getASTContext(), repr);
+
+    auto *baseRepr = repr->getBase();
+    if (auto *attrRepr = dyn_cast<AttributedTypeRepr>(baseRepr)) {
+      baseRepr = attrs.accumulate(attrRepr);
+    }
+
+    type = resolveAttributedType(baseRepr, options, attrs);
+
+    attrs.diagnoseUnclaimed(resolution, options, type);
+  }
+
   if (type->hasError())
     return ErrorType::get(getASTContext());
 
@@ -5295,15 +5336,6 @@ TypeResolver::resolveCallerIsolatedTypeRepr(CallerIsolatedTypeRepr *repr,
   if (!fnType->isAsync()) {
     diagnoseInvalid(repr, repr->getStartLoc(),
                     diag::nonisolated_nonsending_only_on_async, repr);
-  }
-
-  if (auto *ATR = dyn_cast<AttributedTypeRepr>(repr->getBase())) {
-    if (ATR->get(TypeAttrKind::Concurrent)) {
-      diagnoseInvalid(
-          repr, repr->getStartLoc(),
-          diag::cannot_use_nonisolated_nonsending_together_with_concurrent,
-          repr);
-    }
   }
 
   switch (fnType->getIsolation().getKind()) {

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -19,7 +19,7 @@ do {
     isolation: isolated (any Actor)? = #isolation
   ) async {}
 
-  // expected-warning@+1:20 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async local function 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:20 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async local function 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{3-3=@concurrent }}{{none}}
   nonisolated func asyncF() async {}
 
   struct S {
@@ -27,14 +27,14 @@ do {
     @concurrent init(concurrentAsync: ()) async {}
     nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async {}
     @MainActor init(mainActorAsync: ()) async {}
-    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     init(async: ()) async {}
 
     func syncF() {}
     @concurrent func concurrentAsyncF() async {}
     nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async {}
     @MainActor func mainActorAsyncF() async {}
-    // expected-warning@+2:17 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:17 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     nonisolated
     public func asyncF() async {}
   }
@@ -44,14 +44,14 @@ do {
     @concurrent init(concurrentAsync: ()) async
     nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async
     @MainActor init(mainActorAsync: ()) async
-    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     init(async: ()) async
 
     func syncF()
     @concurrent func concurrentAsyncF() async
     nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async
     @MainActor func mainActorAsyncF() async
-    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     func asyncF() async
   }
 }
@@ -61,14 +61,14 @@ extension Functions {
   @concurrent init(concurrentAsync: ()) async {}
   nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async {}
   @MainActor init(mainActorAsync: ()) async {}
-  // expected-warning@+1:3 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:3 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{3-3=@concurrent }}{{none}}
   init(async: ()) async {}
 
   func syncF() {}
   @concurrent func concurrentAsyncF() async {}
   nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async {}
   @MainActor func mainActorAsyncF() async {}
-  // expected-warning@+1:8 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
+  // expected-warning@+1:8 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{3-3=@concurrent }}{{none}}
   func asyncF() async {}
 }
 
@@ -90,11 +90,11 @@ do {
     @MainActor var mainActorAsyncS: Int { get async {} }
     @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async {} }
 
-    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     var asyncS: Int {
       get async {}
     }
-    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
+    // expected-warning@+2:7 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     subscript(asyncS _: Int) -> Int {
       get async throws {}
     }
@@ -113,9 +113,9 @@ do {
     @MainActor var mainActorAsyncS: Int { get async }
     @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async }
 
-    // expected-warning@+1:23 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:23 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     var asyncS: Int { get async }
-    // expected-warning@+1:39 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
+    // expected-warning@+1:39 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{5-5=@concurrent }}{{none}}
     subscript(asyncS _: Int) -> Int { get async }
   }
 }
@@ -133,11 +133,11 @@ extension Storage {
   @MainActor var mainActorAsyncS: Int { get async {} }
   @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async {} }
 
-  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
+  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for property 'asyncS' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
   var asyncS: Int {
     get async {}
   }
-  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
+  // expected-warning@+2:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async getter for subscript 'subscript' to run on the caller's actor; use '@concurrent' to preserve behavior}}{{-1:3-3=@concurrent }}{{none}}
   subscript(asyncS _: Int) -> Int {
     get async throws {}
   }
@@ -152,9 +152,9 @@ do {
       concurrentAsync: @concurrent () async -> Void,
       nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
       mainActorAsync: @MainActor () async -> Void,
-      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14=@concurrent }}{{none}}
       async: () async -> Void,
-      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{26-26=@concurrent }}{{none}}
       structuralAsync: G<() async -> Void>
     )
   }
@@ -165,9 +165,9 @@ do {
       concurrentAsync: @concurrent () async -> Void,
       nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
       mainActorAsync: @MainActor () async -> Void,
-      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+      // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14=@concurrent }}{{none}}
       async: () async -> Void,
-      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+      // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{26-26=@concurrent }}{{none}}
       structuralAsync: G<() async -> Void>
     ) -> Int {
       0
@@ -179,9 +179,9 @@ do {
     concurrentAsync: @concurrent () async -> Void,
     nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
     mainActorAsync: @MainActor () async -> Void,
-    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{12-12=@concurrent }}{{none}}
     async: () async -> Void,
-    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{24-24=@concurrent }}{{none}}
     structuralAsync: G<() async -> Void>
   ) {}
 
@@ -190,9 +190,9 @@ do {
     concurrentAsync: @concurrent () async -> Void,
     nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
     mainActorAsync: @MainActor () async -> Void,
-    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+    // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{12-12=@concurrent }}{{none}}
     async: () async -> Void,
-    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+    // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{24-24=@concurrent }}{{none}}
     structuralAsync: G<() async -> Void>
   ) in
   }
@@ -205,9 +205,9 @@ do {
     struct ConcurrentAsync where T == @concurrent () async -> Void {}
     struct NonisolatedNonsendingAsync where T == nonisolated(nonsending) () async -> Void {}
     struct MainActorAsync where T == @MainActor () async -> Void {}
-    // expected-warning@+1:29 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{29-29=@concurrent }}{{none}}
+    // expected-warning@+1:29 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{29-29=@concurrent }}{{none}}
     struct Async where T == () async -> Void {}
-    // expected-warning@+1:41 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{41-41=@concurrent }}{{none}}
+    // expected-warning@+1:41 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{41-41=@concurrent }}{{none}}
     struct StructuralAsync where T == G<() async -> Void> {}
   }
 }
@@ -218,9 +218,9 @@ do {
   let _: @concurrent () async -> Void
   let _: nonisolated(nonsending) () async -> Void
   let _: @MainActor () async -> Void
-  // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{10-10=@concurrent }}{{none}}
+  // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{10-10=@concurrent }}{{none}}
   let _: () async -> Void
-  // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
+  // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{12-12=@concurrent }}{{none}}
   let _: G<() async -> Void>
 }
 
@@ -232,9 +232,9 @@ do {
   let _ = anything as? @concurrent () async -> Void
   let _ = anything as? nonisolated(nonsending) () async -> Void
   let _ = anything as? @MainActor () async -> Void
-  // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
+  // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{24-24=@concurrent }}{{none}}
   let _ = anything as? () async -> Void
-  // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{26-26=@concurrent }}{{none}}
+  // expected-warning@+1:26 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{26-26=@concurrent }}{{none}}
   let _ = anything as? G<() async -> Void>
 }
 
@@ -249,56 +249,56 @@ do {
     let _ = { @concurrent () async -> Void in }
     let _ = { @MainActor () async -> Void in }
 
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{15-15=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{15-15=@concurrent }}{{none}}
     let _ = { () async -> Void in }
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{15-15=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{15-15=@concurrent }}{{none}}
     let _ = { [x] () async -> Void in _ = x }
 
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {await globalAsyncF()}
-      // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+      // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14=@concurrent }}{{none}}
     let _ = {[x] in await globalAsyncF(); _ = x}
 
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {
       await globalAsyncF()
     }
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {
       await globalAsyncF()
       func takesInts(_: Int...) {}
       takesInts($0, $1, $2)
     }
 
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{25-25=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{25-25=@concurrent }}{{none}}
     let _ = { @Sendable in
       await globalAsyncF()
     }
-    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{25-25=@concurrent }}{{none}}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{25-25=@concurrent }}{{none}}
     let _ = { @Sendable [x] in
       _ = x
       await globalAsyncF()
     }
 
-    // expected-warning@+2:18 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{18-18=@concurrent }}{{none}}
-    // expected-warning@+1:45 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{47-47=@concurrent }}{{none}}
+    // expected-warning@+2:18 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use '@concurrent' to preserve behavior}}{{18-18=@concurrent }}{{none}}
+    // expected-warning@+1:45 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{47-47=@concurrent }}{{none}}
     var closure: (Int, Int) async -> Void = { a, b in
       await globalAsyncF()
     }
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{17-17=@concurrent }}{{none}}
     closure = { [x] a, b in _ = x }
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
     closure = {
       a, b async in ()
     }
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
     closure = {
       [x] a, b async in _ = x
     }
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{17-17=@concurrent }}{{none}}
     closure = { (a, b) in () }
 
-    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{17-17=@concurrent }}{{none}}
     closure = { [x] (a, b) in _ = x }
 
     let _ = closure

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -12,8 +12,8 @@ struct G<T> {
 // MARK: Functions
 do {
   func syncF() {}
-  @concurrent func executionConcurrentAsyncF() async {}
-  nonisolated(nonsending) func executionCallerAsyncF() async {}
+  @concurrent func concurrentAsyncF() async {}
+  nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async {}
   @MainActor func mainActorAsyncF() async {}
   func isolatedParamAsyncF(
     isolation: isolated (any Actor)? = #isolation
@@ -24,13 +24,15 @@ do {
 
   struct S {
     init(sync: ()) {}
-    @concurrent init(executionAsync: ()) async {}
+    @concurrent init(concurrentAsync: ()) async {}
+    nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async {}
     @MainActor init(mainActorAsync: ()) async {}
     // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
     init(async: ()) async {}
 
     func syncF() {}
-    @concurrent func executionAsyncF() async {}
+    @concurrent func concurrentAsyncF() async {}
+    nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async {}
     @MainActor func mainActorAsyncF() async {}
     // expected-warning@+2:17 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{-1:5-5=@concurrent }}{{none}}
     nonisolated
@@ -39,13 +41,15 @@ do {
 
   protocol P {
     init(sync: ())
-    @concurrent init(executionAsync: ()) async
+    @concurrent init(concurrentAsync: ()) async
+    nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async
     @MainActor init(mainActorAsync: ()) async
     // expected-warning@+1:5 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
     init(async: ()) async
 
     func syncF()
-    @concurrent func executionAsyncF() async
+    @concurrent func concurrentAsyncF() async
+    nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async
     @MainActor func mainActorAsyncF() async
     // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{5-5=@concurrent }}{{none}}
     func asyncF() async
@@ -54,13 +58,15 @@ do {
 protocol Functions {}
 extension Functions {
   init(sync: ()) {}
-  @concurrent init(executionAsync: ()) async {}
+  @concurrent init(concurrentAsync: ()) async {}
+  nonisolated(nonsending) init(nonisolatedNonsendingAsync: ()) async {}
   @MainActor init(mainActorAsync: ()) async {}
   // expected-warning@+1:3 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async initializer 'init' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
   init(async: ()) async {}
 
   func syncF() {}
-  @concurrent func executionAsyncF() async {}
+  @concurrent func concurrentAsyncF() async {}
+  nonisolated(nonsending) func nonisolatedNonsendingAsyncF() async {}
   @MainActor func mainActorAsyncF() async {}
   // expected-warning@+1:8 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async instance method 'asyncF' to run on the caller's actor; use @concurrent to preserve behavior}}{{3-3=@concurrent }}{{none}}
   func asyncF() async {}
@@ -75,8 +81,11 @@ do {
     var syncS: Int { get {} set {} }
     subscript(syncS _: Int) -> Int { get {} }
 
-    @concurrent var executionAsyncS: Int { get async {} }
-    @concurrent subscript(executionAsyncS _: Int) -> Int { get async {} }
+    @concurrent var concurrentAsyncS: Int { get async {} }
+    @concurrent subscript(concurrentAsyncS _: Int) -> Int { get async {} }
+
+    nonisolated(nonsending) var nonisolatedNonsendingAsyncS: Int { get async {} }
+    nonisolated(nonsending) subscript(nonisolatedNonsendingAsyncS _: Int) -> Int { get async {} }
 
     @MainActor var mainActorAsyncS: Int { get async {} }
     @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async {} }
@@ -95,8 +104,11 @@ do {
     var syncS: Int { get }
     subscript(syncS _: Int) -> Int { get }
 
-    @concurrent var executionAsyncS: Int { get async }
-    @concurrent subscript(executionAsyncS _: Int) -> Int { get async }
+    @concurrent var concurrentAsyncS: Int { get async }
+    @concurrent subscript(concurrentAsyncS _: Int) -> Int { get async }
+
+    nonisolated(nonsending) var nonisolatedNonsendingAsyncS: Int { get async }
+    nonisolated(nonsending) subscript(nonisolatedNonsendingAsyncS _: Int) -> Int { get async }
 
     @MainActor var mainActorAsyncS: Int { get async }
     @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async }
@@ -112,8 +124,11 @@ extension Storage {
   var syncS: Int { get {} set {} }
   subscript(syncS _: Int) -> Int { get {} }
 
-  @concurrent var executionAsyncS: Int { get async {} }
-  @concurrent subscript(executionAsyncS _: Int) -> Int { get async {} }
+  @concurrent var concurrentAsyncS: Int { get async {} }
+  @concurrent subscript(concurrentAsyncS _: Int) -> Int { get async {} }
+
+  nonisolated(nonsending) var nonisolatedNonsendingAsyncS: Int { get async {} }
+  nonisolated(nonsending) subscript(nonisolatedNonsendingAsyncS _: Int) -> Int { get async {} }
 
   @MainActor var mainActorAsyncS: Int { get async {} }
   @MainActor subscript(mainActorAsyncS _: Int) -> Int { get async {} }
@@ -134,7 +149,8 @@ do {
   enum E {
     case esac(
       sync: () -> Void,
-      executionAsync: @concurrent () async -> Void,
+      concurrentAsync: @concurrent () async -> Void,
+      nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
       mainActorAsync: @MainActor () async -> Void,
       // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
       async: () async -> Void,
@@ -146,7 +162,8 @@ do {
   struct S {
     subscript(
       sync: () -> Void,
-      executionAsync: @concurrent () async -> Void,
+      concurrentAsync: @concurrent () async -> Void,
+      nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
       mainActorAsync: @MainActor () async -> Void,
       // expected-warning@+1:14 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
       async: () async -> Void,
@@ -159,7 +176,8 @@ do {
 
   func foo(
     sync: () -> Void,
-    executionAsync: @concurrent () async -> Void,
+    concurrentAsync: @concurrent () async -> Void,
+    nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
     mainActorAsync: @MainActor () async -> Void,
     // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
     async: () async -> Void,
@@ -169,7 +187,8 @@ do {
 
   let _ = { (
     sync: () -> Void,
-    executionAsync: @concurrent () async -> Void,
+    concurrentAsync: @concurrent () async -> Void,
+    nonisolatedNonsendingAsync: nonisolated(nonsending) () async -> Void,
     mainActorAsync: @MainActor () async -> Void,
     // expected-warning@+1:12 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{12-12=@concurrent }}{{none}}
     async: () async -> Void,
@@ -183,7 +202,8 @@ do {
 do {
   struct G<T> {
     struct Sync where T == () -> Void {}
-    struct ExecutionAsync where T == @concurrent () async -> Void {}
+    struct ConcurrentAsync where T == @concurrent () async -> Void {}
+    struct NonisolatedNonsendingAsync where T == nonisolated(nonsending) () async -> Void {}
     struct MainActorAsync where T == @MainActor () async -> Void {}
     // expected-warning@+1:29 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{29-29=@concurrent }}{{none}}
     struct Async where T == () async -> Void {}
@@ -196,6 +216,7 @@ do {
 do {
   let _: () -> Void
   let _: @concurrent () async -> Void
+  let _: nonisolated(nonsending) () async -> Void
   let _: @MainActor () async -> Void
   // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{10-10=@concurrent }}{{none}}
   let _: () async -> Void
@@ -209,6 +230,7 @@ do {
 
   let _ = anything as? () -> Void
   let _ = anything as? @concurrent () async -> Void
+  let _ = anything as? nonisolated(nonsending) () async -> Void
   let _ = anything as? @MainActor () async -> Void
   // expected-warning@+1:24 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{24-24=@concurrent }}{{none}}
   let _ = anything as? () async -> Void

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -220,6 +220,8 @@ do {
 do {
   nonisolated
   func nonisolatedF() {
+    let x = 0
+
     let _ = { () -> Void in }
 
     let _ = { @concurrent () async -> Void in }
@@ -227,11 +229,14 @@ do {
 
     // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{15-15=@concurrent }}{{none}}
     let _ = { () async -> Void in }
-
-    func takesInts(_: Int...) {}
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{15-15=@concurrent }}{{none}}
+    let _ = { [x] () async -> Void in _ = x }
 
     // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {await globalAsyncF()}
+      // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14=@concurrent }}{{none}}
+    let _ = {[x] in await globalAsyncF(); _ = x}
+
     // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {
       await globalAsyncF()
@@ -239,26 +244,40 @@ do {
     // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{14-14= @concurrent in }}{{none}}
     let _ = {
       await globalAsyncF()
+      func takesInts(_: Int...) {}
       takesInts($0, $1, $2)
     }
+
     // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{25-25=@concurrent }}{{none}}
     let _ = { @Sendable in
       await globalAsyncF()
     }
+    // expected-warning@+1:13 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{25-25=@concurrent }}{{none}}
+    let _ = { @Sendable [x] in
+      _ = x
+      await globalAsyncF()
+    }
+
     // expected-warning@+2:18 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async function type to be treated as specified to run on the caller's actor; use @concurrent to preserve behavior}}{{18-18=@concurrent }}{{none}}
     // expected-warning@+1:45 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{47-47=@concurrent }}{{none}}
     var closure: (Int, Int) async -> Void = { a, b in
       await globalAsyncF()
     }
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    closure = { [x] a, b in _ = x }
     // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
     closure = {
-      a, b async in
-      await globalAsyncF()
+      a, b async in ()
+    }
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{+1:7-7=@concurrent }}{{none}}
+    closure = {
+      [x] a, b async in _ = x
     }
     // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
-    closure = { (a, b) in
-      await globalAsyncF()
-    }
+    closure = { (a, b) in () }
+
+    // expected-warning@+1:15 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use @concurrent to preserve behavior}}{{17-17=@concurrent }}{{none}}
+    closure = { [x] (a, b) in _ = x }
 
     let _ = closure
   }


### PR DESCRIPTION
- **Explanation**:
  - 2 fixes:
    - Attributes come before a closure capture list. `InFlightDiagnostic::fixItAddAttribute` was not accounting for this.
    - Do not emit migration mode diags if `nonisolated(nonsending)` is explicit. This broke when we split `@execution(...)` into `@concurrent` and `nonisolated(nonsending)` because the latter became its own `TypeRepr`, whereas the condition for whether to attempt migration diagnostics inside `resolveASTFunctionType` was still based on the function type's attributes alone.
  - Prevent `@concurrent` on closures from skipping `throws` inference. Introduction of `@concurrent` attribute caused an unintended side-effect in `ClosureEffectsRequest` since the attribute could only be used on `async` types setting `async` too early prevented body analysis for `throws` from running.
  - Fix UB in `NonisolatedNonsendingByDefault` migration diagnosis. The diagnostic can outlive the locally constructed attribute, which was passed by pointer, if there is an active `DiagnosticTransaction`.
- **Scope**:
  - Diagnostics QoI for `NonisolatedNonsendingByDefault` migration. This code is currently the only client of `InFlightDiagnostic::fixItAddAttribute`.
  - `throws` inference for `@concurrent` closures.
  - `NonisolatedNonsendingByDefault` migration diagnosis.
- **Issues**:
  - —
  - rdar://151421590
  - —
- **Original PRs**:
  - #81538
  - #81549
  - #81570
- **Risk**: Overall low.
- **Testing**:
  - Added regression tests, ran source compatibility suite.
  - Added regression tests.
  - No regression test successfully reduced, issue discovered as a crash while running `swift package migrate` against `swift-build`.
- **Reviewers**:
  - @xedin
  - @hborla
  - @xedin
