### PR TITLE
XFAIL `Interop/cxx/stdlib/use-std-function.swift` on Amazon Linux 2023

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -18,6 +18,7 @@
 // XFAIL: LinuxDistribution=fedora-39
 // XFAIL: LinuxDistribution=fedora-41
 // XFAIL: LinuxDistribution=debian-12
+// XFAIL: LinuxDistribution=amzn-2023
 
 import StdlibUnittest
 import StdFunction


### PR DESCRIPTION
This pr xfails a crashing test on Amazon Linux 2023 similar to the other distros.