### PR TITLE
[TypeLowering] Record packs used in signatures.

### DIFF
--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1353,7 +1353,7 @@ bool SILInstruction::isDeallocatingStack() const {
 }
 
 static bool typeOrLayoutInvolvesPack(SILType ty, SILFunction const &F) {
-  return ty.hasAnyPack() || ty.isOrContainsPack(F);
+  return ty.isOrContainsPack(F);
 }
 
 bool SILInstruction::mayRequirePackMetadata(SILFunction const &F) const {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2290,12 +2290,14 @@ namespace {
 
     TypeLowering *handleTrivial(CanType type,
                                 RecursiveProperties properties) {
+      properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC) TrivialTypeLowering(silType, properties, Expansion);
     }
 
     TypeLowering *handleReference(CanType type,
                                   RecursiveProperties properties) {
+      properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
       if (type.isForeignReferenceType() &&
           type->getReferenceCounting() == ReferenceCounting::None)
@@ -2307,6 +2309,7 @@ namespace {
 
     TypeLowering *handleMoveOnlyReference(CanType type,
                                           RecursiveProperties properties) {
+      properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
       return new (TC)
           MoveOnlyReferenceTypeLowering(silType, properties, Expansion);
@@ -2314,6 +2317,7 @@ namespace {
 
     TypeLowering *handleMoveOnlyAddressOnly(CanType type,
                                             RecursiveProperties properties) {
+      properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       if (!TC.Context.SILOpts.EnableSILOpaqueValues &&
           !TypeLoweringForceOpaqueValueLowering) {
         auto silType = SILType::getPrimitiveAddressType(type);
@@ -2326,13 +2330,15 @@ namespace {
     }
 
     TypeLowering *handleReference(CanType type) {
+      auto properties = RecursiveProperties::forReference();
+      properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       auto silType = SILType::getPrimitiveObjectType(type);
-      return new (TC) ReferenceTypeLowering(
-          silType, RecursiveProperties::forReference(), Expansion);
+      return new (TC) ReferenceTypeLowering(silType, properties, Expansion);
     }
 
     TypeLowering *handleAddressOnly(CanType type,
                                     RecursiveProperties properties) {
+      properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       if (!TC.Context.SILOpts.EnableSILOpaqueValues &&
           !TypeLoweringForceOpaqueValueLowering) {
         auto silType = SILType::getPrimitiveAddressType(type);
@@ -2347,6 +2353,7 @@ namespace {
     
     TypeLowering *handleInfinite(CanType type,
                                  RecursiveProperties properties) {
+      properties = mergeHasPack(HasPack_t(type->hasAnyPack()), properties);
       // Infinite types cannot actually be instantiated, so treat them as
       // opaque for code generation purposes.
       properties.setAddressOnly();

--- a/validation-test/IRGen/rdar147207926.swift
+++ b/validation-test/IRGen/rdar147207926.swift
@@ -1,0 +1,65 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                              \
+// RUN:     %t/Library.swift                                \
+// RUN:     -emit-module                                    \
+// RUN:     -target %target-swift-5.9-abi-triple            \
+// RUN:     -enable-library-evolution                       \
+// RUN:     -module-name Library                            \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-build-swift                                 \
+// RUN:     %t/Downstream.swift                             \
+// RUN:     -c                                              \
+// RUN:     -target %target-swift-5.9-abi-triple            \
+// RUN:     -parse-as-library                               \
+// RUN:     -module-name main                               \
+// RUN:     -lLibrary                                       \
+// RUN:     -I %t                                           \
+// RUN:     -o %t/Executable.o
+
+//--- Library.swift
+
+public struct Paq<each T> {
+  public var uette: (repeat each T)
+}
+
+public class Loq<each T> {
+}
+
+// Enums don't take packs yet.
+
+// public enum Orq<each T> {
+//   case uette(repeat each T)
+//   case uettette(repeat each T, repeat each T)
+// }
+
+//--- Downstream.swift
+
+import Library
+
+struct Sleeve<T> {
+  var impl: Paq<T>
+}
+
+func bin<Moribund>(_ s: consuming Sleeve<Moribund>) {
+}
+
+struct Laq<T> {
+  var impl: Loq<T>
+  var t: T
+}
+
+@_silgen_name("bun")
+func bun<T>(_ l: consuming Laq<T>) {
+}
+
+// Enums don't take packs yet.
+
+// struct Etiq<T> {
+//   var impl: Orq<T>
+// }
+// 
+// func bon<Moribund>(_ i: consuming Etiq<Moribund>) {
+// }


### PR DESCRIPTION
To determine whether an instruction may require pack metadata, the types of its operands are examined.

Previously, the top level type was checked for having a pack in its signature, and the whole type was checked for having a type anywhere in its layout (via TypeLowering).  This didn't account for the case where the metadata was required for a resilient type which uses a pack in its signature.

Here, during type lowering, a type having a pack in its signature is counted towards the type having a pack.

Fixes a compiler crash.

rdar://147207926
