### PR TITLE
SIL: Resilient types don't need to be treated as addressable-for-dependencies inside their resilience domain.

### DIFF
--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -266,7 +266,7 @@ public:
     static constexpr RecursiveProperties forResilient() {
       return {IsTrivial, IsFixedABI, IsNotAddressOnly, IsResilient,
               IsNotTypeExpansionSensitive, HasRawPointer, IsNotLexical,
-              HasNoPack, IsAddressableForDependencies};
+              HasNoPack, IsNotAddressableForDependencies};
     }
 
     void addSubobject(RecursiveProperties other) {

--- a/test/SILOptimizer/lifetime_dependence/addressable_lifetime_with_resilience.swift
+++ b/test/SILOptimizer/lifetime_dependence/addressable_lifetime_with_resilience.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -enable-experimental-feature AddressableTypes -enable-experimental-feature LifetimeDependence -enable-library-evolution -emit-sil -verify %s
+
+// REQUIRES: swift_feature_AddressableTypes
+// REQUIRES: swift_feature_LifetimeDependence
+
+internal struct Wrapper {
+    let inner: Resilient
+
+    @lifetime(borrow self)
+    borrowing func getSpan() -> RawSpan { self.inner.getSpan() }
+}
+
+public struct Resilient {
+    var field: AnyObject
+
+    @lifetime(borrow self)
+    borrowing func getSpan() -> RawSpan { fatalError() }
+}
+
+/*
+// TODO (rdar://151268401): We still get spurious errors about escaping `self`
+// in cases where the wrapped type is concretely addressable-for-dependencies.
+internal struct AFDWrapper {
+    let inner: AFDResilient
+
+    @lifetime(borrow self)
+    borrowing func getSpan() -> RawSpan { self.inner.getSpan() }
+}
+
+@_addressableForDependencies
+public struct AFDResilient {
+    @lifetime(borrow self)
+    borrowing func getSpan() -> RawSpan { fatalError() }
+}
+*/

--- a/test/SILOptimizer/lifetime_dependence/verify_library_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_library_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-module -emit-module-interface-path %t/test.swiftmodule \
+// RUN:   -swift-version 5 \
 // RUN:   -o /dev/null \
 // RUN:   -enable-library-evolution \
 // RUN:   -verify \
@@ -30,7 +31,7 @@ class C {}
 
 // Test diagnostics on keypath getter.
 //
-// FIXME: rdar://150073405 ([SILGen] support synthesized _modify on top of borrowed getters with library evolution)
+// rdar://150073405 ([SILGen] support synthesized _modify on top of borrowed getters with library evolution)
 //
 // This produces the error:
 // <unknown>:0: error: unexpected error produced: lifetime-dependent value returned by generated thunk
@@ -55,8 +56,6 @@ public struct NoncopyableImplicitAccessors : ~Copyable & ~Escapable {
   public var ne: NE
 
   public var neComputedBorrow: NE {
-    // expected-error @-1{{lifetime-dependent value returned by generated accessor '_modify'}}
-    // expected-note  @-2{{it depends on this scoped access to variable 'self'}}
     @lifetime(borrow self)
     get { ne }
 


### PR DESCRIPTION
Outside of the resilience domain, they have to be treated as opaque and therefore potentially addressable-for-dependencies, but inside of the resilience domain, we may take advantage of knowing the type layout to load indirect parameters out of memory and break the (unnecessary) dependency on a fixed memory location. Fixes rdar://151268401.

We do still however have problems when the type is actually `@_addressableForDependencies` inside of its resilience domain (rdar://151500074). I'll fix that in a follow up.