### PR TITLE
[Swiftify] Copy doc comment from clang node

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9281,10 +9281,17 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
       attachMacro = true;
     printer.printAvailability();
     printer.printTypeMapping(typeMapping);
+
   }
 
-  if (attachMacro)
-    importNontrivialAttribute(MappedDecl, MacroString);
+  if (attachMacro) {
+    if (clang::RawComment *raw = getClangASTContext().getRawCommentForDeclNoCache(ClangDecl)) {
+      auto commentString = raw->getRawText(getClangASTContext().getSourceManager());
+      importNontrivialAttribute(MappedDecl, (commentString + "\n" + MacroString).str());
+    } else {
+      importNontrivialAttribute(MappedDecl, MacroString);
+    }
+  }
 }
 
 static bool isUsingMacroName(clang::SourceManager &SM,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9285,9 +9285,20 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
   }
 
   if (attachMacro) {
-    if (clang::RawComment *raw = getClangASTContext().getRawCommentForDeclNoCache(ClangDecl)) {
-      auto commentString = raw->getRawText(getClangASTContext().getSourceManager());
-      importNontrivialAttribute(MappedDecl, (commentString + "\n" + MacroString).str());
+    if (clang::RawComment *raw =
+            getClangASTContext().getRawCommentForDeclNoCache(ClangDecl)) {
+      // swift::RawDocCommentAttr doesn't contain its text directly, but instead
+      // references the source range of the parsed comment. Instead of creating
+      // a new source file just to parse the doc comment, we can add the
+      // comment to the macro invocation attribute, which the macro has access
+      // to. Waiting until we know that the macro will be attached before
+      // emitting the comment to the string, despite the comment occurring
+      // first, avoids copying a bunch of potentially long comments for nodes
+      // that don't end up with wrappers.
+      auto commentString =
+          raw->getRawText(getClangASTContext().getSourceManager());
+      importNontrivialAttribute(MappedDecl,
+                                (commentString + "\n" + MacroString).str());
     } else {
       importNontrivialAttribute(MappedDecl, MacroString);
     }

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1550,6 +1550,7 @@ public struct SwiftifyImportMacro: PeerMacro {
             + availabilityAttr
             + lifetimeAttrs
             + disfavoredOverload)
+        .with(\.leadingTrivia, node.leadingTrivia)
       return [DeclSyntax(newFunc)]
     } catch let error as DiagnosticError {
       context.diagnose(

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1550,7 +1550,7 @@ public struct SwiftifyImportMacro: PeerMacro {
             + availabilityAttr
             + lifetimeAttrs
             + disfavoredOverload)
-        .with(\.leadingTrivia, node.leadingTrivia)
+        .with(\.leadingTrivia, node.leadingTrivia + .docLineComment("/// This is an auto-generated wrapper for safer interop\n"))
       return [DeclSyntax(newFunc)]
     } catch let error as DiagnosticError {
       context.diagnose(

--- a/test/Interop/C/swiftify-import/Inputs/comments.h
+++ b/test/Interop/C/swiftify-import/Inputs/comments.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+void begin();
+
+// line comment
+void lineComment(int len, int * __counted_by(len) p);
+
+/// line doc comment
+/// 
+/// Here's a more complete description.
+///
+/// @param len the buffer length
+/// @param p the buffer
+void lineDocComment(int len, int * __counted_by(len) p);
+
+/*
+ block comment
+ */
+void blockComment(int len, int * __counted_by(len) p);
+
+/**
+ * block doc comment
+ * 
+ * NB: it's very important to pass the correct length to this function
+ * @param len don't mess this one up
+ * @param p   some integers to play with
+ */
+void blockDocComment(int len, int * __counted_by(len) p);

--- a/test/Interop/C/swiftify-import/Inputs/module.modulemap
+++ b/test/Interop/C/swiftify-import/Inputs/module.modulemap
@@ -14,3 +14,7 @@ module SizedByNoEscapeClang {
     header "sized-by-noescape.h"
     export *
 }
+module CommentsClang {
+    header "comments.h"
+    export *
+}

--- a/test/Interop/C/swiftify-import/comments.swift
+++ b/test/Interop/C/swiftify-import/comments.swift
@@ -1,0 +1,41 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=CommentsClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --strict-whitespace --match-full-lines
+
+// Check that doc comments are carried over from clang to the safe macro expansion.
+
+// CHECK:func begin()
+// CHECK-NEXT:func lineComment(_ len: {{.*}}, _ p: UnsafeMutablePointer<{{.*}}>!)
+// CHECK-NEXT:/// line doc comment
+// CHECK-NEXT:/// 
+// CHECK-NEXT:/// Here's a more complete description.
+// CHECK-NEXT:///
+// CHECK-NEXT:/// @param len the buffer length
+// CHECK-NEXT:/// @param p the buffer
+// CHECK-NEXT:func lineDocComment(_ len: {{.*}}, _ p: UnsafeMutablePointer<{{.*}}>!)
+// CHECK-NEXT:func blockComment(_ len: {{.*}}, _ p: UnsafeMutablePointer<{{.*}}>!)
+// CHECK-NEXT:/**
+// CHECK-NEXT: * block doc comment
+// CHECK-NEXT: * 
+// CHECK-NEXT: * NB: it's very important to pass the correct length to this function
+// CHECK-NEXT: * @param len don't mess this one up
+// CHECK-NEXT: * @param p   some integers to play with
+// CHECK-NEXT: */
+// CHECK-NEXT:func blockDocComment(_ len: {{.*}}, _ p: UnsafeMutablePointer<{{.*}}>!)
+// CHECK-NEXT:@_alwaysEmitIntoClient public func blockComment(_ p: UnsafeMutableBufferPointer<{{.*}}>)
+// CHECK-NEXT:/**
+// CHECK-NEXT: * block doc comment
+// CHECK-NEXT: * 
+// CHECK-NEXT: * NB: it's very important to pass the correct length to this function
+// CHECK-NEXT: * @param len don't mess this one up
+// CHECK-NEXT: * @param p   some integers to play with
+// CHECK-NEXT: */
+// CHECK-NEXT:@_alwaysEmitIntoClient public func blockDocComment(_ p: UnsafeMutableBufferPointer<{{.*}}>)
+// CHECK-NEXT:@_alwaysEmitIntoClient public func lineComment(_ p: UnsafeMutableBufferPointer<{{.*}}>)
+// CHECK-NEXT:/// line doc comment
+// CHECK-NEXT:/// 
+// CHECK-NEXT:/// Here's a more complete description.
+// CHECK-NEXT:///
+// CHECK-NEXT:/// @param len the buffer length
+// CHECK-NEXT:/// @param p the buffer
+// CHECK-NEXT:@_alwaysEmitIntoClient public func lineDocComment(_ p: UnsafeMutableBufferPointer<{{.*}}>)

--- a/test/Interop/C/swiftify-import/comments.swift
+++ b/test/Interop/C/swiftify-import/comments.swift
@@ -5,15 +5,18 @@
 // Check that doc comments are carried over from clang to the safe macro expansion.
 
 // CHECK:func begin()
-// CHECK-NEXT:func lineComment(_ len: {{.*}}, _ p: UnsafeMutablePointer<{{.*}}>!)
+// CHECK-NEXT:func lineComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+
 // CHECK-NEXT:/// line doc comment
 // CHECK-NEXT:/// 
 // CHECK-NEXT:/// Here's a more complete description.
 // CHECK-NEXT:///
 // CHECK-NEXT:/// @param len the buffer length
 // CHECK-NEXT:/// @param p the buffer
-// CHECK-NEXT:func lineDocComment(_ len: {{.*}}, _ p: UnsafeMutablePointer<{{.*}}>!)
-// CHECK-NEXT:func blockComment(_ len: {{.*}}, _ p: UnsafeMutablePointer<{{.*}}>!)
+// CHECK-NEXT:func lineDocComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+
+// CHECK-NEXT:func blockComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+
 // CHECK-NEXT:/**
 // CHECK-NEXT: * block doc comment
 // CHECK-NEXT: * 
@@ -21,8 +24,11 @@
 // CHECK-NEXT: * @param len don't mess this one up
 // CHECK-NEXT: * @param p   some integers to play with
 // CHECK-NEXT: */
-// CHECK-NEXT:func blockDocComment(_ len: {{.*}}, _ p: UnsafeMutablePointer<{{.*}}>!)
-// CHECK-NEXT:@_alwaysEmitIntoClient public func blockComment(_ p: UnsafeMutableBufferPointer<{{.*}}>)
+// CHECK-NEXT:func blockDocComment(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!)
+
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient public func blockComment(_ p: UnsafeMutableBufferPointer<Int32>)
+
 // CHECK-NEXT:/**
 // CHECK-NEXT: * block doc comment
 // CHECK-NEXT: * 
@@ -30,12 +36,17 @@
 // CHECK-NEXT: * @param len don't mess this one up
 // CHECK-NEXT: * @param p   some integers to play with
 // CHECK-NEXT: */
-// CHECK-NEXT:@_alwaysEmitIntoClient public func blockDocComment(_ p: UnsafeMutableBufferPointer<{{.*}}>)
-// CHECK-NEXT:@_alwaysEmitIntoClient public func lineComment(_ p: UnsafeMutableBufferPointer<{{.*}}>)
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient public func blockDocComment(_ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient public func lineComment(_ p: UnsafeMutableBufferPointer<Int32>)
+
 // CHECK-NEXT:/// line doc comment
 // CHECK-NEXT:/// 
 // CHECK-NEXT:/// Here's a more complete description.
 // CHECK-NEXT:///
 // CHECK-NEXT:/// @param len the buffer length
 // CHECK-NEXT:/// @param p the buffer
-// CHECK-NEXT:@_alwaysEmitIntoClient public func lineDocComment(_ p: UnsafeMutableBufferPointer<{{.*}}>)
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient public func lineDocComment(_ p: UnsafeMutableBufferPointer<Int32>)

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -11,33 +11,52 @@
 
 import CountedByNoEscapeClang
 
-// CHECK:      @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(_param1: copy _param1)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func anonymous(_ _param1: inout MutableSpan<Int32>?)
-// CHECK-NEXT:  @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_ p: inout MutableSpan<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_ p: inout MutableSpan<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_ p: inout MutableSpan<Int32>?)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy p)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func returnLifetimeBound(_ len1: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int32) -> UnsafeMutableBufferPointer<Int32>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p1: copy p1)
 // CHECK-NEXT: @lifetime(p2: copy p2)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int32, _ p1: inout MutableSpan<Int32>, _ p2: inout MutableSpan<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_ p: inout MutableSpan<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_ p: inout MutableSpan<Int32>)

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -10,23 +10,59 @@
 
 import CountedByClang
 
-// CHECK:      @_alwaysEmitIntoClient public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func bitwise(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func constFloatCastedToInt(_ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func constInt(_ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_  p: UnsafeMutableBufferPointer<Int{{.*}}>?)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func offBySome(_ len: Int32, _ offset: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_  len: Int{{.*}}) -> UnsafeMutableBufferPointer<Int{{.*}}>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func scalar(_ m: Int32, _ n: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int{{.*}}, _ p1: UnsafeMutableBufferPointer<Int{{.*}}>, _ p2: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simpleFlipped(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func sizeofParam(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func sizeofType(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 
 @inlinable

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -9,21 +9,39 @@
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __noescape parameters.
 import SizedByNoEscapeClang
 
-// CHECK:      @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+
+// CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: RawSpan)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_ p: RawSpan)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_  p: RawSpan)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_  p: RawSpan?)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func opaque(_  p: RawSpan)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int{{.*}}) -> UnsafeRawBufferPointer
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int{{.*}}, _ p1: RawSpan, _ p2: RawSpan)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: RawSpan)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: RawSpan)
 

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -9,14 +9,32 @@
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by parameters.
 import SizedByClang
 
-// CHECK:      @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: UnsafeMutableRawBufferPointer)
+
+// CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: UnsafeMutableRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nonnull(_  p: UnsafeMutableRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullUnspecified(_  p: UnsafeMutableRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func nullable(_  p: UnsafeMutableRawBufferPointer?)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func opaque(_  p: UnsafeRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int{{.*}}) -> UnsafeMutableRawBufferPointer
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func shared(_ len: Int{{.*}}, _ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func simple(_  p: UnsafeMutableRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func swiftAttr(_  p: UnsafeMutableRawBufferPointer)
 
 @inlinable

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -23,70 +23,112 @@ import CxxStdlib
 // CHECK-NEXT: func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> ConstSpanOfInt
 // CHECK:      struct X {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:   @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT:   @_alwaysEmitIntoClient public mutating func methodWithSafeWrapper(_ s: Span<CInt>)
 // CHECK-NEXT:   mutating func methodWithSafeWrapper(_ s: ConstSpanOfInt)
 // CHECK-NEXT: }
 // CHECK: struct SpanWithoutTypeAlias {
 // CHECK-NEXT:   init()
+// CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:   @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT:   @lifetime(borrow self)
 // CHECK-NEXT:   @_alwaysEmitIntoClient @_disfavoredOverload public mutating func bar() -> Span<CInt>
 // CHECK-NEXT:   mutating func bar() -> std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>
+// CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:   @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT:   @_alwaysEmitIntoClient public mutating func foo(_ s: Span<CInt>)
 // CHECK-NEXT:   mutating func foo(_ s: std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>)
 // CHECK-NEXT: }
 
-// CHECK:      @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(s: copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func FuncWithMutableSafeWrapper(_ s: inout MutableSpan<CInt>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy s)
 // CHECK-NEXT: @lifetime(s: copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func FuncWithMutableSafeWrapper2(_ s: inout MutableSpan<CInt>) -> MutableSpan<CInt>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func FuncWithMutableSafeWrapper3(_ v: inout VecOfInt) -> MutableSpan<CInt>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy p)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper1(_ p: inout MutableSpan<Int32>) -> MutableSpan<CInt>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func MixedFuncWithMutableSafeWrapper2(_ v: inout VecOfInt, _ len: Int32) -> MutableSpan<Int32>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(s: copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper3(_ s: inout MutableSpan<CInt>, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(s: copy s)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper4(_ s: inout MutableSpan<CInt>, _ p: inout MutableSpan<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper5(_ s: SpanOfInt, _ p: inout MutableSpan<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper6(_ s: SpanOfInt, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func MixedFuncWithMutableSafeWrapper7(_ p: UnsafeMutableBufferPointer<Int32>) -> SpanOfInt
 
-// CHECK:      @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+
+// CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper(_ s: Span<CInt>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func funcWithSafeWrapper2(_ s: Span<CInt>) -> Span<CInt>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> Span<CInt>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper1(_ p: Span<Int32>) -> Span<CInt>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mixedFuncWithSafeWrapper2(_ v: borrowing VecOfInt, _ len: Int32) -> Span<Int32>
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper3(_ s: Span<CInt>, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper4(_ s: Span<CInt>, _ p: Span<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper5(_ s: ConstSpanOfInt, _ p: Span<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper6(_ s: ConstSpanOfInt, _ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient public func mixedFuncWithSafeWrapper7(_ p: UnsafeBufferPointer<Int32>) -> ConstSpanOfInt

--- a/test/SourceKit/CursorInfo/cursor_doc_comment_from_clang_safe_wrapper.swift
+++ b/test/SourceKit/CursorInfo/cursor_doc_comment_from_clang_safe_wrapper.swift
@@ -3,9 +3,10 @@
 
 //--- header.h
 
-/// This comment contains `markup`.
-///
-/// - And a list
+/** This comment contains `markup`.
+ *
+ * - And a list
+ */
 void testCDecl(const int * __attribute__((__counted_by__(len))) __attribute__((noescape)) p, int len);
 
 //--- module.modulemap
@@ -25,5 +26,5 @@ func test(_ s: Span<CInt>) {
 // CHECK: This comment contains `markup`.
 // CHECK: - And a list
 // CHECK-LABEL: DOC COMMENT XML
-// CHECK: <Function file="@__swiftmacro_So9testCDecl15_SwiftifyImportfMp_.swift" line="4" column="113"><Name>testCDecl(_:)</Name><USR>s:SC9testCDeclyys4SpanVys5Int32VGF</USR><Declaration>@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: public func testCDecl(_ p: Span&lt;Int32&gt;)</Declaration><CommentParts><Abstract><Para>This comment contains <codeVoice>markup</codeVoice>.</Para></Abstract><Discussion><List-Bullet><Item><Para>And a list</Para></Item></List-Bullet></Discussion></CommentParts></Function>
+// CHECK: <Function file="@__swiftmacro_So9testCDecl15_SwiftifyImportfMp_.swift" line="6" column="113"><Name>testCDecl(_:)</Name><USR>s:SC9testCDeclyys4SpanVys5Int32VGF</USR><Declaration>@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: public func testCDecl(_ p: Span&lt;Int32&gt;)</Declaration><CommentParts><Abstract><Para>This comment contains <codeVoice>markup</codeVoice>. *</Para></Abstract><Discussion><List-Bullet><Item><List-Bullet><Item><Para>And a list</Para></Item></List-Bullet></Item></List-Bullet><Para>This is an auto-generated wrapper for safer interop</Para></Discussion></CommentParts></Function>

--- a/test/SourceKit/CursorInfo/cursor_doc_comment_from_clang_safe_wrapper.swift
+++ b/test/SourceKit/CursorInfo/cursor_doc_comment_from_clang_safe_wrapper.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+//--- header.h
+
+/// This comment contains `markup`.
+///
+/// - And a list
+void testCDecl(const int * __attribute__((__counted_by__(len))) __attribute__((noescape)) p, int len);
+
+//--- module.modulemap
+
+module MyClangModule { header "header.h" }
+
+//--- test.swift
+
+import MyClangModule
+
+func test(_ s: Span<CInt>) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):4 %s -- %s -I %t -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+  testCDecl(s)
+}
+
+// CHECK-LABEL: DOC COMMENT
+// CHECK: This comment contains `markup`.
+// CHECK: - And a list
+// CHECK-LABEL: DOC COMMENT XML
+// CHECK: <Function file="@__swiftmacro_So9testCDecl15_SwiftifyImportfMp_.swift" line="4" column="113"><Name>testCDecl(_:)</Name><USR>s:SC9testCDeclyys4SpanVys5Int32VGF</USR><Declaration>@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: public func testCDecl(_ p: Span&lt;Int32&gt;)</Declaration><CommentParts><Abstract><Para>This comment contains <codeVoice>markup</codeVoice>.</Para></Abstract><Discussion><List-Bullet><Item><Para>And a list</Para></Item></List-Bullet></Discussion></CommentParts></Function>

--- a/test/SourceKit/CursorInfo/cursor_doc_comment_from_clang_safe_wrapper.swift
+++ b/test/SourceKit/CursorInfo/cursor_doc_comment_from_clang_safe_wrapper.swift
@@ -1,3 +1,5 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
 // RUN: %empty-directory(%t)
 // RUN: split-file --leading-lines %s %t
 

--- a/test/SourceKit/CursorInfo/cursor_doc_comment_from_clang_safe_wrapper.swift
+++ b/test/SourceKit/CursorInfo/cursor_doc_comment_from_clang_safe_wrapper.swift
@@ -20,7 +20,7 @@ module MyClangModule { header "header.h" }
 import MyClangModule
 
 func test(_ s: Span<CInt>) {
-  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):4 %s -- %s -I %t -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):4 -req-opts=retrieve_symbol_graph=1 %s -- %s -I %t -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
   testCDecl(s)
 }
 
@@ -30,3 +30,76 @@ func test(_ s: Span<CInt>) {
 // CHECK-LABEL: DOC COMMENT XML
 // CHECK: <Function file="@__swiftmacro_So9testCDecl15_SwiftifyImportfMp_.swift" line="6" column="113"><Name>testCDecl(_:)</Name><USR>s:SC9testCDeclyys4SpanVys5Int32VGF</USR><Declaration>@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: public func testCDecl(_ p: Span&lt;Int32&gt;)</Declaration><CommentParts><Abstract><Para>This comment contains <codeVoice>markup</codeVoice>. *</Para></Abstract><Discussion><List-Bullet><Item><List-Bullet><Item><Para>And a list</Para></Item></List-Bullet></Item></List-Bullet><Para>This is an auto-generated wrapper for safer interop</Para></Discussion></CommentParts></Function>
+
+// CHECK-LABEL: SYMBOL GRAPH BEGIN
+// CHECK:      "docComment": {
+// CHECK-NEXT:   "lines": [
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "range": {
+// CHECK-NEXT:         "end": {
+// CHECK-NEXT:           "character": 35,
+// CHECK-NEXT:           "line": 0
+// CHECK-NEXT:         },
+// CHECK-NEXT:         "start": {
+// CHECK-NEXT:           "character": 4,
+// CHECK-NEXT:           "line": 0
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       "text": "This comment contains `markup`."
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "range": {
+// CHECK-NEXT:         "end": {
+// CHECK-NEXT:           "character": 2,
+// CHECK-NEXT:           "line": 1
+// CHECK-NEXT:         },
+// CHECK-NEXT:         "start": {
+// CHECK-NEXT:           "character": 1,
+// CHECK-NEXT:           "line": 1
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       "text": "*"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "range": {
+// CHECK-NEXT:         "end": {
+// CHECK-NEXT:           "character": 15,
+// CHECK-NEXT:           "line": 2
+// CHECK-NEXT:         },
+// CHECK-NEXT:         "start": {
+// CHECK-NEXT:           "character": 1,
+// CHECK-NEXT:           "line": 2
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       "text": "* - And a list"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "range": {
+// CHECK-NEXT:         "end": {
+// CHECK-NEXT:           "character": 1,
+// CHECK-NEXT:           "line": 3
+// CHECK-NEXT:         },
+// CHECK-NEXT:         "start": {
+// CHECK-NEXT:           "character": 1,
+// CHECK-NEXT:           "line": 3
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       "text": ""
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "range": {
+// CHECK-NEXT:         "end": {
+// CHECK-NEXT:           "character": 55,
+// CHECK-NEXT:           "line": 4
+// CHECK-NEXT:         },
+// CHECK-NEXT:         "start": {
+// CHECK-NEXT:           "character": 4,
+// CHECK-NEXT:           "line": 4
+// CHECK-NEXT:         }
+// CHECK-NEXT:       },
+// CHECK-NEXT:       "text": "This is an auto-generated wrapper for safer interop"
+// CHECK-NEXT:     }
+// CHECK-NEXT:   ],
+// CHECK-NEXT:   "module": "MyClangModule",
+// CHECK-NEXT:   "uri": "file://@__swiftmacro_So9testCDecl15_SwiftifyImportfMp_.swift"
+// CHECK-NEXT: }


### PR DESCRIPTION
Swift nodes imported from clang don't have doc comments carried over, but IDEs are clever enough to fetch the comments from the associated clang node. The swift node in the macro expansion from _SwiftifyImport doesn't have a clang node directly associated with it however.

This patch adds the same comment from the clang node to the _SwiftifyImport macro invocation node. Since the macro has access to this node, it can easily copy over its leading trivia.

For now the comment is not altered at all, meaning @param still remains even if the parmeter is removed.

rdar://151346977