### PR TITLE
[Swiftify] Always remove count parameters when possible

### DIFF
--- a/test/Interop/C/swiftify-import/Inputs/counted-by-lifetimebound.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by-lifetimebound.h
@@ -19,3 +19,5 @@ typedef struct foo opaque_t;
 opaque_t * __counted_by(len) opaque(int len, int len2, opaque_t * __counted_by(len2) __lifetimebound p);
 
 int * __counted_by(len) noncountedLifetime(int len, int * __lifetimebound p);
+
+int * __counted_by(13) _Nullable constant(int * __counted_by(13) __lifetimebound _Nullable p);

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -17,6 +17,12 @@ import CountedByLifetimeboundClang
 // CHECK-NEXT: @lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
+// CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func constant(_ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>?
+
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(borrow p)
@@ -93,4 +99,10 @@ public func callSimple(_ p: inout MutableSpan<CInt>) {
 @inlinable
 public func callNoncountedLifetime(_ p: UnsafeMutablePointer<CInt>) {
   let _: MutableSpan<CInt> = noncountedLifetime(73, p)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@inlinable
+public func callConstant(_ p: inout MutableSpan<CInt>?) {
+  let _: MutableSpan<CInt>? = constant(&p)
 }

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -15,7 +15,7 @@ import CountedByLifetimeboundClang
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy p)
 // CHECK-NEXT: @lifetime(p: copy p)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ len2: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -44,7 +44,7 @@ import CountedByLifetimeboundClang
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy p)
 // CHECK-NEXT: @lifetime(p: copy p)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -56,7 +56,7 @@ import CountedByLifetimeboundClang
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callComplexExpr(_ p: inout MutableSpan<CInt>) {
-  let _: MutableSpan<CInt> = complexExpr(73, 37, 42, &p)
+  let _: MutableSpan<CInt> = complexExpr(73, 37, &p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -80,7 +80,7 @@ public func callNullable(_ p: inout MutableSpan<CInt>?) {
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callShared(_ p: inout MutableSpan<CInt>) {
-  let _: MutableSpan<CInt> = shared(CInt(p.count), &p)
+  let _: MutableSpan<CInt> = shared(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -106,7 +106,7 @@ import CountedByNoEscapeClang
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(p1: copy p1)
 // CHECK-NEXT: @lifetime(p2: copy p2)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ len: Int32, _ p1: inout MutableSpan<Int32>, _ p2: inout MutableSpan<Int32>)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p1: inout MutableSpan<Int32>, _ p2: inout MutableSpan<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -165,7 +165,7 @@ public func callReturnPointer() {
 @lifetime(p2: copy p2)
 @inlinable
 public func callShared(_ p: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {
-  shared(CInt(p.count), &p, &p2)
+  shared(&p, &p2)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -48,7 +48,7 @@ import CountedByClang
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func scalar(_ m: Int32, _ n: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ len: Int{{.*}}, _ p1: UnsafeMutableBufferPointer<Int{{.*}}>, _ p2: UnsafeMutableBufferPointer<Int{{.*}}>)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p1: UnsafeMutableBufferPointer<Int{{.*}}>, _ p2: UnsafeMutableBufferPointer<Int{{.*}}>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func simple(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
@@ -108,7 +108,7 @@ public func callScalar(_ p: UnsafeMutableBufferPointer<CInt>) {
 
 @inlinable
 public func callShared(_ p: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
-  shared(CInt(p.count), p, p2)
+  shared(p, p2)
 }
 
 @inlinable

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -14,7 +14,7 @@ import SizedByLifetimeboundClang
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ len2: Int32, _ p: RawSpan) -> RawSpan
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) -> RawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -44,7 +44,7 @@ import SizedByLifetimeboundClang
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ len: Int32, _ p: RawSpan) -> RawSpan
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p: RawSpan) -> RawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -55,7 +55,7 @@ import SizedByLifetimeboundClang
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callComplexExpr(_ p: RawSpan) {
-  let _: RawSpan = complexExpr(73, 37, 42, p)
+  let _: RawSpan = complexExpr(73, 37, p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -79,7 +79,7 @@ public func callNullable(_ p: RawSpan?) {
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callShared(_ p: RawSpan) {
-  let _: RawSpan = shared(CInt(p.byteCount), p)
+  let _: RawSpan = shared(p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -35,7 +35,7 @@ import SizedByNoEscapeClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ len: Int{{.*}}, _ p1: RawSpan, _ p2: RawSpan)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p1: RawSpan, _ p2: RawSpan)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -79,7 +79,7 @@ public func callReturnPointer() {
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callShared(_ p: RawSpan, _ p2: RawSpan) {
-  shared(CInt(p.byteCount), p, p2)
+  shared(p, p2)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -29,7 +29,7 @@ import SizedByClang
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int{{.*}}) -> UnsafeMutableRawBufferPointer
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ len: Int{{.*}}, _ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p1: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func simple(_  p: UnsafeMutableRawBufferPointer)
@@ -70,7 +70,7 @@ public func callReturnPointer() {
 
 @inlinable
 public func callShared(_ p: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
-  shared(CInt(p.count), p, p2)
+  shared(p, p2)
 }
 
 @inlinable

--- a/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
@@ -20,24 +20,28 @@ public func myFunc4(_: UnsafeMutablePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: public func myFunc(_ _myFunc_param0: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe myFunc(_myFunc_param0.baseAddress!, CInt(exactly: _myFunc_param0.count)!)
+// CHECK-NEXT:     let _myFunc_param1 = CInt(exactly: unsafe _myFunc_param0.count)!
+// CHECK-NEXT:     return unsafe myFunc(_myFunc_param0.baseAddress!, _myFunc_param1)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: public func myFunc2(_ _myFunc2_param0: UnsafeBufferPointer<CInt>, _ _myFunc2_param2: CInt) {
-// CHECK-NEXT:     return unsafe myFunc2(_myFunc2_param0.baseAddress!, CInt(exactly: _myFunc2_param0.count)!, _myFunc2_param2)
+// CHECK-NEXT:     let _myFunc2_param1 = CInt(exactly: unsafe _myFunc2_param0.count)!
+// CHECK-NEXT:     return unsafe myFunc2(_myFunc2_param0.baseAddress!, _myFunc2_param1, _myFunc2_param2)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: public func myFunc3(_ _myFunc3_param0: Span<CInt>) {
-// CHECK-NEXT:     return   unsafe _myFunc3_param0.withUnsafeBufferPointer { __myFunc3_param0Ptr in
-// CHECK-NEXT:         return unsafe myFunc3(__myFunc3_param0Ptr.baseAddress!, CInt(exactly: __myFunc3_param0Ptr.count)!)
-// CHECK-NEXT:       }
+// CHECK-NEXT:     let _myFunc3_param1 = CInt(exactly: _myFunc3_param0.count)!
+// CHECK-NEXT:     return unsafe _myFunc3_param0.withUnsafeBufferPointer { __myFunc3_param0Ptr in
+// CHECK-NEXT:       return unsafe myFunc3(__myFunc3_param0Ptr.baseAddress!, _myFunc3_param1)
+// CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(_myFunc4_param0: copy _myFunc4_param0) @_disfavoredOverload
 // CHECK-NEXT: public func myFunc4(_ _myFunc4_param0: inout MutableSpan<CInt>) {
-// CHECK-NEXT:     return   unsafe _myFunc4_param0.withUnsafeMutableBufferPointer { __myFunc4_param0Ptr in
-// CHECK-NEXT:         return unsafe myFunc4(__myFunc4_param0Ptr.baseAddress!, CInt(exactly: __myFunc4_param0Ptr.count)!)
-// CHECK-NEXT:       }
+// CHECK-NEXT:     let _myFunc4_param1 = CInt(exactly: _myFunc4_param0.count)!
+// CHECK-NEXT:     return unsafe _myFunc4_param0.withUnsafeMutableBufferPointer { __myFunc4_param0Ptr in
+// CHECK-NEXT:       return unsafe myFunc4(__myFunc4_param0Ptr.baseAddress!, _myFunc4_param1)
+// CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
@@ -1,0 +1,236 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"))
+func plain(_ ptr: UnsafePointer<CInt>) {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"))
+func opt(_ ptr: UnsafePointer<CInt>?) {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"))
+func mut(_ ptr: UnsafeMutablePointer<CInt>) {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"))
+func mutOpt(_ ptr: UnsafeMutablePointer<CInt>?) {}
+
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"), .nonescaping(pointer: .param(1)))
+func noescape(_ ptr: UnsafePointer<CInt>) {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"), .nonescaping(pointer: .param(1)))
+func noescapeOpt(_ ptr: UnsafePointer<CInt>?) {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"), .nonescaping(pointer: .param(1)))
+func noescapeMut(_ ptr: UnsafeMutablePointer<CInt>) {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"), .nonescaping(pointer: .param(1)))
+func noescapeMutOpt(_ ptr: UnsafeMutablePointer<CInt>?) {}
+
+
+@_SwiftifyImport(.countedBy(pointer: .return, count: "37"))
+func plainReturn() -> UnsafePointer<CInt> {}
+
+@_SwiftifyImport(.countedBy(pointer: .return, count: "37"))
+func optReturn() -> UnsafePointer<CInt>? {}
+
+@_SwiftifyImport(.countedBy(pointer: .return, count: "37"))
+func mutReturn() -> UnsafeMutablePointer<CInt> {}
+
+@_SwiftifyImport(.countedBy(pointer: .return, count: "37"))
+func mutOptReturn() -> UnsafeMutablePointer<CInt>? {}
+
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
+func noescape(_ ptr: UnsafePointer<CInt>) -> UnsafePointer<CInt> {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
+func noescapeOpt(_ ptr: UnsafePointer<CInt>?) -> UnsafePointer<CInt>? {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
+func noescapeMut(_ ptr: UnsafeMutablePointer<CInt>) -> UnsafeMutablePointer<CInt> {}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "37"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy))
+func noescapeMutOpt(_ ptr: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<CInt>? {}
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func plain(_ ptr: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     let _ptrCount = unsafe ptr.count
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in plain: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe plain(ptr.baseAddress!)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func opt(_ ptr: UnsafeBufferPointer<CInt>?) {
+// CHECK-NEXT:     let _ptrCount = unsafe ptr?.count ?? 0
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in opt: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe opt(ptr?.baseAddress)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func mut(_ ptr: UnsafeMutableBufferPointer<CInt>) {
+// CHECK-NEXT:     let _ptrCount = unsafe ptr.count
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in mut: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe mut(ptr.baseAddress!)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func mutOpt(_ ptr: UnsafeMutableBufferPointer<CInt>?) {
+// CHECK-NEXT:     let _ptrCount = unsafe ptr?.count ?? 0
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in mutOpt: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe mutOpt(ptr?.baseAddress)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func noescape(_ ptr: Span<CInt>) {
+// CHECK-NEXT:     let _ptrCount = ptr.count
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in noescape: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
+// CHECK-NEXT:       return unsafe noescape(_ptrPtr.baseAddress!)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func noescape(_ ptr: Span<CInt>) -> UnsafePointer<CInt> {
+// CHECK-NEXT:     let _ptrCount = ptr.count
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in noescape: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
+// CHECK-NEXT:       return unsafe noescape(_ptrPtr.baseAddress!)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func noescapeOpt(_ ptr: Span<CInt>?) {
+// CHECK-NEXT:     let _ptrCount = ptr?.count ?? 0
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in noescapeOpt: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return { () in
+// CHECK-NEXT:         return if ptr == nil {
+// CHECK-NEXT:             unsafe noescapeOpt(nil)
+// CHECK-NEXT:           } else {
+// CHECK-NEXT:             unsafe ptr!.withUnsafeBufferPointer { _ptrPtr in
+// CHECK-NEXT:               return unsafe noescapeOpt(_ptrPtr.baseAddress)
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:     }()
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func noescapeOpt(_ ptr: Span<CInt>?) -> UnsafePointer<CInt>? {
+// CHECK-NEXT:     let _ptrCount = ptr?.count ?? 0
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in noescapeOpt: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return { () in
+// CHECK-NEXT:         return if ptr == nil {
+// CHECK-NEXT:             unsafe noescapeOpt(nil)
+// CHECK-NEXT:           } else {
+// CHECK-NEXT:             unsafe ptr!.withUnsafeBufferPointer { _ptrPtr in
+// CHECK-NEXT:               return unsafe noescapeOpt(_ptrPtr.baseAddress)
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:     }()
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func noescapeMut(_ ptr: inout MutableSpan<CInt>) {
+// CHECK-NEXT:     let _ptrCount = ptr.count
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in noescapeMut: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:       return unsafe noescapeMut(_ptrPtr.baseAddress!)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func noescapeMut(_ ptr: inout MutableSpan<CInt>) -> UnsafeMutablePointer<CInt> {
+// CHECK-NEXT:     let _ptrCount = ptr.count
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in noescapeMut: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:       return unsafe noescapeMut(_ptrPtr.baseAddress!)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func noescapeMutOpt(_ ptr: inout MutableSpan<CInt>?) {
+// CHECK-NEXT:     let _ptrCount = ptr?.count ?? 0
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in noescapeMutOpt: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return { () in
+// CHECK-NEXT:         return if ptr == nil {
+// CHECK-NEXT:             unsafe noescapeMutOpt(nil)
+// CHECK-NEXT:           } else {
+// CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:               return unsafe noescapeMutOpt(_ptrPtr.baseAddress)
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:     }()
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func noescapeMutOpt(_ ptr: inout MutableSpan<CInt>?) -> UnsafeMutablePointer<CInt>? {
+// CHECK-NEXT:     let _ptrCount = ptr?.count ?? 0
+// CHECK-NEXT:     if _ptrCount != 37 {
+// CHECK-NEXT:       fatalError("bounds check failure in noescapeMutOpt: expected \(37) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return { () in
+// CHECK-NEXT:         return if ptr == nil {
+// CHECK-NEXT:             unsafe noescapeMutOpt(nil)
+// CHECK-NEXT:           } else {
+// CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:               return unsafe noescapeMutOpt(_ptrPtr.baseAddress)
+// CHECK-NEXT:             }
+// CHECK-NEXT:           }
+// CHECK-NEXT:     }()
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func plainReturn() -> UnsafeBufferPointer<CInt> {
+// CHECK-NEXT:     return unsafe UnsafeBufferPointer<CInt> (start: unsafe plainReturn(), count: Int(37))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func optReturn() -> UnsafeBufferPointer<CInt>? {
+// CHECK-NEXT:     return unsafe { () in
+// CHECK-NEXT:       let _resultValue = unsafe optReturn()
+// CHECK-NEXT:       if unsafe _resultValue == nil {
+// CHECK-NEXT:         return nil
+// CHECK-NEXT:       } else {
+// CHECK-NEXT:         return unsafe _swiftifyOverrideLifetime(UnsafeBufferPointer<CInt>(start: _resultValue!, count: Int(37)), copying: ())
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }()
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func mutReturn() -> UnsafeMutableBufferPointer<CInt> {
+// CHECK-NEXT:     return unsafe UnsafeMutableBufferPointer<CInt> (start: unsafe mutReturn(), count: Int(37))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func mutOptReturn() -> UnsafeMutableBufferPointer<CInt>? {
+// CHECK-NEXT:     return unsafe { () in
+// CHECK-NEXT:       let _resultValue = unsafe mutOptReturn()
+// CHECK-NEXT:       if unsafe _resultValue == nil {
+// CHECK-NEXT:         return nil
+// CHECK-NEXT:       } else {
+// CHECK-NEXT:         return unsafe _swiftifyOverrideLifetime(UnsafeMutableBufferPointer<CInt>(start: _resultValue!, count: Int(37)), copying: ())
+// CHECK-NEXT:       }
+// CHECK-NEXT:     }()
+// CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/CountExpr.swift
@@ -8,9 +8,9 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ size: CInt, _ count: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ size: CInt, _ count: CInt) {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = size * count
-// CHECK-NEXT:     if ptr.count < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
+// CHECK-NEXT:     let _ptrCount = unsafe ptr.count
+// CHECK-NEXT:     if _ptrCount != size * count {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc: expected \(size * count) but got \(_ptrCount)")
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, count)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/MultipleParams.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MultipleParams.swift
@@ -8,5 +8,7 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt, _ ptr2: UnsafePointer<CInt>
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     let len2 = CInt(exactly: unsafe ptr2.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len, ptr2.baseAddress!, len2)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Mutable.swift
@@ -8,5 +8,6 @@ func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -9,7 +9,8 @@ func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: inout MutableSpan<CInt>) {
+// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, len)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/NamedParams.swift
@@ -28,30 +28,36 @@ func allNamedOther(buf ptr: UnsafePointer<CInt>, count len: CInt) {
 
 // CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func ptrNamed(ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe ptrNamed(ptr: ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe ptrNamed(ptr: ptr.baseAddress!, len)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func ptrNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe ptrNamedOther(buf: ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe ptrNamedOther(buf: ptr.baseAddress!, len)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func lenNamed(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe lenNamed(ptr.baseAddress!, len: CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe lenNamed(ptr.baseAddress!, len: len)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func lenNamedOther(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe lenNamedOther(ptr.baseAddress!, count: CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe lenNamedOther(ptr.baseAddress!, count: len)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func allNamed(ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe allNamed(ptr: ptr.baseAddress!, len: CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe allNamed(ptr: ptr.baseAddress!, len: len)
 // CHECK-NEXT: }
 
 // CHECK: @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func allNamedOther(buf ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe allNamedOther(buf: ptr.baseAddress!, count: CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe allNamedOther(buf: ptr.baseAddress!, count: len)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -20,17 +20,19 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>?) {
-// CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr?.count ?? 0)!
+// CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, len)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
+// CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
 // CHECK-NEXT:     return { () in
 // CHECK-NEXT:         return if ptr == nil {
-// CHECK-NEXT:             unsafe myFunc2(nil, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:             unsafe myFunc2(nil, len)
 // CHECK-NEXT:         } else {
 // CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                 return unsafe myFunc2(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:                 return unsafe myFunc2(_ptrPtr.baseAddress, len)
 // CHECK-NEXT:             }
 // CHECK-NEXT:         }
 // CHECK-NEXT:     }()
@@ -38,14 +40,16 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @lifetime(ptr2: copy ptr2) @_disfavoredOverload
 // CHECK-NEXT: func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) {
+// CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
+// CHECK-NEXT:     let len2 = CInt(exactly: ptr2?.count ?? 0)!
 // CHECK-NEXT:     return { () in
 // CHECK-NEXT:         return if ptr2 == nil {
 // CHECK-NEXT:             { () in
 // CHECK-NEXT:                 return  if ptr == nil {
-// CHECK-NEXT:                     unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                     unsafe myFunc3(nil, len, nil, len2)
 // CHECK-NEXT:                 } else {
 // CHECK-NEXT:                     unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                         return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!, nil, CInt(exactly: ptr2?.count ?? 0)!)
+// CHECK-NEXT:                         return unsafe myFunc3(_ptrPtr.baseAddress, len, nil, len2)
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }
 // CHECK-NEXT:             }()
@@ -53,10 +57,10 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 // CHECK-NEXT:             unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
 // CHECK-NEXT:                 return { () in
 // CHECK-NEXT:                     return if ptr == nil {
-// CHECK-NEXT:                         unsafe myFunc3(nil, CInt(exactly: ptr?.count ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: _ptr2Ptr.count)!)
+// CHECK-NEXT:                         unsafe myFunc3(nil, len, _ptr2Ptr.baseAddress, len2)
 // CHECK-NEXT:                     } else {
 // CHECK-NEXT:                         unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
-// CHECK-NEXT:                             return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!, _ptr2Ptr.baseAddress, CInt(exactly: _ptr2Ptr.count)!)
+// CHECK-NEXT:                             return unsafe myFunc3(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
 // CHECK-NEXT:                         }
 // CHECK-NEXT:                     }
 // CHECK-NEXT:                 }()
@@ -66,11 +70,8 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
-// CHECK-NEXT: func myFunc4(_ ptr: inout MutableSpan<CInt>?, _ len: CInt) -> MutableSpan<CInt>? {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = len
-// CHECK-NEXT:     if ptr?.count ?? 0 < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
-// CHECK-NEXT:     }
+// CHECK-NEXT: func myFunc4(_ ptr: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+// CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime({ () in
 // CHECK-NEXT:         let _resultValue = { () in
 // CHECK-NEXT:             return if ptr == nil {

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -30,12 +30,14 @@ func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart:   unsafe p.withUnsafeBufferPointer { _pPtr in
-// CHECK-NEXT:         return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: _pPtr.count)!, len2)
-// CHECK-NEXT:       }, count: Int(len2)), copying: ())
+// CHECK-NEXT:     let len1 = CInt(exactly: p.count)!
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe p.withUnsafeBufferPointer { _pPtr in
+// CHECK-NEXT:       return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2)
+// CHECK-NEXT:             }, count: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), count: Int(len2)), copying: ())
+// CHECK-NEXT:     let len1 = CInt(exactly: unsafe p.count)!
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, len1, len2), count: Int(len2)), copying: ())
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/QualifiedTypes.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/QualifiedTypes.swift
@@ -12,10 +12,12 @@ func bar(_ ptr: Swift.UnsafePointer<Swift.CInt>, _ len: Swift.Int) -> () {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func foo(_ ptr: Swift.UnsafeBufferPointer<Swift.Int>) -> Swift.Void {
-// CHECK-NEXT:     return unsafe foo(ptr.baseAddress!, ptr.count)
+// CHECK-NEXT:     let len = unsafe ptr.count
+// CHECK-NEXT:     return unsafe foo(ptr.baseAddress!, len)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func bar(_ ptr: Swift.UnsafeBufferPointer<Swift.CInt>) -> () {
-// CHECK-NEXT:     return unsafe bar(ptr.baseAddress!, ptr.count)
+// CHECK-NEXT:     let len = unsafe ptr.count
+// CHECK-NEXT:     return unsafe bar(ptr.baseAddress!, len)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/Return.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Return.swift
@@ -8,5 +8,6 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) -> CInt {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SharedCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SharedCount.swift
@@ -6,15 +6,70 @@
 func myFunc(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ len: CInt) {
 }
 
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .param(2), count: "len * size"))
+func myFunc2(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len"), .countedBy(pointer: .param(2), count: "size"), .countedBy(pointer: .param(3), count: "len * size"))
+func myFunc3(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .param(3), count: "len"), .countedBy(pointer: .param(2), count: "size"), .countedBy(pointer: .param(1), count: "len * size"))
+func myFunc4(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
+}
+
+@_SwiftifyImport(.countedBy(pointer: .param(1), count: "len * size"), .countedBy(pointer: .param(3), count: "len"), .countedBy(pointer: .param(2), count: "size"))
+func myFunc5(_ ptr: UnsafePointer<CInt>, _ ptr2: UnsafePointer<CInt>, _ ptr3: UnsafePointer<CInt>, _ len: CInt, _ size: CInt) {
+}
+
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ len: CInt) {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = len
-// CHECK-NEXT:     if ptr.count < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     let _ptr2Count: some BinaryInteger = len
-// CHECK-NEXT:     if ptr2.count < _ptr2Count || _ptr2Count < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
+// CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     if unsafe ptr2.count != len {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc: expected \(len) but got \(unsafe ptr2.count)")
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, ptr2.baseAddress!, len)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func myFunc2(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ size: CInt) {
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     let _ptr2Count = unsafe ptr2.count
+// CHECK-NEXT:     if _ptr2Count != len * size {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc2: expected \(len * size) but got \(_ptr2Count)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe myFunc2(ptr.baseAddress!, ptr2.baseAddress!, len, size)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func myFunc3(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr2.count)!
+// CHECK-NEXT:     let _ptr3Count = unsafe ptr3.count
+// CHECK-NEXT:     if _ptr3Count != len * size {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc3: expected \(len * size) but got \(_ptr3Count)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe myFunc3(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func myFunc4(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr2.count)!
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr3.count)!
+// CHECK-NEXT:     let _ptrCount = unsafe ptr.count
+// CHECK-NEXT:     if _ptrCount != len * size {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc4: expected \(len * size) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe myFunc4(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func myFunc5(_ ptr: UnsafeBufferPointer<CInt>, _ ptr2: UnsafeBufferPointer<CInt>, _ ptr3: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr2.count)!
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr3.count)!
+// CHECK-NEXT:     let _ptrCount = unsafe ptr.count
+// CHECK-NEXT:     if _ptrCount != len * size {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc5: expected \(len * size) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe myFunc5(ptr.baseAddress!, ptr2.baseAddress!, ptr3.baseAddress!, len, size)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleCount.swift
@@ -8,5 +8,6 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpan.swift
@@ -9,7 +9,8 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: Span<CInt>) {
+// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, len)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SimpleSpanWithReturn.swift
@@ -9,7 +9,8 @@ func myFunc(_ ptr: UnsafePointer<CInt>, _ len: CInt) -> CInt {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: Span<CInt>) -> CInt {
+// CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBufferPointer { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, len)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/SpanAndUnsafeBuffer.swift
@@ -10,7 +10,9 @@ func myFunc(_ ptr1: UnsafePointer<CInt>, _ len1: CInt, _ ptr2: UnsafePointer<CIn
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr1: Span<CInt>, _ ptr2: UnsafeBufferPointer<CInt>) {
+// CHECK-NEXT:     let len1 = CInt(exactly: ptr1.count)!
+// CHECK-NEXT:     let len2 = CInt(exactly: unsafe ptr2.count)!
 // CHECK-NEXT:     return unsafe ptr1.withUnsafeBufferPointer { _ptr1Ptr in
-// CHECK-NEXT:         return unsafe myFunc(_ptr1Ptr.baseAddress!, CInt(exactly: _ptr1Ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
+// CHECK-NEXT:       return unsafe myFunc(_ptr1Ptr.baseAddress!, len1, ptr2.baseAddress!, len2)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Unwrapped.swift
@@ -8,5 +8,6 @@ func myFunc(_ ptr: UnsafePointer<CInt>!, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeBufferPointer<CInt>) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
@@ -1,0 +1,49 @@
+@_SwiftifyImport(.countedBy(pointer: .return, count: "len"), .lifetimeDependence(dependsOn: .param(1), pointer: .return, type: .copy), .countedBy(pointer: .param(1), count: "len"), .nonescaping(pointer: .param(1)), .countedBy(pointer: .param(3), count: "len2"), .nonescaping(pointer: .param(3)))
+func myFunc(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: UnsafeMutablePointer<CInt>?, _ len2: CInt) -> UnsafeMutablePointer<CInt>? {}
+
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines --strict-whitespace %s
+
+// This test is meant to act as an alarm bell to unintended changes in whitespace
+
+// CHECK:------------------------------
+// CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:@_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @lifetime(ptr2: copy ptr2) @_disfavoredOverload
+// CHECK-NEXT:func myFunc(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
+// CHECK-NEXT:    let len = CInt(exactly: ptr?.count ?? 0)!
+// CHECK-NEXT:    let len2 = CInt(exactly: ptr2?.count ?? 0)!
+// CHECK-NEXT:    return unsafe _swiftifyOverrideLifetime({ () in
+// CHECK-NEXT:      let _resultValue = { () in
+// CHECK-NEXT:              return if ptr2 == nil {
+// CHECK-NEXT:                  { () in
+// CHECK-NEXT:                      return if ptr == nil {
+// CHECK-NEXT:                              unsafe myFunc(nil, len, nil, len2)
+// CHECK-NEXT:                            } else {
+// CHECK-NEXT:                              unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:                                return unsafe myFunc(_ptrPtr.baseAddress, len, nil, len2)
+// CHECK-NEXT:                              }
+// CHECK-NEXT:                            }
+// CHECK-NEXT:                  }()
+// CHECK-NEXT:                } else {
+// CHECK-NEXT:                  unsafe ptr2!.withUnsafeMutableBufferPointer { _ptr2Ptr in
+// CHECK-NEXT:                    return { () in
+// CHECK-NEXT:                        return if ptr == nil {
+// CHECK-NEXT:                                unsafe myFunc(nil, len, _ptr2Ptr.baseAddress, len2)
+// CHECK-NEXT:                              } else {
+// CHECK-NEXT:                                unsafe ptr!.withUnsafeMutableBufferPointer { _ptrPtr in
+// CHECK-NEXT:                                  return unsafe myFunc(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
+// CHECK-NEXT:                                }
+// CHECK-NEXT:                              }
+// CHECK-NEXT:                    }()
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                }
+// CHECK-NEXT:          }()
+// CHECK-NEXT:      if unsafe _resultValue == nil {
+// CHECK-NEXT:        return nil
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        return unsafe _swiftifyOverrideLifetime(MutableSpan<CInt>(_unsafeStart: _resultValue!, count: Int(len)), copying: ())
+// CHECK-NEXT:      }
+// CHECK-NEXT:        }(), copying: ())
+// CHECK-NEXT:}
+// CHECK-NEXT:------------------------------

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -88,42 +88,42 @@ func myFunc10(_ self: MutableSpanOfInt) -> MutableSpanOfInt {
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc6(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: CInt) -> Span<CInt> {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = count * size
-// CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
+// CHECK-NEXT:     let _ptrCount = ptr.byteCount
+// CHECK-NEXT:     if _ptrCount != count * size {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc6: expected \(count * size) but got \(_ptrCount)")
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
-// CHECK-NEXT:     }), copying: ())
+// CHECK-NEXT:       return unsafe myFunc6(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
+// CHECK-NEXT:             }), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc7(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: CInt) -> Span<CInt> {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = count * size
-// CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
+// CHECK-NEXT:     let _ptrCount = ptr.byteCount
+// CHECK-NEXT:     if _ptrCount != count * size {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc7: expected \(count * size) but got \(_ptrCount)")
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
-// CHECK-NEXT:     }), copying: ())
+// CHECK-NEXT:       return unsafe myFunc7(SpanOfInt(span), _ptrPtr.baseAddress!, count, size)
+// CHECK-NEXT:             }), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc8(_ ptr: RawSpan, _ span: Span<CInt>, _ count: CInt, _ size: CInt) -> Span<CInt> {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = count * size
-// CHECK-NEXT:     if ptr.byteCount < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
+// CHECK-NEXT:     let _ptrCount = ptr.byteCount
+// CHECK-NEXT:     if _ptrCount != count * size {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc8: expected \(count * size) but got \(_ptrCount)")
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)
-// CHECK-NEXT:     }), copying: ())
+// CHECK-NEXT:       return unsafe myFunc8(_ptrPtr.baseAddress!, SpanOfInt(span), count, size)
+// CHECK-NEXT:             }), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @lifetime(span: copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
-// CHECK-NEXT:         return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
-// CHECK-NEXT:    }), copying: ())
+// CHECK-NEXT:       return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
+// CHECK-NEXT:             }), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy `self`) @lifetime(`self`: copy `self`) @_disfavoredOverload

--- a/test/Macros/SwiftifyImport/SizedBy/MultipleParams.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MultipleParams.swift
@@ -8,5 +8,7 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ ptr2: UnsafeRawPointer, _ s
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer, _ ptr2: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!, ptr2.baseAddress!, CInt(exactly: ptr2.count)!)
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     let size2 = CInt(exactly: unsafe ptr2.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, ptr2.baseAddress!, size2)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Mutable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Mutable.swift
@@ -8,5 +8,6 @@ func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeMutableRawBufferPointer) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -9,7 +9,8 @@ func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: inout MutableRawSpan) {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, size)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
@@ -20,66 +20,67 @@ func myFunc4(_ ptr: UnsafeMutableRawPointer?, _ len: CInt) -> UnsafeMutableRawPo
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer?) {
-// CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr?.count ?? 0)!
+// CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, size)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ ptr: inout MutableRawSpan?) {
-// CHECK-NEXT:     return   { () in
+// CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
+// CHECK-NEXT:     return { () in
 // CHECK-NEXT:         return if ptr == nil {
-// CHECK-NEXT:               unsafe myFunc2(nil, CInt(exactly: ptr?.byteCount ?? 0)!)
-// CHECK-NEXT:             } else {
-// CHECK-NEXT:                 unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:                   return unsafe myFunc2(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!)
-// CHECK-NEXT:                 }
+// CHECK-NEXT:             unsafe myFunc2(nil, len)
+// CHECK-NEXT:           } else {
+// CHECK-NEXT:             unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
+// CHECK-NEXT:               return unsafe myFunc2(_ptrPtr.baseAddress, len)
 // CHECK-NEXT:             }
+// CHECK-NEXT:           }
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @lifetime(ptr2: copy ptr2) @_disfavoredOverload
 // CHECK-NEXT: func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?) {
-// CHECK-NEXT:     return   { () in
+// CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
+// CHECK-NEXT:     let len2 = CInt(exactly: ptr2?.byteCount ?? 0)!
+// CHECK-NEXT:     return { () in
 // CHECK-NEXT:         return if ptr2 == nil {
-// CHECK-NEXT:                 { () in
-// CHECK-NEXT:                     return if ptr == nil {
-// CHECK-NEXT:                                 unsafe myFunc3(nil, CInt(exactly: ptr?.byteCount ?? 0)!, nil, CInt(exactly: ptr2?.byteCount ?? 0)!)
-// CHECK-NEXT:                               } else {
-// CHECK-NEXT:                                   unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:                                     return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!, nil, CInt(exactly: ptr2?.byteCount ?? 0)!)
-// CHECK-NEXT:                                   }
-// CHECK-NEXT:                               }
-// CHECK-NEXT:                 }()
-// CHECK-NEXT:             } else {
-// CHECK-NEXT:                 unsafe ptr2!.withUnsafeMutableBytes { _ptr2Ptr in
-// CHECK-NEXT:                   return   { () in
-// CHECK-NEXT:                       return if ptr == nil {
-// CHECK-NEXT:                                   unsafe myFunc3(nil, CInt(exactly: ptr?.byteCount ?? 0)!, _ptr2Ptr.baseAddress, CInt(exactly: _ptr2Ptr.count)!)
-// CHECK-NEXT:                                 } else {
-// CHECK-NEXT:                                     unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:                                       return unsafe myFunc3(_ptrPtr.baseAddress, CInt(exactly: _ptrPtr.count)!, _ptr2Ptr.baseAddress, CInt(exactly: _ptr2Ptr.count)!)
-// CHECK-NEXT:                                     }
-// CHECK-NEXT:                                 }
-// CHECK-NEXT:                   }()
-// CHECK-NEXT:                 }
+// CHECK-NEXT:             { () in
+// CHECK-NEXT:                 return if ptr == nil {
+// CHECK-NEXT:                         unsafe myFunc3(nil, len, nil, len2)
+// CHECK-NEXT:                       } else {
+// CHECK-NEXT:                         unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
+// CHECK-NEXT:                           return unsafe myFunc3(_ptrPtr.baseAddress, len, nil, len2)
+// CHECK-NEXT:                         }
+// CHECK-NEXT:                       }
+// CHECK-NEXT:             }()
+// CHECK-NEXT:           } else {
+// CHECK-NEXT:             unsafe ptr2!.withUnsafeMutableBytes { _ptr2Ptr in
+// CHECK-NEXT:               return { () in
+// CHECK-NEXT:                   return if ptr == nil {
+// CHECK-NEXT:                           unsafe myFunc3(nil, len, _ptr2Ptr.baseAddress, len2)
+// CHECK-NEXT:                         } else {
+// CHECK-NEXT:                           unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
+// CHECK-NEXT:                             return unsafe myFunc3(_ptrPtr.baseAddress, len, _ptr2Ptr.baseAddress, len2)
+// CHECK-NEXT:                           }
+// CHECK-NEXT:                         }
+// CHECK-NEXT:               }()
 // CHECK-NEXT:             }
+// CHECK-NEXT:           }
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
-// CHECK-NEXT: func myFunc4(_ ptr: inout MutableRawSpan?, _ len: CInt) -> MutableRawSpan? {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = len
-// CHECK-NEXT:       if ptr?.byteCount ?? 0 < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
-// CHECK-NEXT:       }
+// CHECK-NEXT: func myFunc4(_ ptr: inout MutableRawSpan?) -> MutableRawSpan? {
+// CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime({ () in
-// CHECK-NEXT:       let _resultValue =   { () in
+// CHECK-NEXT:       let _resultValue = { () in
 // CHECK-NEXT:               return if ptr == nil {
-// CHECK-NEXT:                     unsafe myFunc4(nil, len)
-// CHECK-NEXT:                   } else {
-// CHECK-NEXT:                       unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
-// CHECK-NEXT:                         return unsafe myFunc4(_ptrPtr.baseAddress, len)
-// CHECK-NEXT:                       }
+// CHECK-NEXT:                   unsafe myFunc4(nil, len)
+// CHECK-NEXT:                 } else {
+// CHECK-NEXT:                   unsafe ptr!.withUnsafeMutableBytes { _ptrPtr in
+// CHECK-NEXT:                     return unsafe myFunc4(_ptrPtr.baseAddress, len)
 // CHECK-NEXT:                   }
+// CHECK-NEXT:                 }
 // CHECK-NEXT:           }()
 // CHECK-NEXT:       if unsafe _resultValue == nil {
 // CHECK-NEXT:         return nil

--- a/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Opaque.swift
@@ -28,42 +28,47 @@ func impNullableSpan(_ ptr: OpaquePointer!, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func nonnullUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return unsafe nonnullUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), CInt(exactly: ptr.count)!)
-// CHECK-NEXT: }
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe nonnullUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), size)
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func nullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer?) {
-// CHECK-NEXT:     return unsafe nullableUnsafeRawBufferPointer(OpaquePointer(ptr?.baseAddress), CInt(exactly: ptr?.count ?? 0)!)
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr?.count ?? 0)!
+// CHECK-NEXT:     return unsafe nullableUnsafeRawBufferPointer(OpaquePointer(ptr?.baseAddress), size)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func impNullableUnsafeRawBufferPointer(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe impNullableUnsafeRawBufferPointer(OpaquePointer(ptr.baseAddress!), size)
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func nonnullSpan(_ ptr: RawSpan) {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:       return unsafe nonnullSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func nullableSpan(_ ptr: RawSpan?) {
+// CHECK-NEXT:     let size = CInt(exactly: ptr?.byteCount ?? 0)!
 // CHECK-NEXT:     return { () in
 // CHECK-NEXT:         return if ptr == nil {
-// CHECK-NEXT:             unsafe nullableSpan(nil, CInt(exactly: ptr?.byteCount ?? 0)!)
-// CHECK-NEXT:         } else {
+// CHECK-NEXT:             unsafe nullableSpan(nil, size)
+// CHECK-NEXT:           } else {
 // CHECK-NEXT:             unsafe ptr!.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:                 return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:               return unsafe nullableSpan(OpaquePointer(_ptrPtr.baseAddress), size)
 // CHECK-NEXT:             }
-// CHECK-NEXT:         }
+// CHECK-NEXT:           }
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func impNullableSpan(_ ptr: RawSpan) {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:       return unsafe impNullableSpan(OpaquePointer(_ptrPtr.baseAddress!), size)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
@@ -39,24 +39,28 @@ func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawPointer, _ len1: 
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentCopy(_ p: RawSpan, _ len2: CInt) -> RawSpan {
+// CHECK-NEXT:     let len1 = CInt(exactly: p.byteCount)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe p.withUnsafeBytes { _pPtr in
-// CHECK-NEXT:       return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, CInt(exactly: _pPtr.count)!, len2)
+// CHECK-NEXT:       return unsafe lifetimeDependentCopy(_pPtr.baseAddress!, len1, len2)
 // CHECK-NEXT:             }, byteCount: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeRawBufferPointer, _ len2: CInt) -> RawSpan {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, CInt(exactly: p.count)!, len2), byteCount: Int(len2)), copying: ())
+// CHECK-NEXT:     let len1 = CInt(exactly: unsafe p.count)!
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(copy p) @lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentCopyMut(_ p: inout MutableRawSpan, _ len2: CInt) -> MutableRawSpan {
+// CHECK-NEXT:     let len1 = CInt(exactly: p.byteCount)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe p.withUnsafeMutableBytes { _pPtr in
-// CHECK-NEXT:       return unsafe lifetimeDependentCopyMut(_pPtr.baseAddress!, CInt(exactly: _pPtr.count)!, len2)
+// CHECK-NEXT:       return unsafe lifetimeDependentCopyMut(_pPtr.baseAddress!, len1, len2)
 // CHECK-NEXT:             }, byteCount: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
 // CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawBufferPointer, _ len2: CInt) -> MutableRawSpan {
-// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe lifetimeDependentBorrowMut(p.baseAddress!, CInt(exactly: p.count)!, len2), byteCount: Int(len2)), copying: ())
+// CHECK-NEXT:     let len1 = CInt(exactly: unsafe p.count)!
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe lifetimeDependentBorrowMut(p.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Return.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Return.swift
@@ -8,5 +8,6 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) -> CInt {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SharedCount.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SharedCount.swift
@@ -7,14 +7,10 @@ func myFunc(_ ptr: UnsafeRawPointer, _ ptr2: UnsafeRawPointer, _ size: CInt) {
 }
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
-// CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer, _ ptr2: UnsafeRawBufferPointer, _ size: CInt) {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = size
-// CHECK-NEXT:     if ptr.count < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
-// CHECK-NEXT:     }
-// CHECK-NEXT:     let _ptr2Count: some BinaryInteger = size
-// CHECK-NEXT:     if ptr2.count < _ptr2Count || _ptr2Count < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
+// CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer, _ ptr2: UnsafeRawBufferPointer) {
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     if unsafe ptr2.count != size {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc: expected \(size) but got \(unsafe ptr2.count)")
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, ptr2.baseAddress!, size)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpan.swift
@@ -9,7 +9,8 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: RawSpan) {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, size)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleRawSpanWithReturn.swift
@@ -9,7 +9,8 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) -> CInt {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: RawSpan) -> CInt {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
-// CHECK-NEXT:         return unsafe myFunc(_ptrPtr.baseAddress!, CInt(exactly: _ptrPtr.count)!)
+// CHECK-NEXT:       return unsafe myFunc(_ptrPtr.baseAddress!, size)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SimpleSize.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SimpleSize.swift
@@ -8,5 +8,6 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/SizeExpr.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/SizeExpr.swift
@@ -8,9 +8,9 @@ func myFunc(_ ptr: UnsafeRawPointer, _ size: CInt, _ count: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer, _ size: CInt, _ count: CInt) {
-// CHECK-NEXT:     let _ptrCount: some BinaryInteger = size * count
-// CHECK-NEXT:     if ptr.count < _ptrCount || _ptrCount < 0 {
-// CHECK-NEXT:         fatalError("bounds check failure when calling unsafe function")
+// CHECK-NEXT:     let _ptrCount = unsafe ptr.count
+// CHECK-NEXT:     if _ptrCount != size * count {
+// CHECK-NEXT:       fatalError("bounds check failure in myFunc: expected \(size * count) but got \(_ptrCount)")
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, size, count)
 // CHECK-NEXT: }

--- a/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Unwrapped.swift
@@ -8,5 +8,6 @@ func myFunc(_ ptr: UnsafeRawPointer!, _ len: CInt) {
 
 // CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: UnsafeRawBufferPointer) {
-// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, CInt(exactly: ptr.count)!)
+// CHECK-NEXT:     let len = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe myFunc(ptr.baseAddress!, len)
 // CHECK-NEXT: }


### PR DESCRIPTION
Previously we did not remove count parameters if any count parameters were shared between count expressions, or if any count expression contained operations. Buffer sizes were also just checked to be larger than or equal than the given count.

We now extract the count from Spans/BufferPointers whenever possible, and store that value in a variable at the start of the function. If multiple parameters share the same count, a bounds check is emitted to make sure that they have the same size. Subspans can be used if one span is larger than necessary.

The message in the bounds check is changed so that it includes the expected and actual value, to aid in debugging.

This patch also fixes some incorrect indentation, and adds the Whitespace.swift test case to act as a regression test in case the indentation changes, since the other test cases don't use significant whitespace.

rdar://151488820
rdar://151511090
rdar://146333006
rdar://147715799
