### PR TITLE
CommandLineSupport: add a directive for autolinking on Windows

### DIFF
--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -37,6 +37,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #include <shellapi.h>
+#pragma comment(lib, "shell32.lib")
 #endif
 
 // Backing storage for overrides of `Swift.CommandLine.arguments`.


### PR DESCRIPTION
We use functions from Shell32.Lib. Ensure that we indicate the autolinking to the linker. This aides when building with a static runtime to avoid having to specify the additional library dependency for clients that are attempting to link against the runtime. This is particularly important for the CMake compiler check where we would need to list Shell32 as a required link library.