### PR TITLE
[Swiftify] Don't create safe wrapper for autoreleasing pointers (#81568)

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9166,6 +9166,14 @@ static bool SwiftifiableCAT(const clang::CountAttributedType *CAT) {
   return CAT && CATExprValidator().Visit(CAT->getCountExpr());
 }
 
+static bool SwiftifiablePointerType(Type swiftType) {
+  // don't try to transform any Swift types that _SwiftifyImport doesn't know how to handle
+  Type nonnullType = swiftType->lookThroughSingleOptionalType();
+  PointerTypeKind PTK;
+  return nonnullType->isOpaquePointer() ||
+    (nonnullType->getAnyPointerElementType(PTK) && PTK != PTK_AutoreleasingUnsafeMutablePointer);
+}
+
 void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
   if (!SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers))
     return;
@@ -9201,10 +9209,11 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
           return false;
         };
     SwiftifyInfoPrinter printer(getClangASTContext(), SwiftContext, out);
+    Type swiftReturnTy = MappedDecl->getResultInterfaceType();
     bool returnIsStdSpan = registerStdSpanTypeMapping(
-        MappedDecl->getResultInterfaceType(), ClangDecl->getReturnType());
+        swiftReturnTy, ClangDecl->getReturnType());
     auto *CAT = ClangDecl->getReturnType()->getAs<clang::CountAttributedType>();
-    if (SwiftifiableCAT(CAT)) {
+    if (SwiftifiableCAT(CAT) && SwiftifiablePointerType(swiftReturnTy)) {
       printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
       attachMacro = true;
     }
@@ -9218,14 +9227,15 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
     for (auto [index, clangParam] : llvm::enumerate(ClangDecl->parameters())) {
       auto clangParamTy = clangParam->getType();
       auto swiftParam = MappedDecl->getParameters()->get(index);
+      Type swiftParamTy = swiftParam->getInterfaceType();
       bool paramHasBoundsInfo = false;
       auto *CAT = clangParamTy->getAs<clang::CountAttributedType>();
-      if (SwiftifiableCAT(CAT)) {
+      if (SwiftifiableCAT(CAT) && SwiftifiablePointerType(swiftParamTy)) {
         printer.printCountedBy(CAT, index);
         attachMacro = paramHasBoundsInfo = true;
       }
       bool paramIsStdSpan = registerStdSpanTypeMapping(
-          swiftParam->getInterfaceType(), clangParamTy);
+          swiftParamTy, clangParamTy);
       paramHasBoundsInfo |= paramIsStdSpan;
 
       bool paramHasLifetimeInfo = false;
@@ -9236,7 +9246,7 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
       if (clangParam->hasAttr<clang::LifetimeBoundAttr>()) {
         printer.printLifetimeboundReturn(
             index, !paramHasBoundsInfo &&
-                       swiftParam->getInterfaceType()->isEscapable());
+                       swiftParamTy->isEscapable());
         paramHasLifetimeInfo = true;
         returnHasLifetimeInfo = true;
       }

--- a/test/Interop/C/swiftify-import/Inputs/module.modulemap
+++ b/test/Interop/C/swiftify-import/Inputs/module.modulemap
@@ -14,4 +14,3 @@ module SizedByNoEscapeClang {
     header "sized-by-noescape.h"
     export *
 }
-

--- a/test/Interop/ObjC/lit.local.cfg
+++ b/test/Interop/ObjC/lit.local.cfg
@@ -1,0 +1,2 @@
+if 'objc_interop' not in config.available_features:
+    config.unsupported = True

--- a/test/Interop/ObjC/swiftify-import/Inputs/module.modulemap
+++ b/test/Interop/ObjC/swiftify-import/Inputs/module.modulemap
@@ -1,0 +1,4 @@
+module NoSwiftifyClang {
+    header "objc-no-swiftify.h"
+    export *
+}

--- a/test/Interop/ObjC/swiftify-import/Inputs/objc-no-swiftify.h
+++ b/test/Interop/ObjC/swiftify-import/Inputs/objc-no-swiftify.h
@@ -1,0 +1,9 @@
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+
+@interface SomeClass
+- (int)numberOfSegments;
+@end
+
+void autoreleaseParam(SomeClass * __autoreleasing * __counted_by(len) p, int len); // expected-note{{declared here}}
+
+SomeClass * __autoreleasing * __counted_by(len) autoreleaseReturn(int len);

--- a/test/Interop/ObjC/swiftify-import/counted-by-in-class.swift
+++ b/test/Interop/ObjC/swiftify-import/counted-by-in-class.swift
@@ -5,8 +5,6 @@
 // RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Method -source-filename=x | %FileCheck %s
 // RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/method.swift -dump-macro-expansions -typecheck -verify
 
-// REQUIRES: objc_interop
-
 // CHECK: class Foo {
 // CHECK:  func bar(_ p: UnsafeMutableBufferPointer<Float>)
 

--- a/test/Interop/ObjC/swiftify-import/objc-no-swiftify.swift
+++ b/test/Interop/ObjC/swiftify-import/objc-no-swiftify.swift
@@ -1,0 +1,22 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=NoSwiftifyClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/NoSwiftify.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s -verify -verify-additional-file %S/Inputs/objc-no-swiftify.h
+
+import NoSwiftifyClang
+
+// CHECK-NOT: @_alwaysEmitIntoClient public func callAutoreleaseParam
+// CHECK-NOT: @_alwaysEmitIntoClient public func callAutoreleaseReturn
+
+public func callAutoreleaseParam(_ p: UnsafeMutableBufferPointer<SomeClass>) {
+    // expected-error@+2{{missing argument for parameter #2 in call}}
+    // expected-error@+1{{cannot convert value of type 'UnsafeMutableBufferPointer<SomeClass>' to expected argument type 'AutoreleasingUnsafeMutablePointer<SomeClass?>'}}
+    autoreleaseParam(p)
+}
+
+public func callAutoreleaseReturn() {
+    // expected-error@+1{{cannot convert value of type 'AutoreleasingUnsafeMutablePointer<SomeClass?>?' to specified type 'UnsafeMutableBufferPointer<SomeClass>'}}
+    let p: UnsafeMutableBufferPointer<SomeClass> = autoreleaseReturn(10)
+}


### PR DESCRIPTION
- **Explanation**:
_SwiftifyImport doesn't know how to handle AutoreleasingUnsafeMutablePointer, so we should not attach any .countedBy information for pointers that are imported as this type.
This also adds defensive checks against adding .countedBy to any pointer type that _SwiftifyImport doesn't know how to transform.
- **Scope**:
  This only affects code using the experimental SafeInteropWrappers feature. Affected code would previously result in a compilation error.
- **Issues**:
rdar://151479521
- **Original PRs**:
https://github.com/swiftlang/swift/pull/81568
- **Risk**:
This is intended to derisk the release by not attaching the _SwiftifyImport macro in cases where it could have unintended consquences.
- **Testing**:
We have and are doing manual testing of this feature since very little code currently uses this feature.
- **Reviewers**:
@j-hui 