### PR TITLE
[region-isolation]fix crash due to missing VectorBaseAddrInst case

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -312,6 +312,7 @@ static bool isStaticallyLookThroughInst(SILInstruction *inst) {
   case SILInstructionKind::UncheckedEnumDataInst:
   case SILInstructionKind::StructElementAddrInst:
   case SILInstructionKind::TupleElementAddrInst:
+  case SILInstructionKind::VectorBaseAddrInst:
     return true;
   case SILInstructionKind::MoveValueInst:
     // Look through if it isn't from a var decl.

--- a/test/Concurrency/regionanalysis_trackable_value.sil
+++ b/test/Concurrency/regionanalysis_trackable_value.sil
@@ -682,3 +682,24 @@ bb3:
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on allock_stack_inline_array_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value: %2 = vector_base_addr %1
+// CHECK: end running test 1 of 1 on allock_stack_inline_array_test: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @allock_stack_inline_array_test : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %0 = alloc_stack $InlineArray<1, UInt8>
+  %1 = struct_element_addr %0: $*InlineArray<1, UInt8>, #InlineArray._storage
+  %2 = vector_base_addr %1 : $*Builtin.FixedArray<1, UInt8>
+  %3 = integer_literal $Builtin.Int8, 0
+  %4 = struct $UInt8 (%3)
+  store %4 to [trivial] %2
+  %6 = load [trivial] %0
+  dealloc_stack %0
+  debug_value [trace] %2
+
+  %7 = tuple ()
+  return %7 : $()
+}

--- a/test/Concurrency/transfernonsendable_rbi_result.swift
+++ b/test/Concurrency/transfernonsendable_rbi_result.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -parse-as-library %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
@@ -134,4 +134,9 @@ func callActorFuncsFromNonisolated(a : A, ns : NonSendable) async {
 func testGenericResults() async {
   let _: NonSendable = await mainActorGenericReturnNonSendable()
   // expected-error @-1 {{non-Sendable 'NonSendable'-typed result can not be returned from main actor-isolated global function 'mainActorGenericReturnNonSendable()' to nonisolated context}}
+}
+
+// https://github.com/swiftlang/swift/issues/81534
+func testInlineArray() {
+  let _: InlineArray<_, UInt8> = [0]
 }


### PR DESCRIPTION
Resolves #81534

It seems we are missing the case for `VectorBaseAddrInst`.

`VectorBaseAddrInst` is statically defined as `LookThrough`. 
https://github.com/swiftlang/swift/blob/d985bf64357cdd7ade546dacd4330514402df116/lib/SILOptimizer/Analysis/RegionAnalysis.cpp#L3414

Regarding tests, similar problems could arise when new `LookThrough` instructions are added in the future. To prevent this, we should consider finding a way to ensure all `LookThrough` instructions are properly handled in `isStaticallyLookThroughInst`. What do you think? Are there any other places that do something similar?

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
