### PR TITLE
stdlib: Resolve `-strict-memory-safety` warnings

### DIFF
--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -144,7 +144,9 @@ extension ContinuousClock: Clock {
 extension ContinuousClock {
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public var systemEpoch: Instant { unsafeBitCast(Duration.seconds(0), to: Instant.self) }
+  public var systemEpoch: Instant {
+    unsafe unsafeBitCast(Duration.seconds(0), to: Instant.self)
+  }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -385,7 +385,7 @@ extension SerialExecutor {
   #if SWIFT_CONCURRENCY_USES_DISPATCH
   @available(SwiftStdlib 6.2, *)
   private var _dispatchQueue: OpaquePointer? {
-    return _getDispatchQueueForExecutor(self.asUnownedSerialExecutor())
+    return unsafe _getDispatchQueueForExecutor(self.asUnownedSerialExecutor())
   }
   #endif
 
@@ -395,8 +395,8 @@ extension SerialExecutor {
       return true
     }
     #if SWIFT_CONCURRENCY_USES_DISPATCH
-    if let rhsQueue = rhs._dispatchQueue {
-      if let ourQueue = _dispatchQueue, ourQueue == rhsQueue {
+    if let rhsQueue = unsafe rhs._dispatchQueue {
+      if let ourQueue = unsafe _dispatchQueue, ourQueue == rhsQueue {
         return true
       }
       return false

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -132,7 +132,9 @@ extension SuspendingClock: Clock {
 extension SuspendingClock {
   @available(SwiftStdlib 5.7, *)
   @_alwaysEmitIntoClient
-  public var systemEpoch: Instant { unsafeBitCast(Duration.seconds(0), to: Instant.self) }
+  public var systemEpoch: Instant {
+    unsafe unsafeBitCast(Duration.seconds(0), to: Instant.self)
+  }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/stdlib/toolchain/CompatibilitySpan/FakeStdlib.swift
+++ b/stdlib/toolchain/CompatibilitySpan/FakeStdlib.swift
@@ -74,10 +74,11 @@ internal func _overrideLifetime<
 }
 
 extension Range {
-    @_alwaysEmitIntoClient
-	internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
-	    self.init(uncheckedBounds: bounds)
-	}
+  @unsafe
+  @_alwaysEmitIntoClient
+  internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
+    self.init(uncheckedBounds: bounds)
+  }
 }
 
 extension Optional {


### PR DESCRIPTION
Add missing `unsafe` operators and `@unsafe` attributes in new code that was generating warnings.