### PR TITLE
Adopt `ABORT` throughout the compiler

### DIFF
--- a/include/swift/Basic/Assertions.h
+++ b/include/swift/Basic/Assertions.h
@@ -17,6 +17,8 @@
 #ifndef SWIFT_BASIC_ASSERTIONS_H
 #define SWIFT_BASIC_ASSERTIONS_H
 
+#include "swift/Basic/LLVM.h"
+
 // Only for use in this header
 #if __has_builtin(__builtin_expect)
 #define ASSERT_UNLIKELY(expression) (__builtin_expect(!!(expression), 0))
@@ -182,5 +184,34 @@ extern int CONDITIONAL_ASSERT_Global_enable_flag;
 // Older version of the same idea:
 #define SWIFT_ASSERT_ONLY_DECL DEBUG_ASSERT_DECL
 #define SWIFT_ASSERT_ONLY DEBUG_ASSERT_EXPR
+
+// ================================ Abort ======================================
+
+/// Implementation for \c ABORT, not to be used directly.
+[[noreturn]]
+void _ABORT(const char *file, int line, const char *func,
+            llvm::function_ref<void(llvm::raw_ostream &)> message);
+
+/// Implementation for \c ABORT, not to be used directly.
+[[noreturn]]
+void _ABORT(const char *file, int line, const char *func,
+            llvm::StringRef message);
+
+// Aborts the program, printing a given message to a PrettyStackTrace frame
+// before exiting. This should be preferred over manually logging to stderr and
+// `abort()`'ing since that won't be picked up by the crash reporter.
+//
+// There are two different forms of ABORT:
+//
+// ```
+// ABORT("abort with string");
+//
+// ABORT([&](auto &out) {
+//   out << "abort with arbitrary stream";
+//   node.dump(out);
+// });
+// ```
+//
+#define ABORT(arg) _ABORT(_FILENAME_FOR_ASSERT, __LINE__, __func__, (arg))
 
 #endif // SWIFT_BASIC_ASSERTIONS_H

--- a/include/swift/Basic/Assertions.h
+++ b/include/swift/Basic/Assertions.h
@@ -24,6 +24,13 @@
 #define ASSERT_UNLIKELY(expression) ((expression))
 #endif
 
+// Visual Studio doesn't have __FILE_NAME__
+#ifdef __FILE_NAME__
+#define _FILENAME_FOR_ASSERT __FILE_NAME__
+#else
+#define _FILENAME_FOR_ASSERT __FILE__
+#endif
+
 // ================================ Mandatory Asserts ================================
 
 // `ASSERT(expr)`:
@@ -41,26 +48,12 @@
 // that are more expensive than you think.  You can switch those to
 // `CONDITIONAL_ASSERT` or `DEBUG_ASSERT` as needed.
 
-// Visual Studio doesn't have __FILE_NAME__
-#ifdef __FILE_NAME__
-
-#define ASSERT(expr) \
-  do { \
-    if (ASSERT_UNLIKELY(!(expr))) {			   \
-      ASSERT_failure(#expr, __FILE_NAME__, __LINE__, __func__); \
-    } \
+#define ASSERT(expr)                                                           \
+  do {                                                                         \
+    if (ASSERT_UNLIKELY(!(expr))) {                                            \
+      ASSERT_failure(#expr, _FILENAME_FOR_ASSERT, __LINE__, __func__);         \
+    }                                                                          \
   } while (0)
-
-#else
-
-#define ASSERT(expr) \
-  do { \
-    if (ASSERT_UNLIKELY(!(expr))) {			   \
-      ASSERT_failure(#expr, __FILE__, __LINE__, __func__); \
-    } \
-  } while (0)
-
-#endif
 
 // Function that reports the actual failure when it occurs.
 void ASSERT_failure(const char *expr, const char *file, int line, const char *func);

--- a/include/swift/Basic/Assertions.h
+++ b/include/swift/Basic/Assertions.h
@@ -190,11 +190,4 @@ extern int CONDITIONAL_ASSERT_Global_enable_flag;
 #define SWIFT_ASSERT_ONLY_DECL DEBUG_ASSERT_DECL
 #define SWIFT_ASSERT_ONLY DEBUG_ASSERT_EXPR
 
-// ================================ Utility and Helper Functions ================================
-
-// Utility function to print out help information for
-// various command-line options that affect the assertion
-// behavior.
-void ASSERT_help();
-
 #endif // SWIFT_BASIC_ASSERTIONS_H

--- a/include/swift/Basic/PrettyStackTrace.h
+++ b/include/swift/Basic/PrettyStackTrace.h
@@ -50,19 +50,6 @@ public:
   void print(llvm::raw_ostream &OS) const override;
 };
 
-/// Aborts the program, printing a given message to a PrettyStackTrace frame
-/// before exiting. This should be preferred over manually logging to stderr and
-/// aborting since that won't be picked up by the crash reporter.
-[[noreturn]]
-void abortWithPrettyStackTraceMessage(
-    llvm::function_ref<void(llvm::raw_ostream &)> message);
-
-/// Aborts the program, printing a given message to a PrettyStackTrace frame
-/// before exiting. This should be preferred over manually logging to stderr and
-/// aborting since that won't be picked up by the crash reporter.
-[[noreturn]]
-void abortWithPrettyStackTraceMessage(llvm::StringRef message);
-
 } // end namespace swift
 
 #endif // SWIFT_BASIC_PRETTYSTACKTRACE_H

--- a/include/swift/Basic/PrettyStackTrace.h
+++ b/include/swift/Basic/PrettyStackTrace.h
@@ -51,13 +51,15 @@ public:
 };
 
 /// Aborts the program, printing a given message to a PrettyStackTrace frame
-/// before exiting.
+/// before exiting. This should be preferred over manually logging to stderr and
+/// aborting since that won't be picked up by the crash reporter.
 [[noreturn]]
 void abortWithPrettyStackTraceMessage(
     llvm::function_ref<void(llvm::raw_ostream &)> message);
 
 /// Aborts the program, printing a given message to a PrettyStackTrace frame
-/// before exiting.
+/// before exiting. This should be preferred over manually logging to stderr and
+/// aborting since that won't be picked up by the crash reporter.
 [[noreturn]]
 void abortWithPrettyStackTraceMessage(llvm::StringRef message);
 

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -557,11 +557,12 @@ protected:
     }
 
     if (substConf.isInvalid()) {
-      llvm::errs() << "Invalid substituted conformance in SIL cloner:\n";
-      Functor.dump(llvm::errs());
-      llvm::errs() << "\noriginal conformance:\n";
-      conformance.dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Invalid substituted conformance in SIL cloner:\n";
+        Functor.dump(out);
+        out << "\noriginal conformance:\n";
+        conformance.dump(out);
+      });
     }
 
     if (asImpl().shouldSubstOpaqueArchetypes()) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5819,9 +5819,10 @@ ProtocolConformanceRef ProtocolConformanceRef::forAbstract(
     break;
 
   default:
-    llvm::errs() << "Abstract conformance with bad subject type:\n";
-    conformingType->dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Abstract conformance with bad subject type:\n";
+      conformingType->dump(out);
+    });
   }
 
   // Figure out which arena this should go in.

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1446,8 +1446,7 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
     case TypeKind::BuiltinUnsafeValueBuffer:
       return appendOperator("BB");
     case TypeKind::BuiltinUnboundGeneric:
-      llvm::errs() << "Don't know how to mangle a BuiltinUnboundGenericType\n";
-      abort();
+      ABORT("Don't know how to mangle a BuiltinUnboundGenericType");
     case TypeKind::Locatable: {
       auto loc = cast<LocatableType>(tybase);
       return appendType(loc->getSinglyDesugaredType(), sig, forDecl);
@@ -1756,9 +1755,10 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
     case TypeKind::PackArchetype:
     case TypeKind::ElementArchetype:
     case TypeKind::ExistentialArchetype:
-      llvm::errs() << "Cannot mangle free-standing archetype: ";
-      tybase->dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Cannot mangle free-standing archetype: ";
+        tybase->dump(out);
+      });
 
     case TypeKind::OpaqueTypeArchetype: {
       auto opaqueType = cast<OpaqueTypeArchetypeType>(tybase);
@@ -4468,8 +4468,7 @@ static unsigned conformanceRequirementIndex(
     ++result;
   }
 
-  llvm::errs() <<"Conformance access path step is missing from requirements";
-  abort();
+  ABORT("Conformance access path step is missing from requirements");
 }
 
 void ASTMangler::appendDependentProtocolConformance(
@@ -4573,9 +4572,10 @@ void ASTMangler::appendAnyProtocolConformance(
   } else if (conformance.isPack()) {
     appendPackProtocolConformance(conformance.getPack(), genericSig);
   } else {
-    llvm::errs() << "Bad conformance in mangler: ";
-    conformance.dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Bad conformance in mangler: ";
+      conformance.dump(out);
+    });
   }
 }
 

--- a/lib/AST/ASTScopePrinting.cpp
+++ b/lib/AST/ASTScopePrinting.cpp
@@ -72,7 +72,7 @@ void ASTScopeImpl::dumpOneScopeMapLocation(
 
 void ASTScopeImpl::abortWithVerificationError(
     llvm::function_ref<void(llvm::raw_ostream &)> messageFn) const {
-  abortWithPrettyStackTraceMessage([&](auto &out) {
+  ABORT([&](auto &out) {
     out << "ASTScopeImpl verification error in source file '"
         << getSourceFile()->getFilename() << "':\n";
     messageFn(out);

--- a/lib/AST/AvailabilityScope.cpp
+++ b/lib/AST/AvailabilityScope.cpp
@@ -519,15 +519,16 @@ static void verificationError(
     ASTContext &ctx, llvm::StringRef msg,
     std::initializer_list<std::pair<const char *, const AvailabilityScope *>>
         labelsAndNodes) {
-  llvm::errs() << msg << "\n";
-  for (auto pair : labelsAndNodes) {
-    auto label = std::get<0>(pair);
-    auto scope = std::get<1>(pair);
-    llvm::errs() << label << ":\n";
-    scope->print(llvm::errs(), ctx.SourceMgr);
-    llvm::errs() << "\n";
-  }
-  abort();
+  ABORT([&](auto &out) {
+    out << msg << "\n";
+    for (auto pair : labelsAndNodes) {
+      auto label = std::get<0>(pair);
+      auto scope = std::get<1>(pair);
+      out << label << ":\n";
+      scope->print(out, ctx.SourceMgr);
+      out << "\n";
+    }
+  });
 }
 
 void AvailabilityScope::verify(const AvailabilityScope *parent,

--- a/lib/AST/Bridging/MiscBridging.cpp
+++ b/lib/AST/Bridging/MiscBridging.cpp
@@ -64,8 +64,9 @@ static SwiftMetatype declMetatypes[(unsigned)DeclKind::Last_Decl + 1];
 SwiftMetatype Decl::getDeclMetatype(DeclKind kind) {
   SwiftMetatype metatype = declMetatypes[(unsigned)kind];
   if (declMetatypesInitialized && !metatype) {
-    llvm::errs() << "Decl " << getKindName(kind) << " not registered\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "Decl " << getKindName(kind) << " not registered";
+    });
   }
   return metatype;
 }
@@ -83,9 +84,9 @@ void registerBridgedDecl(BridgedStringRef bridgedClassName,
                       .Default(std::nullopt);
 
   if (!declKind) {
-    llvm::errs() << "Unknown Decl class " << bridgedClassName.unbridged()
-                 << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "Unknown Decl class " << bridgedClassName.unbridged();
+    });
   }
   declMetatypes[(unsigned)declKind.value()] = metatype;
 }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1994,9 +1994,10 @@ unsigned AbstractClosureExpr::getDiscriminator() const {
   }
 
   if (getRawDiscriminator() == InvalidDiscriminator) {
-    llvm::errs() << "Closure does not have an assigned discriminator:\n";
-    dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Closure does not have an assigned discriminator:\n";
+      this->dump(out);
+    });
   }
 
   return getRawDiscriminator();

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -886,15 +886,18 @@ void GenericSignature::verify() const {
 }
 
 void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
-  auto dumpAndAbort = [&]() {
-    llvm::errs() << "All requirements:\n";
-    for (auto reqt : reqts) {
-      reqt.dump(llvm::errs());
-      llvm::errs() << "\n";
-    }
-    getPointer()->getRequirementMachine()->dump(llvm::errs());
-    abort();
-  };
+  auto dumpAndAbort =
+      [&](llvm::function_ref<void(llvm::raw_ostream &)> message) {
+        ABORT([&](auto &out) {
+          message(out);
+          out << "\nAll requirements:\n";
+          for (auto reqt : reqts) {
+            reqt.dump(out);
+            out << "\n";
+          }
+          getPointer()->getRequirementMachine()->dump(out);
+        });
+      };
 
   auto canSig = getCanonicalSignature();
 
@@ -913,17 +916,17 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
     // Left-hand side must be a canonical type parameter.
     if (reqt.getKind() != RequirementKind::SameType) {
       if (!reqt.getFirstType()->isTypeParameter()) {
-        llvm::errs() << "Left-hand side must be a type parameter: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Left-hand side must be a type parameter: ";
+          reqt.dump(out);
+        });
       }
 
       if (!canSig->isReducedType(reqt.getFirstType())) {
-        llvm::errs() << "Left-hand side is not reduced: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Left-hand side is not reduced: ";
+          reqt.dump(out);
+        });
       }
     }
 
@@ -931,40 +934,40 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
     switch (reqt.getKind()) {
     case RequirementKind::SameShape:
       if (!reqt.getFirstType()->is<GenericTypeParamType>()) {
-        llvm::errs() << "Left hand side is not a generic parameter: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Left hand side is not a generic parameter: ";
+          reqt.dump(out);
+        });
       }
 
       if (!reqt.getFirstType()->isRootParameterPack()) {
-        llvm::errs() << "Left hand side is not a parameter pack: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Left hand side is not a parameter pack: ";
+          reqt.dump(out);
+        });
       }
 
       if (!reqt.getSecondType()->is<GenericTypeParamType>()) {
-        llvm::errs() << "Right hand side is not a generic parameter: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Right hand side is not a generic parameter: ";
+          reqt.dump(out);
+        });
       }
 
       if (!reqt.getSecondType()->isRootParameterPack()) {
-        llvm::errs() << "Right hand side is not a parameter pack: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Right hand side is not a parameter pack: ";
+          reqt.dump(out);
+        });
       }
 
       break;
     case RequirementKind::Superclass:
       if (!canSig->isReducedType(reqt.getSecondType())) {
-        llvm::errs() << "Right-hand side is not reduced: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Right-hand side is not reduced: ";
+          reqt.dump(out);
+        });
       }
       break;
 
@@ -987,53 +990,53 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
       auto &component = sameTypeComponents[canType];
 
       if (!hasReducedOrConcreteParent(firstType)) {
-        llvm::errs() << "Left hand side does not have a reduced parent: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Left hand side does not have a reduced parent: ";
+          reqt.dump(out);
+        });
       }
 
       if (reqt.getSecondType()->isTypeParameter()) {
         if (!hasReducedOrConcreteParent(secondType)) {
-          llvm::errs() << "Right hand side does not have a reduced parent: ";
-          reqt.dump(llvm::errs());
-          llvm::errs() << "\n";
-          dumpAndAbort();
+          dumpAndAbort([&](auto &out) {
+            out << "Right hand side does not have a reduced parent: ";
+            reqt.dump(out);
+          });
         }
 
         if (compareDependentTypes(firstType, secondType) >= 0) {
-          llvm::errs() << "Out-of-order type parameters: ";
-          reqt.dump(llvm::errs());
-          llvm::errs() << "\n";
-          dumpAndAbort();
+          dumpAndAbort([&](auto &out) {
+            out << "Out-of-order type parameters: ";
+            reqt.dump(out);
+          });
         }
 
         if (component.empty()) {
           component.push_back(firstType);
         } else if (!component.back()->isEqual(firstType)) {
-          llvm::errs() << "Same-type requirement within an equiv. class "
-                       << "is out-of-order: ";
-          reqt.dump(llvm::errs());
-          llvm::errs() << "\n";
-          dumpAndAbort();
+          dumpAndAbort([&](auto &out) {
+            out << "Same-type requirement within an equiv. class "
+                << "is out-of-order: ";
+            reqt.dump(out);
+          });
         }
 
         component.push_back(secondType);
       } else {
         if (!canSig->isReducedType(secondType)) {
-          llvm::errs() << "Right hand side is not reduced: ";
-          reqt.dump(llvm::errs());
-          llvm::errs() << "\n";
-          dumpAndAbort();
+          dumpAndAbort([&](auto &out) {
+            out << "Right hand side is not reduced: ";
+            reqt.dump(out);
+          });
         }
 
         if (component.empty()) {
           component.push_back(secondType);
         } else if (!component.back()->isEqual(secondType)) {
-          llvm::errs() << "Inconsistent concrete requirement in equiv. class: ";
-          reqt.dump(llvm::errs());
-          llvm::errs() << "\n";
-          dumpAndAbort();
+          dumpAndAbort([&](auto &out) {
+            out << "Inconsistent concrete requirement in equiv. class: ";
+            reqt.dump(out);
+          });
         }
       }
       break;
@@ -1054,10 +1057,10 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
     int compareLHS =
       compareDependentTypes(prevReqt.getFirstType(), reqt.getFirstType());
     if (compareLHS > 0) {
-      llvm::errs() << "Out-of-order left-hand side: ";
-      reqt.dump(llvm::errs());
-      llvm::errs() << "\n";
-      dumpAndAbort();
+      dumpAndAbort([&](auto &out) {
+        out << "Out-of-order left-hand side: ";
+        reqt.dump(out);
+      });
     }
 
     // If we have a concrete same-type requirement, we shouldn't have any
@@ -1065,19 +1068,19 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
     if (reqt.getKind() == RequirementKind::SameType &&
         !reqt.getSecondType()->isTypeParameter()) {
       if (compareLHS >= 0) {
-        llvm::errs() << "Concrete subject type should not have "
-                     << "any other requirements: ";
-        reqt.dump(llvm::errs());
-        llvm::errs() << "\n";
-        dumpAndAbort();
+        dumpAndAbort([&](auto &out) {
+          out << "Concrete subject type should not have "
+              << "any other requirements: ";
+          reqt.dump(out);
+        });
       }
     }
 
     if (prevReqt.compare(reqt) >= 0) {
-      llvm::errs() << "Out-of-order requirement: ";
-      reqt.dump(llvm::errs());
-      llvm::errs() << "\n";
-      dumpAndAbort();
+      dumpAndAbort([&](auto &out) {
+        out << "Out-of-order requirement: ";
+        reqt.dump(out);
+      });
     }
   }
 
@@ -1092,19 +1095,21 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
     ProtocolType::canonicalizeProtocols(canonicalProtos);
 
     if (protos.size() != canonicalProtos.size()) {
-      llvm::errs() << "Redundant conformance requirements in signature "
-                   << *this << ":\n";
-      llvm::errs() << "Ours:\n";
-      for (auto *proto : protos)
-        llvm::errs() << "- " << proto->getName() << "\n";
-      llvm::errs() << "Theirs:\n";
-      for (auto *proto : canonicalProtos)
-        llvm::errs() << "- " << proto->getName() << "\n";
-      dumpAndAbort();
+      dumpAndAbort([&](auto &out) {
+        out << "Redundant conformance requirements in signature " << *this
+            << ":\n";
+        out << "Ours:\n";
+        for (auto *proto : protos)
+          out << "- " << proto->getName() << "\n";
+        out << "Theirs:\n";
+        for (auto *proto : canonicalProtos)
+          out << "- " << proto->getName();
+      });
     }
     if (!std::equal(protos.begin(), protos.end(), canonicalProtos.begin())) {
-      llvm::errs() << "Out-of-order conformance requirements\n";
-      dumpAndAbort();
+      dumpAndAbort([&](auto &out) {
+        out << "Out-of-order conformance requirements";
+      });
     }
   }
 
@@ -1112,11 +1117,11 @@ void GenericSignature::verify(ArrayRef<Requirement> reqts) const {
   for (const auto &pair : sameTypeComponents) {
     if (pair.second.front()->isTypeParameter() &&
         !canSig->isReducedType(pair.second.front())) {
-      llvm::errs() << "Abstract same-type requirement involving concrete types\n";
-      llvm::errs() << "Reduced type: " << pair.first << "\n";
-      llvm::errs() << "Left hand side of first requirement: "
-                   << pair.second.front() << "\n";
-      dumpAndAbort();
+      dumpAndAbort([&](auto &out) {
+        out << "Abstract same-type requirement involving concrete types\n";
+        out << "Reduced type: " << pair.first << "\n";
+        out << "Left hand side of first requirement: " << pair.second.front();
+      });
     }
   }
 }

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1162,10 +1162,6 @@ static Requirement stripBoundDependentMemberTypes(Requirement req) {
 
 void swift::validateGenericSignature(ASTContext &context,
                                      GenericSignature sig) {
-  llvm::errs() << "Validating generic signature: ";
-  sig->print(llvm::errs());
-  llvm::errs() << "\n";
-
   // Try building a new signature having the same requirements.
   SmallVector<GenericTypeParamType *, 2> genericParams;
   for (auto *genericParam :  sig.getGenericParams())

--- a/lib/AST/LocalArchetypeRequirementCollector.cpp
+++ b/lib/AST/LocalArchetypeRequirementCollector.cpp
@@ -183,9 +183,10 @@ Type MapLocalArchetypesOutOfContext::getInterfaceType(
     ++depth;
   }
 
-  llvm::errs() << "Fell off the end:\n";
-  interfaceTy->dump(llvm::errs());
-  abort();
+  ABORT([&](auto &out) {
+    out << "Fell off the end:\n";
+    interfaceTy->dump(out);
+  });
 }
 
 Type MapLocalArchetypesOutOfContext::operator()(SubstitutableType *type) const {

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -380,10 +380,11 @@ unsigned ParameterList::getOrigParamIndex(SubstitutionMap subMap,
     remappedIndex -= substCount;
   }
 
-  llvm::errs() << "Invalid substituted argument index: " << substIndex << "\n";
-  subMap.dump(llvm::errs());
-  dump(llvm::errs());
-  abort();
+  ABORT([&](auto &out) {
+    out << "Invalid substituted argument index: " << substIndex << "\n";
+    subMap.dump(out);
+    dump(out);
+  });
 }
 
 /// <T...> Foo<T, Pack{Int, String}> => Pack{T..., Int, String}

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -255,10 +255,11 @@ int Requirement::compare(const Requirement &other) const {
 
   // We should only have multiple conformance requirements.
   if (getKind() != RequirementKind::Conformance) {
-    llvm::errs() << "Unordered generic requirements\n";
-    llvm::errs() << "LHS: "; dump(llvm::errs()); llvm::errs() << "\n";
-    llvm::errs() << "RHS: "; other.dump(llvm::errs()); llvm::errs() << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "Unordered generic requirements\n";
+      out << "LHS: "; dump(out); out << "\n";
+      out << "RHS: "; other.dump(out);
+    });
   }
 
   int compareProtos =

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -249,12 +249,13 @@ void PropertyMap::concretizeTypeWitnessInConformance(
   } else if (conformance.isAbstract()) {
     auto archetype = concreteType->getAs<OpaqueTypeArchetypeType>();
     if (archetype == nullptr) {
-      llvm::errs() << "Should only have an abstract conformance with an "
-                   << "opaque archetype type\n";
-      llvm::errs() << "Symbol: " << concreteConformanceSymbol << "\n";
-      llvm::errs() << "Term: " << key << "\n";
-      dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Should only have an abstract conformance with an opaque "
+            << "archetype type\n";
+        out << "Symbol: " << concreteConformanceSymbol << "\n";
+        out << "Term: " << key << "\n";
+        dump(out);
+      });
     }
 
     typeWitness = archetype->getNestedType(assocType)->getCanonicalType();

--- a/lib/AST/RequirementMachine/Diagnostics.cpp
+++ b/lib/AST/RequirementMachine/Diagnostics.cpp
@@ -308,8 +308,9 @@ getRequirementForDiagnostics(Type subject, Symbol property,
                        property.getLayoutConstraint());
 
   default:
-    llvm::errs() << "Bad property symbol: " << property << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "Bad property symbol: " << property;
+    });
   }
 }
 

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -730,11 +730,11 @@ void RewriteSystem::verifyRedundantConformances(
            "Redundant conformance is not a conformance rule?");
 
     if (!rule.isRedundant()) {
-      llvm::errs() << "Homotopy reduction did not eliminate redundant "
-                   << "conformance?\n";
-      llvm::errs() << "(#" << ruleID << ") " << rule << "\n\n";
-      dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Homotopy reduction did not eliminate redundant conformance?\n";
+        out << "(#" << ruleID << ") " << rule << "\n\n";
+        dump(out);
+      });
     }
   }
 }
@@ -752,10 +752,11 @@ void RewriteSystem::verifyMinimizedRules(
     // Ignore the rewrite rule if it is not part of our minimization domain.
     if (!isInMinimizationDomain(rule.getLHS().getRootProtocol())) {
       if (rule.isRedundant()) {
-        llvm::errs() << "Redundant rule outside minimization domain: "
-                     << rule << "\n\n";
-        dump(llvm::errs());
-        abort();
+        ABORT([&](auto &out) {
+          out << "Redundant rule outside minimization domain: " << rule
+              << "\n\n";
+          dump(out);
+        });
       }
 
       continue;
@@ -765,9 +766,10 @@ void RewriteSystem::verifyMinimizedRules(
     // be redundant.
     if (rule.isPermanent()) {
       if (rule.isRedundant()) {
-        llvm::errs() << "Permanent rule is redundant: " << rule << "\n\n";
-        dump(llvm::errs());
-        abort();
+        ABORT([&](auto &out) {
+          out << "Permanent rule is redundant: " << rule << "\n\n";
+          dump(out);
+        });
       }
 
       continue;
@@ -783,18 +785,20 @@ void RewriteSystem::verifyMinimizedRules(
     if (rule.isLHSSimplified() &&
         !rule.isRedundant() &&
         !rule.isProtocolConformanceRule()) {
-      llvm::errs() << "Simplified rule is not redundant: " << rule << "\n\n";
-      dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Simplified rule is not redundant: " << rule << "\n\n";
+        dump(out);
+      });
     }
 
     // RHS-simplified and substitution-simplified rules should be redundant.
     if ((rule.isRHSSimplified() ||
          rule.isSubstitutionSimplified()) &&
         !rule.isRedundant()) {
-      llvm::errs() << "Simplified rule is not redundant: " << rule << "\n\n";
-      dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Simplified rule is not redundant: " << rule << "\n\n";
+        dump(out);
+      });
     }
 
     if (rule.isRedundant() &&
@@ -803,17 +807,19 @@ void RewriteSystem::verifyMinimizedRules(
         !rule.isSubstitutionSimplified() &&
         !rule.containsNameSymbols() &&
         !redundantConformances.count(ruleID)) {
-      llvm::errs() << "Minimal conformance is redundant: " << rule << "\n\n";
-      dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Minimal conformance is redundant: " << rule << "\n\n";
+        dump(out);
+      });
     }
   }
 
   if (RedundantRules.size() != redundantRuleCount) {
-    llvm::errs() << "Expected " << RedundantRules.size() << " redundant rules "
-                 << "but counted " << redundantRuleCount << "\n";
-    dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Expected " << RedundantRules.size() << " redundant rules "
+          << "but counted " << redundantRuleCount << "\n";
+      dump(out);
+    });
   }
 
   // Replacement paths for redundant rules can only reference other redundant
@@ -823,10 +829,11 @@ void RewriteSystem::verifyMinimizedRules(
   for (const auto &pair : llvm::reverse(RedundantRules)) {
     const auto &rule = getRule(pair.first);
     if (!rule.isRedundant()) {
-      llvm::errs() << "Recorded replacement path for non-redundant rule "
-                   << rule << "\n";
-      dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Recorded replacement path for non-redundant rule " << rule
+            << "\n";
+        dump(out);
+      });
     }
 
     for (const auto &step : pair.second) {
@@ -835,10 +842,11 @@ void RewriteSystem::verifyMinimizedRules(
         const auto &otherRule = getRule(otherRuleID);
         if (otherRule.isRedundant() &&
             !laterRedundantRules.count(otherRuleID)) {
-          llvm::errs() << "Redundant requirement path contains a redundant "
-                          "rule " << otherRule << "\n";
-          dump(llvm::errs());
-          abort();
+          ABORT([&](auto &out) {
+            out << "Redundant requirement path contains a redundant rule "
+                << otherRule << "\n";
+            dump(out);
+          });
         }
       }
     }

--- a/lib/AST/RequirementMachine/InterfaceType.cpp
+++ b/lib/AST/RequirementMachine/InterfaceType.cpp
@@ -250,15 +250,14 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
       unsigned index = GenericParamKey(genericParam).findIndexIn(genericParams);
 
       if (index == genericParams.size()) {
-        llvm::errs() << "Cannot build interface type for term "
-                     << MutableTerm(begin, end) << "\n";
-        llvm::errs() << "Invalid generic parameter: "
-                     << Type(genericParam) << "\n";
-        llvm::errs() << "Valid generic parameters: ";
-        for (auto *otherParam : genericParams)
-          llvm::errs() << " " << otherParam->getCanonicalType();
-        llvm::errs() << "\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Cannot build interface type for term "
+              << MutableTerm(begin, end) << "\n";
+          out << "Invalid generic parameter: " << Type(genericParam) << "\n";
+          out << "Valid generic parameters: ";
+          for (auto *otherParam : genericParams)
+            out << " " << otherParam->getCanonicalType();
+        });
       }
 
       result = genericParams[index];
@@ -300,8 +299,9 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
       case Symbol::Kind::ConcreteType:
       case Symbol::Kind::ConcreteConformance:
       case Symbol::Kind::Shape:
-        llvm::errs() << "Invalid root symbol: " << MutableTerm(begin, end) << "\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Invalid root symbol: " << MutableTerm(begin, end);
+        });
       }
     }
 
@@ -348,12 +348,12 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
 
     auto *props = map.lookUpProperties(prefix.rbegin(), prefix.rend());
     if (props == nullptr) {
-      llvm::errs() << "Cannot build interface type for term "
-                   << MutableTerm(begin, end) << "\n";
-      llvm::errs() << "Prefix does not conform to any protocols: "
-                   << prefix << "\n\n";
-      map.dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Cannot build interface type for term "
+            << MutableTerm(begin, end) << "\n";
+        out << "Prefix does not conform to any protocols: " << prefix << "\n\n";
+        map.dump(out);
+      });
     }
 
     // Assert that the associated type's protocol appears among the set
@@ -367,16 +367,16 @@ getTypeForSymbolRange(const Symbol *begin, const Symbol *end,
 
     auto *assocType = props->getAssociatedType(symbol.getName());
     if (assocType == nullptr) {
-      llvm::errs() << "Cannot build interface type for term "
-                   << MutableTerm(begin, end) << "\n";
-      llvm::errs() << "Prefix term does not have a nested type named "
-                   << symbol.getName() << ": "
-                   << prefix << "\n";
-      llvm::errs() << "Property map entry: ";
-      props->dump(llvm::errs());
-      llvm::errs() << "\n\n";
-      map.dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Cannot build interface type for term "
+            << MutableTerm(begin, end) << "\n";
+        out << "Prefix term does not have a nested type named "
+            << symbol.getName() << ": " << prefix << "\n";
+        out << "Property map entry: ";
+        props->dump(out);
+        out << "\n\n";
+        map.dump(out);
+      });
     }
 
     result = DependentMemberType::get(result, assocType);
@@ -487,18 +487,18 @@ Type PropertyMap::getTypeFromSubstitutionSchema(
           bool isShapePosition = (pos == TypePosition::Shape);
           bool isShapeTerm = (substitution.back() == Symbol::forShape(Context));
           if (isShapePosition != isShapeTerm) {
-            llvm::errs() << "Shape vs. type mixup\n\n";
-            schema.dump(llvm::errs());
-            llvm::errs() << "Substitutions:\n";
-            for (auto otherSubst : substitutions) {
-              llvm::errs() << "- ";
-              otherSubst.dump(llvm::errs());
-              llvm::errs() << "\n";
-            }
-            llvm::errs() << "\n";
-            dump(llvm::errs());
-
-            abort();
+            ABORT([&](auto &out) {
+              out << "Shape vs. type mixup\n\n";
+              schema.dump(out);
+              out << "Substitutions:\n";
+              for (auto otherSubst : substitutions) {
+                out << "- ";
+                otherSubst.dump(out);
+                out << "\n";
+              }
+              out << "\n";
+              dump(out);
+            });
           }
 
           // Undo the thing where the count type of a PackExpansionType

--- a/lib/AST/RequirementMachine/PropertyMap.cpp
+++ b/lib/AST/RequirementMachine/PropertyMap.cpp
@@ -364,14 +364,14 @@ PropertyMap::getOrCreateProperties(Term key) {
   Entries.push_back(props);
   auto oldProps = Trie.insert(key.rbegin(), key.rend(), props);
   if (oldProps) {
-    llvm::errs() << "Duplicate property map entry for " << key << "\n";
-    llvm::errs() << "Old:\n";
-    (*oldProps)->dump(llvm::errs());
-    llvm::errs() << "\n";
-    llvm::errs() << "New:\n";
-    props->dump(llvm::errs());
-    llvm::errs() << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "Duplicate property map entry for " << key << "\n";
+      out << "Old:\n";
+      (*oldProps)->dump(out);
+      out << "\n";
+      out << "New:\n";
+      props->dump(out);
+    });
   }
 
   return props;

--- a/lib/AST/RequirementMachine/PropertyUnification.cpp
+++ b/lib/AST/RequirementMachine/PropertyUnification.cpp
@@ -221,9 +221,7 @@ void PropertyMap::addLayoutProperty(
 
     props->LayoutRule = ruleID;
   } else {
-    llvm::errs() << "Arbitrary intersection of layout requirements is "
-                 << "supported yet\n";
-    abort();
+    ABORT("Arbitrary intersection of layout requirements isn't supported yet");
   }
 }
 

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -231,19 +231,22 @@ void RequirementMachine::checkCompletionResult(CompletionResult result) const {
     break;
 
   case CompletionResult::MaxRuleCount:
-    llvm::errs() << "Rewrite system exceeded maximum rule count\n";
-    dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Rewrite system exceeded maximum rule count\n";
+      dump(out);
+    });
 
   case CompletionResult::MaxRuleLength:
-    llvm::errs() << "Rewrite system exceeded rule length limit\n";
-    dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Rewrite system exceeded rule length limit\n";
+      dump(out);
+    });
 
   case CompletionResult::MaxConcreteNesting:
-    llvm::errs() << "Rewrite system exceeded concrete type nesting depth limit\n";
-    dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Rewrite system exceeded concrete type nesting depth limit\n";
+      dump(out);
+    });
   }
 }
 

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -163,15 +163,16 @@ static void splitConcreteEquivalenceClasses(
       ctx.LangOpts.RequirementMachineMaxSplitConcreteEquivClassAttempts;
 
   if (attempt >= maxAttempts) {
-    llvm::errs() << "Splitting concrete equivalence classes did not "
-                 << "reach fixed point after " << attempt << " attempts.\n";
-    llvm::errs() << "Last attempt produced these requirements:\n";
-    for (auto req : requirements) {
-      req.dump(llvm::errs());
-      llvm::errs() << "\n";
-    }
-    machine->dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Splitting concrete equivalence classes did not "
+          << "reach fixed point after " << attempt << " attempts.\n";
+      out << "Last attempt produced these requirements:\n";
+      for (auto req : requirements) {
+        req.dump(out);
+        out << "\n";
+      }
+      machine->dump(out);
+    });
   }
 
   splitRequirements.clear();

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -267,9 +267,9 @@ RequirementMachine *RewriteContext::getRequirementMachine(
   auto &machine = Machines[sig];
   if (machine) {
     if (!machine->isComplete()) {
-      llvm::errs() << "Re-entrant construction of requirement "
-                   << "machine for " << sig << "\n";
-      abort();
+      ABORT([&](auto &out) {
+        out << "Re-entrant construction of requirement machine for " << sig;
+      });
     }
 
     return machine;
@@ -433,10 +433,8 @@ RewriteContext::getProtocolComponentImpl(const ProtocolDecl *proto) {
 
   auto found = Protos.find(proto);
   if (found == Protos.end()) {
-    if (ProtectProtocolComponentRec) {
-      llvm::errs() << "Too much recursion is bad\n";
-      abort();
-    }
+    if (ProtectProtocolComponentRec)
+      ABORT("Too much recursion is bad");
 
     ProtectProtocolComponentRec = true;
 
@@ -469,11 +467,11 @@ RewriteContext::startComputingRequirementSignatures(
   auto &component = getProtocolComponentImpl(proto);
 
   if (component.ComputingRequirementSignatures) {
-    llvm::errs() << "Re-entrant minimization of requirement signatures for: ";
-    for (auto *proto : component.Protos)
-      llvm::errs() << " " << proto->getName();
-    llvm::errs() << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "Re-entrant minimization of requirement signatures for: ";
+      for (auto *proto : component.Protos)
+        out << " " << proto->getName();
+    });
   }
 
   component.ComputingRequirementSignatures = true;
@@ -508,11 +506,11 @@ RequirementMachine *RewriteContext::getRequirementMachine(
 
   if (component.Machine) {
     if (!component.Machine->isComplete()) {
-      llvm::errs() << "Re-entrant construction of requirement machine for: ";
-      for (auto *proto : component.Protos)
-        llvm::errs() << " " << proto->getName();
-      llvm::errs() << "\n";
-      abort();
+      ABORT([&](auto &out) {
+        out << "Re-entrant construction of requirement machine for: ";
+        for (auto *proto : component.Protos)
+          out << " " << proto->getName();
+      });
     }
 
     return component.Machine;

--- a/lib/AST/RequirementMachine/RewriteSystem.cpp
+++ b/lib/AST/RequirementMachine/RewriteSystem.cpp
@@ -261,17 +261,18 @@ bool RewriteSystem::addRule(MutableTerm lhs, MutableTerm rhs,
 
   auto oldRuleID = Trie.insert(lhs.begin(), lhs.end(), newRuleID);
   if (oldRuleID) {
-    llvm::errs() << "Duplicate rewrite rule!\n";
-    const auto &oldRule = getRule(*oldRuleID);
-    llvm::errs() << "Old rule #" << *oldRuleID << ": ";
-    oldRule.dump(llvm::errs());
-    llvm::errs() << "\nTrying to replay what happened when I simplified this term:\n";
-    Debug |= DebugFlags::Simplify;
-    MutableTerm term = lhs;
-    simplify(lhs);
+    ABORT([&](auto &out) {
+      out << "Duplicate rewrite rule!\n";
+      const auto &oldRule = getRule(*oldRuleID);
+      out << "Old rule #" << *oldRuleID << ": ";
+      oldRule.dump(out);
+      out << "\nTrying to replay what happened when I simplified this term:\n";
+      Debug |= DebugFlags::Simplify;
+      MutableTerm term = lhs;
+      simplify(lhs);
 
-    dump(llvm::errs());
-    abort();
+      dump(out);
+    });
   }
 
   // Tell the caller that we added a new rule.
@@ -339,12 +340,13 @@ void RewriteSystem::addRules(
                                  newRule.getLHS().end(),
                                  newRuleID);
     if (oldRuleID) {
-      llvm::errs() << "Imported rules have duplicate left hand sides!\n";
-      llvm::errs() << "New rule #" << newRuleID << ": " << newRule << "\n";
-      const auto &oldRule = getRule(*oldRuleID);
-      llvm::errs() << "Old rule #" << *oldRuleID << ": " << oldRule << "\n\n";
-      dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Imported rules have duplicate left hand sides!\n";
+        out << "New rule #" << newRuleID << ": " << newRule << "\n";
+        const auto &oldRule = getRule(*oldRuleID);
+        out << "Old rule #" << *oldRuleID << ": " << oldRule << "\n\n";
+        dump(out);
+      });
     }
   }
 
@@ -505,12 +507,13 @@ void RewriteSystem::recordRewriteLoop(MutableTerm basepoint,
 }
 
 void RewriteSystem::verifyRewriteRules(ValidityPolicy policy) const {
-#define ASSERT_RULE(expr) \
-  if (!(expr)) { \
-    llvm::errs() << "&&& Malformed rewrite rule: " << rule << "\n"; \
-    llvm::errs() << "&&& " << #expr << "\n\n"; \
-    dump(llvm::errs()); \
-    abort(); \
+#define ASSERT_RULE(expr)                                                      \
+  if (!(expr)) {                                                               \
+    ABORT([&](auto &out) {                                                     \
+      out << "&&& Malformed rewrite rule: " << rule << "\n";                   \
+      out << "&&& " << #expr << "\n\n";                                        \
+      dump(out);                                                               \
+    });                                                                        \
   }
 
   for (const auto &rule : getLocalRules()) {

--- a/lib/AST/RequirementMachine/SimplifySubstitutions.cpp
+++ b/lib/AST/RequirementMachine/SimplifySubstitutions.cpp
@@ -262,10 +262,11 @@ void RewriteSystem::processTypeDifference(const TypeDifference &difference,
   if (lhsRule.getRHS() == difference.BaseTerm &&
       !lhsRule.isSubstitutionSimplified()) {
     if (lhsRule.isFrozen()) {
-      llvm::errs() << "Frozen rule should already be subst-simplified: "
-                   << lhsRule << "\n\n";
-      dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Frozen rule should already be subst-simplified: " << lhsRule
+            << "\n\n";
+        dump(out);
+      });
     }
     lhsRule.markSubstitutionSimplified();
   }

--- a/lib/AST/RequirementMachine/Symbol.cpp
+++ b/lib/AST/RequirementMachine/Symbol.cpp
@@ -613,10 +613,11 @@ std::optional<int> Symbol::compare(Symbol other, RewriteContext &ctx) const {
   }
 
   if (result == 0) {
-    llvm::errs() << "Two distinct symbols should not compare equal\n";
-    llvm::errs() << "LHS: " << *this << "\n";
-    llvm::errs() << "RHS: " << other << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "Two distinct symbols should not compare equal\n";
+      out << "LHS: " << *this << "\n";
+      out << "RHS: " << other;
+    });
   }
 
   return result;
@@ -646,8 +647,9 @@ Symbol Symbol::withConcreteSubstitutions(
     break;
   }
 
-  llvm::errs() << "Bad symbol kind: " << *this << "\n";
-  abort();
+  ABORT([&](auto &out) {
+    out << "Bad symbol kind: " << *this;
+  });
 }
 
 /// For a superclass or concrete type symbol

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -63,9 +63,9 @@ MutableTerm TypeDifference::getReplacementSubstitution(unsigned index) const {
 }
 
 void TypeDifference::dump(llvm::raw_ostream &out) const {
-  llvm::errs() << "Base term: " << BaseTerm << "\n";
-  llvm::errs() << "LHS: " << LHS << "\n";
-  llvm::errs() << "RHS: " << RHS << "\n";
+  out << "Base term: " << BaseTerm << "\n";
+  out << "LHS: " << LHS << "\n";
+  out << "RHS: " << RHS << "\n";
 
   for (const auto &pair : SameTypes) {
     out << "- " << getOriginalSubstitution(pair.first) << " (#";

--- a/lib/AST/RequirementMachine/TypeDifference.cpp
+++ b/lib/AST/RequirementMachine/TypeDifference.cpp
@@ -79,11 +79,12 @@ void TypeDifference::dump(llvm::raw_ostream &out) const {
 }
 
 void TypeDifference::verify(RewriteContext &ctx) const {
-#define VERIFY(expr, str) \
-  if (!(expr)) { \
-    llvm::errs() << "TypeDifference::verify(): " << str << "\n"; \
-    dump(llvm::errs()); \
-    abort(); \
+#define VERIFY(expr, str)                                                      \
+  if (!(expr)) {                                                               \
+    ABORT([&](auto &out) {                                                     \
+      out << "TypeDifference::verify(): " << str << "\n";                      \
+      dump(out);                                                               \
+    });                                                                        \
   }
 
   VERIFY(LHS.getKind() == RHS.getKind(), "Kind mismatch");
@@ -214,12 +215,13 @@ namespace {
     }
 
     void verify() const {
-#define VERIFY(expr, str) \
-  if (!(expr)) { \
-    llvm::errs() << "ConcreteTypeMatcher::verify(): " << str << "\n"; \
-    dump(llvm::errs()); \
-    abort(); \
-  }
+#define VERIFY(expr, str)                                                      \
+    if (!(expr)) {                                                             \
+      ABORT([&](auto &out) {                                                   \
+        out << "ConcreteTypeMatcher::verify(): " << str << "\n";               \
+        dump(out);                                                             \
+      });                                                                      \
+    }
 
       llvm::DenseSet<unsigned> lhsVisited;
       llvm::DenseSet<unsigned> rhsVisited;
@@ -460,16 +462,17 @@ bool RewriteSystem::computeTypeDifference(
   if (!isConflict) {
     // The meet operation should be commutative.
     if (lhsMeetRhs.RHS != rhsMeetLhs.RHS) {
-      llvm::errs() << "Meet operation was not commutative:\n\n";
+      ABORT([&](auto &out) {
+        out << "Meet operation was not commutative:\n\n";
 
-      llvm::errs() << "LHS: " << lhs << "\n";
-      llvm::errs() << "RHS: " << rhs << "\n";
-      matcher.dump(llvm::errs());
+        out << "LHS: " << lhs << "\n";
+        out << "RHS: " << rhs << "\n";
+        matcher.dump(out);
 
-      llvm::errs() << "\n";
-      llvm::errs() << "LHS ∧ RHS: " << lhsMeetRhs.RHS << "\n";
-      llvm::errs() << "RHS ∧ LHS: " << rhsMeetLhs.RHS << "\n";
-      abort();
+        out << "\n";
+        out << "LHS ∧ RHS: " << lhsMeetRhs.RHS << "\n";
+        out << "RHS ∧ LHS: " << rhsMeetLhs.RHS;
+      });
     }
 
     // The meet operation should be idempotent.
@@ -483,16 +486,17 @@ bool RewriteSystem::computeTypeDifference(
       lhsMeetLhsMeetRhs.verify(Context);
 
       if (lhsMeetRhs.RHS != lhsMeetLhsMeetRhs.RHS) {
-        llvm::errs() << "Meet operation was not idempotent:\n\n";
+        ABORT([&](auto &out) {
+          out << "Meet operation was not idempotent:\n\n";
 
-        llvm::errs() << "LHS: " << lhs << "\n";
-        llvm::errs() << "RHS: " << rhs << "\n";
-        matcher.dump(llvm::errs());
+          out << "LHS: " << lhs << "\n";
+          out << "RHS: " << rhs << "\n";
+          matcher.dump(out);
 
-        llvm::errs() << "\n";
-        llvm::errs() << "LHS ∧ RHS: " << lhsMeetRhs.RHS << "\n";
-        llvm::errs() << "LHS ∧ (LHS ∧ RHS): " << lhsMeetLhsMeetRhs.RHS << "\n";
-        abort();
+          out << "\n";
+          out << "LHS ∧ RHS: " << lhsMeetRhs.RHS << "\n";
+          out << "LHS ∧ (LHS ∧ RHS): " << lhsMeetLhsMeetRhs.RHS;
+        });
       }
     }
 
@@ -506,16 +510,17 @@ bool RewriteSystem::computeTypeDifference(
       rhsMeetRhsMeetRhs.verify(Context);
 
       if (lhsMeetRhs.RHS != rhsMeetRhsMeetRhs.RHS) {
-        llvm::errs() << "Meet operation was not idempotent:\n\n";
+        ABORT([&](auto &out) {
+          out << "Meet operation was not idempotent:\n\n";
 
-        llvm::errs() << "LHS: " << lhs << "\n";
-        llvm::errs() << "RHS: " << rhs << "\n";
-        matcher.dump(llvm::errs());
+          out << "LHS: " << lhs << "\n";
+          out << "RHS: " << rhs << "\n";
+          matcher.dump(out);
 
-        llvm::errs() << "\n";
-        llvm::errs() << "RHS ∧ LHS: " << rhsMeetLhs.RHS << "\n";
-        llvm::errs() << "RHS ∧ (RHS ∧ LHS): " << rhsMeetRhsMeetRhs.RHS << "\n";
-        abort();
+          out << "\n";
+          out << "RHS ∧ LHS: " << rhsMeetLhs.RHS << "\n";
+          out << "RHS ∧ (RHS ∧ LHS): " << rhsMeetRhsMeetRhs.RHS;
+        });
       }
     }
   }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -505,10 +505,10 @@ void SubstitutionMap::verify(bool allowInvalid) const {
 
     if (conformance.isInvalid()) {
       if (!allowInvalid) {
-        llvm::errs() << "Unexpected invalid conformance in substitution map:\n";
-        dump(llvm::dbgs());
-        llvm::errs() << "\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Unexpected invalid conformance in substitution map:\n";
+          dump(out);
+        });
       }
 
       continue;
@@ -522,10 +522,10 @@ void SubstitutionMap::verify(bool allowInvalid) const {
           !substType->is<UnresolvedType>() &&
           !substType->is<PlaceholderType>() &&
           !substType->is<ErrorType>()) {
-        llvm::errs() << "Unexpected abstract conformance in substitution map:\n";
-        dump(llvm::errs());
-        llvm::errs() << "\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Unexpected abstract conformance in substitution map:\n";
+          dump(out);
+        });
       }
 
       continue;
@@ -550,12 +550,12 @@ void SubstitutionMap::verify(bool allowInvalid) const {
         if (substType->getSuperclass())
           continue;
 
-        llvm::errs() << "Expected to find a self conformance:\n";
-        substType->dump(llvm::errs());
-        llvm::errs() << "Substitution map:\n";
-        dump(llvm::errs());
-        llvm::errs() << "\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Expected to find a self conformance:\n";
+          substType->dump(out);
+          out << "Substitution map:\n";
+          dump(out);
+        });
       }
 
       continue;
@@ -565,14 +565,14 @@ void SubstitutionMap::verify(bool allowInvalid) const {
       continue;
 
     if (!concrete->getType()->isEqual(substType)) {
-      llvm::errs() << "Conformance with wrong conforming type:\n";
-      concrete->getType()->dump(llvm::errs());
-      llvm::errs() << "Should be:\n";
-      substType->dump(llvm::errs());
-      llvm::errs() << "Substitution map:\n";
-      dump(llvm::errs());
-      llvm::errs() << "\n";
-      abort();
+      ABORT([&](auto &out) {
+        out << "Conformance with wrong conforming type:\n";
+        concrete->getType()->dump(out);
+        out << "Should be:\n";
+        substType->dump(out);
+        out << "Substitution map:\n";
+        dump(out);
+      });
     }
   }
 }

--- a/lib/Basic/Assertions.cpp
+++ b/lib/Basic/Assertions.cpp
@@ -34,6 +34,24 @@ int CONDITIONAL_ASSERT_Global_enable_flag =
   1; // Default to `on` in debug builds
 #endif
 
+static void ASSERT_help() {
+  static int ASSERT_help_shown = 0;
+  if (ASSERT_help_shown) {
+    return;
+  }
+  ASSERT_help_shown = 1;
+
+  if (!AssertHelp) {
+    llvm::errs() << "(to display assertion configuration options: -Xllvm -assert-help)\n";
+    return;
+  }
+
+  llvm::errs() << "\n";
+  llvm::errs() << "Control assertion behavior with one or more of the following options:\n\n";
+  llvm::errs() << " -Xllvm -assert-continue\n";
+  llvm::errs() << "     Continue after any failed assertion\n\n";
+}
+
 void ASSERT_failure(const char *expr, const char *filename, int line, const char *func) {
   // Find the last component of `filename`
   // Needed on Windows MSVC, which lacks __FILE_NAME__
@@ -60,24 +78,6 @@ void ASSERT_failure(const char *expr, const char *filename, int line, const char
   }
 
   abort();
-}
-
-void ASSERT_help() {
-  static int ASSERT_help_shown = 0;
-  if (ASSERT_help_shown) {
-    return;
-  }
-  ASSERT_help_shown = 1;
-
-  if (!AssertHelp) {
-    llvm::errs() << "(to display assertion configuration options: -Xllvm -assert-help)\n";
-    return;
-  }
-
-  llvm::errs() << "\n";
-  llvm::errs() << "Control assertion behavior with one or more of the following options:\n\n";
-  llvm::errs() << " -Xllvm -assert-continue\n";
-  llvm::errs() << "     Continue after any failed assertion\n\n";
 }
 
 // This has to be callable in the same way as the macro version,

--- a/lib/Basic/Assertions.cpp
+++ b/lib/Basic/Assertions.cpp
@@ -120,6 +120,10 @@ static void _abortWithMessage(llvm::StringRef message) {
   // crash reporter.
   PrettyStackTraceMultilineString trace(message);
 
+  // If pretty backtracing is disabled, fall back to dumping to stderr.
+  if (!llvm::SavePrettyStackState())
+    llvm::errs() << message << '\n';
+
   abort();
 }
 

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -202,13 +202,13 @@ void Mangler::verify(StringRef nameStr, ManglingFlavor Flavor) {
   Demangler Dem;
   NodePointer Root = Dem.demangleSymbol(nameStr);
   if (!Root || treeContains(Root, Node::Kind::Suffix)) {
-    abortWithPrettyStackTraceMessage([&](auto &out) {
+    ABORT([&](auto &out) {
       out << "Can't demangle: " << nameStr;
     });
   }
   auto mangling = mangleNode(Root, Flavor);
   if (!mangling.isSuccess()) {
-    abortWithPrettyStackTraceMessage([&](auto &out) {
+    ABORT([&](auto &out) {
       out << "Can't remangle: " << nameStr;
     });
   }
@@ -216,7 +216,7 @@ void Mangler::verify(StringRef nameStr, ManglingFlavor Flavor) {
   if (Remangled == nameStr)
     return;
 
-  abortWithPrettyStackTraceMessage([&](auto &out) {
+  ABORT([&](auto &out) {
     out << "Remangling failed:\n";
     out << "original     = " << nameStr << "\n";
     out << "remangled    = " << Remangled;

--- a/lib/Basic/PrettyStackTrace.cpp
+++ b/lib/Basic/PrettyStackTrace.cpp
@@ -40,17 +40,38 @@ void PrettyStackTraceSwiftVersion::print(llvm::raw_ostream &out) const {
   out << version::getSwiftFullVersion() << '\n';
 }
 
+namespace {
+/// Similar to PrettyStackTraceString, but formats multi-line strings for
+/// the stack trace.
+class PrettyStackTraceMultilineString : public llvm::PrettyStackTraceEntry {
+  StringRef Str;
+
+public:
+  PrettyStackTraceMultilineString(StringRef str) : Str(str) {}
+  void print(raw_ostream &OS) const override {
+    // For each line, add a leading character and indentation to better match
+    // the formatting of the stack trace.
+    for (auto c : Str.rtrim('\n')) {
+      OS << c;
+      if (c == '\n')
+        OS << "| \t";
+    }
+    OS << '\n';
+  }
+};
+} // end anonymous namespace
+
 void swift::abortWithPrettyStackTraceMessage(
     llvm::function_ref<void(llvm::raw_ostream &)> message) {
   llvm::SmallString<0> errorStr;
   llvm::raw_svector_ostream out(errorStr);
   message(out);
-  llvm::PrettyStackTraceString trace(errorStr.c_str());
+
+  PrettyStackTraceMultilineString trace(errorStr);
   abort();
 }
 
 void swift::abortWithPrettyStackTraceMessage(StringRef message) {
-  auto messageStr = message.str();
-  llvm::PrettyStackTraceString trace(messageStr.c_str());
+  PrettyStackTraceMultilineString trace(message);
   abort();
 }

--- a/lib/Basic/PrettyStackTrace.cpp
+++ b/lib/Basic/PrettyStackTrace.cpp
@@ -39,39 +39,3 @@ void PrettyStackTraceFileContents::print(llvm::raw_ostream &out) const {
 void PrettyStackTraceSwiftVersion::print(llvm::raw_ostream &out) const {
   out << version::getSwiftFullVersion() << '\n';
 }
-
-namespace {
-/// Similar to PrettyStackTraceString, but formats multi-line strings for
-/// the stack trace.
-class PrettyStackTraceMultilineString : public llvm::PrettyStackTraceEntry {
-  StringRef Str;
-
-public:
-  PrettyStackTraceMultilineString(StringRef str) : Str(str) {}
-  void print(raw_ostream &OS) const override {
-    // For each line, add a leading character and indentation to better match
-    // the formatting of the stack trace.
-    for (auto c : Str.rtrim('\n')) {
-      OS << c;
-      if (c == '\n')
-        OS << "| \t";
-    }
-    OS << '\n';
-  }
-};
-} // end anonymous namespace
-
-void swift::abortWithPrettyStackTraceMessage(
-    llvm::function_ref<void(llvm::raw_ostream &)> message) {
-  llvm::SmallString<0> errorStr;
-  llvm::raw_svector_ostream out(errorStr);
-  message(out);
-
-  PrettyStackTraceMultilineString trace(errorStr);
-  abort();
-}
-
-void swift::abortWithPrettyStackTraceMessage(StringRef message) {
-  PrettyStackTraceMultilineString trace(message);
-  abort();
-}

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9799,11 +9799,11 @@ static void finishTypeWitnesses(
     }
 
     if (!satisfied) {
-      llvm::errs() << ("Cannot look up associated type for "
-                        "imported conformance:\n");
-      conformance->getType().dump(llvm::errs());
-      assocType->dump(llvm::errs());
-      abort();
+      ABORT([&](auto &out) {
+        out << "Cannot look up associated type for imported conformance:\n";
+        conformance->getType().dump(out);
+        assocType->dump(out);
+      });
     }
   }
 }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1066,34 +1066,34 @@ private:
       auto &Ctx = Ty->getASTContext();
       Type Reconstructed = Demangle::getTypeForMangling(Ctx, SugaredName, Sig);
       if (!Reconstructed) {
-        llvm::errs() << "Failed to reconstruct type for " << SugaredName
-                     << "\n";
-        llvm::errs() << "Original type:\n";
-        Ty->dump(llvm::errs());
-        if (Sig)
-          llvm::errs() << "Generic signature: " << Sig << "\n";
-        llvm::errs() << SWIFT_CRASH_BUG_REPORT_MESSAGE << "\n"
-          << "Pass '-Xfrontend -disable-round-trip-debug-types' to disable "
-             "this assertion.\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Failed to reconstruct type for " << SugaredName << "\n";
+          out << "Original type:\n";
+          Ty->dump(out);
+          if (Sig)
+            out << "Generic signature: " << Sig << "\n";
+          out << SWIFT_CRASH_BUG_REPORT_MESSAGE << "\n"
+              << "Pass '-Xfrontend -disable-round-trip-debug-types' to disable "
+                 "this assertion.";
+        });
       } else if (!Reconstructed->isEqual(Ty) &&
                  // FIXME: Some existential types are reconstructed without
                  // an explicit ExistentialType wrapping the constraint.
                  !equalWithoutExistentialTypes(Reconstructed, Ty) &&
                  !EqualUpToClangTypes().check(Reconstructed, Ty)) {
         // [FIXME: Include-Clang-type-in-mangling] Remove second check
-        llvm::errs() << "Incorrect reconstructed type for " << SugaredName
-                     << "\n";
-        llvm::errs() << "Original type:\n";
-        Ty->dump(llvm::errs());
-        llvm::errs() << "Reconstructed type:\n";
-        Reconstructed->dump(llvm::errs());
-        if (Sig)
-          llvm::errs() << "Generic signature: " << Sig << "\n";
-        llvm::errs() << SWIFT_CRASH_BUG_REPORT_MESSAGE << "\n"
-          << "Pass '-Xfrontend -disable-round-trip-debug-types' to disable "
-             "this assertion.\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Incorrect reconstructed type for " << SugaredName << "\n";
+          out << "Original type:\n";
+          Ty->dump(out);
+          out << "Reconstructed type:\n";
+          Reconstructed->dump(out);
+          if (Sig)
+            out << "Generic signature: " << Sig << "\n";
+          out << SWIFT_CRASH_BUG_REPORT_MESSAGE << "\n"
+              << "Pass '-Xfrontend -disable-round-trip-debug-types' to disable "
+                 "this assertion.";
+        });
       }
     }
 

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -839,14 +839,15 @@ void SILModule::notifyAddedInstruction(SILInstruction *inst) {
     SILValue &val = RootLocalArchetypeDefs[{genericEnv, inst->getFunction()}];
     if (val) {
       if (!isa<PlaceholderValue>(val)) {
-        // Print a useful error message (and not just abort with an assert).
-        llvm::errs() << "re-definition of local environment in function "
-                     << inst->getFunction()->getName() << ":\n";
-        inst->print(llvm::errs());
-        llvm::errs() << "previously defined in function "
-                     << val->getFunction()->getName() << ":\n";
-        val->print(llvm::errs());
-        abort();
+        ABORT([&](auto &out) {
+          // Print a useful error message (and not just abort with an assert).
+          out << "re-definition of local environment in function "
+              << inst->getFunction()->getName() << ":\n";
+          inst->print(out);
+          out << "previously defined in function "
+              << val->getFunction()->getName() << ":\n";
+          val->print(out);
+        });
       }
       // The local environment was unresolved so far. Replace the placeholder
       // by inst.

--- a/lib/SIL/Utils/Dominance.cpp
+++ b/lib/SIL/Utils/Dominance.cpp
@@ -90,11 +90,12 @@ void DominanceInfo::verify() const {
 
   // And compare.
   if (errorOccurredOnComparison(OtherDT)) {
-    llvm::errs() << "DominatorTree is not up to date!\nComputed:\n";
-    print(llvm::errs());
-    llvm::errs() << "\nActual:\n";
-    OtherDT.print(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "DominatorTree is not up to date!\nComputed:\n";
+      print(out);
+      out << "\nActual:\n";
+      OtherDT.print(out);
+    });
   }
 }
 
@@ -147,11 +148,12 @@ void PostDominanceInfo::verify() const {
 
   // And compare.
   if (errorOccurredOnComparison(OtherDT)) {
-    llvm::errs() << "PostDominatorTree is not up to date!\nComputed:\n";
-    print(llvm::errs());
-    llvm::errs() << "\nActual:\n";
-    OtherDT.print(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "PostDominatorTree is not up to date!\nComputed:\n";
+      print(out);
+      out << "\nActual:\n";
+      OtherDT.print(out);
+    });
   }
 }
 

--- a/lib/SIL/Utils/GenericSpecializationMangler.cpp
+++ b/lib/SIL/Utils/GenericSpecializationMangler.cpp
@@ -42,8 +42,9 @@ public:
                                 NodePointer Parent) {
     DemangleInitRAII state(*this, MangledSpecialization, nullptr);
     if (!parseAndPushNodes()) {
-      llvm::errs() << "Can't demangle: " << MangledSpecialization << '\n';
-      abort();
+      ABORT([&](auto &out) {
+        out << "Can't demangle: " << MangledSpecialization;
+      });
     }
     for (Node *Nd : NodeStack) {
       addChild(Parent, Nd);

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -50,8 +50,10 @@ bool swiftModulesInitialized() {
 SwiftMetatype SILNode::getSILNodeMetatype(SILNodeKind kind) {
   SwiftMetatype metatype = nodeMetatypes[(unsigned)kind];
   if (nodeMetatypesInitialized && !metatype) {
-    llvm::errs() << "Instruction " << getSILInstructionName((SILInstructionKind)kind) << " not registered\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "Instruction " << getSILInstructionName((SILInstructionKind)kind)
+          << " not registered";
+    });
   }
   return metatype;
 }
@@ -103,16 +105,18 @@ void registerBridgedClass(BridgedStringRef bridgedClassName, SwiftMetatype metat
     prefixedName = std::string("SIL") + std::string(className);
     iter = valueNamesToKind.find(prefixedName);
     if (iter == valueNamesToKind.end()) {
-      llvm::errs() << "Unknown bridged node class " << className << '\n';
-      abort();
+      ABORT([&](auto &out) {
+        out << "Unknown bridged node class " << className;
+      });
     }
     className = prefixedName;
   }
   SILNodeKind kind = iter->second;
   SwiftMetatype existingTy = nodeMetatypes[(unsigned)kind];
   if (existingTy) {
-    llvm::errs() << "Double registration of class " << className << '\n';
-    abort();
+    ABORT([&](auto &out) {
+      out << "Double registration of class " << className;
+    });
   }
   nodeMetatypes[(unsigned)kind] = metatype;
 }

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -259,9 +259,10 @@ void MemoryLifetimeVerifier::reportError(const Twine &complaint,
   if (DontAbortOnMemoryLifetimeErrors)
     return;
 
-  llvm::errs() << "in function:\n";
-  function->print(llvm::errs());
-  abort();
+  ABORT([&](auto &out) {
+    out << "in function:\n";
+    function->print(out);
+  });
 }
 
 void MemoryLifetimeVerifier::require(const Bits &wrongBits,

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -239,8 +239,9 @@ static void runBridgedModulePass(BridgedModulePassRunFn &runFunction,
     runFunction = bridgedModulePassRunFunctions[passName];
     if (!runFunction) {
       if (passesRegistered) {
-        llvm::errs() << "Swift pass " << passName << " is not registered\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Swift pass " << passName << " is not registered";
+        });
       }
       return;
     }
@@ -259,15 +260,15 @@ static void runBridgedFunctionPass(BridgedFunctionPassRunFn &runFunction,
     runFunction = bridgedFunctionPassRunFunctions[passName];
     if (!runFunction) {
       if (passesRegistered) {
-        llvm::errs() << "Swift pass " << passName << " is not registered\n";
-        abort();
+        ABORT([&](auto &out) {
+          out << "Swift pass " << passName << " is not registered";
+        });
       }
       return;
     }
   }
   if (!f->isBridged()) {
-    llvm::errs() << "SILFunction metatype is not registered\n";
-    abort();
+    ABORT("SILFunction metatype is not registered");
   }
   runFunction({{f}, {passManager->getSwiftPassInvocation()}});
 }

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -613,28 +613,29 @@ void SILCombine_registerInstructionPass(BridgedStringRef instClassName,
   passesRegistered = true;
 }
 
-#define _RUN_SWIFT_SIMPLIFICATON(INST) \
-  static BridgedInstructionPassRunFn runFunction = nullptr;                \
-  static bool passDisabled = false;                                        \
-  if (!runFunction) {                                                      \
-    runFunction = swiftInstPasses[#INST];                                  \
-    if (!runFunction) {                                                    \
-      if (passesRegistered) {                                              \
-        llvm::errs() << "Swift pass " << #INST << " is not registered\n";  \
-        abort();                                                           \
-      } else {                                                             \
-        return nullptr;                                                    \
-      }                                                                    \
-    }                                                                      \
-    StringRef instName = getSILInstructionName(SILInstructionKind::INST);  \
-    passDisabled = SILPassManager::isInstructionPassDisabled(instName);    \
-  }                                                                        \
-  if (passDisabled &&                                                      \
-      SILPassManager::disablePassesForFunction(inst->getFunction())) {     \
-    return nullptr;                                                        \
-  }                                                                        \
-  runSwiftInstructionPass(inst, runFunction);                              \
-  return nullptr;                                                          \
+#define _RUN_SWIFT_SIMPLIFICATON(INST)                                         \
+  static BridgedInstructionPassRunFn runFunction = nullptr;                    \
+  static bool passDisabled = false;                                            \
+  if (!runFunction) {                                                          \
+    runFunction = swiftInstPasses[#INST];                                      \
+    if (!runFunction) {                                                        \
+      if (passesRegistered) {                                                  \
+        ABORT([&](auto &out) {                                                 \
+          out << "Swift pass " << #INST << " is not registered";               \
+        });                                                                    \
+      } else {                                                                 \
+        return nullptr;                                                        \
+      }                                                                        \
+    }                                                                          \
+    StringRef instName = getSILInstructionName(SILInstructionKind::INST);      \
+    passDisabled = SILPassManager::isInstructionPassDisabled(instName);        \
+  }                                                                            \
+  if (passDisabled &&                                                          \
+      SILPassManager::disablePassesForFunction(inst->getFunction())) {         \
+    return nullptr;                                                            \
+  }                                                                            \
+  runSwiftInstructionPass(inst, runFunction);                                  \
+  return nullptr;
 
 #define INSTRUCTION_SIMPLIFICATION(INST) \
 SILInstruction *SILCombiner::visit##INST(INST *inst) {                     \

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8055,10 +8055,11 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   if (fromType->hasUnresolvedType() || toType->hasUnresolvedType())
     return cs.cacheType(new (ctx) UnresolvedTypeConversionExpr(expr, toType));
 
-  llvm::errs() << "Unhandled coercion:\n";
-  fromType->dump(llvm::errs());
-  toType->dump(llvm::errs());
-  abort();
+  ABORT([&](auto &out) {
+    out << "Unhandled coercion:\n";
+    fromType->dump(out);
+    toType->dump(out);
+  });
 }
 
 static bool isSelfRefInInitializer(Expr *baseExpr,

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -254,36 +254,40 @@ void ConstraintGraphNode::truncateEquivalenceClass(unsigned prevSize) {
 void ConstraintGraphNode::addReferencedVar(TypeVariableType *typeVar) {
   bool inserted = References.insert(typeVar);
   if (!inserted) {
-    llvm::errs() << "$T" << TypeVar->getImpl().getID() << " already "
-                 << "references $T" << typeVar->getImpl().getID() << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "$T" << TypeVar->getImpl().getID() << " already "
+          << "references $T" << typeVar->getImpl().getID();
+    });
   }
 }
 
 void ConstraintGraphNode::addReferencedBy(TypeVariableType *typeVar) {
   bool inserted = ReferencedBy.insert(typeVar);
   if (!inserted) {
-    llvm::errs() << "$T" << TypeVar->getImpl().getID() << " already "
-                 << "referenced by $T" << typeVar->getImpl().getID() << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "$T" << TypeVar->getImpl().getID() << " already "
+          << "referenced by $T" << typeVar->getImpl().getID();
+    });
   }
 }
 
 void ConstraintGraphNode::removeReference(TypeVariableType *typeVar) {
   auto removed = References.remove(typeVar);
   if (!removed) {
-    llvm::errs() << "$T" << TypeVar->getImpl().getID() << " does not "
-                 << "reference $T" << typeVar->getImpl().getID() << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "$T" << TypeVar->getImpl().getID() << " does not "
+          << "reference $T" << typeVar->getImpl().getID();
+    });
   }
 }
 
 void ConstraintGraphNode::removeReferencedBy(TypeVariableType *typeVar) {
   auto removed = ReferencedBy.remove(typeVar);
   if (!removed) {
-    llvm::errs() << "$T" << TypeVar->getImpl().getID() << " not "
-                 << "referenced by $T" << typeVar->getImpl().getID() << "\n";
-    abort();
+    ABORT([&](auto &out) {
+      out << "$T" << TypeVar->getImpl().getID() << " not "
+          << "referenced by $T" << typeVar->getImpl().getID();
+    });
   }
 }
 

--- a/lib/Sema/OpenedExistentials.cpp
+++ b/lib/Sema/OpenedExistentials.cpp
@@ -291,9 +291,10 @@ findGenericParameterReferencesRec(CanGenericSignature genericSig,
 
   // Everything else should be a type parameter.
   if (!type->isTypeParameter()) {
-    llvm::errs() << "Unhandled type:\n";
-    type->dump(llvm::errs());
-    abort();
+    ABORT([&](auto &out) {
+      out << "Unhandled type:\n";
+      type->dump(out);
+    });
   }
 
   if (!type->getRootGenericParam()->isEqual(origParam)) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1175,16 +1175,18 @@ void ModuleFile::collectBasicSourceFileInfo(
     auto fingerprintIncludingTypeMembers =
       Fingerprint::fromString(fpStrIncludingTypeMembers);
     if (!fingerprintIncludingTypeMembers) {
-      llvm::errs() << "Unconvertible fingerprint including type members'"
-                   << fpStrIncludingTypeMembers << "'\n";
-      abort();
+      ABORT([&](auto &out) {
+        out << "Unconvertible fingerprint including type members '"
+            << fpStrIncludingTypeMembers << "'";
+      });
     }
     auto fingerprintExcludingTypeMembers =
       Fingerprint::fromString(fpStrExcludingTypeMembers);
     if (!fingerprintExcludingTypeMembers) {
-      llvm::errs() << "Unconvertible fingerprint excluding type members'"
-                   << fpStrExcludingTypeMembers << "'\n";
-      abort();
+      ABORT([&](auto &out) {
+        out << "Unconvertible fingerprint excluding type members '"
+            << fpStrExcludingTypeMembers << "'";
+      });
     }
     callback(BasicSourceFileInfo(filePath,
                                  fingerprintIncludingTypeMembers.value(),

--- a/lib/Serialization/ModuleFileCoreTableInfo.h
+++ b/lib/Serialization/ModuleFileCoreTableInfo.h
@@ -579,8 +579,10 @@ public:
                                Fingerprint::DIGEST_LENGTH};
     if (auto fp = Fingerprint::fromString(str))
       return fp.value();
-    llvm::errs() << "Unconvertable fingerprint '" << str << "'\n";
-    abort();
+
+    ABORT([&](auto &out) {
+      out << "Unconvertable fingerprint '" << str << "'";
+    });
   }
 };
 

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -695,7 +695,7 @@ std::string ModuleFileSharedCore::Dependency::getPrettyPrintedPath() const {
 }
 
 void ModuleFileSharedCore::fatal(llvm::Error error) const {
-  abortWithPrettyStackTraceMessage([&](auto &out) {
+  ABORT([&](auto &out) {
     out << "*** DESERIALIZATION FAILURE ***\n";
     out << "*** If any module named here was modified in the SDK, please delete the ***\n";
     out << "*** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***\n";

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5337,7 +5337,7 @@ void Serializer::writeASTBlockEntity(const Decl *D) {
   SWIFT_DEFER {
     // This is important enough to leave on in Release builds.
     if (initialOffset == Out.GetCurrentBitNo()) {
-      abortWithPrettyStackTraceMessage("failed to serialize anything");
+      ABORT("failed to serialize anything");
     }
   };
 
@@ -6164,7 +6164,7 @@ void Serializer::writeASTBlockEntity(Type ty) {
   SWIFT_DEFER {
     // This is important enough to leave on in Release builds.
     if (initialOffset == Out.GetCurrentBitNo()) {
-      abortWithPrettyStackTraceMessage("failed to serialize anything");
+      ABORT("failed to serialize anything");
     }
   };
 


### PR DESCRIPTION
Turn `abortWithPrettyStackTraceMessage` into the wrapping macro `ABORT`, then convert a bunch of places where we're dumping to stderr and calling `abort` (including `ASSERT` and friends) over to using this new macro such that the message gets printed to the pretty stack trace. This ensures it gets picked up by CrashReporter.