### PR TITLE
[6.2][SourceKit] Allow passing `cancel_on_subsequent_request: 0` for all requests that use a OncePerASTToken

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -1107,6 +1107,7 @@ public:
   virtual void
   editorOpenSwiftSourceInterface(StringRef Name, StringRef SourceName,
                                  ArrayRef<const char *> Args,
+                                 bool CancelOnSubsequentRequest,
                                  SourceKitCancellationToken CancellationToken,
                                  std::shared_ptr<EditorConsumer> Consumer) = 0;
 
@@ -1216,12 +1217,14 @@ public:
   virtual void
   findLocalRenameRanges(StringRef Filename, unsigned Line, unsigned Column,
                         unsigned Length, ArrayRef<const char *> Args,
+                        bool CancelOnSubsequentRequest,
                         SourceKitCancellationToken CancellationToken,
                         CategorizedRenameRangesReceiver Receiver) = 0;
 
   virtual void semanticRefactoring(StringRef PrimaryFilePath,
                                    SemanticRefactoringInfo Info,
                                    ArrayRef<const char *> Args,
+                                   bool CancelOnSubsequentRequest,
                                    SourceKitCancellationToken CancellationToken,
                                    CategorizedEditsReceiver Receiver) = 0;
 
@@ -1240,6 +1243,7 @@ public:
       StringRef PrimaryFilePath, StringRef InputBufferName,
       ArrayRef<const char *> Args, std::optional<unsigned> Offset,
       std::optional<unsigned> Length, bool FullyQualified,
+      bool CancelOnSubsequentRequest,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<VariableTypesInFile> &)>
           Receiver) = 0;

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1418,7 +1418,8 @@ SwiftLangSupport::findRenameRanges(llvm::MemoryBuffer *InputBuf,
 
 void SwiftLangSupport::findLocalRenameRanges(
     StringRef Filename, unsigned Line, unsigned Column, unsigned Length,
-    ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
+    ArrayRef<const char *> Args, bool CancelOnSubsequentRequest,
+    SourceKitCancellationToken CancellationToken,
     CategorizedRenameRangesReceiver Receiver) {
   using ResultType = CancellableResult<std::vector<CategorizedRenameRanges>>;
   std::string Error;
@@ -1465,8 +1466,8 @@ void SwiftLangSupport::findLocalRenameRanges(
   /// FIXME: When request cancellation is implemented and Xcode adopts it,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
-  getASTManager()->processASTAsync(Invok, ASTConsumer, &OncePerASTToken,
-                                   CancellationToken,
+  const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
+  getASTManager()->processASTAsync(Invok, ASTConsumer, Once, CancellationToken,
                                    llvm::vfs::getRealFileSystem());
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -853,6 +853,7 @@ public:
 
 void SwiftLangSupport::editorOpenSwiftSourceInterface(
     StringRef Name, StringRef SourceName, ArrayRef<const char *> Args,
+    bool CancelOnSubsequentRequest,
     SourceKitCancellationToken CancellationToken,
     std::shared_ptr<EditorConsumer> Consumer) {
   std::string Error;
@@ -864,7 +865,8 @@ void SwiftLangSupport::editorOpenSwiftSourceInterface(
   auto AstConsumer = std::make_shared<PrimaryFileInterfaceConsumer>(Name,
     SourceName, IFaceGenContexts, Consumer, Invocation);
   static const char OncePerASTToken = 0;
-  getASTManager()->processASTAsync(Invocation, AstConsumer, &OncePerASTToken,
+  const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
+  getASTManager()->processASTAsync(Invocation, AstConsumer, Once,
                                    CancellationToken,
                                    llvm::vfs::getRealFileSystem());
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -619,6 +619,7 @@ public:
 
   void editorOpenSwiftSourceInterface(
       StringRef Name, StringRef SourceName, ArrayRef<const char *> Args,
+      bool CancelOnSubsequentRequest,
       SourceKitCancellationToken CancellationToken,
       std::shared_ptr<EditorConsumer> Consumer) override;
 
@@ -708,6 +709,7 @@ public:
 
   void findLocalRenameRanges(StringRef Filename, unsigned Line, unsigned Column,
                              unsigned Length, ArrayRef<const char *> Args,
+                             bool CancelOnSubsequentRequest,
                              SourceKitCancellationToken CancellationToken,
                              CategorizedRenameRangesReceiver Receiver) override;
 
@@ -723,6 +725,7 @@ public:
       StringRef PrimaryFilePath, StringRef InputBufferName,
       ArrayRef<const char *> Args, std::optional<unsigned> Offset,
       std::optional<unsigned> Length, bool FullyQualified,
+      bool CancelOnSubsequentRequest,
       SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<VariableTypesInFile> &)> Receiver)
       override;
@@ -730,6 +733,7 @@ public:
   void semanticRefactoring(StringRef PrimaryFilePath,
                            SemanticRefactoringInfo Info,
                            ArrayRef<const char *> Args,
+                           bool CancelOnSubsequentRequest,
                            SourceKitCancellationToken CancellationToken,
                            CategorizedEditsReceiver Receiver) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2776,7 +2776,8 @@ static RefactoringKind getIDERefactoringKind(SemanticRefactoringInfo Info) {
 
 void SwiftLangSupport::semanticRefactoring(
     StringRef PrimaryFilePath, SemanticRefactoringInfo Info,
-    ArrayRef<const char *> Args, SourceKitCancellationToken CancellationToken,
+    ArrayRef<const char *> Args, bool CancelOnSubsequentRequest,
+    SourceKitCancellationToken CancellationToken,
     CategorizedEditsReceiver Receiver) {
   std::string Error;
   SwiftInvocationRef Invok =
@@ -2834,7 +2835,8 @@ void SwiftLangSupport::semanticRefactoring(
   /// FIXME: When request cancellation is implemented and Xcode adopts it,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
-  getASTManager()->processASTAsync(Invok, std::move(Consumer), &OncePerASTToken,
+  const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
+  getASTManager()->processASTAsync(Invok, std::move(Consumer), Once,
                                    CancellationToken,
                                    llvm::vfs::getRealFileSystem());
 }
@@ -2918,6 +2920,7 @@ void SwiftLangSupport::collectVariableTypes(
     StringRef PrimaryFilePath, StringRef InputBufferName,
     ArrayRef<const char *> Args, std::optional<unsigned> Offset,
     std::optional<unsigned> Length, bool FullyQualified,
+    bool CancelOnSubsequentRequest,
     SourceKitCancellationToken CancellationToken,
     std::function<void(const RequestResult<VariableTypesInFile> &)> Receiver) {
   std::string Error;
@@ -2997,7 +3000,8 @@ void SwiftLangSupport::collectVariableTypes(
   /// FIXME: When request cancellation is implemented and Xcode adopts it,
   /// don't use 'OncePerASTToken'.
   static const char OncePerASTToken = 0;
-  getASTManager()->processASTAsync(Invok, std::move(Collector),
-                                   &OncePerASTToken, CancellationToken,
+  const void *Once = CancelOnSubsequentRequest ? &OncePerASTToken : nullptr;
+  getASTManager()->processASTAsync(Invok, std::move(Collector), Once,
+                                   CancellationToken,
                                    llvm::vfs::getRealFileSystem());
 }

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -331,6 +331,7 @@ editorOpenHeaderInterface(StringRef Name, StringRef HeaderName,
 static void
 editorOpenSwiftSourceInterface(StringRef Name, StringRef SourceName,
                                ArrayRef<const char *> Args,
+                               bool CancelOnSubsequentRequest,
                                SourceKitCancellationToken CancellationToken,
                                ResponseReceiver Rec, bool EnableDeclarations);
 
@@ -1053,8 +1054,13 @@ static void handleRequestEditorOpenSwiftSourceInterface(
     // Reporting the declarations array is off by default
     bool EnableDeclarations =
         Req.getOptionalInt64(KeyEnableDeclarations).value_or(false);
+    // For backwards compatibility, the default is 1.
+    int64_t CancelOnSubsequentRequest = 1;
+    Req.getInt64(KeyCancelOnSubsequentRequest, CancelOnSubsequentRequest,
+                 /*isOptional=*/true);
     return editorOpenSwiftSourceInterface(
-        *Name, *FileName, Args, CancellationToken, Rec, EnableDeclarations);
+        *Name, *FileName, Args, CancelOnSubsequentRequest, CancellationToken,
+        Rec, EnableDeclarations);
   }
 }
 
@@ -1705,8 +1711,15 @@ handleRequestSemanticRefactoring(const RequestDict &Req,
         Info.Line = Line;
         Info.Column = Column;
         Info.Length = Length;
+
+        // For backwards compatibility, the default is 1.
+        int64_t CancelOnSubsequentRequest = 1;
+        Req.getInt64(KeyCancelOnSubsequentRequest, CancelOnSubsequentRequest,
+                     /*isOptional=*/true);
+
         return Lang.semanticRefactoring(
-            *PrimaryFilePath, Info, Args, CancellationToken,
+            *PrimaryFilePath, Info, Args, CancelOnSubsequentRequest,
+            CancellationToken,
             [Rec](const RequestResult<ArrayRef<CategorizedEdits>> &Result) {
               Rec(createCategorizedEditsResponse(Result));
             });
@@ -1782,9 +1795,15 @@ handleRequestCollectVariableType(const RequestDict &Req,
                          [](int64_t v) -> unsigned { return v; });
     int64_t FullyQualified = false;
     Req.getInt64(KeyFullyQualified, FullyQualified, /*isOptional=*/true);
+
+    // For backwards compatibility, the default is 1.
+    int64_t CancelOnSubsequentRequest = 1;
+    Req.getInt64(KeyCancelOnSubsequentRequest, CancelOnSubsequentRequest,
+                 /*isOptional=*/true);
+
     return Lang.collectVariableTypes(
         *PrimaryFilePath, InputBufferName, Args, Offset, Length, FullyQualified,
-        CancellationToken,
+        CancelOnSubsequentRequest, CancellationToken,
         [Rec](const RequestResult<VariableTypesInFile> &Result) {
           reportVariableTypeInfo(Result, Rec);
         });
@@ -1814,9 +1833,15 @@ handleRequestFindLocalRenameRanges(const RequestDict &Req,
       return Rec(createErrorRequestInvalid("'key.column' is required"));
     Req.getInt64(KeyLength, Length, /*isOptional=*/true);
 
+    // For backwards compatibility, the default is 1.
+    int64_t CancelOnSubsequentRequest = 1;
+    Req.getInt64(KeyCancelOnSubsequentRequest, CancelOnSubsequentRequest,
+                 /*isOptional=*/true);
+
     LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
     return Lang.findLocalRenameRanges(
-        *PrimaryFilePath, Line, Column, Length, Args, CancellationToken,
+        *PrimaryFilePath, Line, Column, Length, Args, CancelOnSubsequentRequest,
+        CancellationToken,
         [Rec](const CancellableResult<std::vector<CategorizedRenameRanges>>
                   &Result) {
           Rec(createCategorizedRenameRangesResponse(Result));
@@ -3686,6 +3711,7 @@ static sourcekitd_response_t editorOpenInterface(
 static void
 editorOpenSwiftSourceInterface(StringRef Name, StringRef HeaderName,
                                ArrayRef<const char *> Args,
+                               bool CancelOnSubsequentRequest,
                                SourceKitCancellationToken CancellationToken,
                                ResponseReceiver Rec, bool EnableDeclarations) {
   SKEditorConsumerOptions Opts;
@@ -3694,8 +3720,9 @@ editorOpenSwiftSourceInterface(StringRef Name, StringRef HeaderName,
   Opts.EnableDeclarations = EnableDeclarations;
   auto EditC = std::make_shared<SKEditorConsumer>(Rec, Opts);
   LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-  Lang.editorOpenSwiftSourceInterface(Name, HeaderName, Args, CancellationToken,
-                                      EditC);
+  Lang.editorOpenSwiftSourceInterface(Name, HeaderName, Args,
+                                      CancelOnSubsequentRequest,
+                                      CancellationToken, EditC);
 }
 
 static void


### PR DESCRIPTION
- **Explanation**: We need this option for `collectVariableType` (aka inlay type hints) but since I’m at it, I’m adding an option to disable the implicit request cancellation for all requests that have it since we don’t want it in LSP at all. This is a  prerequisite to fixing https://github.com/swiftlang/sourcekit-lsp/issues/2021 / rdar://145871554, need to adopt this option in SourceKit-LSP.
- **Scope**: sourcekitd
- **Issue**: https://github.com/swiftlang/sourcekit-lsp/issues/2021 / rdar://145871554
- **Original PR**: https://github.com/swiftlang/swift/pull/81507
- **Risk**: Low, previous behavior is maintained unless request option is passed
- **Testing**: Tested in sourcekit-lsp
- **Reviewer**: @bnbarham 