### PR TITLE
[6.2] SILGen: insert an `end_lifetime` in the throw-branch of a `Builtin.emplace`

### DIFF
--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2170,6 +2170,13 @@ static ManagedValue emitBuiltinEmplace(SILGenFunction &SGF,
     {
       SGF.B.emitBlock(errorBB);
 
+      // When the closure throws an error, it needs to clean up the buffer. This
+      // means that the buffer is uninitialized at this point.
+      // We need an `end_lifetime` so that the move-only checker doesn't insert
+      // a wrong `destroy_addr` because it thinks that the buffer is initialized
+      // here.
+      SGF.B.createEndLifetime(loc, buffer);
+
       SGF.Cleanups.emitCleanupsForReturn(CleanupLocation(loc), IsForUnwind);
 
       SGF.B.createThrowAddr(loc);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -297,6 +297,7 @@ bool noncopyable::memInstMustConsume(Operand *memOper) {
            (CAI->getDest() == address && !CAI->isInitializationOfDest());
   }
   case SILInstructionKind::DestroyAddrInst:
+  case SILInstructionKind::EndLifetimeInst:
     return true;
   case SILInstructionKind::DropDeinitInst:
     assert(memOper->get()->getType().isValueTypeWithDeinit());

--- a/test/stdlib/InlineArray.swift
+++ b/test/stdlib/InlineArray.swift
@@ -24,6 +24,8 @@
 import StdlibUnittest
 import Synchronization
 
+protocol P {}
+
 @available(SwiftStdlib 6.2, *)
 @main
 enum InlineArrayTests {
@@ -171,6 +173,9 @@ enum InlineArrayTests {
       }
       _expectThrows {
         let _ = try InlineArray<1, String> { _ in throw error }
+      }
+      _expectThrows {
+        let _ = try InlineArray<1, any P> { _ in throw error }
       }
       _expectThrows {
         let _ = try InlineArray<2, String> { index in


### PR DESCRIPTION
* **Explanation**: This fixes a mis-compile which results in a program crash when using the closure-based `InlineArray.init` for arrays with certain non-trivial types. The move-only checker inserted a wrong destroy on the throwing path in the initializer. But this is wrong because the initializer has already cleaned up the array buffer when the closure throws. The fix is to insert an `end_lifetime` instruction so that the move-only checker doesn't insert a wrong `destroy_addr`.
* **Risk**: Low. It only affects this `InlineArray` initializer. This is the only place where the builtin is used with a (potentially) throwing closure.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://151461109
* **Reviewer**:  @atrick
* **Main branch PR**: https://github.com/swiftlang/swift/pull/81567







