### PR TITLE
Frontend: Suppress some unsupported option warnings when verifying interfaces

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1483,10 +1483,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     if (Opts.AllowNonResilientAccess &&
         FrontendOptions::doesActionBuildModuleFromInterface(
             FrontendOpts.RequestedAction)) {
-      Diags.diagnose(
-          SourceLoc(), diag::warn_ignore_option_overriden_by,
-          "-allow-non-resilient-access",
-          "-compile-module-from-interface or -typecheck-module-from-interface");
+      if (FrontendOpts.RequestedAction !=
+          FrontendOptions::ActionType::TypecheckModuleFromInterface)
+        Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+                       "-allow-non-resilient-access",
+                       "-compile-module-from-interface");
       Opts.AllowNonResilientAccess = false;
     }
   }
@@ -3012,9 +3013,10 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_PackageCMO) ||
       LangOpts.hasFeature(Feature::PackageCMO)) {
     if (!LangOpts.AllowNonResilientAccess) {
-      Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
-                     "-package-cmo",
-                     "-allow-non-resilient-access");
+      if (FEOpts.RequestedAction !=
+          FrontendOptions::ActionType::TypecheckModuleFromInterface)
+        Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
+                       "-package-cmo", "-allow-non-resilient-access");
     } else if (!FEOpts.EnableLibraryEvolution) {
       Diags.diagnose(SourceLoc(), diag::package_cmo_requires_library_evolution);
     } else {

--- a/test/SILGen/package_allow_non_resilient_access.swift
+++ b/test/SILGen/package_allow_non_resilient_access.swift
@@ -130,7 +130,7 @@
 // RUN: -allow-non-resilient-access \
 // RUN: %t/Utils.package.swiftinterface -o %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-INTERFACE
-// CHECK-DIAG-INTERFACE: warning: ignoring -allow-non-resilient-access (overriden by -compile-module-from-interface or -typecheck-module-from-interface)
+// CHECK-DIAG-INTERFACE: warning: ignoring -allow-non-resilient-access (overriden by -compile-module-from-interface)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-OFF
 // CHECK-OFF-NOT: ALLOW_NON_RESILIENT_ACCESS
 


### PR DESCRIPTION
The following warnings get emitted every time we build the compiler libraries that are implemented in Swift:

```
<unknown>:0: warning: ignoring -allow-non-resilient-access (overriden by -compile-module-from-interface or -typecheck-module-from-interface)
<unknown>:0: warning: ignoring -package-cmo (requires -allow-non-resilient-access)
<unknown>:0: warning: ignoring -allow-non-resilient-access (overriden by -compile-module-from-interface or -typecheck-module-from-interface)
<unknown>:0: warning: ignoring -package-cmo (requires -allow-non-resilient-access)
```

These warnings are generated because `-allow-non-resilient-access` and `-package-cmo` are being passed in with `-Xfrontend` and are therefore copied into the interface verification jobs, even though they don't apply. Suppress the warnings under these circumstances; they aren't going to help anyone understand a problem, so they're just spam.

Resolves rdar://151616909.