### PR TITLE
[6.2] Frontend: Suppress some unsupported option warnings when verifying interfaces

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1455,10 +1455,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     if (Opts.AllowNonResilientAccess &&
         FrontendOptions::doesActionBuildModuleFromInterface(
             FrontendOpts.RequestedAction)) {
-      Diags.diagnose(
-          SourceLoc(), diag::warn_ignore_option_overriden_by,
-          "-allow-non-resilient-access",
-          "-compile-module-from-interface or -typecheck-module-from-interface");
+      if (FrontendOpts.RequestedAction !=
+          FrontendOptions::ActionType::TypecheckModuleFromInterface)
+        Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+                       "-allow-non-resilient-access",
+                       "-compile-module-from-interface");
       Opts.AllowNonResilientAccess = false;
     }
   }
@@ -2988,9 +2989,10 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_PackageCMO) ||
       LangOpts.hasFeature(Feature::PackageCMO)) {
     if (!LangOpts.AllowNonResilientAccess) {
-      Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
-                     "-package-cmo",
-                     "-allow-non-resilient-access");
+      if (FEOpts.RequestedAction !=
+          FrontendOptions::ActionType::TypecheckModuleFromInterface)
+        Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
+                       "-package-cmo", "-allow-non-resilient-access");
     } else if (!FEOpts.EnableLibraryEvolution) {
       Diags.diagnose(SourceLoc(), diag::package_cmo_requires_library_evolution);
     } else {

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -377,7 +377,7 @@ extension SerialExecutor {
   #if SWIFT_CONCURRENCY_USES_DISPATCH
   @available(SwiftStdlib 6.2, *)
   private var _dispatchQueue: OpaquePointer? {
-    return _getDispatchQueueForExecutor(self.asUnownedSerialExecutor())
+    return unsafe _getDispatchQueueForExecutor(self.asUnownedSerialExecutor())
   }
   #endif
 
@@ -387,8 +387,8 @@ extension SerialExecutor {
       return true
     }
     #if SWIFT_CONCURRENCY_USES_DISPATCH
-    if let rhsQueue = rhs._dispatchQueue {
-      if let ourQueue = _dispatchQueue, ourQueue == rhsQueue {
+    if let rhsQueue = unsafe rhs._dispatchQueue {
+      if let ourQueue = unsafe _dispatchQueue, ourQueue == rhsQueue {
         return true
       }
       return false

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -307,6 +307,7 @@ func swift_isUniquelyReferenced_nonNull_native(object: UnsafeMutablePointer<Heap
 }
 
 @_cdecl("swift_retain")
+@discardableResult
 public func swift_retain(object: Builtin.RawPointer) -> Builtin.RawPointer {
   if !isValidPointerForNativeRetain(object: object) { return object }
 
@@ -335,6 +336,7 @@ func swift_retain_n_(object: UnsafeMutablePointer<HeapObject>, n: UInt32) -> Uns
 }
 
 @_cdecl("swift_bridgeObjectRetain")
+@discardableResult
 public func swift_bridgeObjectRetain(object: Builtin.RawPointer) -> Builtin.RawPointer {
   return swift_bridgeObjectRetain_n(object: object, n: 1)
 }

--- a/stdlib/toolchain/CompatibilitySpan/FakeStdlib.swift
+++ b/stdlib/toolchain/CompatibilitySpan/FakeStdlib.swift
@@ -74,10 +74,11 @@ internal func _overrideLifetime<
 }
 
 extension Range {
-    @_alwaysEmitIntoClient
-	internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
-	    self.init(uncheckedBounds: bounds)
-	}
+  @unsafe
+  @_alwaysEmitIntoClient
+  internal init(_uncheckedBounds bounds: (lower: Bound, upper: Bound)) {
+    self.init(uncheckedBounds: bounds)
+  }
 }
 
 extension Optional {

--- a/test/SILGen/package_allow_non_resilient_access.swift
+++ b/test/SILGen/package_allow_non_resilient_access.swift
@@ -130,7 +130,7 @@
 // RUN: -allow-non-resilient-access \
 // RUN: %t/Utils.package.swiftinterface -o %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-INTERFACE
-// CHECK-DIAG-INTERFACE: warning: ignoring -allow-non-resilient-access (overriden by -compile-module-from-interface or -typecheck-module-from-interface)
+// CHECK-DIAG-INTERFACE: warning: ignoring -allow-non-resilient-access (overriden by -compile-module-from-interface)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-OFF
 // CHECK-OFF-NOT: ALLOW_NON_RESILIENT_ACCESS
 


### PR DESCRIPTION
- **Explanation:** Suppresses spurious warnings emitted while building the Swift compiler and standard libraries.
- **Scope:** Suppresses diagnostics.
- **Issue/Radar:** rdar://151616909
- **Original PR:** https://github.com/swiftlang/swift/pull/81610
- **Risk:** Low. These changes only suppress diagnostics under certain conditions.
- **Testing:** Updated compiler tests.
- **Reviewer:** @artemcm 