### PR TITLE
SILGen: Emit property descriptors for conditionally Copyable and Escapable types.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6276,9 +6276,12 @@ public:
   /// Otherwise, its override must be referenced.
   bool isValidKeyPathComponent() const;
 
-  /// True if the storage exports a property descriptor for key paths in
-  /// other modules.
-  bool exportsPropertyDescriptor() const;
+  /// If the storage exports a property descriptor for key paths in other
+  /// modules, this returns the generic signature in which its member methods
+  /// are emitted. If the storage does not export a property descriptor,
+  /// returns `std::nullopt`.
+  std::optional<GenericSignature>
+  getPropertyDescriptorGenericSignature() const;
 
   /// True if any of the accessors to the storage is private or fileprivate.
   bool hasPrivateAccessor() const;

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -617,6 +617,23 @@ using GenericSignatureErrors = OptionSet<GenericSignatureErrorFlags>;
 using GenericSignatureWithError = llvm::PointerIntPair<GenericSignature, 3,
                                                        GenericSignatureErrors>;
 
+/// Build a generic signature from the given requirements, which are not
+/// required to be minimal or canonical, and may contain unresolved
+/// DependentMemberTypes. The generic signature is returned with the
+/// error flags (if any) that were raised while building the signature.
+///
+/// \param baseSignature if non-null, the new parameters and requirements
+///// are added on; existing requirements of the base signature might become
+///// redundant. Otherwise if null, build a new signature from scratch.
+/// \param allowInverses if true, default requirements to Copyable/Escapable are
+/// expanded for generic parameters.
+GenericSignatureWithError buildGenericSignatureWithError(
+    ASTContext &ctx,
+    GenericSignature baseSignature,
+    SmallVector<GenericTypeParamType *, 2> addedParameters,
+    SmallVector<Requirement, 2> addedRequirements,
+    bool allowInverses);
+
 } // end namespace swift
 
 namespace llvm {

--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1043,7 +1043,7 @@ public:
   }
 
   static LinkEntity forPropertyDescriptor(AbstractStorageDecl *decl) {
-    assert(decl->exportsPropertyDescriptor());
+    assert((bool)decl->getPropertyDescriptorGenericSignature());
     LinkEntity entity;
     entity.setForDecl(Kind::PropertyDescriptor, decl);
     return entity;

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -749,7 +749,8 @@ Type BuildForwardingSubstitutions::operator()(SubstitutableType *type) const {
   return Type();
 }
 
-SubstitutionMap GenericEnvironment::getForwardingSubstitutionMap() const {
+SubstitutionMap
+GenericEnvironment::getForwardingSubstitutionMap() const {
   auto genericSig = getGenericSignature();
   return SubstitutionMap::get(genericSig,
                               BuildForwardingSubstitutions(this),

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -569,7 +569,7 @@ public:
 
   void visitAbstractStorageDecl(AbstractStorageDecl *ASD) {
     // Add the property descriptor if the decl needs it.
-    if (ASD->exportsPropertyDescriptor()) {
+    if (ASD->getPropertyDescriptorGenericSignature()) {
       Visitor.addPropertyDescriptor(ASD);
     }
 

--- a/test/SILGen/conditionally_copyable_conformance_descriptor.swift
+++ b/test/SILGen/conditionally_copyable_conformance_descriptor.swift
@@ -1,0 +1,180 @@
+// RUN: %target-swift-emit-silgen -enable-library-evolution %s | %FileCheck %s
+
+public struct ConditionallyCopyable<T: ~Copyable>: ~Copyable {
+}
+
+extension ConditionallyCopyable: Copyable where T: Copyable {}
+
+public struct NeverCopyable: ~Copyable {}
+
+public struct Index<U: ~Copyable>: Hashable { }
+
+extension ConditionallyCopyable where T: ~Copyable {
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.sometimesCopyableBase_sometimesCopyableValue
+    // CHECK-SAME:    getter @{{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0> (@in_guaranteed ConditionallyCopyable<τ_0_0>) -> @out τ_0_0
+    // CHECK-SAME:    setter @{{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0> (@in_guaranteed τ_0_0, @inout ConditionallyCopyable<τ_0_0>) -> ()
+    public private(set) var sometimesCopyableBase_sometimesCopyableValue: T {
+        get { }
+        set { }
+    }
+
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.sometimesCopyableBase_alwaysCopyableValue
+    // CHECK-SAME:    getter @{{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0> (@in_guaranteed ConditionallyCopyable<τ_0_0>) -> @out Int
+    // CHECK-SAME:    setter @{{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0> (@in_guaranteed Int, @inout ConditionallyCopyable<τ_0_0>) -> ()
+    public private(set) var sometimesCopyableBase_alwaysCopyableValue: Int {
+        get { }
+        set { }
+    }
+
+    // CHECK-NOT: sil_property #ConditionallyCopyable.neverCopyableBase_alwaysCopyableValue
+    public private(set) var sometimesCopyableBase_neverCopyableValue: NeverCopyable {
+        get { }
+        set { }
+    }
+
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.subscript{{.*}}, id @$s45conditionally_copyable_conformance_descriptor21ConditionallyCopyableVAARi_zrlE09sometimesf5Base_gF10IndexValueqd__AA0I0Vyqd__G_tcRi_d__luir
+    // CHECK-SAME:    getter @{{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0><τ_1_0> (@in_guaranteed ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> @out τ_1_0
+    // CHECK-SAME:    setter @{{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0><τ_1_0> (@in_guaranteed τ_1_0, @inout ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> ()
+    public private(set) subscript<U: ~Copyable>(
+        sometimesCopyableBase_sometimesCopyableIndexValue _: Index<U>
+    ) -> U {
+        get { }
+        set { }
+    }
+
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.subscript{{.*}}, id @$s45conditionally_copyable_conformance_descriptor21ConditionallyCopyableVAARi_zrlE09sometimesf5Base_gF5ValuexAA5IndexVyqd__G_tcRi_d__luir
+    // CHECK-SAME:    getter @{{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0><τ_1_0 where τ_1_0 : ~Copyable> (@in_guaranteed ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> @out τ_0_0
+    // CHECK-SAME:    setter @{{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0><τ_1_0 where τ_1_0 : ~Copyable> (@in_guaranteed τ_0_0, @inout ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> ()
+    public private(set) subscript<U: ~Copyable>(
+        sometimesCopyableBase_sometimesCopyableValue _: Index<U>
+    ) -> T {
+        get { }
+        set { }
+    }
+
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.subscript{{.*}}, id @$s45conditionally_copyable_conformance_descriptor21ConditionallyCopyableVAARi_zrlE09sometimesf11Base_alwaysF5ValueSiAA5IndexVyqd__G_tcRi_d__luig
+    // CHECK-SAME:    getter @{{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0><τ_1_0 where τ_1_0 : ~Copyable> (@in_guaranteed ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> @out Int
+    // CHECK-SAME:    setter @{{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0><τ_1_0 where τ_1_0 : ~Copyable> (@in_guaranteed Int, @inout ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> ()
+    public private(set) subscript<U: ~Copyable>(
+        sometimesCopyableBase_alwaysCopyableValue _: Index<U>
+    ) -> Int {
+        get { }
+        set { }
+    }
+
+    // CHECK-NOT: sil_property #ConditionallyCopyable.subscript{{.*}}never
+    public private(set) subscript<U: ~Copyable>(
+        sometimesCopyableBase_neverCopyableValue _: Index<U>
+    ) -> NeverCopyable {
+        get { }
+        set { }
+    }
+}
+
+extension ConditionallyCopyable where T == NeverCopyable, T: ~Copyable {
+    // CHECK-NOT: sil_property #ConditionallyCopyable.neverCopyableBase_sometimesCopyableValue
+    public private(set) var neverCopyableBase_sometimesCopyableValue: T {
+        get { }
+        set { }
+    }
+
+    // CHECK-NOT: sil_property #ConditionallyCopyable.neverCopyableBase_alwaysCopyableValue
+    public private(set) var neverCopyableBase_alwaysCopyableValue: Int {
+        get { }
+        set { }
+    }
+
+    // CHECK-NOT: sil_property #ConditionallyCopyable.neverCopyableBase_neverCopyableValue
+    public private(set) var neverCopyableBase_neverCopyableValue: NeverCopyable {
+        get { }
+        set { }
+    }
+
+    // CHECK-NOT: sil_property #ConditionallyCopyable.subscript{{.*}}never
+    public private(set) subscript<U: ~Copyable>(
+        neverCopyableBase_sometimesCopyableIndexValue _: Index<U>
+    ) -> U {
+        get { }
+        set { }
+    }
+    public private(set) subscript<U: ~Copyable>(
+        neverCopyableBase_sometimesCopyableValue _: Index<U>
+    ) -> T {
+        get { }
+        set { }
+    }
+    public private(set) subscript<U: ~Copyable>(
+        neverCopyableBase_alwaysCopyableValue _: Index<U>
+    ) -> Int {
+        get { }
+        set { }
+    }
+    public private(set) subscript<U: ~Copyable>(
+        neverCopyableBase_neverCopyableValue _: Index<U>
+    ) -> NeverCopyable {
+        get { }
+        set { }
+    }
+}
+
+extension ConditionallyCopyable where T: Copyable {
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.alwaysCopyableBase_sometimesCopyableValue
+    // CHECK-SAME:    getter {{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0> (@in_guaranteed ConditionallyCopyable<τ_0_0>) -> @out τ_0_0
+    // CHECK-SAME:    setter {{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0> (@in_guaranteed τ_0_0, @inout ConditionallyCopyable<τ_0_0>) -> ()
+    public private(set) var alwaysCopyableBase_sometimesCopyableValue: T {
+        get { }
+        set { }
+    }
+
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.alwaysCopyableBase_alwaysCopyableValue
+    // CHECK-SAME:    getter {{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0> (@in_guaranteed ConditionallyCopyable<τ_0_0>) -> @out Int
+    // CHECK-SAME:    setter {{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0> (@in_guaranteed Int, @inout ConditionallyCopyable<τ_0_0>) -> ()
+    public private(set) var alwaysCopyableBase_alwaysCopyableValue: Int {
+        get { }
+        set { }
+    }
+
+    // CHECK-NOT: sil_property alwaysCopyableBase_neverCopyableValue
+    public private(set) var alwaysCopyableBase_neverCopyableValue: NeverCopyable {
+        get { }
+        set { }
+    }
+
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.subscript{{.*}}, id @$s45conditionally_copyable_conformance_descriptor21ConditionallyCopyableV06alwaysf14Base_sometimesF10IndexValueqd__AA0J0Vyqd__G_tcRi_d__luir
+    // CHECK-SAME:    getter {{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0><τ_1_0> (@in_guaranteed ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> @out τ_1_0
+    // CHECK-SAME:    setter {{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0><τ_1_0> (@in_guaranteed τ_1_0, @inout ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> ())
+    public private(set) subscript<U: ~Copyable>(
+        alwaysCopyableBase_sometimesCopyableIndexValue _: Index<U>
+    ) -> U {
+        get { }
+        set { }
+    }
+
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.subscript{{.*}}, id @$s45conditionally_copyable_conformance_descriptor21ConditionallyCopyableV06alwaysf14Base_sometimesF5ValuexAA5IndexVyqd__G_tcRi_d__luig
+    // CHECK-SAME:    getter {{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0><τ_1_0 where τ_1_0 : ~Copyable> (@in_guaranteed ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> @out τ_0_0
+    // CHECK-SAME:    setter {{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0><τ_1_0 where τ_1_0 : ~Copyable> (@in_guaranteed τ_0_0, @inout ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> ()
+    public private(set) subscript<U: ~Copyable>(
+        alwaysCopyableBase_sometimesCopyableValue _: Index<U>
+    ) -> T {
+        get { }
+        set { }
+    }
+
+    // CHECK-LABEL: sil_property #ConditionallyCopyable.subscript{{.*}}, id @$s45conditionally_copyable_conformance_descriptor21ConditionallyCopyableV06alwaysf5Base_gF5ValueSiAA5IndexVyqd__G_tcRi_d__luig
+    // CHECK-SAME:    getter {{[^ ]*}} : $@convention(keypath_accessor_getter) <τ_0_0><τ_1_0 where τ_1_0 : ~Copyable> (@in_guaranteed ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> @out Int
+    // CHECK-SAME:    setter {{[^ ]*}} : $@convention(keypath_accessor_setter) <τ_0_0><τ_1_0 where τ_1_0 : ~Copyable> (@in_guaranteed Int, @inout ConditionallyCopyable<τ_0_0>, @in_guaranteed Index<τ_1_0>) -> ()
+    public private(set) subscript<U: ~Copyable>(
+        alwaysCopyableBase_alwaysCopyableValue _: Index<U>
+    ) -> Int {
+        get { }
+        set { }
+    }
+
+    // CHECK-NOT: sil_property #ConditionallyCopyable.subscript{{.*}}never
+    public private(set) subscript<U: ~Copyable>(
+        alwaysCopyableBase_neverCopyableValue _: Index<U>
+    ) -> NeverCopyable {
+        get { }
+        set { }
+    }
+}

--- a/test/SILOptimizer/lifetime_dependence/verify_library_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_library_diagnostics.swift
@@ -29,16 +29,8 @@ public struct NEImmortal: ~Escapable {
 
 class C {}
 
-// Test diagnostics on keypath getter.
-//
-// rdar://150073405 ([SILGen] support synthesized _modify on top of borrowed getters with library evolution)
-//
-// This produces the error:
-// <unknown>:0: error: unexpected error produced: lifetime-dependent value returned by generated thunk
-// '$s4test17ImplicitAccessorsV10neComputedAA10NEImmortalVvpACTK'
-//
-// Since this error has no source file, we can't verify the diagnostic!
-/*
+// Test that we don't implicitly try to create a keypath getter, since
+// ~Escapable types are not yet supported by keypaths.
 public struct ImplicitAccessors {
   let c: C
 
@@ -50,7 +42,6 @@ public struct ImplicitAccessors {
     }
   }
 }
- */
 
 public struct NoncopyableImplicitAccessors : ~Copyable & ~Escapable {
   public var ne: NE

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -796,21 +796,9 @@ Added: _$sSS5IndexVs28CustomDebugStringConvertiblesWP
 Added: _$ss4SpanVMa
 Added: _$ss4SpanVMn
 Added: _$ss4SpanVsRi_zrlE6_countSivg
-Added: _$ss4SpanVsRi_zrlE6_countSivpMV
 Added: _$ss4SpanVsRi_zrlE8_pointerSVSgvg
-Added: _$ss4SpanVsRi_zrlE8_pointerSVSgvpMV
-Added: _$ss4SpanVsRi_zrlE5countSivpMV
-Added: _$ss4SpanVsRi_zrlE7indicesSnySiGvpMV
-Added: _$ss4SpanVsRi_zrlE7isEmptySbvpMV
-Added: _$ss4SpanVss15BitwiseCopyableRzlE9uncheckedxSi_tcipMV
-Added: _$ss4SpanVss15BitwiseCopyableRzlEyxSicipMV
-Added: _$ss7RawSpanV11byteOffsetsSnySiGvpMV
 Added: _$ss7RawSpanV6_countSivg
-Added: _$ss7RawSpanV6_countSivpMV
-Added: _$ss7RawSpanV7isEmptySbvpMV
 Added: _$ss7RawSpanV8_pointerSVSgvg
-Added: _$ss7RawSpanV8_pointerSVSgvpMV
-Added: _$ss7RawSpanV9byteCountSivpMV
 Added: _$ss7RawSpanVMa
 Added: _$ss7RawSpanVMn
 Added: _$ss7RawSpanVN
@@ -818,9 +806,7 @@ Added: _$ss7RawSpanVN
 // SE-0464 UTF8Span
 Added: _$sSS7copyingSSs8UTF8SpanV_tcfC
 Added: _$sSS8utf8Spans04UTF8B0Vvg
-Added: _$sSS8utf8Spans04UTF8B0VvpMV
 Added: _$sSs8utf8Spans04UTF8B0Vvg
-Added: _$sSs8utf8Spans04UTF8B0VvpMV
 Added: _$ss7UnicodeO4UTF8O15ValidationErrorV11byteOffsetsSnySiGvM
 Added: _$ss7UnicodeO4UTF8O15ValidationErrorV11byteOffsetsSnySiGvg
 Added: _$ss7UnicodeO4UTF8O15ValidationErrorV11byteOffsetsSnySiGvpMV
@@ -873,21 +859,15 @@ Added: _$ss7UnicodeO4UTF8O15ValidationErrorVs23CustomStringConvertiblesMc
 Added: _$ss7UnicodeO4UTF8O15ValidationErrorVs23CustomStringConvertiblesWP
 Added: _$ss7UnicodeO4UTF8O15_checkAllErrorsySayAD15ValidationErrorVGxSTRzs5UInt8V7ElementRtzlFZ
 Added: _$ss8UTF8SpanV9unchecked12isKnownASCIIABs0B0Vys5UInt8VG_SbtcfC
-Added: _$ss8UTF8SpanV10_countMasks6UInt64VvpZMV
-Added: _$ss8UTF8SpanV10_flagsMasks6UInt64VvpZMV
-Added: _$ss8UTF8SpanV10isKnownNFCSbvpMV
 Added: _$ss8UTF8SpanV10validatingABs0B0Vys5UInt8VG_ts7UnicodeO0A0O15ValidationErrorVYKcfC
 Added: _$ss8UTF8SpanV11checkForNFC10quickCheckS2b_tF
-Added: _$ss8UTF8SpanV12isKnownASCIISbvpMV
 Added: _$ss8UTF8SpanV13checkForASCIISbyF
 Added: _$ss8UTF8SpanV14_countAndFlagss6UInt64VvM
 Added: _$ss8UTF8SpanV14_countAndFlagss6UInt64Vvg
-Added: _$ss8UTF8SpanV14_countAndFlagss6UInt64VvpMV
 Added: _$ss8UTF8SpanV14_countAndFlagss6UInt64Vvs
 Added: _$ss8UTF8SpanV17CharacterIteratorV11skipForward2byS2i_tF
 Added: _$ss8UTF8SpanV17CharacterIteratorV11skipForwardSiyF
 Added: _$ss8UTF8SpanV17CharacterIteratorV21currentCodeUnitOffsetSivg
-Added: _$ss8UTF8SpanV17CharacterIteratorV21currentCodeUnitOffsetSivpMV
 Added: _$ss8UTF8SpanV17CharacterIteratorV4nextSJSgyF
 Added: _$ss8UTF8SpanV17CharacterIteratorV5reset20roundingForwardsFromySi_tF
 Added: _$ss8UTF8SpanV17CharacterIteratorV5reset21roundingBackwardsFromySi_tF
@@ -898,19 +878,16 @@ Added: _$ss8UTF8SpanV17CharacterIteratorV8previousSJSgyF
 Added: _$ss8UTF8SpanV17CharacterIteratorV8skipBack2byS2i_tF
 Added: _$ss8UTF8SpanV17CharacterIteratorV8skipBackSiyF
 Added: _$ss8UTF8SpanV17CharacterIteratorV9codeUnitsABvg
-Added: _$ss8UTF8SpanV17CharacterIteratorV9codeUnitsABvpMV
 Added: _$ss8UTF8SpanV17CharacterIteratorVMa
 Added: _$ss8UTF8SpanV17CharacterIteratorVMn
 Added: _$ss8UTF8SpanV17CharacterIteratorVN
 Added: _$ss8UTF8SpanV17CharacterIteratorVyAdBcfC
 Added: _$ss8UTF8SpanV18_unsafeBaseAddressSVSgvM
 Added: _$ss8UTF8SpanV18_unsafeBaseAddressSVSgvg
-Added: _$ss8UTF8SpanV18_unsafeBaseAddressSVSgvpMV
 Added: _$ss8UTF8SpanV18_unsafeBaseAddressSVSgvs
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV11skipForward2byS2i_tF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV11skipForwardSiyF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV21currentCodeUnitOffsetSivg
-Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV21currentCodeUnitOffsetSivpMV
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV4nexts0C0O0D0VSgyF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV5reset20roundingForwardsFromySi_tF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV5reset21roundingBackwardsFromySi_tF
@@ -921,7 +898,6 @@ Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV8previouss0C0O0D0VSgyF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV8skipBack2byS2i_tF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV8skipBackSiyF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV9codeUnitsABvg
-Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV9codeUnitsABvpMV
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorVMa
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorVMn
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorVN
@@ -931,12 +907,7 @@ Added: _$ss8UTF8SpanV21makeCharacterIteratorAB0dE0VyF
 Added: _$ss8UTF8SpanV23isCanonicallyEquivalent2toSbAB_tF
 Added: _$ss8UTF8SpanV25makeUnicodeScalarIteratorAB0deF0VyF
 Added: _$ss8UTF8SpanV4spans0B0Vys5UInt8VGvg
-Added: _$ss8UTF8SpanV4spans0B0Vys5UInt8VGvpMV
-Added: _$ss8UTF8SpanV5countSivpMV
-Added: _$ss8UTF8SpanV7_nfcBits6UInt64VvpZMV
 Added: _$ss8UTF8SpanV7isEmptySbvg
-Added: _$ss8UTF8SpanV7isEmptySbvpMV
-Added: _$ss8UTF8SpanV9_asciiBits6UInt64VvpZMV
 Added: _$ss8UTF8SpanVMa
 Added: _$ss8UTF8SpanVMn
 Added: _$ss8UTF8SpanVN
@@ -955,20 +926,8 @@ Added: _$ss14MutableRawSpanVMn
 Added: _$ss14MutableRawSpanVN
 
 // SE-0456 Span-providing properties
-Added: _$sSRsRi_zrlE4spans4SpanVyxGvpMV
-Added: _$sSW5bytess7RawSpanVvpMV
-Added: _$sSa4spans4SpanVyxGvpMV
-Added: _$sSrsRi_zrlE4spans4SpanVyxGvpMV
-Added: _$sSw5bytess7RawSpanVvpMV
-Added: _$ss10ArraySliceV4spans4SpanVyxGvpMV
-Added: _$ss13KeyValuePairsV4spans4SpanVyx3key_q_5valuetGvpMV
-Added: _$ss15CollectionOfOneV4spans4SpanVyxGvpMV
-Added: _$ss15ContiguousArrayV4spans4SpanVyxGvpMV
-Added: _$ss4SpanVss15BitwiseCopyableRzlE5bytess03RawA0VvpMV
 Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvg
-Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
 Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
-Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
 
 // SE-0467 mutableSpan properties
 Added: _$sSa11mutableSpans07MutableB0VyxGvr
@@ -1101,22 +1060,10 @@ Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss14M
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss14MutableRawSpanVN$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVMa$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVMn$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE5countSivpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE6_countSivg$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE6_countSivpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE7indicesSnySiGvpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE7isEmptySbvpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE8_pointerSVSgvg$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE8_pointerSVSgvpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVss15BitwiseCopyableRzlE9uncheckedxSi_tcipMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVss15BitwiseCopyableRzlEyxSicipMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV11byteOffsetsSnySiGvpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV6_countSivg$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV6_countSivpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV7isEmptySbvpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV8_pointerSVSgvg$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV8_pointerSVSgvpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV9byteCountSivpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVMa$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVMn$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVN$
@@ -1128,3 +1075,15 @@ Added: _$ss8DurationV11nanosecondsyABSdFZ
 Added: _$ss11InlineArrayVsRi__rlE8_storagexq_BVvM
 Added: _$ss11InlineArrayVsRi__rlE8_storagexq_BVvs
 
+// rdar://151628396: Retroactively give property descriptors to conditionally-copyable/escapable properties
+Added: _$ss11InlineArrayVsRi__rlE10startIndexSivpMV
+Added: _$ss11InlineArrayVsRi__rlE5countSivpMV
+Added: _$ss11InlineArrayVsRi__rlE7_bufferSRyq_GvpMV
+Added: _$ss11InlineArrayVsRi__rlE7indicesSnySiGvpMV
+Added: _$ss11InlineArrayVsRi__rlE7isEmptySbvpMV
+Added: _$ss11InlineArrayVsRi__rlE8_addressSPyq_GvpMV
+Added: _$ss11InlineArrayVsRi__rlE8endIndexSivpMV
+Added: _$ss8UTF8SpanV10_countMasks6UInt64VvpZMV
+Added: _$ss8UTF8SpanV10_flagsMasks6UInt64VvpZMV
+Added: _$ss8UTF8SpanV7_nfcBits6UInt64VvpZMV
+Added: _$ss8UTF8SpanV9_asciiBits6UInt64VvpZMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -797,21 +797,9 @@ Added: _$sSS5IndexVs28CustomDebugStringConvertiblesWP
 Added: _$ss4SpanVMa
 Added: _$ss4SpanVMn
 Added: _$ss4SpanVsRi_zrlE6_countSivg
-Added: _$ss4SpanVsRi_zrlE6_countSivpMV
 Added: _$ss4SpanVsRi_zrlE8_pointerSVSgvg
-Added: _$ss4SpanVsRi_zrlE8_pointerSVSgvpMV
-Added: _$ss4SpanVsRi_zrlE5countSivpMV
-Added: _$ss4SpanVsRi_zrlE7indicesSnySiGvpMV
-Added: _$ss4SpanVsRi_zrlE7isEmptySbvpMV
-Added: _$ss4SpanVss15BitwiseCopyableRzlE9uncheckedxSi_tcipMV
-Added: _$ss4SpanVss15BitwiseCopyableRzlEyxSicipMV
-Added: _$ss7RawSpanV11byteOffsetsSnySiGvpMV
 Added: _$ss7RawSpanV6_countSivg
-Added: _$ss7RawSpanV6_countSivpMV
-Added: _$ss7RawSpanV7isEmptySbvpMV
 Added: _$ss7RawSpanV8_pointerSVSgvg
-Added: _$ss7RawSpanV8_pointerSVSgvpMV
-Added: _$ss7RawSpanV9byteCountSivpMV
 Added: _$ss7RawSpanVMa
 Added: _$ss7RawSpanVMn
 Added: _$ss7RawSpanVN
@@ -819,9 +807,7 @@ Added: _$ss7RawSpanVN
 // SE-0464 UTF8Span
 Added: _$sSS7copyingSSs8UTF8SpanV_tcfC
 Added: _$sSS8utf8Spans04UTF8B0Vvg
-Added: _$sSS8utf8Spans04UTF8B0VvpMV
 Added: _$sSs8utf8Spans04UTF8B0Vvg
-Added: _$sSs8utf8Spans04UTF8B0VvpMV
 Added: _$ss7UnicodeO4UTF8O15ValidationErrorV11byteOffsetsSnySiGvM
 Added: _$ss7UnicodeO4UTF8O15ValidationErrorV11byteOffsetsSnySiGvg
 Added: _$ss7UnicodeO4UTF8O15ValidationErrorV11byteOffsetsSnySiGvpMV
@@ -874,21 +860,15 @@ Added: _$ss7UnicodeO4UTF8O15ValidationErrorVs23CustomStringConvertiblesMc
 Added: _$ss7UnicodeO4UTF8O15ValidationErrorVs23CustomStringConvertiblesWP
 Added: _$ss7UnicodeO4UTF8O15_checkAllErrorsySayAD15ValidationErrorVGxSTRzs5UInt8V7ElementRtzlFZ
 Added: _$ss8UTF8SpanV9unchecked12isKnownASCIIABs0B0Vys5UInt8VG_SbtcfC
-Added: _$ss8UTF8SpanV10_countMasks6UInt64VvpZMV
-Added: _$ss8UTF8SpanV10_flagsMasks6UInt64VvpZMV
-Added: _$ss8UTF8SpanV10isKnownNFCSbvpMV
 Added: _$ss8UTF8SpanV10validatingABs0B0Vys5UInt8VG_ts7UnicodeO0A0O15ValidationErrorVYKcfC
 Added: _$ss8UTF8SpanV11checkForNFC10quickCheckS2b_tF
-Added: _$ss8UTF8SpanV12isKnownASCIISbvpMV
 Added: _$ss8UTF8SpanV13checkForASCIISbyF
 Added: _$ss8UTF8SpanV14_countAndFlagss6UInt64VvM
 Added: _$ss8UTF8SpanV14_countAndFlagss6UInt64Vvg
-Added: _$ss8UTF8SpanV14_countAndFlagss6UInt64VvpMV
 Added: _$ss8UTF8SpanV14_countAndFlagss6UInt64Vvs
 Added: _$ss8UTF8SpanV17CharacterIteratorV11skipForward2byS2i_tF
 Added: _$ss8UTF8SpanV17CharacterIteratorV11skipForwardSiyF
 Added: _$ss8UTF8SpanV17CharacterIteratorV21currentCodeUnitOffsetSivg
-Added: _$ss8UTF8SpanV17CharacterIteratorV21currentCodeUnitOffsetSivpMV
 Added: _$ss8UTF8SpanV17CharacterIteratorV4nextSJSgyF
 Added: _$ss8UTF8SpanV17CharacterIteratorV5reset20roundingForwardsFromySi_tF
 Added: _$ss8UTF8SpanV17CharacterIteratorV5reset21roundingBackwardsFromySi_tF
@@ -899,19 +879,16 @@ Added: _$ss8UTF8SpanV17CharacterIteratorV8previousSJSgyF
 Added: _$ss8UTF8SpanV17CharacterIteratorV8skipBack2byS2i_tF
 Added: _$ss8UTF8SpanV17CharacterIteratorV8skipBackSiyF
 Added: _$ss8UTF8SpanV17CharacterIteratorV9codeUnitsABvg
-Added: _$ss8UTF8SpanV17CharacterIteratorV9codeUnitsABvpMV
 Added: _$ss8UTF8SpanV17CharacterIteratorVMa
 Added: _$ss8UTF8SpanV17CharacterIteratorVMn
 Added: _$ss8UTF8SpanV17CharacterIteratorVN
 Added: _$ss8UTF8SpanV17CharacterIteratorVyAdBcfC
 Added: _$ss8UTF8SpanV18_unsafeBaseAddressSVSgvM
 Added: _$ss8UTF8SpanV18_unsafeBaseAddressSVSgvg
-Added: _$ss8UTF8SpanV18_unsafeBaseAddressSVSgvpMV
 Added: _$ss8UTF8SpanV18_unsafeBaseAddressSVSgvs
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV11skipForward2byS2i_tF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV11skipForwardSiyF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV21currentCodeUnitOffsetSivg
-Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV21currentCodeUnitOffsetSivpMV
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV4nexts0C0O0D0VSgyF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV5reset20roundingForwardsFromySi_tF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV5reset21roundingBackwardsFromySi_tF
@@ -922,7 +899,6 @@ Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV8previouss0C0O0D0VSgyF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV8skipBack2byS2i_tF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV8skipBackSiyF
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV9codeUnitsABvg
-Added: _$ss8UTF8SpanV21UnicodeScalarIteratorV9codeUnitsABvpMV
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorVMa
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorVMn
 Added: _$ss8UTF8SpanV21UnicodeScalarIteratorVN
@@ -932,12 +908,7 @@ Added: _$ss8UTF8SpanV21makeCharacterIteratorAB0dE0VyF
 Added: _$ss8UTF8SpanV23isCanonicallyEquivalent2toSbAB_tF
 Added: _$ss8UTF8SpanV25makeUnicodeScalarIteratorAB0deF0VyF
 Added: _$ss8UTF8SpanV4spans0B0Vys5UInt8VGvg
-Added: _$ss8UTF8SpanV4spans0B0Vys5UInt8VGvpMV
-Added: _$ss8UTF8SpanV5countSivpMV
-Added: _$ss8UTF8SpanV7_nfcBits6UInt64VvpZMV
 Added: _$ss8UTF8SpanV7isEmptySbvg
-Added: _$ss8UTF8SpanV7isEmptySbvpMV
-Added: _$ss8UTF8SpanV9_asciiBits6UInt64VvpZMV
 Added: _$ss8UTF8SpanVMa
 Added: _$ss8UTF8SpanVMn
 Added: _$ss8UTF8SpanVN
@@ -956,20 +927,8 @@ Added: _$ss14MutableRawSpanVMn
 Added: _$ss14MutableRawSpanVN
 
 // SE-0456 Span-providing properties
-Added: _$sSRsRi_zrlE4spans4SpanVyxGvpMV
-Added: _$sSW5bytess7RawSpanVvpMV
-Added: _$sSa4spans4SpanVyxGvpMV
-Added: _$sSrsRi_zrlE4spans4SpanVyxGvpMV
-Added: _$sSw5bytess7RawSpanVvpMV
-Added: _$ss10ArraySliceV4spans4SpanVyxGvpMV
-Added: _$ss13KeyValuePairsV4spans4SpanVyx3key_q_5valuetGvpMV
-Added: _$ss15CollectionOfOneV4spans4SpanVyxGvpMV
-Added: _$ss15ContiguousArrayV4spans4SpanVyxGvpMV
-Added: _$ss4SpanVss15BitwiseCopyableRzlE5bytess03RawA0VvpMV
 Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvg
-Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
 Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
-Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvpMV
 
 // SE-0467 mutableSpan properties
 Added: _$sSa11mutableSpans07MutableB0VyxGvr
@@ -1102,22 +1061,10 @@ Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss14M
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss14MutableRawSpanVN$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVMa$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVMn$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE5countSivpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE6_countSivg$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE6_countSivpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE7indicesSnySiGvpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE7isEmptySbvpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE8_pointerSVSgvg$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVsRi_zrlE8_pointerSVSgvpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVss15BitwiseCopyableRzlE9uncheckedxSi_tcipMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss4SpanVss15BitwiseCopyableRzlEyxSicipMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV11byteOffsetsSnySiGvpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV6_countSivg$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV6_countSivpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV7isEmptySbvpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV8_pointerSVSgvg$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV8_pointerSVSgvpMV$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanV9byteCountSivpMV$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVMa$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVMn$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss7RawSpanVN$
@@ -1129,3 +1076,15 @@ Added: _$ss8DurationV11nanosecondsyABSdFZ
 Added: _$ss11InlineArrayVsRi__rlE8_storagexq_BVvM
 Added: _$ss11InlineArrayVsRi__rlE8_storagexq_BVvs
 
+// rdar://151628396: Retroactively give property descriptors to conditionally-copyable/escapable properties
+Added: _$ss11InlineArrayVsRi__rlE10startIndexSivpMV
+Added: _$ss11InlineArrayVsRi__rlE5countSivpMV
+Added: _$ss11InlineArrayVsRi__rlE7_bufferSRyq_GvpMV
+Added: _$ss11InlineArrayVsRi__rlE7indicesSnySiGvpMV
+Added: _$ss11InlineArrayVsRi__rlE7isEmptySbvpMV
+Added: _$ss11InlineArrayVsRi__rlE8_addressSPyq_GvpMV
+Added: _$ss11InlineArrayVsRi__rlE8endIndexSivpMV
+Added: _$ss8UTF8SpanV10_countMasks6UInt64VvpZMV
+Added: _$ss8UTF8SpanV10_flagsMasks6UInt64VvpZMV
+Added: _$ss8UTF8SpanV7_nfcBits6UInt64VvpZMV
+Added: _$ss8UTF8SpanV9_asciiBits6UInt64VvpZMV


### PR DESCRIPTION
Key paths can't reference non-escapable or non-copyable storage declarations,
so we don't need to refer to them resiliently, and can elide their property
descriptors.

However, declarations may still be conditionally Copyable and Escapable, and
if so, then they still need a property descriptor for resilient key path
references. When a property or subscript can be used in a context where it
is fully Copyable and Escapable, emit the property descriptor in a generic
environment constrained by the necessary conditional constraints.

Fixes rdar://151628396.