### PR TITLE
[ModuleInterface] Ignore SDKSettings.json in "sourceFiles"

### DIFF
--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -51,7 +51,7 @@ import ImportsMacroSpecificClangModule
 // CHECK-NEXT:      "sourceFiles": [
 // CHECK-DAG:        "{{.*}}OnlyWithMacro.h"
 // CHECK-DAG:        "{{.*}}module.modulemap"
-// CHECK-NEXT:      ],
+// CHECK:           ],
 // CHECK-NEXT:      "directDependencies": [
 // CHECK-NEXT:      ],
 // CHECK-NEXT:      "linkLibraries": [


### PR DESCRIPTION
This is a counterpart to https://github.com/swiftlang/llvm-project/pull/10679. The intent is to ignore SDKSettings.json as a file dependency, since it's platform-specific.