### PR TITLE
Build Swift-Testing with WMO

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swift_testing.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing.py
@@ -112,6 +112,8 @@ class SwiftTestingCMakeShim(cmake_product.CMakeProduct):
 
         self.cmake_options.define('CMAKE_BUILD_TYPE', self.args.build_variant)
 
+        self.cmake_options.define('CMAKE_Swift_COMPILATION_MODE', 'wholemodule')
+
         # FIXME: If we build macros for the builder, specify the path.
         self.cmake_options.define('SwiftTesting_MACRO', 'NO')
 


### PR DESCRIPTION
This tells build-script to build Swift-testing with WMO. This results in a faster build products, but is also necessary for configurations using the legacy swift driver, which would emit an invalid swift interface in non-WMO builds.

```
/home/build-user/build/bootstrap_stage2/swifttesting-linux-x86_64/swift/Testing.swiftinterface:413:2: error: '@_optimize(none)' attribute cannot be applied to stored properties
 411 | }
 412 | @usableFromInline
 413 | @_optimize(none) nonisolated(unsafe) internal var failureBreakpointValue: Swift.Int
     |  `- error: '@_optimize(none)' attribute cannot be applied to stored properties
 414 | @usableFromInline
 415 | @inline(never) internal func failureBreakpoint()
```

Fixes: rdar://151357567