### PR TITLE
[cxx-interop] Fix assertion failure from unavailable typedef + enum pattern

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -847,26 +847,6 @@ static bool isPrintLikeMethod(DeclName name, const DeclContext *dc) {
 using MirroredMethodEntry =
   std::tuple<const clang::ObjCMethodDecl*, ProtocolDecl*, bool /*isAsync*/>;
 
-ImportedType importer::findOptionSetEnum(clang::QualType type,
-                                         ClangImporter::Implementation &Impl) {
-  if (auto typedefType = dyn_cast<clang::TypedefType>(type)) {
-    if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum =
-              findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(
-            clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-            typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
-          return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
-        }
-      }
-    }
-  }
-  return {};
-}
-
 static bool areRecordFieldsComplete(const clang::CXXRecordDecl *decl) {
   for (const auto *f : decl->fields()) {
     auto *fieldRecord = f->getType()->getAsCXXRecordDecl();

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -255,6 +255,11 @@ ImportedType importer::findOptionSetEnum(clang::QualType type,
     // then this definitely isn't used for {CF,NS}_OPTIONS.
     return ImportedType();
 
+  if (Impl.SwiftContext.LangOpts.EnableCXXInterop &&
+      !isCFOptionsMacro(typedefType->getDecl(), Impl.getClangPreprocessor())) {
+    return ImportedType();
+  }
+
   auto clangEnum = findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType);
   if (!clangEnum)
     return ImportedType();

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -244,10 +244,7 @@ StringRef importer::getCommonPluralPrefix(StringRef singular,
 }
 
 const clang::Type *importer::getUnderlyingType(const clang::EnumDecl *decl) {
-  const clang::Type *underlyingType = decl->getIntegerType().getTypePtr();
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(underlyingType))
-    underlyingType = elaborated->desugar().getTypePtr();
-  return underlyingType;
+  return importer::desugarIfElaborated(decl->getIntegerType().getTypePtr());
 }
 
 /// Determine the prefix to be stripped from the names of the enum constants

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -253,11 +253,11 @@ ImportedType importer::findOptionSetEnum(clang::QualType type,
   if (!typedefType || !Impl.isUnavailableInSwift(typedefType->getDecl()))
     // If this isn't a typedef, or it is a typedef that is available in Swift,
     // then this definitely isn't used for {CF,NS}_OPTIONS.
-    return {};
+    return ImportedType();
 
   auto clangEnum = findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType);
   if (!clangEnum)
-    return {};
+    return ImportedType();
 
   // If this fails, it means that we need a stronger predicate for
   // determining the relationship between an enum and typedef.
@@ -267,7 +267,7 @@ ImportedType importer::findOptionSetEnum(clang::QualType type,
   if (auto *swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion))
     return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
 
-  return {};
+  return ImportedType();
 }
 
 /// Determine the prefix to be stripped from the names of the enum constants

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -259,9 +259,6 @@ ImportedType importer::findOptionSetEnum(clang::QualType type,
   if (!clangEnum)
     return ImportedType();
 
-  // Only ASSERT() on assertions-enabled builds. This preserves existing
-  // behavior and de-risks existing builds, but should be removed after 6.2.
-#ifndef NDEBUG
   // Assert that the typedef has the same underlying integer representation as
   // the enum we think it assigns a type name to.
   //
@@ -275,7 +272,6 @@ ImportedType importer::findOptionSetEnum(clang::QualType type,
     ASSERT(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
            typedefType->getCanonicalTypeInternal());
   }
-#endif // !NDEBUG
 
   if (auto *swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion))
     return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};

--- a/lib/ClangImporter/ImportEnumInfo.h
+++ b/lib/ClangImporter/ImportEnumInfo.h
@@ -19,6 +19,8 @@
 
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
+#include "clang/Lex/Preprocessor.h"
+#include "clang/Sema/Sema.h"
 #include "llvm/ADT/APSInt.h"
 #include "llvm/ADT/DenseMap.h"
 
@@ -164,14 +166,18 @@ StringRef getCommonPluralPrefix(StringRef singular, StringRef plural);
 /// an elaborated type, an unwrapped type is returned.
 const clang::Type *getUnderlyingType(const clang::EnumDecl *decl);
 
-inline bool isCFOptionsMacro(StringRef macroName) {
-  return llvm::StringSwitch<bool>(macroName)
+inline bool isCFOptionsMacro(const clang::NamedDecl *decl,
+                             clang::Preprocessor &preprocessor) {
+  auto loc = decl->getEndLoc();
+  if (!loc.isMacroID())
+    return false;
+  return llvm::StringSwitch<bool>(preprocessor.getImmediateMacroName(loc))
       .Case("CF_OPTIONS", true)
       .Case("NS_OPTIONS", true)
       .Default(false);
 }
 
-}
-}
+} // namespace importer
+} // namespace swift
 
 #endif // SWIFT_CLANG_IMPORT_ENUM_H

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -18,6 +18,7 @@
 #include "CFTypeInfo.h"
 #include "ClangClassTemplateNamePrinter.h"
 #include "ClangDiagnosticConsumer.h"
+#include "ImportEnumInfo.h"
 #include "ImporterImpl.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ClangSwiftTypeCorrespondence.h"
@@ -1877,15 +1878,9 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   // imported into Swift to avoid having two types with the same name, which
   // cause subtle name lookup issues.
   if (swiftCtx.LangOpts.EnableCXXInterop &&
-      isUnavailableInSwift(D, nullptr, true)) {
-    auto loc = D->getEndLoc();
-    if (loc.isMacroID()) {
-      StringRef macroName =
-          clangSema.getPreprocessor().getImmediateMacroName(loc);
-      if (isCFOptionsMacro(macroName))
-        return ImportedName();
-    }
-  }
+      isUnavailableInSwift(D, nullptr, true) &&
+      isCFOptionsMacro(D, clangSema.getPreprocessor()))
+    return ImportedName();
 
   /// Whether the result is a function name.
   bool isFunction = false;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2282,10 +2282,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
     OptionalityOfReturn = OTK_ImplicitlyUnwrappedOptional;
   }
 
-  clang::QualType returnType = clangDecl->getReturnType();
-  if (auto elaborated =
-          dyn_cast<clang::ElaboratedType>(returnType))
-    returnType = elaborated->desugar();
+  clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
   // In C interop mode, the return type of library builtin functions
   // like 'memcpy' from headers like 'string.h' drops
   // any nullability specifiers from their return type, and preserves it on the
@@ -2323,19 +2320,9 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
           ->isTemplateTypeParmType())
     OptionalityOfReturn = OTK_None;
 
-  if (auto typedefType = dyn_cast<clang::TypedefType>(returnType)) {
-    if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
-        }
-      }
-    }
-  }
+  ImportedType optionSetEnum = importer::findOptionSetEnum(returnType, *this);
+  if (optionSetEnum)
+    return optionSetEnum;
 
   // Import the underlying result type.
   if (clangDecl) {
@@ -2399,27 +2386,11 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
 
   // Only eagerly import the return type if it's not too expensive (the current
   // heuristic for that is if it's not a record type).
-  ImportedType importedType;
   ImportDiagnosticAdder addDiag(*this, clangDecl,
                                 clangDecl->getSourceRange().getBegin());
-  clang::QualType returnType = clangDecl->getReturnType();
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(returnType))
-    returnType = elaborated->desugar();
+  clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
 
-  if (auto typedefType = dyn_cast<clang::TypedefType>(returnType)) {
-    if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
-                          false};
-        }
-      }
-    }
-  }
+  ImportedType importedType = importer::findOptionSetEnum(returnType, *this);
 
   if (auto templateType =
           dyn_cast<clang::TemplateTypeParmType>(returnType)) {
@@ -2483,9 +2454,7 @@ ClangImporter::Implementation::importParameterType(
     std::optional<unsigned> completionHandlerErrorParamIndex,
     ArrayRef<GenericTypeParamDecl *> genericParams,
     llvm::function_ref<void(Diagnostic &&)> addImportDiagnosticFn) {
-  auto paramTy = param->getType();
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(paramTy))
-    paramTy = elaborated->desugar();
+  auto paramTy = desugarIfElaborated(param->getType());
 
   ImportTypeKind importKind = paramIsCompletionHandler
                                   ? ImportTypeKind::CompletionHandlerParameter
@@ -2498,23 +2467,8 @@ ClangImporter::Implementation::importParameterType(
   bool isConsuming = false;
   bool isParamTypeImplicitlyUnwrapped = false;
 
-  // Sometimes we import unavailable typedefs as enums. If that's the case,
-  // use the enum, not the typedef here.
-  if (auto typedefType = dyn_cast<clang::TypedefType>(paramTy.getTypePtr())) {
-    if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum =
-              findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()
-                   ->getIntegerType()
-                   ->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          swiftParamTy = cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType();
-        }
-      }
-    }
+  if (auto optionSetEnum = importer::findOptionSetEnum(paramTy, *this)) {
+    swiftParamTy = optionSetEnum.getType();
   } else if (isa<clang::PointerType>(paramTy) &&
              isa<clang::TemplateTypeParmType>(paramTy->getPointeeType())) {
     auto pointeeType = paramTy->getPointeeType();
@@ -3234,26 +3188,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
 
   ImportDiagnosticAdder addImportDiag(*this, clangDecl,
                                       clangDecl->getLocation());
-  clang::QualType resultType = clangDecl->getReturnType();
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(resultType))
-    resultType = elaborated->desugar();
-
-  ImportedType importedType;
-  if (auto typedefType = dyn_cast<clang::TypedefType>(resultType.getTypePtr())) {
-    if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
-                          false};
-        }
-      }
-    }
-  }
-
+  clang::QualType resultType = desugarIfElaborated(clangDecl->getReturnType());
+  ImportedType importedType = importer::findOptionSetEnum(resultType, *this);
   if (!importedType)
     importedType = importType(resultType, resultKind, addImportDiag,
                               allowNSUIntegerAsIntInResult, Bridgeability::Full,
@@ -3501,9 +3437,6 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
           importedType.isImplicitlyUnwrapped()};
 }
 
-ImportedType findOptionSetType(clang::QualType type,
-                               ClangImporter::Implementation &Impl);
-
 ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
     const DeclContext *dc, const clang::ObjCPropertyDecl *property,
     const clang::ObjCMethodDecl *clangDecl, bool isFromSystemModule,
@@ -3529,11 +3462,11 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
   if (!origDC)
     return {Type(), false};
 
-  auto fieldType = isGetter ? clangDecl->getReturnType()
-                            : clangDecl->getParamDecl(0)->getType();
-
+  auto fieldType =
+      desugarIfElaborated(isGetter ? clangDecl->getReturnType()
+                                   : clangDecl->getParamDecl(0)->getType());
   // Import the property type, independent of what kind of accessor this is.
-  ImportedType importedType = findOptionSetType(fieldType, *this);
+  ImportedType importedType = importer::findOptionSetEnum(fieldType, *this);
   if (!importedType)
     importedType = importPropertyType(property, isFromSystemModule);
   if (!importedType)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CFTypeInfo.h"
+#include "ImportEnumInfo.h"
 #include "ImporterImpl.h"
 #include "SwiftDeclSynthesizer.h"
 #include "swift/ABI/MetadataValues.h"
@@ -2909,13 +2910,8 @@ ArgumentAttrs ClangImporter::Implementation::inferDefaultArgument(
           return argumentAttrs;
         }
       }
-      auto loc = typedefDecl->getEndLoc();
-      if (loc.isMacroID()) {
-        StringRef macroName =
-            nameImporter.getClangPreprocessor().getImmediateMacroName(loc);
-        if (isCFOptionsMacro(macroName))
-          return argumentAttrs;
-      }
+      if (isCFOptionsMacro(typedefDecl, nameImporter.getClangPreprocessor()))
+        return argumentAttrs;
     }
   }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2085,6 +2085,27 @@ bool hasEscapableAttr(const clang::RecordDecl *decl);
 
 bool isViewType(const clang::CXXRecordDecl *decl);
 
+inline const clang::Type *desugarIfElaborated(const clang::Type *type) {
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(type))
+    return elaborated->desugar().getTypePtr();
+  return type;
+}
+
+inline clang::QualType desugarIfElaborated(clang::QualType type) {
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(type))
+    return elaborated->desugar();
+  return type;
+}
+
+/// Option set enums are sometimes imported as typedefs which assign a name to
+/// the type, but are unavailable in Swift.
+///
+/// If given such a typedef, this helper function retrieves and imports the
+/// underlying enum type. Returns an empty ImportedType otherwise.
+///
+/// If \a type is an elaborated type, it should be desugared first.
+ImportedType findOptionSetEnum(clang::QualType type,
+                               ClangImporter::Implementation &Impl);
 } // end namespace importer
 } // end namespace swift
 

--- a/test/Interop/Cxx/enum/Inputs/anonymous-with-swift-name.h
+++ b/test/Interop/Cxx/enum/Inputs/anonymous-with-swift-name.h
@@ -1,16 +1,7 @@
 #ifndef TEST_INTEROP_CXX_ENUM_INPUTS_ANONYMOUS_WITH_SWIFT_NAME_H
 #define TEST_INTEROP_CXX_ENUM_INPUTS_ANONYMOUS_WITH_SWIFT_NAME_H
 
-#define SOME_OPTIONS(_type, _name) __attribute__((availability(swift, unavailable))) _type _name; enum __attribute__((flag_enum,enum_extensibility(open))) : _name
 #define CF_OPTIONS(_type, _name) __attribute__((availability(swift, unavailable))) _type _name; enum : _name
-
-typedef SOME_OPTIONS(unsigned, SOColorMask) {
-    kSOColorMaskRed = (1 << 1),
-    kSOColorMaskGreen = (1 << 2),
-    kSOColorMaskBlue = (1 << 3),
-    kSOColorMaskAll = ~0U
-};
-
 
 typedef CF_OPTIONS(unsigned, CFColorMask) {
   kCFColorMaskRed = (1 << 1),
@@ -19,20 +10,19 @@ typedef CF_OPTIONS(unsigned, CFColorMask) {
   kCFColorMaskAll = ~0U
 };
 
-inline SOColorMask useSOColorMask(SOColorMask mask) { return mask; }
 inline CFColorMask useCFColorMask(CFColorMask mask) { return mask; }
 
 struct ParentStruct { };
 
 inline CFColorMask renameCFColorMask(ParentStruct parent)
     __attribute__((swift_name("ParentStruct.childFn(self:)")))
-{ return kSOColorMaskRed; }
+{ return kCFColorMaskRed; }
 
 inline CFColorMask getCFColorMask(ParentStruct parent)
     __attribute__((swift_name("getter:ParentStruct.colorProp(self:)")))
-{ return kSOColorMaskRed; }
+{ return kCFColorMaskRed; }
 
-inline void getCFColorMask(ParentStruct parent, CFColorMask newValue)
+inline void setCFColorMask(ParentStruct parent, CFColorMask newValue)
     __attribute__((swift_name("setter:ParentStruct.colorProp(self:newValue:)")))
 { }
 
@@ -52,7 +42,6 @@ enum __attribute__((flag_enum,enum_extensibility(open))) : GlobalOldName {
 
 #if __OBJC__
 @interface ColorMaker
-- (void)makeColorWithOptions:(SOColorMask)opts;
 - (void)makeOtherColorWithInt:(int) x withOptions:(CFColorMask)opts;
 @end
 #endif // SWIFT_OBJC_INTEROP

--- a/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
+++ b/test/Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift
@@ -1,32 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=AnonymousWithSwiftName -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK: @available(*, unavailable, message: "Not available in Swift")
-// CHECK: typealias SOColorMask = UInt32
-
-// CHECK: struct SOColorMask : OptionSet, @unchecked Sendable {
-// CHECK:   init(rawValue: UInt32)
-// CHECK:   let rawValue: UInt32
-// CHECK:   typealias RawValue = UInt32
-// CHECK:   typealias Element = SOColorMask
-// CHECK:   typealias ArrayLiteralElement = SOColorMask
-
-// CHECK:   static var red: SOColorMask { get }
-// CHECK:   @available(swift, obsoleted: 3, renamed: "red")
-// CHECK:   static var Red: SOColorMask { get }
-
-// CHECK:   static var green: SOColorMask { get }
-// CHECK:   @available(swift, obsoleted: 3, renamed: "green")
-// CHECK:   static var Green: SOColorMask { get }
-
-// CHECK:   static var blue: SOColorMask { get }
-// CHECK:   @available(swift, obsoleted: 3, renamed: "blue")
-// CHECK:   static var Blue: SOColorMask { get }
-
-// CHECK:   static var all: SOColorMask { get }
-// CHECK:   @available(swift, obsoleted: 3, renamed: "all")
-// CHECK:   static var All: SOColorMask { get }
-// CHECK: }
-
 // CHECK-NOT: typealias CFColorMask = UInt32
 
 // CHECK: struct CFColorMask : OptionSet {
@@ -53,7 +26,6 @@
 // CHECK:   static var All: CFColorMask { get }
 // CHECK: }
 
-// CHECK: func useSOColorMask(_ mask: SOColorMask) -> SOColorMask
 // CHECK: func useCFColorMask(_ mask: CFColorMask) -> CFColorMask
 
 // Test rename with "swift_name" attr:

--- a/test/Interop/Cxx/enum/anonymous-with-swift-name-objc-module-interface.swift
+++ b/test/Interop/Cxx/enum/anonymous-with-swift-name-objc-module-interface.swift
@@ -3,12 +3,6 @@
 // REQUIRES: objc_interop
 
 // CHECK: class ColorMaker {
-// CHECK:   class func makeColor(withOptions opts: SOColorMask)
-// CHECK:   func makeColor(withOptions opts: SOColorMask)
-// CHECK:   @available(swift, obsoleted: 3, renamed: "makeColor(withOptions:)")
-// CHECK:   class func makeColorWithOptions(_ opts: SOColorMask)
-// CHECK:   @available(swift, obsoleted: 3, renamed: "makeColor(withOptions:)")
-// CHECK:   func makeColorWithOptions(_ opts: SOColorMask)
 // CHECK:   class func makeOtherColor(with x: Int32, withOptions opts: CFColorMask)
 // CHECK:   func makeOtherColor(with x: Int32, withOptions opts: CFColorMask)
 // CHECK:   @available(swift, obsoleted: 3, renamed: "makeOtherColor(with:withOptions:)")

--- a/test/Interop/Cxx/enum/anonymous-with-swift-name.swift
+++ b/test/Interop/Cxx/enum/anonymous-with-swift-name.swift
@@ -7,18 +7,6 @@ import StdlibUnittest
 
 var AnonymousEnumsTestSuite = TestSuite("Anonymous Enums With Swift Name")
 
-AnonymousEnumsTestSuite.test("SOME_OPTIONS") {
-  let red: SOColorMask = .red
-  let green = SOColorMask.green
-  let blue = .blue as SOColorMask
-  let all: SOColorMask = .all
-
-  expectEqual(red.rawValue, 2)
-  expectEqual(green.rawValue, 4)
-  expectEqual(blue.rawValue, 8)
-   expectEqual(all.rawValue, ~CUnsignedInt(0))
-}
-
 AnonymousEnumsTestSuite.test("CF_OPTIONS") {
   let red: CFColorMask = .red
   let green = CFColorMask.green
@@ -35,8 +23,8 @@ AnonymousEnumsTestSuite.test("Parameter types") {
   let red: CFColorMask = .red
   let green = CFColorMask.green
 
-  let blue = useSOColorMask(.blue)
-  let all = useSOColorMask(.all)
+  let blue = useCFColorMask(.blue)
+  let all = useCFColorMask(.all)
 
   expectEqual(red, useCFColorMask(.red))
   expectEqual(green, useCFColorMask(.green))

--- a/test/Interop/Cxx/objc-correctness/ns-enum-with-unavailable-typedef.swift
+++ b/test/Interop/Cxx/objc-correctness/ns-enum-with-unavailable-typedef.swift
@@ -1,0 +1,60 @@
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t/include -module-name main
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t/include -module-name main -cxx-interoperability-mode=default
+// REQUIRES: objc_interop
+
+//--- include/module.modulemap
+module ObjCModule {
+    header "header.h"
+}
+
+//--- include/header.h
+#include <Foundation/Foundation.h>
+
+#define UNAVAILABLE API_UNAVAILABLE(macos)
+
+UNAVAILABLE
+typedef NS_ENUM(NSUInteger, MyUnavailableEnum) {
+    MyUnavailableEnumCase1 = 0,
+    MyUnavailableEnumCase2,
+};
+
+UNAVAILABLE
+void unavailableParam(MyUnavailableEnum e);
+
+UNAVAILABLE
+MyUnavailableEnum unavailableReturn(void);
+
+struct UNAVAILABLE UnavailableStruct {
+  MyUnavailableEnum field;
+};
+
+UNAVAILABLE
+@interface UnavailableClass
+@property (nonatomic, readonly) MyUnavailableEnum prop;
+@end
+
+UNAVAILABLE
+__attribute__((swift_name("getter:UnavailableStruct.iProp(self:)")))
+inline MyUnavailableEnum getUnavailableInjProp(struct UnavailableStruct s) {
+  return MyUnavailableEnumCase1;
+}
+
+//--- main.swift
+import Foundation
+import ObjCModule
+
+@available(*, unavailable)
+func useParam(_ e: MyUnavailableEnum) { unavailableParam(e) }
+
+@available(*, unavailable)
+func useReturn() -> MyUnavailableEnum { return unavailableReturn() }
+
+@available(*, unavailable)
+func useField(_ o: UnavailableStruct) -> MyUnavailableEnum { return o.field }
+
+@available(*, unavailable)
+func useIProp(_ o: UnavailableStruct) -> MyUnavailableEnum { return o.iProp }
+
+@available(*, unavailable)
+func useProp(_ o: UnavailableClass) -> MyUnavailableEnum { return o.prop }


### PR DESCRIPTION
The `NS_OPTIONS` macro sometimes uses a pattern where it loosely
associates a typedef with an anonymous enum via a shared underlying
integer type (emphasis on "loosely"). The typedef is marked as
unavailable in Swift so as to not cause name ambiguity when we associate
the anonymous enum with said typedef. We use unavailability as
a heuristic during the import process, but that conflates `NS_OPTIONS`
with `NS_ENUM`s that can be marked as unavailable for entirely unrelated
reasons.

That in and of itself is fine, because the import logic is general
enough to handle both cases, but we have an assertion that seems to be
unaware of this scenario, and trips on unavailable `NS_ENUM`s. (In those
cases, the typedef points to the enum rather than the underlying integer
type.) This patch fixes the assertion to be resilient against such cases
by looking through the enum a typedef refers to.

This PR also includes some NFC commits which consolidate usage of the `findOptionSetEnum()` helper function. This pattern (and the failing assertion) was previously duplicated across six distinct locations across `ImportDecl.cpp` and `ImportType.cpp`. The interface and behavior of this function is based on `findOptionSetType()`, which was previously defined in `ImportDecl.cpp` but also used in `ImportType.cpp` via an ad hoc function declaration.

Those NFC commits make way for [80db054](https://github.com/swiftlang/swift/pull/81625/commits/80db05455f926d61a6a2b0e2f152bd9507764760), where the actual fix is contained to a fairly small change.

rdar://150399978
Resolves #79636