### PR TITLE
[ClangImporter] Add OriginalSourceRange to generated buffers of non-trivial attrs

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1062,8 +1062,9 @@ public:
 
   /// Retrieve the placeholder source file for use in parsing Swift attributes
   /// in the given module.
-  SourceFile &getClangSwiftAttrSourceFile(
-      ModuleDecl &module, StringRef attributeText, bool cached);
+  SourceFile &getClangSwiftAttrSourceFile(ModuleDecl &module,
+                                          SourceRange originalRange,
+                                          StringRef attributeText, bool cached);
 
   /// Create attribute with given text and attach it to decl, creating or
   /// retrieving a chached source file as needed.


### PR DESCRIPTION
Adding this should help SourceKit/IDE features like jump to definition

rdar://151020332