### PR TITLE
Handle mark_dependence instruction in AllocBoxToStack

### DIFF
--- a/test/SILOptimizer/allocbox_to_stack_ne.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ne.sil
@@ -1,0 +1,50 @@
+// RUN: %target-sil-opt -enable-experimental-feature LifetimeDependence -allocbox-to-stack %s | %FileCheck %s
+
+import Swift
+import Builtin
+
+public struct View : ~Escapable {
+  let _ptr: UnsafeRawPointer
+}
+
+sil hidden [ossa] @initFn : $@convention(method) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @owned View {
+bb0(%0 : $UnsafeRawPointer, %1 : $@thin View.Type):
+  %2 = alloc_box ${ var View }, var, name "self"  
+  %3 = mark_uninitialized [rootself] %2           
+  %4 = begin_borrow [var_decl] %3                 
+  %5 = project_box %4, 0                          
+  %7 = begin_access [modify] [unknown] %5         
+  %8 = struct_element_addr %7, #View._ptr         
+  assign %0 to %8                                 
+  end_access %7                                   
+  %11 = load [copy] %5                            
+  end_borrow %4                                   
+  destroy_value %3                                
+  return %11                                      
+} 
+
+// CHECK-LABEL:  sil [ossa] @testBoxedParam :
+// CHECK-NOT: alloc_box
+// CHECK-LABEL: } // end sil function 'testBoxedParam'
+sil [ossa] @testBoxedParam : $@convention(thin) (@owned View) -> @lifetime(copy 0) @owned View {
+bb0(%0 : @noImplicitCopy @_eagerMove @owned $View):
+  %1 = alloc_box ${ var @moveOnly View }, var, name "that" 
+  %2 = begin_borrow [var_decl] %1                 
+  %3 = project_box %2, 0                          
+  %4 = moveonlywrapper_to_copyable_addr %3        
+  store %0 to [init] %4                           
+  %6 = metatype $@thin View.Type                  
+  %7 = begin_access [read] [static] %3            
+  %8 = mark_unresolved_non_copyable_value [no_consume_or_assign] %7 
+  %9 = struct_element_addr %8, #View._ptr         
+  %10 = load_borrow %9                            
+  %11 = moveonlywrapper_to_copyable [guaranteed] %10 
+  end_borrow %10                                  
+  end_access %7                                   
+  %14 = function_ref @initFn : $@convention(method) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @owned View 
+  %15 = apply %14(%11, %6) : $@convention(method) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @owned View 
+  %16 = mark_dependence [unresolved] %15 on %2    
+  end_borrow %2                                   
+  destroy_value %1                                
+  return %16                                      
+} 


### PR DESCRIPTION
Permit uses of alloc_box as base operand in a mark_dependence instruction in the AllocBoxToStack optimization. 

rdar://150398673