### PR TITLE
[6.2][Concurrency] Infer `@preconcurrency @MainActor` in default main acto…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5828,8 +5828,13 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
         if (isa<TypeDecl>(value) || isa<ExtensionDecl>(value) ||
             isa<AbstractStorageDecl>(value) || isa<FuncDecl>(value) ||
             isa<ConstructorDecl>(value)) {
-          return {
-              {{ActorIsolation::forGlobalActor(globalActor), {}}, nullptr, {}}};
+          // Preconcurrency here is used to stage the diagnostics
+          // when users select `@MainActor` default isolation with
+          // non-strict concurrency modes (pre Swift 6).
+          auto isolation =
+              ActorIsolation::forGlobalActor(globalActor)
+                  .withPreconcurrency(!ctx.LangOpts.isSwiftVersionAtLeast(6));
+          return {{{isolation, {}}, nullptr, {}}};
         }
       }
 

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift5-
+// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift6-
 
 // READ THIS! This test is meant to check the specific isolation when
 // `-default-isolation` is set to `MainActor` in combination with validating
@@ -7,13 +8,16 @@
 
 // Fake Sendable Data
 class SendableData : @unchecked Sendable {}
+// expected-swift5-note@-1 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
 
 nonisolated func getDataFromSocket() -> SendableData { SendableData() }
+// expected-swift5-warning@-1 {{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context; this is an error in the Swift 6 language mode}}
 
-class Klass { // expected-note 3 {{}}
+class Klass { // expected-swift5-note 3 {{}} expected-swift6-note 3 {{}}
   let s = SendableData()
+  // expected-swift5-note@-1 2 {{}}
 
-  init() { s = SendableData() }
+  init() { s = SendableData() } // expected-swift5-error {{immutable value 'self.s' may only be initialized once}}
   init(_ s: SendableData) {}
 
   func doSomething() {}
@@ -50,9 +54,15 @@ func unspecifiedFunctionTest2() async {
 
 nonisolated func nonisolatedFunctionTest() async {
   let k = await StructContainingKlass()
-  await unspecifiedAsync(k.k) // expected-error {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
-  await nonisolatedAsync(k.k) // expected-error {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
-  await mainActorAsync(k.k) // expected-error {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  await unspecifiedAsync(k.k)
+  // expected-swift5-warning@-1 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift6-error@-2 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  await nonisolatedAsync(k.k)
+  // expected-swift5-warning@-1 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift6-error@-2 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  await mainActorAsync(k.k)
+  // expected-swift5-warning@-1 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift6-error@-2 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
 }
 
 func testTask() async {


### PR DESCRIPTION
…r mode for language modes < 6

Cherry-pick of https://github.com/swiftlang/swift/pull/81627

---

- Explanation:

  `@MainActor` errors are hard errors, even in minimal concurrency checking in Swift 5 mode. When users set the default isolation to main actor, we should infer `@preconcurrency @MainActor` in language modes < 6 to get the right diagnostic staging behavior.

- Main Branch PR: https://github.com/swiftlang/swift/pull/81627

- Risk: Low (New check downgrades errors to warnings in `-default-isolation MainActor` mode which allows more code to type-check).

- Reviewed By: @hborla

- Resolves: rdar://151029517

- Testing: Added new tests to the suite.

(cherry picked from commit 6561476059148622031a1387deb823d812c0e250)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
