### PR TITLE
[Test] Disable chained fixups for typeref_decoding_asan.swift.

### DIFF
--- a/test/Reflection/typeref_decoding_asan.swift
+++ b/test/Reflection/typeref_decoding_asan.swift
@@ -6,7 +6,7 @@
 
 // REQUIRES: asan_runtime
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-swift-5.2-abi-triple %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect -sanitize=address -o %t/%target-library-name(TypesToReflect)
+// RUN: %target-build-swift -target %target-swift-5.2-abi-triple %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library -module-name TypesToReflect %no-fixup-chains -sanitize=address -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) | %FileCheck %s
 
 // CHECK: FIELDS:


### PR DESCRIPTION
ObjectFileContext doesn't currently support chained fixups. We previously disabled chained ifxups in some other reflection tests but not this one.

rdar://137532051