### PR TITLE
[test] Fix IRGen/framepointer.sil for the test-simulator CI

### DIFF
--- a/test/IRGen/framepointer.sil
+++ b/test/IRGen/framepointer.sil
@@ -31,12 +31,12 @@ entry(%i : $Int32):
 // CHECK: entry:
 // CHECK:   %1 = call swiftcc i32 @leaf_function_no_frame_pointer(i32 %0)
 // CHECK:   ret i32 %1
-// CHECK: }
 
-// CHECK-SYSV: Function Attrs:
+// CHECK-SYSV: }
 // CHECK-SYSV-macosx: attributes [[ATTR]] = { {{.*}}"frame-pointer"="all"
 // CHECK-SYSV-linux-gnu: attributes [[ATTR]] = { {{.*}}"frame-pointer"="all"
 // CHECK-SYSV-linux-android: attributes [[ATTR]] = { {{.*}}"frame-pointer"="non-leaf"
+// CHECK-WIN: }
 // CHECK-WIN: attributes [[ATTR]] = { {{.*}}
 
 // CHECK-ALL: define{{.*}} swiftcc i32 @leaf_function_no_frame_pointer(i32 %0) [[ATTR:#.*]] {


### PR DESCRIPTION
which generates IR without a llvm.trap function

All the normal CI generated this:
```
ret i32 %1
}

; Function Attrs: cold noreturn nounwind memory(inaccessiblemem: write)
declare void @llvm.trap() #1

attributes #0 = { "frame-pointer"=
```
But the test-simulator CI doesn't for some reason, so just check for the closing brace instead.

@aschwaighofer, let me know what you think.

