### PR TITLE
[DO NOT MERGE] [swift-demangle] Add syntax highlighting for name and parameters

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -492,7 +492,7 @@ public:
   std::string
   demangleSymbolAsString(llvm::StringRef MangledName,
                          const DemangleOptions &Options = DemangleOptions(),
-                         DemanglerPrinter *printer = nullptr);
+                         std::unique_ptr<DemanglerPrinter> printer = nullptr);
 
   /// Demangle the given type and return the readable name.
   ///
@@ -550,7 +550,7 @@ public:
 std::string
 demangleSymbolAsString(const char *mangledName, size_t mangledNameLength,
                        const DemangleOptions &options = DemangleOptions(),
-                       DemanglerPrinter *printer = nullptr);
+                       std::unique_ptr<DemanglerPrinter> printer = nullptr);
 
 /// Standalone utility function to demangle the given symbol as string.
 ///
@@ -561,9 +561,9 @@ demangleSymbolAsString(const char *mangledName, size_t mangledNameLength,
 inline std::string
 demangleSymbolAsString(const std::string &mangledName,
                        const DemangleOptions &options = DemangleOptions(),
-                       DemanglerPrinter *printer = nullptr) {
+                       std::unique_ptr<DemanglerPrinter> printer = nullptr) {
   return demangleSymbolAsString(mangledName.data(), mangledName.size(), options,
-                                printer);
+                                std::move(printer));
 }
 
 /// Standalone utility function to demangle the given symbol as string.
@@ -575,9 +575,9 @@ demangleSymbolAsString(const std::string &mangledName,
 inline std::string
 demangleSymbolAsString(llvm::StringRef MangledName,
                        const DemangleOptions &Options = DemangleOptions(),
-                       DemanglerPrinter *printer = nullptr) {
+                       std::unique_ptr<DemanglerPrinter> printer = nullptr) {
   return demangleSymbolAsString(MangledName.data(), MangledName.size(), Options,
-                                printer);
+                                std::move(printer));
 }
 
 /// Standalone utility function to demangle the given type as string.
@@ -752,7 +752,7 @@ ManglingErrorOr<const char *> mangleNodeAsObjcCString(NodePointer node,
 ///
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options = DemangleOptions(),
-                         DemanglerPrinter *printer = nullptr);
+                         std::unique_ptr<DemanglerPrinter> printer = nullptr);
 
 /// Transforms a mangled key path accessor thunk helper
 /// into the identfier/subscript that would be used to invoke it in swift code.

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -492,7 +492,7 @@ public:
   std::string
   demangleSymbolAsString(llvm::StringRef MangledName,
                          const DemangleOptions &Options = DemangleOptions(),
-                         std::unique_ptr<DemanglerPrinter> printer = nullptr);
+                         DemanglerPrinter *printer = nullptr);
 
   /// Demangle the given type and return the readable name.
   ///
@@ -550,7 +550,7 @@ public:
 std::string
 demangleSymbolAsString(const char *mangledName, size_t mangledNameLength,
                        const DemangleOptions &options = DemangleOptions(),
-                       std::unique_ptr<DemanglerPrinter> printer = nullptr);
+                       DemanglerPrinter *printer = nullptr);
 
 /// Standalone utility function to demangle the given symbol as string.
 ///
@@ -561,9 +561,9 @@ demangleSymbolAsString(const char *mangledName, size_t mangledNameLength,
 inline std::string
 demangleSymbolAsString(const std::string &mangledName,
                        const DemangleOptions &options = DemangleOptions(),
-                       std::unique_ptr<DemanglerPrinter> printer = nullptr) {
+                       DemanglerPrinter *printer = nullptr) {
   return demangleSymbolAsString(mangledName.data(), mangledName.size(), options,
-                                std::move(printer));
+                                printer);
 }
 
 /// Standalone utility function to demangle the given symbol as string.
@@ -575,9 +575,9 @@ demangleSymbolAsString(const std::string &mangledName,
 inline std::string
 demangleSymbolAsString(llvm::StringRef MangledName,
                        const DemangleOptions &Options = DemangleOptions(),
-                       std::unique_ptr<DemanglerPrinter> printer = nullptr) {
+                       DemanglerPrinter *printer = nullptr) {
   return demangleSymbolAsString(MangledName.data(), MangledName.size(), Options,
-                                std::move(printer));
+                                printer);
 }
 
 /// Standalone utility function to demangle the given type as string.
@@ -752,7 +752,7 @@ ManglingErrorOr<const char *> mangleNodeAsObjcCString(NodePointer node,
 ///
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options = DemangleOptions(),
-                         std::unique_ptr<DemanglerPrinter> printer = nullptr);
+                         DemanglerPrinter *printer = nullptr);
 
 /// Transforms a mangled key path accessor thunk helper
 /// into the identfier/subscript that would be used to invoke it in swift code.

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -23,6 +23,7 @@
 #include "swift/Demangling/Errors.h"
 #include "swift/Demangling/ManglingFlavor.h"
 #include "swift/Demangling/NamespaceMacros.h"
+#include "swift/Strings.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
 
@@ -100,6 +101,7 @@ struct DemangleOptions {
 
 class Node;
 using NodePointer = Node *;
+class NodePrinter;
 
 enum class FunctionSigSpecializationParamKind : unsigned {
   // Option Flags use bits 0-5. This give us 6 bits implying 64 entries to
@@ -492,7 +494,7 @@ public:
   std::string
   demangleSymbolAsString(llvm::StringRef MangledName,
                          const DemangleOptions &Options = DemangleOptions(),
-                         DemanglerPrinter *printer = nullptr);
+                         NodePrinter *printer = nullptr);
 
   /// Demangle the given type and return the readable name.
   ///
@@ -550,7 +552,7 @@ public:
 std::string
 demangleSymbolAsString(const char *mangledName, size_t mangledNameLength,
                        const DemangleOptions &options = DemangleOptions(),
-                       DemanglerPrinter *printer = nullptr);
+                       NodePrinter *printer = nullptr);
 
 /// Standalone utility function to demangle the given symbol as string.
 ///
@@ -561,7 +563,7 @@ demangleSymbolAsString(const char *mangledName, size_t mangledNameLength,
 inline std::string
 demangleSymbolAsString(const std::string &mangledName,
                        const DemangleOptions &options = DemangleOptions(),
-                       DemanglerPrinter *printer = nullptr) {
+                       NodePrinter *printer = nullptr) {
   return demangleSymbolAsString(mangledName.data(), mangledName.size(), options,
                                 printer);
 }
@@ -575,7 +577,7 @@ demangleSymbolAsString(const std::string &mangledName,
 inline std::string
 demangleSymbolAsString(llvm::StringRef MangledName,
                        const DemangleOptions &Options = DemangleOptions(),
-                       DemanglerPrinter *printer = nullptr) {
+                       NodePrinter *printer = nullptr) {
   return demangleSymbolAsString(MangledName.data(), MangledName.size(), Options,
                                 printer);
 }
@@ -752,7 +754,7 @@ ManglingErrorOr<const char *> mangleNodeAsObjcCString(NodePointer node,
 ///
 std::string nodeToString(NodePointer Root,
                          const DemangleOptions &Options = DemangleOptions(),
-                         DemanglerPrinter *printer = nullptr);
+                         NodePrinter *printer = nullptr);
 
 /// Transforms a mangled key path accessor thunk helper
 /// into the identfier/subscript that would be used to invoke it in swift code.
@@ -807,71 +809,8 @@ public:
     Stream.resize(toPos);
   }
 
-  /// Mark the start of the name of a function.
-  virtual void startName() {}
-
-  /// Mark the end of the name of a function.
-  virtual void endName() {}
-
-  /// Mark the start of the parameters of a function.
-  ///
-  /// \param depth Current depth of the parameters that are being printed.
-  virtual void startParameters(unsigned depth) {}
-
-  /// Mark the end of the parameters of a function.
-  ///
-  /// \param depth Current depth of the parameters that are being printed.
-  virtual void endParameters(unsigned depth) {}
-
-  virtual ~DemanglerPrinter() {}
-
 private:
   std::string Stream;
-};
-
-/// A class for printing to a std::string while tracking ranges.
-class TrackingDemanglerPrinter : public swift::Demangle::DemanglerPrinter {
-public:
-  size_t getNameStart() { return baseNameRange.first; }
-  size_t getNameEnd() { return baseNameRange.second; }
-  size_t getParametersStart() { return parametersRange.first; }
-  size_t getParametersEnd() { return parametersRange.second; }
-  bool hasBaseName() { return baseNameRange.first < baseNameRange.second; }
-  bool hasParameters() {
-    return parametersRange.first < parametersRange.second;
-  }
-
-  void startName() override {
-    if (!hasBaseName())
-      baseNameRange.first = getStreamLength();
-  }
-
-  void endName() override {
-    if (!hasBaseName())
-      baseNameRange.second = getStreamLength();
-  }
-
-  void startParameters(unsigned depth) override {
-    if (parametersDepth || !hasBaseName() || hasParameters()) {
-      return;
-    }
-    parametersRange.first = getStreamLength();
-    parametersDepth = depth;
-  }
-
-  void endParameters(unsigned depth) override {
-    if (!parametersDepth || *parametersDepth != depth || hasParameters()) {
-      return;
-    }
-    parametersRange.second = getStreamLength();
-  }
-
-private:
-  std::pair<size_t, size_t> baseNameRange;
-
-  std::pair<size_t, size_t> parametersRange;
-
-  std::optional<unsigned> parametersDepth;
 };
 
 /// Returns a the node kind \p k as string.
@@ -905,6 +844,147 @@ llvm::StringRef makeSymbolicMangledNameStringRef(const char *base);
 std::string mangledNameForTypeMetadataAccessor(
     llvm::StringRef moduleName, llvm::StringRef typeName, Node::Kind typeKind,
     Mangle::ManglingFlavor Flavor = Mangle::ManglingFlavor::Default);
+
+class NodePrinter {
+protected:
+  DemanglerPrinter Printer;
+  DemangleOptions Options;
+  bool SpecializationPrefixPrinted = false;
+  bool isValid = true;
+
+public:
+  NodePrinter(DemangleOptions options) : Options(options) {}
+
+  virtual ~NodePrinter() {}
+
+  std::string printRoot(NodePointer root) {
+    isValid = true;
+    print(root, 0);
+    if (isValid)
+      return std::move(Printer).str();
+    return "";
+  }
+
+protected:
+  static const unsigned MaxDepth = 768;
+
+  size_t getStreamLength() { return Printer.getStreamLength(); }
+
+  /// Called when the node tree in valid.
+  ///
+  /// The demangler already catches most error cases and mostly produces valid
+  /// node trees. But some cases are difficult to catch in the demangler and
+  /// instead the NodePrinter bails.
+  void setInvalid() { isValid = false; }
+
+  void printChildren(Node::iterator begin, Node::iterator end, unsigned depth,
+                     const char *sep = nullptr);
+
+  void printChildren(NodePointer Node, unsigned depth,
+                     const char *sep = nullptr);
+
+  NodePointer getFirstChildOfKind(NodePointer Node, Node::Kind kind);
+
+  void printBoundGenericNoSugar(NodePointer Node, unsigned depth);
+
+  void printOptionalIndex(NodePointer node);
+
+  static bool isSwiftModule(NodePointer node) {
+    return (node->getKind() == Node::Kind::Module &&
+            node->getText() == STDLIB_NAME);
+  }
+
+  static bool isIdentifier(NodePointer node, StringRef desired) {
+    return (node->getKind() == Node::Kind::Identifier &&
+            node->getText() == desired);
+  }
+
+  bool printContext(NodePointer Context);
+
+  enum class SugarType {
+    None,
+    Optional,
+    ImplicitlyUnwrappedOptional,
+    Array,
+    Dictionary
+  };
+
+  enum class TypePrinting { NoType, WithColon, FunctionStyle };
+
+  /// Determine whether this is a "simple" type, from the type-simple
+  /// production.
+  bool isSimpleType(NodePointer Node);
+
+  void printWithParens(NodePointer type, unsigned depth);
+
+  SugarType findSugar(NodePointer Node);
+
+  void printBoundGeneric(NodePointer Node, unsigned depth);
+
+  NodePointer getChildIf(NodePointer Node, Node::Kind Kind);
+
+  virtual void printFunctionParameters(NodePointer LabelList,
+                                       NodePointer ParameterType,
+                                       unsigned depth, bool showTypes);
+
+  void printFunctionType(NodePointer LabelList, NodePointer node,
+                         unsigned depth);
+
+  void printImplFunctionType(NodePointer fn, unsigned depth);
+
+  void printGenericSignature(NodePointer Node, unsigned depth);
+
+  void printFunctionSigSpecializationParams(NodePointer Node, unsigned depth);
+
+  void printSpecializationPrefix(NodePointer node, StringRef Description,
+                                 unsigned depth,
+                                 StringRef ParamPrefix = StringRef());
+
+  /// The main big print function.
+  NodePointer print(NodePointer Node, unsigned depth,
+                    bool asPrefixContext = false);
+
+  NodePointer printAbstractStorage(NodePointer Node, unsigned depth,
+                                   bool asPrefixContent, StringRef ExtraName);
+
+  /// Utility function to print entities.
+  ///
+  /// \param Entity The entity node to print
+  /// \param depth The depth in the print() call tree.
+  /// \param asPrefixContext Should the entity printed as a context which as a
+  ///        prefix to another entity, e.g. the Abc in Abc.def()
+  /// \param TypePr How should the type of the entity be printed, if at all.
+  ///        E.g. with a colon for properties or as a function type.
+  /// \param hasName Does the entity has a name, e.g. a function in contrast to
+  ///        an initializer.
+  /// \param ExtraName An extra name added to the entity name (if any).
+  /// \param ExtraIndex An extra index added to the entity name (if any),
+  ///        e.g. closure #1
+  /// \param OverwriteName If non-empty, print this name instead of the one
+  ///        provided by the node. Gets printed even if hasName is false.
+  /// \return If a non-null node is returned it's a context which must be
+  ///         printed in postfix-form after the entity: "<entity> in <context>".
+  NodePointer printEntity(NodePointer Entity, unsigned depth,
+                          bool asPrefixContext, TypePrinting TypePr,
+                          bool hasName, StringRef ExtraName = "",
+                          int ExtraIndex = -1, StringRef OverwriteName = "");
+
+  virtual void printFunctionName(bool hasName, llvm::StringRef &OverwriteName,
+                                 llvm::StringRef &ExtraName, bool MultiWordName,
+                                 int &ExtraIndex,
+                                 swift::Demangle::NodePointer Entity,
+                                 unsigned int depth);
+
+  /// Print the type of an entity.
+  ///
+  /// \param Entity The entity.
+  /// \param type The type of the entity.
+  /// \param genericFunctionTypeList If not null, the generic argument types
+  ///           which is printed in the generic signature.
+  /// \param depth The depth in the print() call tree.
+  void printEntityType(NodePointer Entity, NodePointer type,
+                       NodePointer genericFunctionTypeList, unsigned depth);
+};
 
 SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -55,10 +55,9 @@ NodePointer Context::demangleTypeAsNode(llvm::StringRef MangledName) {
 
 #if SWIFT_STDLIB_HAS_TYPE_PRINTING
 
-std::string
-Context::demangleSymbolAsString(llvm::StringRef MangledName,
-                                const DemangleOptions &Options,
-                                std::unique_ptr<DemanglerPrinter> printer) {
+std::string Context::demangleSymbolAsString(llvm::StringRef MangledName,
+                                            const DemangleOptions &Options,
+                                            std::unique_ptr<DemanglerPrinter> printer) {
   NodePointer root = demangleSymbolAsNode(MangledName);
   if (!root) return MangledName.str();
 

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -56,11 +56,12 @@ NodePointer Context::demangleTypeAsNode(llvm::StringRef MangledName) {
 #if SWIFT_STDLIB_HAS_TYPE_PRINTING
 
 std::string Context::demangleSymbolAsString(llvm::StringRef MangledName,
-                                            const DemangleOptions &Options) {
+                                            const DemangleOptions &Options,
+                                            DemanglerPrinter *printer) {
   NodePointer root = demangleSymbolAsNode(MangledName);
   if (!root) return MangledName.str();
 
-  std::string demangling = nodeToString(root, Options);
+  std::string demangling = nodeToString(root, Options, printer);
   if (demangling.empty())
     return MangledName.str();
   return demangling;
@@ -269,10 +270,11 @@ std::string Context::getModuleName(llvm::StringRef mangledName) {
 
 std::string demangleSymbolAsString(const char *MangledName,
                                    size_t MangledNameLength,
-                                   const DemangleOptions &Options) {
+                                   const DemangleOptions &Options,
+                                   DemanglerPrinter *printer) {
   Context Ctx;
   return Ctx.demangleSymbolAsString(StringRef(MangledName, MangledNameLength),
-                                    Options);
+                                    Options, printer);
 }
 
 std::string demangleTypeAsString(const char *MangledName,

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -57,11 +57,11 @@ NodePointer Context::demangleTypeAsNode(llvm::StringRef MangledName) {
 
 std::string Context::demangleSymbolAsString(llvm::StringRef MangledName,
                                             const DemangleOptions &Options,
-                                            DemanglerPrinter *printer) {
+                                            std::unique_ptr<DemanglerPrinter> printer) {
   NodePointer root = demangleSymbolAsNode(MangledName);
   if (!root) return MangledName.str();
 
-  std::string demangling = nodeToString(root, Options, printer);
+  std::string demangling = nodeToString(root, Options, std::move(printer));
   if (demangling.empty())
     return MangledName.str();
   return demangling;
@@ -271,10 +271,10 @@ std::string Context::getModuleName(llvm::StringRef mangledName) {
 std::string demangleSymbolAsString(const char *MangledName,
                                    size_t MangledNameLength,
                                    const DemangleOptions &Options,
-                                   DemanglerPrinter *printer) {
+                                   std::unique_ptr<DemanglerPrinter> printer) {
   Context Ctx;
   return Ctx.demangleSymbolAsString(StringRef(MangledName, MangledNameLength),
-                                    Options, printer);
+                                    Options, std::move(printer));
 }
 
 std::string demangleTypeAsString(const char *MangledName,

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -55,9 +55,10 @@ NodePointer Context::demangleTypeAsNode(llvm::StringRef MangledName) {
 
 #if SWIFT_STDLIB_HAS_TYPE_PRINTING
 
-std::string Context::demangleSymbolAsString(llvm::StringRef MangledName,
-                                            const DemangleOptions &Options,
-                                            std::unique_ptr<DemanglerPrinter> printer) {
+std::string
+Context::demangleSymbolAsString(llvm::StringRef MangledName,
+                                const DemangleOptions &Options,
+                                std::unique_ptr<DemanglerPrinter> printer) {
   NodePointer root = demangleSymbolAsNode(MangledName);
   if (!root) return MangledName.str();
 

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -57,11 +57,11 @@ NodePointer Context::demangleTypeAsNode(llvm::StringRef MangledName) {
 
 std::string Context::demangleSymbolAsString(llvm::StringRef MangledName,
                                             const DemangleOptions &Options,
-                                            std::unique_ptr<DemanglerPrinter> printer) {
+                                            DemanglerPrinter *printer) {
   NodePointer root = demangleSymbolAsNode(MangledName);
   if (!root) return MangledName.str();
 
-  std::string demangling = nodeToString(root, Options, std::move(printer));
+  std::string demangling = nodeToString(root, Options, printer);
   if (demangling.empty())
     return MangledName.str();
   return demangling;
@@ -271,10 +271,10 @@ std::string Context::getModuleName(llvm::StringRef mangledName) {
 std::string demangleSymbolAsString(const char *MangledName,
                                    size_t MangledNameLength,
                                    const DemangleOptions &Options,
-                                   std::unique_ptr<DemanglerPrinter> printer) {
+                                   DemanglerPrinter *printer) {
   Context Ctx;
   return Ctx.demangleSymbolAsString(StringRef(MangledName, MangledNameLength),
-                                    Options, std::move(printer));
+                                    Options, printer);
 }
 
 std::string demangleTypeAsString(const char *MangledName,

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -57,7 +57,7 @@ NodePointer Context::demangleTypeAsNode(llvm::StringRef MangledName) {
 
 std::string Context::demangleSymbolAsString(llvm::StringRef MangledName,
                                             const DemangleOptions &Options,
-                                            DemanglerPrinter *printer) {
+                                            NodePrinter *printer) {
   NodePointer root = demangleSymbolAsNode(MangledName);
   if (!root) return MangledName.str();
 
@@ -271,7 +271,7 @@ std::string Context::getModuleName(llvm::StringRef mangledName) {
 std::string demangleSymbolAsString(const char *MangledName,
                                    size_t MangledNameLength,
                                    const DemangleOptions &Options,
-                                   DemanglerPrinter *printer) {
+                                   NodePrinter *printer) {
   Context Ctx;
   return Ctx.demangleSymbolAsString(StringRef(MangledName, MangledNameLength),
                                     Options, printer);

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -168,8 +168,8 @@ static StringRef toString(ValueWitnessKind k) {
 }
 
 template <typename T>
-auto operator<<(const std::unique_ptr<DemanglerPrinter> &printer,
-                const T &n) -> decltype((*printer) << n) {
+auto operator<<(const std::unique_ptr<DemanglerPrinter> &printer, const T &n)
+    -> decltype((*printer) << n) {
   return (*printer) << n;
 }
 
@@ -181,8 +181,10 @@ private:
   bool isValid = true;
 
 public:
-  NodePrinter(DemangleOptions options, std::unique_ptr<DemanglerPrinter> printer = nullptr)
-      : Printer(printer ? std::move(printer) : std::make_unique<DemanglerPrinter>()),
+  NodePrinter(DemangleOptions options,
+              std::unique_ptr<DemanglerPrinter> printer = nullptr)
+      : Printer(printer ? std::move(printer)
+                        : std::make_unique<DemanglerPrinter>()),
         Options(options) {}
 
   std::string printRoot(NodePointer root) {

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -167,29 +167,27 @@ static StringRef toString(ValueWitnessKind k) {
   printer_unreachable("bad value witness kind");
 }
 
-template <typename T>
-auto operator<<(const std::unique_ptr<DemanglerPrinter> &printer,
-                const T &n) -> decltype((*printer) << n) {
-  return (*printer) << n;
-}
-
 class NodePrinter {
 private:
-  std::unique_ptr<DemanglerPrinter> Printer;
+  std::unique_ptr<DemanglerPrinter> PrinterStorage;
+  DemanglerPrinter &Printer;
   DemangleOptions Options;
   bool SpecializationPrefixPrinted = false;
   bool isValid = true;
 
 public:
-  NodePrinter(DemangleOptions options, std::unique_ptr<DemanglerPrinter> printer = nullptr)
-      : Printer(printer ? std::move(printer) : std::make_unique<DemanglerPrinter>()),
+  NodePrinter(DemangleOptions options, DemanglerPrinter *printer = nullptr)
+      : PrinterStorage(),
+        Printer(printer
+                    ? *printer
+                    : *(PrinterStorage = std::make_unique<DemanglerPrinter>())),
         Options(options) {}
 
   std::string printRoot(NodePointer root) {
     isValid = true;
     print(root, 0);
     if (isValid)
-      return std::move(*Printer).str();
+      return std::move(Printer).str();
     return "";
   }
 
@@ -810,7 +808,7 @@ private:
       return;
     }
 
-    Printer->startParameters(depth);
+    Printer.startParameters(depth);
     NodePointer Parameters = ParameterType->getFirstChild();
     assert(Parameters->getKind() == Node::Kind::Type);
     Parameters = Parameters->getFirstChild();
@@ -823,7 +821,7 @@ private:
       } else {
         Printer << "(_:)";
       }
-      Printer->endParameters(depth);
+      Printer.endParameters(depth);
       return;
     }
 
@@ -863,7 +861,7 @@ private:
         },
         [&]() { Printer << (showTypes ? ", " : ""); });
     Printer << ')';
-    Printer->endParameters(depth);
+    Printer.endParameters(depth);
   }
 
   void printFunctionType(NodePointer LabelList, NodePointer node,
@@ -2416,11 +2414,11 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     return nullptr;
   case Node::Kind::TypeSymbolicReference:
     Printer << "type symbolic reference 0x";
-    Printer->writeHex(Node->getIndex());
+    Printer.writeHex(Node->getIndex());
     return nullptr;
   case Node::Kind::OpaqueTypeDescriptorSymbolicReference:
     Printer << "opaque type symbolic reference 0x";
-    Printer->writeHex(Node->getIndex());
+    Printer.writeHex(Node->getIndex());
     return nullptr;
   case Node::Kind::DistributedThunk:
     if (!Options.ShortenThunk) {
@@ -2462,7 +2460,7 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     return nullptr;
   case Node::Kind::ProtocolSymbolicReference:
     Printer << "protocol symbolic reference 0x";
-    Printer->writeHex(Node->getIndex());
+    Printer.writeHex(Node->getIndex());
     return nullptr;
   case Node::Kind::GenericTypeMetadataPattern:
     Printer << "generic type metadata pattern for ";
@@ -3474,15 +3472,15 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
   }
   case Node::Kind::UniqueExtendedExistentialTypeShapeSymbolicReference:
     Printer << "unique existential shape symbolic reference 0x";
-    Printer->writeHex(Node->getIndex());
+    Printer.writeHex(Node->getIndex());
     return nullptr;
   case Node::Kind::NonUniqueExtendedExistentialTypeShapeSymbolicReference:
     Printer << "non-unique existential shape symbolic reference 0x";
-    Printer->writeHex(Node->getIndex());
+    Printer.writeHex(Node->getIndex());
     return nullptr;
   case Node::Kind::ObjectiveCProtocolSymbolicReference:
     Printer << "objective-c protocol symbolic reference 0x";
-    Printer->writeHex(Node->getIndex());
+    Printer.writeHex(Node->getIndex());
     return nullptr;
   case Node::Kind::SymbolicExtendedExistentialType: {
     auto shape = Node->getChild(0);
@@ -3492,7 +3490,7 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     Printer << "symbolic existential type ("
             << (isUnique ? "" : "non-")
             << "unique) 0x";
-    Printer->writeHex(shape->getIndex());
+    Printer.writeHex(shape->getIndex());
     Printer << " <";
     print(Node->getChild(1), depth + 1);
     if (Node->getNumChildren() > 2) {
@@ -3579,16 +3577,16 @@ NodePointer NodePrinter::printEntity(NodePointer Entity, unsigned depth,
       // later in suffix form.
       PostfixContext = Context;
     } else {
-      size_t CurrentPos = Printer->getStringRef().size();
+      size_t CurrentPos = Printer.getStringRef().size();
       PostfixContext = print(Context, depth + 1, /*asPrefixContext*/ true);
 
       // Was the context printed as prefix?
-      if (Printer->getStringRef().size() != CurrentPos)
+      if (Printer.getStringRef().size() != CurrentPos)
         Printer << '.';
     }
   }
   if (Entity->shouldTrackNameRange()) {
-    Printer->startName();
+    Printer.startName();
   }
   if (hasName || !OverwriteName.empty()) {
     if (!ExtraName.empty() && MultiWordName) {
@@ -3600,7 +3598,7 @@ NodePointer NodePrinter::printEntity(NodePointer Entity, unsigned depth,
       ExtraName = "";
       ExtraIndex = -1;
     }
-    size_t CurrentPos = Printer->getStringRef().size();
+    size_t CurrentPos = Printer.getStringRef().size();
     if (!OverwriteName.empty()) {
       Printer << OverwriteName;
     } else {
@@ -3611,7 +3609,7 @@ NodePointer NodePrinter::printEntity(NodePointer Entity, unsigned depth,
       if (auto PrivateName = getChildIf(Entity, Node::Kind::PrivateDeclName))
         print(PrivateName, depth + 1);
     }
-    if (Printer->getStringRef().size() != CurrentPos && !ExtraName.empty())
+    if (Printer.getStringRef().size() != CurrentPos && !ExtraName.empty())
       Printer << '.';
   }
   if (!ExtraName.empty()) {
@@ -3620,7 +3618,7 @@ NodePointer NodePrinter::printEntity(NodePointer Entity, unsigned depth,
       Printer << ExtraIndex;
   }
   if (Entity->shouldTrackNameRange()) {
-    Printer->endName();
+    Printer.endName();
   }
   if (TypePr != TypePrinting::NoType) {
     NodePointer type = getChildIf(Entity, Node::Kind::Type);
@@ -3853,11 +3851,11 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
 
 std::string Demangle::nodeToString(NodePointer root,
                                    const DemangleOptions &options,
-                                   std::unique_ptr<DemanglerPrinter> printer) {
+                                   DemanglerPrinter *printer) {
   if (!root)
     return "";
 
-  return NodePrinter(options, std::move(printer)).printRoot(root);
+  return NodePrinter(options, printer).printRoot(root);
 }
 
 #endif

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -168,8 +168,8 @@ static StringRef toString(ValueWitnessKind k) {
 }
 
 template <typename T>
-auto operator<<(const std::unique_ptr<DemanglerPrinter> &printer, const T &n)
-    -> decltype((*printer) << n) {
+auto operator<<(const std::unique_ptr<DemanglerPrinter> &printer,
+                const T &n) -> decltype((*printer) << n) {
   return (*printer) << n;
 }
 
@@ -181,10 +181,8 @@ private:
   bool isValid = true;
 
 public:
-  NodePrinter(DemangleOptions options,
-              std::unique_ptr<DemanglerPrinter> printer = nullptr)
-      : Printer(printer ? std::move(printer)
-                        : std::make_unique<DemanglerPrinter>()),
+  NodePrinter(DemangleOptions options, std::unique_ptr<DemanglerPrinter> printer = nullptr)
+      : Printer(printer ? std::move(printer) : std::make_unique<DemanglerPrinter>()),
         Options(options) {}
 
   std::string printRoot(NodePointer root) {

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -17,10 +17,7 @@
 #include "swift/AST/Ownership.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Demangling/Demangle.h"
-#include "swift/Strings.h"
-#include <cassert>
 #include <cstdio>
-#include <cstdlib>
 #include <vector>
 
 using namespace swift;
@@ -166,399 +163,341 @@ static StringRef toString(ValueWitnessKind k) {
   }
   printer_unreachable("bad value witness kind");
 }
+} // end anonymous namespace
 
-class NodePrinter {
-private:
-  std::unique_ptr<DemanglerPrinter> PrinterStorage;
-  DemanglerPrinter &Printer;
-  DemangleOptions Options;
-  bool SpecializationPrefixPrinted = false;
-  bool isValid = true;
-
-public:
-  NodePrinter(DemangleOptions options, DemanglerPrinter *printer = nullptr)
-      : PrinterStorage(),
-        Printer(printer
-                    ? *printer
-                    : *(PrinterStorage = std::make_unique<DemanglerPrinter>())),
-        Options(options) {}
-
-  std::string printRoot(NodePointer root) {
-    isValid = true;
-    print(root, 0);
-    if (isValid)
-      return std::move(Printer).str();
-    return "";
+void NodePrinter::printChildren(Node::iterator begin, Node::iterator end,
+                                unsigned depth, const char *sep) {
+  for (; begin != end;) {
+    print(*begin, depth + 1);
+    ++begin;
+    if (sep && begin != end)
+      Printer << sep;
   }
+}
 
-private:
-  static const unsigned MaxDepth = 768;
+void NodePrinter::printChildren(NodePointer Node, unsigned depth,
+                                const char *sep) {
+  if (!Node)
+    return;
+  Node::iterator begin = Node->begin(), end = Node->end();
+  printChildren(begin, end, depth, sep);
+}
 
-  /// Called when the node tree in valid.
-  ///
-  /// The demangler already catches most error cases and mostly produces valid
-  /// node trees. But some cases are difficult to catch in the demangler and
-  /// instead the NodePrinter bails.
-  void setInvalid() { isValid = false; }
-
-  void printChildren(Node::iterator begin, Node::iterator end, unsigned depth,
-                     const char *sep = nullptr) {
-    for (; begin != end;) {
-      print(*begin, depth + 1);
-      ++begin;
-      if (sep && begin != end)
-        Printer << sep;
-    }
-  }
-
-  void printChildren(NodePointer Node, unsigned depth,
-                     const char *sep = nullptr) {
-    if (!Node)
-      return;
-    Node::iterator begin = Node->begin(), end = Node->end();
-    printChildren(begin, end, depth, sep);
-  }
-
-  NodePointer getFirstChildOfKind(NodePointer Node, Node::Kind kind) {
-    if (!Node)
-      return nullptr;
-    for (NodePointer child : *Node) {
-      if (child && child->getKind() == kind)
-        return child;
-    }
+NodePointer NodePrinter::getFirstChildOfKind(NodePointer Node,
+                                             Node::Kind kind) {
+  if (!Node)
     return nullptr;
+  for (NodePointer child : *Node) {
+    if (child && child->getKind() == kind)
+      return child;
   }
+  return nullptr;
+}
 
-  void printBoundGenericNoSugar(NodePointer Node, unsigned depth) {
-    if (Node->getNumChildren() < 2)
-      return;
-    NodePointer typelist = Node->getChild(1);
-    print(Node->getChild(0), depth + 1);
-    Printer << "<";
-    printChildren(typelist, depth, ", ");
-    Printer << ">";
-  }
+void NodePrinter::printBoundGenericNoSugar(NodePointer Node, unsigned depth) {
+  if (Node->getNumChildren() < 2)
+    return;
+  NodePointer typelist = Node->getChild(1);
+  print(Node->getChild(0), depth + 1);
+  Printer << "<";
+  printChildren(typelist, depth, ", ");
+  Printer << ">";
+}
 
-  void printOptionalIndex(NodePointer node) {
-    assert(node->getKind() == Node::Kind::Index ||
-           node->getKind() == Node::Kind::UnknownIndex);
-    if (node->hasIndex())
-      Printer << "#" << node->getIndex() << " ";
-  }
+void NodePrinter::printOptionalIndex(NodePointer node) {
+  assert(node->getKind() == Node::Kind::Index ||
+         node->getKind() == Node::Kind::UnknownIndex);
+  if (node->hasIndex())
+    Printer << "#" << node->getIndex() << " ";
+}
 
-  static bool isSwiftModule(NodePointer node) {
-    return (node->getKind() == Node::Kind::Module &&
-            node->getText() == STDLIB_NAME);
-  }
-  
-  bool printContext(NodePointer Context) {
-    if (!Options.QualifyEntities)
+bool NodePrinter::printContext(NodePointer Context) {
+  if (!Options.QualifyEntities)
+    return false;
+
+  if (Context->getKind() == Node::Kind::Module) {
+    if (Context->getText() == swift::STDLIB_NAME)
+      return Options.DisplayStdlibModule;
+    if (Context->getText() == swift::MANGLING_MODULE_OBJC)
+      return Options.DisplayObjCModule;
+    if (Context->getText() == Options.HidingCurrentModule)
       return false;
+    if (Context->getText().starts_with(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX))
+      return Options.DisplayDebuggerGeneratedModule;
+  }
+  return true;
+}
 
-    if (Context->getKind() == Node::Kind::Module) {
-      if (Context->getText() == swift::STDLIB_NAME)
-        return Options.DisplayStdlibModule;
-      if (Context->getText() == swift::MANGLING_MODULE_OBJC)
-        return Options.DisplayObjCModule;
-      if (Context->getText() == Options.HidingCurrentModule)
-        return false;
-      if (Context->getText().starts_with(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX))
-        return Options.DisplayDebuggerGeneratedModule;
-    }
+bool NodePrinter::isSimpleType(NodePointer Node) {
+  switch (Node->getKind()) {
+  case Node::Kind::AssociatedType:
+  case Node::Kind::AssociatedTypeRef:
+  case Node::Kind::BoundGenericClass:
+  case Node::Kind::BoundGenericEnum:
+  case Node::Kind::BoundGenericStructure:
+  case Node::Kind::BoundGenericProtocol:
+  case Node::Kind::BoundGenericOtherNominalType:
+  case Node::Kind::BoundGenericTypeAlias:
+  case Node::Kind::BoundGenericFunction:
+  case Node::Kind::BuiltinTypeName:
+  case Node::Kind::BuiltinTupleType:
+  case Node::Kind::BuiltinFixedArray:
+  case Node::Kind::Class:
+  case Node::Kind::DependentGenericType:
+  case Node::Kind::DependentMemberType:
+  case Node::Kind::DependentGenericParamType:
+  case Node::Kind::DynamicSelf:
+  case Node::Kind::Enum:
+  case Node::Kind::ErrorType:
+  case Node::Kind::ExistentialMetatype:
+  case Node::Kind::Metatype:
+  case Node::Kind::MetatypeRepresentation:
+  case Node::Kind::Module:
+  case Node::Kind::Tuple:
+  case Node::Kind::Pack:
+  case Node::Kind::SILPackDirect:
+  case Node::Kind::SILPackIndirect:
+  case Node::Kind::ConstrainedExistentialRequirementList:
+  case Node::Kind::ConstrainedExistentialSelf:
+  case Node::Kind::Protocol:
+  case Node::Kind::ProtocolSymbolicReference:
+  case Node::Kind::ReturnType:
+  case Node::Kind::SILBoxType:
+  case Node::Kind::SILBoxTypeWithLayout:
+  case Node::Kind::Structure:
+  case Node::Kind::OtherNominalType:
+  case Node::Kind::TupleElementName:
+  case Node::Kind::TypeAlias:
+  case Node::Kind::TypeList:
+  case Node::Kind::LabelList:
+  case Node::Kind::TypeSymbolicReference:
+  case Node::Kind::SugaredOptional:
+  case Node::Kind::SugaredArray:
+  case Node::Kind::SugaredInlineArray:
+  case Node::Kind::SugaredDictionary:
+  case Node::Kind::SugaredParen:
+  case Node::Kind::Integer:
+  case Node::Kind::NegativeInteger:
     return true;
-  }
 
-  static bool isIdentifier(NodePointer node, StringRef desired) {
-    return (node->getKind() == Node::Kind::Identifier &&
-            node->getText() == desired);
-  }
-  
-  enum class SugarType {
-    None,
-    Optional,
-    ImplicitlyUnwrappedOptional,
-    Array,
-    Dictionary
-  };
+  case Node::Kind::Type:
+    return isSimpleType(Node->getChild(0));
 
-  enum class TypePrinting {
-    NoType,
-    WithColon,
-    FunctionStyle
-  };
+  case Node::Kind::ProtocolList:
+    return Node->getChild(0)->getNumChildren() <= 1;
 
-  /// Determine whether this is a "simple" type, from the type-simple
-  /// production.
-  bool isSimpleType(NodePointer Node) {
-    switch (Node->getKind()) {
-    case Node::Kind::AssociatedType:
-    case Node::Kind::AssociatedTypeRef:
-    case Node::Kind::BoundGenericClass:
-    case Node::Kind::BoundGenericEnum:
-    case Node::Kind::BoundGenericStructure:
-    case Node::Kind::BoundGenericProtocol:
-    case Node::Kind::BoundGenericOtherNominalType:
-    case Node::Kind::BoundGenericTypeAlias:
-    case Node::Kind::BoundGenericFunction:
-    case Node::Kind::BuiltinTypeName:
-    case Node::Kind::BuiltinTupleType:
-    case Node::Kind::BuiltinFixedArray:
-    case Node::Kind::Class:
-    case Node::Kind::DependentGenericType:
-    case Node::Kind::DependentMemberType:
-    case Node::Kind::DependentGenericParamType:
-    case Node::Kind::DynamicSelf:
-    case Node::Kind::Enum:
-    case Node::Kind::ErrorType:
-    case Node::Kind::ExistentialMetatype:
-    case Node::Kind::Metatype:
-    case Node::Kind::MetatypeRepresentation:
-    case Node::Kind::Module:
-    case Node::Kind::Tuple:
-    case Node::Kind::Pack:
-    case Node::Kind::SILPackDirect:
-    case Node::Kind::SILPackIndirect:
-    case Node::Kind::ConstrainedExistentialRequirementList:
-    case Node::Kind::ConstrainedExistentialSelf:
-    case Node::Kind::Protocol:
-    case Node::Kind::ProtocolSymbolicReference:
-    case Node::Kind::ReturnType:
-    case Node::Kind::SILBoxType:
-    case Node::Kind::SILBoxTypeWithLayout:
-    case Node::Kind::Structure:
-    case Node::Kind::OtherNominalType:
-    case Node::Kind::TupleElementName:
-    case Node::Kind::TypeAlias:
-    case Node::Kind::TypeList:
-    case Node::Kind::LabelList:
-    case Node::Kind::TypeSymbolicReference:
-    case Node::Kind::SugaredOptional:
-    case Node::Kind::SugaredArray:
-    case Node::Kind::SugaredInlineArray:
-    case Node::Kind::SugaredDictionary:
-    case Node::Kind::SugaredParen:
-    case Node::Kind::Integer:
-    case Node::Kind::NegativeInteger:
-      return true;
+  case Node::Kind::ProtocolListWithAnyObject:
+    return Node->getChild(0)->getChild(0)->getNumChildren() == 0;
 
-    case Node::Kind::Type:
-      return isSimpleType(Node->getChild(0));
-
-    case Node::Kind::ProtocolList:
-      return Node->getChild(0)->getNumChildren() <= 1;
-
-    case Node::Kind::ProtocolListWithAnyObject:
-      return Node->getChild(0)->getChild(0)->getNumChildren() == 0;
-
-    case Node::Kind::ConstrainedExistential:
-    case Node::Kind::PackElement:
-    case Node::Kind::PackElementLevel:
-    case Node::Kind::PackExpansion:
-    case Node::Kind::ProtocolListWithClass:
-    case Node::Kind::AccessorAttachedMacroExpansion:
-    case Node::Kind::AccessorFunctionReference:
-    case Node::Kind::Allocator:
-    case Node::Kind::ArgumentTuple:
-    case Node::Kind::AssociatedConformanceDescriptor:
-    case Node::Kind::AssociatedTypeDescriptor:
-    case Node::Kind::AssociatedTypeMetadataAccessor:
-    case Node::Kind::AssociatedTypeWitnessTableAccessor:
-    case Node::Kind::AsyncRemoved:
-    case Node::Kind::AutoClosureType:
-    case Node::Kind::BaseConformanceDescriptor:
-    case Node::Kind::BaseWitnessTableAccessor:
-    case Node::Kind::BodyAttachedMacroExpansion:
-    case Node::Kind::ClangType:
-    case Node::Kind::ClassMetadataBaseOffset:
-    case Node::Kind::CFunctionPointer:
-    case Node::Kind::ConformanceAttachedMacroExpansion:
-    case Node::Kind::Constructor:
-    case Node::Kind::CoroutineContinuationPrototype:
-    case Node::Kind::CurryThunk:
-    case Node::Kind::SILThunkIdentity:
-    case Node::Kind::DispatchThunk:
-    case Node::Kind::Deallocator:
-    case Node::Kind::IsolatedDeallocator:
-    case Node::Kind::DeclContext:
-    case Node::Kind::DefaultArgumentInitializer:
-    case Node::Kind::DefaultAssociatedTypeMetadataAccessor:
-    case Node::Kind::DefaultAssociatedConformanceAccessor:
-    case Node::Kind::DependentAssociatedTypeRef:
-    case Node::Kind::DependentGenericSignature:
-    case Node::Kind::DependentGenericParamPackMarker:
-    case Node::Kind::DependentGenericParamCount:
-    case Node::Kind::DependentGenericConformanceRequirement:
-    case Node::Kind::DependentGenericLayoutRequirement:
-    case Node::Kind::DependentGenericSameTypeRequirement:
-    case Node::Kind::DependentGenericSameShapeRequirement:
-    case Node::Kind::DependentPseudogenericSignature:
-    case Node::Kind::Destructor:
-    case Node::Kind::DidSet:
-    case Node::Kind::DirectMethodReferenceAttribute:
-    case Node::Kind::Directness:
-    case Node::Kind::DynamicAttribute:
-    case Node::Kind::EscapingAutoClosureType:
-    case Node::Kind::EscapingObjCBlock:
-    case Node::Kind::NoEscapeFunctionType:
-    case Node::Kind::ExplicitClosure:
-    case Node::Kind::Extension:
-    case Node::Kind::ExtensionAttachedMacroExpansion:
-    case Node::Kind::EnumCase:
-    case Node::Kind::FieldOffset:
-    case Node::Kind::FreestandingMacroExpansion:
-    case Node::Kind::FullObjCResilientClassStub:
-    case Node::Kind::FullTypeMetadata:
-    case Node::Kind::Function:
-    case Node::Kind::FunctionSignatureSpecialization:
-    case Node::Kind::FunctionSignatureSpecializationParam:
-    case Node::Kind::FunctionSignatureSpecializationReturn:
-    case Node::Kind::FunctionSignatureSpecializationParamKind:
-    case Node::Kind::FunctionSignatureSpecializationParamPayload:
-    case Node::Kind::FunctionType:
-    case Node::Kind::GenericProtocolWitnessTable:
-    case Node::Kind::GenericProtocolWitnessTableInstantiationFunction:
-    case Node::Kind::GenericPartialSpecialization:
-    case Node::Kind::GenericPartialSpecializationNotReAbstracted:
-    case Node::Kind::GenericSpecialization:
-    case Node::Kind::GenericSpecializationNotReAbstracted:
-    case Node::Kind::GenericSpecializationInResilienceDomain:
-    case Node::Kind::GenericSpecializationParam:
-    case Node::Kind::GenericSpecializationPrespecialized:
-    case Node::Kind::InlinedGenericFunction:
-    case Node::Kind::GenericTypeMetadataPattern:
-    case Node::Kind::Getter:
-    case Node::Kind::Global:
-    case Node::Kind::GlobalGetter:
-    case Node::Kind::Identifier:
-    case Node::Kind::Index:
-    case Node::Kind::InitAccessor:
-    case Node::Kind::IVarInitializer:
-    case Node::Kind::IVarDestroyer:
-    case Node::Kind::ImplDifferentiabilityKind:
-    case Node::Kind::ImplEscaping:
-    case Node::Kind::ImplErasedIsolation:
-    case Node::Kind::ImplSendingResult:
-    case Node::Kind::ImplConvention:
-    case Node::Kind::ImplParameterResultDifferentiability:
-    case Node::Kind::ImplParameterSending:
-    case Node::Kind::ImplFunctionAttribute:
-    case Node::Kind::ImplFunctionConvention:
-    case Node::Kind::ImplFunctionConventionName:
-    case Node::Kind::ImplFunctionType:
-    case Node::Kind::ImplCoroutineKind:
-    case Node::Kind::ImplInvocationSubstitutions:
-    case Node::Kind::ImplPatternSubstitutions:
-    case Node::Kind::ImplicitClosure:
-    case Node::Kind::ImplParameter:
-    case Node::Kind::ImplResult:
-    case Node::Kind::ImplYield:
-    case Node::Kind::ImplErrorResult:
-    case Node::Kind::InOut:
-    case Node::Kind::InfixOperator:
-    case Node::Kind::Initializer:
-    case Node::Kind::Isolated:
-    case Node::Kind::Sending:
-    case Node::Kind::CompileTimeLiteral:
-    case Node::Kind::ConstValue:
-    case Node::Kind::PropertyWrapperBackingInitializer:
-    case Node::Kind::PropertyWrapperInitFromProjectedValue:
-    case Node::Kind::KeyPathGetterThunkHelper:
-    case Node::Kind::KeyPathSetterThunkHelper:
-    case Node::Kind::KeyPathUnappliedMethodThunkHelper:
-    case Node::Kind::KeyPathAppliedMethodThunkHelper:
-    case Node::Kind::KeyPathEqualsThunkHelper:
-    case Node::Kind::KeyPathHashThunkHelper:
-    case Node::Kind::LazyProtocolWitnessTableAccessor:
-    case Node::Kind::LazyProtocolWitnessTableCacheVariable:
-    case Node::Kind::LocalDeclName:
-    case Node::Kind::Macro:
-    case Node::Kind::MacroExpansionLoc:
-    case Node::Kind::MacroExpansionUniqueName:
-    case Node::Kind::MaterializeForSet:
-    case Node::Kind::MemberAttributeAttachedMacroExpansion:
-    case Node::Kind::MemberAttachedMacroExpansion:
-    case Node::Kind::MergedFunction:
-    case Node::Kind::Metaclass:
-    case Node::Kind::MethodDescriptor:
-    case Node::Kind::MethodLookupFunction:
-    case Node::Kind::ModifyAccessor:
-    case Node::Kind::Modify2Accessor:
-    case Node::Kind::NativeOwningAddressor:
-    case Node::Kind::NativeOwningMutableAddressor:
-    case Node::Kind::NativePinningAddressor:
-    case Node::Kind::NativePinningMutableAddressor:
-    case Node::Kind::NominalTypeDescriptor:
-    case Node::Kind::NominalTypeDescriptorRecord:
-    case Node::Kind::NonObjCAttribute:
-    case Node::Kind::Number:
-    case Node::Kind::ObjCAsyncCompletionHandlerImpl:
-    case Node::Kind::ObjCAttribute:
-    case Node::Kind::ObjCBlock:
-    case Node::Kind::ObjCMetadataUpdateFunction:
-    case Node::Kind::ObjCResilientClassStub:
-    case Node::Kind::OpaqueTypeDescriptor:
-    case Node::Kind::OpaqueTypeDescriptorRecord:
-    case Node::Kind::OpaqueTypeDescriptorAccessor:
-    case Node::Kind::OpaqueTypeDescriptorAccessorImpl:
-    case Node::Kind::OpaqueTypeDescriptorAccessorKey:
-    case Node::Kind::OpaqueTypeDescriptorAccessorVar:
-    case Node::Kind::Owned:
-    case Node::Kind::OwningAddressor:
-    case Node::Kind::OwningMutableAddressor:
-    case Node::Kind::PartialApplyForwarder:
-    case Node::Kind::PartialApplyObjCForwarder:
-    case Node::Kind::PeerAttachedMacroExpansion:
-    case Node::Kind::PostfixOperator:
-    case Node::Kind::PreambleAttachedMacroExpansion:
-    case Node::Kind::PredefinedObjCAsyncCompletionHandlerImpl:
-    case Node::Kind::PrefixOperator:
-    case Node::Kind::PrivateDeclName:
-    case Node::Kind::PropertyDescriptor:
-    case Node::Kind::ProtocolConformance:
-    case Node::Kind::ProtocolConformanceDescriptor:
-    case Node::Kind::ProtocolConformanceDescriptorRecord:
-    case Node::Kind::MetadataInstantiationCache:
-    case Node::Kind::ProtocolDescriptor:
-    case Node::Kind::ProtocolDescriptorRecord:
-    case Node::Kind::ProtocolRequirementsBaseDescriptor:
-    case Node::Kind::ProtocolSelfConformanceDescriptor:
-    case Node::Kind::ProtocolSelfConformanceWitness:
-    case Node::Kind::ProtocolSelfConformanceWitnessTable:
-    case Node::Kind::ProtocolWitness:
-    case Node::Kind::ProtocolWitnessTable:
-    case Node::Kind::ProtocolWitnessTableAccessor:
-    case Node::Kind::ProtocolWitnessTablePattern:
-    case Node::Kind::ReabstractionThunk:
-    case Node::Kind::ReabstractionThunkHelper:
-    case Node::Kind::ReabstractionThunkHelperWithSelf:
-    case Node::Kind::ReabstractionThunkHelperWithGlobalActor:
-    case Node::Kind::ReadAccessor:
-    case Node::Kind::Read2Accessor:
-    case Node::Kind::RelatedEntityDeclName:
-    case Node::Kind::RetroactiveConformance:
-    case Node::Kind::Setter:
-    case Node::Kind::Shared:
-    case Node::Kind::SILBoxLayout:
-    case Node::Kind::SILBoxMutableField:
-    case Node::Kind::SILBoxImmutableField:
-    case Node::Kind::IsSerialized:
-    case Node::Kind::DroppedArgument:
-    case Node::Kind::SpecializationPassID:
-    case Node::Kind::Static:
-    case Node::Kind::Subscript:
-    case Node::Kind::Suffix:
-    case Node::Kind::ThinFunctionType:
-    case Node::Kind::TupleElement:
-    case Node::Kind::TypeMangling:
-    case Node::Kind::TypeMetadata:
-    case Node::Kind::TypeMetadataAccessFunction:
-    case Node::Kind::TypeMetadataCompletionFunction:
-    case Node::Kind::TypeMetadataInstantiationCache:
-    case Node::Kind::TypeMetadataInstantiationFunction:
-    case Node::Kind::TypeMetadataSingletonInitializationCache:
-    case Node::Kind::TypeMetadataDemanglingCache:
-    case Node::Kind::TypeMetadataLazyCache:
-    case Node::Kind::UncurriedFunctionType:
+  case Node::Kind::ConstrainedExistential:
+  case Node::Kind::PackElement:
+  case Node::Kind::PackElementLevel:
+  case Node::Kind::PackExpansion:
+  case Node::Kind::ProtocolListWithClass:
+  case Node::Kind::AccessorAttachedMacroExpansion:
+  case Node::Kind::AccessorFunctionReference:
+  case Node::Kind::Allocator:
+  case Node::Kind::ArgumentTuple:
+  case Node::Kind::AssociatedConformanceDescriptor:
+  case Node::Kind::AssociatedTypeDescriptor:
+  case Node::Kind::AssociatedTypeMetadataAccessor:
+  case Node::Kind::AssociatedTypeWitnessTableAccessor:
+  case Node::Kind::AsyncRemoved:
+  case Node::Kind::AutoClosureType:
+  case Node::Kind::BaseConformanceDescriptor:
+  case Node::Kind::BaseWitnessTableAccessor:
+  case Node::Kind::BodyAttachedMacroExpansion:
+  case Node::Kind::ClangType:
+  case Node::Kind::ClassMetadataBaseOffset:
+  case Node::Kind::CFunctionPointer:
+  case Node::Kind::ConformanceAttachedMacroExpansion:
+  case Node::Kind::Constructor:
+  case Node::Kind::CoroutineContinuationPrototype:
+  case Node::Kind::CurryThunk:
+  case Node::Kind::SILThunkIdentity:
+  case Node::Kind::DispatchThunk:
+  case Node::Kind::Deallocator:
+  case Node::Kind::IsolatedDeallocator:
+  case Node::Kind::DeclContext:
+  case Node::Kind::DefaultArgumentInitializer:
+  case Node::Kind::DefaultAssociatedTypeMetadataAccessor:
+  case Node::Kind::DefaultAssociatedConformanceAccessor:
+  case Node::Kind::DependentAssociatedTypeRef:
+  case Node::Kind::DependentGenericSignature:
+  case Node::Kind::DependentGenericParamPackMarker:
+  case Node::Kind::DependentGenericParamCount:
+  case Node::Kind::DependentGenericConformanceRequirement:
+  case Node::Kind::DependentGenericLayoutRequirement:
+  case Node::Kind::DependentGenericSameTypeRequirement:
+  case Node::Kind::DependentGenericSameShapeRequirement:
+  case Node::Kind::DependentPseudogenericSignature:
+  case Node::Kind::Destructor:
+  case Node::Kind::DidSet:
+  case Node::Kind::DirectMethodReferenceAttribute:
+  case Node::Kind::Directness:
+  case Node::Kind::DynamicAttribute:
+  case Node::Kind::EscapingAutoClosureType:
+  case Node::Kind::EscapingObjCBlock:
+  case Node::Kind::NoEscapeFunctionType:
+  case Node::Kind::ExplicitClosure:
+  case Node::Kind::Extension:
+  case Node::Kind::ExtensionAttachedMacroExpansion:
+  case Node::Kind::EnumCase:
+  case Node::Kind::FieldOffset:
+  case Node::Kind::FreestandingMacroExpansion:
+  case Node::Kind::FullObjCResilientClassStub:
+  case Node::Kind::FullTypeMetadata:
+  case Node::Kind::Function:
+  case Node::Kind::FunctionSignatureSpecialization:
+  case Node::Kind::FunctionSignatureSpecializationParam:
+  case Node::Kind::FunctionSignatureSpecializationReturn:
+  case Node::Kind::FunctionSignatureSpecializationParamKind:
+  case Node::Kind::FunctionSignatureSpecializationParamPayload:
+  case Node::Kind::FunctionType:
+  case Node::Kind::GenericProtocolWitnessTable:
+  case Node::Kind::GenericProtocolWitnessTableInstantiationFunction:
+  case Node::Kind::GenericPartialSpecialization:
+  case Node::Kind::GenericPartialSpecializationNotReAbstracted:
+  case Node::Kind::GenericSpecialization:
+  case Node::Kind::GenericSpecializationNotReAbstracted:
+  case Node::Kind::GenericSpecializationInResilienceDomain:
+  case Node::Kind::GenericSpecializationParam:
+  case Node::Kind::GenericSpecializationPrespecialized:
+  case Node::Kind::InlinedGenericFunction:
+  case Node::Kind::GenericTypeMetadataPattern:
+  case Node::Kind::Getter:
+  case Node::Kind::Global:
+  case Node::Kind::GlobalGetter:
+  case Node::Kind::Identifier:
+  case Node::Kind::Index:
+  case Node::Kind::InitAccessor:
+  case Node::Kind::IVarInitializer:
+  case Node::Kind::IVarDestroyer:
+  case Node::Kind::ImplDifferentiabilityKind:
+  case Node::Kind::ImplEscaping:
+  case Node::Kind::ImplErasedIsolation:
+  case Node::Kind::ImplSendingResult:
+  case Node::Kind::ImplConvention:
+  case Node::Kind::ImplParameterResultDifferentiability:
+  case Node::Kind::ImplParameterSending:
+  case Node::Kind::ImplFunctionAttribute:
+  case Node::Kind::ImplFunctionConvention:
+  case Node::Kind::ImplFunctionConventionName:
+  case Node::Kind::ImplFunctionType:
+  case Node::Kind::ImplCoroutineKind:
+  case Node::Kind::ImplInvocationSubstitutions:
+  case Node::Kind::ImplPatternSubstitutions:
+  case Node::Kind::ImplicitClosure:
+  case Node::Kind::ImplParameter:
+  case Node::Kind::ImplResult:
+  case Node::Kind::ImplYield:
+  case Node::Kind::ImplErrorResult:
+  case Node::Kind::InOut:
+  case Node::Kind::InfixOperator:
+  case Node::Kind::Initializer:
+  case Node::Kind::Isolated:
+  case Node::Kind::Sending:
+  case Node::Kind::CompileTimeLiteral:
+  case Node::Kind::ConstValue:
+  case Node::Kind::PropertyWrapperBackingInitializer:
+  case Node::Kind::PropertyWrapperInitFromProjectedValue:
+  case Node::Kind::KeyPathGetterThunkHelper:
+  case Node::Kind::KeyPathSetterThunkHelper:
+  case Node::Kind::KeyPathUnappliedMethodThunkHelper:
+  case Node::Kind::KeyPathAppliedMethodThunkHelper:
+  case Node::Kind::KeyPathEqualsThunkHelper:
+  case Node::Kind::KeyPathHashThunkHelper:
+  case Node::Kind::LazyProtocolWitnessTableAccessor:
+  case Node::Kind::LazyProtocolWitnessTableCacheVariable:
+  case Node::Kind::LocalDeclName:
+  case Node::Kind::Macro:
+  case Node::Kind::MacroExpansionLoc:
+  case Node::Kind::MacroExpansionUniqueName:
+  case Node::Kind::MaterializeForSet:
+  case Node::Kind::MemberAttributeAttachedMacroExpansion:
+  case Node::Kind::MemberAttachedMacroExpansion:
+  case Node::Kind::MergedFunction:
+  case Node::Kind::Metaclass:
+  case Node::Kind::MethodDescriptor:
+  case Node::Kind::MethodLookupFunction:
+  case Node::Kind::ModifyAccessor:
+  case Node::Kind::Modify2Accessor:
+  case Node::Kind::NativeOwningAddressor:
+  case Node::Kind::NativeOwningMutableAddressor:
+  case Node::Kind::NativePinningAddressor:
+  case Node::Kind::NativePinningMutableAddressor:
+  case Node::Kind::NominalTypeDescriptor:
+  case Node::Kind::NominalTypeDescriptorRecord:
+  case Node::Kind::NonObjCAttribute:
+  case Node::Kind::Number:
+  case Node::Kind::ObjCAsyncCompletionHandlerImpl:
+  case Node::Kind::ObjCAttribute:
+  case Node::Kind::ObjCBlock:
+  case Node::Kind::ObjCMetadataUpdateFunction:
+  case Node::Kind::ObjCResilientClassStub:
+  case Node::Kind::OpaqueTypeDescriptor:
+  case Node::Kind::OpaqueTypeDescriptorRecord:
+  case Node::Kind::OpaqueTypeDescriptorAccessor:
+  case Node::Kind::OpaqueTypeDescriptorAccessorImpl:
+  case Node::Kind::OpaqueTypeDescriptorAccessorKey:
+  case Node::Kind::OpaqueTypeDescriptorAccessorVar:
+  case Node::Kind::Owned:
+  case Node::Kind::OwningAddressor:
+  case Node::Kind::OwningMutableAddressor:
+  case Node::Kind::PartialApplyForwarder:
+  case Node::Kind::PartialApplyObjCForwarder:
+  case Node::Kind::PeerAttachedMacroExpansion:
+  case Node::Kind::PostfixOperator:
+  case Node::Kind::PreambleAttachedMacroExpansion:
+  case Node::Kind::PredefinedObjCAsyncCompletionHandlerImpl:
+  case Node::Kind::PrefixOperator:
+  case Node::Kind::PrivateDeclName:
+  case Node::Kind::PropertyDescriptor:
+  case Node::Kind::ProtocolConformance:
+  case Node::Kind::ProtocolConformanceDescriptor:
+  case Node::Kind::ProtocolConformanceDescriptorRecord:
+  case Node::Kind::MetadataInstantiationCache:
+  case Node::Kind::ProtocolDescriptor:
+  case Node::Kind::ProtocolDescriptorRecord:
+  case Node::Kind::ProtocolRequirementsBaseDescriptor:
+  case Node::Kind::ProtocolSelfConformanceDescriptor:
+  case Node::Kind::ProtocolSelfConformanceWitness:
+  case Node::Kind::ProtocolSelfConformanceWitnessTable:
+  case Node::Kind::ProtocolWitness:
+  case Node::Kind::ProtocolWitnessTable:
+  case Node::Kind::ProtocolWitnessTableAccessor:
+  case Node::Kind::ProtocolWitnessTablePattern:
+  case Node::Kind::ReabstractionThunk:
+  case Node::Kind::ReabstractionThunkHelper:
+  case Node::Kind::ReabstractionThunkHelperWithSelf:
+  case Node::Kind::ReabstractionThunkHelperWithGlobalActor:
+  case Node::Kind::ReadAccessor:
+  case Node::Kind::Read2Accessor:
+  case Node::Kind::RelatedEntityDeclName:
+  case Node::Kind::RetroactiveConformance:
+  case Node::Kind::Setter:
+  case Node::Kind::Shared:
+  case Node::Kind::SILBoxLayout:
+  case Node::Kind::SILBoxMutableField:
+  case Node::Kind::SILBoxImmutableField:
+  case Node::Kind::IsSerialized:
+  case Node::Kind::DroppedArgument:
+  case Node::Kind::SpecializationPassID:
+  case Node::Kind::Static:
+  case Node::Kind::Subscript:
+  case Node::Kind::Suffix:
+  case Node::Kind::ThinFunctionType:
+  case Node::Kind::TupleElement:
+  case Node::Kind::TypeMangling:
+  case Node::Kind::TypeMetadata:
+  case Node::Kind::TypeMetadataAccessFunction:
+  case Node::Kind::TypeMetadataCompletionFunction:
+  case Node::Kind::TypeMetadataInstantiationCache:
+  case Node::Kind::TypeMetadataInstantiationFunction:
+  case Node::Kind::TypeMetadataSingletonInitializationCache:
+  case Node::Kind::TypeMetadataDemanglingCache:
+  case Node::Kind::TypeMetadataLazyCache:
+  case Node::Kind::UncurriedFunctionType:
 #define REF_STORAGE(Name, ...) \
     case Node::Kind::Name:
 #include "swift/AST/ReferenceStorage.def"
@@ -671,584 +610,536 @@ private:
       return false;
     }
     printer_unreachable("bad node kind");
-  }
+}
 
-  void printWithParens(NodePointer type, unsigned depth) {
-    bool needs_parens = !isSimpleType(type);
-    if (needs_parens)
-      Printer << "(";
-    print(type, depth + 1);
-    if (needs_parens)
-      Printer << ")";
-  }
+void NodePrinter::printWithParens(NodePointer type, unsigned depth) {
+  bool needs_parens = !isSimpleType(type);
+  if (needs_parens)
+    Printer << "(";
+  print(type, depth + 1);
+  if (needs_parens)
+    Printer << ")";
+}
 
-  SugarType findSugar(NodePointer Node) {
-    if (Node->getNumChildren() == 1 &&
-        Node->getKind() == Node::Kind::Type)
-      return findSugar(Node->getChild(0));
-    
-    if (Node->getNumChildren() != 2)
-      return SugarType::None;
-    
-    if (Node->getKind() != Node::Kind::BoundGenericEnum &&
-        Node->getKind() != Node::Kind::BoundGenericStructure)
-      return SugarType::None;
+NodePrinter::SugarType NodePrinter::findSugar(NodePointer Node) {
+  if (Node->getNumChildren() == 1 && Node->getKind() == Node::Kind::Type)
+    return findSugar(Node->getChild(0));
 
-    auto unboundType = Node->getChild(0)->getChild(0); // drill through Type
-    auto typeArgs = Node->getChild(1);
-    
-    if (Node->getKind() == Node::Kind::BoundGenericEnum) {
-      // Swift.Optional
-      if (isIdentifier(unboundType->getChild(1), "Optional") &&
-          typeArgs->getNumChildren() == 1 &&
-          isSwiftModule(unboundType->getChild(0))) {
-        return SugarType::Optional;
-      }
+  if (Node->getNumChildren() != 2)
+    return SugarType::None;
 
-      // Swift.ImplicitlyUnwrappedOptional
-      if (isIdentifier(unboundType->getChild(1), 
-                       "ImplicitlyUnwrappedOptional") &&
-          typeArgs->getNumChildren() == 1 &&
-          isSwiftModule(unboundType->getChild(0))) {
-        return SugarType::ImplicitlyUnwrappedOptional;
-      }
+  if (Node->getKind() != Node::Kind::BoundGenericEnum &&
+      Node->getKind() != Node::Kind::BoundGenericStructure)
+    return SugarType::None;
 
-      return SugarType::None;
-    }
+  auto unboundType = Node->getChild(0)->getChild(0); // drill through Type
+  auto typeArgs = Node->getChild(1);
 
-    assert(Node->getKind() == Node::Kind::BoundGenericStructure);
-
-    // Array
-    if (isIdentifier(unboundType->getChild(1), "Array") &&
+  if (Node->getKind() == Node::Kind::BoundGenericEnum) {
+    // Swift.Optional
+    if (isIdentifier(unboundType->getChild(1), "Optional") &&
         typeArgs->getNumChildren() == 1 &&
         isSwiftModule(unboundType->getChild(0))) {
-      return SugarType::Array;
+      return SugarType::Optional;
     }
 
-    // Dictionary
-    if (isIdentifier(unboundType->getChild(1), "Dictionary") &&
-        typeArgs->getNumChildren() == 2 &&
+    // Swift.ImplicitlyUnwrappedOptional
+    if (isIdentifier(unboundType->getChild(1), "ImplicitlyUnwrappedOptional") &&
+        typeArgs->getNumChildren() == 1 &&
         isSwiftModule(unboundType->getChild(0))) {
-      return SugarType::Dictionary;
+      return SugarType::ImplicitlyUnwrappedOptional;
     }
 
     return SugarType::None;
   }
 
-  void printBoundGeneric(NodePointer Node, unsigned depth) {
-    if (Node->getNumChildren() < 2)
-      return;
-    if (Node->getNumChildren() != 2) {
-      printBoundGenericNoSugar(Node, depth);
-      return;
-    }
+  assert(Node->getKind() == Node::Kind::BoundGenericStructure);
 
-    if (!Options.SynthesizeSugarOnTypes ||
-        Node->getKind() == Node::Kind::BoundGenericClass)
-    {
-      // no sugar here
-      printBoundGenericNoSugar(Node, depth);
-      return;
-    }
-
-    // Print the conforming type for a "bound" protocol node "as" the protocol
-    // type.
-    if (Node->getKind() == Node::Kind::BoundGenericProtocol) {
-      printChildren(Node->getChild(1), depth);
-      Printer << " as ";
-      print(Node->getChild(0), depth + 1);
-      return;
-    }
-
-    SugarType sugarType = findSugar(Node);
-    
-    switch (sugarType) {
-      case SugarType::None:
-        printBoundGenericNoSugar(Node, depth);
-        break;
-      case SugarType::Optional:
-      case SugarType::ImplicitlyUnwrappedOptional: {
-        NodePointer type = Node->getChild(1)->getChild(0);
-        printWithParens(type, depth);
-        Printer << (sugarType == SugarType::Optional ? "?" : "!");
-        break;
-      }
-      case SugarType::Array: {
-        NodePointer type = Node->getChild(1)->getChild(0);
-        Printer << "[";
-        print(type, depth + 1);
-        Printer << "]";
-        break;
-      }
-      case SugarType::Dictionary: {
-        NodePointer keyType = Node->getChild(1)->getChild(0);
-        NodePointer valueType = Node->getChild(1)->getChild(1);
-        Printer << "[";
-        print(keyType, depth + 1);
-        Printer << " : ";
-        print(valueType, depth + 1);
-        Printer << "]";
-        break;
-      }
-    }
+  // Array
+  if (isIdentifier(unboundType->getChild(1), "Array") &&
+      typeArgs->getNumChildren() == 1 &&
+      isSwiftModule(unboundType->getChild(0))) {
+    return SugarType::Array;
   }
 
-  NodePointer getChildIf(NodePointer Node, Node::Kind Kind) {
-    auto result =
-        std::find_if(Node->begin(), Node->end(), [&](NodePointer child) {
-          return child->getKind() == Kind;
-        });
-    return result != Node->end() ? *result : nullptr;
+  // Dictionary
+  if (isIdentifier(unboundType->getChild(1), "Dictionary") &&
+      typeArgs->getNumChildren() == 2 &&
+      isSwiftModule(unboundType->getChild(0))) {
+    return SugarType::Dictionary;
   }
 
-  void printFunctionParameters(NodePointer LabelList, NodePointer ParameterType,
-                               unsigned depth, bool showTypes) {
-    if (ParameterType->getKind() != Node::Kind::ArgumentTuple) {
-      setInvalid();
-      return;
-    }
+  return SugarType::None;
+}
 
-    Printer.startParameters(depth);
-    NodePointer Parameters = ParameterType->getFirstChild();
-    assert(Parameters->getKind() == Node::Kind::Type);
-    Parameters = Parameters->getFirstChild();
-    if (Parameters->getKind() != Node::Kind::Tuple) {
-      // only a single not-named parameter
-      if (showTypes) {
+void NodePrinter::printBoundGeneric(NodePointer Node, unsigned depth) {
+  if (Node->getNumChildren() < 2)
+    return;
+  if (Node->getNumChildren() != 2) {
+    printBoundGenericNoSugar(Node, depth);
+    return;
+  }
+
+  if (!Options.SynthesizeSugarOnTypes ||
+      Node->getKind() == Node::Kind::BoundGenericClass) {
+    // no sugar here
+    printBoundGenericNoSugar(Node, depth);
+    return;
+  }
+
+  // Print the conforming type for a "bound" protocol node "as" the protocol
+  // type.
+  if (Node->getKind() == Node::Kind::BoundGenericProtocol) {
+    printChildren(Node->getChild(1), depth);
+    Printer << " as ";
+    print(Node->getChild(0), depth + 1);
+    return;
+  }
+
+  SugarType sugarType = findSugar(Node);
+
+  switch (sugarType) {
+  case SugarType::None:
+    printBoundGenericNoSugar(Node, depth);
+    break;
+  case SugarType::Optional:
+  case SugarType::ImplicitlyUnwrappedOptional: {
+    NodePointer type = Node->getChild(1)->getChild(0);
+    printWithParens(type, depth);
+    Printer << (sugarType == SugarType::Optional ? "?" : "!");
+    break;
+  }
+  case SugarType::Array: {
+    NodePointer type = Node->getChild(1)->getChild(0);
+    Printer << "[";
+    print(type, depth + 1);
+    Printer << "]";
+    break;
+  }
+  case SugarType::Dictionary: {
+    NodePointer keyType = Node->getChild(1)->getChild(0);
+    NodePointer valueType = Node->getChild(1)->getChild(1);
+    Printer << "[";
+    print(keyType, depth + 1);
+    Printer << " : ";
+    print(valueType, depth + 1);
+    Printer << "]";
+    break;
+  }
+  }
+}
+
+NodePointer NodePrinter::getChildIf(NodePointer Node, Node::Kind Kind) {
+  auto result =
+      std::find_if(Node->begin(), Node->end(),
+                   [&](NodePointer child) { return child->getKind() == Kind; });
+  return result != Node->end() ? *result : nullptr;
+}
+
+void NodePrinter::printFunctionParameters(NodePointer LabelList,
+                                          NodePointer ParameterType,
+                                          unsigned depth, bool showTypes) {
+  if (ParameterType->getKind() != Node::Kind::ArgumentTuple) {
+    setInvalid();
+    return;
+  }
+
+  NodePointer Parameters = ParameterType->getFirstChild();
+  assert(Parameters->getKind() == Node::Kind::Type);
+  Parameters = Parameters->getFirstChild();
+  if (Parameters->getKind() != Node::Kind::Tuple) {
+    // only a single not-named parameter
+    if (showTypes) {
+      Printer << '(';
+      print(Parameters, depth + 1);
+      Printer << ')';
+    } else {
+      Printer << "(_:)";
+    }
+    return;
+  }
+
+  auto getLabelFor = [&](NodePointer Param, unsigned Index) -> std::string {
+    auto Label = LabelList->getChild(Index);
+    assert(Label && (Label->getKind() == Node::Kind::Identifier ||
+                     Label->getKind() == Node::Kind::FirstElementMarker));
+    return Label->getKind() == Node::Kind::Identifier ? Label->getText().str()
+                                                      : "_";
+  };
+
+  unsigned ParamIndex = 0;
+  bool hasLabels = LabelList && LabelList->getNumChildren() > 0;
+
+  Printer << '(';
+  llvm::interleave(
+      Parameters->begin(), Parameters->end(),
+      [&](NodePointer Param) {
+        assert(Param->getKind() == Node::Kind::TupleElement);
+
+        if (hasLabels) {
+          Printer << getLabelFor(Param, ParamIndex) << ':';
+        } else if (!showTypes) {
+          if (auto Label = getChildIf(Param, Node::Kind::TupleElementName))
+            Printer << Label->getText() << ":";
+          else
+            Printer << "_:";
+        }
+
+        if (hasLabels && showTypes)
+          Printer << ' ';
+
+        ++ParamIndex;
+
+        if (showTypes)
+          print(Param, depth + 1);
+      },
+      [&]() { Printer << (showTypes ? ", " : ""); });
+  Printer << ')';
+}
+
+void NodePrinter::printFunctionType(NodePointer LabelList, NodePointer node,
+                                    unsigned depth) {
+  if (node->getNumChildren() < 2) {
+    setInvalid();
+    return;
+  }
+
+  auto printConventionWithMangledCType = [this, node,
+                                          depth](const char *convention) {
+    Printer << "@convention(" << convention;
+    if (node->getFirstChild()->getKind() == Node::Kind::ClangType) {
+      Printer << ", mangledCType: \"";
+      print(node->getFirstChild(), depth + 1);
+      Printer << '"';
+    }
+    Printer << ") ";
+  };
+
+  switch (node->getKind()) {
+  case Node::Kind::FunctionType:
+  case Node::Kind::UncurriedFunctionType:
+  case Node::Kind::NoEscapeFunctionType:
+    break;
+  case Node::Kind::AutoClosureType:
+  case Node::Kind::EscapingAutoClosureType:
+    Printer << "@autoclosure ";
+    break;
+  case Node::Kind::ThinFunctionType:
+    Printer << "@convention(thin) ";
+    break;
+  case Node::Kind::CFunctionPointer:
+    printConventionWithMangledCType("c");
+    break;
+  case Node::Kind::EscapingObjCBlock:
+    Printer << "@escaping ";
+    LLVM_FALLTHROUGH;
+  case Node::Kind::ObjCBlock:
+    printConventionWithMangledCType("block");
+    break;
+  default:
+    assert(false && "Unhandled function type in printFunctionType!");
+  }
+
+  unsigned argIndex = node->getNumChildren() - 2;
+  unsigned startIndex = 0;
+  bool isSendable = false, isAsync = false, hasSendingResult = false;
+  auto diffKind = MangledDifferentiabilityKind::NonDifferentiable;
+  if (node->getChild(startIndex)->getKind() == Node::Kind::ClangType) {
+    // handled earlier
+    ++startIndex;
+  }
+
+  // Be sure to check for function signature components in the same
+  // order that they're added by the demangler, which is the reverse
+  // of the order that they appear in the mangling grammar.
+
+  if (node->getChild(startIndex)->getKind() ==
+      Node::Kind::SendingResultFunctionType) {
+    ++startIndex;
+    hasSendingResult = true;
+  }
+
+  // function-isolation; note that these can't actually both appear.
+  if (node->getChild(startIndex)->getKind() ==
+      Node::Kind::IsolatedAnyFunctionType) {
+    print(node->getChild(startIndex), depth + 1);
+    ++startIndex;
+  }
+
+  Node *nonIsolatedCallerNode = nullptr;
+  if (node->getChild(startIndex)->getKind() ==
+      Node::Kind::NonIsolatedCallerFunctionType) {
+    nonIsolatedCallerNode = node->getChild(startIndex);
+    ++startIndex;
+  }
+
+  if (node->getChild(startIndex)->getKind() ==
+      Node::Kind::GlobalActorFunctionType) {
+    print(node->getChild(startIndex), depth + 1);
+    ++startIndex;
+  }
+
+  if (node->getChild(startIndex)->getKind() ==
+      Node::Kind::DifferentiableFunctionType) {
+    diffKind =
+        (MangledDifferentiabilityKind)node->getChild(startIndex)->getIndex();
+    ++startIndex;
+  }
+
+  Node *thrownErrorNode = nullptr;
+  if (node->getChild(startIndex)->getKind() == Node::Kind::ThrowsAnnotation ||
+      node->getChild(startIndex)->getKind() ==
+          Node::Kind::TypedThrowsAnnotation) {
+    thrownErrorNode = node->getChild(startIndex);
+    ++startIndex;
+  }
+
+  if (node->getChild(startIndex)->getKind() ==
+      Node::Kind::ConcurrentFunctionType) {
+    ++startIndex;
+    isSendable = true;
+  }
+  if (node->getChild(startIndex)->getKind() == Node::Kind::AsyncAnnotation) {
+    ++startIndex;
+    isAsync = true;
+  }
+
+  switch (diffKind) {
+  case MangledDifferentiabilityKind::Forward:
+    Printer << "@differentiable(_forward) ";
+    break;
+  case MangledDifferentiabilityKind::Reverse:
+    Printer << "@differentiable(reverse) ";
+    break;
+  case MangledDifferentiabilityKind::Linear:
+    Printer << "@differentiable(_linear) ";
+    break;
+  case MangledDifferentiabilityKind::Normal:
+    Printer << "@differentiable ";
+    break;
+  case MangledDifferentiabilityKind::NonDifferentiable:
+    break;
+  }
+
+  if (nonIsolatedCallerNode)
+    print(nonIsolatedCallerNode, depth + 1);
+
+  if (isSendable)
+    Printer << "@Sendable ";
+
+  printFunctionParameters(LabelList, node->getChild(argIndex), depth,
+                          Options.ShowFunctionArgumentTypes);
+
+  if (!Options.ShowFunctionArgumentTypes)
+    return;
+
+  if (isAsync)
+    Printer << " async";
+
+  if (thrownErrorNode) {
+    print(thrownErrorNode, depth + 1);
+  }
+
+  Printer << " -> ";
+
+  if (hasSendingResult)
+    Printer << "sending ";
+
+  print(node->getChild(argIndex + 1), depth + 1);
+}
+
+void NodePrinter::printImplFunctionType(NodePointer fn, unsigned depth) {
+  NodePointer patternSubs = nullptr;
+  NodePointer invocationSubs = nullptr;
+  NodePointer sendingResult = nullptr;
+  enum State { Attrs, Inputs, Results } curState = Attrs;
+  auto transitionTo = [&](State newState) {
+    assert(newState >= curState);
+    for (; curState != newState; curState = State(curState + 1)) {
+      switch (curState) {
+      case Attrs:
+        if (patternSubs) {
+          Printer << "@substituted ";
+          print(patternSubs->getChild(0), depth + 1);
+          Printer << ' ';
+        }
         Printer << '(';
-        print(Parameters, depth + 1);
-        Printer << ')';
-      } else {
-        Printer << "(_:)";
-      }
-      Printer.endParameters(depth);
-      return;
-    }
-
-    auto getLabelFor = [&](NodePointer Param, unsigned Index) -> std::string {
-      auto Label = LabelList->getChild(Index);
-      assert(Label && (Label->getKind() == Node::Kind::Identifier ||
-                       Label->getKind() == Node::Kind::FirstElementMarker));
-      return Label->getKind() == Node::Kind::Identifier ? Label->getText().str()
-                                                        : "_";
-    };
-
-    unsigned ParamIndex = 0;
-    bool hasLabels = LabelList && LabelList->getNumChildren() > 0;
-
-    Printer << '(';
-    llvm::interleave(
-        Parameters->begin(), Parameters->end(),
-        [&](NodePointer Param) {
-          assert(Param->getKind() == Node::Kind::TupleElement);
-
-          if (hasLabels) {
-            Printer << getLabelFor(Param, ParamIndex) << ':';
-          } else if (!showTypes) {
-            if (auto Label = getChildIf(Param, Node::Kind::TupleElementName))
-              Printer << Label->getText() << ":";
-            else
-              Printer << "_:";
-          }
-
-          if (hasLabels && showTypes)
-            Printer << ' ';
-
-          ++ParamIndex;
-
-          if (showTypes)
-            print(Param, depth + 1);
-        },
-        [&]() { Printer << (showTypes ? ", " : ""); });
-    Printer << ')';
-    Printer.endParameters(depth);
-  }
-
-  void printFunctionType(NodePointer LabelList, NodePointer node,
-                         unsigned depth) {
-    if (node->getNumChildren() < 2) {
-      setInvalid();
-      return;
-    }
-
-    auto printConventionWithMangledCType = [this, node,
-                                            depth](const char *convention) {
-      Printer << "@convention(" << convention;
-      if (node->getFirstChild()->getKind() == Node::Kind::ClangType) {
-        Printer << ", mangledCType: \"";
-        print(node->getFirstChild(), depth + 1);
-        Printer << '"';
-      }
-      Printer << ") ";
-    };
-
-    switch (node->getKind()) {
-    case Node::Kind::FunctionType:
-    case Node::Kind::UncurriedFunctionType:
-    case Node::Kind::NoEscapeFunctionType:
-      break;
-    case Node::Kind::AutoClosureType:
-    case Node::Kind::EscapingAutoClosureType:
-      Printer << "@autoclosure "; break;
-    case Node::Kind::ThinFunctionType:
-      Printer << "@convention(thin) "; break;
-    case Node::Kind::CFunctionPointer:
-      printConventionWithMangledCType("c");
-      break;
-    case Node::Kind::EscapingObjCBlock:
-      Printer << "@escaping ";
-      LLVM_FALLTHROUGH;
-    case Node::Kind::ObjCBlock:
-      printConventionWithMangledCType("block");
-      break;
-    default:
-      assert(false && "Unhandled function type in printFunctionType!");
-    }
-
-    unsigned argIndex = node->getNumChildren() - 2;
-    unsigned startIndex = 0;
-    bool isSendable = false, isAsync = false, hasSendingResult = false;
-    auto diffKind = MangledDifferentiabilityKind::NonDifferentiable;
-    if (node->getChild(startIndex)->getKind() == Node::Kind::ClangType) {
-      // handled earlier
-      ++startIndex;
-    }
-
-    // Be sure to check for function signature components in the same
-    // order that they're added by the demangler, which is the reverse
-    // of the order that they appear in the mangling grammar.
-
-    if (node->getChild(startIndex)->getKind() ==
-        Node::Kind::SendingResultFunctionType) {
-      ++startIndex;
-      hasSendingResult = true;
-    }
-
-    // function-isolation; note that these can't actually both appear.
-    if (node->getChild(startIndex)->getKind()
-            == Node::Kind::IsolatedAnyFunctionType) {
-      print(node->getChild(startIndex), depth + 1);
-      ++startIndex;
-    }
-
-    Node *nonIsolatedCallerNode = nullptr;
-    if (node->getChild(startIndex)->getKind() ==
-          Node::Kind::NonIsolatedCallerFunctionType) {
-      nonIsolatedCallerNode = node->getChild(startIndex);
-      ++startIndex;
-    }
-
-    if (node->getChild(startIndex)->getKind() ==
-          Node::Kind::GlobalActorFunctionType) {
-      print(node->getChild(startIndex), depth + 1);
-      ++startIndex;
-    }
-
-    if (node->getChild(startIndex)->getKind() ==
-        Node::Kind::DifferentiableFunctionType) {
-      diffKind =
-          (MangledDifferentiabilityKind)node->getChild(startIndex)->getIndex();
-      ++startIndex;
-    }
-
-    Node *thrownErrorNode = nullptr;
-    if (node->getChild(startIndex)->getKind() == Node::Kind::ThrowsAnnotation ||
-        node->getChild(startIndex)->getKind()
-          == Node::Kind::TypedThrowsAnnotation) {
-      thrownErrorNode = node->getChild(startIndex);
-      ++startIndex;
-    }
-
-    if (node->getChild(startIndex)->getKind()
-            == Node::Kind::ConcurrentFunctionType) {
-      ++startIndex;
-      isSendable = true;
-    }
-    if (node->getChild(startIndex)->getKind() == Node::Kind::AsyncAnnotation) {
-      ++startIndex;
-      isAsync = true;
-    }
-
-    switch (diffKind) {
-    case MangledDifferentiabilityKind::Forward:
-      Printer << "@differentiable(_forward) ";
-      break;
-    case MangledDifferentiabilityKind::Reverse:
-      Printer << "@differentiable(reverse) ";
-      break;
-    case MangledDifferentiabilityKind::Linear:
-      Printer << "@differentiable(_linear) ";
-      break;
-    case MangledDifferentiabilityKind::Normal:
-      Printer << "@differentiable ";
-      break;
-    case MangledDifferentiabilityKind::NonDifferentiable:
-      break;
-    }
-
-    if (nonIsolatedCallerNode)
-      print(nonIsolatedCallerNode, depth + 1);
-
-    if (isSendable)
-      Printer << "@Sendable ";
-
-    printFunctionParameters(LabelList, node->getChild(argIndex), depth,
-                            Options.ShowFunctionArgumentTypes);
-
-    if (!Options.ShowFunctionArgumentTypes)
-      return;
-
-    if (isAsync)
-      Printer << " async";
-
-    if (thrownErrorNode) {
-      print(thrownErrorNode, depth + 1);
-    }
-
-    Printer << " -> ";
-
-    if (hasSendingResult)
-      Printer << "sending ";
-
-    print(node->getChild(argIndex + 1), depth + 1);
-  }
-
-  void printImplFunctionType(NodePointer fn, unsigned depth) {
-    NodePointer patternSubs = nullptr;
-    NodePointer invocationSubs = nullptr;
-    NodePointer sendingResult = nullptr;
-    enum State { Attrs, Inputs, Results } curState = Attrs;
-    auto transitionTo = [&](State newState) {
-      assert(newState >= curState);
-      for (; curState != newState; curState = State(curState + 1)) {
-        switch (curState) {
-        case Attrs:
-          if (patternSubs) {
-            Printer << "@substituted ";
-            print(patternSubs->getChild(0), depth + 1);
-            Printer << ' ';
-          }
-          Printer << '(';
-          continue;
-        case Inputs:
-          Printer << ") -> ";
-          if (sendingResult) {
-            print(sendingResult, depth + 1);
-            Printer << " ";
-          }
-          Printer << "(";
-          continue;
-        case Results: printer_unreachable("no state after Results");
+        continue;
+      case Inputs:
+        Printer << ") -> ";
+        if (sendingResult) {
+          print(sendingResult, depth + 1);
+          Printer << " ";
         }
-        printer_unreachable("bad state");
+        Printer << "(";
+        continue;
+      case Results:
+        printer_unreachable("no state after Results");
       }
-    };
-
-    for (auto &child : *fn) {
-      if (child->getKind() == Node::Kind::ImplParameter) {
-        if (curState == Inputs) Printer << ", ";
-        transitionTo(Inputs);
-        print(child, depth + 1);
-      } else if (child->getKind() == Node::Kind::ImplResult
-                 || child->getKind() == Node::Kind::ImplYield
-                 || child->getKind() == Node::Kind::ImplErrorResult) {
-        if (curState == Results) Printer << ", ";
-        transitionTo(Results);
-        print(child, depth + 1);
-      } else if (child->getKind() == Node::Kind::ImplPatternSubstitutions) {
-        patternSubs = child;
-      } else if (child->getKind() == Node::Kind::ImplInvocationSubstitutions) {
-        invocationSubs = child;
-      } else if (child->getKind() == Node::Kind::ImplSendingResult) {
-        sendingResult = child;
-      } else {
-        assert(curState == Attrs);
-        print(child, depth + 1);
-        Printer << ' ';
-      }
+      printer_unreachable("bad state");
     }
-    transitionTo(Results);
-    Printer << ')';
+  };
 
-    if (patternSubs) {
-      Printer << " for <";
-      printChildren(patternSubs->getChild(1), depth);
-      Printer << '>';
-    }
-    if (invocationSubs) {
-      Printer << " for <";
-      printChildren(invocationSubs->getChild(0), depth);
-      Printer << '>';
+  for (auto &child : *fn) {
+    if (child->getKind() == Node::Kind::ImplParameter) {
+      if (curState == Inputs)
+        Printer << ", ";
+      transitionTo(Inputs);
+      print(child, depth + 1);
+    } else if (child->getKind() == Node::Kind::ImplResult ||
+               child->getKind() == Node::Kind::ImplYield ||
+               child->getKind() == Node::Kind::ImplErrorResult) {
+      if (curState == Results)
+        Printer << ", ";
+      transitionTo(Results);
+      print(child, depth + 1);
+    } else if (child->getKind() == Node::Kind::ImplPatternSubstitutions) {
+      patternSubs = child;
+    } else if (child->getKind() == Node::Kind::ImplInvocationSubstitutions) {
+      invocationSubs = child;
+    } else if (child->getKind() == Node::Kind::ImplSendingResult) {
+      sendingResult = child;
+    } else {
+      assert(curState == Attrs);
+      print(child, depth + 1);
+      Printer << ' ';
     }
   }
+  transitionTo(Results);
+  Printer << ')';
 
-  void printGenericSignature(NodePointer Node, unsigned depth) {
-    Printer << '<';
-
-    unsigned numChildren = Node->getNumChildren();
-
-    unsigned numGenericParams = 0;
-    for (; numGenericParams < numChildren; ++numGenericParams) {
-      if (Node->getChild(numGenericParams)->getKind()
-               != Node::Kind::DependentGenericParamCount) {
-        break;
-      }
-    }
-
-    unsigned firstRequirement = numGenericParams;
-    for (; firstRequirement < numChildren; ++firstRequirement) {
-      auto child = Node->getChild(firstRequirement);
-      if (child->getKind() == Node::Kind::Type)
-        child = child->getChild(0);
-      if (child->getKind() != Node::Kind::DependentGenericParamPackMarker &&
-          child->getKind() != Node::Kind::DependentGenericParamValueMarker) {
-        break;
-      }
-    }
-
-    auto isGenericParamPack = [&](unsigned depth, unsigned index) {
-      for (unsigned i = numGenericParams; i < firstRequirement; ++i) {
-        auto child = Node->getChild(i);
-        if (child->getKind() != Node::Kind::DependentGenericParamPackMarker)
-          continue;
-        child = child->getChild(0);
-
-        if (child->getKind() != Node::Kind::Type)
-          continue;
-
-        child = child->getChild(0);
-        if (child->getKind() != Node::Kind::DependentGenericParamType)
-          continue;
-
-        if (index == child->getChild(0)->getIndex() &&
-            depth == child->getChild(1)->getIndex()) {
-          return true;
-        }
-      }
-
-      return false;
-    };
-
-    auto isGenericParamValue = [&](unsigned depth, unsigned index) {
-      for (unsigned i = numGenericParams; i < firstRequirement; ++i) {
-        auto child = Node->getChild(i);
-        if (child->getKind() != Node::Kind::DependentGenericParamValueMarker)
-          continue;
-        child = child->getChild(0);
-
-        if (child->getKind() != Node::Kind::Type)
-          continue;
-
-        auto param = child->getChild(0);
-        auto type = child->getChild(1);
-        if (param->getKind() != Node::Kind::DependentGenericParamType)
-          continue;
-
-        if (index == param->getChild(0)->getIndex() &&
-            depth == param->getChild(1)->getIndex()) {
-          return std::make_pair(true, type);
-        }
-      }
-
-      return std::make_pair(false, NodePointer());
-    };
-
-    unsigned gpDepth = 0;
-    for (; gpDepth < numGenericParams; ++gpDepth) {
-      if (gpDepth != 0)
-        Printer << "><";
-
-      unsigned count = Node->getChild(gpDepth)->getIndex();
-      for (unsigned index = 0; index < count; ++index) {
-        if (index != 0)
-          Printer << ", ";
-
-        // Limit the number of printed generic parameters. In practice this
-        // it will never be exceeded. The limit is only important for malformed
-        // symbols where count can be really huge.
-        if (index >= 128) {
-          Printer << "...";
-          break;
-        }
-
-        if (isGenericParamPack(gpDepth, index))
-          Printer << "each ";
-
-        auto value = isGenericParamValue(gpDepth, index);
-
-        if (value.first)
-          Printer << "let ";
-
-        // FIXME: Depth won't match when a generic signature applies to a
-        // method in generic type context.
-        Printer << Options.GenericParameterName(gpDepth, index);
-
-        if (value.second) {
-          Printer << ": ";
-          print(value.second, depth + 1);
-        }
-      }
-    }
-
-    if (firstRequirement != numChildren) {
-      if (Options.DisplayWhereClauses) {
-        Printer << " where ";
-        for (unsigned i = firstRequirement; i < numChildren; ++i) {
-          if (i > firstRequirement)
-            Printer << ", ";
-          print(Node->getChild(i), depth + 1);
-        }
-      }
-    }
+  if (patternSubs) {
+    Printer << " for <";
+    printChildren(patternSubs->getChild(1), depth);
     Printer << '>';
   }
+  if (invocationSubs) {
+    Printer << " for <";
+    printChildren(invocationSubs->getChild(0), depth);
+    Printer << '>';
+  }
+}
 
-  void printFunctionSigSpecializationParams(NodePointer Node, unsigned depth);
+void NodePrinter::printGenericSignature(NodePointer Node, unsigned depth) {
+  Printer << '<';
 
-  void printSpecializationPrefix(NodePointer node, StringRef Description,
-                                 unsigned depth,
-                                 StringRef ParamPrefix = StringRef());
+  unsigned numChildren = Node->getNumChildren();
 
-  /// The main big print function.
-  NodePointer print(NodePointer Node, unsigned depth,
-                    bool asPrefixContext = false);
+  unsigned numGenericParams = 0;
+  for (; numGenericParams < numChildren; ++numGenericParams) {
+    if (Node->getChild(numGenericParams)->getKind() !=
+        Node::Kind::DependentGenericParamCount) {
+      break;
+    }
+  }
 
-  NodePointer printAbstractStorage(NodePointer Node, unsigned depth,
-                                   bool asPrefixContent, StringRef ExtraName);
+  unsigned firstRequirement = numGenericParams;
+  for (; firstRequirement < numChildren; ++firstRequirement) {
+    auto child = Node->getChild(firstRequirement);
+    if (child->getKind() == Node::Kind::Type)
+      child = child->getChild(0);
+    if (child->getKind() != Node::Kind::DependentGenericParamPackMarker &&
+        child->getKind() != Node::Kind::DependentGenericParamValueMarker) {
+      break;
+    }
+  }
 
-  /// Utility function to print entities.
-  ///
-  /// \param Entity The entity node to print
-  /// \param depth The depth in the print() call tree.
-  /// \param asPrefixContext Should the entity printed as a context which as a
-  ///        prefix to another entity, e.g. the Abc in Abc.def()
-  /// \param TypePr How should the type of the entity be printed, if at all.
-  ///        E.g. with a colon for properties or as a function type.
-  /// \param hasName Does the entity has a name, e.g. a function in contrast to
-  ///        an initializer.
-  /// \param ExtraName An extra name added to the entity name (if any).
-  /// \param ExtraIndex An extra index added to the entity name (if any),
-  ///        e.g. closure #1
-  /// \param OverwriteName If non-empty, print this name instead of the one
-  ///        provided by the node. Gets printed even if hasName is false.
-  /// \return If a non-null node is returned it's a context which must be
-  ///         printed in postfix-form after the entity: "<entity> in <context>".
-  NodePointer printEntity(NodePointer Entity, unsigned depth,
-                          bool asPrefixContext, TypePrinting TypePr,
-                          bool hasName, StringRef ExtraName = "",
-                          int ExtraIndex = -1, StringRef OverwriteName = "");
+  auto isGenericParamPack = [&](unsigned depth, unsigned index) {
+    for (unsigned i = numGenericParams; i < firstRequirement; ++i) {
+      auto child = Node->getChild(i);
+      if (child->getKind() != Node::Kind::DependentGenericParamPackMarker)
+        continue;
+      child = child->getChild(0);
 
-  /// Print the type of an entity.
-  ///
-  /// \param Entity The entity.
-  /// \param type The type of the entity.
-  /// \param genericFunctionTypeList If not null, the generic argument types
-  ///           which is printed in the generic signature.
-  /// \param depth The depth in the print() call tree.
-  void printEntityType(NodePointer Entity, NodePointer type,
-                       NodePointer genericFunctionTypeList, unsigned depth);
-};
-} // end anonymous namespace
+      if (child->getKind() != Node::Kind::Type)
+        continue;
+
+      child = child->getChild(0);
+      if (child->getKind() != Node::Kind::DependentGenericParamType)
+        continue;
+
+      if (index == child->getChild(0)->getIndex() &&
+          depth == child->getChild(1)->getIndex()) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  auto isGenericParamValue = [&](unsigned depth, unsigned index) {
+    for (unsigned i = numGenericParams; i < firstRequirement; ++i) {
+      auto child = Node->getChild(i);
+      if (child->getKind() != Node::Kind::DependentGenericParamValueMarker)
+        continue;
+      child = child->getChild(0);
+
+      if (child->getKind() != Node::Kind::Type)
+        continue;
+
+      auto param = child->getChild(0);
+      auto type = child->getChild(1);
+      if (param->getKind() != Node::Kind::DependentGenericParamType)
+        continue;
+
+      if (index == param->getChild(0)->getIndex() &&
+          depth == param->getChild(1)->getIndex()) {
+        return std::make_pair(true, type);
+      }
+    }
+
+    return std::make_pair(false, NodePointer());
+  };
+
+  unsigned gpDepth = 0;
+  for (; gpDepth < numGenericParams; ++gpDepth) {
+    if (gpDepth != 0)
+      Printer << "><";
+
+    unsigned count = Node->getChild(gpDepth)->getIndex();
+    for (unsigned index = 0; index < count; ++index) {
+      if (index != 0)
+        Printer << ", ";
+
+      // Limit the number of printed generic parameters. In practice this
+      // it will never be exceeded. The limit is only important for malformed
+      // symbols where count can be really huge.
+      if (index >= 128) {
+        Printer << "...";
+        break;
+      }
+
+      if (isGenericParamPack(gpDepth, index))
+        Printer << "each ";
+
+      auto value = isGenericParamValue(gpDepth, index);
+
+      if (value.first)
+        Printer << "let ";
+
+      // FIXME: Depth won't match when a generic signature applies to a
+      // method in generic type context.
+      Printer << Options.GenericParameterName(gpDepth, index);
+
+      if (value.second) {
+        Printer << ": ";
+        print(value.second, depth + 1);
+      }
+    }
+  }
+
+  if (firstRequirement != numChildren) {
+    if (Options.DisplayWhereClauses) {
+      Printer << " where ";
+      for (unsigned i = firstRequirement; i < numChildren; ++i) {
+        if (i > firstRequirement)
+          Printer << ", ";
+        print(Node->getChild(i), depth + 1);
+      }
+    }
+  }
+  Printer << '>';
+}
 
 static bool isExistentialType(NodePointer node) {
   return (node->getKind() == Node::Kind::ExistentialMetatype ||
@@ -3585,41 +3476,10 @@ NodePointer NodePrinter::printEntity(NodePointer Entity, unsigned depth,
         Printer << '.';
     }
   }
-  if (Entity->shouldTrackNameRange()) {
-    Printer.startName();
-  }
-  if (hasName || !OverwriteName.empty()) {
-    if (!ExtraName.empty() && MultiWordName) {
-      Printer << ExtraName;
-      if (ExtraIndex >= 0)
-        Printer << ExtraIndex;
 
-      Printer << " of ";
-      ExtraName = "";
-      ExtraIndex = -1;
-    }
-    size_t CurrentPos = Printer.getStringRef().size();
-    if (!OverwriteName.empty()) {
-      Printer << OverwriteName;
-    } else {
-      auto Name = Entity->getChild(1);
-      if (Name->getKind() != Node::Kind::PrivateDeclName)
-        print(Name, depth + 1);
+  printFunctionName(hasName, OverwriteName, ExtraName, MultiWordName,
+                    ExtraIndex, Entity, depth);
 
-      if (auto PrivateName = getChildIf(Entity, Node::Kind::PrivateDeclName))
-        print(PrivateName, depth + 1);
-    }
-    if (Printer.getStringRef().size() != CurrentPos && !ExtraName.empty())
-      Printer << '.';
-  }
-  if (!ExtraName.empty()) {
-    Printer << ExtraName;
-    if (ExtraIndex >= 0)
-      Printer << ExtraIndex;
-  }
-  if (Entity->shouldTrackNameRange()) {
-    Printer.endName();
-  }
   if (TypePr != TypePrinting::NoType) {
     NodePointer type = getChildIf(Entity, Node::Kind::Type);
     assert(type && "malformed entity");
@@ -3669,6 +3529,43 @@ NodePointer NodePrinter::printEntity(NodePointer Entity, unsigned depth,
     PostfixContext = nullptr;
   }
   return PostfixContext;
+}
+
+void NodePrinter::printFunctionName(bool hasName,
+                                    llvm::StringRef &OverwriteName,
+                                    llvm::StringRef &ExtraName,
+                                    bool MultiWordName, int &ExtraIndex,
+                                    swift::Demangle::NodePointer Entity,
+                                    unsigned int depth) {
+  if (hasName || !OverwriteName.empty()) {
+    if (!ExtraName.empty() && MultiWordName) {
+      Printer << ExtraName;
+      if (ExtraIndex >= 0)
+        Printer << ExtraIndex;
+
+      Printer << " of ";
+      ExtraName = "";
+      ExtraIndex = -1;
+    }
+    size_t CurrentPos = Printer.getStringRef().size();
+    if (!OverwriteName.empty()) {
+      Printer << OverwriteName;
+    } else {
+      auto Name = Entity->getChild(1);
+      if (Name->getKind() != Node::Kind::PrivateDeclName)
+        print(Name, depth + 1);
+
+      if (auto PrivateName = getChildIf(Entity, Node::Kind::PrivateDeclName))
+        print(PrivateName, depth + 1);
+    }
+    if (Printer.getStringRef().size() != CurrentPos && !ExtraName.empty())
+      Printer << '.';
+  }
+  if (!ExtraName.empty()) {
+    Printer << ExtraName;
+    if (ExtraIndex >= 0)
+      Printer << ExtraIndex;
+  }
 }
 
 void NodePrinter::printEntityType(NodePointer Entity, NodePointer type,
@@ -3851,11 +3748,14 @@ std::string Demangle::keyPathSourceString(const char *MangledName,
 
 std::string Demangle::nodeToString(NodePointer root,
                                    const DemangleOptions &options,
-                                   DemanglerPrinter *printer) {
+                                   NodePrinter *printer) {
   if (!root)
     return "";
 
-  return NodePrinter(options, printer).printRoot(root);
+  if (printer) {
+    return printer->printRoot(root);
+  }
+  return NodePrinter(options).printRoot(root);
 }
 
 #endif

--- a/test/DebugInfo/sugar_inline_array.swift
+++ b/test/DebugInfo/sugar_inline_array.swift
@@ -8,8 +8,8 @@ let b: ([3 x [1 x String]], InlineArray<3, InlineArray<1, String>>) = ([[""], ["
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$s$2_SiXSA_s11InlineArrayVy$2_SiGtD", {{.*}})
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$s$2_$0_SSXSAXSA_s11InlineArrayVy$2_ABy$0_SSGGtD", {{.*}})
 
-// RUN: swift-demangle 's$2_SiXSA_s11InlineArrayVy$2_SiGtD' | %FileCheck %s --check-prefix SIMPLE
+// RUN: swift-demangle -no-colors 's$2_SiXSA_s11InlineArrayVy$2_SiGtD' | %FileCheck %s --check-prefix SIMPLE
 // SIMPLE: ([3 x Swift.Int], Swift.InlineArray<3, Swift.Int>)
 
-// RUN: swift-demangle 's$2_$0_SSXSAXSA_s11InlineArrayVy$2_ABy$0_SSGGtD' | %FileCheck %s --check-prefix NESTED
+// RUN: swift-demangle -no-colors 's$2_$0_SSXSAXSA_s11InlineArrayVy$2_ABy$0_SSGGtD' | %FileCheck %s --check-prefix NESTED
 // NESTED: ([3 x [1 x Swift.String]], Swift.InlineArray<3, Swift.InlineArray<1, Swift.String>>)

--- a/test/Demangle/Inputs/manglings-with-highlighting.txt
+++ b/test/Demangle/Inputs/manglings-with-highlighting.txt
@@ -1,0 +1,489 @@
+_TtBf32_ ---> Builtin.FPIEEE32
+_TtBf64_ ---> Builtin.FPIEEE64
+_TtBf80_ ---> Builtin.FPIEEE80
+_TtBi32_ ---> Builtin.Int32
+$sBf32_ ---> Builtin.FPIEEE32
+$sBf64_ ---> Builtin.FPIEEE64
+$sBf80_ ---> Builtin.FPIEEE80
+$sBi32_ ---> Builtin.Int32
+_TtBw ---> Builtin.Word
+_TtBO ---> Builtin.UnknownObject
+_TtBo ---> Builtin.NativeObject
+_TtBp ---> Builtin.RawPointer
+_TtBt ---> Builtin.SILToken
+_TtBv4Bi8_ ---> Builtin.Vec4xInt8
+_TtBv4Bf16_ ---> Builtin.Vec4xFPIEEE16
+_TtBv4Bp ---> Builtin.Vec4xRawPointer
+$sBi8_Bv4_ ---> Builtin.Vec4xInt8
+$sBf16_Bv4_ ---> Builtin.Vec4xFPIEEE16
+$sBpBv4_ ---> Builtin.Vec4xRawPointer
+_TtSa ---> Swift.Array
+_TtSb ---> Swift.Bool
+_TtSc ---> Swift.UnicodeScalar
+_TtSd ---> Swift.Double
+_TtSf ---> Swift.Float
+_TtSi ---> Swift.Int
+_TtSq ---> Swift.Optional
+_TtSS ---> Swift.String
+_TtSu ---> Swift.UInt
+_TtGSPSi_ ---> Swift.UnsafePointer<Swift.Int>
+_TtGSpSi_ ---> Swift.UnsafeMutablePointer<Swift.Int>
+_TtSV ---> Swift.UnsafeRawPointer
+_TtSv ---> Swift.UnsafeMutableRawPointer
+_TtGSaSS_ ---> [Swift.String]
+_TtGSqSS_ ---> Swift.String?
+_TtGVs10DictionarySSSi_ ---> [Swift.String : Swift.Int]
+_TtVs7CString ---> Swift.CString
+_TtCSo8NSObject ---> __C.NSObject
+_TtO6Monads6Either ---> Monads.Either
+_TtbSiSu ---> @convention(block) (Swift.Int) -> Swift.UInt
+_TtcSiSu ---> @convention(c) (Swift.Int) -> Swift.UInt
+_TtbTSiSc_Su ---> @convention(block) (Swift.Int, Swift.UnicodeScalar) -> Swift.UInt
+_TtcTSiSc_Su ---> @convention(c) (Swift.Int, Swift.UnicodeScalar) -> Swift.UInt
+_TtFSiSu ---> (Swift.Int) -> Swift.UInt
+_TtKSiSu ---> @autoclosure (Swift.Int) -> Swift.UInt
+_TtFSiFScSu ---> (Swift.Int) -> (Swift.UnicodeScalar) -> Swift.UInt
+_TtMSi ---> Swift.Int.Type
+_TtP_ ---> Any
+_TtP3foo3bar_ ---> foo.bar
+_TtP3foo3barS_3bas_ ---> foo.bar & foo.bas
+_TtTP3foo3barS_3bas_PS1__PS1_S_3zimS0___ ---> (foo.bar & foo.bas, foo.bas, foo.bas & foo.zim & foo.bar)
+_TtRSi ---> inout Swift.Int
+_TtTSiSu_ ---> (Swift.Int, Swift.UInt)
+_TttSiSu_ ---> (Swift.Int, Swift.UInt...)
+_TtT3fooSi3barSu_ ---> (foo: Swift.Int, bar: Swift.UInt)
+_TturFxx ---> <A>(A) -> A
+_TtuzrFT_T_ ---> <>() -> ()
+_Ttu__rFxqd__ ---> <A><A1>(A) -> A1
+_Ttu_z_rFxqd0__ ---> <A><><A2>(A) -> A2
+_Ttu0_rFxq_ ---> <A, B>(A) -> B
+_TtuRxs8RunciblerFxwx5Mince ---> <A where A: Swift.Runcible>(A) -> A.Mince
+_TtuRxle64xs8RunciblerFxwx5Mince ---> <A where A: _Trivial(64), A: Swift.Runcible>(A) -> A.Mince
+_TtuRxlE64_16rFxwx5Mince ---> <A where A: _Trivial(64, 16)>(A) -> A.Mince
+_TtuRxlE64_32xs8RunciblerFxwx5Mince ---> <A where A: _Trivial(64, 32), A: Swift.Runcible>(A) -> A.Mince
+_TtuRxlM64_16rFxwx5Mince ---> <A where A: _TrivialAtMost(64, 16)>(A) -> A.Mince
+_TtuRxle64rFxwx5Mince ---> <A where A: _Trivial(64)>(A) -> A.Mince
+_TtuRxlm64rFxwx5Mince ---> <A where A: _TrivialAtMost(64)>(A) -> A.Mince
+_TtuRxlNrFxwx5Mince ---> <A where A: _NativeRefCountedObject>(A) -> A.Mince
+_TtuRxlRrFxwx5Mince ---> <A where A: _RefCountedObject>(A) -> A.Mince
+_TtuRxlUrFxwx5Mince ---> <A where A: _UnknownLayout>(A) -> A.Mince
+_TtuRxs8RunciblerFxWx5Mince6Quince_ ---> <A where A: Swift.Runcible>(A) -> A.Mince.Quince
+_TtuRxs8Runciblexs8FungiblerFxwxPS_5Mince ---> <A where A: Swift.Runcible, A: Swift.Fungible>(A) -> A.Swift.Runcible.Mince
+_TtuRxCs22AbstractRuncingFactoryrFxx ---> <A where A: Swift.AbstractRuncingFactory>(A) -> A
+_TtuRxs8Runciblewx5MincezxrFxx ---> <A where A: Swift.Runcible, A.Mince == A>(A) -> A
+_TtuRxs8RuncibleWx5Mince6Quince_zxrFxx ---> <A where A: Swift.Runcible, A.Mince.Quince == A>(A) -> A
+_Ttu0_Rxs8Runcible_S_wx5Minces8Fungiblew_S0_S1_rFxq_ ---> <A, B where A: Swift.Runcible, B: Swift.Runcible, A.Mince: Swift.Fungible, B.Mince: Swift.Fungible>(A) -> B
+_Ttu0_Rx3Foo3BarxCS_3Bas_S0__S1_rT_ ---> <A, B where A: Foo.Bar, A: Foo.Bas, B: Foo.Bar, B: Foo.Bas> ()
+_Tv3foo3barSi ---> foo.bar : Swift.Int
+_TF3fooau3barSi ---> foo.bar.unsafeMutableAddressor : Swift.Int
+_TF3foolu3barSi ---> foo.bar.unsafeAddressor : Swift.Int
+_TF3fooaO3barSi ---> foo.bar.owningMutableAddressor : Swift.Int
+_TF3foolO3barSi ---> foo.bar.owningAddressor : Swift.Int
+_TF3fooao3barSi ---> foo.bar.nativeOwningMutableAddressor : Swift.Int
+_TF3foolo3barSi ---> foo.bar.nativeOwningAddressor : Swift.Int
+_TF3fooap3barSi ---> foo.bar.nativePinningMutableAddressor : Swift.Int
+_TF3foolp3barSi ---> foo.bar.nativePinningAddressor : Swift.Int
+_TF3foog3barSi ---> foo.bar.getter : Swift.Int
+_TF3foos3barSi ---> foo.bar.setter : Swift.Int
+_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
+_TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$s3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$s3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_$sSC3fooyS2d_SdtFTO ---> {T:_$sSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$sTA.123 ---> {T:} partial apply forwarder with unmangled suffix ".123"
+$s4main3fooyySiFyyXEfU_TA.1 ---> {T:} partial apply forwarder for closure #1 () -> () in main.foo(Swift.Int) -> () () -> () in main.foo(Swift.Int) -> () with unmangled suffix ".1"
+$s4main8MyStructV3fooyyFAA1XV_Tg5.foo ---> generic specialization <main.X> of main.MyStruct.foo() -> () with unmangled suffix ".foo"
+_TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> ()
+_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
+_TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim
+_TF3foooP1xFTCS_3barVS_3bas_OS_3zim ---> foo.^ postfix(foo.bar, foo.bas) -> foo.zim
+_TFC3foo3barCfT_S0_ ---> foo.bar.__allocating_init() -> foo.bar
+_TFC3foo3barcfT_S0_ ---> foo.bar.init() -> foo.bar
+_TFC3foo3barD ---> foo.bar.__deallocating_deinit
+_TFC3foo3barZ ---> foo.bar.__isolated_deallocating_deinit
+_TFC3foo3bard ---> foo.bar.deinit
+_TMPC3foo3bar ---> generic type metadata pattern for foo.bar
+_TMnC3foo3bar ---> nominal type descriptor for foo.bar
+_TMmC3foo3bar ---> metaclass for foo.bar
+_TMC3foo3bar ---> type metadata for foo.bar
+_TMfC3foo3bar ---> full type metadata for foo.bar
+_TwalC3foo3bar ---> {C} allocateBuffer value witness for foo.bar
+_TwcaC3foo3bar ---> {C} assignWithCopy value witness for foo.bar
+_TwtaC3foo3bar ---> {C} assignWithTake value witness for foo.bar
+_TwdeC3foo3bar ---> {C} deallocateBuffer value witness for foo.bar
+_TwxxC3foo3bar ---> {C} destroy value witness for foo.bar
+_TwXXC3foo3bar ---> {C} destroyBuffer value witness for foo.bar
+_TwCPC3foo3bar ---> {C} initializeBufferWithCopyOfBuffer value witness for foo.bar
+_TwCpC3foo3bar ---> {C} initializeBufferWithCopy value witness for foo.bar
+_TwcpC3foo3bar ---> {C} initializeWithCopy value witness for foo.bar
+_TwTKC3foo3bar ---> {C} initializeBufferWithTakeOfBuffer value witness for foo.bar
+_TwTkC3foo3bar ---> {C} initializeBufferWithTake value witness for foo.bar
+_TwtkC3foo3bar ---> {C} initializeWithTake value witness for foo.bar
+_TwprC3foo3bar ---> {C} projectBuffer value witness for foo.bar
+_TWVC3foo3bar ---> value witness table for foo.bar
+_TWvdvC3foo3bar3basSi ---> direct field offset for foo.bar.bas : Swift.Int
+_TWvivC3foo3bar3basSi ---> indirect field offset for foo.bar.bas : Swift.Int
+_TWPC3foo3barS_8barrables ---> protocol witness table for foo.bar : foo.barrable in Swift
+_TWaC3foo3barS_8barrableS_ ---> {C} protocol witness table accessor for foo.bar : foo.barrable in foo
+_TWlC3foo3barS0_S_8barrableS_ ---> {C} lazy protocol witness table accessor for type foo.bar and conformance foo.bar : foo.barrable in foo
+_TWLC3foo3barS0_S_8barrableS_ ---> lazy protocol witness table cache variable for type foo.bar and conformance foo.bar : foo.barrable in foo
+_TWGC3foo3barS_8barrableS_ ---> generic protocol witness table for foo.bar : foo.barrable in foo
+_TWIC3foo3barS_8barrableS_ ---> {C} instantiation function for generic protocol witness table for foo.bar : foo.barrable in foo
+_TWtC3foo3barS_8barrableS_4fred ---> {C} associated type metadata accessor for fred in foo.bar : foo.barrable in foo
+_TWTC3foo3barS_8barrableS_4fredS_6thomas ---> {C} associated type witness table accessor for fred : foo.thomas in foo.bar : foo.barrable in foo
+_TFSCg5greenVSC5Color ---> __C_Synthesized.green.getter : __C_Synthesized.Color
+_TIF1t1fFT1iSi1sSS_T_A_ ---> default argument 0 of t.f(i: Swift.Int, s: Swift.String) -> ()
+_TIF1t1fFT1iSi1sSS_T_A0_ ---> default argument 1 of t.f(i: Swift.Int, s: Swift.String) -> ()
+_TFSqcfT_GSqx_ ---> Swift.Optional.init() -> A?
+_TF21class_bound_protocols32class_bound_protocol_compositionFT1xPS_10ClassBoundS_13NotClassBound__PS0_S1__ ---> class_bound_protocols.class_bound_protocol_composition(x: class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound) -> class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound
+_TtZZ ---> _TtZZ
+_TtB ---> _TtB
+_TtBSi ---> _TtBSi
+_TtBx ---> _TtBx
+_TtC ---> _TtC
+_TtT ---> _TtT
+_TtTSi ---> _TtTSi
+_TtQd_ ---> _TtQd_
+_TtU__FQo_Si ---> _TtU__FQo_Si
+_TtU__FQD__Si ---> _TtU__FQD__Si
+_TtU___FQ_U____FQd0__T_ ---> _TtU___FQ_U____FQd0__T_
+_TtU___FQ_U____FQd_1_T_ ---> _TtU___FQ_U____FQd_1_T_
+_TtU___FQ_U____FQ2_T_ ---> _TtU___FQ_U____FQ2_T_
+_Tw ---> _Tw
+_TWa ---> _TWa
+_Twal ---> _Twal
+_T ---> _T
+_TTo ---> {T:_T} _TTo
+_TC ---> _TC
+_TM ---> _TM
+_TM ---> _TM
+_TW ---> _TW
+_TWV ---> _TWV
+_TWo ---> _TWo
+_TWv ---> _TWv
+_TWvd ---> _TWvd
+_TWvi ---> _TWvi
+_TWvx ---> _TWvx
+_TtVCC4main3Foo4Ding3Str ---> main.Foo.Ding.Str
+_TFVCC6nested6AClass12AnotherClass7AStruct9aFunctionfT1aSi_S2_ ---> nested.AClass.AnotherClass.AStruct.aFunction(a: Swift.Int) -> nested.AClass.AnotherClass.AStruct
+_TtXwC10attributes10SwiftClass ---> weak attributes.SwiftClass
+_TtXoC10attributes10SwiftClass ---> unowned attributes.SwiftClass
+_TtERR ---> <ERROR TYPE>
+_TtGSqGSaC5sugar7MyClass__ ---> [sugar.MyClass]?
+_TtGSaGSqC5sugar7MyClass__ ---> [sugar.MyClass?]
+_TtaC9typealias5DWARF9DIEOffset ---> typealias.DWARF.DIEOffset
+_Tta1t5Alias ---> t.Alias
+_Ttas3Int ---> Swift.Int
+_TTRXFo_dSc_dSb_XFo_iSc_iSb_ ---> reabstraction thunk helper from @callee_owned (@in Swift.UnicodeScalar) -> (@out Swift.Bool) to @callee_owned (@unowned Swift.UnicodeScalar) -> (@unowned Swift.Bool)
+_TTRXFo_dSi_dGSqSi__XFo_iSi_iGSqSi__ ---> reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@out Swift.Int?) to @callee_owned (@unowned Swift.Int) -> (@unowned Swift.Int?)
+_TTRGrXFo_iV18switch_abstraction1A_ix_XFo_dS0__ix_ ---> reabstraction thunk helper <A> from @callee_owned (@unowned switch_abstraction.A) -> (@out A) to @callee_owned (@in switch_abstraction.A) -> (@out A)
+_TFCF5types1gFT1bSb_T_L0_10Collection3zimfT_T_ ---> zim() -> () in Collection #2 in types.g(b: Swift.Bool) -> ()
+_TFF17capture_promotion22test_capture_promotionFT_FT_SiU_FT_Si_promote0 ---> closure #1 () -> Swif() -> Swift.Int in capture_promotion.test_capture_promotion() -> () -> Swift.Int with unmangled suffix "_promote0"
+_TFIVs8_Processi10_argumentsGSaSS_U_FT_GSaSS_ ---> _arguments_arguments : [Swift.String] in variable initialization expression of Swift._Process with unmangled suffix "U_FT_GSaSS_"
+_TFIvVs8_Process10_argumentsGSaSS_iU_FT_GSaSS_ ---> closure #1 () -> [Swi() -> [Swift.String] in variable initialization expression of Swift._Process._arguments : [Swift.String]
+_TFCSo1AE ---> __C.A.__ivar_destroyer
+_TFCSo1Ae ---> __C.A.__ivar_initializer
+_TTWC13call_protocol1CS_1PS_FS1_3foofT_Si ---> protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
+_T013call_protocol1CCAA1PA2aDP3fooSiyFTW ---> {T:} protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
+_TFC12dynamic_self1X1ffT_DS0_ ---> dynamic_self.X.f() -> Self
+_TTSg5Si___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int> of Swift.Optional.init() -> A?
+_TTSgq5Si___TFSqcfT_GSqx_ ---> generic specialization <serialized, Swift.Int> of Swift.Optional.init() -> A?
+_TTSg5SiSis3Foos_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int with Swift.Int : Swift.Foo in Swift, Swift.Float> of Swift.Optional.init() -> A?
+_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A?
+_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A?
+_TTSgS ---> _TTSgS
+_TTSg5S ---> _TTSg5S
+_TTSgSi ---> _TTSgSi
+_TTSg5Si ---> _TTSg5Si
+_TTSgSi_ ---> _TTSgSi_
+_TTSgSi__ ---> _TTSgSi__
+_TTSgSiS_ ---> _TTSgSiS_
+_TTSgSi__xyz ---> _TTSgSi__xyz
+_TTSr5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <Swift.Int> of test.generic<A>(A) -> A(A) -> A
+_TTSrq5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <serialized, Swift.Int> of test.generic<A>(A) -> A(A) -> A
+_TPA__TTRXFo_oSSoSS_dSb_XFo_iSSiSS_dSb_ ---> {T:_TTRXFo_oSSoSS_dSb_XFo_iSSiSS_dSb_} partial apply forwarder for reabstraction thunk helper from @callee_owned (@in Swift.String, @in Swift.String) -> (@unowned Swift.Bool) to @callee_owned (@owned Swift.String, @owned Swift.String) -> (@unowned Swift.Bool)
+_TPAo__TTRGrXFo_dGSPx__dGSPx_zoPs5Error__XFo_iGSPx__iGSPx_zoPS___ ---> {T:_TTRGrXFo_dGSPx__dGSPx_zoPs5Error__XFo_iGSPx__iGSPx_zoPS___} partial apply ObjC forwarder for reabstraction thunk helper <A> from @callee_owned (@in Swift.UnsafePointer<A>) -> (@out Swift.UnsafePointer<A>, @error @owned Swift.Error) to @callee_owned (@unowned Swift.UnsafePointer<A>) -> (@unowned Swift.UnsafePointer<A>, @error @owned Swift.Error)
+_T0S2SSbIxxxd_S2SSbIxiid_TRTA ---> {T:_T0S2SSbIxxxd_S2SSbIxiid_TR} partial apply forwarder for reabstraction thunk helper from @callee_owned (@owned Swift.String, @owned Swift.String) -> (@unowned Swift.Bool) to @callee_owned (@in Swift.String, @in Swift.String) -> (@unowned Swift.Bool)
+_T0SPyxGAAs5Error_pIxydzo_A2AsAB_pIxirzo_lTRTa ---> {T:_T0SPyxGAAs5Error_pIxydzo_A2AsAB_pIxirzo_lTR} partial apply ObjC forwarder for reabstraction thunk helper <A> from @callee_owned (@unowned Swift.UnsafePointer<A>) -> (@unowned Swift.UnsafePointer<A>, @error @owned Swift.Error) to @callee_owned (@in Swift.UnsafePointer<A>) -> (@out Swift.UnsafePointer<A>, @error @owned Swift.Error)
+_TiC4Meow5MyCls9subscriptFT1iSi_Sf ---> Meow.MyCls.subscript(i: Swift.Int) -> Swift.Float
+_TF8manglingX22egbpdajGbuEbxfgehfvwxnFT_T_ ---> mangling.ليهمابتكلموشعربي؟() -> ()
+_TF8manglingX24ihqwcrbEcvIaIdqgAFGpqjyeFT_T_ ---> mangling.他们为什么不说中文() -> ()
+_TF8manglingX27ihqwctvzcJBfGFJdrssDxIboAybFT_T_ ---> mangling.他們爲什麽不說中文() -> ()
+_TF8manglingX30Proprostnemluvesky_uybCEdmaEBaFT_T_ ---> mangling.Pročprostěnemluvíčesky() -> ()
+_TF8manglingXoi7p_qcaDcFTSiSi_Si ---> mangling.«+» infix(Swift.Int, Swift.Int) -> Swift.Int
+_TF8manglingoi2qqFTSiSi_T_ ---> mangling.?? infix(Swift.Int, Swift.Int) -> ()
+_TFE11ext_structAV11def_structA1A4testfT_T_ ---> (extension in ext_structA):def_structA.A.test() -> ()
+_TF13devirt_accessP5_DISC15getPrivateClassFT_CS_P5_DISC12PrivateClass ---> devirt_access.(getPrivateClass in _DISC)() -> devirt_access.(PrivateClass in _DISC)
+_TF4mainP5_mainX3wxaFT_T_ ---> main.(λ in _main)() -> ()
+_TF4mainP5_main3abcFT_aS_P5_DISC3xyz ---> main.(abc in _main)() -> main.(xyz in _DISC)
+_TtPMP_ ---> Any.Type
+_TFCs13_NSSwiftArray29canStoreElementsOfDynamicTypefPMP_Sb ---> Swift._NSSwiftArray.canStoreElementsOfDynamicType(Any.Type) -> Swift.Bool
+_TFCs13_NSSwiftArrayg17staticElementTypePMP_ ---> Swift._NSSwiftArray.staticElementType.getter : Any.Type
+_TFCs17_DictionaryMirrorg9valueTypePMP_ ---> Swift._DictionaryMirror.valueType.getter : Any.Type
+_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSfq1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <serialized, Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TTSg5Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of generic specialization <Swift.Int> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSg5Si___TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> generic specialization <Swift.Int> of function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSf1cpfr24_TF8capturep6helperFSiT__n___TTRXFo_dSi_dT__XFo_iSi_dT__ ---> function signature specialization <Arg[0] = [Constant Propagated Function : capturep.helper(Swift.Int) -> ()]> of reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@unowned ()) to @callee_owned (@unowned Swift.Int) -> (@unowned ())
+_TTSf1cpfr24_TF8capturep6helperFSiT__n___TTRXFo_dSi_DT__XFo_iSi_DT__ ---> function signature specialization <Arg[0] = [Constant Propagated Function : capturep.helper(Swift.Int) -> ()]> of reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@unowned_inner_pointer ()) to @callee_owned (@unowned Swift.Int) -> (@unowned_inner_pointer ())
+_TTSf1cpi0_cpfl0_cpse0v4u123_cpg53globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8_cpfr36_TFtest_capture_propagation2_closure___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Constant Propagated Integer : 0], Arg[1] = [Constant Propagated Float : 0], Arg[2] = [Constant Propagated String : u8'u123'], Arg[3] = [Constant Propagated Global : globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8], Arg[4] = [Constant Propagated Function : _TFtest_capture_propagation2_closure]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSf0gs___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Owned To Guaranteed and Exploded> of Swift._LegacyStringCore._invariantCheck() -> ()
+_TTSf2g___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf2dg___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf2dgs___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf3d_i_d_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[2] = Dead, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf3d_i_n_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TFIZvV8mangling10HasVarInit5stateSbiu_KT_Sb ---> implicit closure #1 : @autoclosure () -> Swift.Bool in variable initialization expression of static mangling.HasVarInit.state : Swift.Bool
+_TFFV23interface_type_mangling18GenericTypeContext23closureInGenericContexturFqd__T_L_3fooFTqd__x_T_ ---> foo #1 (A1, A(A1, A) -> () in interface_type_mangling.GenericTypeContext.closureInGenericContext<A>(A1) -> ()
+_TFFV23interface_type_mangling18GenericTypeContextg31closureInGenericPropertyContextxL_3fooFT_x ---> foo #1 () -> () -> A in interface_type_mangling.GenericTypeContext.closureInGenericPropertyContext.getter : A
+_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_23closureInGenericContextuRxS1_rfqd__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.closureInGenericContext<A where A: interface_type_mangling.GenericWitnessTest>(A1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface(A1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
+_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_g31closureInGenericPropertyContextwx3Tee ---> protocol witness for interface_type_mangling.GenericWitnessTest.closureInGenericPropertyContext.getter : A.Tee in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
+_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_16twoParamsAtDepthu0_RxS1_rfTqd__1yqd_0__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.twoParamsAtDepth<A, B where A: interface_type_mangling.GenericWitnessTest>(A1, y: B1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<(A1, y: B1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
+_TFC3red11BaseClassEHcfzT1aSi_S0_ ---> red.BaseClassEH.init(a: Swift.Int) throws -> red.BaseClassEH
+_TFe27mangling_generic_extensionsRxS_8RunciblerVS_3Foog1aSi ---> (extension in mangling_generic_extensions):mangling_generic_extensions.Foo<A where A: mangling_generic_extensions.Runcible>.a.getter : Swift.Int
+_TFe27mangling_generic_extensionsRxS_8RunciblerVS_3Foog1bx ---> (extension in mangling_generic_extensions):mangling_generic_extensions.Foo<A where A: mangling_generic_extensions.Runcible>.b.getter : A
+_TTRXFo_iT__iT_zoPs5Error__XFo__dT_zoPS___ ---> reabstraction thunk helper from @callee_owned () -> (@unowned (), @error @owned Swift.Error) to @callee_owned (@in ()) -> (@out (), @error @owned Swift.Error)
+_TFE1a ---> _TFE1a
+_TF21$__lldb_module_for_E0au3$E0Ps5Error_ ---> $__lldb_module_for_E0.$E0.unsafeMutableAddressor : Swift.Error
+_TMps10Comparable ---> protocol descriptor for Swift.Comparable
+_TFC4testP33_83378C430F65473055F1BD53F3ADCDB71C5doFoofT_T_ ---> test.(C in _83378C430F65473055F1BD53F3ADCDB7).doFoo() -> ()
+_TFVV15nested_generics5Lunch6DinnerCfT11firstCoursex12secondCourseGSqqd___9leftoversx14transformationFxqd___GS1_x_qd___ ---> nested_generics.Lunch.Dinner.init(firstCourse: A, secondCourse: A1?, leftovers: A, transformation: (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1>
+_TFVFC15nested_generics7HotDogs11applyRelishFT_T_L_6RelishCfT8materialx_GS1_x_ ---> init(material: A) -> Relish #1 in nested_generics.HotDogs.applyRelish() -> ()<A> in Relish #1 in nested_generics.HotDogs.applyRelish() -> ()
+_TFVFE15nested_genericsSS3fooFT_T_L_6CheeseCfT8materialx_GS0_x_ ---> init(material: A) -> Cheese #1 in (extension in nested_generics):Swift.String.foo() -> ()<A> in Cheese #1 in (extension in nested_generics):Swift.String.foo() -> ()
+_TTWOE5imojiCSo5Imoji14ImojiMatchRankS_9RankValueS_FS2_g9rankValueqq_Ss16RawRepresentable8RawValue ---> _TTWOE5imojiCSo5Imoji14ImojiMatchRankS_9RankValueS_FS2_g9rankValueqq_Ss16RawRepresentable8RawValue
+_T0s17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD05Indexs01_A9IndexablePQzAM15shiftingToStart_tFAJs01_J4BasePQzAQcfU_ ---> closure #1 (A.Swift._(A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index
+_$Ss17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD015shiftingToStart5Indexs01_A9IndexablePQzAN_tFAKs01_M4BasePQzAQcfU_ ---> closure #1 (A.Swift._(A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index
+_T03foo4_123ABTf3psbpsb_n ---> function signature specialization <Arg[0] = [Constant Propagated String : u8'123'], Arg[1] = [Constant Propagated String : u8'123']> of foo
+_T04main5innerys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> ()
+_$S4main5inneryys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> ()
+_T03foo6testityyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> ()
+_$S3foo6testityyyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> ()
+_SocketJoinOrLeaveMulticast ---> _SocketJoinOrLeaveMulticast
+_T0s10DictionaryV3t17E6Index2V1loiSbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool
+_T08mangling14varargsVsArrayySi3arrd_SS1ntF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> ()
+_T08mangling14varargsVsArrayySaySiG3arr_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> ()
+_T08mangling14varargsVsArrayySaySiG3arrd_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> ()
+_T08mangling14varargsVsArrayySi3arrd_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> ()
+_T08mangling14varargsVsArrayySaySiG3arrd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> ()
+_$Ss10DictionaryV3t17E6Index2V1loiySbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool
+_$S8mangling14varargsVsArray3arr1nySid_SStF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> ()
+_$S8mangling14varargsVsArray3arr1nySaySiG_SStF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> ()
+_$S8mangling14varargsVsArray3arr1nySaySiGd_SStF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> ()
+_$S8mangling14varargsVsArray3arrySid_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> ()
+_$S8mangling14varargsVsArray3arrySaySiGd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> ()
+_T0s13_UnicodeViewsVss22RandomAccessCollectionRzs0A8EncodingR_11SubSequence_5IndexQZAFRtzsAcERpzAE_AEQZAIRSs15UnsignedInteger8Iterator_7ElementRPzAE_AlMQZANRS13EncodedScalar_AlMQY_AORSr0_lE13CharacterViewVyxq__G ---> (extension in Swift):Swift._UnicodeViews<A, B><A, B where A: Swift.RandomAccessCollection, B: Swift.UnicodeEncoding, A.Index == A.SubSequence.Index, A.SubSequence: Swift.RandomAccessCollection, A.SubSequence == A.SubSequence.SubSequence, A.Iterator.Element: Swift.UnsignedInteger, A.Iterator.Element == A.SubSequence.Iterator.Element, A.SubSequence.Iterator.Element == B.EncodedScalar.Iterator.Element>.CharacterView
+_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
+_$S10Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiySbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
+_T04main1_yyF ---> main._() -> ()
+_T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
+_$S4test6testitySiyt_tF ---> test.testit(()) -> Swift.Int
+_T08_ElementQzSbs5Error_pIxxdzo_ABSbsAC_pIxidzo_s26RangeReplaceableCollectionRzABRLClTR ---> {T:} reabstraction thunk helper <A where A: Swift.RangeReplaceableCollection, A._Element: AnyObject> from @callee_owned (@owned A._Element) -> (@unowned Swift.Bool, @error @owned Swift.Error) to @callee_owned (@in A._Element) -> (@unowned Swift.Bool, @error @owned Swift.Error)
+_T0Ix_IyB_Tr ---> {T:} reabstraction thunk from @callee_owned () -> () to @callee_unowned @convention(block) () -> ()
+_T0Rml ---> _T0Rml
+_T0Tk ---> _T0Tk
+_T0A8 ---> _T0A8
+_T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n ---> _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n
+_T03abc6testitySiFTm ---> merged abc.testit(Swift.Int) -> ()
+_T04main4TestCACSi1x_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test
+_$S3abc6testityySiFTm ---> merged abc.testit(Swift.Int) -> ()
+_$S4main4TestC1xACSi_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test
+_T0SqWOy.17 ---> outlined copy of Swift.Optional with unmangled suffix ".17"
+_T0SqWOC ---> outlined init with copy of Swift.Optional
+_T0SqWOD ---> outlined assign with take of Swift.Optional
+_T0SqWOF ---> outlined assign with copy of Swift.Optional
+_T0SqWOH ---> outlined destroy of Swift.Optional
+_T03nix6testitSaySiGyFTv_ ---> outlined variable #0 of nix.testit() -> [Swift.Int]
+_T03nix6testitSaySiGyFTv_r ---> outlined read-only object #0 of nix.testit() -> [Swift.Int]
+_T03nix6testitSaySiGyFTv0_ ---> outlined variable #1 of nix.testit() -> [Swift.Int]
+_T0So11UITextFieldC4textSSSgvgToTepb_ ---> outlined bridged method (pb) of @objc __C.UITextField.text.getter : Swift.String?
+_T0So11UITextFieldC4textSSSgvgToTeab_ ---> outlined bridged method (ab) of @objc __C.UITextField.text.getter : Swift.String?
+$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_ ---> outlined bridged method (mbgnn) of @objc __C.Gizmo.doSomething([Swift.String]?) -> Any?
+_T04test1SVyxGAA1RA2A1ZRzAA1Y2ZZRpzl1A_AhaGPWT ---> {C} associated type witness table accessor for A.ZZ : test.Y in <A where A: test.Z, A.ZZ: test.Y> test.S<A> : test.R in test
+_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfC ---> {T:_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfc} Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69).init() -> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69)
+_T0D ---> _T0D
+_T0s18EnumeratedIteratorVyxGs8Sequencess0B8ProtocolRzlsADP5splitSay03SubC0QzGSi9maxSplits_Sb25omittingEmptySubsequencesSb7ElementQzKc14whereSeparatortKFTW ---> {T:} protocol witness for Swift.Sequence.split(maxSplits: Swift.Int, omittingEmptySubsequences: Swift.Bool, whereSeparator: (A.Element) throws -> Swift.Bool) throws -> [A.SubSequence] in conformance <A where A: Swift.IteratorProtocol> Swift.EnumeratedIterator<A> : Swift.Sequence in Swift
+_T0s3SetVyxGs10CollectiotySivm ---> _T0s3SetVyxGs10CollectiotySivm
+_S$s3SetVyxGs10CollectiotySivm ---> _S$s3SetVyxGs10CollectiotySivm
+_T0s18ReversedCollectionVyxGs04LazyB8ProtocolfC ---> _T0s18ReversedCollectionVyxGs04LazyB8ProtocolfC
+_S$s18ReversedCollectionVyxGs04LazyB8ProtocolfC ---> _S$s18ReversedCollectionVyxGs04LazyB8ProtocolfC
+_T0iW ---> _T0iW
+_S$iW ---> _S$iW
+_T0s5print_9separator10terminatoryypfC ---> _T0s5print_9separator10terminatoryypfC
+_S$s5print_9separator10terminatoryypfC ---> _S$s5print_9separator10terminatoryypfC
+_T0So13GenericOptionas8HashableSCsACP9hashValueSivgTW ---> {T:} protocol witness for Swift.Hashable.hashValue.getter : Swift.Int in conformance __C.GenericOption : Swift.Hashable in __C_Synthesized
+_T0So11CrappyColorVs16RawRepresentableSCMA ---> reflection metadata associated type descriptor __C.CrappyColor : Swift.RawRepresentable in __C_Synthesized
+$S28protocol_conformance_records15NativeValueTypeVAA8RuncibleAAMc ---> protocol conformance descriptor for protocol_conformance_records.NativeValueType : protocol_conformance_records.Runcible in protocol_conformance_records
+$ss6SimpleHr ---> protocol descriptor runtime record for Swift.Simple
+$ss5OtherVs6SimplesHc ---> protocol conformance descriptor runtime record for Swift.Other : Swift.Simple in Swift
+$ss5OtherVHn ---> nominal type descriptor runtime record for Swift.Other
+$s18opaque_return_type3fooQryFQOHo ---> opaque type descriptor runtime record for <<opaque return type of opaque_return_type.foo() -> some>>
+$SSC9SomeErrorLeVD ---> __C_Synthesized.related decl 'e' for SomeError
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PAAyHCg_AiJ1QAAyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHPyHCg_AiJ1QHPyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHpyHCg_AiJ1QHpyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
+_T0LiteralAByxGxd_tcfC ---> _T0LiteralAByxGxd_tcfC
+_T0XZ ---> _T0XZ
+_TTSf0os___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Guaranteed To Owned and Exploded> of Swift._LegacyStringCore._invariantCheck() -> ()
+_TTSf2o___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf2do___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf2dos___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf ---> _TTSf
+_TtW0_j ---> _TtW0_j
+_TtW_4m3a3v ---> _TtW_4m3a3v
+_TVGVGSS_2v0 ---> _TVGVGSS_2v0
+$SSD1BySSSBsg_G ---> $SSD1BySSSBsg_G
+_Ttu4222222222222222222222222_rW_2T_2TJ_ ---> <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z, AB, BB, CB, DB, EB, FB, GB, HB, IB, JB, KB, LB, MB, NB, OB, PB, QB, RB, SB, TB, UB, VB, WB, XB, YB, ZB, AC, BC, CC, DC, EC, FC, GC, HC, IC, JC, KC, LC, MC, NC, OC, PC, QC, RC, SC, TC, UC, VC, WC, XC, YC, ZC, AD, BD, CD, DD, ED, FD, GD, HD, ID, JD, KD, LD, MD, ND, OD, PD, QD, RD, SD, TD, UD, VD, WD, XD, YD, ZD, AE, BE, CE, DE, EE, FE, GE, HE, IE, JE, KE, LE, ME, NE, OE, PE, QE, RE, SE, TE, UE, VE, WE, XE, ...> B.T_.TJ
+_$S3BBBBf0602365061_ ---> _$S3BBBBf0602365061_
+_$S3BBBBi0602365061_ ---> _$S3BBBBi0602365061_
+_$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
+_T0lxxxmmmTk ---> _T0lxxxmmmTk
+_TtCF4test11doNotCrash1FT_QuL_8MyClass1 ---> MyClass1 #1 in test.doNotCrash1() -> some
+$s3Bar3FooVAA5DrinkVyxGs5Error_pSeRzSERzlyShy4AbcdAHO6MemberVGALSeHPAKSeAAyHC_HCg_ALSEHPAKSEAAyHC_HCg0_Iseggozo_SgWOe ---> outlined consume of (@escaping @callee_guaranteed @substituted <A where A: Swift.Decodable, A: Swift.Encodable> (@guaranteed Bar.Foo) -> (@owned Bar.Drink<A>, @error @owned Swift.Error) for <Swift.Set<Abcd.Abcd.Member>>)?
+$s4Test5ProtoP8IteratorV10collectionAEy_qd__Gqd___tcfc ---> Test.Proto.Iterator.init(collection: A1) -> Test.Proto.Iterator<A1>
+$s4test3fooV4blahyAA1SV1fQryFQOy_Qo_AHF ---> test.foo.blah(<<opaque return type of test.S.f() -> some>>.0) -> <<opaque return type of test.S.f() -> some>>.0
+$S3nix8MystructV1xACyxGx_tcfc7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.init(x: A) -> nix.Mystruct<A>
+$S3nix7MyclassCfd7MyaliasL_ayx__GD ---> Myalias #1 in nix.Myclass<A>.deinit
+$S3nix8MystructVyS2icig7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.subscript.getter : (Swift.Int) -> Swift.Int
+$S3nix8MystructV1x1uACyxGx_qd__tclufc7MyaliasL_ayx_qd___GD ---> Myalias #1 in nix.Mystruct<A>.<A1>(x: A, u: A1) -> nix.Mystruct<A>
+$S3nix8MystructV6testit1xyx_tF7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.testit(x: A) -> ()
+$S3nix8MystructV6testit1x1u1vyx_qd__qd_0_tr0_lF7MyaliasL_ayx_qd__qd_0__GD ---> Myalias #1 in nix.Mystruct<A>.testit<A1, B1>(x: A, u: A1, v: B1) -> ()(x: A, u: A1, v: B1) -> ()
+$S4blah8PatatinoaySiGD ---> blah.Patatino<Swift.Int>
+$SSiSHsWP ---> protocol witness table for Swift.Int : Swift.Hashable in Swift
+$S7TestMod5OuterV3Fooayx_SiGD ---> TestMod.Outer<A>.Foo<Swift.Int>
+$Ss17_VariantSetBufferO05CocoaC0ayx_GD ---> Swift._VariantSetBuffer<A>.CocoaBuffer
+$S2t21QP22ProtocolTypeAliasThingayAA4BlahV5SomeQa_GSgD ---> t2.Blah.SomeQ as t2.Q.ProtocolTypeAliasThing?
+$s1A1gyyxlFx_qd__t_Ti5 ---> inlined generic function <(A, A1)> of A.g<A>(A) -> ()(A) -> ()
+$S1T19protocol_resilience17ResilientProtocolPTl ---> associated type descriptor for protocol_resilience.ResilientProtocol.T
+$S18resilient_protocol21ResilientBaseProtocolTL ---> protocol requirements base descriptor for resilient_protocol.ResilientBaseProtocol
+$S1t1PP10AssocType2_AA1QTn ---> associated conformance descriptor for t.P.AssocType2: t.Q
+$S1t1PP10AssocType2_AA1QTN ---> default associated conformance accessor for t.P.AssocType2: t.Q
+$s4Test6testityyxlFAA8MystructV_TB5 ---> generic specialization <Test.Mystruct> of Test.testit<A>(A) -> ()(A) -> ()
+$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A(A1) -> A
+$s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> ()(A, B) -> ()
+$sSD5IndexVy__GD ---> $sSD5IndexVy__GD
+$s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str
+$s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized
+$s3red4testyAA3ResOyxSayq_GAEs5ErrorAAq_sAFHD1__HCg_GADyxq_GsAFR_r0_lF ---> red.test<A, B where B: Swift.Error>(red.Res(red.Res<A, B>) -> red.Res<A, [B]>
+$s3red4testyAA7OurTypeOy4them05TheirD0Vy5AssocQzGAjE0F8ProtocolAAxAA0c7DerivedH0HD1_AA0c4BaseH0HI1_AieKHA2__HCg_GxmAaLRzlF ---> red.test<A where A: red.OurDerivedProtocol>(A.Type)(A.Type) -> red.OurType<them.TheirType<A.Assoc>>
+$s17property_wrappers10WithTuplesV9fractionsSd_S2dtvpfP ---> property wrapper backing initializer of property_wrappers.WithTuples.fractions : (Swift.Double, Swift.Double, Swift.Double)
+$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTOTA ---> {T:$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTO} partial apply forwarder for @nonobjc __C.OS_dispatch_queue.sync(execute: () -> ()) -> ()
+$s4main1gyySiXCvp ---> main.g : @convention(c) (Swift.Int) -> ()
+$s4main1gyySiXBvp ---> main.g : @convention(block) (Swift.Int) -> ()
+$sxq_Ifgnr_D ---> @differentiable(_forward) @callee_guaranteed (@in_guaranteed A) -> (@out B)
+$sxq_Irgnr_D ---> @differentiable(reverse) @callee_guaranteed (@in_guaranteed A) -> (@out B)
+$sxq_Idgnr_D ---> @differentiable @callee_guaranteed (@in_guaranteed A) -> (@out B)
+$sxq_Ilgnr_D ---> @differentiable(_linear) @callee_guaranteed (@in_guaranteed A) -> (@out B)
+$sS3fIedgyywd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned @noDerivative Swift.Float) -> (@unowned Swift.Float)
+$sS5fIertyyywddw_D ---> @escaping @differentiable(reverse) @convention(thin) (@unowned Swift.Float, @unowned Swift.Float, @unowned @noDerivative Swift.Float) -> (@unowned Swift.Float, @unowned @noDerivative Swift.Float)
+$syQo ---> $syQo
+$s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee ---> $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee
+$sx1td_t ---> (t: A...)
+$s7example1fyyYaF ---> example.f() async -> ()
+$s7example1fyyYaKF ---> example.f() async throws -> ()
+$s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> ()
+$s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE
+$s4main6testityyYaFTu ---> async function pointer to main.testit() async -> ()
+$s13test_mangling3fooyS2f_S2ftFTJfUSSpSr ---> forward-mode derivative of test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {1, 2} and results {0}
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} an(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJVrSpSr ---> vtable thunk for reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} wit(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSr ---> pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFTSAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of protocol self-conformance witness for test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Dif(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTj ---> dispatch thunk of pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTq ---> method descriptor for pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to (Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
+$s13TangentVector16_Differentiation14DifferentiablePQzAaDQy_SdAFIegnnnr_TJSdSSSpSrSUSP ---> autodiff subset parameters thunk for differential from @escaping @callee_guaranteed (@in_guaranteed A._Differentiation.Differentiable.TangentVector, @in_guaranteed B._Differentiation.Differentiable.TangentVector, @in_guaranteed Swift.Double) -> (@out B._Differentiation.Differentiable.TangentVector) with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2}
+$s13TangentVector16_Differentiation14DifferentiablePQy_AaDQzAESdIegnrrr_TJSpSSSpSrSUSP ---> autodiff subset parameters thunk for pullback from @escaping @callee_guaranteed (@in_guaranteed B._Differentiation.Differentiable.TangentVector) -> (@out A._Differentiation.Differentiable.TangentVector, @out B._Differentiation.Differentiable.TangentVector, @out Swift.Double) with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2}
+$s39differentiation_subset_parameters_thunk19inoutIndirectCalleryq_x_q_q0_t16_Differentiation14DifferentiableRzAcDR_AcDR0_r1_lFxq_Sdq_xq_Sdr0_ly13TangentVectorAcDPQy_AeFQzIsegnrr_Iegnnnro_TJSrSSSpSrSUSP ---> autodiff subset parameters thunk for reverse-mode derivative from differentiation_subset_parameters_thunk.inoutIndirectCaller<A, B, C where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, C: _Differentiation.Differentiable>(A, B, C) -> B with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2} of type @escaping @callee_guaranteed(A, B, C) -> B with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2} of type @escaping @callee_guaranteed (@in_guaranteed A, @in_guaranteed B, @in_guaranteed Swift.Double) -> (@out B, @owned @escaping @callee_guaranteed @substituted <A, B> (@in_guaranteed A) -> (@out B, @out Swift.Double) for <B._Differentiation.Differentiable.TangentVectorA._Differentiation.Differentiable.TangentVector>)
+$sS2f8mangling3FooV13TangentVectorVIegydd_SfAESfIegydd_TJOp ---> autodiff self-reordering reabstraction thunk for pullback from @escaping @callee_guaranteed (@unowned Swift.Float) -> (@unowned Swift.Float, @unowned mangling.Foo.TangentVector) to @escaping @callee_guaranteed (@unowned Swift.Float) -> (@unowned mangling.Foo.TangentVector, @unowned Swift.Float)
+$s13test_mangling3fooyS2f_S2ftFWJrSpSr ---> reverse-mode differentiability witness for test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {0} and results {0}
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lWJrUSSpSr ---> reverse-mode differentiability witness for test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameter(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
+$s5async1hyyS2iYbXEF ---> async.h(@Sendable (Swift.Int) -> Swift.Int) -> ()
+$s5Actor02MyA0C17testAsyncFunctionyyYaKFTY0_ ---> (1) suspend resume partial function for Actor.MyActor.testAsyncFunction() async throws -> ()
+$s5Actor02MyA0C17testAsyncFunctionyyYaKFTQ1_ ---> (2) await resume partial function for Actor.MyActor.testAsyncFunction() async throws -> ()
+$s4diff1hyyS2iYjfXEF ---> diff.h(@differentiable(_forward) (Swift.Int) -> Swift.Int) -> ()
+$s4diff1hyyS2iYjrXEF ---> diff.h(@differentiable(reverse) (Swift.Int) -> Swift.Int) -> ()
+$s4diff1hyyS2iYjdXEF ---> diff.h(@differentiable (Swift.Int) -> Swift.Int) -> ()
+$s4diff1hyyS2iYjlXEF ---> diff.h(@differentiable(_linear) (Swift.Int) -> Swift.Int) -> ()
+$s4test3fooyyS2f_SfYkztYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, inout @noDerivative Swift.Float) -> Swift.Float) -> ()
+$s4test3fooyyS2f_SfYkntYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, __owned @noDerivative Swift.Float) -> Swift.Float) -> ()
+$s4test3fooyyS2f_SfYktYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, @noDerivative Swift.Float) -> Swift.Float) -> ()
+$s4test3fooyyS2f_SfYktYaYbYjrXEF ---> test.foo(@differentiable(reverse) @Sendable (Swift.Float, @noDerivative Swift.Float) async -> Swift.Float) -> ()
+$SSSTf4pd44444_pf ---> function signature specialization <Arg[0] = [Constant Propagated Float : 44444], Return = > of Swift.String
+$sScA ---> Swift.Actor
+$sScGySiG ---> Swift.TaskGroup<Swift.Int>
+$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainAc((@Swift.MainActor () -> A)?) -> (() -> A)?
+$sSvSgA3ASbIetCyyd_SgSbIetCyyyd_SgD ---> (@escaping @convention(thin) @convention(c) (@unowned Swift.UnsafeMutableRawPointer?, @unowned Swift.UnsafeMutableRawPointer?, @unowned (@escaping @convention(thin) @convention(c) (@unowned Swift.UnsafeMutableRawPointer?, @unowned Swift.UnsafeMutableRawPointer?) -> (@unowned Swift.Bool))?) -> (@unowned Swift.Bool))?
+$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainAc((@Swift.MainActor () -> A)?) -> (() -> A)?
+$s1t10globalFuncyyAA7MyActorCYiF ---> t.globalFunc(isolated t.MyActor) -> ()
+$sSIxip6foobarP ---> foobar in Swift.DefaultIndices.subscript : A
+$s13__lldb_expr_110$10016c2d8yXZ1B10$10016c2e0LLC ---> __lldb_expr_1.(unknown context at $10016c2d8).(B in $10016c2e0)
+$s__TJO ---> $s__TJO
+$s6Foobar7Vector2VAASdRszlE10simdMatrix5scale6rotate9translateSo0C10_double3x3aACySdG_SdAJtFZ0D4TypeL_aySd__GD ---> MatrixType #1 in static (extension in Foobar):Foobar.Vector2<Swift.Double><A where A == Swift.Double>.simdMatrix(scale: Foobar.Vector2<Swift.Double>, rotate: Swift.Double, translate: Foobar.Vector2<Swift.Double>) -> __C.simd_double3x3
+$s17distributed_thunk2DAC1fyyFTE ---> distributed thunk distributed_thunk.DA.f() -> ()
+$s16distributed_test1XC7computeyS2iFTF ---> distributed accessor for distributed_test.X.compute(Swift.Int) -> Swift.Int
+$s27distributed_actor_accessors7MyActorC7simple2ySSSiFTETFHF ---> accessible function runtime record for distributed accessor for distributed thunk distributed_actor_accessors.MyActor.simple2(Swift.Int) -> Swift.String
+$s1A3bar1aySSYt_tF ---> A.bar(a: _const Swift.String) -> ()
+$s1t1fyyFSiAA3StrVcs7KeyPathCyADSiGcfu_SiADcfu0_33_556644b740b1b333fecb81e55a7cce98ADSiTf3npk_n ---> function signature specialization <Arg[1] = [Constant Propagated KeyPath : _556644b740b1b333fecb81e55a7cce98<t.Str,Swift.Int>]> of implicit closure #2 (t.Str) -> Swift.Int in implicit closure #1 (Swift.KeyPath<t.Str, Swift.Int>) -> (t.Str) -> Swift.Int in t.f() -> ()
+$s21back_deploy_attribute0A12DeployedFuncyyFTwb ---> back deployment thunk for back_deploy_attribute.backDeployedFunc() -> ()
+$s21back_deploy_attribute0A12DeployedFuncyyFTwB ---> back deployment fallback for back_deploy_attribute.backDeployedFunc() -> ()
+$s4test3fooyyAA1P_px1TRts_XPlF ---> test.foo<A>(any tes(any test.P<Self.T == A>) -> ()
+$s4test3fooyyAA1P_pSS1TAaCPRts_Si1UAERtsXPF ---> test.foo(any test.P<Self.test.P.T == Swift.String, Self.test.P.U == Swift.Int>) -> ()
+$s4test3FooVAAyyAA1P_pF ---> test.Foo.test(test.P) -> ()
+$sxxxIxzCXxxxesy ---> $sxxxIxzCXxxxesy
+$Sxxx_x_xxIxzCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC$x ---> $Sxxx_x_xxIxzCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC$x
+$sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTATQ0_ ---> {T:$sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTR} (1) await resume partial function for partial apply forwarder for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
+$sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTQ0_ ---> {T:} (1) await resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
+$sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTY0_ ---> {T:} (1) suspend resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
+$sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTY_ ---> {T:} (0) suspend resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
+$sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTQ12_ ---> {T:} (13) await resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
+$s7Library3fooyyFTwS ---> #_hasSymbol query for Library.foo() -> ()
+$s7Library5KlassCTwS ---> #_hasSymbol query for Library.Klass
+$s14swift_ide_test14myColorLiteral3red5green4blue5alphaAA0E0VSf_S3ftcfm ---> swift_ide_test.myColorLiteral(red: Swift.Float, green: Swift.Float, blue: Swift.Float, alpha: Swift.Float) -> swift_ide_test.Color
+$s14swift_ide_test10myFilenamexfm ---> swift_ide_test.myFilename : A
+$s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> ()
+$s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> ()
+@__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_ ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()
+@__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_ ---> peer macro @addCompletionHandler expansion #1 of f in macro_expand_peers.S
+@__swiftmacro_9MacroUser16MemberNotCoveredV33_4361AD9339943F52AE6186DD51E04E91Ll0dE0fMf0_ ---> freestanding macro expansion #2 of NotCovered(in _4361AD9339943F52AE6186DD51E04E91) in MacroUser.MemberNotCovered
+$sxSo8_NSRangeVRlzCRl_Cr0_llySo12ModelRequestCyxq_GIsPetWAlYl_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(witness_method) @yield_once <A, B where A: AnyObject, B: AnyObject> @substituted <A> (@inout A) -> (@yields @inout __C._NSRange) for <__C.ModelRequest<A, B>>
+$SyyySGSS_IIxxxxx____xsIyFSySIxx_@xIxx____xxI ---> $SyyySGSS_IIxxxxx____xsIyFSySIxx_@xIxx____xxI
+$s12typed_throws15rethrowConcreteyyAA7MyErrorOYKF ---> typed_throws.rethrowConcrete() throws(typed_throws.MyError) -> ()
+$s3red3use2fnySiyYAXE_tF ---> red.use(fn: @isolated(any) () -> Swift.Int) -> ()
+$s4testAAyAA5KlassC_ACtACnYTF ---> test.test(__owned test.Klass) -> sending (test.Klass, test.Klass)
+$s5test24testyyAA5KlassCnYuF ---> test2.test(sending __owned test2.Klass) -> ()
+$s7ElementSTQzqd__s5Error_pIgnrzo_ABqd__sAC_pIegnrzr_SlRzr__lTR ---> {T:} reabstraction thunk helper <A><A1 where A: Swift.Collection> from @callee_guaranteed (@in_guaranteed A.Swift.Sequence.Element) -> (@out A1, @error @owned Swift.Error) to @escaping @callee_guaranteed (@in_guaranteed A.Swift.Sequence.Element) -> (@out A1, @error @out Swift.Error)
+$sS3fIedgyywTd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned @noDerivative sending Swift.Float) -> (@unowned Swift.Float)
+$sS3fIedgyyTd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned sending Swift.Float) -> (@unowned Swift.Float)
+$s4testA2A5KlassCyYTF ---> test.test() -> sending test.Klass
+$s4main5KlassCACYTcMD ---> demangling cache variable for type metadata for (main.Klass) -> sending main.Klass
+$s4null19transferAsyncResultAA16NonSendableKlassCyYaYTF ---> null.transferAsyncResult() async -> sending null.NonSendableKlass
+$s4null16NonSendableKlassCIegHo_ACs5Error_pIegHTrzo_TR ---> {T:} reabstraction thunk helper from @escaping @callee_guaranteed @async () -> (@owned null.NonSendableKlass) to @escaping @callee_guaranteed @async () -> sending (@out null.NonSendableKlass, @error @owned Swift.Error)
+$sSRyxG15Synchronization19AtomicRepresentableABRi_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Copyable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
+$sSRyxG15Synchronization19AtomicRepresentableABRi0_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Escapable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
+$sSRyxG15Synchronization19AtomicRepresentableABRi1_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.<bit 2>> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
+$s23variadic_generic_opaque2G2VyAA2S1V_AA2S2VQPGAA1PHPAeA1QHPyHC_AgaJHPyHCHX_HC ---> concrete protocol conformance variadic_generic_opaque.G2<Pack{variadic_generic_opaque.S1, variadic_generic_opaque.S2}> to protocol conformance ref (type's module) variadic_generic_opaque.P with conditional requirements: (pack protocol conformance (concrete protocol conformance variadic_generic_opaque.S1 to protocol conformance ref (type's module) variadic_generic_opaque.Q, concrete protocol conformance variadic_generic_opaque.S2 to protocol conformance ref (type's module) variadic_generic_opaque.Q))
+$s9MacroUser0023macro_expandswift_elFCffMX436_4_23bitwidthNumberedStructsfMf_ ---> freestanding macro expansion #1 of bitwidthNumberedStructs in module MacroUser file macro_expand.swift line 437 column 5
+$sxq_IyXd_D ---> @callee_unowned (@in_cxx A) -> (@unowned B)
+$s2hi1SV1iSivx ---> hi.S.i.modify2 : Swift.Int
+$s2hi1SV1iSivy ---> hi.S.i.read2 : Swift.Int
+$s2hi1SVIetMIy_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(method) @yield_once_2 (@unowned hi.S) -> ()
+$s4main4SlabVy$1_SiG ---> main.Slab<2, Swift.Int>
+$s$n3_SSBV ---> Builtin.FixedArray<-4, Swift.String>
+$s3red7MyActorC3runyxxyYaKACYcYTXEYaKlFZ ---> static red.MyActor.run<A>(@red.MyActor () async(@red.MyActor () async throws -> sending A) async throws -> A
+$s3red7MyActorC3runyxxyYaKYAYTXEYaKlFZ ---> static red.MyActor.run<A>(@isolated(any) () asy(@isolated(any) () async throws -> sending A) async throws -> A
+$s7ToolKit10TypedValueOACs5Error_pIgHTnTrzo_A2CsAD_pIegHiTrzr_TR ---> {T:} reabstraction thunk helper from @callee_guaranteed @async (@in_guaranteed sending ToolKit.TypedValue) -> sending (@out ToolKit.TypedValue, @error @owned Swift.Error) to @escaping @callee_guaranteed @async (@in sending ToolKit.TypedValue) -> (@out ToolKit.TypedValue, @error @out Swift.Error)
+$s16sending_mangling16NonSendableKlassCACIegTiTr_A2CIegTxTo_TR ---> {T:} reabstraction thunk helper from @escaping @callee_guaranteed (@in sending sending_mangling.NonSendableKlass) -> sending (@out sending_mangling.NonSendableKlass) to @escaping @callee_guaranteed (@owned sending sending_mangling.NonSendableKlass) -> sending (@owned sending_mangling.NonSendableKlass)
+$s3red7MyActorC3runyxxyYaKYCXEYaKlFZ ---> static red.MyActor.run<A>(nonisolated(nonsendin(nonisolated(nonsending) () async throws -> A) async throws -> A
+$s5thing1PP1sAA1SVvxTwc ---> coro function pointer to thing.P.s.modify2 : thing.S
+_$s15raw_identifiers0020foospace_liaADEDGcjayyF ---> raw_identifiers.`foo space`() -> ()
+_$s15raw_identifiers0018_3times_pgaIGJCFbhayyF ---> raw_identifiers.`3 times`() -> ()
+_$s15raw_identifiers0019test_yeaIIBCEapkagayyF ---> raw_identifiers.`test +`() -> ()
+_$s15raw_identifiers0020pathfoo_yuEHaaCiJskayyF ---> raw_identifiers.`path://foo`() -> ()
+_$s15raw_identifiers10FontWeightO009_100_FpEpdyyFZ ---> static raw_identifiers.FontWeight.`100`() -> ()
+$s7Library1BC1iSivxTwd ---> default override of Library.B.i.modify2 : Swift.Int
+$s7Library1BC1iSivxTwdTwc ---> coro function pointer to default override of Library.B.i.modify2 : Swift.Int

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -85,26 +85,26 @@ _TF3fooap3barSi ---> foo.bar.nativePinningMutableAddressor : Swift.Int
 _TF3foolp3barSi ---> foo.bar.nativePinningAddressor : Swift.Int
 _TF3foog3barSi ---> foo.bar.getter : Swift.Int
 _TF3foos3barSi ---> foo.bar.setter : Swift.Int
-_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> () | {(8,11) - (11,25)}
-_TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
-_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
-_T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
-_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
-_$s3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$s3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
-_$sSC3fooyS2d_SdtFTO ---> {T:_$sSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
-_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
-_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
-_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
-_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
+_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
+_TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$s3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$s3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_$sSC3fooyS2d_SdtFTO ---> {T:_$sSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
+_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
 _$sTA.123 ---> {T:} partial apply forwarder with unmangled suffix ".123"
-$s4main3fooyySiFyyXEfU_TA.1 ---> {T:} partial apply forwarder for closure #1 () -> () in main.foo(Swift.Int) -> () with unmangled suffix ".1" | {(28,38) - (39,41)}
-$s4main8MyStructV3fooyyFAA1XV_Tg5.foo ---> generic specialization <main.X> of main.MyStruct.foo() -> () with unmangled suffix ".foo" | {(49,52) - (52,54)}
-_TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> () | {(16,19) - (19,33)}
-_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> () | {(8,11) - (11,25)}
-_TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim | {(4,11) - (11,29)}
-_TF3foooP1xFTCS_3barVS_3bas_OS_3zim ---> foo.^ postfix(foo.bar, foo.bas) -> foo.zim | {(4,13) - (13,31)}
-_TFC3foo3barCfT_S0_ ---> foo.bar.__allocating_init() -> foo.bar | {(8,25) - (25,27)}
-_TFC3foo3barcfT_S0_ ---> foo.bar.init() -> foo.bar | {(8,12) - (12,14)}
+$s4main3fooyySiFyyXEfU_TA.1 ---> {T:} partial apply forwarder for closure #1 () -> () in main.foo(Swift.Int) -> () with unmangled suffix ".1"
+$s4main8MyStructV3fooyyFAA1XV_Tg5.foo ---> generic specialization <main.X> of main.MyStruct.foo() -> () with unmangled suffix ".foo"
+_TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> ()
+_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
+_TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim
+_TF3foooP1xFTCS_3barVS_3bas_OS_3zim ---> foo.^ postfix(foo.bar, foo.bas) -> foo.zim
+_TFC3foo3barCfT_S0_ ---> foo.bar.__allocating_init() -> foo.bar
+_TFC3foo3barcfT_S0_ ---> foo.bar.init() -> foo.bar
 _TFC3foo3barD ---> foo.bar.__deallocating_deinit
 _TFC3foo3barZ ---> foo.bar.__isolated_deallocating_deinit
 _TFC3foo3bard ---> foo.bar.deinit
@@ -138,10 +138,10 @@ _TWIC3foo3barS_8barrableS_ ---> {C} instantiation function for generic protocol 
 _TWtC3foo3barS_8barrableS_4fred ---> {C} associated type metadata accessor for fred in foo.bar : foo.barrable in foo
 _TWTC3foo3barS_8barrableS_4fredS_6thomas ---> {C} associated type witness table accessor for fred : foo.thomas in foo.bar : foo.barrable in foo
 _TFSCg5greenVSC5Color ---> __C_Synthesized.green.getter : __C_Synthesized.Color
-_TIF1t1fFT1iSi1sSS_T_A_ ---> default argument 0 of t.f(i: Swift.Int, s: Swift.String) -> () | {(24,25) - (25,56)}
-_TIF1t1fFT1iSi1sSS_T_A0_ ---> default argument 1 of t.f(i: Swift.Int, s: Swift.String) -> () | {(24,25) - (25,56)}
-_TFSqcfT_GSqx_ ---> Swift.Optional.init() -> A? | {(15,19) - (19,21)}
-_TF21class_bound_protocols32class_bound_protocol_compositionFT1xPS_10ClassBoundS_13NotClassBound__PS0_S1__ ---> class_bound_protocols.class_bound_protocol_composition(x: class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound) -> class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound | {(22,54) - (54,129)}
+_TIF1t1fFT1iSi1sSS_T_A_ ---> default argument 0 of t.f(i: Swift.Int, s: Swift.String) -> ()
+_TIF1t1fFT1iSi1sSS_T_A0_ ---> default argument 1 of t.f(i: Swift.Int, s: Swift.String) -> ()
+_TFSqcfT_GSqx_ ---> Swift.Optional.init() -> A?
+_TF21class_bound_protocols32class_bound_protocol_compositionFT1xPS_10ClassBoundS_13NotClassBound__PS0_S1__ ---> class_bound_protocols.class_bound_protocol_composition(x: class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound) -> class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound
 _TtZZ ---> _TtZZ
 _TtB ---> _TtB
 _TtBSi ---> _TtBSi
@@ -171,7 +171,7 @@ _TWvd ---> _TWvd
 _TWvi ---> _TWvi
 _TWvx ---> _TWvx
 _TtVCC4main3Foo4Ding3Str ---> main.Foo.Ding.Str
-_TFVCC6nested6AClass12AnotherClass7AStruct9aFunctionfT1aSi_S2_ ---> nested.AClass.AnotherClass.AStruct.aFunction(a: Swift.Int) -> nested.AClass.AnotherClass.AStruct | {(35,44) - (44,58)}
+_TFVCC6nested6AClass12AnotherClass7AStruct9aFunctionfT1aSi_S2_ ---> nested.AClass.AnotherClass.AStruct.aFunction(a: Swift.Int) -> nested.AClass.AnotherClass.AStruct
 _TtXwC10attributes10SwiftClass ---> weak attributes.SwiftClass
 _TtXoC10attributes10SwiftClass ---> unowned attributes.SwiftClass
 _TtERR ---> <ERROR TYPE>
@@ -183,20 +183,20 @@ _Ttas3Int ---> Swift.Int
 _TTRXFo_dSc_dSb_XFo_iSc_iSb_ ---> reabstraction thunk helper from @callee_owned (@in Swift.UnicodeScalar) -> (@out Swift.Bool) to @callee_owned (@unowned Swift.UnicodeScalar) -> (@unowned Swift.Bool)
 _TTRXFo_dSi_dGSqSi__XFo_iSi_iGSqSi__ ---> reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@out Swift.Int?) to @callee_owned (@unowned Swift.Int) -> (@unowned Swift.Int?)
 _TTRGrXFo_iV18switch_abstraction1A_ix_XFo_dS0__ix_ ---> reabstraction thunk helper <A> from @callee_owned (@unowned switch_abstraction.A) -> (@out A) to @callee_owned (@in switch_abstraction.A) -> (@out A)
-_TFCF5types1gFT1bSb_T_L0_10Collection3zimfT_T_ ---> zim() -> () in Collection #2 in types.g(b: Swift.Bool) -> () | {(0,3) - (3,5)}
-_TFF17capture_promotion22test_capture_promotionFT_FT_SiU_FT_Si_promote0 ---> closure #1 () -> Swift.Int in capture_promotion.test_capture_promotion() -> () -> Swift.Int with unmangled suffix "_promote0" | {(0,10) - (11,13)}
-_TFIVs8_Processi10_argumentsGSaSS_U_FT_GSaSS_ ---> _arguments : [Swift.String] in variable initialization expression of Swift._Process with unmangled suffix "U_FT_GSaSS_" | {(0,10) - ()}
-_TFIvVs8_Process10_argumentsGSaSS_iU_FT_GSaSS_ ---> closure #1 () -> [Swift.String] in variable initialization expression of Swift._Process._arguments : [Swift.String] | {(0,10) - (11,13)}
+_TFCF5types1gFT1bSb_T_L0_10Collection3zimfT_T_ ---> zim() -> () in Collection #2 in types.g(b: Swift.Bool) -> ()
+_TFF17capture_promotion22test_capture_promotionFT_FT_SiU_FT_Si_promote0 ---> closure #1 () -> Swift.Int in capture_promotion.test_capture_promotion() -> () -> Swift.Int with unmangled suffix "_promote0"
+_TFIVs8_Processi10_argumentsGSaSS_U_FT_GSaSS_ ---> _arguments : [Swift.String] in variable initialization expression of Swift._Process with unmangled suffix "U_FT_GSaSS_"
+_TFIvVs8_Process10_argumentsGSaSS_iU_FT_GSaSS_ ---> closure #1 () -> [Swift.String] in variable initialization expression of Swift._Process._arguments : [Swift.String]
 _TFCSo1AE ---> __C.A.__ivar_destroyer
 _TFCSo1Ae ---> __C.A.__ivar_initializer
-_TTWC13call_protocol1CS_1PS_FS1_3foofT_Si ---> protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol | {(37,40) - (40,42)}
-_T013call_protocol1CCAA1PA2aDP3fooSiyFTW ---> {T:} protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol | {(37,40) - (40,42)}
-_TFC12dynamic_self1X1ffT_DS0_ ---> dynamic_self.X.f() -> Self | {(15,16) - (16,18)}
-_TTSg5Si___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int> of Swift.Optional.init() -> A? | {(53,57) - (57,59)}
-_TTSgq5Si___TFSqcfT_GSqx_ ---> generic specialization <serialized, Swift.Int> of Swift.Optional.init() -> A? | {(65,69) - (69,71)}
-_TTSg5SiSis3Foos_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int with Swift.Int : Swift.Foo in Swift, Swift.Float> of Swift.Optional.init() -> A? | {(102,106) - (106,108)}
-_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A? | {(66,70) - (70,72)}
-_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A? | {(66,70) - (70,72)}
+_TTWC13call_protocol1CS_1PS_FS1_3foofT_Si ---> protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
+_T013call_protocol1CCAA1PA2aDP3fooSiyFTW ---> {T:} protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
+_TFC12dynamic_self1X1ffT_DS0_ ---> dynamic_self.X.f() -> Self
+_TTSg5Si___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int> of Swift.Optional.init() -> A?
+_TTSgq5Si___TFSqcfT_GSqx_ ---> generic specialization <serialized, Swift.Int> of Swift.Optional.init() -> A?
+_TTSg5SiSis3Foos_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int with Swift.Int : Swift.Foo in Swift, Swift.Float> of Swift.Optional.init() -> A?
+_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A?
+_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A?
 _TTSgS ---> _TTSgS
 _TTSg5S ---> _TTSg5S
 _TTSgSi ---> _TTSgSi
@@ -205,109 +205,109 @@ _TTSgSi_ ---> _TTSgSi_
 _TTSgSi__ ---> _TTSgSi__
 _TTSgSiS_ ---> _TTSgSiS_
 _TTSgSi__xyz ---> _TTSgSi__xyz
-_TTSr5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <Swift.Int> of test.generic<A>(A) -> A | {(61,68) - (71,74)}
-_TTSrq5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <serialized, Swift.Int> of test.generic<A>(A) -> A | {(73,80) - (83,86)}
+_TTSr5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <Swift.Int> of test.generic<A>(A) -> A
+_TTSrq5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <serialized, Swift.Int> of test.generic<A>(A) -> A
 _TPA__TTRXFo_oSSoSS_dSb_XFo_iSSiSS_dSb_ ---> {T:_TTRXFo_oSSoSS_dSb_XFo_iSSiSS_dSb_} partial apply forwarder for reabstraction thunk helper from @callee_owned (@in Swift.String, @in Swift.String) -> (@unowned Swift.Bool) to @callee_owned (@owned Swift.String, @owned Swift.String) -> (@unowned Swift.Bool)
 _TPAo__TTRGrXFo_dGSPx__dGSPx_zoPs5Error__XFo_iGSPx__iGSPx_zoPS___ ---> {T:_TTRGrXFo_dGSPx__dGSPx_zoPs5Error__XFo_iGSPx__iGSPx_zoPS___} partial apply ObjC forwarder for reabstraction thunk helper <A> from @callee_owned (@in Swift.UnsafePointer<A>) -> (@out Swift.UnsafePointer<A>, @error @owned Swift.Error) to @callee_owned (@unowned Swift.UnsafePointer<A>) -> (@unowned Swift.UnsafePointer<A>, @error @owned Swift.Error)
 _T0S2SSbIxxxd_S2SSbIxiid_TRTA ---> {T:_T0S2SSbIxxxd_S2SSbIxiid_TR} partial apply forwarder for reabstraction thunk helper from @callee_owned (@owned Swift.String, @owned Swift.String) -> (@unowned Swift.Bool) to @callee_owned (@in Swift.String, @in Swift.String) -> (@unowned Swift.Bool)
 _T0SPyxGAAs5Error_pIxydzo_A2AsAB_pIxirzo_lTRTa ---> {T:_T0SPyxGAAs5Error_pIxydzo_A2AsAB_pIxirzo_lTR} partial apply ObjC forwarder for reabstraction thunk helper <A> from @callee_owned (@unowned Swift.UnsafePointer<A>) -> (@unowned Swift.UnsafePointer<A>, @error @owned Swift.Error) to @callee_owned (@in Swift.UnsafePointer<A>) -> (@out Swift.UnsafePointer<A>, @error @owned Swift.Error)
 _TiC4Meow5MyCls9subscriptFT1iSi_Sf ---> Meow.MyCls.subscript(i: Swift.Int) -> Swift.Float
-_TF8manglingX22egbpdajGbuEbxfgehfvwxnFT_T_ ---> mangling.ليهمابتكلموشعربي؟() -> () | {(9,43) - (43,45)}
-_TF8manglingX24ihqwcrbEcvIaIdqgAFGpqjyeFT_T_ ---> mangling.他们为什么不说中文() -> () | {(9,36) - (36,38)}
-_TF8manglingX27ihqwctvzcJBfGFJdrssDxIboAybFT_T_ ---> mangling.他們爲什麽不說中文() -> () | {(9,36) - (36,38)}
-_TF8manglingX30Proprostnemluvesky_uybCEdmaEBaFT_T_ ---> mangling.Pročprostěnemluvíčesky() -> () | {(9,35) - (35,37)}
-_TF8manglingXoi7p_qcaDcFTSiSi_Si ---> mangling.«+» infix(Swift.Int, Swift.Int) -> Swift.Int | {(9,20) - (20,42)}
-_TF8manglingoi2qqFTSiSi_T_ ---> mangling.?? infix(Swift.Int, Swift.Int) -> () | {(9,17) - (17,39)}
-_TFE11ext_structAV11def_structA1A4testfT_T_ ---> (extension in ext_structA):def_structA.A.test() -> () | {(41,45) - (45,47)}
-_TF13devirt_accessP5_DISC15getPrivateClassFT_CS_P5_DISC12PrivateClass ---> devirt_access.(getPrivateClass in _DISC)() -> devirt_access.(PrivateClass in _DISC) | {(14,40) - (40,42)}
-_TF4mainP5_mainX3wxaFT_T_ ---> main.(λ in _main)() -> () | {(5,18) - (18,20)}
-_TF4mainP5_main3abcFT_aS_P5_DISC3xyz ---> main.(abc in _main)() -> main.(xyz in _DISC) | {(5,19) - (19,21)}
+_TF8manglingX22egbpdajGbuEbxfgehfvwxnFT_T_ ---> mangling.ليهمابتكلموشعربي؟() -> ()
+_TF8manglingX24ihqwcrbEcvIaIdqgAFGpqjyeFT_T_ ---> mangling.他们为什么不说中文() -> ()
+_TF8manglingX27ihqwctvzcJBfGFJdrssDxIboAybFT_T_ ---> mangling.他們爲什麽不說中文() -> ()
+_TF8manglingX30Proprostnemluvesky_uybCEdmaEBaFT_T_ ---> mangling.Pročprostěnemluvíčesky() -> ()
+_TF8manglingXoi7p_qcaDcFTSiSi_Si ---> mangling.«+» infix(Swift.Int, Swift.Int) -> Swift.Int
+_TF8manglingoi2qqFTSiSi_T_ ---> mangling.?? infix(Swift.Int, Swift.Int) -> ()
+_TFE11ext_structAV11def_structA1A4testfT_T_ ---> (extension in ext_structA):def_structA.A.test() -> ()
+_TF13devirt_accessP5_DISC15getPrivateClassFT_CS_P5_DISC12PrivateClass ---> devirt_access.(getPrivateClass in _DISC)() -> devirt_access.(PrivateClass in _DISC)
+_TF4mainP5_mainX3wxaFT_T_ ---> main.(λ in _main)() -> ()
+_TF4mainP5_main3abcFT_aS_P5_DISC3xyz ---> main.(abc in _main)() -> main.(xyz in _DISC)
 _TtPMP_ ---> Any.Type
-_TFCs13_NSSwiftArray29canStoreElementsOfDynamicTypefPMP_Sb ---> Swift._NSSwiftArray.canStoreElementsOfDynamicType(Any.Type) -> Swift.Bool | {(20,49) - (49,59)}
+_TFCs13_NSSwiftArray29canStoreElementsOfDynamicTypefPMP_Sb ---> Swift._NSSwiftArray.canStoreElementsOfDynamicType(Any.Type) -> Swift.Bool
 _TFCs13_NSSwiftArrayg17staticElementTypePMP_ ---> Swift._NSSwiftArray.staticElementType.getter : Any.Type
 _TFCs17_DictionaryMirrorg9valueTypePMP_ ---> Swift._DictionaryMirror.valueType.getter : Any.Type
-_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(183,195) - (195,225)}
-_TTSfq1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <serialized, Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(195,207) - (207,237)}
-_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TTSg5Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of generic specialization <Swift.Int> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(221,233) - (233,263)}
-_TTSg5Si___TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> generic specialization <Swift.Int> of function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(221,233) - (233,263)}
+_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSfq1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <serialized, Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TTSg5Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of generic specialization <Swift.Int> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSg5Si___TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> generic specialization <Swift.Int> of function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
 _TTSf1cpfr24_TF8capturep6helperFSiT__n___TTRXFo_dSi_dT__XFo_iSi_dT__ ---> function signature specialization <Arg[0] = [Constant Propagated Function : capturep.helper(Swift.Int) -> ()]> of reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@unowned ()) to @callee_owned (@unowned Swift.Int) -> (@unowned ())
 _TTSf1cpfr24_TF8capturep6helperFSiT__n___TTRXFo_dSi_DT__XFo_iSi_DT__ ---> function signature specialization <Arg[0] = [Constant Propagated Function : capturep.helper(Swift.Int) -> ()]> of reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@unowned_inner_pointer ()) to @callee_owned (@unowned Swift.Int) -> (@unowned_inner_pointer ())
-_TTSf1cpi0_cpfl0_cpse0v4u123_cpg53globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8_cpfr36_TFtest_capture_propagation2_closure___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Constant Propagated Integer : 0], Arg[1] = [Constant Propagated Float : 0], Arg[2] = [Constant Propagated String : u8'u123'], Arg[3] = [Constant Propagated Global : globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8], Arg[4] = [Constant Propagated Function : _TFtest_capture_propagation2_closure]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(357,369) - (369,399)}
-_TTSf0gs___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Owned To Guaranteed and Exploded> of Swift._LegacyStringCore._invariantCheck() -> () | {(105,120) - (120,122)}
-_TTSf2g___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(164,168) - (168,189)}
-_TTSf2dg___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(173,177) - (177,198)}
-_TTSf2dgs___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(186,190) - (190,211)}
-_TTSf3d_i_d_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[2] = Dead, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(209,213) - (213,234)}
-_TTSf3d_i_n_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(194,198) - (198,219)}
+_TTSf1cpi0_cpfl0_cpse0v4u123_cpg53globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8_cpfr36_TFtest_capture_propagation2_closure___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Constant Propagated Integer : 0], Arg[1] = [Constant Propagated Float : 0], Arg[2] = [Constant Propagated String : u8'u123'], Arg[3] = [Constant Propagated Global : globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8], Arg[4] = [Constant Propagated Function : _TFtest_capture_propagation2_closure]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSf0gs___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Owned To Guaranteed and Exploded> of Swift._LegacyStringCore._invariantCheck() -> ()
+_TTSf2g___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf2dg___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf2dgs___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf3d_i_d_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[2] = Dead, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf3d_i_n_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
 _TFIZvV8mangling10HasVarInit5stateSbiu_KT_Sb ---> implicit closure #1 : @autoclosure () -> Swift.Bool in variable initialization expression of static mangling.HasVarInit.state : Swift.Bool
-_TFFV23interface_type_mangling18GenericTypeContext23closureInGenericContexturFqd__T_L_3fooFTqd__x_T_ ---> foo #1 (A1, A) -> () in interface_type_mangling.GenericTypeContext.closureInGenericContext<A>(A1) -> () | {(0,6) - (7,14)}
-_TFFV23interface_type_mangling18GenericTypeContextg31closureInGenericPropertyContextxL_3fooFT_x ---> foo #1 () -> A in interface_type_mangling.GenericTypeContext.closureInGenericPropertyContext.getter : A | {(0,6) - (7,9)}
-_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_23closureInGenericContextuRxS1_rfqd__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.closureInGenericContext<A where A: interface_type_mangling.GenericWitnessTest>(A1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling | {(64,87) - (142,146)}
+_TFFV23interface_type_mangling18GenericTypeContext23closureInGenericContexturFqd__T_L_3fooFTqd__x_T_ ---> foo #1 (A1, A) -> () in interface_type_mangling.GenericTypeContext.closureInGenericContext<A>(A1) -> ()
+_TFFV23interface_type_mangling18GenericTypeContextg31closureInGenericPropertyContextxL_3fooFT_x ---> foo #1 () -> A in interface_type_mangling.GenericTypeContext.closureInGenericPropertyContext.getter : A
+_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_23closureInGenericContextuRxS1_rfqd__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.closureInGenericContext<A where A: interface_type_mangling.GenericWitnessTest>(A1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
 _TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_g31closureInGenericPropertyContextwx3Tee ---> protocol witness for interface_type_mangling.GenericWitnessTest.closureInGenericPropertyContext.getter : A.Tee in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
-_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_16twoParamsAtDepthu0_RxS1_rfTqd__1yqd_0__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.twoParamsAtDepth<A, B where A: interface_type_mangling.GenericWitnessTest>(A1, y: B1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling | {(64,80) - (138,149)}
-_TFC3red11BaseClassEHcfzT1aSi_S0_ ---> red.BaseClassEH.init(a: Swift.Int) throws -> red.BaseClassEH | {(16,20) - (20,34)}
+_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_16twoParamsAtDepthu0_RxS1_rfTqd__1yqd_0__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.twoParamsAtDepth<A, B where A: interface_type_mangling.GenericWitnessTest>(A1, y: B1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
+_TFC3red11BaseClassEHcfzT1aSi_S0_ ---> red.BaseClassEH.init(a: Swift.Int) throws -> red.BaseClassEH
 _TFe27mangling_generic_extensionsRxS_8RunciblerVS_3Foog1aSi ---> (extension in mangling_generic_extensions):mangling_generic_extensions.Foo<A where A: mangling_generic_extensions.Runcible>.a.getter : Swift.Int
 _TFe27mangling_generic_extensionsRxS_8RunciblerVS_3Foog1bx ---> (extension in mangling_generic_extensions):mangling_generic_extensions.Foo<A where A: mangling_generic_extensions.Runcible>.b.getter : A
 _TTRXFo_iT__iT_zoPs5Error__XFo__dT_zoPS___ ---> reabstraction thunk helper from @callee_owned () -> (@unowned (), @error @owned Swift.Error) to @callee_owned (@in ()) -> (@out (), @error @owned Swift.Error)
 _TFE1a ---> _TFE1a
 _TF21$__lldb_module_for_E0au3$E0Ps5Error_ ---> $__lldb_module_for_E0.$E0.unsafeMutableAddressor : Swift.Error
 _TMps10Comparable ---> protocol descriptor for Swift.Comparable
-_TFC4testP33_83378C430F65473055F1BD53F3ADCDB71C5doFoofT_T_ ---> test.(C in _83378C430F65473055F1BD53F3ADCDB7).doFoo() -> () | {(46,51) - (51,53)}
-_TFVV15nested_generics5Lunch6DinnerCfT11firstCoursex12secondCourseGSqqd___9leftoversx14transformationFxqd___GS1_x_qd___ ---> nested_generics.Lunch.Dinner.init(firstCourse: A, secondCourse: A1?, leftovers: A, transformation: (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1> | {(29,33) - (33,109)}
-_TFVFC15nested_generics7HotDogs11applyRelishFT_T_L_6RelishCfT8materialx_GS1_x_ ---> init(material: A) -> Relish #1 in nested_generics.HotDogs.applyRelish() -> ()<A> in Relish #1 in nested_generics.HotDogs.applyRelish() -> () | {(0,4) - (4,17)}
-_TFVFE15nested_genericsSS3fooFT_T_L_6CheeseCfT8materialx_GS0_x_ ---> init(material: A) -> Cheese #1 in (extension in nested_generics):Swift.String.foo() -> ()<A> in Cheese #1 in (extension in nested_generics):Swift.String.foo() -> () | {(0,4) - (4,17)}
+_TFC4testP33_83378C430F65473055F1BD53F3ADCDB71C5doFoofT_T_ ---> test.(C in _83378C430F65473055F1BD53F3ADCDB7).doFoo() -> ()
+_TFVV15nested_generics5Lunch6DinnerCfT11firstCoursex12secondCourseGSqqd___9leftoversx14transformationFxqd___GS1_x_qd___ ---> nested_generics.Lunch.Dinner.init(firstCourse: A, secondCourse: A1?, leftovers: A, transformation: (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1>
+_TFVFC15nested_generics7HotDogs11applyRelishFT_T_L_6RelishCfT8materialx_GS1_x_ ---> init(material: A) -> Relish #1 in nested_generics.HotDogs.applyRelish() -> ()<A> in Relish #1 in nested_generics.HotDogs.applyRelish() -> ()
+_TFVFE15nested_genericsSS3fooFT_T_L_6CheeseCfT8materialx_GS0_x_ ---> init(material: A) -> Cheese #1 in (extension in nested_generics):Swift.String.foo() -> ()<A> in Cheese #1 in (extension in nested_generics):Swift.String.foo() -> ()
 _TTWOE5imojiCSo5Imoji14ImojiMatchRankS_9RankValueS_FS2_g9rankValueqq_Ss16RawRepresentable8RawValue ---> _TTWOE5imojiCSo5Imoji14ImojiMatchRankS_9RankValueS_FS2_g9rankValueqq_Ss16RawRepresentable8RawValue
-_T0s17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD05Indexs01_A9IndexablePQzAM15shiftingToStart_tFAJs01_J4BasePQzAQcfU_ ---> closure #1 (A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index | {(0,10) - (11,41)}
-_$Ss17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD015shiftingToStart5Indexs01_A9IndexablePQzAN_tFAKs01_M4BasePQzAQcfU_ ---> closure #1 (A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index | {(0,10) - (11,41)}
+_T0s17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD05Indexs01_A9IndexablePQzAM15shiftingToStart_tFAJs01_J4BasePQzAQcfU_ ---> closure #1 (A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index
+_$Ss17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD015shiftingToStart5Indexs01_A9IndexablePQzAN_tFAKs01_M4BasePQzAQcfU_ ---> closure #1 (A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index
 _T03foo4_123ABTf3psbpsb_n ---> function signature specialization <Arg[0] = [Constant Propagated String : u8'123'], Arg[1] = [Constant Propagated String : u8'123']> of foo
-_T04main5innerys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> () | {(151,156) - (156,196)}
-_$S4main5inneryys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> () | {(151,156) - (156,196)}
-_T03foo6testityyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> () | {(132,138) - (138,158)}
-_$S3foo6testityyyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> () | {(132,138) - (138,158)}
+_T04main5innerys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> ()
+_$S4main5inneryys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> ()
+_T03foo6testityyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> ()
+_$S3foo6testityyyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> ()
 _SocketJoinOrLeaveMulticast ---> _SocketJoinOrLeaveMulticast
-_T0s10DictionaryV3t17E6Index2V1loiSbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool | {(50,57) - (57,127)}
-_T08mangling14varargsVsArrayySi3arrd_SS1ntF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> () | {(9,23) - (23,59)}
-_T08mangling14varargsVsArrayySaySiG3arr_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> () | {(9,23) - (23,58)}
-_T08mangling14varargsVsArrayySaySiG3arrd_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> () | {(9,23) - (23,61)}
-_T08mangling14varargsVsArrayySi3arrd_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> () | {(9,23) - (23,42)}
-_T08mangling14varargsVsArrayySaySiG3arrd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> () | {(9,23) - (23,44)}
-_$Ss10DictionaryV3t17E6Index2V1loiySbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool | {(50,57) - (57,127)}
-_$S8mangling14varargsVsArray3arr1nySid_SStF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> () | {(9,23) - (23,59)}
-_$S8mangling14varargsVsArray3arr1nySaySiG_SStF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> () | {(9,23) - (23,58)}
-_$S8mangling14varargsVsArray3arr1nySaySiGd_SStF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> () | {(9,23) - (23,61)}
-_$S8mangling14varargsVsArray3arrySid_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> () | {(9,23) - (23,42)}
-_$S8mangling14varargsVsArray3arrySaySiGd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> () | {(9,23) - (23,44)}
+_T0s10DictionaryV3t17E6Index2V1loiSbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool
+_T08mangling14varargsVsArrayySi3arrd_SS1ntF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> ()
+_T08mangling14varargsVsArrayySaySiG3arr_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> ()
+_T08mangling14varargsVsArrayySaySiG3arrd_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> ()
+_T08mangling14varargsVsArrayySi3arrd_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> ()
+_T08mangling14varargsVsArrayySaySiG3arrd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> ()
+_$Ss10DictionaryV3t17E6Index2V1loiySbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool
+_$S8mangling14varargsVsArray3arr1nySid_SStF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> ()
+_$S8mangling14varargsVsArray3arr1nySaySiG_SStF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> ()
+_$S8mangling14varargsVsArray3arr1nySaySiGd_SStF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> ()
+_$S8mangling14varargsVsArray3arrySid_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> ()
+_$S8mangling14varargsVsArray3arrySaySiGd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> ()
 _T0s13_UnicodeViewsVss22RandomAccessCollectionRzs0A8EncodingR_11SubSequence_5IndexQZAFRtzsAcERpzAE_AEQZAIRSs15UnsignedInteger8Iterator_7ElementRPzAE_AlMQZANRS13EncodedScalar_AlMQY_AORSr0_lE13CharacterViewVyxq__G ---> (extension in Swift):Swift._UnicodeViews<A, B><A, B where A: Swift.RandomAccessCollection, B: Swift.UnicodeEncoding, A.Index == A.SubSequence.Index, A.SubSequence: Swift.RandomAccessCollection, A.SubSequence == A.SubSequence.SubSequence, A.Iterator.Element: Swift.UnsignedInteger, A.Iterator.Element == A.SubSequence.Iterator.Element, A.SubSequence.Iterator.Element == B.EncodedScalar.Iterator.Element>.CharacterView
-_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool | {(98,106) - (106,264)}
-_$S10Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiySbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool | {(98,106) - (106,264)}
-_T04main1_yyF ---> main._() -> () | {(5,6) - (6,8)}
-_T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int | {(5,11) - (11,15)}
-_$S4test6testitySiyt_tF ---> test.testit(()) -> Swift.Int | {(5,11) - (11,15)}
+_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
+_$S10Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiySbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
+_T04main1_yyF ---> main._() -> ()
+_T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
+_$S4test6testitySiyt_tF ---> test.testit(()) -> Swift.Int
 _T08_ElementQzSbs5Error_pIxxdzo_ABSbsAC_pIxidzo_s26RangeReplaceableCollectionRzABRLClTR ---> {T:} reabstraction thunk helper <A where A: Swift.RangeReplaceableCollection, A._Element: AnyObject> from @callee_owned (@owned A._Element) -> (@unowned Swift.Bool, @error @owned Swift.Error) to @callee_owned (@in A._Element) -> (@unowned Swift.Bool, @error @owned Swift.Error)
 _T0Ix_IyB_Tr ---> {T:} reabstraction thunk from @callee_owned () -> () to @callee_unowned @convention(block) () -> ()
 _T0Rml ---> _T0Rml
 _T0Tk ---> _T0Tk
 _T0A8 ---> _T0A8
 _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n ---> _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n
-_T03abc6testitySiFTm ---> merged abc.testit(Swift.Int) -> () | {(11,17) - (17,28)}
-_T04main4TestCACSi1x_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test | {(10,26) - (26,40)}
-_$S3abc6testityySiFTm ---> merged abc.testit(Swift.Int) -> () | {(11,17) - (17,28)}
-_$S4main4TestC1xACSi_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test | {(10,26) - (26,40)}
+_T03abc6testitySiFTm ---> merged abc.testit(Swift.Int) -> ()
+_T04main4TestCACSi1x_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test
+_$S3abc6testityySiFTm ---> merged abc.testit(Swift.Int) -> ()
+_$S4main4TestC1xACSi_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test
 _T0SqWOy.17 ---> outlined copy of Swift.Optional with unmangled suffix ".17"
 _T0SqWOC ---> outlined init with copy of Swift.Optional
 _T0SqWOD ---> outlined assign with take of Swift.Optional
 _T0SqWOF ---> outlined assign with copy of Swift.Optional
 _T0SqWOH ---> outlined destroy of Swift.Optional
-_T03nix6testitSaySiGyFTv_ ---> outlined variable #0 of nix.testit() -> [Swift.Int] | {(28,34) - (34,36)}
-_T03nix6testitSaySiGyFTv_r ---> outlined read-only object #0 of nix.testit() -> [Swift.Int] | {(36,42) - (42,44)}
-_T03nix6testitSaySiGyFTv0_ ---> outlined variable #1 of nix.testit() -> [Swift.Int] | {(28,34) - (34,36)}
+_T03nix6testitSaySiGyFTv_ ---> outlined variable #0 of nix.testit() -> [Swift.Int]
+_T03nix6testitSaySiGyFTv_r ---> outlined read-only object #0 of nix.testit() -> [Swift.Int]
+_T03nix6testitSaySiGyFTv0_ ---> outlined variable #1 of nix.testit() -> [Swift.Int]
 _T0So11UITextFieldC4textSSSgvgToTepb_ ---> outlined bridged method (pb) of @objc __C.UITextField.text.getter : Swift.String?
 _T0So11UITextFieldC4textSSSgvgToTeab_ ---> outlined bridged method (ab) of @objc __C.UITextField.text.getter : Swift.String?
-$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_ ---> outlined bridged method (mbgnn) of @objc __C.Gizmo.doSomething([Swift.String]?) -> Any? | {(51,62) - (62,79)}
+$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_ ---> outlined bridged method (mbgnn) of @objc __C.Gizmo.doSomething([Swift.String]?) -> Any?
 _T04test1SVyxGAA1RA2A1ZRzAA1Y2ZZRpzl1A_AhaGPWT ---> {C} associated type witness table accessor for A.ZZ : test.Y in <A where A: test.Z, A.ZZ: test.Y> test.S<A> : test.R in test
-_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfC ---> {T:_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfc} Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69).init() -> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69) | {(70,74) - (74,76)}
+_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfC ---> {T:_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfc} Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69).init() -> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69)
 _T0D ---> _T0D
-_T0s18EnumeratedIteratorVyxGs8Sequencess0B8ProtocolRzlsADP5splitSay03SubC0QzGSi9maxSplits_Sb25omittingEmptySubsequencesSb7ElementQzKc14whereSeparatortKFTW ---> {T:} protocol witness for Swift.Sequence.split(maxSplits: Swift.Int, omittingEmptySubsequences: Swift.Bool, whereSeparator: (A.Element) throws -> Swift.Bool) throws -> [A.SubSequence] in conformance <A where A: Swift.IteratorProtocol> Swift.EnumeratedIterator<A> : Swift.Sequence in Swift | {(36,41) - (41,152)}
+_T0s18EnumeratedIteratorVyxGs8Sequencess0B8ProtocolRzlsADP5splitSay03SubC0QzGSi9maxSplits_Sb25omittingEmptySubsequencesSb7ElementQzKc14whereSeparatortKFTW ---> {T:} protocol witness for Swift.Sequence.split(maxSplits: Swift.Int, omittingEmptySubsequences: Swift.Bool, whereSeparator: (A.Element) throws -> Swift.Bool) throws -> [A.SubSequence] in conformance <A where A: Swift.IteratorProtocol> Swift.EnumeratedIterator<A> : Swift.Sequence in Swift
 _T0s3SetVyxGs10CollectiotySivm ---> _T0s3SetVyxGs10CollectiotySivm
 _S$s3SetVyxGs10CollectiotySivm ---> _S$s3SetVyxGs10CollectiotySivm
 _T0s18ReversedCollectionVyxGs04LazyB8ProtocolfC ---> _T0s18ReversedCollectionVyxGs04LazyB8ProtocolfC
@@ -322,17 +322,17 @@ $S28protocol_conformance_records15NativeValueTypeVAA8RuncibleAAMc ---> protocol 
 $ss6SimpleHr ---> protocol descriptor runtime record for Swift.Simple
 $ss5OtherVs6SimplesHc ---> protocol conformance descriptor runtime record for Swift.Other : Swift.Simple in Swift
 $ss5OtherVHn ---> nominal type descriptor runtime record for Swift.Other
-$s18opaque_return_type3fooQryFQOHo ---> opaque type descriptor runtime record for <<opaque return type of opaque_return_type.foo() -> some>> | {(85,88) - (88,90)}
+$s18opaque_return_type3fooQryFQOHo ---> opaque type descriptor runtime record for <<opaque return type of opaque_return_type.foo() -> some>>
 $SSC9SomeErrorLeVD ---> __C_Synthesized.related decl 'e' for SomeError
-$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PAAyHCg_AiJ1QAAyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> () | {(21,26) - (26,93)}
-$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHPyHCg_AiJ1QHPyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> () | {(21,26) - (26,93)}
-$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHpyHCg_AiJ1QHpyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> () | {(21,26) - (26,93)}
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PAAyHCg_AiJ1QAAyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHPyHCg_AiJ1QHPyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHpyHCg_AiJ1QHpyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
 _T0LiteralAByxGxd_tcfC ---> _T0LiteralAByxGxd_tcfC
 _T0XZ ---> _T0XZ
-_TTSf0os___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Guaranteed To Owned and Exploded> of Swift._LegacyStringCore._invariantCheck() -> () | {(105,120) - (120,122)}
-_TTSf2o___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(164,168) - (168,189)}
-_TTSf2do___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(173,177) - (177,198)}
-_TTSf2dos___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(186,190) - (190,211)}
+_TTSf0os___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Guaranteed To Owned and Exploded> of Swift._LegacyStringCore._invariantCheck() -> ()
+_TTSf2o___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf2do___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf2dos___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
 _TTSf ---> _TTSf
 _TtW0_j ---> _TtW0_j
 _TtW_4m3a3v ---> _TtW_4m3a3v
@@ -343,36 +343,36 @@ _$S3BBBBf0602365061_ ---> _$S3BBBBf0602365061_
 _$S3BBBBi0602365061_ ---> _$S3BBBBi0602365061_
 _$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
 _T0lxxxmmmTk ---> _T0lxxxmmmTk
-_TtCF4test11doNotCrash1FT_QuL_8MyClass1 ---> MyClass1 #1 in test.doNotCrash1() -> some | {(20,31) - (31,33)}
+_TtCF4test11doNotCrash1FT_QuL_8MyClass1 ---> MyClass1 #1 in test.doNotCrash1() -> some
 $s3Bar3FooVAA5DrinkVyxGs5Error_pSeRzSERzlyShy4AbcdAHO6MemberVGALSeHPAKSeAAyHC_HCg_ALSEHPAKSEAAyHC_HCg0_Iseggozo_SgWOe ---> outlined consume of (@escaping @callee_guaranteed @substituted <A where A: Swift.Decodable, A: Swift.Encodable> (@guaranteed Bar.Foo) -> (@owned Bar.Drink<A>, @error @owned Swift.Error) for <Swift.Set<Abcd.Abcd.Member>>)?
-$s4Test5ProtoP8IteratorV10collectionAEy_qd__Gqd___tcfc ---> Test.Proto.Iterator.init(collection: A1) -> Test.Proto.Iterator<A1> | {(20,24) - (24,40)}
-$s4test3fooV4blahyAA1SV1fQryFQOy_Qo_AHF ---> test.foo.blah(<<opaque return type of test.S.f() -> some>>.0) -> <<opaque return type of test.S.f() -> some>>.0 | {(9,13) - (13,61)}
-$S3nix8MystructV1xACyxGx_tcfc7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.init(x: A) -> nix.Mystruct<A> | {(30,34) - (34,40)}
+$s4Test5ProtoP8IteratorV10collectionAEy_qd__Gqd___tcfc ---> Test.Proto.Iterator.init(collection: A1) -> Test.Proto.Iterator<A1>
+$s4test3fooV4blahyAA1SV1fQryFQOy_Qo_AHF ---> test.foo.blah(<<opaque return type of test.S.f() -> some>>.0) -> <<opaque return type of test.S.f() -> some>>.0
+$S3nix8MystructV1xACyxGx_tcfc7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.init(x: A) -> nix.Mystruct<A>
 $S3nix7MyclassCfd7MyaliasL_ayx__GD ---> Myalias #1 in nix.Myclass<A>.deinit
 $S3nix8MystructVyS2icig7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.subscript.getter : (Swift.Int) -> Swift.Int
 $S3nix8MystructV1x1uACyxGx_qd__tclufc7MyaliasL_ayx_qd___GD ---> Myalias #1 in nix.Mystruct<A>.<A1>(x: A, u: A1) -> nix.Mystruct<A>
-$S3nix8MystructV6testit1xyx_tF7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.testit(x: A) -> () | {(30,36) - (36,42)}
-$S3nix8MystructV6testit1x1u1vyx_qd__qd_0_tr0_lF7MyaliasL_ayx_qd__qd_0__GD ---> Myalias #1 in nix.Mystruct<A>.testit<A1, B1>(x: A, u: A1, v: B1) -> () | {(30,36) - (44,64)}
+$S3nix8MystructV6testit1xyx_tF7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.testit(x: A) -> ()
+$S3nix8MystructV6testit1x1u1vyx_qd__qd_0_tr0_lF7MyaliasL_ayx_qd__qd_0__GD ---> Myalias #1 in nix.Mystruct<A>.testit<A1, B1>(x: A, u: A1, v: B1) -> ()
 $S4blah8PatatinoaySiGD ---> blah.Patatino<Swift.Int>
 $SSiSHsWP ---> protocol witness table for Swift.Int : Swift.Hashable in Swift
 $S7TestMod5OuterV3Fooayx_SiGD ---> TestMod.Outer<A>.Foo<Swift.Int>
 $Ss17_VariantSetBufferO05CocoaC0ayx_GD ---> Swift._VariantSetBuffer<A>.CocoaBuffer
 $S2t21QP22ProtocolTypeAliasThingayAA4BlahV5SomeQa_GSgD ---> t2.Blah.SomeQ as t2.Q.ProtocolTypeAliasThing?
-$s1A1gyyxlFx_qd__t_Ti5 ---> inlined generic function <(A, A1)> of A.g<A>(A) -> () | {(40,41) - (44,47)}
+$s1A1gyyxlFx_qd__t_Ti5 ---> inlined generic function <(A, A1)> of A.g<A>(A) -> ()
 $S1T19protocol_resilience17ResilientProtocolPTl ---> associated type descriptor for protocol_resilience.ResilientProtocol.T
 $S18resilient_protocol21ResilientBaseProtocolTL ---> protocol requirements base descriptor for resilient_protocol.ResilientBaseProtocol
 $S1t1PP10AssocType2_AA1QTn ---> associated conformance descriptor for t.P.AssocType2: t.Q
 $S1t1PP10AssocType2_AA1QTN ---> default associated conformance accessor for t.P.AssocType2: t.Q
-$s4Test6testityyxlFAA8MystructV_TB5 ---> generic specialization <Test.Mystruct> of Test.testit<A>(A) -> () | {(47,53) - (56,59)}
-$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A | {(128,132) - (165,169)}
-$s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> () | {(55,62) - (68,74)}
+$s4Test6testityyxlFAA8MystructV_TB5 ---> generic specialization <Test.Mystruct> of Test.testit<A>(A) -> ()
+$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A
+$s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> ()
 $sSD5IndexVy__GD ---> $sSD5IndexVy__GD
-$s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str | {(9,26) - (26,28)}
+$s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str
 $s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized
-$s3red4testyAA3ResOyxSayq_GAEs5ErrorAAq_sAFHD1__HCg_GADyxq_GsAFR_r0_lF ---> red.test<A, B where B: Swift.Error>(red.Res<A, B>) -> red.Res<A, [B]> | {(4,8) - (35,50)}
-$s3red4testyAA7OurTypeOy4them05TheirD0Vy5AssocQzGAjE0F8ProtocolAAxAA0c7DerivedH0HD1_AA0c4BaseH0HI1_AieKHA2__HCg_GxmAaLRzlF ---> red.test<A where A: red.OurDerivedProtocol>(A.Type) -> red.OurType<them.TheirType<A.Assoc>> | {(4,8) - (43,51)}
+$s3red4testyAA3ResOyxSayq_GAEs5ErrorAAq_sAFHD1__HCg_GADyxq_GsAFR_r0_lF ---> red.test<A, B where B: Swift.Error>(red.Res<A, B>) -> red.Res<A, [B]>
+$s3red4testyAA7OurTypeOy4them05TheirD0Vy5AssocQzGAjE0F8ProtocolAAxAA0c7DerivedH0HD1_AA0c4BaseH0HI1_AieKHA2__HCg_GxmAaLRzlF ---> red.test<A where A: red.OurDerivedProtocol>(A.Type) -> red.OurType<them.TheirType<A.Assoc>>
 $s17property_wrappers10WithTuplesV9fractionsSd_S2dtvpfP ---> property wrapper backing initializer of property_wrappers.WithTuples.fractions : (Swift.Double, Swift.Double, Swift.Double)
-$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTOTA ---> {T:$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTO} partial apply forwarder for @nonobjc __C.OS_dispatch_queue.sync(execute: () -> ()) -> () | {(59,63) - (63,82)}
+$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTOTA ---> {T:$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTO} partial apply forwarder for @nonobjc __C.OS_dispatch_queue.sync(execute: () -> ()) -> ()
 $s4main1gyySiXCvp ---> main.g : @convention(c) (Swift.Int) -> ()
 $s4main1gyySiXBvp ---> main.g : @convention(block) (Swift.Int) -> ()
 $sxq_Ifgnr_D ---> @differentiable(_forward) @callee_guaranteed (@in_guaranteed A) -> (@out B)
@@ -384,56 +384,56 @@ $sS5fIertyyywddw_D ---> @escaping @differentiable(reverse) @convention(thin) (@u
 $syQo ---> $syQo
 $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee ---> $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee
 $sx1td_t ---> (t: A...)
-$s7example1fyyYaF ---> example.f() async -> () | {(8,9) - (9,11)}
-$s7example1fyyYaKF ---> example.f() async throws -> () | {(8,9) - (9,11)}
-$s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> () | {(5,25) - (25,71)}
-$s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE | {(5,24) - (24,26)}
-$s4main6testityyYaFTu ---> async function pointer to main.testit() async -> () | {(31,37) - (37,39)}
-$s13test_mangling3fooyS2f_S2ftFTJfUSSpSr ---> forward-mode derivative of test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {1, 2} and results {0} | {(41,44) - (44,83)}
-$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P> | {(41,45) - (126,132)}
-$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJVrSpSr ---> vtable thunk for reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P> | {(58,62) - (143,149)}
-$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSr ---> pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable> | {(26,29) - (76,95)}
-$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFTSAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of protocol self-conformance witness for test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P> | {(79,83) - (164,170)}
-$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTj ---> dispatch thunk of pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable> | {(44,47) - (94,113)}
-$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTq ---> method descriptor for pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable> | {(48,51) - (98,117)}
+$s7example1fyyYaF ---> example.f() async -> ()
+$s7example1fyyYaKF ---> example.f() async throws -> ()
+$s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> ()
+$s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE
+$s4main6testityyYaFTu ---> async function pointer to main.testit() async -> ()
+$s13test_mangling3fooyS2f_S2ftFTJfUSSpSr ---> forward-mode derivative of test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {1, 2} and results {0}
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJVrSpSr ---> vtable thunk for reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSr ---> pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFTSAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of protocol self-conformance witness for test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTj ---> dispatch thunk of pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTq ---> method descriptor for pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
 $s13TangentVector16_Differentiation14DifferentiablePQzAaDQy_SdAFIegnnnr_TJSdSSSpSrSUSP ---> autodiff subset parameters thunk for differential from @escaping @callee_guaranteed (@in_guaranteed A._Differentiation.Differentiable.TangentVector, @in_guaranteed B._Differentiation.Differentiable.TangentVector, @in_guaranteed Swift.Double) -> (@out B._Differentiation.Differentiable.TangentVector) with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2}
 $s13TangentVector16_Differentiation14DifferentiablePQy_AaDQzAESdIegnrrr_TJSpSSSpSrSUSP ---> autodiff subset parameters thunk for pullback from @escaping @callee_guaranteed (@in_guaranteed B._Differentiation.Differentiable.TangentVector) -> (@out A._Differentiation.Differentiable.TangentVector, @out B._Differentiation.Differentiable.TangentVector, @out Swift.Double) with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2}
-$s39differentiation_subset_parameters_thunk19inoutIndirectCalleryq_x_q_q0_t16_Differentiation14DifferentiableRzAcDR_AcDR0_r1_lFxq_Sdq_xq_Sdr0_ly13TangentVectorAcDPQy_AeFQzIsegnrr_Iegnnnro_TJSrSSSpSrSUSP ---> autodiff subset parameters thunk for reverse-mode derivative from differentiation_subset_parameters_thunk.inoutIndirectCaller<A, B, C where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, C: _Differentiation.Differentiable>(A, B, C) -> B with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2} of type @escaping @callee_guaranteed (@in_guaranteed A, @in_guaranteed B, @in_guaranteed Swift.Double) -> (@out B, @owned @escaping @callee_guaranteed @substituted <A, B> (@in_guaranteed A) -> (@out B, @out Swift.Double) for <B._Differentiation.Differentiable.TangentVectorA._Differentiation.Differentiable.TangentVector>) | {(106,125) - (247,256)}
+$s39differentiation_subset_parameters_thunk19inoutIndirectCalleryq_x_q_q0_t16_Differentiation14DifferentiableRzAcDR_AcDR0_r1_lFxq_Sdq_xq_Sdr0_ly13TangentVectorAcDPQy_AeFQzIsegnrr_Iegnnnro_TJSrSSSpSrSUSP ---> autodiff subset parameters thunk for reverse-mode derivative from differentiation_subset_parameters_thunk.inoutIndirectCaller<A, B, C where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, C: _Differentiation.Differentiable>(A, B, C) -> B with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2} of type @escaping @callee_guaranteed (@in_guaranteed A, @in_guaranteed B, @in_guaranteed Swift.Double) -> (@out B, @owned @escaping @callee_guaranteed @substituted <A, B> (@in_guaranteed A) -> (@out B, @out Swift.Double) for <B._Differentiation.Differentiable.TangentVectorA._Differentiation.Differentiable.TangentVector>)
 $sS2f8mangling3FooV13TangentVectorVIegydd_SfAESfIegydd_TJOp ---> autodiff self-reordering reabstraction thunk for pullback from @escaping @callee_guaranteed (@unowned Swift.Float) -> (@unowned Swift.Float, @unowned mangling.Foo.TangentVector) to @escaping @callee_guaranteed (@unowned Swift.Float) -> (@unowned mangling.Foo.TangentVector, @unowned Swift.Float)
-$s13test_mangling3fooyS2f_S2ftFWJrSpSr ---> reverse-mode differentiability witness for test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {0} and results {0} | {(57,60) - (60,99)}
-$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lWJrUSSpSr ---> reverse-mode differentiability witness for test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable> | {(57,60) - (107,126)}
-$s5async1hyyS2iYbXEF ---> async.h(@Sendable (Swift.Int) -> Swift.Int) -> () | {(6,7) - (7,43)}
-$s5Actor02MyA0C17testAsyncFunctionyyYaKFTY0_ ---> (1) suspend resume partial function for Actor.MyActor.testAsyncFunction() async throws -> () | {(54,71) - (71,73)}
-$s5Actor02MyA0C17testAsyncFunctionyyYaKFTQ1_ ---> (2) await resume partial function for Actor.MyActor.testAsyncFunction() async throws -> () | {(52,69) - (69,71)}
-$s4diff1hyyS2iYjfXEF ---> diff.h(@differentiable(_forward) (Swift.Int) -> Swift.Int) -> () | {(5,6) - (6,58)}
-$s4diff1hyyS2iYjrXEF ---> diff.h(@differentiable(reverse) (Swift.Int) -> Swift.Int) -> () | {(5,6) - (6,57)}
-$s4diff1hyyS2iYjdXEF ---> diff.h(@differentiable (Swift.Int) -> Swift.Int) -> () | {(5,6) - (6,48)}
-$s4diff1hyyS2iYjlXEF ---> diff.h(@differentiable(_linear) (Swift.Int) -> Swift.Int) -> () | {(5,6) - (6,57)}
-$s4test3fooyyS2f_SfYkztYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, inout @noDerivative Swift.Float) -> Swift.Float) -> () | {(5,8) - (8,96)}
-$s4test3fooyyS2f_SfYkntYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, __owned @noDerivative Swift.Float) -> Swift.Float) -> () | {(5,8) - (8,98)}
-$s4test3fooyyS2f_SfYktYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, @noDerivative Swift.Float) -> Swift.Float) -> () | {(5,8) - (8,90)}
-$s4test3fooyyS2f_SfYktYaYbYjrXEF ---> test.foo(@differentiable(reverse) @Sendable (Swift.Float, @noDerivative Swift.Float) async -> Swift.Float) -> () | {(5,8) - (8,106)}
+$s13test_mangling3fooyS2f_S2ftFWJrSpSr ---> reverse-mode differentiability witness for test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {0} and results {0}
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lWJrUSSpSr ---> reverse-mode differentiability witness for test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
+$s5async1hyyS2iYbXEF ---> async.h(@Sendable (Swift.Int) -> Swift.Int) -> ()
+$s5Actor02MyA0C17testAsyncFunctionyyYaKFTY0_ ---> (1) suspend resume partial function for Actor.MyActor.testAsyncFunction() async throws -> ()
+$s5Actor02MyA0C17testAsyncFunctionyyYaKFTQ1_ ---> (2) await resume partial function for Actor.MyActor.testAsyncFunction() async throws -> ()
+$s4diff1hyyS2iYjfXEF ---> diff.h(@differentiable(_forward) (Swift.Int) -> Swift.Int) -> ()
+$s4diff1hyyS2iYjrXEF ---> diff.h(@differentiable(reverse) (Swift.Int) -> Swift.Int) -> ()
+$s4diff1hyyS2iYjdXEF ---> diff.h(@differentiable (Swift.Int) -> Swift.Int) -> ()
+$s4diff1hyyS2iYjlXEF ---> diff.h(@differentiable(_linear) (Swift.Int) -> Swift.Int) -> ()
+$s4test3fooyyS2f_SfYkztYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, inout @noDerivative Swift.Float) -> Swift.Float) -> ()
+$s4test3fooyyS2f_SfYkntYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, __owned @noDerivative Swift.Float) -> Swift.Float) -> ()
+$s4test3fooyyS2f_SfYktYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, @noDerivative Swift.Float) -> Swift.Float) -> ()
+$s4test3fooyyS2f_SfYktYaYbYjrXEF ---> test.foo(@differentiable(reverse) @Sendable (Swift.Float, @noDerivative Swift.Float) async -> Swift.Float) -> ()
 $SSSTf4pd44444_pf ---> function signature specialization <Arg[0] = [Constant Propagated Float : 44444], Return = > of Swift.String
 $sScA ---> Swift.Actor
 $sScGySiG ---> Swift.TaskGroup<Swift.Int>
-$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor () -> A)?) -> (() -> A)? | {(5,15) - (18,47)}
+$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor () -> A)?) -> (() -> A)?
 $sSvSgA3ASbIetCyyd_SgSbIetCyyyd_SgD ---> (@escaping @convention(thin) @convention(c) (@unowned Swift.UnsafeMutableRawPointer?, @unowned Swift.UnsafeMutableRawPointer?, @unowned (@escaping @convention(thin) @convention(c) (@unowned Swift.UnsafeMutableRawPointer?, @unowned Swift.UnsafeMutableRawPointer?) -> (@unowned Swift.Bool))?) -> (@unowned Swift.Bool))?
-$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor () -> A)?) -> (() -> A)? | {(5,15) - (18,47)}
-$s1t10globalFuncyyAA7MyActorCYiF ---> t.globalFunc(isolated t.MyActor) -> () | {(2,12) - (12,32)}
+$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor () -> A)?) -> (() -> A)?
+$s1t10globalFuncyyAA7MyActorCYiF ---> t.globalFunc(isolated t.MyActor) -> ()
 $sSIxip6foobarP ---> foobar in Swift.DefaultIndices.subscript : A
 $s13__lldb_expr_110$10016c2d8yXZ1B10$10016c2e0LLC ---> __lldb_expr_1.(unknown context at $10016c2d8).(B in $10016c2e0)
 $s__TJO ---> $s__TJO
-$s6Foobar7Vector2VAASdRszlE10simdMatrix5scale6rotate9translateSo0C10_double3x3aACySdG_SdAJtFZ0D4TypeL_aySd__GD ---> MatrixType #1 in static (extension in Foobar):Foobar.Vector2<Swift.Double><A where A == Swift.Double>.simdMatrix(scale: Foobar.Vector2<Swift.Double>, rotate: Swift.Double, translate: Foobar.Vector2<Swift.Double>) -> __C.simd_double3x3 | {(102,112) - (112,212)}
-$s17distributed_thunk2DAC1fyyFTE ---> distributed thunk distributed_thunk.DA.f() -> () | {(39,40) - (40,42)}
-$s16distributed_test1XC7computeyS2iFTF ---> distributed accessor for distributed_test.X.compute(Swift.Int) -> Swift.Int | {(44,51) - (51,62)}
-$s27distributed_actor_accessors7MyActorC7simple2ySSSiFTETFHF ---> accessible function runtime record for distributed accessor for distributed thunk distributed_actor_accessors.MyActor.simple2(Swift.Int) -> Swift.String | {(118,125) - (125,136)}
-$s1A3bar1aySSYt_tF ---> A.bar(a: _const Swift.String) -> () | {(2,5) - (5,29)}
-$s1t1fyyFSiAA3StrVcs7KeyPathCyADSiGcfu_SiADcfu0_33_556644b740b1b333fecb81e55a7cce98ADSiTf3npk_n ---> function signature specialization <Arg[1] = [Constant Propagated KeyPath : _556644b740b1b333fecb81e55a7cce98<t.Str,Swift.Int>]> of implicit closure #2 (t.Str) -> Swift.Int in implicit closure #1 (Swift.KeyPath<t.Str, Swift.Int>) -> (t.Str) -> Swift.Int in t.f() -> () | {(258,259) - (259,261)}
-$s21back_deploy_attribute0A12DeployedFuncyyFTwb ---> back deployment thunk for back_deploy_attribute.backDeployedFunc() -> () | {(48,64) - (64,66)}
-$s21back_deploy_attribute0A12DeployedFuncyyFTwB ---> back deployment fallback for back_deploy_attribute.backDeployedFunc() -> () | {(51,67) - (67,69)}
-$s4test3fooyyAA1P_px1TRts_XPlF ---> test.foo<A>(any test.P<Self.T == A>) -> () | {(5,8) - (11,36)}
-$s4test3fooyyAA1P_pSS1TAaCPRts_Si1UAERtsXPF ---> test.foo(any test.P<Self.test.P.T == Swift.String, Self.test.P.U == Swift.Int>) -> () | {(5,8) - (8,79)}
-$s4test3FooVAAyyAA1P_pF ---> test.Foo.test(test.P) -> () | {(9,13) - (13,21)}
+$s6Foobar7Vector2VAASdRszlE10simdMatrix5scale6rotate9translateSo0C10_double3x3aACySdG_SdAJtFZ0D4TypeL_aySd__GD ---> MatrixType #1 in static (extension in Foobar):Foobar.Vector2<Swift.Double><A where A == Swift.Double>.simdMatrix(scale: Foobar.Vector2<Swift.Double>, rotate: Swift.Double, translate: Foobar.Vector2<Swift.Double>) -> __C.simd_double3x3
+$s17distributed_thunk2DAC1fyyFTE ---> distributed thunk distributed_thunk.DA.f() -> ()
+$s16distributed_test1XC7computeyS2iFTF ---> distributed accessor for distributed_test.X.compute(Swift.Int) -> Swift.Int
+$s27distributed_actor_accessors7MyActorC7simple2ySSSiFTETFHF ---> accessible function runtime record for distributed accessor for distributed thunk distributed_actor_accessors.MyActor.simple2(Swift.Int) -> Swift.String
+$s1A3bar1aySSYt_tF ---> A.bar(a: _const Swift.String) -> ()
+$s1t1fyyFSiAA3StrVcs7KeyPathCyADSiGcfu_SiADcfu0_33_556644b740b1b333fecb81e55a7cce98ADSiTf3npk_n ---> function signature specialization <Arg[1] = [Constant Propagated KeyPath : _556644b740b1b333fecb81e55a7cce98<t.Str,Swift.Int>]> of implicit closure #2 (t.Str) -> Swift.Int in implicit closure #1 (Swift.KeyPath<t.Str, Swift.Int>) -> (t.Str) -> Swift.Int in t.f() -> ()
+$s21back_deploy_attribute0A12DeployedFuncyyFTwb ---> back deployment thunk for back_deploy_attribute.backDeployedFunc() -> ()
+$s21back_deploy_attribute0A12DeployedFuncyyFTwB ---> back deployment fallback for back_deploy_attribute.backDeployedFunc() -> ()
+$s4test3fooyyAA1P_px1TRts_XPlF ---> test.foo<A>(any test.P<Self.T == A>) -> ()
+$s4test3fooyyAA1P_pSS1TAaCPRts_Si1UAERtsXPF ---> test.foo(any test.P<Self.test.P.T == Swift.String, Self.test.P.U == Swift.Int>) -> ()
+$s4test3FooVAAyyAA1P_pF ---> test.Foo.test(test.P) -> ()
 $sxxxIxzCXxxxesy ---> $sxxxIxzCXxxxesy
 $Sxxx_x_xxIxzCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC$x ---> $Sxxx_x_xxIxzCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC$x
 $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTATQ0_ ---> {T:$sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTR} (1) await resume partial function for partial apply forwarder for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
@@ -441,27 +441,27 @@ $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTQ0_ ---> {T:} (1) awai
 $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTY0_ ---> {T:} (1) suspend resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
 $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTY_ ---> {T:} (0) suspend resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
 $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTQ12_ ---> {T:} (13) await resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
-$s7Library3fooyyFTwS ---> #_hasSymbol query for Library.foo() -> () | {(30,33) - (33,35)}
+$s7Library3fooyyFTwS ---> #_hasSymbol query for Library.foo() -> ()
 $s7Library5KlassCTwS ---> #_hasSymbol query for Library.Klass
 $s14swift_ide_test14myColorLiteral3red5green4blue5alphaAA0E0VSf_S3ftcfm ---> swift_ide_test.myColorLiteral(red: Swift.Float, green: Swift.Float, blue: Swift.Float, alpha: Swift.Float) -> swift_ide_test.Color
 $s14swift_ide_test10myFilenamexfm ---> swift_ide_test.myFilename : A
-$s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> () | {(58,71) - (71,99)}
-$s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> () | {(111,141) - (141,143)}
-@__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_ ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> () | {(50,63) - (63,91)}
+$s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> ()
+$s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> ()
+@__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_ ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()
 @__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_ ---> peer macro @addCompletionHandler expansion #1 of f in macro_expand_peers.S
 @__swiftmacro_9MacroUser16MemberNotCoveredV33_4361AD9339943F52AE6186DD51E04E91Ll0dE0fMf0_ ---> freestanding macro expansion #2 of NotCovered(in _4361AD9339943F52AE6186DD51E04E91) in MacroUser.MemberNotCovered
 $sxSo8_NSRangeVRlzCRl_Cr0_llySo12ModelRequestCyxq_GIsPetWAlYl_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(witness_method) @yield_once <A, B where A: AnyObject, B: AnyObject> @substituted <A> (@inout A) -> (@yields @inout __C._NSRange) for <__C.ModelRequest<A, B>>
 $SyyySGSS_IIxxxxx____xsIyFSySIxx_@xIxx____xxI ---> $SyyySGSS_IIxxxxx____xsIyFSySIxx_@xIxx____xxI
-$s12typed_throws15rethrowConcreteyyAA7MyErrorOYKF ---> typed_throws.rethrowConcrete() throws(typed_throws.MyError) -> () | {(13,28) - (28,30)}
-$s3red3use2fnySiyYAXE_tF ---> red.use(fn: @isolated(any) () -> Swift.Int) -> () | {(4,7) - (7,43)}
-$s4testAAyAA5KlassC_ACtACnYTF ---> test.test(__owned test.Klass) -> sending (test.Klass, test.Klass) | {(5,9) - (9,29)}
-$s5test24testyyAA5KlassCnYuF ---> test2.test(sending __owned test2.Klass) -> () | {(6,10) - (10,39)}
+$s12typed_throws15rethrowConcreteyyAA7MyErrorOYKF ---> typed_throws.rethrowConcrete() throws(typed_throws.MyError) -> ()
+$s3red3use2fnySiyYAXE_tF ---> red.use(fn: @isolated(any) () -> Swift.Int) -> ()
+$s4testAAyAA5KlassC_ACtACnYTF ---> test.test(__owned test.Klass) -> sending (test.Klass, test.Klass)
+$s5test24testyyAA5KlassCnYuF ---> test2.test(sending __owned test2.Klass) -> ()
 $s7ElementSTQzqd__s5Error_pIgnrzo_ABqd__sAC_pIegnrzr_SlRzr__lTR ---> {T:} reabstraction thunk helper <A><A1 where A: Swift.Collection> from @callee_guaranteed (@in_guaranteed A.Swift.Sequence.Element) -> (@out A1, @error @owned Swift.Error) to @escaping @callee_guaranteed (@in_guaranteed A.Swift.Sequence.Element) -> (@out A1, @error @out Swift.Error)
 $sS3fIedgyywTd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned @noDerivative sending Swift.Float) -> (@unowned Swift.Float)
 $sS3fIedgyyTd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned sending Swift.Float) -> (@unowned Swift.Float)
-$s4testA2A5KlassCyYTF ---> test.test() -> sending test.Klass | {(5,9) - (9,11)}
+$s4testA2A5KlassCyYTF ---> test.test() -> sending test.Klass
 $s4main5KlassCACYTcMD ---> demangling cache variable for type metadata for (main.Klass) -> sending main.Klass
-$s4null19transferAsyncResultAA16NonSendableKlassCyYaYTF ---> null.transferAsyncResult() async -> sending null.NonSendableKlass | {(5,24) - (24,26)}
+$s4null19transferAsyncResultAA16NonSendableKlassCyYaYTF ---> null.transferAsyncResult() async -> sending null.NonSendableKlass
 $s4null16NonSendableKlassCIegHo_ACs5Error_pIegHTrzo_TR ---> {T:} reabstraction thunk helper from @escaping @callee_guaranteed @async () -> (@owned null.NonSendableKlass) to @escaping @callee_guaranteed @async () -> sending (@out null.NonSendableKlass, @error @owned Swift.Error)
 $sSRyxG15Synchronization19AtomicRepresentableABRi_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Copyable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
 $sSRyxG15Synchronization19AtomicRepresentableABRi0_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Escapable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
@@ -474,16 +474,16 @@ $s2hi1SV1iSivy ---> hi.S.i.read2 : Swift.Int
 $s2hi1SVIetMIy_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(method) @yield_once_2 (@unowned hi.S) -> ()
 $s4main4SlabVy$1_SiG ---> main.Slab<2, Swift.Int>
 $s$n3_SSBV ---> Builtin.FixedArray<-4, Swift.String>
-$s3red7MyActorC3runyxxyYaKACYcYTXEYaKlFZ ---> static red.MyActor.run<A>(@red.MyActor () async throws -> sending A) async throws -> A | {(19,22) - (25,68)}
-$s3red7MyActorC3runyxxyYaKYAYTXEYaKlFZ ---> static red.MyActor.run<A>(@isolated(any) () async throws -> sending A) async throws -> A | {(19,22) - (25,70)}
+$s3red7MyActorC3runyxxyYaKACYcYTXEYaKlFZ ---> static red.MyActor.run<A>(@red.MyActor () async throws -> sending A) async throws -> A
+$s3red7MyActorC3runyxxyYaKYAYTXEYaKlFZ ---> static red.MyActor.run<A>(@isolated(any) () async throws -> sending A) async throws -> A
 $s7ToolKit10TypedValueOACs5Error_pIgHTnTrzo_A2CsAD_pIegHiTrzr_TR ---> {T:} reabstraction thunk helper from @callee_guaranteed @async (@in_guaranteed sending ToolKit.TypedValue) -> sending (@out ToolKit.TypedValue, @error @owned Swift.Error) to @escaping @callee_guaranteed @async (@in sending ToolKit.TypedValue) -> (@out ToolKit.TypedValue, @error @out Swift.Error)
 $s16sending_mangling16NonSendableKlassCACIegTiTr_A2CIegTxTo_TR ---> {T:} reabstraction thunk helper from @escaping @callee_guaranteed (@in sending sending_mangling.NonSendableKlass) -> sending (@out sending_mangling.NonSendableKlass) to @escaping @callee_guaranteed (@owned sending sending_mangling.NonSendableKlass) -> sending (@owned sending_mangling.NonSendableKlass)
-$s3red7MyActorC3runyxxyYaKYCXEYaKlFZ ---> static red.MyActor.run<A>(nonisolated(nonsending) () async throws -> A) async throws -> A | {(19,22) - (25,71)}
+$s3red7MyActorC3runyxxyYaKYCXEYaKlFZ ---> static red.MyActor.run<A>(nonisolated(nonsending) () async throws -> A) async throws -> A
 $s5thing1PP1sAA1SVvxTwc ---> coro function pointer to thing.P.s.modify2 : thing.S
-_$s15raw_identifiers0020foospace_liaADEDGcjayyF ---> raw_identifiers.`foo space`() -> () | {(16,28) - (28,30)}
-_$s15raw_identifiers0018_3times_pgaIGJCFbhayyF ---> raw_identifiers.`3 times`() -> () | {(16,26) - (26,28)}
-_$s15raw_identifiers0019test_yeaIIBCEapkagayyF ---> raw_identifiers.`test +`() -> () | {(16,25) - (25,27)}
-_$s15raw_identifiers0020pathfoo_yuEHaaCiJskayyF ---> raw_identifiers.`path://foo`() -> () | {(16,28) - (28,30)}
-_$s15raw_identifiers10FontWeightO009_100_FpEpdyyFZ ---> static raw_identifiers.FontWeight.`100`() -> () | {(34,39) - (39,41)}
+_$s15raw_identifiers0020foospace_liaADEDGcjayyF ---> raw_identifiers.`foo space`() -> ()
+_$s15raw_identifiers0018_3times_pgaIGJCFbhayyF ---> raw_identifiers.`3 times`() -> ()
+_$s15raw_identifiers0019test_yeaIIBCEapkagayyF ---> raw_identifiers.`test +`() -> ()
+_$s15raw_identifiers0020pathfoo_yuEHaaCiJskayyF ---> raw_identifiers.`path://foo`() -> ()
+_$s15raw_identifiers10FontWeightO009_100_FpEpdyyFZ ---> static raw_identifiers.FontWeight.`100`() -> ()
 $s7Library1BC1iSivxTwd ---> default override of Library.B.i.modify2 : Swift.Int
 $s7Library1BC1iSivxTwdTwc ---> coro function pointer to default override of Library.B.i.modify2 : Swift.Int

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -85,26 +85,26 @@ _TF3fooap3barSi ---> foo.bar.nativePinningMutableAddressor : Swift.Int
 _TF3foolp3barSi ---> foo.bar.nativePinningAddressor : Swift.Int
 _TF3foog3barSi ---> foo.bar.getter : Swift.Int
 _TF3foos3barSi ---> foo.bar.setter : Swift.Int
-_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
-_TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
-_T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
-_$s3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$s3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_$sSC3fooyS2d_SdtFTO ---> {T:_$sSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
-_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
-_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> ()
-_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double
+_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> () | {(8,11) - (11,25)}
+_TToFC3foo3bar3basfT3zimCS_3zim_T_ ---> {T:_TFC3foo3bar3basfT3zimCS_3zim_T_,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
+_TTOFSC3fooFTSdSd_Sd ---> {T:_TFSC3fooFTSdSd_Sd} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
+_T03foo3barC3basyAA3zimCAE_tFTo ---> {T:_T03foo3barC3basyAA3zimCAE_tF,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
+_T0SC3fooS2d_SdtFTO ---> {T:_T0SC3fooS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
+_$s3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$s3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
+_$sSC3fooyS2d_SdtFTO ---> {T:_$sSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
+_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
+_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
+_$S3foo3barC3bas3zimyAaEC_tFTo ---> {T:_$S3foo3barC3bas3zimyAaEC_tF,C} @objc foo.bar.bas(zim: foo.zim) -> () | {(14,17) - (17,31)}
+_$SSC3fooyS2d_SdtFTO ---> {T:_$SSC3fooyS2d_SdtF} @nonobjc __C_Synthesized.foo(Swift.Double, Swift.Double) -> Swift.Double | {(25,28) - (28,56)}
 _$sTA.123 ---> {T:} partial apply forwarder with unmangled suffix ".123"
-$s4main3fooyySiFyyXEfU_TA.1 ---> {T:} partial apply forwarder for closure #1 () -> () in main.foo(Swift.Int) -> () with unmangled suffix ".1"
-$s4main8MyStructV3fooyyFAA1XV_Tg5.foo ---> generic specialization <main.X> of main.MyStruct.foo() -> () with unmangled suffix ".foo"
-_TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> ()
-_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> ()
-_TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim
-_TF3foooP1xFTCS_3barVS_3bas_OS_3zim ---> foo.^ postfix(foo.bar, foo.bas) -> foo.zim
-_TFC3foo3barCfT_S0_ ---> foo.bar.__allocating_init() -> foo.bar
-_TFC3foo3barcfT_S0_ ---> foo.bar.init() -> foo.bar
+$s4main3fooyySiFyyXEfU_TA.1 ---> {T:} partial apply forwarder for closure #1 () -> () in main.foo(Swift.Int) -> () with unmangled suffix ".1" | {(28,38) - (39,41)}
+$s4main8MyStructV3fooyyFAA1XV_Tg5.foo ---> generic specialization <main.X> of main.MyStruct.foo() -> () with unmangled suffix ".foo" | {(49,52) - (52,54)}
+_TTDFC3foo3bar3basfT3zimCS_3zim_T_ ---> dynamic foo.bar.bas(zim: foo.zim) -> () | {(16,19) - (19,33)}
+_TFC3foo3bar3basfT3zimCS_3zim_T_ ---> foo.bar.bas(zim: foo.zim) -> () | {(8,11) - (11,25)}
+_TF3foooi1pFTCS_3barVS_3bas_OS_3zim ---> foo.+ infix(foo.bar, foo.bas) -> foo.zim | {(4,11) - (11,29)}
+_TF3foooP1xFTCS_3barVS_3bas_OS_3zim ---> foo.^ postfix(foo.bar, foo.bas) -> foo.zim | {(4,13) - (13,31)}
+_TFC3foo3barCfT_S0_ ---> foo.bar.__allocating_init() -> foo.bar | {(8,25) - (25,27)}
+_TFC3foo3barcfT_S0_ ---> foo.bar.init() -> foo.bar | {(8,12) - (12,14)}
 _TFC3foo3barD ---> foo.bar.__deallocating_deinit
 _TFC3foo3barZ ---> foo.bar.__isolated_deallocating_deinit
 _TFC3foo3bard ---> foo.bar.deinit
@@ -138,10 +138,10 @@ _TWIC3foo3barS_8barrableS_ ---> {C} instantiation function for generic protocol 
 _TWtC3foo3barS_8barrableS_4fred ---> {C} associated type metadata accessor for fred in foo.bar : foo.barrable in foo
 _TWTC3foo3barS_8barrableS_4fredS_6thomas ---> {C} associated type witness table accessor for fred : foo.thomas in foo.bar : foo.barrable in foo
 _TFSCg5greenVSC5Color ---> __C_Synthesized.green.getter : __C_Synthesized.Color
-_TIF1t1fFT1iSi1sSS_T_A_ ---> default argument 0 of t.f(i: Swift.Int, s: Swift.String) -> ()
-_TIF1t1fFT1iSi1sSS_T_A0_ ---> default argument 1 of t.f(i: Swift.Int, s: Swift.String) -> ()
-_TFSqcfT_GSqx_ ---> Swift.Optional.init() -> A?
-_TF21class_bound_protocols32class_bound_protocol_compositionFT1xPS_10ClassBoundS_13NotClassBound__PS0_S1__ ---> class_bound_protocols.class_bound_protocol_composition(x: class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound) -> class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound
+_TIF1t1fFT1iSi1sSS_T_A_ ---> default argument 0 of t.f(i: Swift.Int, s: Swift.String) -> () | {(24,25) - (25,56)}
+_TIF1t1fFT1iSi1sSS_T_A0_ ---> default argument 1 of t.f(i: Swift.Int, s: Swift.String) -> () | {(24,25) - (25,56)}
+_TFSqcfT_GSqx_ ---> Swift.Optional.init() -> A? | {(15,19) - (19,21)}
+_TF21class_bound_protocols32class_bound_protocol_compositionFT1xPS_10ClassBoundS_13NotClassBound__PS0_S1__ ---> class_bound_protocols.class_bound_protocol_composition(x: class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound) -> class_bound_protocols.ClassBound & class_bound_protocols.NotClassBound | {(22,54) - (54,129)}
 _TtZZ ---> _TtZZ
 _TtB ---> _TtB
 _TtBSi ---> _TtBSi
@@ -171,7 +171,7 @@ _TWvd ---> _TWvd
 _TWvi ---> _TWvi
 _TWvx ---> _TWvx
 _TtVCC4main3Foo4Ding3Str ---> main.Foo.Ding.Str
-_TFVCC6nested6AClass12AnotherClass7AStruct9aFunctionfT1aSi_S2_ ---> nested.AClass.AnotherClass.AStruct.aFunction(a: Swift.Int) -> nested.AClass.AnotherClass.AStruct
+_TFVCC6nested6AClass12AnotherClass7AStruct9aFunctionfT1aSi_S2_ ---> nested.AClass.AnotherClass.AStruct.aFunction(a: Swift.Int) -> nested.AClass.AnotherClass.AStruct | {(35,44) - (44,58)}
 _TtXwC10attributes10SwiftClass ---> weak attributes.SwiftClass
 _TtXoC10attributes10SwiftClass ---> unowned attributes.SwiftClass
 _TtERR ---> <ERROR TYPE>
@@ -183,20 +183,20 @@ _Ttas3Int ---> Swift.Int
 _TTRXFo_dSc_dSb_XFo_iSc_iSb_ ---> reabstraction thunk helper from @callee_owned (@in Swift.UnicodeScalar) -> (@out Swift.Bool) to @callee_owned (@unowned Swift.UnicodeScalar) -> (@unowned Swift.Bool)
 _TTRXFo_dSi_dGSqSi__XFo_iSi_iGSqSi__ ---> reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@out Swift.Int?) to @callee_owned (@unowned Swift.Int) -> (@unowned Swift.Int?)
 _TTRGrXFo_iV18switch_abstraction1A_ix_XFo_dS0__ix_ ---> reabstraction thunk helper <A> from @callee_owned (@unowned switch_abstraction.A) -> (@out A) to @callee_owned (@in switch_abstraction.A) -> (@out A)
-_TFCF5types1gFT1bSb_T_L0_10Collection3zimfT_T_ ---> zim() -> () in Collection #2 in types.g(b: Swift.Bool) -> ()
-_TFF17capture_promotion22test_capture_promotionFT_FT_SiU_FT_Si_promote0 ---> closure #1 () -> Swift.Int in capture_promotion.test_capture_promotion() -> () -> Swift.Int with unmangled suffix "_promote0"
-_TFIVs8_Processi10_argumentsGSaSS_U_FT_GSaSS_ ---> _arguments : [Swift.String] in variable initialization expression of Swift._Process with unmangled suffix "U_FT_GSaSS_"
-_TFIvVs8_Process10_argumentsGSaSS_iU_FT_GSaSS_ ---> closure #1 () -> [Swift.String] in variable initialization expression of Swift._Process._arguments : [Swift.String]
+_TFCF5types1gFT1bSb_T_L0_10Collection3zimfT_T_ ---> zim() -> () in Collection #2 in types.g(b: Swift.Bool) -> () | {(0,3) - (3,5)}
+_TFF17capture_promotion22test_capture_promotionFT_FT_SiU_FT_Si_promote0 ---> closure #1 () -> Swift.Int in capture_promotion.test_capture_promotion() -> () -> Swift.Int with unmangled suffix "_promote0" | {(0,10) - (11,13)}
+_TFIVs8_Processi10_argumentsGSaSS_U_FT_GSaSS_ ---> _arguments : [Swift.String] in variable initialization expression of Swift._Process with unmangled suffix "U_FT_GSaSS_" | {(0,10) - ()}
+_TFIvVs8_Process10_argumentsGSaSS_iU_FT_GSaSS_ ---> closure #1 () -> [Swift.String] in variable initialization expression of Swift._Process._arguments : [Swift.String] | {(0,10) - (11,13)}
 _TFCSo1AE ---> __C.A.__ivar_destroyer
 _TFCSo1Ae ---> __C.A.__ivar_initializer
-_TTWC13call_protocol1CS_1PS_FS1_3foofT_Si ---> protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
-_T013call_protocol1CCAA1PA2aDP3fooSiyFTW ---> {T:} protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol
-_TFC12dynamic_self1X1ffT_DS0_ ---> dynamic_self.X.f() -> Self
-_TTSg5Si___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int> of Swift.Optional.init() -> A?
-_TTSgq5Si___TFSqcfT_GSqx_ ---> generic specialization <serialized, Swift.Int> of Swift.Optional.init() -> A?
-_TTSg5SiSis3Foos_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int with Swift.Int : Swift.Foo in Swift, Swift.Float> of Swift.Optional.init() -> A?
-_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A?
-_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A?
+_TTWC13call_protocol1CS_1PS_FS1_3foofT_Si ---> protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol | {(37,40) - (40,42)}
+_T013call_protocol1CCAA1PA2aDP3fooSiyFTW ---> {T:} protocol witness for call_protocol.P.foo() -> Swift.Int in conformance call_protocol.C : call_protocol.P in call_protocol | {(37,40) - (40,42)}
+_TFC12dynamic_self1X1ffT_DS0_ ---> dynamic_self.X.f() -> Self | {(15,16) - (16,18)}
+_TTSg5Si___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int> of Swift.Optional.init() -> A? | {(53,57) - (57,59)}
+_TTSgq5Si___TFSqcfT_GSqx_ ---> generic specialization <serialized, Swift.Int> of Swift.Optional.init() -> A? | {(65,69) - (69,71)}
+_TTSg5SiSis3Foos_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int with Swift.Int : Swift.Foo in Swift, Swift.Float> of Swift.Optional.init() -> A? | {(102,106) - (106,108)}
+_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A? | {(66,70) - (70,72)}
+_TTSg5Si_Sf___TFSqcfT_GSqx_ ---> generic specialization <Swift.Int, Swift.Float> of Swift.Optional.init() -> A? | {(66,70) - (70,72)}
 _TTSgS ---> _TTSgS
 _TTSg5S ---> _TTSg5S
 _TTSgSi ---> _TTSgSi
@@ -205,109 +205,109 @@ _TTSgSi_ ---> _TTSgSi_
 _TTSgSi__ ---> _TTSgSi__
 _TTSgSiS_ ---> _TTSgSiS_
 _TTSgSi__xyz ---> _TTSgSi__xyz
-_TTSr5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <Swift.Int> of test.generic<A>(A) -> A
-_TTSrq5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <serialized, Swift.Int> of test.generic<A>(A) -> A
+_TTSr5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <Swift.Int> of test.generic<A>(A) -> A | {(61,68) - (71,74)}
+_TTSrq5Si___TF4test7genericurFxx ---> generic not re-abstracted specialization <serialized, Swift.Int> of test.generic<A>(A) -> A | {(73,80) - (83,86)}
 _TPA__TTRXFo_oSSoSS_dSb_XFo_iSSiSS_dSb_ ---> {T:_TTRXFo_oSSoSS_dSb_XFo_iSSiSS_dSb_} partial apply forwarder for reabstraction thunk helper from @callee_owned (@in Swift.String, @in Swift.String) -> (@unowned Swift.Bool) to @callee_owned (@owned Swift.String, @owned Swift.String) -> (@unowned Swift.Bool)
 _TPAo__TTRGrXFo_dGSPx__dGSPx_zoPs5Error__XFo_iGSPx__iGSPx_zoPS___ ---> {T:_TTRGrXFo_dGSPx__dGSPx_zoPs5Error__XFo_iGSPx__iGSPx_zoPS___} partial apply ObjC forwarder for reabstraction thunk helper <A> from @callee_owned (@in Swift.UnsafePointer<A>) -> (@out Swift.UnsafePointer<A>, @error @owned Swift.Error) to @callee_owned (@unowned Swift.UnsafePointer<A>) -> (@unowned Swift.UnsafePointer<A>, @error @owned Swift.Error)
 _T0S2SSbIxxxd_S2SSbIxiid_TRTA ---> {T:_T0S2SSbIxxxd_S2SSbIxiid_TR} partial apply forwarder for reabstraction thunk helper from @callee_owned (@owned Swift.String, @owned Swift.String) -> (@unowned Swift.Bool) to @callee_owned (@in Swift.String, @in Swift.String) -> (@unowned Swift.Bool)
 _T0SPyxGAAs5Error_pIxydzo_A2AsAB_pIxirzo_lTRTa ---> {T:_T0SPyxGAAs5Error_pIxydzo_A2AsAB_pIxirzo_lTR} partial apply ObjC forwarder for reabstraction thunk helper <A> from @callee_owned (@unowned Swift.UnsafePointer<A>) -> (@unowned Swift.UnsafePointer<A>, @error @owned Swift.Error) to @callee_owned (@in Swift.UnsafePointer<A>) -> (@out Swift.UnsafePointer<A>, @error @owned Swift.Error)
 _TiC4Meow5MyCls9subscriptFT1iSi_Sf ---> Meow.MyCls.subscript(i: Swift.Int) -> Swift.Float
-_TF8manglingX22egbpdajGbuEbxfgehfvwxnFT_T_ ---> mangling.ليهمابتكلموشعربي؟() -> ()
-_TF8manglingX24ihqwcrbEcvIaIdqgAFGpqjyeFT_T_ ---> mangling.他们为什么不说中文() -> ()
-_TF8manglingX27ihqwctvzcJBfGFJdrssDxIboAybFT_T_ ---> mangling.他們爲什麽不說中文() -> ()
-_TF8manglingX30Proprostnemluvesky_uybCEdmaEBaFT_T_ ---> mangling.Pročprostěnemluvíčesky() -> ()
-_TF8manglingXoi7p_qcaDcFTSiSi_Si ---> mangling.«+» infix(Swift.Int, Swift.Int) -> Swift.Int
-_TF8manglingoi2qqFTSiSi_T_ ---> mangling.?? infix(Swift.Int, Swift.Int) -> ()
-_TFE11ext_structAV11def_structA1A4testfT_T_ ---> (extension in ext_structA):def_structA.A.test() -> ()
-_TF13devirt_accessP5_DISC15getPrivateClassFT_CS_P5_DISC12PrivateClass ---> devirt_access.(getPrivateClass in _DISC)() -> devirt_access.(PrivateClass in _DISC)
-_TF4mainP5_mainX3wxaFT_T_ ---> main.(λ in _main)() -> ()
-_TF4mainP5_main3abcFT_aS_P5_DISC3xyz ---> main.(abc in _main)() -> main.(xyz in _DISC)
+_TF8manglingX22egbpdajGbuEbxfgehfvwxnFT_T_ ---> mangling.ليهمابتكلموشعربي؟() -> () | {(9,43) - (43,45)}
+_TF8manglingX24ihqwcrbEcvIaIdqgAFGpqjyeFT_T_ ---> mangling.他们为什么不说中文() -> () | {(9,36) - (36,38)}
+_TF8manglingX27ihqwctvzcJBfGFJdrssDxIboAybFT_T_ ---> mangling.他們爲什麽不說中文() -> () | {(9,36) - (36,38)}
+_TF8manglingX30Proprostnemluvesky_uybCEdmaEBaFT_T_ ---> mangling.Pročprostěnemluvíčesky() -> () | {(9,35) - (35,37)}
+_TF8manglingXoi7p_qcaDcFTSiSi_Si ---> mangling.«+» infix(Swift.Int, Swift.Int) -> Swift.Int | {(9,20) - (20,42)}
+_TF8manglingoi2qqFTSiSi_T_ ---> mangling.?? infix(Swift.Int, Swift.Int) -> () | {(9,17) - (17,39)}
+_TFE11ext_structAV11def_structA1A4testfT_T_ ---> (extension in ext_structA):def_structA.A.test() -> () | {(41,45) - (45,47)}
+_TF13devirt_accessP5_DISC15getPrivateClassFT_CS_P5_DISC12PrivateClass ---> devirt_access.(getPrivateClass in _DISC)() -> devirt_access.(PrivateClass in _DISC) | {(14,40) - (40,42)}
+_TF4mainP5_mainX3wxaFT_T_ ---> main.(λ in _main)() -> () | {(5,18) - (18,20)}
+_TF4mainP5_main3abcFT_aS_P5_DISC3xyz ---> main.(abc in _main)() -> main.(xyz in _DISC) | {(5,19) - (19,21)}
 _TtPMP_ ---> Any.Type
-_TFCs13_NSSwiftArray29canStoreElementsOfDynamicTypefPMP_Sb ---> Swift._NSSwiftArray.canStoreElementsOfDynamicType(Any.Type) -> Swift.Bool
+_TFCs13_NSSwiftArray29canStoreElementsOfDynamicTypefPMP_Sb ---> Swift._NSSwiftArray.canStoreElementsOfDynamicType(Any.Type) -> Swift.Bool | {(20,49) - (49,59)}
 _TFCs13_NSSwiftArrayg17staticElementTypePMP_ ---> Swift._NSSwiftArray.staticElementType.getter : Any.Type
 _TFCs17_DictionaryMirrorg9valueTypePMP_ ---> Swift._DictionaryMirror.valueType.getter : Any.Type
-_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
-_TTSfq1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <serialized, Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
-_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TTSg5Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of generic specialization <Swift.Int> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
-_TTSg5Si___TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> generic specialization <Swift.Int> of function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
+_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(183,195) - (195,225)}
+_TTSfq1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <serialized, Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(195,207) - (207,237)}
+_TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TTSg5Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of generic specialization <Swift.Int> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(221,233) - (233,263)}
+_TTSg5Si___TTSf1cl35_TFF7specgen6callerFSiT_U_FTSiSi_T_Si___TF7specgen12take_closureFFTSiSi_T_T_ ---> generic specialization <Swift.Int> of function signature specialization <Arg[0] = [Closure Propagated : closure #1 (Swift.Int, Swift.Int) -> () in specgen.caller(Swift.Int) -> (), Argument Types : [Swift.Int]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(221,233) - (233,263)}
 _TTSf1cpfr24_TF8capturep6helperFSiT__n___TTRXFo_dSi_dT__XFo_iSi_dT__ ---> function signature specialization <Arg[0] = [Constant Propagated Function : capturep.helper(Swift.Int) -> ()]> of reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@unowned ()) to @callee_owned (@unowned Swift.Int) -> (@unowned ())
 _TTSf1cpfr24_TF8capturep6helperFSiT__n___TTRXFo_dSi_DT__XFo_iSi_DT__ ---> function signature specialization <Arg[0] = [Constant Propagated Function : capturep.helper(Swift.Int) -> ()]> of reabstraction thunk helper from @callee_owned (@in Swift.Int) -> (@unowned_inner_pointer ()) to @callee_owned (@unowned Swift.Int) -> (@unowned_inner_pointer ())
-_TTSf1cpi0_cpfl0_cpse0v4u123_cpg53globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8_cpfr36_TFtest_capture_propagation2_closure___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Constant Propagated Integer : 0], Arg[1] = [Constant Propagated Float : 0], Arg[2] = [Constant Propagated String : u8'u123'], Arg[3] = [Constant Propagated Global : globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8], Arg[4] = [Constant Propagated Function : _TFtest_capture_propagation2_closure]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> ()
-_TTSf0gs___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Owned To Guaranteed and Exploded> of Swift._LegacyStringCore._invariantCheck() -> ()
-_TTSf2g___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
-_TTSf2dg___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
-_TTSf2dgs___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
-_TTSf3d_i_d_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[2] = Dead, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
-_TTSf3d_i_n_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf1cpi0_cpfl0_cpse0v4u123_cpg53globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8_cpfr36_TFtest_capture_propagation2_closure___TF7specgen12take_closureFFTSiSi_T_T_ ---> function signature specialization <Arg[0] = [Constant Propagated Integer : 0], Arg[1] = [Constant Propagated Float : 0], Arg[2] = [Constant Propagated String : u8'u123'], Arg[3] = [Constant Propagated Global : globalinit_33_06E7F1D906492AE070936A9B58CBAE1C_token8], Arg[4] = [Constant Propagated Function : _TFtest_capture_propagation2_closure]> of specgen.take_closure((Swift.Int, Swift.Int) -> ()) -> () | {(357,369) - (369,399)}
+_TTSf0gs___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Owned To Guaranteed and Exploded> of Swift._LegacyStringCore._invariantCheck() -> () | {(105,120) - (120,122)}
+_TTSf2g___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(164,168) - (168,189)}
+_TTSf2dg___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(173,177) - (177,198)}
+_TTSf2dgs___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Owned To Guaranteed and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(186,190) - (190,211)}
+_TTSf3d_i_d_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[2] = Dead, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(209,213) - (213,234)}
+_TTSf3d_i_n_i_d_i___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead, Arg[1] = Value Promoted from Box, Arg[3] = Value Promoted from Box, Arg[4] = Dead, Arg[5] = Value Promoted from Box> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(194,198) - (198,219)}
 _TFIZvV8mangling10HasVarInit5stateSbiu_KT_Sb ---> implicit closure #1 : @autoclosure () -> Swift.Bool in variable initialization expression of static mangling.HasVarInit.state : Swift.Bool
-_TFFV23interface_type_mangling18GenericTypeContext23closureInGenericContexturFqd__T_L_3fooFTqd__x_T_ ---> foo #1 (A1, A) -> () in interface_type_mangling.GenericTypeContext.closureInGenericContext<A>(A1) -> ()
-_TFFV23interface_type_mangling18GenericTypeContextg31closureInGenericPropertyContextxL_3fooFT_x ---> foo #1 () -> A in interface_type_mangling.GenericTypeContext.closureInGenericPropertyContext.getter : A
-_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_23closureInGenericContextuRxS1_rfqd__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.closureInGenericContext<A where A: interface_type_mangling.GenericWitnessTest>(A1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
+_TFFV23interface_type_mangling18GenericTypeContext23closureInGenericContexturFqd__T_L_3fooFTqd__x_T_ ---> foo #1 (A1, A) -> () in interface_type_mangling.GenericTypeContext.closureInGenericContext<A>(A1) -> () | {(0,6) - (7,14)}
+_TFFV23interface_type_mangling18GenericTypeContextg31closureInGenericPropertyContextxL_3fooFT_x ---> foo #1 () -> A in interface_type_mangling.GenericTypeContext.closureInGenericPropertyContext.getter : A | {(0,6) - (7,9)}
+_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_23closureInGenericContextuRxS1_rfqd__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.closureInGenericContext<A where A: interface_type_mangling.GenericWitnessTest>(A1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling | {(64,87) - (142,146)}
 _TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_g31closureInGenericPropertyContextwx3Tee ---> protocol witness for interface_type_mangling.GenericWitnessTest.closureInGenericPropertyContext.getter : A.Tee in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
-_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_16twoParamsAtDepthu0_RxS1_rfTqd__1yqd_0__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.twoParamsAtDepth<A, B where A: interface_type_mangling.GenericWitnessTest>(A1, y: B1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling
-_TFC3red11BaseClassEHcfzT1aSi_S0_ ---> red.BaseClassEH.init(a: Swift.Int) throws -> red.BaseClassEH
+_TTWurGV23interface_type_mangling18GenericTypeContextx_S_18GenericWitnessTestS_FS1_16twoParamsAtDepthu0_RxS1_rfTqd__1yqd_0__T_ ---> protocol witness for interface_type_mangling.GenericWitnessTest.twoParamsAtDepth<A, B where A: interface_type_mangling.GenericWitnessTest>(A1, y: B1) -> () in conformance <A> interface_type_mangling.GenericTypeContext<A> : interface_type_mangling.GenericWitnessTest in interface_type_mangling | {(64,80) - (138,149)}
+_TFC3red11BaseClassEHcfzT1aSi_S0_ ---> red.BaseClassEH.init(a: Swift.Int) throws -> red.BaseClassEH | {(16,20) - (20,34)}
 _TFe27mangling_generic_extensionsRxS_8RunciblerVS_3Foog1aSi ---> (extension in mangling_generic_extensions):mangling_generic_extensions.Foo<A where A: mangling_generic_extensions.Runcible>.a.getter : Swift.Int
 _TFe27mangling_generic_extensionsRxS_8RunciblerVS_3Foog1bx ---> (extension in mangling_generic_extensions):mangling_generic_extensions.Foo<A where A: mangling_generic_extensions.Runcible>.b.getter : A
 _TTRXFo_iT__iT_zoPs5Error__XFo__dT_zoPS___ ---> reabstraction thunk helper from @callee_owned () -> (@unowned (), @error @owned Swift.Error) to @callee_owned (@in ()) -> (@out (), @error @owned Swift.Error)
 _TFE1a ---> _TFE1a
 _TF21$__lldb_module_for_E0au3$E0Ps5Error_ ---> $__lldb_module_for_E0.$E0.unsafeMutableAddressor : Swift.Error
 _TMps10Comparable ---> protocol descriptor for Swift.Comparable
-_TFC4testP33_83378C430F65473055F1BD53F3ADCDB71C5doFoofT_T_ ---> test.(C in _83378C430F65473055F1BD53F3ADCDB7).doFoo() -> ()
-_TFVV15nested_generics5Lunch6DinnerCfT11firstCoursex12secondCourseGSqqd___9leftoversx14transformationFxqd___GS1_x_qd___ ---> nested_generics.Lunch.Dinner.init(firstCourse: A, secondCourse: A1?, leftovers: A, transformation: (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1>
-_TFVFC15nested_generics7HotDogs11applyRelishFT_T_L_6RelishCfT8materialx_GS1_x_ ---> init(material: A) -> Relish #1 in nested_generics.HotDogs.applyRelish() -> ()<A> in Relish #1 in nested_generics.HotDogs.applyRelish() -> ()
-_TFVFE15nested_genericsSS3fooFT_T_L_6CheeseCfT8materialx_GS0_x_ ---> init(material: A) -> Cheese #1 in (extension in nested_generics):Swift.String.foo() -> ()<A> in Cheese #1 in (extension in nested_generics):Swift.String.foo() -> ()
+_TFC4testP33_83378C430F65473055F1BD53F3ADCDB71C5doFoofT_T_ ---> test.(C in _83378C430F65473055F1BD53F3ADCDB7).doFoo() -> () | {(46,51) - (51,53)}
+_TFVV15nested_generics5Lunch6DinnerCfT11firstCoursex12secondCourseGSqqd___9leftoversx14transformationFxqd___GS1_x_qd___ ---> nested_generics.Lunch.Dinner.init(firstCourse: A, secondCourse: A1?, leftovers: A, transformation: (A) -> A1) -> nested_generics.Lunch<A>.Dinner<A1> | {(29,33) - (33,109)}
+_TFVFC15nested_generics7HotDogs11applyRelishFT_T_L_6RelishCfT8materialx_GS1_x_ ---> init(material: A) -> Relish #1 in nested_generics.HotDogs.applyRelish() -> ()<A> in Relish #1 in nested_generics.HotDogs.applyRelish() -> () | {(0,4) - (4,17)}
+_TFVFE15nested_genericsSS3fooFT_T_L_6CheeseCfT8materialx_GS0_x_ ---> init(material: A) -> Cheese #1 in (extension in nested_generics):Swift.String.foo() -> ()<A> in Cheese #1 in (extension in nested_generics):Swift.String.foo() -> () | {(0,4) - (4,17)}
 _TTWOE5imojiCSo5Imoji14ImojiMatchRankS_9RankValueS_FS2_g9rankValueqq_Ss16RawRepresentable8RawValue ---> _TTWOE5imojiCSo5Imoji14ImojiMatchRankS_9RankValueS_FS2_g9rankValueqq_Ss16RawRepresentable8RawValue
-_T0s17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD05Indexs01_A9IndexablePQzAM15shiftingToStart_tFAJs01_J4BasePQzAQcfU_ ---> closure #1 (A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index
-_$Ss17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD015shiftingToStart5Indexs01_A9IndexablePQzAN_tFAKs01_M4BasePQzAQcfU_ ---> closure #1 (A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index
+_T0s17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD05Indexs01_A9IndexablePQzAM15shiftingToStart_tFAJs01_J4BasePQzAQcfU_ ---> closure #1 (A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index | {(0,10) - (11,41)}
+_$Ss17MutableCollectionP1asAARzs012RandomAccessB0RzsAA11SubSequences013BidirectionalB0PRpzsAdHRQlE06rotatecD015shiftingToStart5Indexs01_A9IndexablePQzAN_tFAKs01_M4BasePQzAQcfU_ ---> closure #1 (A.Swift._IndexableBase.Index) -> A.Swift._IndexableBase.Index in (extension in a):Swift.MutableCollection<A where A: Swift.MutableCollection, A: Swift.RandomAccessCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.MutableCollection, A.Swift.BidirectionalCollection.SubSequence: Swift.RandomAccessCollection>.rotateRandomAccess(shiftingToStart: A.Swift._MutableIndexable.Index) -> A.Swift._MutableIndexable.Index | {(0,10) - (11,41)}
 _T03foo4_123ABTf3psbpsb_n ---> function signature specialization <Arg[0] = [Constant Propagated String : u8'123'], Arg[1] = [Constant Propagated String : u8'123']> of foo
-_T04main5innerys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> ()
-_$S4main5inneryys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> ()
-_T03foo6testityyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> ()
-_$S3foo6testityyyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> ()
+_T04main5innerys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> () | {(151,156) - (156,196)}
+_$S4main5inneryys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n ---> function signature specialization <Arg[1] = [Closure Propagated : closure_with_box_argument, Argument Types : [<A> { var A } <Builtin.Int32>]> of main.inner(inout Swift.Int32, (Swift.Int32) -> ()) -> () | {(151,156) - (156,196)}
+_T03foo6testityyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> () | {(132,138) - (138,158)}
+_$S3foo6testityyyyc_yyctF1a1bTf3pfpf_n ---> function signature specialization <Arg[0] = [Constant Propagated Function : a], Arg[1] = [Constant Propagated Function : b]> of foo.testit(() -> (), () -> ()) -> () | {(132,138) - (138,158)}
 _SocketJoinOrLeaveMulticast ---> _SocketJoinOrLeaveMulticast
-_T0s10DictionaryV3t17E6Index2V1loiSbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool
-_T08mangling14varargsVsArrayySi3arrd_SS1ntF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> ()
-_T08mangling14varargsVsArrayySaySiG3arr_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> ()
-_T08mangling14varargsVsArrayySaySiG3arrd_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> ()
-_T08mangling14varargsVsArrayySi3arrd_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> ()
-_T08mangling14varargsVsArrayySaySiG3arrd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> ()
-_$Ss10DictionaryV3t17E6Index2V1loiySbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool
-_$S8mangling14varargsVsArray3arr1nySid_SStF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> ()
-_$S8mangling14varargsVsArray3arr1nySaySiG_SStF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> ()
-_$S8mangling14varargsVsArray3arr1nySaySiGd_SStF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> ()
-_$S8mangling14varargsVsArray3arrySid_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> ()
-_$S8mangling14varargsVsArray3arrySaySiGd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> ()
+_T0s10DictionaryV3t17E6Index2V1loiSbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool | {(50,57) - (57,127)}
+_T08mangling14varargsVsArrayySi3arrd_SS1ntF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> () | {(9,23) - (23,59)}
+_T08mangling14varargsVsArrayySaySiG3arr_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> () | {(9,23) - (23,58)}
+_T08mangling14varargsVsArrayySaySiG3arrd_SS1ntF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> () | {(9,23) - (23,61)}
+_T08mangling14varargsVsArrayySi3arrd_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> () | {(9,23) - (23,42)}
+_T08mangling14varargsVsArrayySaySiG3arrd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> () | {(9,23) - (23,44)}
+_$Ss10DictionaryV3t17E6Index2V1loiySbAEyxq__G_AGtFZ ---> static (extension in t17):Swift.Dictionary.Index2.< infix((extension in t17):[A : B].Index2, (extension in t17):[A : B].Index2) -> Swift.Bool | {(50,57) - (57,127)}
+_$S8mangling14varargsVsArray3arr1nySid_SStF ---> mangling.varargsVsArray(arr: Swift.Int..., n: Swift.String) -> () | {(9,23) - (23,59)}
+_$S8mangling14varargsVsArray3arr1nySaySiG_SStF ---> mangling.varargsVsArray(arr: [Swift.Int], n: Swift.String) -> () | {(9,23) - (23,58)}
+_$S8mangling14varargsVsArray3arr1nySaySiGd_SStF ---> mangling.varargsVsArray(arr: [Swift.Int]..., n: Swift.String) -> () | {(9,23) - (23,61)}
+_$S8mangling14varargsVsArray3arrySid_tF ---> mangling.varargsVsArray(arr: Swift.Int...) -> () | {(9,23) - (23,42)}
+_$S8mangling14varargsVsArray3arrySaySiGd_tF ---> mangling.varargsVsArray(arr: [Swift.Int]...) -> () | {(9,23) - (23,44)}
 _T0s13_UnicodeViewsVss22RandomAccessCollectionRzs0A8EncodingR_11SubSequence_5IndexQZAFRtzsAcERpzAE_AEQZAIRSs15UnsignedInteger8Iterator_7ElementRPzAE_AlMQZANRS13EncodedScalar_AlMQY_AORSr0_lE13CharacterViewVyxq__G ---> (extension in Swift):Swift._UnicodeViews<A, B><A, B where A: Swift.RandomAccessCollection, B: Swift.UnicodeEncoding, A.Index == A.SubSequence.Index, A.SubSequence: Swift.RandomAccessCollection, A.SubSequence == A.SubSequence.SubSequence, A.Iterator.Element: Swift.UnsignedInteger, A.Iterator.Element == A.SubSequence.Iterator.Element, A.SubSequence.Iterator.Element == B.EncodedScalar.Iterator.Element>.CharacterView
-_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
-_$S10Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiySbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool
-_T04main1_yyF ---> main._() -> ()
-_T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int
-_$S4test6testitySiyt_tF ---> test.testit(()) -> Swift.Int
+_T010Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiSbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool | {(98,106) - (106,264)}
+_$S10Foundation11MeasurementV12SimulatorKitSo9UnitAngleCRszlE11OrientationO2eeoiySbAcDEAGOyAF_G_AKtFZ ---> static (extension in SimulatorKit):Foundation.Measurement<A where A == __C.UnitAngle>.Orientation.== infix((extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation, (extension in SimulatorKit):Foundation.Measurement<__C.UnitAngle>.Orientation) -> Swift.Bool | {(98,106) - (106,264)}
+_T04main1_yyF ---> main._() -> () | {(5,6) - (6,8)}
+_T04test6testitSiyt_tF ---> test.testit(()) -> Swift.Int | {(5,11) - (11,15)}
+_$S4test6testitySiyt_tF ---> test.testit(()) -> Swift.Int | {(5,11) - (11,15)}
 _T08_ElementQzSbs5Error_pIxxdzo_ABSbsAC_pIxidzo_s26RangeReplaceableCollectionRzABRLClTR ---> {T:} reabstraction thunk helper <A where A: Swift.RangeReplaceableCollection, A._Element: AnyObject> from @callee_owned (@owned A._Element) -> (@unowned Swift.Bool, @error @owned Swift.Error) to @callee_owned (@in A._Element) -> (@unowned Swift.Bool, @error @owned Swift.Error)
 _T0Ix_IyB_Tr ---> {T:} reabstraction thunk from @callee_owned () -> () to @callee_unowned @convention(block) () -> ()
 _T0Rml ---> _T0Rml
 _T0Tk ---> _T0Tk
 _T0A8 ---> _T0A8
 _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n ---> _T0s30ReversedRandomAccessCollectionVyxGTfq3nnpf_nTfq1cn_nTfq4x_n
-_T03abc6testitySiFTm ---> merged abc.testit(Swift.Int) -> ()
-_T04main4TestCACSi1x_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test
-_$S3abc6testityySiFTm ---> merged abc.testit(Swift.Int) -> ()
-_$S4main4TestC1xACSi_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test
+_T03abc6testitySiFTm ---> merged abc.testit(Swift.Int) -> () | {(11,17) - (17,28)}
+_T04main4TestCACSi1x_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test | {(10,26) - (26,40)}
+_$S3abc6testityySiFTm ---> merged abc.testit(Swift.Int) -> () | {(11,17) - (17,28)}
+_$S4main4TestC1xACSi_tc6_PRIV_Llfc ---> main.Test.(in _PRIV_).init(x: Swift.Int) -> main.Test | {(10,26) - (26,40)}
 _T0SqWOy.17 ---> outlined copy of Swift.Optional with unmangled suffix ".17"
 _T0SqWOC ---> outlined init with copy of Swift.Optional
 _T0SqWOD ---> outlined assign with take of Swift.Optional
 _T0SqWOF ---> outlined assign with copy of Swift.Optional
 _T0SqWOH ---> outlined destroy of Swift.Optional
-_T03nix6testitSaySiGyFTv_ ---> outlined variable #0 of nix.testit() -> [Swift.Int]
-_T03nix6testitSaySiGyFTv_r ---> outlined read-only object #0 of nix.testit() -> [Swift.Int]
-_T03nix6testitSaySiGyFTv0_ ---> outlined variable #1 of nix.testit() -> [Swift.Int]
+_T03nix6testitSaySiGyFTv_ ---> outlined variable #0 of nix.testit() -> [Swift.Int] | {(28,34) - (34,36)}
+_T03nix6testitSaySiGyFTv_r ---> outlined read-only object #0 of nix.testit() -> [Swift.Int] | {(36,42) - (42,44)}
+_T03nix6testitSaySiGyFTv0_ ---> outlined variable #1 of nix.testit() -> [Swift.Int] | {(28,34) - (34,36)}
 _T0So11UITextFieldC4textSSSgvgToTepb_ ---> outlined bridged method (pb) of @objc __C.UITextField.text.getter : Swift.String?
 _T0So11UITextFieldC4textSSSgvgToTeab_ ---> outlined bridged method (ab) of @objc __C.UITextField.text.getter : Swift.String?
-$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_ ---> outlined bridged method (mbgnn) of @objc __C.Gizmo.doSomething([Swift.String]?) -> Any?
+$sSo5GizmoC11doSomethingyypSgSaySSGSgFToTembgnn_ ---> outlined bridged method (mbgnn) of @objc __C.Gizmo.doSomething([Swift.String]?) -> Any? | {(51,62) - (62,79)}
 _T04test1SVyxGAA1RA2A1ZRzAA1Y2ZZRpzl1A_AhaGPWT ---> {C} associated type witness table accessor for A.ZZ : test.Y in <A where A: test.Z, A.ZZ: test.Y> test.S<A> : test.R in test
-_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfC ---> {T:_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfc} Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69).init() -> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69)
+_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfC ---> {T:_T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfc} Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69).init() -> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69) | {(70,74) - (74,76)}
 _T0D ---> _T0D
-_T0s18EnumeratedIteratorVyxGs8Sequencess0B8ProtocolRzlsADP5splitSay03SubC0QzGSi9maxSplits_Sb25omittingEmptySubsequencesSb7ElementQzKc14whereSeparatortKFTW ---> {T:} protocol witness for Swift.Sequence.split(maxSplits: Swift.Int, omittingEmptySubsequences: Swift.Bool, whereSeparator: (A.Element) throws -> Swift.Bool) throws -> [A.SubSequence] in conformance <A where A: Swift.IteratorProtocol> Swift.EnumeratedIterator<A> : Swift.Sequence in Swift
+_T0s18EnumeratedIteratorVyxGs8Sequencess0B8ProtocolRzlsADP5splitSay03SubC0QzGSi9maxSplits_Sb25omittingEmptySubsequencesSb7ElementQzKc14whereSeparatortKFTW ---> {T:} protocol witness for Swift.Sequence.split(maxSplits: Swift.Int, omittingEmptySubsequences: Swift.Bool, whereSeparator: (A.Element) throws -> Swift.Bool) throws -> [A.SubSequence] in conformance <A where A: Swift.IteratorProtocol> Swift.EnumeratedIterator<A> : Swift.Sequence in Swift | {(36,41) - (41,152)}
 _T0s3SetVyxGs10CollectiotySivm ---> _T0s3SetVyxGs10CollectiotySivm
 _S$s3SetVyxGs10CollectiotySivm ---> _S$s3SetVyxGs10CollectiotySivm
 _T0s18ReversedCollectionVyxGs04LazyB8ProtocolfC ---> _T0s18ReversedCollectionVyxGs04LazyB8ProtocolfC
@@ -322,17 +322,17 @@ $S28protocol_conformance_records15NativeValueTypeVAA8RuncibleAAMc ---> protocol 
 $ss6SimpleHr ---> protocol descriptor runtime record for Swift.Simple
 $ss5OtherVs6SimplesHc ---> protocol conformance descriptor runtime record for Swift.Other : Swift.Simple in Swift
 $ss5OtherVHn ---> nominal type descriptor runtime record for Swift.Other
-$s18opaque_return_type3fooQryFQOHo ---> opaque type descriptor runtime record for <<opaque return type of opaque_return_type.foo() -> some>>
+$s18opaque_return_type3fooQryFQOHo ---> opaque type descriptor runtime record for <<opaque return type of opaque_return_type.foo() -> some>> | {(85,88) - (88,90)}
 $SSC9SomeErrorLeVD ---> __C_Synthesized.related decl 'e' for SomeError
-$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PAAyHCg_AiJ1QAAyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
-$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHPyHCg_AiJ1QHPyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
-$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHpyHCg_AiJ1QHpyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> ()
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PAAyHCg_AiJ1QAAyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> () | {(21,26) - (26,93)}
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHPyHCg_AiJ1QHPyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> () | {(21,26) - (26,93)}
+$s20mangling_retroactive5test0yyAA1ZVy12RetroactiveB1XVSiAE1YVAG0D1A1PHpyHCg_AiJ1QHpyHCg1_GF ---> mangling_retroactive.test0(mangling_retroactive.Z<RetroactiveB.X, Swift.Int, RetroactiveB.Y>) -> () | {(21,26) - (26,93)}
 _T0LiteralAByxGxd_tcfC ---> _T0LiteralAByxGxd_tcfC
 _T0XZ ---> _T0XZ
-_TTSf0os___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Guaranteed To Owned and Exploded> of Swift._LegacyStringCore._invariantCheck() -> ()
-_TTSf2o___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
-_TTSf2do___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
-_TTSf2dos___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore
+_TTSf0os___TFVs17_LegacyStringCore15_invariantCheckfT_T_ ---> function signature specialization <Arg[0] = Guaranteed To Owned and Exploded> of Swift._LegacyStringCore._invariantCheck() -> () | {(105,120) - (120,122)}
+_TTSf2o___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(164,168) - (168,189)}
+_TTSf2do___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(173,177) - (177,198)}
+_TTSf2dos___TTSf2s_d___TFVs17_LegacyStringCoreCfVs13_StringBufferS_ ---> function signature specialization <Arg[0] = Dead and Guaranteed To Owned and Exploded> of function signature specialization <Arg[0] = Exploded, Arg[1] = Dead> of Swift._LegacyStringCore.init(Swift._StringBuffer) -> Swift._LegacyStringCore | {(186,190) - (190,211)}
 _TTSf ---> _TTSf
 _TtW0_j ---> _TtW0_j
 _TtW_4m3a3v ---> _TtW_4m3a3v
@@ -343,39 +343,36 @@ _$S3BBBBf0602365061_ ---> _$S3BBBBf0602365061_
 _$S3BBBBi0602365061_ ---> _$S3BBBBi0602365061_
 _$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
 _T0lxxxmmmTk ---> _T0lxxxmmmTk
-_TtCF4test11doNotCrash1FT_QuL_8MyClass1 ---> MyClass1 #1 in test.doNotCrash1() -> some
+_TtCF4test11doNotCrash1FT_QuL_8MyClass1 ---> MyClass1 #1 in test.doNotCrash1() -> some | {(20,31) - (31,33)}
 $s3Bar3FooVAA5DrinkVyxGs5Error_pSeRzSERzlyShy4AbcdAHO6MemberVGALSeHPAKSeAAyHC_HCg_ALSEHPAKSEAAyHC_HCg0_Iseggozo_SgWOe ---> outlined consume of (@escaping @callee_guaranteed @substituted <A where A: Swift.Decodable, A: Swift.Encodable> (@guaranteed Bar.Foo) -> (@owned Bar.Drink<A>, @error @owned Swift.Error) for <Swift.Set<Abcd.Abcd.Member>>)?
-$s4Test5ProtoP8IteratorV10collectionAEy_qd__Gqd___tcfc ---> Test.Proto.Iterator.init(collection: A1) -> Test.Proto.Iterator<A1>
-$s4test3fooV4blahyAA1SV1fQryFQOy_Qo_AHF ---> test.foo.blah(<<opaque return type of test.S.f() -> some>>.0) -> <<opaque return type of test.S.f() -> some>>.0
-$S3nix8MystructV1xACyxGx_tcfc7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.init(x: A) -> nix.Mystruct<A>
+$s4Test5ProtoP8IteratorV10collectionAEy_qd__Gqd___tcfc ---> Test.Proto.Iterator.init(collection: A1) -> Test.Proto.Iterator<A1> | {(20,24) - (24,40)}
+$s4test3fooV4blahyAA1SV1fQryFQOy_Qo_AHF ---> test.foo.blah(<<opaque return type of test.S.f() -> some>>.0) -> <<opaque return type of test.S.f() -> some>>.0 | {(9,13) - (13,61)}
+$S3nix8MystructV1xACyxGx_tcfc7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.init(x: A) -> nix.Mystruct<A> | {(30,34) - (34,40)}
 $S3nix7MyclassCfd7MyaliasL_ayx__GD ---> Myalias #1 in nix.Myclass<A>.deinit
 $S3nix8MystructVyS2icig7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.subscript.getter : (Swift.Int) -> Swift.Int
 $S3nix8MystructV1x1uACyxGx_qd__tclufc7MyaliasL_ayx_qd___GD ---> Myalias #1 in nix.Mystruct<A>.<A1>(x: A, u: A1) -> nix.Mystruct<A>
-$S3nix8MystructV6testit1xyx_tF7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.testit(x: A) -> ()
-$S3nix8MystructV6testit1x1u1vyx_qd__qd_0_tr0_lF7MyaliasL_ayx_qd__qd_0__GD ---> Myalias #1 in nix.Mystruct<A>.testit<A1, B1>(x: A, u: A1, v: B1) -> ()
+$S3nix8MystructV6testit1xyx_tF7MyaliasL_ayx__GD ---> Myalias #1 in nix.Mystruct<A>.testit(x: A) -> () | {(30,36) - (36,42)}
+$S3nix8MystructV6testit1x1u1vyx_qd__qd_0_tr0_lF7MyaliasL_ayx_qd__qd_0__GD ---> Myalias #1 in nix.Mystruct<A>.testit<A1, B1>(x: A, u: A1, v: B1) -> () | {(30,36) - (44,64)}
 $S4blah8PatatinoaySiGD ---> blah.Patatino<Swift.Int>
 $SSiSHsWP ---> protocol witness table for Swift.Int : Swift.Hashable in Swift
 $S7TestMod5OuterV3Fooayx_SiGD ---> TestMod.Outer<A>.Foo<Swift.Int>
 $Ss17_VariantSetBufferO05CocoaC0ayx_GD ---> Swift._VariantSetBuffer<A>.CocoaBuffer
 $S2t21QP22ProtocolTypeAliasThingayAA4BlahV5SomeQa_GSgD ---> t2.Blah.SomeQ as t2.Q.ProtocolTypeAliasThing?
-$s1A1gyyxlFx_qd__t_Ti5 ---> inlined generic function <(A, A1)> of A.g<A>(A) -> ()
+$s1A1gyyxlFx_qd__t_Ti5 ---> inlined generic function <(A, A1)> of A.g<A>(A) -> () | {(40,41) - (44,47)}
 $S1T19protocol_resilience17ResilientProtocolPTl ---> associated type descriptor for protocol_resilience.ResilientProtocol.T
 $S18resilient_protocol21ResilientBaseProtocolTL ---> protocol requirements base descriptor for resilient_protocol.ResilientBaseProtocol
 $S1t1PP10AssocType2_AA1QTn ---> associated conformance descriptor for t.P.AssocType2: t.Q
 $S1t1PP10AssocType2_AA1QTN ---> default associated conformance accessor for t.P.AssocType2: t.Q
-$s4Test6testityyxlFAA8MystructV_TB5 ---> generic specialization <Test.Mystruct> of Test.testit<A>(A) -> ()
-$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A
-$s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> ()
+$s4Test6testityyxlFAA8MystructV_TB5 ---> generic specialization <Test.Mystruct> of Test.testit<A>(A) -> () | {(47,53) - (56,59)}
+$sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specialization <Swift.UInt, Swift.Int> of (extension in Swift):Swift.UnsignedInteger< where A: Swift.FixedWidthInteger>.init<A where A1: Swift.BinaryInteger>(A1) -> A | {(128,132) - (165,169)}
+$s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> () | {(55,62) - (68,74)}
 $sSD5IndexVy__GD ---> $sSD5IndexVy__GD
-$s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str
-@$s8keypaths1KV3valACSi_tcfcACmTkmu : $@convention(keypath_accessor_getter) (@in_guaranteed @thick K.Type) -> @out @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int, K>)
-@$s8keypaths1KVACycfcACmTkMA : $@convention(keypath_accessor_getter) (@in_guaranteed @thick K.Type) -> @out K)
-$s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq  ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized
-$s18resilient_protocol24ResilientDerivedProtocolPxAA0c4BaseE0Tn --> associated conformance descriptor for resilient_protocol.ResilientDerivedProtocol.A: resilient_protocol.ResilientBaseProtocol
-$s3red4testyAA3ResOyxSayq_GAEs5ErrorAAq_sAFHD1__HCg_GADyxq_GsAFR_r0_lF ---> red.test<A, B where B: Swift.Error>(red.Res<A, B>) -> red.Res<A, [B]>
-$s3red4testyAA7OurTypeOy4them05TheirD0Vy5AssocQzGAjE0F8ProtocolAAxAA0c7DerivedH0HD1_AA0c4BaseH0HI1_AieKHA2__HCg_GxmAaLRzlF ---> red.test<A where A: red.OurDerivedProtocol>(A.Type) -> red.OurType<them.TheirType<A.Assoc>>
+$s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str | {(9,26) - (26,28)}
+$s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized
+$s3red4testyAA3ResOyxSayq_GAEs5ErrorAAq_sAFHD1__HCg_GADyxq_GsAFR_r0_lF ---> red.test<A, B where B: Swift.Error>(red.Res<A, B>) -> red.Res<A, [B]> | {(4,8) - (35,50)}
+$s3red4testyAA7OurTypeOy4them05TheirD0Vy5AssocQzGAjE0F8ProtocolAAxAA0c7DerivedH0HD1_AA0c4BaseH0HI1_AieKHA2__HCg_GxmAaLRzlF ---> red.test<A where A: red.OurDerivedProtocol>(A.Type) -> red.OurType<them.TheirType<A.Assoc>> | {(4,8) - (43,51)}
 $s17property_wrappers10WithTuplesV9fractionsSd_S2dtvpfP ---> property wrapper backing initializer of property_wrappers.WithTuples.fractions : (Swift.Double, Swift.Double, Swift.Double)
-$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTOTA ---> {T:$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTO} partial apply forwarder for @nonobjc __C.OS_dispatch_queue.sync(execute: () -> ()) -> ()
+$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTOTA ---> {T:$sSo17OS_dispatch_queueC4sync7executeyyyXE_tFTO} partial apply forwarder for @nonobjc __C.OS_dispatch_queue.sync(execute: () -> ()) -> () | {(59,63) - (63,82)}
 $s4main1gyySiXCvp ---> main.g : @convention(c) (Swift.Int) -> ()
 $s4main1gyySiXBvp ---> main.g : @convention(block) (Swift.Int) -> ()
 $sxq_Ifgnr_D ---> @differentiable(_forward) @callee_guaranteed (@in_guaranteed A) -> (@out B)
@@ -387,60 +384,56 @@ $sS5fIertyyywddw_D ---> @escaping @differentiable(reverse) @convention(thin) (@u
 $syQo ---> $syQo
 $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee ---> $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee
 $sx1td_t ---> (t: A...)
-$s7example1fyyYaF ---> example.f() async -> ()
-$s7example1fyyYaKF ---> example.f() async throws -> ()
-s7example1fyyYjfYaKF -> example.f@differentiable(_forward) () async throws -> ()
-s7example1fyyYjrYaKF -> example.f@differentiable(reverse) () async throws -> ()
-s7example1fyyYjdYaKF -> example.f@differentiable () async throws -> ()
-s7example1fyyYjlYaKF -> example.f@differentiable(_linear) () async throws -> ()
-$s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> ()
-$s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE
-$s4main6testityyYaFTu ---> async function pointer to main.testit() async -> ()
-$s13test_mangling3fooyS2f_S2ftFTJfUSSpSr ---> forward-mode derivative of test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {1, 2} and results {0}
-$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
-$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJVrSpSr ---> vtable thunk for reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
-$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSr ---> pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
-$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFTSAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of protocol self-conformance witness for test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P>
-$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTj ---> dispatch thunk of pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
-$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTq ---> method descriptor for pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
+$s7example1fyyYaF ---> example.f() async -> () | {(8,9) - (9,11)}
+$s7example1fyyYaKF ---> example.f() async throws -> () | {(8,9) - (9,11)}
+$s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> () | {(5,25) - (25,71)}
+$s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE | {(5,24) - (24,26)}
+$s4main6testityyYaFTu ---> async function pointer to main.testit() async -> () | {(31,37) - (37,39)}
+$s13test_mangling3fooyS2f_S2ftFTJfUSSpSr ---> forward-mode derivative of test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {1, 2} and results {0} | {(41,44) - (44,83)}
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P> | {(41,45) - (126,132)}
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFAdERzAdER_AafGRpzAafHRQr0_lTJVrSpSr ---> vtable thunk for reverse-mode derivative of test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P> | {(58,62) - (143,149)}
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSr ---> pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable> | {(26,29) - (76,95)}
+$s13test_mangling4foo21xq_x_t16_Differentiation14DifferentiableR_AA1P13TangentVectorRp_r0_lFTSAdERzAdER_AafGRpzAafHRQr0_lTJrSpSr ---> reverse-mode derivative of protocol self-conformance witness for test_mangling.foo2<A, B where B: _Differentiation.Differentiable, B.TangentVector: test_mangling.P>(x: A) -> B with respect to parameters {0} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, A.TangentVector: test_mangling.P, B.TangentVector: test_mangling.P> | {(79,83) - (164,170)}
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTj ---> dispatch thunk of pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable> | {(44,47) - (94,113)}
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lTJpUSSpSrTq ---> method descriptor for pullback of test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable> | {(48,51) - (98,117)}
 $s13TangentVector16_Differentiation14DifferentiablePQzAaDQy_SdAFIegnnnr_TJSdSSSpSrSUSP ---> autodiff subset parameters thunk for differential from @escaping @callee_guaranteed (@in_guaranteed A._Differentiation.Differentiable.TangentVector, @in_guaranteed B._Differentiation.Differentiable.TangentVector, @in_guaranteed Swift.Double) -> (@out B._Differentiation.Differentiable.TangentVector) with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2}
 $s13TangentVector16_Differentiation14DifferentiablePQy_AaDQzAESdIegnrrr_TJSpSSSpSrSUSP ---> autodiff subset parameters thunk for pullback from @escaping @callee_guaranteed (@in_guaranteed B._Differentiation.Differentiable.TangentVector) -> (@out A._Differentiation.Differentiable.TangentVector, @out B._Differentiation.Differentiable.TangentVector, @out Swift.Double) with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2}
-$s39differentiation_subset_parameters_thunk19inoutIndirectCalleryq_x_q_q0_t16_Differentiation14DifferentiableRzAcDR_AcDR0_r1_lFxq_Sdq_xq_Sdr0_ly13TangentVectorAcDPQy_AeFQzIsegnrr_Iegnnnro_TJSrSSSpSrSUSP ---> autodiff subset parameters thunk for reverse-mode derivative from differentiation_subset_parameters_thunk.inoutIndirectCaller<A, B, C where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, C: _Differentiation.Differentiable>(A, B, C) -> B with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2} of type @escaping @callee_guaranteed (@in_guaranteed A, @in_guaranteed B, @in_guaranteed Swift.Double) -> (@out B, @owned @escaping @callee_guaranteed @substituted <A, B> (@in_guaranteed A) -> (@out B, @out Swift.Double) for <B._Differentiation.Differentiable.TangentVectorA._Differentiation.Differentiable.TangentVector>)
+$s39differentiation_subset_parameters_thunk19inoutIndirectCalleryq_x_q_q0_t16_Differentiation14DifferentiableRzAcDR_AcDR0_r1_lFxq_Sdq_xq_Sdr0_ly13TangentVectorAcDPQy_AeFQzIsegnrr_Iegnnnro_TJSrSSSpSrSUSP ---> autodiff subset parameters thunk for reverse-mode derivative from differentiation_subset_parameters_thunk.inoutIndirectCaller<A, B, C where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable, C: _Differentiation.Differentiable>(A, B, C) -> B with respect to parameters {0, 1, 2} and results {0} to parameters {0, 2} of type @escaping @callee_guaranteed (@in_guaranteed A, @in_guaranteed B, @in_guaranteed Swift.Double) -> (@out B, @owned @escaping @callee_guaranteed @substituted <A, B> (@in_guaranteed A) -> (@out B, @out Swift.Double) for <B._Differentiation.Differentiable.TangentVectorA._Differentiation.Differentiable.TangentVector>) | {(106,125) - (247,256)}
 $sS2f8mangling3FooV13TangentVectorVIegydd_SfAESfIegydd_TJOp ---> autodiff self-reordering reabstraction thunk for pullback from @escaping @callee_guaranteed (@unowned Swift.Float) -> (@unowned Swift.Float, @unowned mangling.Foo.TangentVector) to @escaping @callee_guaranteed (@unowned Swift.Float) -> (@unowned mangling.Foo.TangentVector, @unowned Swift.Float)
-$s13test_mangling3fooyS2f_S2ftFWJrSpSr ---> reverse-mode differentiability witness for test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {0} and results {0}
-$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lWJrUSSpSr ---> reverse-mode differentiability witness for test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable>
-$s5async1hyyS2iYbXEF ---> async.h(@Sendable (Swift.Int) -> Swift.Int) -> ()
-$s5Actor02MyA0C17testAsyncFunctionyyYaKFTY0_ ---> (1) suspend resume partial function for Actor.MyActor.testAsyncFunction() async throws -> ()
-$s5Actor02MyA0C17testAsyncFunctionyyYaKFTQ1_ ---> (2) await resume partial function for Actor.MyActor.testAsyncFunction() async throws -> ()
-$s4diff1hyyS2iYjfXEF ---> diff.h(@differentiable(_forward) (Swift.Int) -> Swift.Int) -> ()
-$s4diff1hyyS2iYjrXEF ---> diff.h(@differentiable(reverse) (Swift.Int) -> Swift.Int) -> ()
-$s4diff1hyyS2iYjdXEF ---> diff.h(@differentiable (Swift.Int) -> Swift.Int) -> ()
-$s4diff1hyyS2iYjlXEF ---> diff.h(@differentiable(_linear) (Swift.Int) -> Swift.Int) -> ()
-$s4test3fooyyS2f_SfYkztYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, inout @noDerivative Swift.Float) -> Swift.Float) -> ()
-$s4test3fooyyS2f_SfYkntYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, __owned @noDerivative Swift.Float) -> Swift.Float) -> ()
-$s4test3fooyyS2f_SfYktYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, @noDerivative Swift.Float) -> Swift.Float) -> ()
-$s4test3fooyyS2f_SfYktYaYbYjrXEF ---> test.foo(@differentiable(reverse) @Sendable (Swift.Float, @noDerivative Swift.Float) async -> Swift.Float) -> ()
+$s13test_mangling3fooyS2f_S2ftFWJrSpSr ---> reverse-mode differentiability witness for test_mangling.foo(Swift.Float, Swift.Float, Swift.Float) -> Swift.Float with respect to parameters {0} and results {0} | {(57,60) - (60,99)}
+$s13test_mangling3fooyS2f_xq_t16_Differentiation14DifferentiableR_r0_lFAcDRzAcDR_r0_lWJrUSSpSr ---> reverse-mode differentiability witness for test_mangling.foo<A, B where B: _Differentiation.Differentiable>(Swift.Float, A, B) -> Swift.Float with respect to parameters {1, 2} and results {0} with <A, B where A: _Differentiation.Differentiable, B: _Differentiation.Differentiable> | {(57,60) - (107,126)}
+$s5async1hyyS2iYbXEF ---> async.h(@Sendable (Swift.Int) -> Swift.Int) -> () | {(6,7) - (7,43)}
+$s5Actor02MyA0C17testAsyncFunctionyyYaKFTY0_ ---> (1) suspend resume partial function for Actor.MyActor.testAsyncFunction() async throws -> () | {(54,71) - (71,73)}
+$s5Actor02MyA0C17testAsyncFunctionyyYaKFTQ1_ ---> (2) await resume partial function for Actor.MyActor.testAsyncFunction() async throws -> () | {(52,69) - (69,71)}
+$s4diff1hyyS2iYjfXEF ---> diff.h(@differentiable(_forward) (Swift.Int) -> Swift.Int) -> () | {(5,6) - (6,58)}
+$s4diff1hyyS2iYjrXEF ---> diff.h(@differentiable(reverse) (Swift.Int) -> Swift.Int) -> () | {(5,6) - (6,57)}
+$s4diff1hyyS2iYjdXEF ---> diff.h(@differentiable (Swift.Int) -> Swift.Int) -> () | {(5,6) - (6,48)}
+$s4diff1hyyS2iYjlXEF ---> diff.h(@differentiable(_linear) (Swift.Int) -> Swift.Int) -> () | {(5,6) - (6,57)}
+$s4test3fooyyS2f_SfYkztYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, inout @noDerivative Swift.Float) -> Swift.Float) -> () | {(5,8) - (8,96)}
+$s4test3fooyyS2f_SfYkntYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, __owned @noDerivative Swift.Float) -> Swift.Float) -> () | {(5,8) - (8,98)}
+$s4test3fooyyS2f_SfYktYjrXEF ---> test.foo(@differentiable(reverse) (Swift.Float, @noDerivative Swift.Float) -> Swift.Float) -> () | {(5,8) - (8,90)}
+$s4test3fooyyS2f_SfYktYaYbYjrXEF ---> test.foo(@differentiable(reverse) @Sendable (Swift.Float, @noDerivative Swift.Float) async -> Swift.Float) -> () | {(5,8) - (8,106)}
 $SSSTf4pd44444_pf ---> function signature specialization <Arg[0] = [Constant Propagated Float : 44444], Return = > of Swift.String
 $sScA ---> Swift.Actor
 $sScGySiG ---> Swift.TaskGroup<Swift.Int>
-$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor () -> A)?) -> (() -> A)?
+$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor () -> A)?) -> (() -> A)? | {(5,15) - (18,47)}
 $sSvSgA3ASbIetCyyd_SgSbIetCyyyd_SgD ---> (@escaping @convention(thin) @convention(c) (@unowned Swift.UnsafeMutableRawPointer?, @unowned Swift.UnsafeMutableRawPointer?, @unowned (@escaping @convention(thin) @convention(c) (@unowned Swift.UnsafeMutableRawPointer?, @unowned Swift.UnsafeMutableRawPointer?) -> (@unowned Swift.Bool))?) -> (@unowned Swift.Bool))?
-$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor () -> A)?) -> (() -> A)?
-$s1t10globalFuncyyAA7MyActorCYiF ---> t.globalFunc(isolated t.MyActor) -> ()
+$s4test10returnsOptyxycSgxyScMYccSglF ---> test.returnsOpt<A>((@Swift.MainActor () -> A)?) -> (() -> A)? | {(5,15) - (18,47)}
+$s1t10globalFuncyyAA7MyActorCYiF ---> t.globalFunc(isolated t.MyActor) -> () | {(2,12) - (12,32)}
 $sSIxip6foobarP ---> foobar in Swift.DefaultIndices.subscript : A
 $s13__lldb_expr_110$10016c2d8yXZ1B10$10016c2e0LLC ---> __lldb_expr_1.(unknown context at $10016c2d8).(B in $10016c2e0)
 $s__TJO ---> $s__TJO
-$s6Foobar7Vector2VAASdRszlE10simdMatrix5scale6rotate9translateSo0C10_double3x3aACySdG_SdAJtFZ0D4TypeL_aySd__GD ---> MatrixType #1 in static (extension in Foobar):Foobar.Vector2<Swift.Double><A where A == Swift.Double>.simdMatrix(scale: Foobar.Vector2<Swift.Double>, rotate: Swift.Double, translate: Foobar.Vector2<Swift.Double>) -> __C.simd_double3x3
-$s17distributed_thunk2DAC1fyyFTE ---> distributed thunk distributed_thunk.DA.f() -> ()
-$s16distributed_test1XC7computeyS2iFTF ---> distributed accessor for distributed_test.X.compute(Swift.Int) -> Swift.Int
-$s27distributed_actor_accessors7MyActorC7simple2ySSSiFTETFHF ---> accessible function runtime record for distributed accessor for distributed thunk distributed_actor_accessors.MyActor.simple2(Swift.Int) -> Swift.String
-$s1A3bar1aySSYt_tF ---> A.bar(a: _const Swift.String) -> ()
-$s1t1fyyFSiAA3StrVcs7KeyPathCyADSiGcfu_SiADcfu0_33_556644b740b1b333fecb81e55a7cce98ADSiTf3npk_n ---> function signature specialization <Arg[1] = [Constant Propagated KeyPath : _556644b740b1b333fecb81e55a7cce98<t.Str,Swift.Int>]> of implicit closure #2 (t.Str) -> Swift.Int in implicit closure #1 (Swift.KeyPath<t.Str, Swift.Int>) -> (t.Str) -> Swift.Int in t.f() -> ()
-$s21back_deploy_attribute0A12DeployedFuncyyFTwb ---> back deployment thunk for back_deploy_attribute.backDeployedFunc() -> ()
-$s21back_deploy_attribute0A12DeployedFuncyyFTwB ---> back deployment fallback for back_deploy_attribute.backDeployedFunc() -> ()
-$s4test3fooyyAA1P_px1TRts_XPlF ---> test.foo<A>(any test.P<Self.T == A>) -> ()
-$s4test3fooyyAA1P_pSS1TAaCPRts_Si1UAERtsXPF ---> test.foo(any test.P<Self.test.P.T == Swift.String, Self.test.P.U == Swift.Int>) -> ()
-$s4test3FooVAAyyAA1P_pF ---> test.Foo.test(test.P) -> ()
+$s6Foobar7Vector2VAASdRszlE10simdMatrix5scale6rotate9translateSo0C10_double3x3aACySdG_SdAJtFZ0D4TypeL_aySd__GD ---> MatrixType #1 in static (extension in Foobar):Foobar.Vector2<Swift.Double><A where A == Swift.Double>.simdMatrix(scale: Foobar.Vector2<Swift.Double>, rotate: Swift.Double, translate: Foobar.Vector2<Swift.Double>) -> __C.simd_double3x3 | {(102,112) - (112,212)}
+$s17distributed_thunk2DAC1fyyFTE ---> distributed thunk distributed_thunk.DA.f() -> () | {(39,40) - (40,42)}
+$s16distributed_test1XC7computeyS2iFTF ---> distributed accessor for distributed_test.X.compute(Swift.Int) -> Swift.Int | {(44,51) - (51,62)}
+$s27distributed_actor_accessors7MyActorC7simple2ySSSiFTETFHF ---> accessible function runtime record for distributed accessor for distributed thunk distributed_actor_accessors.MyActor.simple2(Swift.Int) -> Swift.String | {(118,125) - (125,136)}
+$s1A3bar1aySSYt_tF ---> A.bar(a: _const Swift.String) -> () | {(2,5) - (5,29)}
+$s1t1fyyFSiAA3StrVcs7KeyPathCyADSiGcfu_SiADcfu0_33_556644b740b1b333fecb81e55a7cce98ADSiTf3npk_n ---> function signature specialization <Arg[1] = [Constant Propagated KeyPath : _556644b740b1b333fecb81e55a7cce98<t.Str,Swift.Int>]> of implicit closure #2 (t.Str) -> Swift.Int in implicit closure #1 (Swift.KeyPath<t.Str, Swift.Int>) -> (t.Str) -> Swift.Int in t.f() -> () | {(258,259) - (259,261)}
+$s21back_deploy_attribute0A12DeployedFuncyyFTwb ---> back deployment thunk for back_deploy_attribute.backDeployedFunc() -> () | {(48,64) - (64,66)}
+$s21back_deploy_attribute0A12DeployedFuncyyFTwB ---> back deployment fallback for back_deploy_attribute.backDeployedFunc() -> () | {(51,67) - (67,69)}
+$s4test3fooyyAA1P_px1TRts_XPlF ---> test.foo<A>(any test.P<Self.T == A>) -> () | {(5,8) - (11,36)}
+$s4test3fooyyAA1P_pSS1TAaCPRts_Si1UAERtsXPF ---> test.foo(any test.P<Self.test.P.T == Swift.String, Self.test.P.U == Swift.Int>) -> () | {(5,8) - (8,79)}
+$s4test3FooVAAyyAA1P_pF ---> test.Foo.test(test.P) -> () | {(9,13) - (13,21)}
 $sxxxIxzCXxxxesy ---> $sxxxIxzCXxxxesy
 $Sxxx_x_xxIxzCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC$x ---> $Sxxx_x_xxIxzCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC$x
 $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTATQ0_ ---> {T:$sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTR} (1) await resume partial function for partial apply forwarder for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
@@ -448,52 +441,49 @@ $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTQ0_ ---> {T:} (1) awai
 $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTY0_ ---> {T:} (1) suspend resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
 $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTY_ ---> {T:} (0) suspend resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
 $sxIeghHr_xs5Error_pIegHrzo_s8SendableRzs5NeverORs_r0_lTRTQ12_ ---> {T:} (13) await resume partial function for reabstraction thunk helper <A, B where A: Swift.Sendable, B == Swift.Never> from @escaping @callee_guaranteed @Sendable @async () -> (@out A) to @escaping @callee_guaranteed @async () -> (@out A, @error @owned Swift.Error)
-$s7Library3fooyyFTwS ---> #_hasSymbol query for Library.foo() -> ()
+$s7Library3fooyyFTwS ---> #_hasSymbol query for Library.foo() -> () | {(30,33) - (33,35)}
 $s7Library5KlassCTwS ---> #_hasSymbol query for Library.Klass
 $s14swift_ide_test14myColorLiteral3red5green4blue5alphaAA0E0VSf_S3ftcfm ---> swift_ide_test.myColorLiteral(red: Swift.Float, green: Swift.Float, blue: Swift.Float, alpha: Swift.Float) -> swift_ide_test.Color
 $s14swift_ide_test10myFilenamexfm ---> swift_ide_test.myFilename : A
-$s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> ()
-$s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> ()
-@__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_  ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()
+$s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> () | {(58,71) - (71,99)}
+$s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> () | {(111,141) - (141,143)}
+@__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_ ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> () | {(50,63) - (63,91)}
 @__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_ ---> peer macro @addCompletionHandler expansion #1 of f in macro_expand_peers.S
 @__swiftmacro_9MacroUser16MemberNotCoveredV33_4361AD9339943F52AE6186DD51E04E91Ll0dE0fMf0_ ---> freestanding macro expansion #2 of NotCovered(in _4361AD9339943F52AE6186DD51E04E91) in MacroUser.MemberNotCovered
 $sxSo8_NSRangeVRlzCRl_Cr0_llySo12ModelRequestCyxq_GIsPetWAlYl_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(witness_method) @yield_once <A, B where A: AnyObject, B: AnyObject> @substituted <A> (@inout A) -> (@yields @inout __C._NSRange) for <__C.ModelRequest<A, B>>
 $SyyySGSS_IIxxxxx____xsIyFSySIxx_@xIxx____xxI ---> $SyyySGSS_IIxxxxx____xsIyFSySIxx_@xIxx____xxI
-$s12typed_throws15rethrowConcreteyyAA7MyErrorOYKF ---> typed_throws.rethrowConcrete() throws(typed_throws.MyError) -> ()
-$s3red3use2fnySiyYAXE_tF ---> red.use(fn: @isolated(any) () -> Swift.Int) -> ()
-$s4testAAyAA5KlassC_ACtACnYTF ---> test.test(__owned test.Klass) -> sending (test.Klass, test.Klass)
-$s5test24testyyAA5KlassCnYuF ---> test2.test(sending __owned test2.Klass) -> ()
+$s12typed_throws15rethrowConcreteyyAA7MyErrorOYKF ---> typed_throws.rethrowConcrete() throws(typed_throws.MyError) -> () | {(13,28) - (28,30)}
+$s3red3use2fnySiyYAXE_tF ---> red.use(fn: @isolated(any) () -> Swift.Int) -> () | {(4,7) - (7,43)}
+$s4testAAyAA5KlassC_ACtACnYTF ---> test.test(__owned test.Klass) -> sending (test.Klass, test.Klass) | {(5,9) - (9,29)}
+$s5test24testyyAA5KlassCnYuF ---> test2.test(sending __owned test2.Klass) -> () | {(6,10) - (10,39)}
 $s7ElementSTQzqd__s5Error_pIgnrzo_ABqd__sAC_pIegnrzr_SlRzr__lTR ---> {T:} reabstraction thunk helper <A><A1 where A: Swift.Collection> from @callee_guaranteed (@in_guaranteed A.Swift.Sequence.Element) -> (@out A1, @error @owned Swift.Error) to @escaping @callee_guaranteed (@in_guaranteed A.Swift.Sequence.Element) -> (@out A1, @error @out Swift.Error)
 $sS3fIedgyywTd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned @noDerivative sending Swift.Float) -> (@unowned Swift.Float)
 $sS3fIedgyyTd_D ---> @escaping @differentiable @callee_guaranteed (@unowned Swift.Float, @unowned sending Swift.Float) -> (@unowned Swift.Float)
-$s4testA2A5KlassCyYTF ---> test.test() -> sending test.Klass
+$s4testA2A5KlassCyYTF ---> test.test() -> sending test.Klass | {(5,9) - (9,11)}
 $s4main5KlassCACYTcMD ---> demangling cache variable for type metadata for (main.Klass) -> sending main.Klass
-$s4null19transferAsyncResultAA16NonSendableKlassCyYaYTF ---> null.transferAsyncResult() async -> sending null.NonSendableKlass
+$s4null19transferAsyncResultAA16NonSendableKlassCyYaYTF ---> null.transferAsyncResult() async -> sending null.NonSendableKlass | {(5,24) - (24,26)}
 $s4null16NonSendableKlassCIegHo_ACs5Error_pIegHTrzo_TR ---> {T:} reabstraction thunk helper from @escaping @callee_guaranteed @async () -> (@owned null.NonSendableKlass) to @escaping @callee_guaranteed @async () -> sending (@out null.NonSendableKlass, @error @owned Swift.Error)
 $sSRyxG15Synchronization19AtomicRepresentableABRi_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Copyable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
 $sSRyxG15Synchronization19AtomicRepresentableABRi0_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Escapable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
 $sSRyxG15Synchronization19AtomicRepresentableABRi1_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.<bit 2>> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
-
 $s23variadic_generic_opaque2G2VyAA2S1V_AA2S2VQPGAA1PHPAeA1QHPyHC_AgaJHPyHCHX_HC ---> concrete protocol conformance variadic_generic_opaque.G2<Pack{variadic_generic_opaque.S1, variadic_generic_opaque.S2}> to protocol conformance ref (type's module) variadic_generic_opaque.P with conditional requirements: (pack protocol conformance (concrete protocol conformance variadic_generic_opaque.S1 to protocol conformance ref (type's module) variadic_generic_opaque.Q, concrete protocol conformance variadic_generic_opaque.S2 to protocol conformance ref (type's module) variadic_generic_opaque.Q))
-
 $s9MacroUser0023macro_expandswift_elFCffMX436_4_23bitwidthNumberedStructsfMf_ ---> freestanding macro expansion #1 of bitwidthNumberedStructs in module MacroUser file macro_expand.swift line 437 column 5
 $sxq_IyXd_D ---> @callee_unowned (@in_cxx A) -> (@unowned B)
 $s2hi1SV1iSivx ---> hi.S.i.modify2 : Swift.Int
 $s2hi1SV1iSivy ---> hi.S.i.read2 : Swift.Int
-$s2hi1SVIetMIy_TC  ---> coroutine continuation prototype for @escaping @convention(thin) @convention(method) @yield_once_2 (@unowned hi.S) -> ()
-
+$s2hi1SVIetMIy_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(method) @yield_once_2 (@unowned hi.S) -> ()
 $s4main4SlabVy$1_SiG ---> main.Slab<2, Swift.Int>
 $s$n3_SSBV ---> Builtin.FixedArray<-4, Swift.String>
-$s3red7MyActorC3runyxxyYaKACYcYTXEYaKlFZ ---> static red.MyActor.run<A>(@red.MyActor () async throws -> sending A) async throws -> A
-$s3red7MyActorC3runyxxyYaKYAYTXEYaKlFZ ---> static red.MyActor.run<A>(@isolated(any) () async throws -> sending A) async throws -> A
+$s3red7MyActorC3runyxxyYaKACYcYTXEYaKlFZ ---> static red.MyActor.run<A>(@red.MyActor () async throws -> sending A) async throws -> A | {(19,22) - (25,68)}
+$s3red7MyActorC3runyxxyYaKYAYTXEYaKlFZ ---> static red.MyActor.run<A>(@isolated(any) () async throws -> sending A) async throws -> A | {(19,22) - (25,70)}
 $s7ToolKit10TypedValueOACs5Error_pIgHTnTrzo_A2CsAD_pIegHiTrzr_TR ---> {T:} reabstraction thunk helper from @callee_guaranteed @async (@in_guaranteed sending ToolKit.TypedValue) -> sending (@out ToolKit.TypedValue, @error @owned Swift.Error) to @escaping @callee_guaranteed @async (@in sending ToolKit.TypedValue) -> (@out ToolKit.TypedValue, @error @out Swift.Error)
 $s16sending_mangling16NonSendableKlassCACIegTiTr_A2CIegTxTo_TR ---> {T:} reabstraction thunk helper from @escaping @callee_guaranteed (@in sending sending_mangling.NonSendableKlass) -> sending (@out sending_mangling.NonSendableKlass) to @escaping @callee_guaranteed (@owned sending sending_mangling.NonSendableKlass) -> sending (@owned sending_mangling.NonSendableKlass)
-$s3red7MyActorC3runyxxyYaKYCXEYaKlFZ ---> static red.MyActor.run<A>(nonisolated(nonsending) () async throws -> A) async throws -> A
+$s3red7MyActorC3runyxxyYaKYCXEYaKlFZ ---> static red.MyActor.run<A>(nonisolated(nonsending) () async throws -> A) async throws -> A | {(19,22) - (25,71)}
 $s5thing1PP1sAA1SVvxTwc ---> coro function pointer to thing.P.s.modify2 : thing.S
-_$s15raw_identifiers0020foospace_liaADEDGcjayyF ---> raw_identifiers.`foo space`() -> ()
-_$s15raw_identifiers0018_3times_pgaIGJCFbhayyF ---> raw_identifiers.`3 times`() -> ()
-_$s15raw_identifiers0019test_yeaIIBCEapkagayyF ---> raw_identifiers.`test +`() -> ()
-_$s15raw_identifiers0020pathfoo_yuEHaaCiJskayyF ---> raw_identifiers.`path://foo`() -> ()
-_$s15raw_identifiers10FontWeightO009_100_FpEpdyyFZ ---> static raw_identifiers.FontWeight.`100`() -> ()
+_$s15raw_identifiers0020foospace_liaADEDGcjayyF ---> raw_identifiers.`foo space`() -> () | {(16,28) - (28,30)}
+_$s15raw_identifiers0018_3times_pgaIGJCFbhayyF ---> raw_identifiers.`3 times`() -> () | {(16,26) - (26,28)}
+_$s15raw_identifiers0019test_yeaIIBCEapkagayyF ---> raw_identifiers.`test +`() -> () | {(16,25) - (25,27)}
+_$s15raw_identifiers0020pathfoo_yuEHaaCiJskayyF ---> raw_identifiers.`path://foo`() -> () | {(16,28) - (28,30)}
+_$s15raw_identifiers10FontWeightO009_100_FpEpdyyFZ ---> static raw_identifiers.FontWeight.`100`() -> () | {(34,39) - (39,41)}
 $s7Library1BC1iSivxTwd ---> default override of Library.B.i.modify2 : Swift.Int
 $s7Library1BC1iSivxTwdTwc ---> coro function pointer to default override of Library.B.i.modify2 : Swift.Int

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -368,7 +368,10 @@ $sSUss17FixedWidthIntegerRzrlEyxqd__cSzRd__lufCSu_SiTg5 ---> generic specializat
 $s4test7genFuncyyx_q_tr0_lFSi_SbTtt1g5 ---> generic specialization <Swift.Int, Swift.Bool> of test.genFunc<A, B>(A, B) -> ()
 $sSD5IndexVy__GD ---> $sSD5IndexVy__GD
 $s4test3StrCACycfC ---> {T:$s4test3StrCACycfc} test.Str.__allocating_init() -> test.Str
-$s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized
+@$s8keypaths1KV3valACSi_tcfcACmTkmu : $@convention(keypath_accessor_getter) (@in_guaranteed @thick K.Type) -> @out @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> @out τ_0_1 for <Int, K>)
+@$s8keypaths1KVACycfcACmTkMA : $@convention(keypath_accessor_getter) (@in_guaranteed @thick K.Type) -> @out K)
+$s18keypaths_inlinable13KeypathStructV8computedSSvpACTKq  ---> key path getter for keypaths_inlinable.KeypathStruct.computed : Swift.String : keypaths_inlinable.KeypathStruct, serialized
+$s18resilient_protocol24ResilientDerivedProtocolPxAA0c4BaseE0Tn --> associated conformance descriptor for resilient_protocol.ResilientDerivedProtocol.A: resilient_protocol.ResilientBaseProtocol
 $s3red4testyAA3ResOyxSayq_GAEs5ErrorAAq_sAFHD1__HCg_GADyxq_GsAFR_r0_lF ---> red.test<A, B where B: Swift.Error>(red.Res<A, B>) -> red.Res<A, [B]>
 $s3red4testyAA7OurTypeOy4them05TheirD0Vy5AssocQzGAjE0F8ProtocolAAxAA0c7DerivedH0HD1_AA0c4BaseH0HI1_AieKHA2__HCg_GxmAaLRzlF ---> red.test<A where A: red.OurDerivedProtocol>(A.Type) -> red.OurType<them.TheirType<A.Assoc>>
 $s17property_wrappers10WithTuplesV9fractionsSd_S2dtvpfP ---> property wrapper backing initializer of property_wrappers.WithTuples.fractions : (Swift.Double, Swift.Double, Swift.Double)
@@ -386,6 +389,10 @@ $s0059xxxxxxxxxxxxxxx_ttttttttBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBee ---> $s0059xx
 $sx1td_t ---> (t: A...)
 $s7example1fyyYaF ---> example.f() async -> ()
 $s7example1fyyYaKF ---> example.f() async throws -> ()
+s7example1fyyYjfYaKF -> example.f@differentiable(_forward) () async throws -> ()
+s7example1fyyYjrYaKF -> example.f@differentiable(reverse) () async throws -> ()
+s7example1fyyYjdYaKF -> example.f@differentiable () async throws -> ()
+s7example1fyyYjlYaKF -> example.f@differentiable(_linear) () async throws -> ()
 $s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> ()
 $s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE
 $s4main6testityyYaFTu ---> async function pointer to main.testit() async -> ()
@@ -447,7 +454,7 @@ $s14swift_ide_test14myColorLiteral3red5green4blue5alphaAA0E0VSf_S3ftcfm ---> swi
 $s14swift_ide_test10myFilenamexfm ---> swift_ide_test.myFilename : A
 $s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> ()
 $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> ()
-@__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_ ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()
+@__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_  ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()
 @__swiftmacro_18macro_expand_peers1SV1f20addCompletionHandlerfMp_ ---> peer macro @addCompletionHandler expansion #1 of f in macro_expand_peers.S
 @__swiftmacro_9MacroUser16MemberNotCoveredV33_4361AD9339943F52AE6186DD51E04E91Ll0dE0fMf0_ ---> freestanding macro expansion #2 of NotCovered(in _4361AD9339943F52AE6186DD51E04E91) in MacroUser.MemberNotCovered
 $sxSo8_NSRangeVRlzCRl_Cr0_llySo12ModelRequestCyxq_GIsPetWAlYl_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(witness_method) @yield_once <A, B where A: AnyObject, B: AnyObject> @substituted <A> (@inout A) -> (@yields @inout __C._NSRange) for <__C.ModelRequest<A, B>>
@@ -466,12 +473,15 @@ $s4null16NonSendableKlassCIegHo_ACs5Error_pIegHTrzo_TR ---> {T:} reabstraction t
 $sSRyxG15Synchronization19AtomicRepresentableABRi_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Copyable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
 $sSRyxG15Synchronization19AtomicRepresentableABRi0_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.Escapable> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
 $sSRyxG15Synchronization19AtomicRepresentableABRi1_zrlMc ---> protocol conformance descriptor for < where A: ~Swift.<bit 2>> Swift.UnsafeBufferPointer<A> : Synchronization.AtomicRepresentable in Synchronization
+
 $s23variadic_generic_opaque2G2VyAA2S1V_AA2S2VQPGAA1PHPAeA1QHPyHC_AgaJHPyHCHX_HC ---> concrete protocol conformance variadic_generic_opaque.G2<Pack{variadic_generic_opaque.S1, variadic_generic_opaque.S2}> to protocol conformance ref (type's module) variadic_generic_opaque.P with conditional requirements: (pack protocol conformance (concrete protocol conformance variadic_generic_opaque.S1 to protocol conformance ref (type's module) variadic_generic_opaque.Q, concrete protocol conformance variadic_generic_opaque.S2 to protocol conformance ref (type's module) variadic_generic_opaque.Q))
+
 $s9MacroUser0023macro_expandswift_elFCffMX436_4_23bitwidthNumberedStructsfMf_ ---> freestanding macro expansion #1 of bitwidthNumberedStructs in module MacroUser file macro_expand.swift line 437 column 5
 $sxq_IyXd_D ---> @callee_unowned (@in_cxx A) -> (@unowned B)
 $s2hi1SV1iSivx ---> hi.S.i.modify2 : Swift.Int
 $s2hi1SV1iSivy ---> hi.S.i.read2 : Swift.Int
-$s2hi1SVIetMIy_TC ---> coroutine continuation prototype for @escaping @convention(thin) @convention(method) @yield_once_2 (@unowned hi.S) -> ()
+$s2hi1SVIetMIy_TC  ---> coroutine continuation prototype for @escaping @convention(thin) @convention(method) @yield_once_2 (@unowned hi.S) -> ()
+
 $s4main4SlabVy$1_SiG ---> main.Slab<2, Swift.Int>
 $s$n3_SSBV ---> Builtin.FixedArray<-4, Swift.String>
 $s3red7MyActorC3runyxxyYaKACYcYTXEYaKlFZ ---> static red.MyActor.run<A>(@red.MyActor () async throws -> sending A) async throws -> A
@@ -487,3 +497,4 @@ _$s15raw_identifiers0020pathfoo_yuEHaaCiJskayyF ---> raw_identifiers.`path://foo
 _$s15raw_identifiers10FontWeightO009_100_FpEpdyyFZ ---> static raw_identifiers.FontWeight.`100`() -> ()
 $s7Library1BC1iSivxTwd ---> default override of Library.B.i.modify2 : Swift.Int
 $s7Library1BC1iSivxTwdTwc ---> coro function pointer to default override of Library.B.i.modify2 : Swift.Int
+$s3use1xAA3OfPVy3lib1GVyAA1fQryFQOyQo_GAjE1PAAxAeKHD1_AIHO_HCg_Gvp ---> use.x : use.OfP<lib.G<<<opaque return type of use.f() -> some>>.0>>

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -497,4 +497,3 @@ _$s15raw_identifiers0020pathfoo_yuEHaaCiJskayyF ---> raw_identifiers.`path://foo
 _$s15raw_identifiers10FontWeightO009_100_FpEpdyyFZ ---> static raw_identifiers.FontWeight.`100`() -> ()
 $s7Library1BC1iSivxTwd ---> default override of Library.B.i.modify2 : Swift.Int
 $s7Library1BC1iSivxTwdTwc ---> coro function pointer to default override of Library.B.i.modify2 : Swift.Int
-$s3use1xAA3OfPVy3lib1GVyAA1fQryFQOyQo_GAjE1PAAxAeKHD1_AIHO_HCg_Gvp ---> use.x : use.OfP<lib.G<<<opaque return type of use.f() -> some>>.0>>

--- a/test/Demangle/clang-function-types-android.swift
+++ b/test/Demangle/clang-function-types-android.swift
@@ -9,7 +9,7 @@
 // RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings-with-clang-types.txt > %t.input
 // %t.check: "A ---> B" ==> "B"
 // RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/manglings-with-clang-types.txt > %t.check
-// RUN: swift-demangle -classify < %t.input > %t.output
+// RUN: swift-demangle -classify -no-colors < %t.input > %t.output
 // RUN: diff %t.check %t.output
 
 // REQUIRES: OS=linux-android || OS=linux-androideabi

--- a/test/Demangle/clang-function-types.swift
+++ b/test/Demangle/clang-function-types.swift
@@ -9,7 +9,7 @@
 // RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings-with-clang-types.txt > %t.input
 // %t.check: "A ---> B" ==> "B"
 // RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/manglings-with-clang-types.txt > %t.check
-// RUN: swift-demangle -classify < %t.input > %t.output
+// RUN: swift-demangle -classify -no-colors < %t.input > %t.output
 // RUN: diff %t.check %t.output
 
 // Other tests already check mangling for Windows, so we don't need to

--- a/test/Demangle/demangle-embedded.swift
+++ b/test/Demangle/demangle-embedded.swift
@@ -1,7 +1,7 @@
 ; This is not really a Swift source file: -*- Text -*-
 
 ; RUN: echo '$e4main8MyStructV3fooyyFAA1XV_Tg5' | swift-demangle | %FileCheck %s
-; RUN: swift-demangle '$e4main8MyStructV3fooyyFAA1XV_Tg5' | %FileCheck %s
-; RUN: swift-demangle e4main8MyStructV3fooyyFAA1XV_Tg5 | %FileCheck %s
+; RUN: swift-demangle -no-colors '$e4main8MyStructV3fooyyFAA1XV_Tg5' | %FileCheck %s
+; RUN: swift-demangle -no-colors e4main8MyStructV3fooyyFAA1XV_Tg5 | %FileCheck %s
 
 ; CHECK: generic specialization <main.X> of main.MyStruct.foo() -> ()

--- a/test/Demangle/demangle-simplified.swift
+++ b/test/Demangle/demangle-simplified.swift
@@ -6,5 +6,5 @@ RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/simplified-manglings.txt > %t.in
 %t.check: "A ---> B" ==> "B"
 RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/simplified-manglings.txt > %t.check
 
-RUN: swift-demangle -simplified < %t.input > %t.output
+RUN: swift-demangle -simplified -no-colors < %t.input > %t.output
 RUN: diff %t.check %t.output

--- a/test/Demangle/demangle-special-options.test
+++ b/test/Demangle/demangle-special-options.test
@@ -1,21 +1,21 @@
-RUN: swift-demangle -display-stdlib-module=true sSi | %FileCheck %s --check-prefix=SWIFT-INT
+RUN: swift-demangle -no-colors -display-stdlib-module=true sSi | %FileCheck %s --check-prefix=SWIFT-INT
 SWIFT-INT: {{ Swift.Int$}}
-RUN: swift-demangle -display-stdlib-module=false sSi | %FileCheck %s --check-prefix=INT
+RUN: swift-demangle -no-colors -display-stdlib-module=false sSi | %FileCheck %s --check-prefix=INT
 INT: {{ Int$}}
 
-RUN: swift-demangle -display-objc-module=true sSo6CGRectVD | %FileCheck %s --check-prefix=OBJC-CGRECT
+RUN: swift-demangle -no-colors -display-objc-module=true sSo6CGRectVD | %FileCheck %s --check-prefix=OBJC-CGRECT
 OBJC-CGRECT: {{ __C.CGRect$}}
-RUN: swift-demangle -display-objc-module=false sSo6CGRectVD | %FileCheck %s --check-prefix=CGRECT
+RUN: swift-demangle -no-colors -display-objc-module=false sSo6CGRectVD | %FileCheck %s --check-prefix=CGRECT
 CGRECT: {{ CGRect$}}
 
-RUN: swift-demangle -hiding-module=foo _TtC3foo3bar | %FileCheck %s --check-prefix=BAR
+RUN: swift-demangle -no-colors -hiding-module=foo _TtC3foo3bar | %FileCheck %s --check-prefix=BAR
 BAR: {{ bar$}}
 
-RUN: swift-demangle -display-local-name-contexts=true s1a4mainyyFySRys5UInt8VGXEfU4_10ByteBufferL_aD | %FileCheck %s --check-prefix=LOCAL
+RUN: swift-demangle -no-colors -display-local-name-contexts=true s1a4mainyyFySRys5UInt8VGXEfU4_10ByteBufferL_aD | %FileCheck %s --check-prefix=LOCAL
 LOCAL: ByteBuffer #1 in closure #6
 
-RUN: swift-demangle -display-local-name-contexts=false s1a4mainyyFySRys5UInt8VGXEfU4_10ByteBufferL_aD | %FileCheck %s --check-prefix=NOLOCAL
+RUN: swift-demangle -no-colors -display-local-name-contexts=false s1a4mainyyFySRys5UInt8VGXEfU4_10ByteBufferL_aD | %FileCheck %s --check-prefix=NOLOCAL
 NOLOCAL: {{ ByteBuffer$}}
 
-RUN: swift-demangle -show-closure-signature=false s4mainySiXEfU_ySiXEfU_ | %FileCheck %s --check-prefix=CLOSURE
+RUN: swift-demangle -no-colors -show-closure-signature=false s4mainySiXEfU_ySiXEfU_ | %FileCheck %s --check-prefix=CLOSURE
 CLOSURE: closure #1 in closure #1 in main

--- a/test/Demangle/demangle.swift
+++ b/test/Demangle/demangle.swift
@@ -6,8 +6,17 @@ RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings.txt > %t.input
 %t.check: "A ---> B" ==> "B"
 RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/manglings.txt > %t.check
 
-RUN: swift-demangle -classify -ranges < %t.input > %t.output
+RUN: swift-demangle -classify -ranges -no-colors < %t.input > %t.output
 RUN: diff %t.check %t.output
 
-; RUN: swift-demangle __TtSi | %FileCheck %s -check-prefix=DOUBLE
+%t.input: "A ---> B" ==> "A"
+RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings-with-highlighting.txt > %t.input
+
+%t.check: "A ---> B" ==> "B"
+RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/manglings-with-highlighting.txt > %t.check
+
+RUN: swift-demangle -classify < %t.input > %t.output
+RUN: diff %t.check %t.output
+
+; RUN: swift-demangle -no-colors __TtSi | %FileCheck %s -check-prefix=DOUBLE
 ; DOUBLE: _TtSi ---> Swift.Int

--- a/test/Demangle/demangle.swift
+++ b/test/Demangle/demangle.swift
@@ -6,7 +6,7 @@ RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings.txt > %t.input
 %t.check: "A ---> B" ==> "B"
 RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/manglings.txt > %t.check
 
-RUN: swift-demangle -classify < %t.input > %t.output
+RUN: swift-demangle -classify -ranges < %t.input > %t.output
 RUN: diff %t.check %t.output
 
 ; RUN: swift-demangle __TtSi | %FileCheck %s -check-prefix=DOUBLE

--- a/test/Demangle/demangle.swift
+++ b/test/Demangle/demangle.swift
@@ -6,7 +6,7 @@ RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings.txt > %t.input
 %t.check: "A ---> B" ==> "B"
 RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/manglings.txt > %t.check
 
-RUN: swift-demangle -classify -ranges < %t.input > %t.output
+RUN: swift-demangle -classify < %t.input > %t.output
 RUN: diff %t.check %t.output
 
 ; RUN: swift-demangle __TtSi | %FileCheck %s -check-prefix=DOUBLE

--- a/test/Demangle/demangle.swift
+++ b/test/Demangle/demangle.swift
@@ -6,9 +6,8 @@ RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings.txt > %t.input
 %t.check: "A ---> B" ==> "B"
 RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/manglings.txt > %t.check
 
-RUN: swift-demangle -classify < %t.input > %t.output
+RUN: swift-demangle -classify -ranges < %t.input > %t.output
 RUN: diff %t.check %t.output
 
 ; RUN: swift-demangle __TtSi | %FileCheck %s -check-prefix=DOUBLE
 ; DOUBLE: _TtSi ---> Swift.Int
-

--- a/test/Demangle/recursion-limit.swift
+++ b/test/Demangle/recursion-limit.swift
@@ -3,12 +3,12 @@
 ; We need sed, so Windows is out
 UNSUPPORTED: OS=windows-msvc
 
-RUN: swift-demangle < %S/Inputs/bigtype.txt 2>&1 > %t.check
+RUN: swift-demangle -no-colors < %S/Inputs/bigtype.txt 2>&1 > %t.check
 RUN: %diff -u %S/Inputs/bigtype-demangle.txt %t.check
 
-RUN: swift-demangle -remangle-new < %S/Inputs/bigtype.txt 2>&1 | sed 's/([0-9]*:[0-9]*)/(pos)/g'  > %t.check || true
+RUN: swift-demangle -no-colors -remangle-new < %S/Inputs/bigtype.txt 2>&1 | sed 's/([0-9]*:[0-9]*)/(pos)/g'  > %t.check || true
 RUN: %diff -u %S/Inputs/bigtype-remangle.txt %t.check
 
-RUN: swift-demangle -remangle-objc-rt < %S/Inputs/bigtype.txt 2>&1 | sed 's/([0-9]*:[0-9]*)/(pos)/g' > %t.check || true
+RUN: swift-demangle -no-colors -remangle-objc-rt < %S/Inputs/bigtype.txt 2>&1 | sed 's/([0-9]*:[0-9]*)/(pos)/g' > %t.check || true
 RUN: %diff -u %S/Inputs/bigtype-objcrt.txt %t.check
 

--- a/test/Demangle/remangle.swift
+++ b/test/Demangle/remangle.swift
@@ -3,23 +3,23 @@
 %t.input: "A ---> B" ==> "A"
 RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/manglings.txt > %t.input
 
-RUN: swift-demangle -test-remangle < %t.input > %t.output
+RUN: swift-demangle -no-colors -test-remangle < %t.input > %t.output
 RUN: diff %t.input %t.output
 
 // CHECK: _TVsP33_7B40D7ED6632C2BEA2CA3BFFD57E34358Mystruct
-RUN: swift-demangle -remangle-objc-rt '$ss8Mystruct33_7B40D7ED6632C2BEA2CA3BFFD57E3435LLV' | %FileCheck %s
+RUN: swift-demangle -no-colors -remangle-objc-rt '$ss8Mystruct33_7B40D7ED6632C2BEA2CA3BFFD57E3435LLV' | %FileCheck %s
 
 // CHECK-OLD: _TPF1_1?FT1Ps16UnsafeRawPointer_SV1r
-RUN: swift-demangle -remangle-objc-rt '$s1_1?1PSVSVF1rP' | %FileCheck -check-prefix CHECK-OLD %s
+RUN: swift-demangle -no-colors -remangle-objc-rt '$s1_1?1PSVSVF1rP' | %FileCheck -check-prefix CHECK-OLD %s
 
 // CHECK-OLD2: _TPSiP2$BMSPs16IteratorProtocol_
-RUN: swift-demangle -remangle-objc-rt '$sSiStMSLB_p' | %FileCheck -check-prefix CHECK-OLD2 %s
+RUN: swift-demangle -no-colors -remangle-objc-rt '$sSiStMSLB_p' | %FileCheck -check-prefix CHECK-OLD2 %s
 
 // CHECK-OLD3: _TPsP2$HPA
-RUN: swift-demangle -remangle-objc-rt '$ssTALHP' | %FileCheck -check-prefix CHECK-OLD3 %s
+RUN: swift-demangle -no-colors -remangle-objc-rt '$ssTALHP' | %FileCheck -check-prefix CHECK-OLD3 %s
 
 // CHECK-OLD4: _TPiVs14DefaultIndicesx6foobar
-RUN: swift-demangle -remangle-objc-rt '$sSIxip6foobarP' | %FileCheck -check-prefix CHECK-OLD4 %s
+RUN: swift-demangle -no-colors -remangle-objc-rt '$sSIxip6foobarP' | %FileCheck -check-prefix CHECK-OLD4 %s
 
 // CHECK-GENERICEXT: _TtGCs23_ContiguousArrayStorageGVEsVs15FlattenSequence5IndexGV24StdlibCollectionUnittest30MinimalBidirectionalCollectionGS3_Si_____
-RUN: swift-demangle -remangle-objc-rt '$ss23_ContiguousArrayStorageCys15FlattenSequenceVsE5IndexVy24StdlibCollectionUnittest020MinimalBidirectionalH0VyAIySiGG_GGD' | %FileCheck -check-prefix CHECK-GENERICEXT %s
+RUN: swift-demangle -no-colors -remangle-objc-rt '$ss23_ContiguousArrayStorageCys15FlattenSequenceVsE5IndexVy24StdlibCollectionUnittest020MinimalBidirectionalH0VyAIySiGG_GGD' | %FileCheck -check-prefix CHECK-GENERICEXT %s

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -255,9 +255,9 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
       return;
     }
 
-    TrackingDemanglerPrinter printer;
+    std::unique_ptr<TrackingDemanglerPrinter> printer;
     std::string string =
-        swift::Demangle::nodeToString(pointer, options, &printer);
+        swift::Demangle::nodeToString(pointer, options, std::move(printer));
     if (!CompactMode)
       os << name << " ---> ";
 
@@ -284,13 +284,13 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
     os << (string.empty() ? name : llvm::StringRef(string));
 
     if (!string.empty() && Ranges &&
-        (printer.hasBaseName() || printer.hasParameters())) {
+        (printer->hasBaseName() || printer->hasParameters())) {
       os << " | {(";
-      if (printer.hasBaseName())
-        os << printer.getNameStart() << "," << printer.getNameEnd();
+      if (printer->hasBaseName())
+        os << printer->getNameStart() << "," << printer->getNameEnd();
       os << ") - (";
-      if (printer.hasParameters())
-        os << printer.getParametersStart() << "," << printer.getParametersEnd();
+      if (printer->hasParameters())
+        os << printer->getParametersStart() << "," << printer->getParametersEnd();
       os << ")}";
     }
   }

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -290,7 +290,8 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
         os << printer->getNameStart() << "," << printer->getNameEnd();
       os << ") - (";
       if (printer->hasParameters())
-        os << printer->getParametersStart() << "," << printer->getParametersEnd();
+        os << printer->getParametersStart() << ","
+           << printer->getParametersEnd();
       os << ")}";
     }
   }

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -290,8 +290,7 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
         os << printer->getNameStart() << "," << printer->getNameEnd();
       os << ") - (";
       if (printer->hasParameters())
-        os << printer->getParametersStart() << ","
-           << printer->getParametersEnd();
+        os << printer->getParametersStart() << "," << printer->getParametersEnd();
       os << ")}";
     }
   }

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -255,9 +255,9 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
       return;
     }
 
-    std::unique_ptr<TrackingDemanglerPrinter> printer;
+    TrackingDemanglerPrinter printer;
     std::string string =
-        swift::Demangle::nodeToString(pointer, options, std::move(printer));
+        swift::Demangle::nodeToString(pointer, options, &printer);
     if (!CompactMode)
       os << name << " ---> ";
 
@@ -284,13 +284,13 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
     os << (string.empty() ? name : llvm::StringRef(string));
 
     if (!string.empty() && Ranges &&
-        (printer->hasBaseName() || printer->hasParameters())) {
+        (printer.hasBaseName() || printer.hasParameters())) {
       os << " | {(";
-      if (printer->hasBaseName())
-        os << printer->getNameStart() << "," << printer->getNameEnd();
+      if (printer.hasBaseName())
+        os << printer.getNameStart() << "," << printer.getNameEnd();
       os << ") - (";
-      if (printer->hasParameters())
-        os << printer->getParametersStart() << "," << printer->getParametersEnd();
+      if (printer.hasParameters())
+        os << printer.getParametersStart() << "," << printer.getParametersEnd();
       os << ")}";
     }
   }


### PR DESCRIPTION
# Description

This PR adds syntax highlighting for the name and the parameters of a demangled Swift function. Please see the screenshot below:

<img width="1276" alt="Screenshot 2025-05-20 at 19 05 57" src="https://github.com/user-attachments/assets/68280433-d358-4ae1-b6dc-0a86e8b99e4d" />

This is a continuation of https://github.com/swiftlang/swift/pull/81511 and a port of the features introduced in https://github.com/swiftlang/llvm-project/pull/10710.

# Testing

A new test has been added, which reuses manglings.txt, but this time, with the colors in the expected output.