### PR TITLE
[Dependency Scanning][C++ Interop] Remap lookup of Clang module `CxxStdlib` to `std`

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -164,6 +164,11 @@ struct ScannerImportStatementInfo {
       : importLocations({location}), importIdentifier(importIdentifier),
         isExported(isExported) {}
 
+  ScannerImportStatementInfo(std::string importIdentifier, bool isExported,
+                             SmallVector<ImportDiagnosticLocationInfo, 4> locations)
+      : importLocations(locations), importIdentifier(importIdentifier),
+        isExported(isExported) {}
+
   void addImportLocation(ImportDiagnosticLocationInfo location) {
     importLocations.push_back(location);
   }

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -128,19 +128,6 @@ public:
   performDependencyScan(ModuleDependencyID rootModuleID,
                         ModuleDependenciesCache &cache);
 
-  /// Query the module dependency info for the Clang module with the given name.
-  /// Explicit by-name lookups are useful for batch mode scanning.
-  std::optional<const ModuleDependencyInfo *>
-  getNamedClangModuleDependencyInfo(StringRef moduleName,
-                                    ModuleDependenciesCache &cache,
-                                    ModuleDependencyIDSetVector &discoveredClangModules);
-
-  /// Query the module dependency info for the Swift module with the given name.
-  /// Explicit by-name lookups are useful for batch mode scanning.
-  std::optional<const ModuleDependencyInfo *>
-  getNamedSwiftModuleDependencyInfo(StringRef moduleName,
-                                    ModuleDependenciesCache &cache);
-
   /// How many filesystem lookups were performed by the scanner
   unsigned getNumLookups() { return NumLookups; }
 

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1404,7 +1404,8 @@ static void resolveImplicitLinkLibraries(const CompilerInstance &instance,
 
   if (langOpts.EnableCXXInterop) {
     auto OptionalCxxDep = cache.findDependency(CXX_MODULE_NAME);
-    auto OptionalCxxStdLibDep = cache.findDependency("CxxStdlib");
+    auto OptionalCxxStdLibDep =
+        cache.findDependency(instance.getASTContext().Id_CxxStdlib.str());
     bool hasStaticCxx =
         OptionalCxxDep.has_value() && OptionalCxxDep.value()->isStaticLibrary();
     bool hasStaticCxxStdlib = OptionalCxxStdLibDep.has_value() &&

--- a/test/ScanDependencies/cxx-overlay-underlying-module-lookup.swift
+++ b/test/ScanDependencies/cxx-overlay-underlying-module-lookup.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %s -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+// rdar://151780437: libstdc++ VFS modulemap redirects not functioning with EBM enabled
+// REQUIRES: OS=macosx
+
+import CxxStdlib
+
+// CHECK: "mainModuleName": "deps"
+
+/// --------Main module
+// CHECK-LABEL: "modulePath": "deps.swiftmodule",
+// CHECK-NEXT: "sourceFiles": [
+// CHECK-NEXT: cxx-overlay-underlying-module-lookup.swift
+// CHECK-NEXT: ],
+
+// CHECK-NEXT: "directDependencies": [
+// CHECK-DAG:     "clang": "CxxShim"
+// CHECK-DAG:     "swift": "CxxStdlib"
+// CHECK-DAG:     "swift": "Cxx"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK: ],
+
+/// ----------
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}CxxStdlib-{{.*}}.swiftmodule"
+// CHECK-NEXT: "sourceFiles": []
+// CHECK-NEXT: "directDependencies": [
+// CHECK-DAG:     "swift": "Cxx"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "clang": "std"
+// CHECK-DAG:     "clang": "CxxStdlibShim"
+// CHECK: ],


### PR DESCRIPTION
Otherwise querying this clang module, e.g. from the corresponding Swift overlay's underlying module import, will fail, since no such module exists.

Resolves rdar://151718115
