### PR TITLE
[update-checkout] Gracefully degrade timestamp matching.

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -100,8 +100,15 @@ def confirm_tag_in_repo(tag, repo_name) -> Optional[str]:
 
 
 def find_rev_by_timestamp(timestamp, repo_name, refspec):
+    refspec_exists = True
+    try:
+        shell.run(["git", "rev-parse", "--verify", refspec])
+    except Exception:
+        refspec_exists = False
     args = ["git", "log", "-1", "--format=%H", "--first-parent",
-            '--before=' + timestamp, refspec]
+            '--before=' + timestamp]
+    if refspec_exists:
+        args.append(refspec)
     rev = shell.capture(args).strip()
     if rev:
         return rev


### PR DESCRIPTION
Previously, when invoking the script with match-timestamp, if the refspec was absent, the find_rev_by_timestamp function would throw an exception and the script would hang forever.

Here, it is first checked via `git rev-parse --verify $REFSPEC` that the refspec actually exists in the target repo.  If it does not, the refspec is just omitted from the command, giving the latest commit before the currently checked out one.
