### PR TITLE
Revert "[Dependency Scanning] Update Uses of ModuleDeps::ClangModuleDeps #81243"

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -242,11 +242,13 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
         clangModuleDep.IsSystem);
 
     std::vector<ModuleDependencyID> directDependencyIDs;
-    for (const auto &DepInfo : clangModuleDep.ClangModuleDeps) {
-      auto moduleName = DepInfo.ID.ModuleName;
-      dependencies.addModuleImport(moduleName, DepInfo.Exported, &alreadyAddedModules);
+    for (const auto &moduleName : clangModuleDep.ClangModuleDeps) {
+      // FIXME: This assumes, conservatively, that all Clang module imports
+      // are exported. We need to fix this once the clang scanner gains the appropriate
+      // API to query this.
+      dependencies.addModuleImport(moduleName.ModuleName, /* isExported */ true, &alreadyAddedModules);
       // It is safe to assume that all dependencies of a Clang module are Clang modules.
-      directDependencyIDs.push_back({moduleName, ModuleDependencyKind::Clang});
+      directDependencyIDs.push_back({moduleName.ModuleName, ModuleDependencyKind::Clang});
     }
     dependencies.setImportedClangDependencies(directDependencyIDs);
     result.push_back(std::make_pair(ModuleDependencyID{clangModuleDep.ID.ModuleName,


### PR DESCRIPTION
This reverts commit 024dbd040fc11f2ad3f7ce017a703f7a2f756455, reversing changes made to a08b1cbb1db5409afd5524489d1ddacfa1c70f00.

The commit did not solve the fundamental issue we need to handle and is no longer necessary.

rdar://144794793

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
