### PR TITLE
Fix accidental deletion of part of test

### DIFF
--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -250,6 +250,12 @@ public func copyableVarArgTest(_ k: inout Klass) {
 // DWARF-NEXT: DW_AT_decl_line (
 // DWARF-NEXT: DW_AT_type      (
 //
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("m")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
 public func addressOnlyValueTest<T : P>(_ x: T) {
     let k = x
     k.doSomething()
@@ -265,6 +271,33 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
 // CHECK: ret void
 // CHECK-NEXT: }
 //
+// DWARF: DW_AT_linkage_name   ("$s3out23addressOnlyValueArgTestyyxnAA1PRzlF")
+// DWARF-NEXT: DW_AT_name      ("addressOnlyValueArgTest")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_external  (
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location  (0x{{[a-z0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name      ("k")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("$\317\204_0_0")
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_artificial        (true)
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("m")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
 public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
     k.doSomething()
     let m = consume k
@@ -279,6 +312,35 @@ public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
 // CHECK: ret void
 // CHECK-NEXT: }
 //
+// DWARF: DW_AT_linkage_name   ("$s3out18addressOnlyVarTestyyxAA1PRzlF")
+// DWARF-NEXT: DW_AT_name      ("addressOnlyVarTest")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_external  (
+//
+// DWARF: DW_TAG_formal_parameter
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("x")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (
+// DWARF-NEXT: DW_AT_name      ("$\317\204_0_0")
+// DWARF-NEXT: DW_AT_type      (
+// DWARF-NEXT: DW_AT_artificial        (true)
+//
+// DWARF: DW_TAG_variable
+// DWARF-NEXT: DW_AT_location  (0x{{[a-z0-9]+}}:
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// TODO: Missing def in dbg info here.
+// DWARF-NEXT:    [0x{{[a-z0-9]+}}, 0x{{[a-z0-9]+}}):
+// DWARF-NEXT: DW_AT_name      ("k")
+// DWARF-NEXT: DW_AT_decl_file (
+// DWARF-NEXT: DW_AT_decl_line (
+// DWARF-NEXT: DW_AT_type      (
 public func addressOnlyVarTest<T : P>(_ x: T) {
     var k = x // << this
     k.doSomething()
@@ -612,3 +674,4 @@ public func addressOnlyVarArgTestCCFlowReinitInBlockTest<T : P>(_ k: inout (any 
 // CHECK-DAG: ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_OUT_BLOCK_METADATA]] = !DILocalVariable(name: "k",
 // CHECK-DAG: ![[K_ADDRESSONLY_VAR_CCFLOW_REINIT_IN_BLOCK_METADATA]] = !DILocalVariable(name: "k",
 // CHECK-DAG: ![[K_COPYABLE_LET_CCFLOW_METADATA]] = !DILocalVariable(name: "k",
+


### PR DESCRIPTION
Commit 53d10f4c651934d1ac76b59f2f0ce2f52059f956 accidentally deleted parts of move_function_dbginfo test. This just reintroduces the deleted lines

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
