### PR TITLE
Fix the ARM architecture on FreeBSD

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -417,7 +417,7 @@ macro(configure_sdk_unix name architectures)
           message(FATAL_ERROR "unknown arch for ${prefix}: ${arch}")
         endif()
       elseif("${prefix}" STREQUAL "FREEBSD")
-        if(NOT arch MATCHES "(arm64|x86_64)")
+        if(NOT arch MATCHES "(aarch64|x86_64)")
           message(FATAL_ERROR "unsupported arch for FreeBSD: ${arch}")
         endif()
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -461,7 +461,7 @@ function should_execute_host_actions_for_phase() {
 function verify_host_is_supported() {
     local host="$1"
     case ${host} in
-      freebsd-arm64             \
+      freebsd-aarch64           \
       | freebsd-x86_64          \
       | openbsd-x86_64          \
       | openbsd-aarch64         \

--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -290,7 +290,7 @@ class StdlibDeploymentTarget(object):
         "riscv64",
         "s390x"])
 
-    FreeBSD = Platform("freebsd", archs=["x86_64", "arm64"])
+    FreeBSD = Platform("freebsd", archs=["x86_64", "aarch64"])
 
     LinuxStatic = Platform('linux-static', sdk_name='LINUX_STATIC', archs=[
         'x86_64',
@@ -399,7 +399,7 @@ class StdlibDeploymentTarget(object):
             if machine == 'amd64':
                 return StdlibDeploymentTarget.FreeBSD.x86_64
             elif machine == 'arm64':
-                return StdlibDeploymentTarget.FreeBSD.arm64
+                return StdlibDeploymentTarget.FreeBSD.aarch64
 
         elif system == 'OpenBSD':
             if machine == 'amd64':


### PR DESCRIPTION
The 64-bit ARM architecture spelling on FreeBSD is aarch64, not arm64. This results in a build failure about a missing
`freebsd/arm64/swiftrt.o` while building the runtimes.