### PR TITLE
[Swiftify] add debug logs for safe interop

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2344,6 +2344,8 @@ public:
 
   bool isEquivalent(const CustomAttr *other, Decl *attachedTo) const;
 
+  void printCustomAttr(ASTPrinter &Printer, const PrintOptions &Options) const;
+
 private:
   friend class CustomAttrNominalRequest;
   void resetTypeInformation(TypeExpr *repr);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4851,8 +4851,8 @@ void CustomAttr::printCustomAttr(ASTPrinter &Printer, const PrintOptions &Option
   else
     getTypeRepr()->print(Printer, Options);
   Printer.printNamePost(PrintNameContext::Attribute);
-  if (ArgumentList *args = getArgs()) {
-    PrintAST(Printer, Options).printArgumentList(args);
+  if (hasArgs() && Options.PrintExprs) {
+    PrintAST(Printer, Options).printArgumentList(argList);
   }
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4843,6 +4843,16 @@ void PrintAST::visitMacroExpansionDecl(MacroExpansionDecl *decl) {
   Printer << ')';
 }
 
+void CustomAttr::printCustomAttr(ASTPrinter &Printer, const PrintOptions &Options) const {
+  Printer.callPrintNamePre(PrintNameContext::Attribute);
+  Printer << "@";
+  if (auto type = getType())
+    type.print(Printer, Options);
+  else
+    getTypeRepr()->print(Printer, Options);
+  Printer.printNamePost(PrintNameContext::Attribute);
+}
+
 void PrintAST::visitIntegerLiteralExpr(IntegerLiteralExpr *expr) {
   Printer << expr->getDigitsText();
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1103,6 +1103,8 @@ public:
   void printRequirement(const InverseRequirement &inverse,
                         bool forInherited);
 
+  void printArgumentList(ArgumentList *args, bool forSubscript = false);
+
 private:
   bool shouldPrint(const Decl *D, bool Notify = false);
   bool shouldPrintPattern(const Pattern *P);
@@ -1138,8 +1140,6 @@ private:
   void printFunctionParameters(AbstractFunctionDecl *AFD);
 
   void printArgument(const Argument &arg);
-  
-  void printArgumentList(ArgumentList *args, bool forSubscript = false);
 
   void printAvailabilitySpec(AvailabilitySpec *spec);
 
@@ -4851,6 +4851,9 @@ void CustomAttr::printCustomAttr(ASTPrinter &Printer, const PrintOptions &Option
   else
     getTypeRepr()->print(Printer, Options);
   Printer.printNamePost(PrintNameContext::Attribute);
+  if (ArgumentList *args = getArgs()) {
+    PrintAST(Printer, Options).printArgumentList(args);
+  }
 }
 
 void PrintAST::visitIntegerLiteralExpr(IntegerLiteralExpr *expr) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1453,14 +1453,8 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   }
 
   case DeclAttrKind::Custom: {
-    Printer.callPrintNamePre(PrintNameContext::Attribute);
-    Printer << "@";
     auto *attr = cast<CustomAttr>(this);
-    if (auto type = attr->getType())
-      type.print(Printer, Options);
-    else
-      attr->getTypeRepr()->print(Printer, Options);
-    Printer.printNamePost(PrintNameContext::Attribute);
+    attr->printCustomAttr(Printer, Options);
     break;
   }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9408,6 +9408,8 @@ void ClangImporter::Implementation::addOptionSetTypealiases(
                           selfType);
 }
 
+#define SIW_DBG(x) DEBUG_WITH_TYPE("safe-interop-wrappers", llvm::dbgs() << x)
+
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   if (!SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers))
     return;
@@ -9415,6 +9417,7 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
       dyn_cast_or_null<clang::FunctionDecl>(MappedDecl->getClangDecl());
   if (!ClangDecl)
     return;
+  SIW_DBG("Checking " << *ClangDecl << " for bounds and lifetime info\n");
 
   // FIXME: for private macro generated functions we do not serialize the
   // SILFunction's body anywhere triggering assertions.
@@ -9470,11 +9473,13 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     auto *CAT = ClangDecl->getReturnType()->getAs<clang::CountAttributedType>();
     if (SwiftifiableCAT(getClangASTContext(), CAT, swiftReturnTy)) {
       printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
+      SIW_DBG("  Found bounds info '" << clang::QualType(CAT, 0) << "' on return value\n");
       attachMacro = true;
     }
     bool returnHasLifetimeInfo = false;
     if (SwiftDeclConverter::getImplicitObjectParamAnnotation<
             clang::LifetimeBoundAttr>(ClangDecl)) {
+      SIW_DBG("  Found lifetimebound attribute on implicit 'this'\n");
       printer.printLifetimeboundReturn(SwiftifyInfoPrinter::SELF_PARAM_INDEX,
                                        true);
       returnHasLifetimeInfo = true;
@@ -9487,6 +9492,8 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
       auto *CAT = clangParamTy->getAs<clang::CountAttributedType>();
       if (SwiftifiableCAT(getClangASTContext(), CAT, swiftParamTy)) {
         printer.printCountedBy(CAT, index);
+        SIW_DBG("  Found bounds info '" << clangParamTy
+                << "' on parameter '" << *clangParam << "'\n");
         attachMacro = paramHasBoundsInfo = true;
       }
       bool paramIsStdSpan = registerStdSpanTypeMapping(
@@ -9495,10 +9502,13 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
 
       bool paramHasLifetimeInfo = false;
       if (clangParam->hasAttr<clang::NoEscapeAttr>()) {
+        SIW_DBG("  Found noescape attribute on parameter '" << *clangParam << "'\n");
         printer.printNonEscaping(index);
         paramHasLifetimeInfo = true;
       }
       if (clangParam->hasAttr<clang::LifetimeBoundAttr>()) {
+        SIW_DBG("  Found lifetimebound attribute on parameter '"
+                        << *clangParam << "'\n");
         // If this parameter has bounds info we will tranform it into a Span,
         // so then it will no longer be Escapable.
         bool willBeEscapable = swiftParamTy->isEscapable() && !paramHasBoundsInfo;
@@ -9506,17 +9516,23 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
         paramHasLifetimeInfo = true;
         returnHasLifetimeInfo = true;
       }
-      if (paramIsStdSpan && paramHasLifetimeInfo)
+      if (paramIsStdSpan && paramHasLifetimeInfo) {
+        SIW_DBG("  Found both std::span and lifetime info "
+                        "for parameter '" << *clangParam << "'\n");
         attachMacro = true;
+      }
     }
-    if (returnIsStdSpan && returnHasLifetimeInfo)
+    if (returnIsStdSpan && returnHasLifetimeInfo) {
+      SIW_DBG("  Found both std::span and lifetime info for return value\n");
       attachMacro = true;
+    }
     printer.printAvailability();
     printer.printTypeMapping(typeMapping);
 
   }
 
   if (attachMacro) {
+    SIW_DBG("Attaching safe interop macro: " << MacroString << "\n");
     if (clang::RawComment *raw =
             getClangASTContext().getRawCommentForDeclNoCache(ClangDecl)) {
       // swift::RawDocCommentAttr doesn't contain its text directly, but instead
@@ -9536,6 +9552,7 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
     }
   }
 }
+#undef SIW_DBG
 
 static bool isUsingMacroName(clang::SourceManager &SM,
                              clang::SourceLocation loc,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -52,6 +52,8 @@
 #include "swift/Subsystems.h"
 #include "llvm/Config/config.h"
 
+#define DEBUG_TYPE "macros"
+
 using namespace swift;
 
 /// Translate an argument provided as a string literal into an identifier,
@@ -1201,6 +1203,11 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
 
     PrettyStackTraceFreestandingMacroExpansion debugStack(
         "expanding freestanding macro", expansion);
+    LLVM_DEBUG(
+      llvm::dbgs() << "\nexpanding macro:\n";
+      macro->print(llvm::dbgs(), PrintOptions::printEverything());
+      llvm::dbgs() << "\n";
+    );
 
     // Builtin macros are handled via ASTGen.
     auto *astGenSourceFile = sourceFile->getExportedSourceFile();
@@ -1527,6 +1534,18 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
     auto *astGenAttrSourceFile = attrSourceFile->getExportedSourceFile();
     if (!astGenAttrSourceFile)
       return nullptr;
+    LLVM_DEBUG(
+      StreamPrinter P(llvm::dbgs());
+      llvm::dbgs() << "\nexpanding macro:\n";
+      attr->print(P, PrintOptions::printEverything(), attachedTo);
+      llvm::dbgs() << "\nattached to:\n";
+      attachedTo->print(P, PrintOptions::printEverything());
+      if (parentDecl) {
+        llvm::dbgs() << "\nwith parent:\n";
+        parentDecl->print(P, PrintOptions::printEverything());
+      }
+      llvm::dbgs() << "\n";
+    );
 
     auto *astGenDeclSourceFile = declSourceFile->getExportedSourceFile();
     if (!astGenDeclSourceFile)
@@ -1677,6 +1696,14 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro,
 #if SWIFT_BUILD_SWIFT_SYNTAX
     PrettyStackTraceExpr debugStack(
       ctx, "expanding attached macro", attachedTo);
+    LLVM_DEBUG(
+      StreamPrinter P(llvm::dbgs());
+      llvm::dbgs() << "\nexpanding macro:\n";
+      attr->print(P, PrintOptions::printEverything(), nullptr);
+      llvm::dbgs() << "\nattached to:\n";
+      attachedTo->print(P, PrintOptions::printEverything());
+      llvm::dbgs() << "\n";
+    );
 
     auto *astGenAttrSourceFile = attrSourceFile->getExportedSourceFile();
     if (!astGenAttrSourceFile)


### PR DESCRIPTION
This adds some dynamically togglable debug logs for the `swiftify` function in the ClangImporter under `-Xllvm -debug-only=safe-interop-wrappers`, and for the `_SwiftifyImport` macro under `-Xllvm -debug-only=swiftify-import`