### PR TITLE
Revert "preset: build with no assertion for swiftpm on linux"

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1970,9 +1970,7 @@ mixin-preset=mixin_swiftpm_linux_platform
 
 # Build Release without debug info, because it is faster to build.
 release
-# work around https://github.com/swiftlang/swift/issues/81144
 assertions
-no-swift-stdlib-assertions
 
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
@@ -1983,7 +1981,6 @@ toolchain-benchmarks
 skip-test-toolchain-benchmarks
 
 skip-test-llbuild
-
 
 #===------------------------------------------------------------------------===#
 # Test llbuild on macOS builder


### PR DESCRIPTION
Reverts swiftlang/swift#81217 as #81144 is closed.