### PR TITLE
[rebranch] DebugInfo: Restore old behavior in call to `llvm::DIBuilder::createOb…

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1942,7 +1942,7 @@ private:
           nullptr, PtrSize, 0,
           /* DWARFAddressSpace */ std::nullopt, MangledName);
 
-      return DBuilder.createObjectPointerType(PTy, /*Implicit=*/false);
+      return DBuilder.createObjectPointerType(PTy, /*Implicit=*/true);
     }
     case TypeKind::BuiltinExecutor: {
       return createDoublePointerSizedStruct(


### PR DESCRIPTION
…jectPointerType`

Fix my mistake in 66a6df9a4445434bf54faf6d2c845bbc6d82e270. `false` is the wrong value for the new `Implicit` parameter because it causes the `FlagArtificial` flag to not be set as before that change. The flag itself looks appropriate because the entry is constructed for a built-in type.