### PR TITLE
XFAIL clang-args-transitive-availability.swift

### DIFF
--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -9,6 +9,8 @@
 // RUN: %validate-json %t/deps.json &>/dev/null
 // RUN: %FileCheck %s < %t/deps.json
 
+// REQUIRES: rdar151740686
+
 import ImportsMacroSpecificClangModule
 
 // CHECK:      "directDependencies": [


### PR DESCRIPTION
It is failing, probably due to swiftlang/llvm-project#10679. See rdar://151740686.