### PR TITLE
[6.2] InFlightDiagnostic: Minor improvement to `fixItAddAttribute`

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -414,9 +414,20 @@ InFlightDiagnostic::fixItAddAttribute(const DeclAttribute *Attr,
   if (insertionLoc.isValid()) {
     return fixItInsert(insertionLoc, "%0 ", {Attr});
   } else {
-    insertionLoc = E->getBody()->getLBraceLoc();
+    auto *body = E->getBody();
+
+    insertionLoc = body->getLBraceLoc();
     ASSERT(insertionLoc.isValid());
-    return fixItInsertAfter(insertionLoc, " %0 in ", {Attr});
+
+    StringRef fixIt = " %0 in";
+    // If the first token in the body literally begins with the next char after
+    // '{', play it safe with a trailing space.
+    if (body->getContentStartLoc() ==
+        insertionLoc.getAdvancedLoc(/*ByteOffset=*/1)) {
+      fixIt = " %0 in ";
+    }
+
+    return fixItInsertAfter(insertionLoc, fixIt, {Attr});
   }
 }
 

--- a/test/Concurrency/attr_execution/adoption_mode.swift
+++ b/test/Concurrency/attr_execution/adoption_mode.swift
@@ -325,8 +325,22 @@ do {
     // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{12-12=@concurrent }}{{none}}
     test { a, b async in                                          await asyncOnly(a, b) }
     test { @concurrent a, b async in                              await asyncOnly(a, b) }
-    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{11-11= @concurrent in }}{{none}}
+
+    // No space after 'in' necessary.
+    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{11-11= @concurrent in}}{{none}}
     test {                                                        try await asyncThrows($0, $1) }
+    // No space after 'in' necessary.
+    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{11-11= @concurrent in}}{{none}}
+    test { try await asyncThrows($0, $1) }
+    // No space after 'in' necessary.
+    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{11-11= @concurrent in}}{{none}}
+    test {
+      try await asyncThrows($0, $1)
+    }
+    // Add a space after in.
+    // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{11-11= @concurrent in }}{{none}}
+    test {try await asyncThrows($0, $1)}
+
     test { @concurrent in                                         try await asyncThrows($0, $1) }
     // expected-warning@+1:10 {{feature 'NonisolatedNonsendingByDefault' will cause nonisolated async closure to run on the caller's actor; use '@concurrent' to preserve behavior}}{{12-12=@concurrent }}{{none}}
     test { [x] in                                                 try await asyncThrows($0, $1 + x) }


### PR DESCRIPTION
- **Explanation**: Do not follow `in` keyword with a space unless the first token inside the body begins with the next char after `{`.
- **Scope**: `NonisolatedNonsendingByDefault` migration diagnostics QoI (currently the only client).
- **Issues**: —
- **Original PRs**: https://github.com/swiftlang/swift/pull/81671
- **Risk**: Very low.
- **Testing**: Added regression tests.
- **Reviewers**: @xedin