### PR TITLE
Fix use-after-free on substituting function type involving conditional ~Escapable with Escapable type

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -740,11 +740,18 @@ public:
                              globalActor, thrownError, lifetimeDependencies);
   }
 
+  /// \p lifetimeDependencies should be arena allocated and not a temporary
+  /// Function types are allocated on the are arena and their ExtInfo should be
+  /// valid throughout their lifetime.
   [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
       llvm::ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
     return ASTExtInfoBuilder(bits, clangTypeInfo, globalActor, thrownError,
                              lifetimeDependencies);
   }
+
+  [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
+      SmallVectorImpl<LifetimeDependenceInfo> lifetimeDependencies) const =
+      delete;
 
   [[nodiscard]]
   ASTExtInfoBuilder withIsolation(FunctionTypeIsolation isolation) const {
@@ -920,10 +927,17 @@ public:
       .build();
   }
 
+  /// \p lifetimeDependencies should be arena allocated and not a temporary
+  /// Function types are allocated on the are arena and their ExtInfo should be
+  /// valid throughout their lifetime.
   [[nodiscard]] ASTExtInfo withLifetimeDependencies(
       ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
     return builder.withLifetimeDependencies(lifetimeDependencies).build();
   }
+
+  [[nodiscard]] ASTExtInfo withLifetimeDependencies(
+      SmallVectorImpl<LifetimeDependenceInfo> lifetimeDependencies) const =
+      delete;
 
   void Profile(llvm::FoldingSetNodeID &ID) const { builder.Profile(ID); }
 
@@ -1227,10 +1241,18 @@ public:
     return SILExtInfoBuilder(bits, ClangTypeInfo(type).getCanonical(),
                              lifetimeDependencies);
   }
+
+  /// \p lifetimeDependencies should be arena allocated and not a temporary
+  /// Function types are allocated on the are arena and their ExtInfo should be
+  /// valid throughout their lifetime.
   [[nodiscard]] SILExtInfoBuilder withLifetimeDependencies(
       ArrayRef<LifetimeDependenceInfo> lifetimeDependenceInfo) const {
     return SILExtInfoBuilder(bits, clangTypeInfo, lifetimeDependenceInfo);
   }
+
+  [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
+      SmallVectorImpl<LifetimeDependenceInfo> lifetimeDependencies) const =
+      delete;
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddInteger(bits);
@@ -1368,10 +1390,16 @@ public:
     return builder.withUnimplementable(isUnimplementable).build();
   }
 
+  /// \p lifetimeDependencies should be arena allocated and not a temporary
+  /// Function types are allocated on the are arena and their ExtInfo should be
+  /// valid throughout their lifetime.
   SILExtInfo withLifetimeDependencies(
       ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
     return builder.withLifetimeDependencies(lifetimeDependencies);
   }
+
+  SILExtInfo withLifetimeDependencies(SmallVectorImpl<LifetimeDependenceInfo>
+                                          lifetimeDependencies) const = delete;
 
   void Profile(llvm::FoldingSetNodeID &ID) const { builder.Profile(ID); }
 

--- a/include/swift/AST/TypeTransform.h
+++ b/include/swift/AST/TypeTransform.h
@@ -358,7 +358,8 @@ case TypeKind::Id:
             }
           });
         if (didRemoveLifetimeDependencies) {
-          extInfo = extInfo.withLifetimeDependencies(substDependenceInfos);
+          extInfo = extInfo.withLifetimeDependencies(
+              ctx.AllocateCopy(substDependenceInfos));
         }
       }
 
@@ -939,7 +940,8 @@ case TypeKind::Id:
           });
 
         if (didRemoveLifetimeDependencies) {
-          extInfo = extInfo->withLifetimeDependencies(substDependenceInfos);
+          extInfo = extInfo->withLifetimeDependencies(
+              ctx.AllocateCopy(substDependenceInfos));
         }
       }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5210,12 +5210,12 @@ public:
   /// Given an existing ExtInfo, and a set of interface parameters and results
   /// destined for a new SILFunctionType, return a new ExtInfo with only the
   /// lifetime dependencies relevant after substitution.
-  static ExtInfo
-  getSubstLifetimeDependencies(GenericSignature genericSig,
-                               ExtInfo origExtInfo,
-                               ArrayRef<SILParameterInfo> params,
-                               ArrayRef<SILYieldInfo> yields,
-                               ArrayRef<SILResultInfo> results);
+  static ExtInfo getSubstLifetimeDependencies(GenericSignature genericSig,
+                                              ExtInfo origExtInfo,
+                                              ASTContext &context,
+                                              ArrayRef<SILParameterInfo> params,
+                                              ArrayRef<SILYieldInfo> yields,
+                                              ArrayRef<SILResultInfo> results);
 
   /// Return a structurally-identical function type with a slightly tweaked
   /// ExtInfo.

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -240,11 +240,10 @@ public:
     auto genericSig = IFS.shouldSubstituteOpaqueArchetypes()
                         ? origType->getInvocationGenericSignature()
                         : nullptr;
-                        
-    extInfo = SILFunctionType::getSubstLifetimeDependencies(genericSig, extInfo,
-                                                            substParams,
-                                                            substYields,
-                                                            substResults);
+
+    extInfo = SILFunctionType::getSubstLifetimeDependencies(
+        genericSig, extInfo, TC.Context, substParams, substYields,
+        substResults);
 
     return SILFunctionType::get(genericSig, extInfo,
                                 origType->getCoroutineKind(),

--- a/test/Serialization/Inputs/ne_types.swift
+++ b/test/Serialization/Inputs/ne_types.swift
@@ -1,0 +1,98 @@
+@_addressableForDependencies
+public struct Something {
+  public struct View<T: BitwiseCopyable> : ~Copyable, ~Escapable {
+    var ptr: UnsafeBufferPointer<T>
+    
+    @lifetime(borrow ptr)
+    public init(ptr: borrowing UnsafeBufferPointer<T>) {
+      self.ptr = copy ptr
+    }
+    
+    public var span: Span<T> {
+      @lifetime(borrow self)
+      borrowing get {
+        Span(_unsafeElements: ptr)
+      }
+    }
+  }
+  
+  public struct MutableView<T: BitwiseCopyable> : ~Copyable, ~Escapable {
+    var ptr: UnsafeMutableBufferPointer<T>
+    
+    @lifetime(borrow ptr)
+    public init(ptr: borrowing UnsafeMutableBufferPointer<T>) {
+      self.ptr = copy ptr
+    }
+    
+    public var mutableSpan: MutableSpan<T> {
+      @lifetime(&self)
+      mutating get {
+        MutableSpan(_unsafeElements: ptr)
+      }
+    }
+  }
+  
+  var ptr: UnsafeMutableRawBufferPointer
+  public init(ptr: UnsafeMutableRawBufferPointer) {
+    self.ptr = ptr
+  }
+  
+  @lifetime(borrow self)
+  public func view<T>(of type: T.Type = T.self) -> View<T> {
+    let tp = ptr.assumingMemoryBound(to: T.self)
+    return __overrideLifetime(View(ptr: .init(tp)), borrowing: self)
+  }
+  
+  @lifetime(&self)
+  public mutating func mutableView<T>(of type: T.Type = T.self) -> MutableView<T> {
+    let tp = ptr.assumingMemoryBound(to: T.self)
+    return __overrideLifetime(MutableView(ptr: tp), mutating: &self)
+  }
+}
+
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(borrow source)
+public func __overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, borrowing source: borrowing U
+) -> T {
+  dependent
+}
+
+/// Unsafely discard any lifetime dependency on the `dependent` argument. Return
+/// a value identical to `dependent` that inherits all lifetime dependencies from
+/// the `source` argument.
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(copy source)
+public func __overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T, copying source: borrowing U
+) -> T {
+  dependent
+}
+
+/// Unsafely discard any lifetime dependency on the `dependent` argument.
+/// Return a value identical to `dependent` with a lifetime dependency
+/// on the caller's exclusive borrow scope of the `source` argument.
+@unsafe
+@_unsafeNonescapableResult
+@_alwaysEmitIntoClient
+@_transparent
+@lifetime(&source)
+public func __overrideLifetime<
+  T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
+>(
+  _ dependent: consuming T,
+  mutating source: inout U
+) -> T {
+  dependent
+}
+

--- a/test/Serialization/non_escapable_subst_test.swift
+++ b/test/Serialization/non_escapable_subst_test.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/ne_types.swift \
+// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature AddressableTypes \
+// RUN: -enable-library-evolution \
+// RUN: -emit-module-path %t/ne_types.swiftmodule 
+
+// RUN: %target-swift-frontend -emit-silgen -I %t %s \
+// RUN: -enable-experimental-feature LifetimeDependence
+
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_AddressableTypes
+
+import ne_types
+
+// Ensure no memory crashes during SILGen
+
+struct NonEscapableFrameworkThingTests {
+  func example() async throws {
+    let ptr = UnsafeMutableRawBufferPointer.allocate(byteCount: 40, alignment: 1)
+    defer { ptr.deallocate() }
+    var something = Something(ptr: ptr)
+    var mutableView = something.mutableView(of: Float32.self)
+    var mutableSpan = mutableView.mutableSpan
+  }
+}


### PR DESCRIPTION
While type substituting a conditionally ~Escapable type with an Escapable type, we have to drop lifetime dependencies from the function type. The newly constructed lifetime dependencies after dropping substituted dependencies was from a temporary whose lifetime is shorter than needed. Allocate it on the ASTContext like all other instances.

Fixes rdar://151769354