### PR TITLE
[6.2] Fix use-after-free on substituting function type involving conditional ~Escapable with Escapable type

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -740,11 +740,18 @@ public:
                              globalActor, thrownError, lifetimeDependencies);
   }
 
+  /// \p lifetimeDependencies should be arena allocated and not a temporary
+  /// Function types are allocated on the are arena and their ExtInfo should be
+  /// valid throughout their lifetime.
   [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
       llvm::ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
     return ASTExtInfoBuilder(bits, clangTypeInfo, globalActor, thrownError,
                              lifetimeDependencies);
   }
+
+  [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
+      SmallVectorImpl<LifetimeDependenceInfo> lifetimeDependencies) const =
+      delete;
 
   [[nodiscard]]
   ASTExtInfoBuilder withIsolation(FunctionTypeIsolation isolation) const {
@@ -920,10 +927,17 @@ public:
       .build();
   }
 
+  /// \p lifetimeDependencies should be arena allocated and not a temporary
+  /// Function types are allocated on the are arena and their ExtInfo should be
+  /// valid throughout their lifetime.
   [[nodiscard]] ASTExtInfo withLifetimeDependencies(
       ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
     return builder.withLifetimeDependencies(lifetimeDependencies).build();
   }
+
+  [[nodiscard]] ASTExtInfo withLifetimeDependencies(
+      SmallVectorImpl<LifetimeDependenceInfo> lifetimeDependencies) const =
+      delete;
 
   void Profile(llvm::FoldingSetNodeID &ID) const { builder.Profile(ID); }
 
@@ -1227,10 +1241,18 @@ public:
     return SILExtInfoBuilder(bits, ClangTypeInfo(type).getCanonical(),
                              lifetimeDependencies);
   }
+
+  /// \p lifetimeDependencies should be arena allocated and not a temporary
+  /// Function types are allocated on the are arena and their ExtInfo should be
+  /// valid throughout their lifetime.
   [[nodiscard]] SILExtInfoBuilder withLifetimeDependencies(
       ArrayRef<LifetimeDependenceInfo> lifetimeDependenceInfo) const {
     return SILExtInfoBuilder(bits, clangTypeInfo, lifetimeDependenceInfo);
   }
+
+  [[nodiscard]] ASTExtInfoBuilder withLifetimeDependencies(
+      SmallVectorImpl<LifetimeDependenceInfo> lifetimeDependencies) const =
+      delete;
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddInteger(bits);
@@ -1368,10 +1390,16 @@ public:
     return builder.withUnimplementable(isUnimplementable).build();
   }
 
+  /// \p lifetimeDependencies should be arena allocated and not a temporary
+  /// Function types are allocated on the are arena and their ExtInfo should be
+  /// valid throughout their lifetime.
   SILExtInfo withLifetimeDependencies(
       ArrayRef<LifetimeDependenceInfo> lifetimeDependencies) const {
     return builder.withLifetimeDependencies(lifetimeDependencies);
   }
+
+  SILExtInfo withLifetimeDependencies(SmallVectorImpl<LifetimeDependenceInfo>
+                                          lifetimeDependencies) const = delete;
 
   void Profile(llvm::FoldingSetNodeID &ID) const { builder.Profile(ID); }
 

--- a/include/swift/AST/TypeTransform.h
+++ b/include/swift/AST/TypeTransform.h
@@ -358,7 +358,8 @@ case TypeKind::Id:
             }
           });
         if (didRemoveLifetimeDependencies) {
-          extInfo = extInfo.withLifetimeDependencies(substDependenceInfos);
+          extInfo = extInfo.withLifetimeDependencies(
+              ctx.AllocateCopy(substDependenceInfos));
         }
       }
 
@@ -939,7 +940,8 @@ case TypeKind::Id:
           });
 
         if (didRemoveLifetimeDependencies) {
-          extInfo = extInfo->withLifetimeDependencies(substDependenceInfos);
+          extInfo = extInfo->withLifetimeDependencies(
+              ctx.AllocateCopy(substDependenceInfos));
         }
       }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5198,12 +5198,12 @@ public:
   /// Given an existing ExtInfo, and a set of interface parameters and results
   /// destined for a new SILFunctionType, return a new ExtInfo with only the
   /// lifetime dependencies relevant after substitution.
-  static ExtInfo
-  getSubstLifetimeDependencies(GenericSignature genericSig,
-                               ExtInfo origExtInfo,
-                               ArrayRef<SILParameterInfo> params,
-                               ArrayRef<SILYieldInfo> yields,
-                               ArrayRef<SILResultInfo> results);
+  static ExtInfo getSubstLifetimeDependencies(GenericSignature genericSig,
+                                              ExtInfo origExtInfo,
+                                              ASTContext &context,
+                                              ArrayRef<SILParameterInfo> params,
+                                              ArrayRef<SILYieldInfo> yields,
+                                              ArrayRef<SILResultInfo> results);
 
   /// Return a structurally-identical function type with a slightly tweaked
   /// ExtInfo.

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -59,12 +59,10 @@ SILType SILFunctionType::substInterfaceType(SILModule &M,
   return interfaceType;
 }
 
-SILFunctionType::ExtInfo
-SILFunctionType::getSubstLifetimeDependencies(GenericSignature genericSig,
-                                              ExtInfo origExtInfo,
-                                              ArrayRef<SILParameterInfo> params,
-                                              ArrayRef<SILYieldInfo> yields,
-                                              ArrayRef<SILResultInfo> results) {
+SILFunctionType::ExtInfo SILFunctionType::getSubstLifetimeDependencies(
+    GenericSignature genericSig, ExtInfo origExtInfo, ASTContext &context,
+    ArrayRef<SILParameterInfo> params, ArrayRef<SILYieldInfo> yields,
+    ArrayRef<SILResultInfo> results) {
   if (origExtInfo.getLifetimeDependencies().empty()) {
     return origExtInfo;
   }
@@ -87,7 +85,8 @@ SILFunctionType::getSubstLifetimeDependencies(GenericSignature genericSig,
       }
     });
   if (didRemoveLifetimeDependencies) {
-    return origExtInfo.withLifetimeDependencies(substLifetimeDependencies);
+    return origExtInfo.withLifetimeDependencies(
+        context.AllocateCopy(substLifetimeDependencies));
   }
   return origExtInfo;
 }
@@ -131,10 +130,10 @@ CanSILFunctionType SILFunctionType::getUnsubstitutedType(SILModule &M) const {
 
   auto signature = isPolymorphic() ? getInvocationGenericSignature()
                                    : CanGenericSignature();
-  
-  auto extInfo = getSubstLifetimeDependencies(signature, getExtInfo(),
-                                              params, yields, results);
-  
+
+  auto extInfo = getSubstLifetimeDependencies(
+      signature, getExtInfo(), getASTContext(), params, yields, results);
+
   return SILFunctionType::get(signature,
                               extInfo,
                               getCoroutineKind(),
@@ -2829,7 +2828,7 @@ static CanSILFunctionType getSILFunctionType(
           .withSendable(isSendable)
           .withAsync(isAsync)
           .withUnimplementable(unimplementable)
-          .withLifetimeDependencies(loweredLifetimes)
+          .withLifetimeDependencies(TC.Context.AllocateCopy(loweredLifetimes))
           .build();
 
   return SILFunctionType::get(genericSig, silExtInfo, coroutineKind,

--- a/lib/SIL/IR/SILTypeSubstitution.cpp
+++ b/lib/SIL/IR/SILTypeSubstitution.cpp
@@ -240,11 +240,10 @@ public:
     auto genericSig = IFS.shouldSubstituteOpaqueArchetypes()
                         ? origType->getInvocationGenericSignature()
                         : nullptr;
-                        
-    extInfo = SILFunctionType::getSubstLifetimeDependencies(genericSig, extInfo,
-                                                            substParams,
-                                                            substYields,
-                                                            substResults);
+
+    extInfo = SILFunctionType::getSubstLifetimeDependencies(
+        genericSig, extInfo, TC.Context, substParams, substYields,
+        substResults);
 
     return SILFunctionType::get(genericSig, extInfo,
                                 origType->getCoroutineKind(),


### PR DESCRIPTION
Explanation: While type substituting a conditionally ~Escapable type with an Escapable type, we have to drop lifetime dependencies from the function type. The newly constructed lifetime dependencies after dropping substituted dependencies was from a temporary whose lifetime is shorter than needed. Allocate it on the ASTContext like all other instances. 

Scope: Effects conditionally non escapable types 

Risk: Low

Main PR: https://github.com/swiftlang/swift/pull/81678

Issue: rdar://151769354

Reviewer: @atrick 