### PR TITLE
SIL: define `mark_dependence_addr` to read and write to its address operand

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -253,8 +253,17 @@ struct AliasAnalysis {
     case let storeBorrow as StoreBorrowInst:
       return memLoc.mayAlias(with: storeBorrow.destination, self) ? .init(write: true) : .noEffects
 
-    case let mdi as MarkDependenceInstruction:
+    case let mdi as MarkDependenceInst:
       if mdi.base.type.isAddress && memLoc.mayAlias(with: mdi.base, self) {
+        return .init(read: true)
+      }
+      return .noEffects
+
+    case let mdai as MarkDependenceAddrInst:
+      if memLoc.mayAlias(with: mdai.address, self) {
+        return .init(read: true, write: true)
+      }
+      if mdai.base.type.isAddress && memLoc.mayAlias(with: mdai.base, self) {
         return .init(read: true)
       }
       return .noEffects

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -907,7 +907,7 @@ NON_VALUE_INST(IncrementProfilerCounterInst, increment_profiler_counter,
 // MarkDependenceAddrInst has read effects for the base operand. See
 // getMemoryBehavior().
 NON_VALUE_INST(MarkDependenceAddrInst, mark_dependence_addr,
-               SILInstruction, None, DoesNotRelease)
+               SILInstruction, MayReadWrite, DoesNotRelease)
 
 NON_VALUE_INST(EndCOWMutationAddrInst, end_cow_mutation_addr,
                SILInstruction, MayHaveSideEffects, DoesNotRelease)

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -1097,8 +1097,8 @@ MemoryBehavior SILInstruction::getMemoryBehavior() const {
     llvm_unreachable("Covered switch isn't covered?!");
   }
   
-  if (auto mdi = MarkDependenceInstruction(this)) {
-    if (mdi.getBase()->getType().isAddress())
+  if (auto *mdi = dyn_cast<MarkDependenceInst>(this)) {
+    if (mdi->getBase()->getType().isAddress())
       return MemoryBehavior::MayRead;
     return MemoryBehavior::None;
   }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -253,6 +253,9 @@ bool noncopyable::memInstMustReinitialize(Operand *memOper) {
     auto *CAI = cast<ExplicitCopyAddrInst>(memInst);
     return CAI->getDest() == address && !CAI->isInitializationOfDest();
   }
+  case SILInstructionKind::MarkDependenceAddrInst: {
+    return true;
+  }
   case SILInstructionKind::YieldInst: {
     auto *yield = cast<YieldInst>(memInst);
     return yield->getYieldInfoForOperand(*memOper).isIndirectInOut();

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1925,7 +1925,7 @@ bb0(%0 : $*C, %1 : $*C, %2 : @owned $C):
 // CHECK:      PAIR #1.
 // CHECK-NEXT:   mark_dependence_addr %1 : $*C on %2 : $C
 // CHECK-NEXT:   %1 = argument of bb0 : $*C
-// CHECK-NEXT:   r=0,w=0
+// CHECK-NEXT:   r=1,w=1
 // CHECK:      PAIR #2.
 // CHECK-NEXT:     mark_dependence_addr %1 : $*C on %0 : $*C
 // CHECK-NEXT:   %0 = argument of bb0 : $*C
@@ -1933,8 +1933,8 @@ bb0(%0 : $*C, %1 : $*C, %2 : @owned $C):
 // CHECK:      PAIR #3.
 // CHECK-NEXT:    mark_dependence_addr %1 : $*C on %0 : $*C
 // CHECK-NEXT:  %1 = argument of bb0 : $*C
-// CHECK-NEXT:  r=0,w=0
-sil [ossa] @test_mark_dependence_addr : $@convention(thin) (@in_guaranteed C, @in_guaranteed C, @guaranteed C) -> () {
+// CHECK-NEXT:  r=1,w=1
+sil [ossa] @test_mark_dependence_addr : $@convention(thin) (@in_guaranteed C, @inout C, @guaranteed C) -> () {
 bb0(%0 : $*C, %1 : $*C, %2 : @guaranteed $C):
   mark_dependence_addr %1 on %2
   mark_dependence_addr %1 on %0

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5411,6 +5411,16 @@ bb1(%10 : @owned $Optional<@callee_guaranteed () -> ()>, %11 : @guaranteed $Opti
   return %12 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @not_dead_mark_dependence_addr :
+// CHECK:         mark_dependence_addr %0 : $*B on %1
+// CHECK-LABEL: } // end sil function 'not_dead_mark_dependence_addr'
+sil [ossa] @not_dead_mark_dependence_addr : $@convention(thin) (@inout B, @in_guaranteed B) -> @owned B {
+bb0(%0 : $*B, %1 : $*B):
+  mark_dependence_addr %0 on %1
+  %3 = load [copy] %0
+  return %3
+}
+
 // CHECK-LABEL: sil [ossa] @remove_borrow_of_thin_function :
 // CHECK:         [[F:%.*]] = function_ref @unknown
 // CHECK:         [[T:%.*]] = thin_to_thick_function [[F]]


### PR DESCRIPTION
This prevents simplification and SILCombine passes to remove (alive) `mark_dependence_addr`. The instruction is conceptually equivalent to
```
  %v = load %addr
  %d = mark_dependence %v on %base
  store %d to %addr
```

Therefore the address operand has to be defined as writing to the address.

rdar://151903915