### PR TITLE
[6.2] Diagnostic message: suppress printing "requires LifetimeDependence"

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8219,15 +8219,13 @@ ERROR(lifetime_parameter_requires_inout, none,
 //------------------------------------------------------------------------------
 
 ERROR(lifetime_dependence_feature_required_return, none,
-      "%0 with a ~Escapable result requires "
-      "'-enable-experimental-feature LifetimeDependence'", (StringRef))
+      "%0 cannot return a ~Escapable result", (StringRef))
 ERROR(lifetime_dependence_feature_required_mutating, none,
-      "%0 with ~Escapable 'self' requires "
-      "'-enable-experimental-feature LifetimeDependence'", (StringRef))
+      "%0 cannot have a ~Escapable 'self'", (StringRef))
 ERROR(lifetime_dependence_feature_required_inout, none,
-      "%0 with a ~Escapable 'inout' parameter requires "
-      "'-enable-experimental-feature LifetimeDependence'",
-      // arg list is interchangable with lifetime_dependence_cannot_infer_inout
+      "%0 cannot have a ~Escapable 'inout' parameter %1",
+      // this arg list must be compatible with
+      // lifetime_dependence_cannot_infer_inout
       (StringRef, Identifier))
 
 ERROR(lifetime_dependence_cannot_infer_return, none,

--- a/test/Interop/Cxx/class/nonescapable-errors.swift
+++ b/test/Interop/Cxx/class/nonescapable-errors.swift
@@ -109,7 +109,7 @@ public func importInvalid(_ x: Invalid) {
 }
 
 // CHECK: error: a function with a ~Escapable result needs a parameter to depend on
-// CHECK-NO-LIFETIMES: test.swift:11:32: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+// CHECK-NO-LIFETIMES: test.swift:11:32: error: a function cannot return a ~Escapable result
 public func noAnnotations() -> View {
     // CHECK: nonescapable.h:16:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies [#ClangDeclarationImport]
     // CHECK-NO-LIFETIMES: nonescapable.h:16:7: warning: the returned type 'Owner' is annotated as escapable; it cannot have lifetime dependencies [#ClangDeclarationImport]
@@ -121,12 +121,12 @@ public func noAnnotations() -> View {
     f2(nil, nil)
     // CHECK: nonescapable.h:24:6: warning: the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated [#ClangDeclarationImport]
     // CHECK-NO-LIFETIMES: nonescapable.h:24:6: warning: the returned type 'View' is annotated as non-escapable; its lifetime dependencies must be annotated [#ClangDeclarationImport]
-    // CHECK-NO-LIFETIMES: nonescapable.h:24:6: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:24:6: error: a function cannot return a ~Escapable result
     g(nil)
     h1(nil)
-    // CHECK-NO-LIFETIMES: nonescapable.h:34:21: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:34:21: error: a function cannot return a ~Escapable result
     h2(nil)
-    // CHECK-NO-LIFETIMES: nonescapable.h:35:21: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:35:21: error: a function cannot return a ~Escapable result
     h3(nil)
     i1()
     // CHECK: nonescapable.h:39:39: error: template parameter 'Missing' does not exist
@@ -135,18 +135,18 @@ public func noAnnotations() -> View {
     // CHECK: nonescapable.h:45:33: error: template parameter 'S' expected to be a type parameter
     // CHECK-NO-LIFETIMES: nonescapable.h:45:33: error: template parameter 'S' expected to be a type parameter
     j1()
-    // CHECK-NO-LIFETIMES: nonescapable.h:63:41: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:63:41: error: a function cannot return a ~Escapable result
     j2()
-    // CHECK-NO-LIFETIMES: nonescapable.h:64:41: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:64:41: error: a function cannot return a ~Escapable result
     j3()
     k1();
-    // CHECK-NO-LIFETIMES: nonescapable.h:70:15: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:70:15: error: a function cannot return a ~Escapable result
     k2();
-    // CHECK-NO-LIFETIMES: nonescapable.h:71:22: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:71:22: error: a function cannot return a ~Escapable result
     k3();
     l1();
     // CHECK: nonescapable.h:77:12: error: a function with a ~Escapable result needs a parameter to depend on
-    // CHECK-NO-LIFETIMES: nonescapable.h:77:12: error: a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'
+    // CHECK-NO-LIFETIMES: nonescapable.h:77:12: error: a function cannot return a ~Escapable result
     l2();
     return View()
 }

--- a/test/Sema/lifetime_attr_nofeature.swift
+++ b/test/Sema/lifetime_attr_nofeature.swift
@@ -1,10 +1,10 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking
 // REQUIRES: asserts
 
-struct NE : ~Escapable { // expected-error{{an implicit initializer with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'}}
+struct NE : ~Escapable { // expected-error{{an implicit initializer cannot return a ~Escapable result}}
 }
 
 @lifetime(copy ne) // expected-error{{'@lifetime' attribute is only valid when experimental feature LifetimeDependence is enabled}} expected-error{{expected declaration}}
-func derive(_ ne: NE) -> NE { // expected-error{{a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'}}
+func derive(_ ne: NE) -> NE { // expected-error{{a function cannot return a ~Escapable result}}
   ne
 }

--- a/test/Sema/lifetime_depend_nofeature.swift
+++ b/test/Sema/lifetime_depend_nofeature.swift
@@ -6,29 +6,29 @@
 // Check that functions that require lifetime dependence are prohibited without the flag.
 
 // Don't allow empty initialization.
-struct EmptyNonEscapable: ~Escapable {} // expected-error{{an implicit initializer with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'}}
+struct EmptyNonEscapable: ~Escapable {} // expected-error{{an implicit initializer cannot return a ~Escapable result}}
 
 // Don't allow non-Escapable return values.
-func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a function with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'}}
+func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a function cannot return a ~Escapable result}}
 
 func neInout(span: inout RawSpan) {} // OK
 
-func neInoutNEParam(span: inout RawSpan, _: RawSpan) {} // expected-error{{a function with a ~Escapable 'inout' parameter requires '-enable-experimental-feature LifetimeDependence'}}
+func neInoutNEParam(span: inout RawSpan, _: RawSpan) {} // expected-error{{a function cannot have a ~Escapable 'inout' parameter 'span'}}
 
 struct S {
-  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'}}
+  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method cannot return a ~Escapable result}}
 
   func neInout(span: inout RawSpan) {} // OK
 
-  func neInoutNEParam(span: inout RawSpan, _: RawSpan) {} // expected-error{{a method with a ~Escapable 'inout' parameter requires '-enable-experimental-feature LifetimeDependence'}}
+  func neInoutNEParam(span: inout RawSpan, _: RawSpan) {} // expected-error{{a method cannot have a ~Escapable 'inout' parameter 'span'}}
 
   mutating func mutatingNEInout(span: inout RawSpan) {} // OK
 
-  mutating func mutatingNEInoutParam(span: inout RawSpan, _: RawSpan) {} // expected-error{{a mutating method with a ~Escapable 'inout' parameter requires '-enable-experimental-feature LifetimeDependence'}}
+  mutating func mutatingNEInoutParam(span: inout RawSpan, _: RawSpan) {} // expected-error{{a mutating method cannot have a ~Escapable 'inout' parameter 'span'}}
 }
 
 class C {
-  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'}}
+  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method cannot return a ~Escapable result}}
 
   func neInout(span: inout RawSpan) {} // OK
 }
@@ -36,12 +36,12 @@ class C {
 extension MutableSpan {
   func method() {} // OK
 
-  mutating func mutatingMethod() {} // expected-error{{a mutating method with ~Escapable 'self' requires '-enable-experimental-feature LifetimeDependence'}}
+  mutating func mutatingMethod() {} // expected-error{{a mutating method cannot have a ~Escapable 'self'}}
 
-  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '-enable-experimental-feature LifetimeDependence'}}
+  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method cannot return a ~Escapable result}}
 
-  func neInout(span: inout RawSpan) {} // expected-error{{a method with a ~Escapable 'inout' parameter requires '-enable-experimental-feature LifetimeDependence'}}
+  func neInout(span: inout RawSpan) {} // expected-error{{a method cannot have a ~Escapable 'inout' parameter 'span'}}
 
-  mutating func mutatingNEInout(span: inout RawSpan) {} // expected-error{{a mutating method with ~Escapable 'self' requires '-enable-experimental-feature LifetimeDependence'}}
-  // expected-error@-1{{a mutating method with a ~Escapable 'inout' parameter requires '-enable-experimental-feature LifetimeDependence'}}
+  mutating func mutatingNEInout(span: inout RawSpan) {} // expected-error{{a mutating method cannot have a ~Escapable 'self'}}
+  // expected-error@-1{{a mutating method cannot have a ~Escapable 'inout' parameter 'span'}}
 }


### PR DESCRIPTION
Adopters of the new Span and MutableSpan types should not encounter information
about an experimental feature when they attempt to use these types in
unsupported ways, such as simply returning them from a function.

Fixes rdar://151788740 (Diagnostic message: suppress printing "requires
'-enable-experimental-feature LifetimeDependence'")

(cherry picked from commit 50a69bcee3dff4afeba6eebe510584f43faf6c75)

--- CCC ---

Explanation: Adopters of the new Span and MutableSpan types should not
encounter information about an experimental feature when they attempt
to use these types in unsupported ways, such as simply returning one
from a function.

Scope: This change only affects the text of a diagnostic message that
is new in this release. This message will only be seen by adopters of
the new Span and MutableSpan types.

Radar/SR Issue: rdar://151788740 (Diagnostic message: suppress
printing "requires '-enable-experimental-feature LifetimeDependence'")

main PR: https://github.com/swiftlang/swift/pull/81685

Risk: None

Testing: Updated several unit tests for this diagnostic.

Reviewer: Joe Groff
