### PR TITLE
[sema] Change non-sendable -> non-Sendable in diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -92,7 +92,7 @@ GROUPED_WARNING(clang_swift_attr_unhandled, ClangDeclarationImport, none,
         "ignoring unknown Swift attribute or modifier '%0'", (StringRef))
 
 GROUPED_WARNING(clang_error_code_must_be_sendable, ClangDeclarationImport, none,
-        "cannot make error code type '%0' non-sendable because Swift errors "
+        "cannot make error code type '%0' non-Sendable because Swift errors "
         "are always sendable", (StringRef))
 
 GROUPED_WARNING(clang_ignored_sendable_attr, ClangDeclarationImport, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5008,28 +5008,28 @@ NOTE(silence_debug_description_in_interpolation_segment_call,none,
      "use 'String(describing:)' to silence this warning", ())
 
 NOTE(noescape_parameter,none,
-    "parameter %1 is implicitly %select{non-escaping|non-sendable}0",
+    "parameter %1 is implicitly %select{non-escaping|non-Sendable}0",
      (unsigned, Identifier))
 NOTE(generic_parameters_always_escaping,none,
      "generic parameters are always considered '@escaping'", ())
 
 ERROR(passing_noattrfunc_to_attrfunc,none,
-      "passing %select{non-escaping|non-sendable}0 parameter %1 to function "
+      "passing %select{non-escaping|non-Sendable}0 parameter %1 to function "
       "expecting %select{an '@escaping'|a '@Sendable'}0 closure",
       (unsigned, Identifier))
 ERROR(converting_noescape_param_to_generic_type,none,
       "converting non-escaping parameter %0 to generic parameter %1 may allow it to escape",
       (Identifier, Type))
 ERROR(assigning_noattrfunc_to_attrfunc,none,
-      "assigning %select{non-escaping|non-sendable}0 parameter %1 to "
+      "assigning %select{non-escaping|non-Sendable}0 parameter %1 to "
       "%select{an '@escaping'|a '@Sendable'}0 closure",
       (unsigned, Identifier))
 ERROR(general_noattrfunc_to_attr,none,
-      "using %select{non-escaping|non-sendable}0 parameter %1 in a context "
+      "using %select{non-escaping|non-Sendable}0 parameter %1 in a context "
       "expecting %select{an '@escaping'|a '@Sendable'}0 closure",
       (unsigned, Identifier))
 ERROR(converting_noattrfunc_to_type,none,
-      "converting %select{non-escaping|non-sendable function}0 value to %1 "
+      "converting %select{non-escaping|non-Sendable function}0 value to %1 "
       "may %select{allow it to escape|introduce data races}0",
       (unsigned, Type))
 NOTE(escape_expected_at_parameter_position,none,
@@ -5672,15 +5672,15 @@ GROUPED_ERROR(concurrent_access_of_inout_param,SendableClosureCaptures,none,
       "concurrently-executing code",
       (DeclName))
 GROUPED_ERROR(non_sendable_capture,SendableClosureCaptures,none,
-      "capture of %1 with non-sendable type %0 in a '@Sendable' "
+      "capture of %1 with non-Sendable type %0 in a '@Sendable' "
       "%select{local function|closure}2",
       (Type, DeclName, bool))
 ERROR(non_sendable_isolated_capture,none,
-      "capture of %1 with non-sendable type %0 in an isolated "
+      "capture of %1 with non-Sendable type %0 in an isolated "
       "%select{local function|closure}2",
       (Type, DeclName, bool))
 ERROR(non_sendable_metatype_capture,none,
-      "capture of non-sendable type %0 in an isolated "
+      "capture of non-Sendable type %0 in an isolated "
       "%select{local function|closure}1",
       (Type, bool))
 ERROR(self_capture_deinit_task,none,
@@ -5817,77 +5817,77 @@ NOTE(in_derived_witness, none,
      (const ValueDecl *, DeclName, Type))
 
 ERROR(non_sendable_arg_into_actor,none,
-      "non-sendable type %0 cannot be sent into %2 context in call to %kind1",
+      "non-Sendable type %0 cannot be sent into %2 context in call to %kind1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_arg_exits_actor,none,
-      "non-sendable type %0 cannot exit %2 context in call to nonisolated "
+      "non-Sendable type %0 cannot exit %2 context in call to nonisolated "
       "%kind1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_param_in_witness,none,
-      "non-sendable parameter type %0 cannot be sent from caller of "
+      "non-Sendable parameter type %0 cannot be sent from caller of "
       "protocol requirement %1 into %2 implementation",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_param_in_override,none,
-      "non-sendable parameter type %0 cannot be sent from caller of "
+      "non-Sendable parameter type %0 cannot be sent from caller of "
       "superclass %kind1 into %2 override",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_param_in_objc,none,
-      "non-sendable parameter type %0 of %2 '@objc' %kind1 cannot cross actor "
+      "non-Sendable parameter type %0 of %2 '@objc' %kind1 cannot cross actor "
       "boundary",
       (Type, const ValueDecl *, ActorIsolation))
 
 ERROR(non_sendable_result_into_actor,none,
-      "non-sendable result type %0 cannot be sent from %2 context in call "
+      "non-Sendable result type %0 cannot be sent from %2 context in call "
       "to %kind1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_result_exits_actor,none,
-      "non-sendable result type %0 cannot exit %2 context in call to "
+      "non-Sendable result type %0 cannot exit %2 context in call to "
       "nonisolated %kind1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_result_in_witness,none,
-      "non-sendable type %0 cannot be returned from %2 implementation "
+      "non-Sendable type %0 cannot be returned from %2 implementation "
       "to caller of protocol requirement %1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_result_in_override,none,
-      "non-sendable type %0 cannot be returned from %2 override to "
+      "non-Sendable type %0 cannot be returned from %2 override to "
       "caller of superclass %kind1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_result_in_objc,none,
-      "non-sendable type %0 returned by %2 '@objc' %kind1 cannot cross "
+      "non-Sendable type %0 returned by %2 '@objc' %kind1 cannot cross "
       "actor boundary",
       (Type, const ValueDecl *, ActorIsolation))
 
 ERROR(non_sendable_call_result_type,none,
-      "non-sendable result type %0 cannot be sent from %1 context in call "
+      "non-Sendable result type %0 cannot be sent from %1 context in call "
       "to async function",
       (Type, ActorIsolation))
 
 ERROR(non_sendable_property_exits_actor,none,
-      "non-sendable type %0 of %kind1 cannot exit %2 context",
+      "non-Sendable type %0 of %kind1 cannot exit %2 context",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_property_into_actor,none,
-      "non-sendable type %0 of nonisolated %kind1 cannot be sent to "
+      "non-Sendable type %0 of nonisolated %kind1 cannot be sent to "
       "%2 context",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_property_in_witness,none,
-      "non-sendable type %0 cannot be returned from %2 implementation "
+      "non-Sendable type %0 cannot be returned from %2 implementation "
       "to caller of protocol requirement %1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_property_in_override,none,
-      "non-sendable type %0 cannot be returned from %2 override to "
+      "non-Sendable type %0 cannot be returned from %2 override to "
       "caller of superclass %kind1",
       (Type, const ValueDecl *, ActorIsolation))
 ERROR(non_sendable_property_in_objc,none,
-      "non-sendable type %0 returned by %2 '@objc' %kind1 cannot cross "
+      "non-Sendable type %0 returned by %2 '@objc' %kind1 cannot cross "
       "actor boundary",
       (Type, const ValueDecl *, ActorIsolation))
 
 ERROR(non_sendable_keypath_capture,none,
-      "cannot form key path that captures non-sendable type %0",
+      "cannot form key path that captures non-Sendable type %0",
       (Type))
 ERROR(non_concurrent_type_member,none,
       "%select{stored property %2|associated value %2}1 of "
-      "'Sendable'-conforming %kind3 has non-sendable type %0",
+      "'Sendable'-conforming %kind3 has non-Sendable type %0",
       (Type, bool, DeclName, const ValueDecl *))
 ERROR(concurrent_value_class_mutable_property,none,
       "stored property %0 of 'Sendable'-conforming %kind1 is mutable",
@@ -5986,7 +5986,7 @@ ERROR(nonisolated_lazy,none,
       ())
 
 ERROR(non_sendable_from_deinit,none,
-        "cannot access %kind1 with a non-sendable type %0 from nonisolated "
+        "cannot access %kind1 with a non-Sendable type %0 from nonisolated "
         "deinit",
         (Type, const VarDecl *))
 

--- a/include/swift/Sema/Concurrency.h
+++ b/include/swift/Sema/Concurrency.h
@@ -36,7 +36,7 @@ struct DiagnosticBehavior;
 /// that the attribute be removed.
 void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
 
-/// Diagnose the use of an instance property of non-sendable type from an
+/// Diagnose the use of an instance property of non-Sendable type from an
 /// nonisolated deinitializer within an actor-isolated type.
 ///
 /// \returns true iff a diagnostic was emitted for this reference.

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -137,22 +137,22 @@ func testSendableAttrs(
 
   doSomethingConcurrently {
     print(sendableClass)               // no-error
-    print(nonSendableClass)            // expected-warning{{capture of 'nonSendableClass' with non-sendable type 'NonSendableClass' in a '@Sendable' closure}}
+    print(nonSendableClass)            // expected-warning{{capture of 'nonSendableClass' with non-Sendable type 'NonSendableClass' in a '@Sendable' closure}}
 
     print(sendableEnum)                // no-error
-    print(nonSendableEnum)             // expected-warning{{capture of 'nonSendableEnum' with non-sendable type 'NonSendableEnum' in a '@Sendable' closure}}
+    print(nonSendableEnum)             // expected-warning{{capture of 'nonSendableEnum' with non-Sendable type 'NonSendableEnum' in a '@Sendable' closure}}
 
     print(sendableOptions)             // no-error
-    print(nonSendableOptions)          // expected-warning{{capture of 'nonSendableOptions' with non-sendable type 'NonSendableOptions' in a '@Sendable' closure}}
+    print(nonSendableOptions)          // expected-warning{{capture of 'nonSendableOptions' with non-Sendable type 'NonSendableOptions' in a '@Sendable' closure}}
 
     print(sendableError)               // no-error
     print(nonSendableError)            // no-error--we don't respect `@_nonSendable` on `ns_error_domain` types because all errors are Sendable
 
     print(sendableStringEnum)          // no-error
-    print(nonSendableStringEnum)       // expected-warning{{capture of 'nonSendableStringEnum' with non-sendable type 'NonSendableStringEnum' in a '@Sendable' closure}}
+    print(nonSendableStringEnum)       // expected-warning{{capture of 'nonSendableStringEnum' with non-Sendable type 'NonSendableStringEnum' in a '@Sendable' closure}}
 
     print(sendableStringStruct)        // no-error
-    print(nonSendableStringStruct)     // expected-warning{{capture of 'nonSendableStringStruct' with non-sendable type 'NonSendableStringStruct' in a '@Sendable' closure}}
+    print(nonSendableStringStruct)     // expected-warning{{capture of 'nonSendableStringStruct' with non-Sendable type 'NonSendableStringStruct' in a '@Sendable' closure}}
   }
 }
 

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -176,11 +176,11 @@ func someAsyncFunc() async {
   ////////////
   // effectful properties from outside the actor instance
 
-  // expected-warning@+2 {{non-sendable type 'Box' of property 'effPropA' cannot exit actor-isolated context}}
+  // expected-warning@+2 {{non-Sendable type 'Box' of property 'effPropA' cannot exit actor-isolated context}}
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = a.effPropA
 
-  // expected-warning@+3 {{non-sendable type 'Box' of property 'effPropT' cannot exit actor-isolated context}}
+  // expected-warning@+3 {{non-Sendable type 'Box' of property 'effPropT' cannot exit actor-isolated context}}
   // expected-error@+2{{property access can throw, but it is not marked with 'try' and the error is not handled}}
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
   _ = a.effPropT
@@ -190,8 +190,8 @@ func someAsyncFunc() async {
   _ = a.effPropAT
 
   // (mostly) corrected ones
-  _ = await a.effPropA  // expected-warning {{non-sendable type 'Box' of property 'effPropA' cannot exit actor-isolated context}}
-  _ = try! await a.effPropT // expected-warning {{non-sendable type 'Box' of property 'effPropT' cannot exit actor-isolated context}}
+  _ = await a.effPropA  // expected-warning {{non-Sendable type 'Box' of property 'effPropA' cannot exit actor-isolated context}}
+  _ = try! await a.effPropT // expected-warning {{non-Sendable type 'Box' of property 'effPropT' cannot exit actor-isolated context}}
   _ = try? await a.effPropAT
 
   print("ok!")

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -119,7 +119,7 @@ extension TestActor {
   func passStateIntoDifferentClassMethod() async {
     let other = NonAsyncClass()
     let otherCurry = other.modifyOtherAsync
-    // expected-targeted-complete-tns-warning @-1 {{non-sendable type 'NonAsyncClass' cannot exit actor-isolated context in call to nonisolated instance method 'modifyOtherAsync'}}
+    // expected-targeted-complete-tns-warning @-1 {{non-Sendable type 'NonAsyncClass' cannot exit actor-isolated context in call to nonisolated instance method 'modifyOtherAsync'}}
     await other.modifyOtherAsync(&value2)
     // expected-error @-1 {{actor-isolated property 'value2' cannot be passed 'inout' to 'async' function call}}
 
@@ -288,11 +288,11 @@ actor ProtectArray {
   func test() async {
     // FIXME: this is invalid too!
     _ = await array.mutateAsynchronously
-    // expected-targeted-complete-tns-warning@-1 {{non-sendable type '@lvalue [Int]' cannot exit actor-isolated context in call to nonisolated property 'mutateAsynchronously'}}
+    // expected-targeted-complete-tns-warning@-1 {{non-Sendable type '@lvalue [Int]' cannot exit actor-isolated context in call to nonisolated property 'mutateAsynchronously'}}
 
     _ = await array[mutateAsynchronously: 0]
     // expected-error@-1 {{actor-isolated property 'array' cannot be passed 'inout' to 'async' function call}}
-    // expected-targeted-complete-tns-warning@-2 {{non-sendable type 'inout Array<Int>' cannot exit actor-isolated context in call to nonisolated subscript 'subscript(mutateAsynchronously:)'}}
+    // expected-targeted-complete-tns-warning@-2 {{non-Sendable type 'inout Array<Int>' cannot exit actor-isolated context in call to nonisolated subscript 'subscript(mutateAsynchronously:)'}}
 
     await passToAsync(array[0])
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -116,7 +116,7 @@ func checkAsyncPropertyAccess() async {
   act.text[0] += "hello" // expected-error{{actor-isolated property 'text' can not be mutated from a nonisolated context}}
   // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
 
-  _ = act.point  // expected-warning{{non-sendable type 'Point' of property 'point' cannot exit actor-isolated context}}
+  _ = act.point  // expected-warning{{non-Sendable type 'Point' of property 'point' cannot exit actor-isolated context}}
   // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-2 {{property access is 'async'}}
 }
@@ -156,20 +156,20 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
                              _ ext: InferredFromContext,
                              _ anno: NoGlobalActorValueType) async {
   // these still do need an await in Swift 5
-  _ = await ext.point // expected-warning {{non-sendable type 'Point' of property 'point' cannot exit main actor-isolated context}}
-  _ = await anno.point // expected-warning {{non-sendable type 'Point' of property 'point' cannot exit global actor 'SomeGlobalActor'-isolated context}}
-  // expected-warning@-1 {{non-sendable type 'NoGlobalActorValueType' cannot be sent into global actor 'SomeGlobalActor'-isolated context in call to property 'point'}}
+  _ = await ext.point // expected-warning {{non-Sendable type 'Point' of property 'point' cannot exit main actor-isolated context}}
+  _ = await anno.point // expected-warning {{non-Sendable type 'Point' of property 'point' cannot exit global actor 'SomeGlobalActor'-isolated context}}
+  // expected-warning@-1 {{non-Sendable type 'NoGlobalActorValueType' cannot be sent into global actor 'SomeGlobalActor'-isolated context in call to property 'point'}}
 
   _ = formance.counter
   _ = anno.counter
 
   // these will always need an await
-  _ = await (formance as MainCounter).counter // expected-warning {{non-sendable type 'any MainCounter' cannot be sent into main actor-isolated context in call to property 'counter'}}
+  _ = await (formance as MainCounter).counter // expected-warning {{non-Sendable type 'any MainCounter' cannot be sent into main actor-isolated context in call to property 'counter'}}
   _ = await ext[1]
   _ = await formance.ticker
-  _ = await ext.polygon // expected-warning {{non-sendable type '[Point]' of property 'polygon' cannot exit main actor-isolated context}}
+  _ = await ext.polygon // expected-warning {{non-Sendable type '[Point]' of property 'polygon' cannot exit main actor-isolated context}}
   _ = await InferredFromContext.stuff
-  _ = await NoGlobalActorValueType.polygon // expected-warning {{non-sendable type '[Point]' of static property 'polygon' cannot exit main actor-isolated context}}
+  _ = await NoGlobalActorValueType.polygon // expected-warning {{non-Sendable type '[Point]' of static property 'polygon' cannot exit main actor-isolated context}}
 }
 
 // expected-warning@+2 {{memberwise initializer for 'NoGlobalActorValueType' cannot be both nonisolated and global actor 'SomeGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
@@ -734,7 +734,7 @@ func checkLocalFunctions() async {
   local1()
   local2()
 
-  // non-sendable closures don't cause problems.
+  // non-Sendable closures don't cause problems.
   acceptClosure {
     local1()
     local2()
@@ -742,7 +742,7 @@ func checkLocalFunctions() async {
 
   // Escaping closures can make the local function execute concurrently.
   acceptConcurrentClosure {
-    local2() // expected-warning{{capture of 'local2()' with non-sendable type '() -> ()' in a '@Sendable' closure}}
+    local2() // expected-warning{{capture of 'local2()' with non-Sendable type '() -> ()' in a '@Sendable' closure}}
     // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 
@@ -752,7 +752,7 @@ func checkLocalFunctions() async {
   var k = 17
   func local4() {
     acceptConcurrentClosure {
-      local3() // expected-warning{{capture of 'local3()' with non-sendable type '() -> ()' in a '@Sendable' closure}}
+      local3() // expected-warning{{capture of 'local3()' with non-Sendable type '() -> ()' in a '@Sendable' closure}}
       // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }
   }
@@ -889,7 +889,7 @@ actor SomeActorWithInits {
   // expected-note@+1 {{mutation of this property is only permitted within the actor}}
   let nonSendable: SomeClass
 
-  // Sema should not complain about referencing non-sendable members
+  // Sema should not complain about referencing non-Sendable members
   // in an actor init or deinit, as those are diagnosed later by flow-isolation.
   init(_ x: SomeClass) {
     self.nonSendable = x
@@ -1078,8 +1078,8 @@ func testCrossModuleLets(actor: OtherModuleActor) async {
   _ = actor.b         // okay
   _ = actor.c // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{property access is 'async'}}
-  // expected-warning@-2{{non-sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
-  _ = await actor.c // expected-warning{{non-sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
+  // expected-warning@-2{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
+  _ = await actor.c // expected-warning{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
   _ = await actor.d // okay
 }
 
@@ -1114,8 +1114,8 @@ actor CrossModuleFromInitsActor {
     _ = actor.b         // okay
     _ = actor.c // expected-error{{expression is 'async' but is not marked with 'await'}}
     // expected-note@-1{{property access is 'async'}}
-    // expected-warning@-2{{non-sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
-    _ = await actor.c // expected-warning{{non-sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
+    // expected-warning@-2{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
+    _ = await actor.c // expected-warning{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
     _ = await actor.d // okay
   }
 }
@@ -1679,7 +1679,7 @@ class ReferenceActor {
   init() async {
     self.a = ProtectNonSendable()
 
-    // expected-warning@+3 {{non-sendable type 'NonSendable' of property 'ns' cannot exit actor-isolated context}}
+    // expected-warning@+3 {{non-Sendable type 'NonSendable' of property 'ns' cannot exit actor-isolated context}}
     // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@+1 {{property access is 'async'}}
     _ = a.ns
@@ -1764,7 +1764,7 @@ struct ReferenceSelfDotMethods {
   private func testCurry() -> (Self) -> (@MainActor () -> Void) {
     let functionRef = Self.mainActorAffinedFunction
     // warning goes away with InferSendableFromCaptures, see actor_isolation_swift6.swift
-    return functionRef // expected-warning {{converting non-sendable function value to '@MainActor @Sendable () -> Void' may introduce data races}}
+    return functionRef // expected-warning {{converting non-Sendable function value to '@MainActor @Sendable () -> Void' may introduce data races}}
   }
 
   @MainActor

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -65,7 +65,7 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
 
   // these do need await, regardless of reference or value type
   _ = await (formance as any MainCounter).counter
-  // expected-error@-1 {{non-sendable type 'any MainCounter' cannot be sent into main actor-isolated context in call to property 'counter'}}
+  // expected-error@-1 {{non-Sendable type 'any MainCounter' cannot be sent into main actor-isolated context in call to property 'counter'}}
   _ = await ext[1]
   _ = await formance.ticker
   _ = await ext.polygon

--- a/test/Concurrency/assume_mainactor_typechecker_errors.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors.swift
@@ -55,14 +55,14 @@ func unspecifiedFunctionTest2() async {
 nonisolated func nonisolatedFunctionTest() async {
   let k = await StructContainingKlass()
   await unspecifiedAsync(k.k)
-  // expected-swift5-warning@-1 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
-  // expected-swift6-error@-2 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift5-warning@-1 {{non-Sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift6-error@-2 {{non-Sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
   await nonisolatedAsync(k.k)
-  // expected-swift5-warning@-1 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
-  // expected-swift6-error@-2 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift5-warning@-1 {{non-Sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift6-error@-2 {{non-Sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
   await mainActorAsync(k.k)
-  // expected-swift5-warning@-1 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
-  // expected-swift6-error@-2 {{non-sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift5-warning@-1 {{non-Sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
+  // expected-swift6-error@-2 {{non-Sendable type 'Klass' of property 'k' cannot exit main actor-isolated context}}
 }
 
 func testTask() async {

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -99,7 +99,7 @@ extension A1 {
     _ = await self.asynchronous(nil)
 
     // Across to a different actor, so Sendable restriction is enforced.
-    _ = other.localLet // expected-warning{{non-sendable type 'NotConcurrent' of property 'localLet' cannot exit actor-isolated context}}
+    _ = other.localLet // expected-warning{{non-Sendable type 'NotConcurrent' of property 'localLet' cannot exit actor-isolated context}}
     // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-2 {{property access is 'async'}}
     _ = await other.synchronous() // expected-tns-warning {{non-Sendable 'NotConcurrent?'-typed result can not be returned from actor-isolated instance method 'synchronous()' to actor-isolated context}}
@@ -140,13 +140,13 @@ enum E {
 func globalTest() async {
   // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@+1 {{property access is 'async'}}
-  let a = globalValue // expected-warning{{non-sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
+  let a = globalValue // expected-warning{{non-Sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
   await globalAsync(a)
   await globalSync(a)
 
   // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@+1 {{property access is 'async'}}
-  let _ = E.notSafe // expected-warning{{non-sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
+  let _ = E.notSafe // expected-warning{{non-Sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
 
 #if ALLOW_TYPECHECKER_ERRORS
   // expected-typechecker-error@+3 {{expression is 'async' but is not marked with 'await'}}
@@ -154,7 +154,7 @@ func globalTest() async {
   // expected-typechecker-note@+1 {{property access is 'async'}}
   globalAsync(E.notSafe)
 
-  // expected-typechecker-warning@-2 {{non-sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
+  // expected-typechecker-warning@-2 {{non-Sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
 #endif
 }
 
@@ -176,7 +176,7 @@ class ClassWithGlobalActorInits { // expected-tns-note 2{{class 'ClassWithGlobal
 func globalTestMain(nc: NotConcurrent) async {
   // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@+1 {{property access is 'async'}}
-  let a = globalValue // expected-warning {{non-sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
+  let a = globalValue // expected-warning {{non-Sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
   await globalAsync(a)
   await globalSync(a)
   _ = await ClassWithGlobalActorInits(nc)
@@ -208,8 +208,8 @@ func testConcurrency() {
     print(y) // okay
   }
   acceptConcurrent {
-    print(x) // expected-warning{{capture of 'x' with non-sendable type 'NotConcurrent' in a '@Sendable' closure}}
-    print(y) // expected-warning{{capture of 'y' with non-sendable type 'NotConcurrent' in a '@Sendable' closure}}
+    print(x) // expected-warning{{capture of 'x' with non-Sendable type 'NotConcurrent' in a '@Sendable' closure}}
+    print(y) // expected-warning{{capture of 'y' with non-Sendable type 'NotConcurrent' in a '@Sendable' closure}}
     // expected-warning@-1{{reference to captured var 'y' in concurrently-executing code}}
   }
 }
@@ -245,7 +245,7 @@ class HasNC {
 }
 
 func testKeyPaths(dict: [NC: Int], nc: NC) {
-  _ = \HasNC.dict[nc] // expected-warning{{cannot form key path that captures non-sendable type 'NC'}}
+  _ = \HasNC.dict[nc] // expected-warning{{cannot form key path that captures non-Sendable type 'NC'}}
 }
 
 // ----------------------------------------------------------------------
@@ -257,7 +257,7 @@ actor ANI {
 }
 
 func testANI(ani: ANI) async {
-  _ = ani.nc // expected-warning{{non-sendable type 'NC' of property 'nc' cannot exit nonisolated context}}
+  _ = ani.nc // expected-warning{{non-Sendable type 'NC' of property 'nc' cannot exit nonisolated context}}
 }
 
 // ----------------------------------------------------------------------
@@ -268,7 +268,7 @@ protocol AsyncProto {
 }
 
 extension A1: AsyncProto {
-  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMethod' into actor-isolated implementation}}
+  func asyncMethod(_: NotConcurrent) async { } // expected-warning{{non-Sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMethod' into actor-isolated implementation}}
 }
 
 protocol MainActorProto {
@@ -277,7 +277,7 @@ protocol MainActorProto {
 
 class SomeClass: MainActorProto {
   @SomeGlobalActor
-  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMainMethod' into global actor 'SomeGlobalActor'-isolated implementation}}
+  func asyncMainMethod(_: NotConcurrent) async { } // expected-warning{{non-Sendable parameter type 'NotConcurrent' cannot be sent from caller of protocol requirement 'asyncMainMethod' into global actor 'SomeGlobalActor'-isolated implementation}}
 }
 
 // ----------------------------------------------------------------------
@@ -306,7 +306,7 @@ func acceptConcurrentUnary<T>(_: @Sendable (T) -> T) { }
 func concurrentClosures<T: SendableMetatype>(_: T) { // expected-note{{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{44-44= & Sendable}}
   acceptConcurrentUnary { (x: T) in
     _ = x // ok
-    acceptConcurrentUnary { _ in x } // expected-warning{{capture of 'x' with non-sendable type 'T' in a '@Sendable' closure}}
+    acceptConcurrentUnary { _ in x } // expected-warning{{capture of 'x' with non-Sendable type 'T' in a '@Sendable' closure}}
     let y: T? = nil
     return y!
   }
@@ -316,11 +316,11 @@ func concurrentClosures<T: SendableMetatype>(_: T) { // expected-note{{consider 
 // Sendable checking
 // ----------------------------------------------------------------------
 struct S1: Sendable {
-  var nc: NotConcurrent // expected-warning{{stored property 'nc' of 'Sendable'-conforming struct 'S1' has non-sendable type 'NotConcurrent'}}
+  var nc: NotConcurrent // expected-warning{{stored property 'nc' of 'Sendable'-conforming struct 'S1' has non-Sendable type 'NotConcurrent'}}
 }
 
 struct S2<T>: Sendable { // expected-note{{consider making generic parameter 'T' conform to the 'Sendable' protocol}} {{12-12=: Sendable}}
-  var nc: T // expected-warning{{stored property 'nc' of 'Sendable'-conforming generic struct 'S2' has non-sendable type 'T'}}
+  var nc: T // expected-warning{{stored property 'nc' of 'Sendable'-conforming generic struct 'S2' has non-Sendable type 'T'}}
 }
 
 struct S3<T> {
@@ -331,7 +331,7 @@ struct S3<T> {
 extension S3: Sendable where T: Sendable { }
 
 enum E1: Sendable {
-  case payload(NotConcurrent) // expected-warning{{associated value 'payload' of 'Sendable'-conforming enum 'E1' has non-sendable type 'NotConcurrent'}}
+  case payload(NotConcurrent) // expected-warning{{associated value 'payload' of 'Sendable'-conforming enum 'E1' has non-Sendable type 'NotConcurrent'}}
 }
 
 enum E2<T> {
@@ -341,7 +341,7 @@ enum E2<T> {
 extension E2: Sendable where T: Sendable { }
 
 final class C1: Sendable {
-  let nc: NotConcurrent? = nil // expected-warning{{stored property 'nc' of 'Sendable'-conforming class 'C1' has non-sendable type 'NotConcurrent?'}}
+  let nc: NotConcurrent? = nil // expected-warning{{stored property 'nc' of 'Sendable'-conforming class 'C1' has non-Sendable type 'NotConcurrent?'}}
   var x: Int = 0 // expected-warning{{stored property 'x' of 'Sendable'-conforming class 'C1' is mutable}}
   let i: Int = 0
 }
@@ -473,7 +473,7 @@ enum E12<T>: UnsafeSendable { // expected-warning{{'UnsafeSendable' is deprecate
 func testSendableOptionalInference(nc: NotConcurrent) {
   var fn: (@Sendable () -> Void)? = nil
   fn = {
-    print(nc) // expected-warning{{capture of 'nc' with non-sendable type 'NotConcurrent' in a '@Sendable' closure}}
+    print(nc) // expected-warning{{capture of 'nc' with non-Sendable type 'NotConcurrent' in a '@Sendable' closure}}
   }
   _ = fn
 }

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -17,7 +17,7 @@ final class B: NSObject, Sendable {
 class C { } // expected-note{{class 'C' does not conform to the 'Sendable' protocol}}
 
 final class D: NSObject, Sendable {
-  let c: C = C() // expected-warning{{stored property 'c' of 'Sendable'-conforming class 'D' has non-sendable type 'C'}}
+  let c: C = C() // expected-warning{{stored property 'c' of 'Sendable'-conforming class 'D' has non-Sendable type 'C'}}
 }
 
 

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -128,7 +128,7 @@ actor Demons {
   }
 
   deinit {
-    let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -161,13 +161,13 @@ actor ExampleFromProposal {
   deinit {
     _ = self.immutableSendable  // ok
     _ = self.mutableSendable    // ok
-    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
 
     f() // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
 
     _ = self.immutableSendable  // ok
     _ = self.mutableSendable    // expected-warning {{cannot access property 'mutableSendable' here in deinitializer; this is an error in the Swift 6 language mode}}
-    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated func f() {}
@@ -199,7 +199,7 @@ class CheckGAIT1 {
   }
 
   deinit {
-    _ = ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    _ = ns // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType' from nonisolated deinit; this is an error in the Swift 6 language mode}}
     f()     // expected-note {{after calling instance method 'f()', only nonisolated properties of 'self' can be accessed from a deinit}}
     _ = silly // expected-warning {{cannot access property 'silly' here in deinitializer; this is an error in the Swift 6 language mode}}
 
@@ -733,8 +733,8 @@ actor OhBrother {
 class CheckDeinitFromClass: AwesomeUIView {
   var ns: NonSendableType?
   deinit {
-    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    ns?.f() // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    ns = nil // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -742,8 +742,8 @@ class CheckDeinitFromClass: AwesomeUIView {
 actor CheckDeinitFromActor {
   var ns: NonSendableType?
   deinit {
-    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
-    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    ns?.f() // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
+    ns = nil // expected-warning {{cannot access property 'ns' with a non-Sendable type 'NonSendableType?' from nonisolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 

--- a/test/Concurrency/global_actor_serialized.swift
+++ b/test/Concurrency/global_actor_serialized.swift
@@ -14,5 +14,5 @@ import SerializedStruct // expected-warning {{add '@preconcurrency' to treat 'Se
 // use it to force the right checks happen.
 func test() async -> Int {
   let x = MySerializedStruct()
-  return await x.counter // expected-error {{non-sendable type 'MySerializedStruct' cannot be sent into main actor-isolated context in call to property 'counter'}}
+  return await x.counter // expected-error {{non-Sendable type 'MySerializedStruct' cannot be sent into main actor-isolated context in call to property 'counter'}}
 }

--- a/test/Concurrency/implied_sendable_conformance_swift5.swift
+++ b/test/Concurrency/implied_sendable_conformance_swift5.swift
@@ -5,13 +5,13 @@ protocol P: Sendable {}
 protocol Q: Sendable {}
 
 struct One<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
-  var t: T  // expected-warning {{stored property 't' of 'Sendable'-conforming generic struct 'One' has non-sendable type 'T'; this is an error in the Swift 6 language mode}}
+  var t: T  // expected-warning {{stored property 't' of 'Sendable'-conforming generic struct 'One' has non-Sendable type 'T'; this is an error in the Swift 6 language mode}}
 }
 
 extension One: P where T: P {}
 
 struct Both<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
-  var t: T  // expected-warning {{stored property 't' of 'Sendable'-conforming generic struct 'Both' has non-sendable type 'T'; this is an error in the Swift 6 language mode}}
+  var t: T  // expected-warning {{stored property 't' of 'Sendable'-conforming generic struct 'Both' has non-Sendable type 'T'; this is an error in the Swift 6 language mode}}
 }
 
 extension Both: P where T: P {}

--- a/test/Concurrency/implied_sendable_conformance_swift6.swift
+++ b/test/Concurrency/implied_sendable_conformance_swift6.swift
@@ -4,7 +4,7 @@ protocol P: Sendable {}
 protocol Q: Sendable {}
 
 struct One<T> {  // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
-  var t: T  // expected-error {{stored property 't' of 'Sendable'-conforming generic struct 'One' has non-sendable type 'T'}}
+  var t: T  // expected-error {{stored property 't' of 'Sendable'-conforming generic struct 'One' has non-Sendable type 'T'}}
 }
 
 extension One: P where T: P {}
@@ -14,7 +14,7 @@ extension One: P where T: P {}
 // expected-note@-4 {{did you mean to explicitly state the conformance with different bounds?}}
 
 struct Both<T> { // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
-  var t: T  // expected-error {{stored property 't' of 'Sendable'-conforming generic struct 'Both' has non-sendable type 'T'}}
+  var t: T  // expected-error {{stored property 't' of 'Sendable'-conforming generic struct 'Both' has non-Sendable type 'T'}}
 }
 
 extension Both: P where T: P {}

--- a/test/Concurrency/isolated_any.swift
+++ b/test/Concurrency/isolated_any.swift
@@ -138,21 +138,21 @@ func testFunctionIsolationExprTuple(
 }
 
 func nonSendableIsolatedAnySyncToSendableSync(
-  _ fn: @escaping @isolated(any) () -> Void // expected-note {{parameter 'fn' is implicitly non-sendable}}
+  _ fn: @escaping @isolated(any) () -> Void // expected-note {{parameter 'fn' is implicitly non-Sendable}}
 ) {
-  let _: @Sendable () -> Void = fn  // expected-warning {{using non-sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
+  let _: @Sendable () -> Void = fn  // expected-warning {{using non-Sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
   // expected-warning @-1 {{converting @isolated(any) function of type '@isolated(any) () -> Void' to synchronous function type '@Sendable () -> Void' is not allowed; this will be an error in a future Swift language mode}}
 }
 
 func nonSendableIsolatedAnyAsyncToSendableSync(
-  _ fn: @escaping @isolated(any) () async -> Void // expected-note {{parameter 'fn' is implicitly non-sendable}}
+  _ fn: @escaping @isolated(any) () async -> Void // expected-note {{parameter 'fn' is implicitly non-Sendable}}
 ) {
-  let _: @Sendable () -> Void = fn  // expected-warning {{using non-sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
+  let _: @Sendable () -> Void = fn  // expected-warning {{using non-Sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
   // expected-error @-1 {{invalid conversion from 'async' function of type '@isolated(any) () async -> Void' to synchronous function type '@Sendable () -> Void'}}
 }
 
 func nonSendableIsolatedAnyAsyncToSendableAsync(
-  _ fn: @escaping @isolated(any) () async -> Void // expected-note {{parameter 'fn' is implicitly non-sendable}}
+  _ fn: @escaping @isolated(any) () async -> Void // expected-note {{parameter 'fn' is implicitly non-Sendable}}
 ) {
-  let _: @Sendable () async -> Void = fn  // expected-warning {{using non-sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
+  let _: @Sendable () async -> Void = fn  // expected-warning {{using non-Sendable parameter 'fn' in a context expecting a '@Sendable' closure}}
 }

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -41,7 +41,7 @@ class NotSendable {
   await { @YourActor in
     // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
-    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
+    // expected-complete-warning@+1 {{capture of 'ns' with non-Sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
 
@@ -63,7 +63,7 @@ class NotSendable {
   await { @YourActor in
     // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
-    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
+    // expected-complete-warning@+1 {{capture of 'ns' with non-Sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
 
@@ -84,7 +84,7 @@ class NotSendable {
   await { @YourActor in
     // expected-region-isolation-warning @+3 {{sending 'ns' risks causing data races}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
-    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
+    // expected-complete-warning@+1 {{capture of 'ns' with non-Sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
 

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -176,7 +176,7 @@ struct S: P {
 func checkConformer(_ s: S, _ p: any P, _ ma: MyActor) async {
   s.m(thing: ma)
   await p.m(thing: ma)
-  // expected-complete-warning@-1 {{passing argument of non-sendable type 'any P' into actor-isolated context may introduce data races}}
+  // expected-complete-warning@-1 {{passing argument of non-Sendable type 'any P' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'p' risks causing data races}}
   // expected-tns-note @-3 {{sending task-isolated 'p' to actor-isolated instance method 'm(thing:)' risks causing data races between actor-isolated and task-isolated uses}}
 }
@@ -437,7 +437,7 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-3 {{sending task-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and task-isolated uses}}
 
@@ -445,13 +445,13 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   optionalIsolatedSync(ns, to: myActor)
   // expected-typechecker-error@-1 {{expression is 'async' but is not marked with 'await'}}
   // expected-typechecker-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-warning@-3 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning@-3 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
   #endif
 }
 
 @MainActor func callFromMainActor(ns: NotSendable) async {
   await optionalIsolated(ns, to: nil)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NotSendable' outside of main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NotSendable' outside of main actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-3 {{sending main actor-isolated 'ns' to nonisolated global function 'optionalIsolated(_:to:)' risks causing data races between nonisolated and main actor-isolated uses}}
 
@@ -460,7 +460,7 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
-  // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning@-1 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-3 {{sending main actor-isolated 'ns' to actor-isolated global function 'optionalIsolated(_:to:)' risks causing data races between actor-isolated and main actor-isolated uses}}
 
@@ -468,7 +468,7 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   optionalIsolatedSync(ns, to: myActor)
   // expected-typechecker-error@-1 {{expression is 'async' but is not marked with 'await'}}
   // expected-typechecker-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-warning@-3 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning@-3 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
 #endif
 }
 

--- a/test/Concurrency/issue-70019.swift
+++ b/test/Concurrency/issue-70019.swift
@@ -12,5 +12,5 @@ struct Foo { // expected-note {{consider making struct 'Foo' conform to the 'Sen
 
 struct Bar: Sendable {
   // FIXME: This warning should only be thrown in library evolution mode. If @usableFromInline is removed from Foo the Sendable conformance is synthesized as expected.
-  var foo: Foo // expected-warning {{stored property 'foo' of 'Sendable'-conforming struct 'Bar' has non-sendable type 'Foo'}}
+  var foo: Foo // expected-warning {{stored property 'foo' of 'Sendable'-conforming struct 'Bar' has non-Sendable type 'Foo'}}
 }

--- a/test/Concurrency/nonisolated_inherits_isolation_sema.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation_sema.swift
@@ -19,7 +19,7 @@ struct MainActorIsolatedStruct {
 struct NonisolatedStruct {
   // Validate we can still not access global state.
   func asyncMethod() async {
-    let _ = await global // expected-error {{non-sendable type 'NonSendable' of var 'global' cannot exit main actor-isolated context}}
+    let _ = await global // expected-error {{non-Sendable type 'NonSendable' of var 'global' cannot exit main actor-isolated context}}
 
     let x = await MainActorIsolatedStruct()
     await x.syncMethod()

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -43,10 +43,10 @@ func asyncWithAwait() async {
 // completion handler's implicit `@Sendable` isn't respected.
 extension Delegate {
   nonisolated func makeRequest(_ req: Request??, completionHandler: (() -> Void)? = nil) {
-    // expected-note@-1 {{parameter 'completionHandler' is implicitly non-sendable}}
+    // expected-note@-1 {{parameter 'completionHandler' is implicitly non-Sendable}}
     if let req = (req ?? nil) {
       makeRequest1(req, completionHandler: completionHandler)
-      // expected-warning@-1 {{passing non-sendable parameter 'completionHandler' to function expecting a '@Sendable' closure}}
+      // expected-warning@-1 {{passing non-Sendable parameter 'completionHandler' to function expecting a '@Sendable' closure}}
     }
   }
 }

--- a/test/Concurrency/preconcurrency_overload.swift
+++ b/test/Concurrency/preconcurrency_overload.swift
@@ -24,9 +24,9 @@ extension Future {
 extension Future {
   @available(*, deprecated, message: "")
   func flatMap<NewValue>(file: StaticString = #file, line: UInt = #line, _ callback: @escaping (T) -> Future<NewValue>) -> Future<NewValue> { // #2
-    // expected-complete-and-tns-note @-1 {{parameter 'callback' is implicitly non-sendable}}
+    // expected-complete-and-tns-note @-1 {{parameter 'callback' is implicitly non-Sendable}}
     return self.flatMap(callback)
-    // expected-complete-and-tns-warning @-1 {{passing non-sendable parameter 'callback' to function expecting a '@Sendable' closure}}
+    // expected-complete-and-tns-warning @-1 {{passing non-Sendable parameter 'callback' to function expecting a '@Sendable' closure}}
   }
 
   @inlinable

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -60,7 +60,7 @@ func testAsync() async {
 class C { // expected-complete-tns-note {{class 'C' does not conform to the 'Sendable' protocol}}
   func test() {
     f(arg: 5, withFn: { [weak self] () -> OtherHandler? in
-        _ = self // expected-complete-tns-warning {{capture of 'self' with non-sendable type 'C?' in a '@Sendable' closure}}
+        _ = self // expected-complete-tns-warning {{capture of 'self' with non-Sendable type 'C?' in a '@Sendable' closure}}
         return nil
       })
   }

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -27,7 +27,7 @@ struct X {
 
 @MainActor func onMainActor() { }
 
-func testInAsync(x: X, plainClosure: () -> Void) async { // expected-note 2{{parameter 'plainClosure' is implicitly non-sendable}}
+func testInAsync(x: X, plainClosure: () -> Void) async { // expected-note 2{{parameter 'plainClosure' is implicitly non-Sendable}}
   let _: Int = unsafelySendableClosure // expected-error{{type '(@Sendable () -> Void) -> ()'}}
   let _: Int = unsafelyMainActorClosure // expected-error{{type '(@MainActor () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
@@ -41,9 +41,9 @@ func testInAsync(x: X, plainClosure: () -> Void) async { // expected-note 2{{par
   let _: Int = x[{ onMainActor() }] // expected-error{{type '@Sendable () -> Void'}}
   let _: Int = X[statically: { onMainActor() }] // expected-error{{type '@Sendable () -> Void'}}
 
-  unsafelySendableClosure(plainClosure) // expected-warning {{passing non-sendable parameter 'plainClosure' to function expecting a '@Sendable' closure}}
+  unsafelySendableClosure(plainClosure) // expected-warning {{passing non-Sendable parameter 'plainClosure' to function expecting a '@Sendable' closure}}
   unsafelyMainActorClosure(plainClosure)
-  unsafelyDoEverythingClosure(plainClosure) // expected-warning {{passing non-sendable parameter 'plainClosure' to function expecting a '@Sendable' closure}}
+  unsafelyDoEverythingClosure(plainClosure) // expected-warning {{passing non-Sendable parameter 'plainClosure' to function expecting a '@Sendable' closure}}
 }
 
 func testElsewhere(x: X) {
@@ -133,15 +133,15 @@ class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' pro
 // expected-complete-tns-note @-1 2{{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct S1: P {
-  var ns: NS // expected-complete-tns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S1' has non-sendable type 'NS'}}
+  var ns: NS // expected-complete-tns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S1' has non-Sendable type 'NS'}}
 }
 
 struct S2: Q {
-  var ns: NS // expected-complete-tns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S2' has non-sendable type 'NS'}}
+  var ns: NS // expected-complete-tns-warning {{stored property 'ns' of 'Sendable'-conforming struct 'S2' has non-Sendable type 'NS'}}
 }
 
 struct S3: Q, Sendable {
-  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'S3' has non-sendable type 'NS'}}
+  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'S3' has non-Sendable type 'NS'}}
 }
 
 // ---------------------------------------------------------------------------
@@ -201,9 +201,9 @@ class C { // expected-complete-tns-note {{'C' does not conform to the 'Sendable'
     func doNext() { // expected-complete-tns-warning {{concurrently-executed local function 'doNext()' must be marked as '@Sendable'}}
       doPreconcurrency {
         self.ev?.scheduleTask(deadline: i, doNext)
-        // expected-complete-tns-warning @-1 {{capture of 'self' with non-sendable type 'C' in a '@Sendable' closure}}
-        // expected-complete-tns-warning @-2 {{converting non-sendable function value to '@Sendable () throws -> ()' may introduce data races}}
-        // expected-complete-tns-warning @-3 {{capture of 'doNext()' with non-sendable type '() -> ()' in a '@Sendable' closure}}
+        // expected-complete-tns-warning @-1 {{capture of 'self' with non-Sendable type 'C' in a '@Sendable' closure}}
+        // expected-complete-tns-warning @-2 {{converting non-Sendable function value to '@Sendable () throws -> ()' may introduce data races}}
+        // expected-complete-tns-warning @-3 {{capture of 'doNext()' with non-Sendable type '() -> ()' in a '@Sendable' closure}}
         // expected-complete-tns-note @-4 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
         return
       }

--- a/test/Concurrency/predates_concurrency_import_deinit.swift
+++ b/test/Concurrency/predates_concurrency_import_deinit.swift
@@ -17,6 +17,6 @@ actor ActorWithDeinit {
 
   deinit {
     print(ns)
-    print(ss) // expected-warning{{cannot access property 'ss' with a non-sendable type 'StrictStruct' from nonisolated deinit}}
+    print(ss) // expected-warning{{cannot access property 'ss' with a non-Sendable type 'StrictStruct' from nonisolated deinit}}
   }
 }

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -93,15 +93,15 @@ protocol Q: P { }
 class NS { } // expected-note 3{{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct S1: P {
-  var ns: NS // expected-error{{stored property 'ns' of 'Sendable'-conforming struct 'S1' has non-sendable type 'NS'}}
+  var ns: NS // expected-error{{stored property 'ns' of 'Sendable'-conforming struct 'S1' has non-Sendable type 'NS'}}
 }
 
 struct S2: Q {
-  var ns: NS // expected-error{{stored property 'ns' of 'Sendable'-conforming struct 'S2' has non-sendable type 'NS'}}
+  var ns: NS // expected-error{{stored property 'ns' of 'Sendable'-conforming struct 'S2' has non-Sendable type 'NS'}}
 }
 
 struct S3: Q, Sendable {
-  var ns: NS // expected-error{{stored property 'ns' of 'Sendable'-conforming struct 'S3' has non-sendable type 'NS'}}
+  var ns: NS // expected-error{{stored property 'ns' of 'Sendable'-conforming struct 'S3' has non-Sendable type 'NS'}}
 }
 
 // ---------------------------------------------------------------------------
@@ -189,7 +189,7 @@ func withSendableClosure(_: @Sendable () -> Void) {}
 func conversionDowngrade() {
   let ns: () -> Void = {}
   withSendableClosure(ns)
-  // expected-warning@-1 {{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
+  // expected-warning@-1 {{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
 }
 
 @preconcurrency

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -98,7 +98,7 @@ public struct S10 { // expected-warning{{public struct 'S10' does not specify wh
 }
 
 struct S11: Sendable {
-  var s7: S7 // expected-warning{{stored property 's7' of 'Sendable'-conforming struct 'S11' has non-sendable type 'S7'}}
+  var s7: S7 // expected-warning{{stored property 's7' of 'Sendable'-conforming struct 'S11' has non-Sendable type 'S7'}}
 }
 
 @_nonSendable public struct S12 { }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -38,7 +38,7 @@ func acceptSendableFn(_: @Sendable @escaping () -> Void) { }
 func testCV(
   ns1: NS1, ns1array: [NS1], ns2: NS2, ns3: NS3, ns4: NS4,
   fn: @escaping () -> Void
-  // expected-note @-1 {{parameter 'fn' is implicitly non-sendable}}
+  // expected-note @-1 {{parameter 'fn' is implicitly non-Sendable}}
 ) {
   acceptCV(ns1) // expected-warning {{conformance of 'NS1' to 'Sendable' is unavailable}}
 
@@ -54,14 +54,14 @@ func testCV(
   acceptCV(fn) // expected-complete-and-tns-warning {{type '() -> Void' does not conform to the 'Sendable' protocol}}
   // expected-complete-and-tns-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-  acceptSendableFn(fn) // expected-warning{{passing non-sendable parameter 'fn' to function expecting a '@Sendable' closure}}
+  acceptSendableFn(fn) // expected-warning{{passing non-Sendable parameter 'fn' to function expecting a '@Sendable' closure}}
 }
 
 @available(SwiftStdlib 5.1, *)
 func testCV(
   ns1: NS1, ns1array: [NS1], ns2: NS2, ns3: NS3, ns4: NS4,
   fn: @escaping () -> Void
-  // expected-note@-1{{parameter 'fn' is implicitly non-sendable}}
+  // expected-note@-1{{parameter 'fn' is implicitly non-Sendable}}
 ) async {
   acceptCV(ns1) // expected-warning{{conformance of 'NS1' to 'Sendable' is unavailable}}
   acceptCV(ns1array) // expected-warning{{conformance of 'NS1' to 'Sendable' is unavailable}}
@@ -71,7 +71,7 @@ func testCV(
   acceptCV(ns4) // expected-warning{{type 'NS4' does not conform to the 'Sendable' protocol}}
   acceptCV(fn) // expected-warning{{type '() -> Void' does not conform to the 'Sendable' protocol}}
   // expected-note@-1{{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  acceptSendableFn(fn) // expected-warning{{passing non-sendable parameter 'fn' to function expecting a '@Sendable' closure}}
+  acceptSendableFn(fn) // expected-warning{{passing non-Sendable parameter 'fn' to function expecting a '@Sendable' closure}}
 }
 
 // rdar://83942484 - spurious Sendable diagnostics
@@ -144,15 +144,15 @@ protocol P {
   func foo(x : () -> ()) -> () {}
 
   func bar(x : () -> ()) -> () {}
-  // expected-warning@-1 {{non-sendable parameter type '() -> ()' cannot be sent from caller of protocol requirement 'bar(x:)' into actor-isolated implementation}}
+  // expected-warning@-1 {{non-Sendable parameter type '() -> ()' cannot be sent from caller of protocol requirement 'bar(x:)' into actor-isolated implementation}}
 
   func foo2<T>(x : T) -> () {}
 
   func bar2<T>(x : T) -> () {}
-  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar2(x:)' into actor-isolated implementation}}
+  // expected-warning@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar2(x:)' into actor-isolated implementation}}
 
   func bar3<T: Equatable>(x : T) -> () {}
-  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar3(x:)' into actor-isolated implementation}}
+  // expected-warning@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of protocol requirement 'bar3(x:)' into actor-isolated implementation}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -183,15 +183,15 @@ class Sub : Super {
   override nonisolated func foo(x : () -> ()) async {}
 
   override nonisolated func bar(x : () -> ()) async {}
-  // expected-warning@-1 {{non-sendable parameter type '() -> ()' cannot be sent from caller of superclass instance method 'bar(x:)' into nonisolated override}}
+  // expected-warning@-1 {{non-Sendable parameter type '() -> ()' cannot be sent from caller of superclass instance method 'bar(x:)' into nonisolated override}}
 
   override nonisolated func foo2<T>(x: T) async {}
 
   override nonisolated func bar2<T>(x: T) async {}
-  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of superclass instance method 'bar2(x:)' into nonisolated override}}
+  // expected-warning@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of superclass instance method 'bar2(x:)' into nonisolated override}}
 
   override nonisolated func bar3<T>(x: T) async {}
-  // expected-warning@-1 {{non-sendable parameter type 'T' cannot be sent from caller of superclass instance method 'bar3(x:)' into nonisolated override}}
+  // expected-warning@-1 {{non-Sendable parameter type 'T' cannot be sent from caller of superclass instance method 'bar3(x:)' into nonisolated override}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -228,8 +228,8 @@ class SuperWUnsafeSubscript {
 class SubWUnsafeSubscript : SuperWUnsafeSubscript {
   override nonisolated subscript<T>(x : T) -> Int {
     get async {
-      // expected-warning@-2{{non-sendable parameter type 'T' cannot be sent from caller of superclass subscript 'subscript(_:)' into nonisolated override}}
-      // expected-warning@-2{{non-sendable parameter type 'T' cannot be sent from caller of superclass getter for subscript 'subscript(_:)' into nonisolated override}}
+      // expected-warning@-2{{non-Sendable parameter type 'T' cannot be sent from caller of superclass subscript 'subscript(_:)' into nonisolated override}}
+      // expected-warning@-2{{non-Sendable parameter type 'T' cannot be sent from caller of superclass getter for subscript 'subscript(_:)' into nonisolated override}}
       // there really shouldn't be two warnings produced here, see rdar://110846040 (Sendable diagnostics reported twice for subscript getters)
       return 0
     }
@@ -281,10 +281,10 @@ final class NonSendable {
     // expected-tns-note @-2 {{sending task-isolated 'self' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and task-isolated uses}}
 
     _ = await x
-    // expected-warning@-1 {{non-sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
+    // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
 
     _ = await self.x
-      // expected-warning@-1 {{non-sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
+      // expected-warning@-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
   }
 
   @MainActor
@@ -306,7 +306,7 @@ func testNonSendableBaseArg() async {
   // expected-tns-note @-2 {{sending 't' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   _ = await t.x
-  // expected-warning @-1 {{non-sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
+  // expected-warning @-1 {{non-Sendable type 'NonSendable' cannot be sent into main actor-isolated context in call to property 'x'}}
   // expected-tns-note @-2 {{access can happen concurrently}}
 }
 
@@ -321,7 +321,7 @@ func testNonSendableBaseArg2() async {
   // expected-tns-note @-4 {{sending 't' to main actor-isolated instance method 'update()' risks causing data races between main actor-isolated and local nonisolated uses}}
 
   _ = await t.y
-  // expected-warning @-1 {{non-sendable type 'NonSendable' cannot be sent into global actor 'CustomActor'-isolated context in call to property 'y'}}
+  // expected-warning @-1 {{non-Sendable type 'NonSendable' cannot be sent into global actor 'CustomActor'-isolated context in call to property 'y'}}
   // expected-tns-note @-2 {{access can happen concurrently}}
 }
 
@@ -364,7 +364,7 @@ func testLocalCaptures() {
   @Sendable
   func a2() -> NonSendable {
     return ns
-    // expected-complete-and-tns-warning @-1 {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' local function}}
+    // expected-complete-and-tns-warning @-1 {{capture of 'ns' with non-Sendable type 'NonSendable' in a '@Sendable' local function}}
   }
 }
 
@@ -446,8 +446,8 @@ struct DowngradeForPreconcurrency {
     preconcurrencyContext {
       Task {
         completion()
-        // expected-warning@-1 {{capture of 'completion' with non-sendable type '@MainActor () -> Void' in a '@Sendable' closure}}
-        // expected-warning@-2 {{capture of 'completion' with non-sendable type '@MainActor () -> Void' in an isolated closure}}
+        // expected-warning@-1 {{capture of 'completion' with non-Sendable type '@MainActor () -> Void' in a '@Sendable' closure}}
+        // expected-warning@-2 {{capture of 'completion' with non-Sendable type '@MainActor () -> Void' in an isolated closure}}
         // expected-note@-3 2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
         // expected-warning@-4 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
         // expected-note@-5 {{calls to parameter 'completion' from outside of its actor context are implicitly asynchronous}}
@@ -461,7 +461,7 @@ struct DowngradeForPreconcurrency {
       self.x
       // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
       // expected-note@-2 {{property access is 'async'}}
-      // expected-warning@-3 {{non-sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
+      // expected-warning@-3 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
     }
   }
 }

--- a/test/Concurrency/sendable_checking_captures_swift5.swift
+++ b/test/Concurrency/sendable_checking_captures_swift5.swift
@@ -9,10 +9,10 @@ var testLocalCaptures: Int {
   let ns = NonSendable()
 
   @Sendable func localFunc() -> NonSendable {
-    return ns // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' local function}}
+    return ns // expected-complete-warning {{capture of 'ns' with non-Sendable type 'NonSendable' in a '@Sendable' local function}}
   }
 
-  callee { return ns } // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' closure}}
+  callee { return ns } // expected-complete-warning {{capture of 'ns' with non-Sendable type 'NonSendable' in a '@Sendable' closure}}
 
   return 3
 }
@@ -20,7 +20,7 @@ var testLocalCaptures: Int {
 struct Bad {
   var c: Int = {
     let ns = NonSendable()
-    callee { return ns } // expected-complete-warning {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' closure}}
+    callee { return ns } // expected-complete-warning {{capture of 'ns' with non-Sendable type 'NonSendable' in a '@Sendable' closure}}
     return 3
   }()
 }
@@ -40,13 +40,13 @@ do {
   withMutable { test in
     sendable {
       test.update()
-      // expected-complete-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a '@Sendable' closure}}
+      // expected-complete-warning@-1 {{capture of 'test' with non-Sendable type 'Test' in a '@Sendable' closure}}
       // expected-warning@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
 
     sendable_preconcurrency {
       test.update()
-      // expected-complete-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a '@Sendable' closure}}
+      // expected-complete-warning@-1 {{capture of 'test' with non-Sendable type 'Test' in a '@Sendable' closure}}
       // expected-complete-warning@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
   }
@@ -63,7 +63,7 @@ func testPreconcurrencyDowngrade(ns: NotSendable) {
   var x = 0
   withSendableClosure {
     _ = ns
-    // expected-complete-warning@-1 {{capture of 'ns' with non-sendable type 'NotSendable' in a '@Sendable' closure}}
+    // expected-complete-warning@-1 {{capture of 'ns' with non-Sendable type 'NotSendable' in a '@Sendable' closure}}
 
     x += 1
     // expected-complete-warning@-1 {{mutation of captured var 'x' in concurrently-executing code}}

--- a/test/Concurrency/sendable_checking_captures_swift6.swift
+++ b/test/Concurrency/sendable_checking_captures_swift6.swift
@@ -8,10 +8,10 @@ var testLocalCaptures: Int {
   let ns = NonSendable()
 
   @Sendable func localFunc() -> NonSendable {
-    return ns // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' local function}}
+    return ns // expected-error {{capture of 'ns' with non-Sendable type 'NonSendable' in a '@Sendable' local function}}
   }
 
-  callee { return ns } // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' closure}}
+  callee { return ns } // expected-error {{capture of 'ns' with non-Sendable type 'NonSendable' in a '@Sendable' closure}}
 
   return 3
 }
@@ -19,7 +19,7 @@ var testLocalCaptures: Int {
 struct Bad {
   var c: Int = {
     let ns = NonSendable()
-    callee { return ns } // expected-error {{capture of 'ns' with non-sendable type 'NonSendable' in a '@Sendable' closure}}
+    callee { return ns } // expected-error {{capture of 'ns' with non-Sendable type 'NonSendable' in a '@Sendable' closure}}
     return 3
   }()
 }
@@ -39,13 +39,13 @@ do {
   withMutable { test in
     sendable {
       test.update()
-      // expected-error@-1 {{capture of 'test' with non-sendable type 'Test' in a '@Sendable' closure}}
+      // expected-error@-1 {{capture of 'test' with non-Sendable type 'Test' in a '@Sendable' closure}}
       // expected-error@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
 
     sendable_preconcurrency {
       test.update()
-      // expected-warning@-1 {{capture of 'test' with non-sendable type 'Test' in a '@Sendable' closure}}
+      // expected-warning@-1 {{capture of 'test' with non-Sendable type 'Test' in a '@Sendable' closure}}
       // expected-warning@-2 {{mutable capture of 'inout' parameter 'test' is not allowed in concurrently-executing code}}
     }
   }
@@ -63,7 +63,7 @@ do {
     func fooDirect() {
       C.f {
         use(self)
-        // expected-warning@-1 {{capture of 'self' with non-sendable type 'SelfCapture' in a '@Sendable' closure}}
+        // expected-warning@-1 {{capture of 'self' with non-Sendable type 'SelfCapture' in a '@Sendable' closure}}
         // expected-warning@-2 {{implicit capture of 'self' requires that 'SelfCapture' conforms to 'Sendable'}}
       }
     }
@@ -71,8 +71,8 @@ do {
     func fooThroughClosure() {
       C.f {
         { use(self) }()
-        // expected-warning@-1 {{capture of 'self' with non-sendable type 'SelfCapture' in a '@Sendable' closure}}
-        // expected-warning@-2 {{capture of 'self' with non-sendable type 'SelfCapture' in an isolated closure}}
+        // expected-warning@-1 {{capture of 'self' with non-Sendable type 'SelfCapture' in a '@Sendable' closure}}
+        // expected-warning@-2 {{capture of 'self' with non-Sendable type 'SelfCapture' in an isolated closure}}
         // expected-warning@-3 {{implicit capture of 'self' requires that 'SelfCapture' conforms to 'Sendable'}}
       }
     }

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -38,7 +38,7 @@ actor A2: IsolatedWithNotSendableRequirements {
   nonisolated var prop: NotSendable { NotSendable() }
 
   nonisolated func fAsync() async -> NotSendable { NotSendable() }
-  // expected-warning@-1{{non-sendable type 'NotSendable' cannot be returned from nonisolated implementation to caller of protocol requirement 'fAsync()'}}
+  // expected-warning@-1{{non-Sendable type 'NotSendable' cannot be returned from nonisolated implementation to caller of protocol requirement 'fAsync()'}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -51,9 +51,9 @@ protocol AsyncProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A3: AsyncProtocolWithNotSendable {
-  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-Sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
+  var prop: NotSendable { // expected-warning{{non-Sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
     get async {
       NotSendable()
     }
@@ -64,9 +64,9 @@ actor A3: AsyncProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A4: AsyncProtocolWithNotSendable {
-  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
+  func f() -> NotSendable { NotSendable() } // expected-warning{{non-Sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
+  var prop: NotSendable { // expected-warning{{non-Sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
     get {
       NotSendable()
     }
@@ -109,9 +109,9 @@ protocol AsyncThrowingProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A7: AsyncThrowingProtocolWithNotSendable {
-  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
+  func f() async -> NotSendable { NotSendable() } // expected-warning{{non-Sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
+  var prop: NotSendable { // expected-warning{{non-Sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
     get async {
       NotSendable()
     }
@@ -122,9 +122,9 @@ actor A7: AsyncThrowingProtocolWithNotSendable {
 // actor's domain.
 @available(SwiftStdlib 5.1, *)
 actor A8: AsyncThrowingProtocolWithNotSendable {
-  func f() -> NotSendable { NotSendable() } // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
+  func f() -> NotSendable { NotSendable() } // expected-warning{{non-Sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'f()'}}
 
-  var prop: NotSendable { // expected-warning{{non-sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
+  var prop: NotSendable { // expected-warning{{non-Sendable type 'NotSendable' cannot be returned from actor-isolated implementation to caller of protocol requirement 'prop'}}
     get {
       NotSendable()
     }

--- a/test/Concurrency/sendable_conformance_checking_skip_sending.swift
+++ b/test/Concurrency/sendable_conformance_checking_skip_sending.swift
@@ -23,8 +23,8 @@ protocol P2 {
 @MainActor
 class P2Class: P2 {
   func bar(_ a: NonSendableKlass2) async -> NonSendableKlass2 { a }
-  // expected-error@-1 {{non-sendable type 'NonSendableKlass2' cannot be returned from main actor-isolated implementation to caller of protocol requirement 'bar'}}
-  // expected-error@-2 {{non-sendable parameter type 'NonSendableKlass2' cannot be sent from caller of protocol requirement 'bar' into main actor-isolated implementation}}
+  // expected-error@-1 {{non-Sendable type 'NonSendableKlass2' cannot be returned from main actor-isolated implementation to caller of protocol requirement 'bar'}}
+  // expected-error@-2 {{non-Sendable parameter type 'NonSendableKlass2' cannot be sent from caller of protocol requirement 'bar' into main actor-isolated implementation}}
 }
 
 class NonSendableKlass3 {}
@@ -46,8 +46,8 @@ protocol P4 {
 
 actor P4Actor: P4 {
   func bar(_ a: NonSendableKlass4) async -> NonSendableKlass4 { NonSendableKlass4() }
-  // expected-error@-1 {{non-sendable type 'NonSendableKlass4' cannot be returned from actor-isolated implementation to caller of protocol requirement 'bar'}}
-  // expected-error@-2 {{non-sendable parameter type 'NonSendableKlass4' cannot be sent from caller of protocol requirement 'bar' into actor-isolated implementation}}
+  // expected-error@-1 {{non-Sendable type 'NonSendableKlass4' cannot be returned from actor-isolated implementation to caller of protocol requirement 'bar'}}
+  // expected-error@-2 {{non-Sendable parameter type 'NonSendableKlass4' cannot be sent from caller of protocol requirement 'bar' into actor-isolated implementation}}
 }
 
 class NonSendableKlass5 {}
@@ -61,7 +61,7 @@ protocol P5 {
 @MainActor
 class P5Class: P5 {
   func bar(_ a: sending NonSendableKlass5, _ b: NonSendableKlass5) async -> sending NonSendableKlass5 { a }
-  // expected-error@-1 {{non-sendable parameter type 'NonSendableKlass5' cannot be sent from caller of protocol requirement 'bar' into main actor-isolated implementation}}
+  // expected-error@-1 {{non-Sendable parameter type 'NonSendableKlass5' cannot be sent from caller of protocol requirement 'bar' into main actor-isolated implementation}}
 }
 
 class NonSendableKlass6 {}

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -67,7 +67,7 @@ do {
   test(nonSendableKP) // expected-warning {{type 'KeyPath<K, Bool>' does not conform to the 'Sendable' protocol}}
 }
 
-// Test using sendable and non-sendable key paths.
+// Test using sendable and non-Sendable key paths.
 do {
   class V {
     var i: Int = 0
@@ -97,13 +97,13 @@ do {
   testSendableFn(v: v, \.[42]) // Ok
 
   testSendableKP(v: v, \.[NonSendable()]) // expected-warning {{type 'KeyPath<V, Int>' does not conform to the 'Sendable' protocol}}
-  testSendableFn(v: v, \.[NonSendable()]) // expected-warning {{converting non-sendable function value to '@Sendable (V) -> Int' may introduce data races}}
+  testSendableFn(v: v, \.[NonSendable()]) // expected-warning {{converting non-Sendable function value to '@Sendable (V) -> Int' may introduce data races}}
 
   testNonSendableKP(v: v, \.[NonSendable()]) // Ok
   testNonSendableFn(v: v, \.[NonSendable()]) // Ok
 
   let _: @Sendable (V) -> Int = \.[NonSendable()]
-  // expected-warning@-1 {{converting non-sendable function value to '@Sendable (V) -> Int' may introduce data races}}
+  // expected-warning@-1 {{converting non-Sendable function value to '@Sendable (V) -> Int' may introduce data races}}
 
   let _: KeyPath<V, Int> & Sendable = \.[42, CondSendable(NonSendable(data: [1, 2, 3]))]
   // expected-warning@-1 {{type 'ReferenceWritableKeyPath<V, Int>' does not conform to the 'Sendable' protocol}}
@@ -116,7 +116,7 @@ do {
   testSendableKP(v: v, \.[42, CondSendable(NonSendable(data: [1, 2, 3]))])
   // expected-warning@-1 {{type 'ReferenceWritableKeyPath<V, Int>' does not conform to the 'Sendable' protocol}}
   testSendableFn(v: v, \.[42, CondSendable(NonSendable(data: [1, 2, 3]))])
-  // expected-warning@-1 {{converting non-sendable function value to '@Sendable (V) -> Int' may introduce data races}}
+  // expected-warning@-1 {{converting non-Sendable function value to '@Sendable (V) -> Int' may introduce data races}}
   testSendableKP(v: v, \.[42, CondSendable(42)]) // Ok
 
   let nonSendable = NonSendable()
@@ -124,7 +124,7 @@ do {
   // expected-warning@-1 {{type 'ReferenceWritableKeyPath<V, Int>' does not conform to the 'Sendable' protocol}}
 
   testSendableFn(v: v, \.[42, CondSendable(nonSendable)])
-  // expected-warning@-1 {{converting non-sendable function value to '@Sendable (V) -> Int' may introduce data races}}
+  // expected-warning@-1 {{converting non-Sendable function value to '@Sendable (V) -> Int' may introduce data races}}
 }
 
 // @dynamicMemberLookup with Sendable requirement

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: concurrency
 
-// This test checks for typecheck-only diagnostics involving non-sendable
+// This test checks for typecheck-only diagnostics involving non-Sendable
 // metatypes.
 
 protocol Q {
@@ -21,9 +21,9 @@ func testSendableExistential() {
 nonisolated func acceptMeta<T>(_: T.Type) { }
 
 nonisolated func staticCallThroughMetaVal<T: Q>(_: T.Type) {
-  let x = T.self // expected-warning{{capture of non-sendable type 'T.Type' in an isolated closure}}
+  let x = T.self // expected-warning{{capture of non-Sendable type 'T.Type' in an isolated closure}}
   Task.detached {
-    x.g() // expected-warning{{capture of non-sendable type 'T.Type' in an isolated closure}}
+    x.g() // expected-warning{{capture of non-Sendable type 'T.Type' in an isolated closure}}
   }
 }
 
@@ -35,21 +35,21 @@ nonisolated func captureThroughMetaValMoReqs<T>(_: T.Type) {
 }
 
 nonisolated func passMetaVal<T: Q>(_: T.Type) {
-  let x = T.self // expected-warning{{capture of non-sendable type 'T.Type' in an isolated closure}}
+  let x = T.self // expected-warning{{capture of non-Sendable type 'T.Type' in an isolated closure}}
   Task.detached {
-    acceptMeta(x) // expected-warning{{capture of non-sendable type}}
+    acceptMeta(x) // expected-warning{{capture of non-Sendable type}}
   }
 }
 
 nonisolated func staticCallThroughMeta<T: Q>(_: T.Type) {
   Task.detached {
-    T.g() // expected-warning{{capture of non-sendable type}}
+    T.g() // expected-warning{{capture of non-Sendable type}}
   }
 }
 
 nonisolated func passMeta<T: Q>(_: T.Type) {
   Task.detached {
-    acceptMeta(T.self) // expected-warning{{capture of non-sendable type 'T.Type' in an isolated closure}}
+    acceptMeta(T.self) // expected-warning{{capture of non-Sendable type 'T.Type' in an isolated closure}}
   }
 }
 
@@ -96,7 +96,7 @@ struct GenericThingy<Element> {
     searchMe(<)
 
     let _: (Element, Element) -> Bool = (>)
-    let _: @Sendable (Element, Element) -> Bool = (>) // expected-error{{converting non-sendable function value to '@Sendable (Element, Element) -> Bool' may introduce data races}}
+    let _: @Sendable (Element, Element) -> Bool = (>) // expected-error{{converting non-Sendable function value to '@Sendable (Element, Element) -> Bool' may introduce data races}}
   }
 }
 
@@ -119,11 +119,11 @@ class Holder: @unchecked Sendable {
 }
 
 enum E: Sendable {
-case q(Q.Type, Int) // expected-warning{{associated value 'q' of 'Sendable'-conforming enum 'E' has non-sendable type 'any Q.Type'}}
+case q(Q.Type, Int) // expected-warning{{associated value 'q' of 'Sendable'-conforming enum 'E' has non-Sendable type 'any Q.Type'}}
 }
 
 struct S: Sendable {
-  var tuple: ([Q.Type], Int) // expected-warning{{stored property 'tuple' of 'Sendable'-conforming struct 'S' has non-sendable type '([any Q.Type], Int)'}}
+  var tuple: ([Q.Type], Int) // expected-warning{{stored property 'tuple' of 'Sendable'-conforming struct 'S' has non-Sendable type '([any Q.Type], Int)'}}
 }
 
 extension Q {
@@ -157,8 +157,8 @@ do {
   func compute<T>(_: S<T>, _: @escaping @Sendable (T, T) -> Bool) {}
 
   func test<T: Comparable>(s: S<T>) {
-    compute(s, >) // expected-warning {{converting non-sendable function value to '@Sendable (T, T) -> Bool' may introduce data races}}
-    compute(s, S.test) // expected-warning {{capture of non-sendable type 'T.Type' in an isolated closure}}
+    compute(s, >) // expected-warning {{converting non-Sendable function value to '@Sendable (T, T) -> Bool' may introduce data races}}
+    compute(s, S.test) // expected-warning {{capture of non-Sendable type 'T.Type' in an isolated closure}}
   }
 }
 
@@ -173,5 +173,5 @@ extension TestUnapplied {
 }
 
 func testUnappliedWithOpetator<T: Comparable>(v: TestUnapplied<T>) {
-  v<=>(>) // expected-error {{converting non-sendable function value to '@Sendable (T, T) -> Bool' may introduce data races}}
+  v<=>(>) // expected-error {{converting non-Sendable function value to '@Sendable (T, T) -> Bool' may introduce data races}}
 }

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -10,7 +10,7 @@ func outer() {
     func nonSendable() {}
 
     let _ : @Sendable () -> Void = sendable
-    let _ : @Sendable () -> Void = nonSendable // expected-warning{{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
+    let _ : @Sendable () -> Void = nonSendable // expected-warning{{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
 }
 
 
@@ -118,7 +118,7 @@ h(GenericQ<NonSendable>().f) // ok
 h(GenericS(NonSendable()).f) // ok
 h(GenericS<Int>().f)
 h(GenericS(1).f)
-h(NonSendable().f) // expected-warning{{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
+h(NonSendable().f) // expected-warning{{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
 
 func executeAsTask (_ f: @escaping  @Sendable () -> Void) {
   Task {
@@ -128,7 +128,7 @@ func executeAsTask (_ f: @escaping  @Sendable () -> Void) {
 executeAsTask(S().f)
 executeAsTask(C().f)
 executeAsTask(E().f)
-executeAsTask(NonSendable().f) // expected-warning{{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
+executeAsTask(NonSendable().f) // expected-warning{{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
 
 do {
   let f = S.f
@@ -148,9 +148,9 @@ var partialClass : @Sendable () -> Void = C().f
 var partialEnum : @Sendable () -> Void = E().f
 
 // Reassign
-partialClass = NonSendable().f // expected-warning{{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
-partialStruct = NonSendable().f // expected-warning{{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
-partialEnum = NonSendable().f // expected-warning{{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
+partialClass = NonSendable().f // expected-warning{{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
+partialStruct = NonSendable().f // expected-warning{{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
+partialEnum = NonSendable().f // expected-warning{{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
 
 // Static Functions 
 struct World {
@@ -309,7 +309,7 @@ do {
   let _: @Sendable (S) -> @Sendable () -> Void = S.foo // Ok
 
   let classFn = NonSendable.f(NonSendable())
-  bar(classFn) // expected-warning {{converting non-sendable function value to '@Sendable () -> Void' may introduce data races}}
+  bar(classFn) // expected-warning {{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
 
   let _: @Sendable (NonSendable) -> () -> Void = NonSendable.f // Ok
 

--- a/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context_swift6.swift
@@ -231,7 +231,7 @@ class SelfCapture { // expected-note 5 {{class 'SelfCapture' does not conform to
   func testDirect() {
     TestSelfCapture.do {
       Self.use(self)
-      // expected-warning@-1 {{capture of 'self' with non-sendable type 'SelfCapture' in a '@Sendable' closure}}
+      // expected-warning@-1 {{capture of 'self' with non-Sendable type 'SelfCapture' in a '@Sendable' closure}}
       // expected-warning@-2 {{implicit capture of 'self' requires that 'SelfCapture' conforms to 'Sendable'}}
     }
   }
@@ -239,8 +239,8 @@ class SelfCapture { // expected-note 5 {{class 'SelfCapture' does not conform to
   func testThroughClosure() {
     TestSelfCapture.do {
       let _ = { Self.use(self) }()
-      // expected-warning@-1 {{capture of 'self' with non-sendable type 'SelfCapture' in a '@Sendable' closure}}
-      // expected-warning@-2 {{capture of 'self' with non-sendable type 'SelfCapture' in an isolated closure}}
+      // expected-warning@-1 {{capture of 'self' with non-Sendable type 'SelfCapture' in a '@Sendable' closure}}
+      // expected-warning@-2 {{capture of 'self' with non-Sendable type 'SelfCapture' in an isolated closure}}
       // expected-warning@-3 {{implicit capture of 'self' requires that 'SelfCapture' conforms to 'Sendable'}}
     }
   }

--- a/test/Concurrency/sendable_override_checking.swift
+++ b/test/Concurrency/sendable_override_checking.swift
@@ -24,10 +24,10 @@ class Super {
 @available(SwiftStdlib 5.1, *)
 class Sub: Super {
   @MainActor override func f(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable parameter type 'NotSendable' cannot be sent from caller of superclass instance method 'f' into main actor-isolated override}}
+  // expected-warning@-1{{non-Sendable parameter type 'NotSendable' cannot be sent from caller of superclass instance method 'f' into main actor-isolated override}}
 
   nonisolated override func g1(_: NotSendable) { } // okay, synchronous
 
   nonisolated override func g2(_: NotSendable) async { }
-  // expected-warning@-1{{non-sendable parameter type 'NotSendable' cannot be sent from caller of superclass instance method 'g2' into nonisolated override}}
+  // expected-warning@-1{{non-Sendable parameter type 'NotSendable' cannot be sent from caller of superclass instance method 'g2' into nonisolated override}}
 }

--- a/test/Concurrency/sendable_preconcurrency.swift
+++ b/test/Concurrency/sendable_preconcurrency.swift
@@ -23,7 +23,7 @@ struct MyType {
 
 struct MyType2: Sendable {
   var nsc: NonStrictClass // no warning; @preconcurrency suppressed it
-  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NS'}}
+  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-Sendable type 'NS'}}
 }
 
 struct MyType3 {

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -24,8 +24,8 @@ struct MyType {
 }
 
 struct MyType2: Sendable {
-  var nsc: NonStrictClass // expected-warning{{stored property 'nsc' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NonStrictClass'}}
-  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-sendable type 'NS'}}
+  var nsc: NonStrictClass // expected-warning{{stored property 'nsc' of 'Sendable'-conforming struct 'MyType2' has non-Sendable type 'NonStrictClass'}}
+  var ns: NS // expected-warning{{stored property 'ns' of 'Sendable'-conforming struct 'MyType2' has non-Sendable type 'NS'}}
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -19,8 +19,8 @@ class C3 { }
 extension C3: Sendable { }
 
 struct S1: Sendable {
-  let c1: C1 // expected-warning{{stored property 'c1' of 'Sendable'-conforming struct 'S1' has non-sendable type 'C1'}}
-  let c2: C2 // expected-warning{{stored property 'c2' of 'Sendable'-conforming struct 'S1' has non-sendable type 'C2'}}
+  let c1: C1 // expected-warning{{stored property 'c1' of 'Sendable'-conforming struct 'S1' has non-Sendable type 'C1'}}
+  let c2: C2 // expected-warning{{stored property 'c2' of 'Sendable'-conforming struct 'S1' has non-Sendable type 'C2'}}
   let c3: C3 // expected-warning{{stored property 'c3'}}
 }
 
@@ -42,22 +42,22 @@ func passSendable(
 ) async {
   // Don't warn about implicitly non-Sendable types when minimal is
   // enabled... but do when we are doing targeted
-  takeSendable { print(c1) } // expected-targeted-warning {{capture of 'c1' with non-sendable type 'C1' in a '@Sendable' closure}}
-  takeSendable { print(fn) } // expected-targeted-warning {{capture of 'fn' with non-sendable type '() -> Void' in a '@Sendable' closure}}
+  takeSendable { print(c1) } // expected-targeted-warning {{capture of 'c1' with non-Sendable type 'C1' in a '@Sendable' closure}}
+  takeSendable { print(fn) } // expected-targeted-warning {{capture of 'fn' with non-Sendable type '() -> Void' in a '@Sendable' closure}}
   // expected-targeted-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   // Warn about explicitly non-Sendable types
-  takeSendable { print(c2) } // expected-warning {{capture of 'c2' with non-sendable type 'C2' in a '@Sendable' closure}}
-  takeSendable { print(c3) } // expected-warning {{capture of 'c3' with non-sendable type 'C3' in a '@Sendable' closure}}
+  takeSendable { print(c2) } // expected-warning {{capture of 'c2' with non-Sendable type 'C2' in a '@Sendable' closure}}
+  takeSendable { print(c3) } // expected-warning {{capture of 'c3' with non-Sendable type 'C3' in a '@Sendable' closure}}
 
   // Don't warn about explicitly Sendable type, even when it's wrong.
   takeSendable { print(s1) }
 
   // Don't warn when we wrapped an implicitly non-Sendable type in a struct unless we are >= targeted
-  takeSendable { print(s2) } // expected-targeted-warning {{capture of 's2' with non-sendable type 'S2' in a '@Sendable' closure}}
+  takeSendable { print(s2) } // expected-targeted-warning {{capture of 's2' with non-Sendable type 'S2' in a '@Sendable' closure}}
 
   // FIXME: Ideally, we would warn about cases where a type in this module is
   // inferred to be non-Sendable based on something explicitly non-Sendable,
   // like in the case below. We do warn about it with >= targeted.
-  takeSendable { print(s3) } // expected-targeted-warning {{capture of 's3' with non-sendable type 'S3' in a '@Sendable' closure}}
+  takeSendable { print(s3) } // expected-targeted-warning {{capture of 's3' with non-Sendable type 'S3' in a '@Sendable' closure}}
 }

--- a/test/Concurrency/taskgroup_cancelAll_from_child.swift
+++ b/test/Concurrency/taskgroup_cancelAll_from_child.swift
@@ -17,14 +17,14 @@ func test_taskGroup_cancelAll() async {
        }
 
        group.spawn { // expected-error {{escaping closure captures 'inout' parameter 'group'}}
-         group.cancelAll() //expected-warning{{capture of 'group' with non-sendable type 'TaskGroup<Int>' in a '@Sendable' closure}}
+         group.cancelAll() //expected-warning{{capture of 'group' with non-Sendable type 'TaskGroup<Int>' in a '@Sendable' closure}}
          //expected-warning@-1{{mutable capture of 'inout' parameter 'group' is not allowed in concurrently-executing code; this is an error in the Swift 6 language mode}}
          // expected-note@-2 {{captured here}}
 
          return 0
        }
        group.spawn { [group] in
-         group.cancelAll() //expected-warning{{capture of 'group' with non-sendable type 'TaskGroup<Int>' in a '@Sendable' closure}}
+         group.cancelAll() //expected-warning{{capture of 'group' with non-Sendable type 'TaskGroup<Int>' in a '@Sendable' closure}}
          return 0
        }
        _ = await group.next()

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -13,7 +13,7 @@
 // MARK: Declarations //
 ////////////////////////
 
-/// Classes are always non-sendable, so this is non-sendable
+/// Classes are always non-Sendable, so this is non-Sendable
 class NonSendableKlass { // expected-complete-note 53{{}}
   // expected-typechecker-only-note @-1 3{{}}
   // expected-tns-note @-2 {{}}
@@ -99,14 +99,14 @@ struct SendableGenericStruct : Sendable {
 
 extension MyActor {
   func warningIfCallingGetter() async {
-    await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
+    await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{sending 'self.klass' risks causing data races}}
     // expected-tns-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
-    await self.finalKlass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
+    await self.finalKlass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{sending 'self.finalKlass' risks causing data races}}
     // expected-tns-note @-2 {{sending 'self'-isolated 'self.finalKlass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
@@ -120,7 +120,7 @@ extension MyActor {
 extension FinalActor {
   func warningIfCallingAsyncOnFinalField() async {
     // Since our whole class is final, we emit the error directly here.
-    await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
+    await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{sending 'self.klass' risks causing data races}}
     // expected-tns-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
@@ -150,7 +150,7 @@ func closureInOut(_ a: MyActor) async {
   closure = { useInOut(&contents) }
 
   await a.useKlass(ns0)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass'}}
   // expected-tns-warning @-2 {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
 
@@ -173,7 +173,7 @@ func closureInOutDifferentActor(_ a: MyActor, _ a2: MyActor) async {
   closure = { useInOut(&contents) }
 
   await a.useKlass(ns0)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass'}}
   // expected-tns-warning @-2 {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
 
@@ -181,7 +181,7 @@ func closureInOutDifferentActor(_ a: MyActor, _ a2: MyActor) async {
   // the use and the closure.
   if await booleanFlag {
     await a2.useKlass(ns1) // expected-tns-note {{access can happen concurrently}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass'}}
   } else {
     closure() // expected-tns-note {{access can happen concurrently}}
   }
@@ -200,13 +200,13 @@ func closureInOut2(_ a: MyActor) async {
 
   await a.useKlass(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{access can happen concurrently}}
 
   await a.useKlass(ns1) // expected-tns-warning {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{access can happen concurrently}}
 }
@@ -222,13 +222,13 @@ func closureNonInOut(_ a: MyActor) async {
   var closure = {}
 
   await a.useKlass(ns0)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass'}}
 
   closure = { useValue(contents) }
 
   await a.useKlass(ns1) // expected-tns-warning {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{access can happen concurrently}}
 }
@@ -242,11 +242,11 @@ func transferNonIsolatedNonAsyncClosureTwice() async {
 
   // This is nonisolated and non-async... we can transfer it safely.
   var actorCaptureClosure = { print(a) }
-  await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   actorCaptureClosure = { print(a) }
-  await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -256,7 +256,7 @@ extension MyActor {
     let closure: () -> () = {
       print(self.klass)
     }
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -267,7 +267,7 @@ extension MyActor {
       print(self.klass)
     }
     let x = (1, closure)
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type '(Int, () -> ())' into main actor-isolated context may introduce data races}}
+    await transferToMain(x) // expected-complete-warning {{passing argument of non-Sendable type '(Int, () -> ())' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending value of non-Sendable type '(Int, () -> ())' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated value of non-Sendable type '(Int, () -> ())' to main actor-isolated global function 'transferToMain' risks causing races in between 'self'-isolated and main actor-isolated uses}}
@@ -288,7 +288,7 @@ extension MyActor {
       print(self.klass)
     }
     let x: Any? = (1, closure)
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
+    await transferToMain(x) // expected-complete-warning {{passing argument of non-Sendable type 'Any?' into main actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
@@ -301,7 +301,7 @@ extension MyActor {
     // we are forming is an Any?  so we actually form the tuple as an object and
     // store it all as once.
     let x: Any? = (closure, 1)
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
+    await transferToMain(x) // expected-complete-warning {{passing argument of non-Sendable type 'Any?' into main actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
   }
@@ -312,7 +312,7 @@ extension MyActor {
     }
 
     // Error here.
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -321,7 +321,7 @@ extension MyActor {
 
     // But not here.
     await transferToMain(closure)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 
@@ -330,7 +330,7 @@ extension MyActor {
 
     // No error here.
     await transferToMain(closure)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
     closure = {
@@ -338,7 +338,7 @@ extension MyActor {
     }
 
     // Error here.
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -348,7 +348,7 @@ extension MyActor {
     var closure: () -> () = {}
 
     // We get a transfer after use error.
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
@@ -359,7 +359,7 @@ extension MyActor {
       }
     }
 
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-note @-2 {{access can happen concurrently}}
     // expected-tns-warning @-3 {{sending 'closure' risks causing data races}}
@@ -372,7 +372,7 @@ extension MyActor {
     var closure: () -> () = {}
 
     await transferToMain(closure)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
     if await booleanFlag {
@@ -383,7 +383,7 @@ extension MyActor {
       closure = {}
     }
 
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -401,7 +401,7 @@ extension MyActor {
       print(x.0.klass) // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
     }
     await transferToMain(closure)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 
@@ -412,7 +412,7 @@ extension MyActor {
     let closure: () -> () = {
       print(x.1)
     }
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -423,7 +423,7 @@ extension MyActor {
     let closure: () -> () = {
       print(x.1)
     }
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -434,7 +434,7 @@ extension MyActor {
     let closure: () -> () = {
       print(x as Any)
     }
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -444,7 +444,7 @@ extension MyActor {
 func testSimpleLetClosureCaptureActor() async {
   let a = MyActor()
   let closure = { print(a) }
-  await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -454,7 +454,7 @@ func testSimpleLetClosureCaptureActorField() async {
   let a = MyActor()
   let closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -462,7 +462,7 @@ func testSimpleLetClosureCaptureActorFieldThroughTuple() async {
   let a = (MyActor(), 0)
   let closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -470,7 +470,7 @@ func testSimpleLetClosureCaptureActorFieldThroughOptional() async {
   let a: MyActor? = MyActor()
   let closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -480,7 +480,7 @@ func testSimpleVarClosureCaptureActor() async {
   let a = MyActor()
   var closure = {}
   closure = { print(a) }
-  await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -491,7 +491,7 @@ func testSimpleVarClosureCaptureActorField() async {
   var closure = {}
   closure = { print(a.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -500,7 +500,7 @@ func testSimpleVarClosureCaptureActorFieldThroughTuple() async {
   var closure = {}
   closure = { print(a.0.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -509,7 +509,7 @@ func testSimpleVarClosureCaptureActorFieldThroughOptional() async {
   var closure = {}
   closure = { print(a!.klass) } // expected-typechecker-only-error {{actor-isolated property 'klass' can not be referenced from a nonisolated context}}
   await transferToMain(closure)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -523,7 +523,7 @@ extension MyActor {
     let closure: () -> () = {
       print(f)
     }
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -536,7 +536,7 @@ extension MyActor {
     let closure: () -> () = {
       print(f.field!)
     }
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -550,7 +550,7 @@ extension MyActor {
     }
 
     // This should error.
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'self'-isolated 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
@@ -558,13 +558,13 @@ extension MyActor {
     // This doesnt since we re-assign
     closure = {}
     await transferToMain(closure)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
     // This re-assignment shouldn't error.
     closure = {}
     // But this transfer should.
-    await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
+    await transferToMain(closure) // expected-complete-warning {{passing argument of non-Sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{sending 'closure' risks causing data races}}
     // expected-tns-note @-3 {{sending 'closure' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local actor-isolated uses}}
@@ -588,7 +588,7 @@ func testConversionsAndSendable(a: MyActor, f: @Sendable () -> Void, f2: () -> V
   await a.useNonSendableFunction(f)
 
   // Show that we error if we are not sendable.
-  await a.useNonSendableFunction(f2) // expected-complete-warning {{passing argument of non-sendable type '() -> Void' into actor-isolated context may introduce data races}}
+  await a.useNonSendableFunction(f2) // expected-complete-warning {{passing argument of non-Sendable type '() -> Void' into actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   // expected-tns-warning @-2 {{sending 'f2' risks causing data races}}
   // expected-tns-note @-3 {{sending task-isolated 'f2' to actor-isolated instance method 'useNonSendableFunction' risks causing data races between actor-isolated and task-isolated uses}}
@@ -597,14 +597,14 @@ func testConversionsAndSendable(a: MyActor, f: @Sendable () -> Void, f2: () -> V
 func testSendableClosureCapturesNonSendable(a: MyActor) {
   let klass = NonSendableKlass()
   let _ = { @Sendable in
-    _ = klass // expected-warning {{capture of 'klass' with non-sendable type 'NonSendableKlass' in a '@Sendable' closure}}
+    _ = klass // expected-warning {{capture of 'klass' with non-Sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
 }
 
 func testSendableClosureCapturesNonSendable2(a: FinalMainActorIsolatedKlass) {
   let klass = NonSendableKlass()
   let _ = { @Sendable @MainActor in
-    a.klass = klass // expected-complete-warning {{capture of 'klass' with non-sendable type 'NonSendableKlass' in a '@Sendable' closure}}
+    a.klass = klass // expected-complete-warning {{capture of 'klass' with non-Sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
 }
 
@@ -618,7 +618,7 @@ func singleFieldVarMergeTest() async {
 
   // This transfers the entire region.
   await transferToMain(box.k)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // But since box has only a single element, this doesn't race.
   box.k = NonSendableKlass()
@@ -627,7 +627,7 @@ func singleFieldVarMergeTest() async {
 
   // We transfer the box back to main.
   await transferToMain(box)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
 
   // And reassign over the entire box, so again we can use it again.
   box = SingleFieldKlassBox()
@@ -637,7 +637,7 @@ func singleFieldVarMergeTest() async {
 
   await transferToMain(box) // expected-tns-warning {{sending 'box' risks causing data races}}
   // expected-tns-note @-1 {{sending 'box' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
 
 
   // But if we use box.k here, we emit an error since we didn't reinitialize at
@@ -652,7 +652,7 @@ func multipleFieldVarMergeTest1() async {
   // This transfers the entire region.
   await transferToMain(box.k1) // expected-tns-warning {{sending 'box.k1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'box.k1' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
 
   // So even if we reassign over k1, since we did a merge, this should error.
@@ -666,7 +666,7 @@ func multipleFieldVarMergeTest2() async {
 
   // This transfers the entire region.
   await transferToMain(box.k1)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // But if we assign over box completely, we can use it again.
   box = TwoFieldKlassBox()
@@ -676,7 +676,7 @@ func multipleFieldVarMergeTest2() async {
   useValue(box)
 
   await transferToMain(box.k2)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // But if we assign over box completely, we can use it again.
   box = TwoFieldKlassBox()
@@ -693,7 +693,7 @@ func multipleFieldTupleMergeTest1() async {
   // This transfers the entire region.
   await transferToMain(box.0) // expected-tns-warning {{sending 'box.0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'box.0' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // So even if we reassign over k1, since we did a merge, this should error.
   box.0 = NonSendableKlass() // expected-tns-note {{access can happen concurrently}}
@@ -708,7 +708,7 @@ func multipleFieldTupleMergeTest2() async {
 
   // This transfers the entire region.
   await transferToMain(box.0)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let box2 = (NonSendableKlass(), NonSendableKlass())
   // But if we assign over box completely, we can use it again.
@@ -719,7 +719,7 @@ func multipleFieldTupleMergeTest2() async {
   useValue(box)
 
   await transferToMain(box.1)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // But if we assign over box completely, we can use it again.
   box = (NonSendableKlass(), NonSendableKlass())
@@ -746,7 +746,7 @@ func letSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -755,7 +755,7 @@ func letSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
 
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access can happen concurrently}}
@@ -765,7 +765,7 @@ func letNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -774,7 +774,7 @@ func varSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -783,7 +783,7 @@ func varSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -792,7 +792,7 @@ func varNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -814,7 +814,7 @@ func letSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -823,7 +823,7 @@ func letSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -832,7 +832,7 @@ func letNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -841,7 +841,7 @@ func varSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -850,7 +850,7 @@ func varSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -859,7 +859,7 @@ func varNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -881,7 +881,7 @@ func letSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -890,7 +890,7 @@ func letSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -899,7 +899,7 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   useValue(test)
@@ -910,7 +910,7 @@ func letSendableTrivialVarStructFieldTest() async {
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -920,7 +920,7 @@ func letSendableNonTrivialVarStructFieldTest() async {
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -930,7 +930,7 @@ func letNonSendableNonTrivialVarStructFieldTest() async {
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   useValue(test)
@@ -950,7 +950,7 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
   _ = cls2
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   let z2 = test.varSendableNonTrivial
@@ -962,7 +962,7 @@ func varSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -971,7 +971,7 @@ func varSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -980,7 +980,7 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   useValue(test)
@@ -991,7 +991,7 @@ func varSendableTrivialVarStructFieldTest() async {
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -1001,7 +1001,7 @@ func varSendableNonTrivialVarStructFieldTest() async {
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -1011,7 +1011,7 @@ func varNonSendableNonTrivialVarStructFieldTest() async {
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   useValue(test)
@@ -1027,7 +1027,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   useValue(test)
@@ -1042,7 +1042,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   useValue(test)
@@ -1057,7 +1057,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -1073,7 +1073,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   useValue(test)
@@ -1089,7 +1089,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access can happen concurrently}}
   _ = z
   useValue(test)
@@ -1105,7 +1105,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -1120,7 +1120,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -1135,7 +1135,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -1150,7 +1150,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
   _ = cls
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
   useValue(test)
 }
@@ -1168,7 +1168,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
   } else {
     await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
     // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
     test.varSendableNonTrivial = SendableKlass()
   }
@@ -1189,7 +1189,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
 
     await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
     // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
@@ -1211,7 +1211,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
   } else {
     await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
     // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass()
@@ -1261,7 +1261,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
     await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{access can happen concurrently}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests()
   }
 
@@ -1284,11 +1284,11 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
     _ = cls
     await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
     await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
@@ -1305,7 +1305,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
   if await booleanFlag {
     await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
     cls = {
       useInOut(&test.varSendableNonTrivial)
@@ -1313,7 +1313,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
     _ = cls
     await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access can happen concurrently}}
@@ -1328,7 +1328,7 @@ func varSendableTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.0
   useValue(z)
   useValue(test) // expected-tns-note {{access can happen concurrently}}
@@ -1338,7 +1338,7 @@ func varSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.1
   useValue(z)
   useValue(test) // expected-tns-note {{access can happen concurrently}}
@@ -1348,7 +1348,7 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{access can happen concurrently}}
   useValue(z)
   useValue(test)
@@ -1359,7 +1359,7 @@ func varSendableTrivialVarTupleFieldTest() async {
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.0
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -1369,7 +1369,7 @@ func varSendableTrivialVarTupleFieldTest2() async {
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test.2) // expected-tns-warning {{sending 'test.2' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test.2' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   _ = test.0
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -1379,7 +1379,7 @@ func varSendableNonTrivialVarTupleFieldTest() async {
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.1
   useValue(test) // expected-tns-note {{access can happen concurrently}}
 }
@@ -1389,7 +1389,7 @@ func varNonSendableNonTrivialVarTupleFieldTest() async {
   test = (0, SendableKlass(), NonSendableKlass())
   await transferToMain(test) // expected-tns-warning {{sending 'test' risks causing data races}}
   // expected-tns-note @-1 {{sending 'test' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{access can happen concurrently}}
   useValue(z)
   useValue(test)
@@ -1405,11 +1405,11 @@ func controlFlowTest1() async {
   if await booleanFlag {
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   } else {
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   useValue(x) // expected-tns-note 2{{access can happen concurrently}}
@@ -1430,7 +1430,7 @@ func controlFlowTest2() async {
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{access can happen concurrently}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     x = NonSendableKlass()
   }
@@ -1454,7 +1454,7 @@ actor ActorWithSetter {
     self.field = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test2() async {
@@ -1462,7 +1462,7 @@ actor ActorWithSetter {
     self.twoFieldBox.k1 = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test3() async {
@@ -1470,7 +1470,7 @@ actor ActorWithSetter {
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1478,11 +1478,11 @@ actor ActorWithSetter {
   func recursive() async {
     let x = NonSendableKlass()
     await self.recursive!.twoFieldBoxInTuple.1.k2 = x
-    // expected-typechecker-only-warning @-1 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
-    // expected-typechecker-only-warning @-2 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+    // expected-typechecker-only-warning @-1 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+    // expected-typechecker-only-warning @-2 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
 
-    await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
   #endif
 
@@ -1491,7 +1491,7 @@ actor ActorWithSetter {
     self.classBox.k1 = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
 
@@ -1507,7 +1507,7 @@ final actor FinalActorWithSetter {
     self.field = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test2() async {
@@ -1515,7 +1515,7 @@ final actor FinalActorWithSetter {
     self.twoFieldBox.k1 = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test3() async {
@@ -1523,7 +1523,7 @@ final actor FinalActorWithSetter {
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1531,11 +1531,11 @@ final actor FinalActorWithSetter {
   func recursive() async {
     let x = NonSendableKlass()
     await self.recursive!.twoFieldBoxInTuple.1.k2 = x
-    // expected-typechecker-only-warning @-1 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
-    // expected-typechecker-only-warning @-2 {{non-sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+    // expected-typechecker-only-warning @-1 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
+    // expected-typechecker-only-warning @-2 {{non-Sendable type '(NonSendableKlass, TwoFieldKlassBox)' of property 'twoFieldBoxInTuple' cannot exit actor-isolated context}}
 
-    await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMain(x) // xpected-tns-warning {{call site passes `self` or a non-Sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
   #endif
 
@@ -1544,7 +1544,7 @@ final actor FinalActorWithSetter {
     self.classBox.k1 = x
     await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
 
@@ -1552,7 +1552,7 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let _ = { @MainActor in
     let _ = x // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
-    // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '() -> ()' in a '@Sendable' closure}}
+    // expected-complete-warning @-2 {{capture of 'x' with non-Sendable type '() -> ()' in a '@Sendable' closure}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 }
@@ -1568,7 +1568,7 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   for _ in 0..<1024 {
     await useValueAsync(c) // expected-tns-warning {{sending 'c' risks causing data races}}
     // expected-tns-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klass
   }
 }
@@ -1579,7 +1579,7 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   for _ in 0..<1024 {
     await useValueAsync(c) // expected-tns-warning {{sending 'c' risks causing data races}}
     // expected-tns-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klassLet
   }
 }
@@ -1589,7 +1589,7 @@ func testGetActorName() async {
   let x = NonSendableKlass()
   await a.useKlass(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{access can happen concurrently}}
 }
 
@@ -1597,7 +1597,7 @@ extension MyActor {
   func testCallBangIsolatedMethod(other: MyActor) async {
     await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'asyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
 
@@ -1605,7 +1605,7 @@ extension FinalActor {
   func testCallBangIsolatedMethod(other: MyActor) async {
     await klass.asyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'asyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
 
@@ -1618,7 +1618,7 @@ extension MyActor {
   func testCallBangIsolatedDirectMethod(other: MyActor) async {
     await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'directAsyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
 
@@ -1626,7 +1626,7 @@ extension FinalActor {
   func testCallBangIsolatedDirectMethod(other: MyActor) async {
     await klass.directAsyncCallWithIsolatedParameter(isolation: other) // expected-tns-warning {{sending 'self.klass' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'self.klass' to actor-isolated instance method 'directAsyncCallWithIsolatedParameter(isolation:)' risks causing data races between actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
 
@@ -1656,7 +1656,7 @@ extension MyActor {
       await transferToMain(x)
       // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
       // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-      // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+      // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     }
   }
 }
@@ -1717,9 +1717,9 @@ func differentInstanceTest(_ a: MyActor, _ b: MyActor) async {
   await a.useKlass(x)
   // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
   // expected-tns-note @-2 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   await b.useKlass(x) // expected-tns-note {{access can happen concurrently}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
 }
 
 protocol AssociatedTypeTestProtocol {
@@ -1732,7 +1732,7 @@ func associatedTypeTestBasic<T: AssociatedTypeTestProtocol>(_: T, _: isolated T.
 func associatedTypeTestBasic2<T: AssociatedTypeTestProtocol>(_: T, iso: isolated T.A, x: NonSendableKlass) async {
   await transferToMain(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending 'iso'-isolated 'x' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and 'iso'-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
 func sendableGlobalActorIsolated() {
@@ -1740,7 +1740,7 @@ func sendableGlobalActorIsolated() {
   let _ = { @Sendable @MainActor in
     print(x) // expected-tns-warning {{sending 'x' risks causing data races}}
     // expected-tns-note @-1 {{'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
-    // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in a '@Sendable' closure}}
+    // expected-complete-warning @-2 {{capture of 'x' with non-Sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
   print(x) // expected-tns-note {{access can happen concurrently}}
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -7,7 +7,7 @@
 // MARK: Declarations //
 ////////////////////////
 
-/// Classes are always non-sendable, so this is non-sendable
+/// Classes are always non-Sendable, so this is non-Sendable
 class NonSendableKlass {
   // expected-note @-1 {{}}
   var field: NonSendableKlass? = nil

--- a/test/Concurrency/transfernonsendable_defer_and_typecheck_only.swift
+++ b/test/Concurrency/transfernonsendable_defer_and_typecheck_only.swift
@@ -5,7 +5,7 @@
 
 /*
  This file tests the experimental TransferNonSendable feature. This feature causes the passing
- of non-sendable values to isolation-crossing calls to not yield diagnostics during AST passes,
+ of non-Sendable values to isolation-crossing calls to not yield diagnostics during AST passes,
  but to instead emit them later during a mandatory SIL pass. This file in particular checks that
  isolation crossing via argument passing is deferred, but that isolation crossing via returned
  results is not deferred. This is done because flow-sensitive "region" checking
@@ -46,7 +46,7 @@ actor A {
         // Non-sendable value passed from nonisolated to actor isolated
 
         await takesNS(ns)
-        //deferred-warning@-1{{passing argument of non-sendable type 'NonSendable' outside of actor-isolated context may introduce data races}}
+        //deferred-warning@-1{{passing argument of non-Sendable type 'NonSendable' outside of actor-isolated context may introduce data races}}
 
         _ = await retsNS()
     }
@@ -55,7 +55,7 @@ actor A {
         // Non-sendable value passed between the isolation of two different actors
 
         await a.actorTakesNS(ns)
-        //deferred-warning@-1{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+        //deferred-warning@-1{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         _ = await a.actorRetsNS()
     }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -79,13 +79,13 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 
   await transferToMainActor(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
   await transferToMainActor(y) // expected-tns-warning {{sending 'y' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'y' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
 @CustomActor func useCustomActor2() async {
@@ -97,7 +97,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 
   await transferToMainActor(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainActor' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
 @CustomActor func useCustomActor3() async {
@@ -124,7 +124,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
   // This is ok since the nonisolated function cannot transfer x, so once we
   // return x will be isolated again.
   await transferToNonIsolated(x)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' outside of global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableLinkedListNode<Int>' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
   useValue(x)
 }
@@ -141,7 +141,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   // This is ok since the nonisolated function cannot transfer x meaning after
   // we return we know that x will be disconnected upon return as well.
   await transferToNonIsolated(x)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
   useValue(x)
 }
@@ -152,7 +152,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated global function 'transferToNonIsolated' risks causing data races between nonisolated and global actor 'CustomActor'-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
   useValue(x)
 }
@@ -163,8 +163,8 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   // This is safe since the nonisolated function cannot transfer x further.
   await transferToNonIsolated(x)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
   useValue(x)
 }
@@ -176,8 +176,8 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   await transferToNonIsolated(x) // expected-tns-warning {{sending 'x' risks causing data races}}
   // expected-tns-note @-1 {{sending global actor 'CustomActor'-isolated 'x' to nonisolated global function 'transferToNonIsolated' risks causing data races between nonisolated and global actor 'CustomActor'-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
   useValue(x)
 }
@@ -209,7 +209,7 @@ struct Clock {
     // nonisolated instead of custom actor isolated.
     print(ns) // expected-tns-warning {{sending 'ns' risks causing data races}}
     // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
-    // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in a '@Sendable' closure}}
+    // expected-complete-warning @-2 {{capture of 'ns' with non-Sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
 
   useValue(ns)
@@ -259,7 +259,7 @@ struct Clock {
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -268,7 +268,7 @@ struct Clock {
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -277,7 +277,7 @@ struct Clock {
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '(T) -> Void' outside of main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '(T) -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -291,7 +291,7 @@ struct Clock {
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -305,7 +305,7 @@ struct Clock {
 
   await useValueAsync(erased) // expected-tns-warning {{sending 'erased' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -316,7 +316,7 @@ struct Clock {
   // Regions: [{(closure), @MainActor}]
   await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 
@@ -326,7 +326,7 @@ struct Clock {
   }
   await transferToCustomActor(closure) // expected-tns-warning {{sending 'closure' risks causing data races}}
   // expected-tns-note @-1 {{sending main actor-isolated 'closure' to global actor 'CustomActor'-isolated global function 'transferToCustomActor' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 }
 

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -54,36 +54,36 @@ func transferLetNonTransferrableSquelched(_ ns: NonSendableKlass) async {
   await transferToMainDirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns2)
 
   await transferToMainDirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
 func useAfterTransferLetSquelchedDirect() async {
@@ -95,7 +95,7 @@ func useAfterTransferLetSquelchedDirect() async {
   await transferToMainDirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns) // expected-tns-note {{access can happen concurrently}}
 
   await transferToMainDirect(ns2)
@@ -104,13 +104,13 @@ func useAfterTransferLetSquelchedDirect() async {
   await transferToMainDirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns3) // expected-tns-note {{access can happen concurrently}}
 
   await transferToMainDirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns4) // expected-tns-note {{access can happen concurrently}}
 }
 
@@ -123,7 +123,7 @@ func useAfterTransferSquelchedIndirect() async {
   await transferToMainIndirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns) // expected-tns-note {{access can happen concurrently}}
 
   await transferToMainIndirect(ns2)
@@ -132,13 +132,13 @@ func useAfterTransferSquelchedIndirect() async {
   await transferToMainIndirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns3) // expected-tns-note {{access can happen concurrently}}
 
   await transferToMainIndirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns4) // expected-tns-note {{access can happen concurrently}}
 }
 
@@ -149,11 +149,11 @@ func transferNonTransferrableClassField(_ ns: NonSendableKlass) async {
   await transferToMainDirect(ns2.field!)
   // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   await transferToMainIndirect(ns2.field!)
   // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
 // We consider the klass field separate from the klass, so we get an error.
@@ -166,17 +166,17 @@ func transferNonTransferrableStructField(_ ns: NonSendableStruct) async {
   await transferToMainDirect(ns2.field!)
   // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2.field!)
   // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2.field)
   // expected-tns-warning @-1 {{sending 'ns2.field' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns2.field' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
 }
 
 // Make sure that we pattern match the consuming temporary correctly.
@@ -186,12 +186,12 @@ func testConsumingTransfer(_ ns: NonSendableKlass) async {
   await transferToMainDirectConsuming(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirectConsuming' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirectConsuming(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirectConsuming' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirectConsuming(ns2)
 
@@ -209,36 +209,36 @@ func transferVarNonTransferrableSquelched(_ ns: NonSendableKlass) async {
   await transferToMainDirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns2)
 
   await transferToMainDirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainDirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
 func useAfterTransferVarSquelchedDirect() async {
@@ -251,7 +251,7 @@ func useAfterTransferVarSquelchedDirect() async {
   await transferToMainDirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns) // expected-tns-note {{access can happen concurrently}}
 
   await transferToMainDirect(ns2)
@@ -260,13 +260,13 @@ func useAfterTransferVarSquelchedDirect() async {
   await transferToMainDirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns3) // expected-tns-note {{access can happen concurrently}}
 
   await transferToMainDirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending 'ns4' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   print(ns4) // expected-tns-note {{access can happen concurrently}}
 }
 
@@ -284,19 +284,19 @@ func transferLetNonTransferrableSquelchedAddressOnly<T>(_ ns: T) async { // expe
   await transferToMainIndirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns2)
 
   await transferToMainIndirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 
   await transferToMainIndirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
 }
 
 func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ meta: T.Type) async { // expected-complete-note 3{{}}
@@ -308,7 +308,7 @@ func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ 
   await transferToMainIndirect(ns)
   // expected-tns-warning @-1 {{sending 'ns' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns)
 
   await transferToMainIndirect(ns2)
@@ -317,13 +317,13 @@ func useAfterTransferLetSquelchedIndirectAddressOnly<T : ProvidesStaticValue>(_ 
   await transferToMainIndirect(ns3)
   // expected-tns-warning @-1 {{sending 'ns3' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns3' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns3)
 
   await transferToMainIndirect(ns4)
   // expected-tns-warning @-1 {{sending 'ns4' risks causing data races}}
   // expected-tns-note @-2 {{sending task-isolated 'ns4' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'T' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T' into main actor-isolated context may introduce data races}}
   print(ns4)
 }
 
@@ -338,13 +338,13 @@ struct Globals {
 
 func testAccessStaticGlobals() async {
   await transferToMainDirect(Globals.nonIsolatedUnsafeLetObject)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   await transferToMainIndirect(Globals.nonIsolatedUnsafeLetObject)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   await transferToMainDirect(Globals.nonIsolatedUnsafeVarObject)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   await transferToMainIndirect(Globals.nonIsolatedUnsafeVarObject)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 }
 
 nonisolated(unsafe) let globalNonIsolatedUnsafeLetObject = NonSendableKlass()
@@ -382,19 +382,19 @@ actor MyActor {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
 
@@ -404,19 +404,19 @@ final actor MyFinalActor {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending 'self'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
 
@@ -427,13 +427,13 @@ final class FinalNonIsolatedUnsafeFieldKlassSendable: @unchecked Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // 'x' is treated as disconnected since we treat unchecked fields as being
     // disconnected.
@@ -443,7 +443,7 @@ final class FinalNonIsolatedUnsafeFieldKlassSendable: @unchecked Sendable {
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x) // expected-tns-note {{access can happen concurrently}}
   }
 }
@@ -454,13 +454,13 @@ class NonIsolatedUnsafeFieldKlassSendable: @unchecked Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // 'x' is treated as disconnected since we treat unchecked fields as being
     // disconnected.
@@ -470,7 +470,7 @@ class NonIsolatedUnsafeFieldKlassSendable: @unchecked Sendable {
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x) // expected-tns-note {{access can happen concurrently}}
   }
 }
@@ -481,13 +481,13 @@ struct NonIsolatedUnsafeFieldStruct: Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // 'x' is treated as disconnected since we treat unchecked fields as being
     // disconnected.
@@ -497,7 +497,7 @@ struct NonIsolatedUnsafeFieldStruct: Sendable {
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x) // expected-tns-note {{access can happen concurrently}}
   }
 }
@@ -511,9 +511,9 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // 'x' is treated as disconnected since we treat unchecked fields as being
     // disconnected.
@@ -523,7 +523,7 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x) // expected-tns-note {{access can happen concurrently}}
   }
 }
@@ -535,20 +535,20 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // 'x' is treated as global actor 'CustomActor' isolated.
     let x = nonIsolatedLetObject
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
 }
@@ -559,13 +559,13 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // x is treated as global actor 'CustomActor' isolated since the
     // nonisolated(unsafe) only applies to nonIsolatedUnsafeLetObject.
@@ -573,7 +573,7 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
 }
@@ -584,20 +584,20 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // 'x' is treated as global actor 'CustomActor'-isolated.
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
 }
@@ -612,32 +612,32 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // 'x' is treated as global actor 'CustomActor'-isolated.
     let x = nonIsolatedUnsafeLetObject
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     let x2 = nonIsolatedUnsafeVarObject
     await transferToMainDirect(x2)
     // expected-tns-warning @-1 {{sending 'x2' risks causing data races}}
     // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x2' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     let x3 = nonIsolatedUnsafeVarComputedObject
     await transferToMainDirect(x3)
     // expected-tns-warning @-1 {{sending 'x3' risks causing data races}}
     // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x3' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     print(x)
   }
@@ -652,9 +652,9 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
 
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     // 'x' is treated as global actor 'CustomActor' even though
     // nonIsolatedUnsafeVarObject is not.
@@ -662,7 +662,7 @@ enum NonIsolatedUnsafeComputedEnum: Sendable {
     await transferToMainDirect(x)
     // expected-tns-warning @-1 {{sending 'x' risks causing data races}}
     // expected-tns-note @-2 {{sending global actor 'CustomActor'-isolated 'x' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     print(x)
   }
 }
@@ -680,17 +680,17 @@ struct NonIsolatedUnsafeFieldNonSendableStruct {
   // task isolated.
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
     // expected-tns-warning @-1 {{sending 'self.letObject' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
     // expected-tns-warning @-1 {{sending 'self.varObject' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   // This is safe since self will become MainActor isolated as a result of
@@ -713,17 +713,17 @@ final class FinalNonIsolatedUnsafeFieldKlass {
   // task isolated.
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
     // expected-tns-warning @-1 {{sending 'self.letObject' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
     // expected-tns-warning @-1 {{sending 'self.varObject' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   // This is safe since self will become MainActor isolated as a result of
@@ -746,17 +746,17 @@ class NonIsolatedUnsafeFieldKlass {
   // task isolated.
   func test() async {
     await transferToMainDirect(nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(nonIsolatedUnsafeVarObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(letObject)
     // expected-tns-warning @-1 {{sending 'self.letObject' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self.letObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainDirect(varObject)
     // expected-tns-warning @-1 {{sending 'self.varObject' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self.varObject' to main actor-isolated global function 'transferToMainDirect' risks causing data races between main actor-isolated and task-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   // This is safe since self will become MainActor isolated as a result of
@@ -779,15 +779,15 @@ class NonIsolatedUnsafeFieldGenericKlass<T> { // expected-complete-note 4{{}}
   // task isolated.
   func test() async {
     await transferToMainIndirect(nonIsolatedUnsafeLetAddressOnly)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'T?' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'T?' into main actor-isolated context may introduce data races}}
 
     await transferToMainIndirect(nonIsolatedUnsafeVarAddressOnly)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'T?' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'T?' into main actor-isolated context may introduce data races}}
 
     await transferToMainIndirect(letAddressOnly)
     // expected-tns-warning @-1 {{sending 'self.letAddressOnly' risks causing data races}}
     // expected-tns-note @-2 {{sending task-isolated 'self.letAddressOnly' to main actor-isolated global function 'transferToMainIndirect' risks causing data races between main actor-isolated and task-isolated uses}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'T?' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'T?' into main actor-isolated context may introduce data races}}
 
     // TODO: This diagnostic is unfortunate since we are erroring on the
     // temporary created by the class_method call.
@@ -815,7 +815,7 @@ actor ActorContainingSendableStruct {
 
   func test() async {
     await transferToMainDirect(x!.nonIsolatedUnsafeLetObject)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
     await transferToMainIndirect(x)
   }
 }

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -59,7 +59,7 @@ func test_isolation_crossing_sensitivity(a : A) async {
   // This call consumes ns1
   await a.foo(ns1); // expected-tns-warning {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   print(ns0);
   print(ns1); // expected-tns-note {{access can happen concurrently}}
@@ -69,18 +69,18 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
   let ns_let = NonSendable();
 
   // Safe to consume an rvalue.
-  await a.foo(NonSendable()); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(NonSendable()); // expected-complete-warning {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Safe to consume an lvalue.
-  await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns_let); // expected-complete-warning {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Not safe to consume an arg.
   await a.foo(ns_arg); // expected-tns-warning {{sending 'ns_arg' risks causing data races}}
   // expected-tns-note @-1 {{sending task-isolated 'ns_arg' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and task-isolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Check for no duplicate warnings once self is "consumed"
-  await a.foo(NonSendable()); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(NonSendable()); // expected-complete-warning {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func test_closure_capture(a : A) async {
@@ -106,7 +106,7 @@ func test_closure_capture(a : A) async {
   // expected-tns-warning @-1 {{sending 'captures0' risks causing data races}}
   // expected-tns-note @-2 {{sending 'captures0' to actor-isolated instance method 'run_closure' risks causing data races between actor-isolated and local nonisolated uses}}
 
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   print(ns0) // expected-tns-note {{access can happen concurrently}}
@@ -118,7 +118,7 @@ func test_closure_capture(a : A) async {
   await a.run_closure(captures12)
   // expected-tns-warning @-1 {{sending 'captures12' risks causing data races}}
   // expected-tns-note @-2 {{sending 'captures12' to actor-isolated instance method 'run_closure' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   // This only touches ns1/ns2 so we get an error on ns1 since it is first.
@@ -131,7 +131,7 @@ func test_closure_capture(a : A) async {
   await a.run_closure(captures3indirect)
   // expected-tns-warning @-1 {{sending 'captures3indirect' risks causing data races}}
   // expected-tns-note @-2 {{sending 'captures3indirect' to actor-isolated instance method 'run_closure' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into actor-isolated context may introduce data races}}
   // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
   // This only uses ns3 so we should only emit an error on ns3.
@@ -163,7 +163,7 @@ func test_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if (b) {
       print(ns0_0) // expected-tns-note {{access can happen concurrently}}
@@ -173,7 +173,7 @@ func test_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns0_0) // expected-tns-note {{access can happen concurrently}}
@@ -185,7 +185,7 @@ func test_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns1_0) // expected-tns-note {{access can happen concurrently}}
@@ -195,7 +195,7 @@ func test_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns1_0) // expected-tns-note {{access can happen concurrently}}
@@ -207,7 +207,7 @@ func test_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns2_0) // expected-tns-note {{access can happen concurrently}}
@@ -217,7 +217,7 @@ func test_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns2_0) // expected-tns-note {{access can happen concurrently}}
@@ -268,7 +268,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns0_0) // expected-tns-warning {{sending 'ns0_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns0_0) // expected-tns-note {{access can happen concurrently}}
@@ -278,7 +278,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns0_1) // expected-tns-warning {{sending 'ns0_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns0_0) // expected-tns-note {{access can happen concurrently}}
@@ -290,7 +290,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns1_0) // expected-tns-warning {{sending 'ns1_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns1_0) // expected-tns-note {{access can happen concurrently}}
@@ -300,7 +300,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns1_1) // expected-tns-warning {{sending 'ns1_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns1_0) // expected-tns-note {{access can happen concurrently}}
@@ -312,7 +312,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns2_0) // expected-tns-warning {{sending 'ns2_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns2_0) // expected-tns-note {{access can happen concurrently}}
@@ -322,7 +322,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns2_1) // expected-tns-warning {{sending 'ns2_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns2_0) // expected-tns-note {{access can happen concurrently}}
@@ -334,7 +334,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns3_0) // expected-tns-warning {{sending 'ns3_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns3_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns3_0) // expected-tns-note {{access can happen concurrently}}
@@ -344,7 +344,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns3_1) // expected-tns-warning {{sending 'ns3_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns3_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns3_0) // expected-tns-note {{access can happen concurrently}}
@@ -356,7 +356,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns4_0) // expected-tns-warning {{sending 'ns4_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns4_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns4_0) // expected-tns-note {{access can happen concurrently}}
@@ -366,7 +366,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns4_1) // expected-tns-warning {{sending 'ns4_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns4_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns4_0) // expected-tns-note {{access can happen concurrently}}
@@ -378,7 +378,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   if (b) {
     await a.foo(ns5_0) // expected-tns-warning {{sending 'ns5_0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns5_0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns5_0) // expected-tns-note {{access can happen concurrently}}
@@ -388,7 +388,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   } else {
     await a.foo(ns5_1) // expected-tns-warning {{sending 'ns5_1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns5_1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any' into actor-isolated context may introduce data races}}
 
     if b {
       print(ns5_0) // expected-tns-note {{access can happen concurrently}}
@@ -412,7 +412,7 @@ class C_NonSendable {
     // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
     await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' risks causing data races}}
     // expected-tns-note @-1 {{sending task-isolated 'captures_self' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and task-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 }
@@ -428,7 +428,7 @@ final class C_Sendable : Sendable {
 
     // this is a cross-isolation, but self is Sendable, so it should be permitted
     await a.foo(captures_self)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 {{passing argument of non-Sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 }
@@ -449,7 +449,7 @@ actor A_Sendable {
     // the specific actor.
     await a.foo(captures_self) // expected-tns-warning {{sending 'captures_self' risks causing data races}}
     // expected-tns-note @-1 {{sending 'self'-isolated 'captures_self' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and 'self'-isolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
 }
@@ -461,7 +461,7 @@ func basic_loopiness(a : A, b : Bool) async {
     await a.foo(ns) // expected-tns-warning {{sending 'ns' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{access can happen concurrently}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-3 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   }
 }
 
@@ -478,9 +478,9 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns3) // expected-tns-note {{access can happen concurrently}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func basic_loopiness_safe(a : A, b : Bool) async {
@@ -495,9 +495,9 @@ func basic_loopiness_safe(a : A, b : Bool) async {
   }
 
   await a.foo(ns0)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns3)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 struct StructBox {
@@ -518,9 +518,9 @@ func test_struct_assign_doesnt_merge(a : A, b : Bool) async {
   box.contents = ns1
 
   await a.foo(ns0)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 class ClassBox {
@@ -543,9 +543,9 @@ func test_class_assign_merges(a : A, b : Bool) async {
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{access can happen concurrently}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func test_stack_assign_doesnt_merge(a : A, b : Bool) async {
@@ -560,9 +560,9 @@ func test_stack_assign_doesnt_merge(a : A, b : Bool) async {
   foo_noniso(contents) //must use var to avoid warning
 
   await a.foo(ns0)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1)
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
@@ -580,9 +580,9 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
 
   await a.foo(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{access can happen concurrently}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func test_tuple_formation(a : A, i : Int) async {
@@ -598,7 +598,7 @@ func test_tuple_formation(a : A, i : Int) async {
   case 0:
     await a.foo(ns0) // expected-tns-warning {{sending 'ns0' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
       foo_noniso(ns0); // expected-tns-note {{access can happen concurrently}}
@@ -618,7 +618,7 @@ func test_tuple_formation(a : A, i : Int) async {
   case 1:
     await a.foo(ns1) // expected-tns-warning {{sending 'ns1' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
       foo_noniso(ns0); // expected-tns-note {{access can happen concurrently}}
@@ -638,7 +638,7 @@ func test_tuple_formation(a : A, i : Int) async {
   case 2:
     await a.foo(ns2) // expected-tns-warning {{sending 'ns2' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     if bool {
       foo_noniso(ns0); // expected-tns-note {{access can happen concurrently}}
@@ -658,7 +658,7 @@ func test_tuple_formation(a : A, i : Int) async {
   case 3:
     await a.foo(ns4) // expected-tns-warning {{sending 'ns4' risks causing data races}}
     // expected-tns-note @-1 {{sending 'ns4' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     foo_noniso(ns0);
     foo_noniso(ns1);
@@ -669,7 +669,7 @@ func test_tuple_formation(a : A, i : Int) async {
   case 4:
     await a.foo(ns012) // expected-tns-warning {{sending value of non-Sendable type '(NonSendable, NonSendable, NonSendable)' risks causing data races}}
     // expected-tns-note @-1 {{sending value of non-Sendable type '(NonSendable, NonSendable, NonSendable)' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-2 3{{passing argument of non-Sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
     if bool {
       foo_noniso(ns0); // expected-tns-note {{access can happen concurrently}}
@@ -689,7 +689,7 @@ func test_tuple_formation(a : A, i : Int) async {
   default:
       await a.foo(ns13) // expected-tns-warning {{sending value of non-Sendable type '(NonSendable, NonSendable)' risks causing data races}}
       // expected-tns-note @-1 {{sending value of non-Sendable type '(NonSendable, NonSendable)' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-    // expected-complete-warning @-1 2{{passing argument of non-sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
+    // expected-complete-warning @-1 2{{passing argument of non-Sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
     if bool {
       foo_noniso(ns0); // expected-tns-note {{access can happen concurrently}}
@@ -716,9 +716,9 @@ func reuse_args_safe(a : A) async {
 
   // this should be perfectly legal - arguments are assumed to come from the same region
   await a.foo_multi(ns0, ns0, ns0);
-  // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns1, ns2, ns1);
-  // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func one_consume_many_require(a : A) async {
@@ -729,7 +729,7 @@ func one_consume_many_require(a : A) async {
   let ns4 = NonSendable();
 
   await a.foo_multi(ns0, ns1, ns2);
-  // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-4 {{sending 'ns1' risks causing data races}}
@@ -748,7 +748,7 @@ func one_consume_one_require(a : A) async {
   let ns2 = NonSendable();
 
   await a.foo_multi(ns0, ns1, ns2);
-  // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-3 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
   // expected-tns-warning @-4 {{sending 'ns1' risks causing data races}}
@@ -769,13 +769,13 @@ func many_consume_one_require(a : A) async {
 
   await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{access can happen concurrently}}
 }
 
@@ -791,13 +791,13 @@ func many_consume_many_require(a : A) async {
 
   await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{sending 'ns0' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns0' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{sending 'ns1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns1' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{sending 'ns2' risks causing data races}}
   // expected-tns-note @-1 {{sending 'ns2' to actor-isolated instance method 'foo_multi' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 3{{passing argument of non-Sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{access can happen concurrently}}
   foo_noniso_multi(ns6, ns1, ns7); // expected-tns-note {{access can happen concurrently}}
@@ -812,9 +812,9 @@ func reuse_args_safe_vararg(a : A) async {
 
   // this should be perfectly legal - arguments are assumed to come from the same region
   await a.foo_vararg(ns0, ns0, ns0);
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns1, ns2, ns1);
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-1 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
 }
 
 func one_consume_many_require_varag(a : A) async {
@@ -828,7 +828,7 @@ func one_consume_many_require_varag(a : A) async {
   await a.foo_vararg(ns0, ns1, ns2);
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' risks causing data races}}
   // expected-tns-note @-2 {{sending value of non-Sendable type 'Any...' to actor-isolated instance method 'foo_vararg' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   if bool {
     foo_noniso_vararg(ns0, ns3, ns4); // expected-tns-note {{access can happen concurrently}}
@@ -847,7 +847,7 @@ func one_consume_one_require_vararg(a : A) async {
   await a.foo_vararg(ns0, ns1, ns2);
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' risks causing data races}}
   // expected-tns-note @-2 {{sending value of non-Sendable type 'Any...' to actor-isolated instance method 'foo_vararg' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{access can happen concurrently}}
 }
@@ -863,15 +863,15 @@ func many_consume_one_require_vararg(a : A) async {
   await a.foo_vararg(ns0, ns3, ns3)
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' risks causing data races}}
   // expected-tns-note @-2 {{sending value of non-Sendable type 'Any...' to actor-isolated instance method 'foo_vararg' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns4, ns1, ns4)
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' risks causing data races}}
   // expected-tns-note @-2 {{sending value of non-Sendable type 'Any...' to actor-isolated instance method 'foo_vararg' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns5, ns5, ns2)
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' risks causing data races}}
   // expected-tns-note @-2 {{sending value of non-Sendable type 'Any...' to actor-isolated instance method 'foo_vararg' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{access can happen concurrently}}
 }
@@ -889,15 +889,15 @@ func many_consume_many_require_vararg(a : A) async {
   await a.foo_vararg(ns0, ns3, ns3)
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' risks causing data races}}
   // expected-tns-note @-2 {{sending value of non-Sendable type 'Any...' to actor-isolated instance method 'foo_vararg' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns4, ns1, ns4)
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' risks causing data races}}
   // expected-tns-note @-2 {{sending value of non-Sendable type 'Any...' to actor-isolated instance method 'foo_vararg' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
   await a.foo_vararg(ns5, ns5, ns2)
   // expected-tns-warning @-1 {{sending value of non-Sendable type 'Any...' risks causing data races}}
   // expected-tns-note @-2 {{sending value of non-Sendable type 'Any...' to actor-isolated instance method 'foo_vararg' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'Any...' into actor-isolated context may introduce data races}}
 
   if bool {
     foo_noniso_vararg(ns0, ns6, ns7); // expected-tns-note {{access can happen concurrently}}
@@ -936,7 +936,7 @@ func enum_test(a : A) async {
       case let .E3(ns3):
         await a.foo(ns3.x) // expected-tns-warning {{sending value of non-Sendable type 'Any' risks causing data races}}
         // expected-tns-note @-1 {{sending value of non-Sendable type 'Any' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
+        // expected-complete-warning @-1 {{passing argument of non-Sendable type 'Any' into actor-isolated context may introduce data races}}
       default: ()
       }
 
@@ -947,7 +947,7 @@ func enum_test(a : A) async {
 
   await a.foo(e1); // expected-tns-warning {{sending 'e1' risks causing data races}}
   // expected-tns-note @-1 {{sending 'e1' to actor-isolated instance method 'foo' risks causing data races between actor-isolated and local nonisolated uses}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
+  // expected-complete-warning @-2 {{passing argument of non-Sendable type 'E' into actor-isolated context may introduce data races}}
   foo_noniso(e2); // expected-tns-note {{access can happen concurrently}}
   foo_noniso(e3); // expected-tns-note {{access can happen concurrently}}
   foo_noniso(e4);

--- a/test/Concurrency/voucher_propagation.swift
+++ b/test/Concurrency/voucher_propagation.swift
@@ -228,7 +228,7 @@ func withVouchers(call: @Sendable @escaping (voucher_t?, voucher_t?, voucher_t?)
 
       // Clear any voucher that the call adopted.
       adopt(voucher: nil)
-      group.leave() // expected-complete-tns-warning {{capture of 'group' with non-sendable type 'DispatchGroup' in a '@Sendable' closure}}
+      group.leave() // expected-complete-tns-warning {{capture of 'group' with non-Sendable type 'DispatchGroup' in a '@Sendable' closure}}
     }
     group.wait()
 
@@ -417,7 +417,7 @@ if #available(SwiftStdlib 5.1, *) {
            _ = await (g, add)
 
            if await n.get() >= limit {
-             group.leave() // expected-warning 2{{capture of 'group' with non-sendable type 'DispatchGroup' in a '@Sendable' closure}}
+             group.leave() // expected-warning 2{{capture of 'group' with non-Sendable type 'DispatchGroup' in a '@Sendable' closure}}
            } else {
              await n.increment()
              await detachedTask()

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -260,7 +260,7 @@ typedef NS_ERROR_ENUM(unsigned, SendableErrorCode, SendableErrorDomain) {
 typedef NS_ERROR_ENUM(unsigned, NonSendableErrorCode, NonSendableErrorDomain) {
   NonSendableErrorCodeFoo, NonSendableErrorCodeBar
 } NONSENDABLE;
-// expected-warning@-3 {{cannot make error code type 'NonSendableErrorCode' non-sendable because Swift errors are always sendable}}
+// expected-warning@-3 {{cannot make error code type 'NonSendableErrorCode' non-Sendable because Swift errors are always sendable}}
 
 UI_ACTOR
 @interface PictureFrame : NSObject

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -65,12 +65,12 @@ func caller() async {
 // now make sure you can't form a Sendable existential from a move-only type.
 
 struct RefPair: Sendable, ~Copyable {
-  var left: Ref // expected-warning {{stored property 'left' of 'Sendable'-conforming struct 'RefPair' has non-sendable type 'Ref'}}
-  var right: Ref  // expected-warning {{stored property 'right' of 'Sendable'-conforming struct 'RefPair' has non-sendable type 'Ref'}}
+  var left: Ref // expected-warning {{stored property 'left' of 'Sendable'-conforming struct 'RefPair' has non-Sendable type 'Ref'}}
+  var right: Ref  // expected-warning {{stored property 'right' of 'Sendable'-conforming struct 'RefPair' has non-Sendable type 'Ref'}}
 }
 
 enum MaybeRef: Sendable, ~Copyable {
-  case ref(Ref) // expected-warning {{associated value 'ref' of 'Sendable'-conforming enum 'MaybeRef' has non-sendable type 'Ref'}}
+  case ref(Ref) // expected-warning {{associated value 'ref' of 'Sendable'-conforming enum 'MaybeRef' has non-Sendable type 'Ref'}}
   case null
 }
 
@@ -80,7 +80,7 @@ enum OK_NoncopyableOption<T: Sendable> : Sendable, ~Copyable {
 }
 
 enum Wrong_NoncopyableOption<T> : Sendable, ~Copyable { // expected-note {{consider making generic parameter 'T' conform to the 'Sendable' protocol}}
-  case some(T) // expected-warning {{associated value 'some' of 'Sendable'-conforming generic enum 'Wrong_NoncopyableOption' has non-sendable type 'T'}}
+  case some(T) // expected-warning {{associated value 'some' of 'Sendable'-conforming generic enum 'Wrong_NoncopyableOption' has non-Sendable type 'T'}}
   case none
 }
 

--- a/test/Sema/raw_layout_sendable.swift
+++ b/test/Sema/raw_layout_sendable.swift
@@ -14,7 +14,7 @@ struct NotAutomaticallySendable: ~Copyable {} // expected-note{{}}
 func testNotAutomaticallySendable() {
     let s = NotAutomaticallySendable()
 
-    checkSendable { _ = s } // expected-warning{{capture of 's' with non-sendable type 'NotAutomaticallySendable'}}
+    checkSendable { _ = s } // expected-warning{{capture of 's' with non-Sendable type 'NotAutomaticallySendable'}}
 }
 
 @_rawLayout(size: 4, alignment: 4)

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -24,7 +24,7 @@ func acceptsNonConcurrent(_ fn: (Int) -> Int) { }
 
 func passingConcurrentOrNot(
   _ cfn: @Sendable (Int) -> Int,
-  ncfn: (Int) -> Int // expected-note{{parameter 'ncfn' is implicitly non-sendable}}{{9-9=@Sendable }}
+  ncfn: (Int) -> Int // expected-note{{parameter 'ncfn' is implicitly non-Sendable}}{{9-9=@Sendable }}
 ) {
   // Ambiguous because preconcurrency code doesn't consider `@Sendable`.
   f(cfn) // expected-error{{ambiguous use of 'f'}}
@@ -33,7 +33,7 @@ func passingConcurrentOrNot(
   f(ncfn)
 
   acceptsConcurrent(cfn) // okay
-  acceptsConcurrent(ncfn) // expected-warning{{passing non-sendable parameter 'ncfn' to function expecting a '@Sendable' closure}}
+  acceptsConcurrent(ncfn) // expected-warning{{passing non-Sendable parameter 'ncfn' to function expecting a '@Sendable' closure}}
   acceptsNonConcurrent(cfn) // okay
   acceptsNonConcurrent(ncfn) // okay
 
@@ -53,8 +53,8 @@ func closures() {
       return i
     })
 
-  let closure1 = { $0 + 1 } // inferred to be non-sendable
-  acceptsConcurrent(closure1) // expected-warning{{converting non-sendable function value to '@Sendable (Int) -> Int' may introduce data races}}
+  let closure1 = { $0 + 1 } // inferred to be non-Sendable
+  acceptsConcurrent(closure1) // expected-warning{{converting non-Sendable function value to '@Sendable (Int) -> Int' may introduce data races}}
 }
 
 // Mutation of captured locals from within @Sendable functions.

--- a/test/attr/attr_objc_async.swift
+++ b/test/attr/attr_objc_async.swift
@@ -38,7 +38,7 @@ actor MyActor {
   // CHECK-DUMP-LABEL: func_decl{{.*}}doBigJobOrFailActor{{.*}}
   // CHECK-DUMP: (foreign_async_convention completion_handler_type="@convention(block) (Optional<AnyObject>, Int, Optional<any Error>) -> ()" completion_handler_param=1 error_param=2)
   @objc func doBigJobOrFailActor(_: Int) async throws -> (AnyObject, Int) { return (self, 0) }
-  // expected-warning@-1{{non-sendable type '(AnyObject, Int)' returned by actor-isolated '@objc' instance method 'doBigJobOrFailActor' cannot cross actor boundary}}
+  // expected-warning@-1{{non-Sendable type '(AnyObject, Int)' returned by actor-isolated '@objc' instance method 'doBigJobOrFailActor' cannot cross actor boundary}}
 
   // Actor-isolated entities cannot be exposed to Objective-C.
   @objc func synchronousBad() { } // expected-error{{actor-isolated instance method 'synchronousBad()' cannot be '@objc'}}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -90,7 +90,7 @@ protocol HasAssoc {
 
 do {
   enum MyError: Error {
-    case bad(Any) // expected-swift-6-error {{associated value 'bad' of 'Sendable'-conforming enum 'MyError' has non-sendable type 'Any'}}
+    case bad(Any) // expected-swift-6-error {{associated value 'bad' of 'Sendable'-conforming enum 'MyError' has non-Sendable type 'Any'}}
   }
 
   func checkIt(_ js: Any) throws {

--- a/userdocs/diagnostics/sendable-closure-captures.md
+++ b/userdocs/diagnostics/sendable-closure-captures.md
@@ -80,7 +80,7 @@ The compiler diagnoses the capture of `model` in a `@Sendable` closure:
 | func capture(model: MyModel) async {
 |   callConcurrently {
 |     model.log()
-|     `- error: capture of 'model' with non-sendable type 'MyModel' in a '@Sendable' closure
+|     `- error: capture of 'model' with non-Sendable type 'MyModel' in a '@Sendable' closure
 |   }
 | }
 ```

--- a/validation-test/Sema/SwiftUI/rdar76252310.swift
+++ b/validation-test/Sema/SwiftUI/rdar76252310.swift
@@ -42,7 +42,7 @@ func fromConcurrencyAware() async {
   let view = CoffeeTrackerView() // synthesized 'init' is 'nonisolated'
 
   // expected-note@+3 {{property access is 'async'}}
-  // expected-warning@+2 {{non-sendable type 'some View' of property 'body' cannot exit main actor-isolated context}}
+  // expected-warning@+2 {{non-Sendable type 'some View' of property 'body' cannot exit main actor-isolated context}}
   // expected-warning@+1 {{expression is 'async' but is not marked with 'await'}}
   _ = view.body
 


### PR DESCRIPTION
This matches send non sendable but importantly also makes it clear that we are talking about something that doesn't conform to the Sendable protocol which is capitalized.

rdar://151802975
