### PR TITLE
[Sema] Use shared CodingKeys implementation for enum cases without as…

### DIFF
--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -81,6 +81,13 @@ static Identifier caseCodingKeysIdentifier(const ASTContext &C,
   return C.getIdentifier(scratch.str());
 }
 
+static Identifier emptyCodingKeysIdentifier(const ASTContext &C) {
+  llvm::SmallString<16> scratch;
+  camel_case::appendSentenceCase(scratch, "__empty__");
+  scratch += C.Id_CodingKeys.str();
+  return C.getIdentifier(scratch.str());
+}
+
 /// Fetches the \c CodingKeys enum nested in \c target, potentially reaching
 /// through a typealias if the "CodingKeys" entity is a typealias.
 ///
@@ -219,6 +226,27 @@ static EnumDecl *addImplicitCaseCodingKeys(EnumDecl *target,
 
       caseIdentifiers.push_back(paramIdentifier);
     }
+  }
+
+  if (caseIdentifiers.empty()) {
+    auto emptyIdentifier = emptyCodingKeysIdentifier(C);
+    auto emptyCodingKeys =
+        lookupEvaluatedCodingKeysEnum(C, target, emptyIdentifier);
+    if (!emptyCodingKeys) {
+      emptyCodingKeys =
+          addImplicitCodingKeys(target, caseIdentifiers, emptyIdentifier);
+    }
+
+    auto *alias = new (C)
+        TypeAliasDecl(SourceLoc(), SourceLoc(), enumIdentifier, SourceLoc(),
+                      /*GenericParams*/ nullptr, target);
+    alias->setUnderlyingType(emptyCodingKeys->getDeclaredInterfaceType());
+    alias->setAccess(AccessLevel::Private);
+    alias->setImplicit();
+    alias->setSynthesized();
+    target->addMember(alias);
+
+    return emptyCodingKeys;
   }
 
   return addImplicitCodingKeys(target, caseIdentifiers, enumIdentifier);
@@ -1143,9 +1171,15 @@ deriveBodyEncodable_enum_encode(AbstractFunctionDecl *encodeDecl, void *) {
 
           caseStatements.push_back(throwStmt);
         } else {
-          auto caseIdentifier = caseCodingKeysIdentifier(C, elt);
-          auto *caseCodingKeys =
-              lookupEvaluatedCodingKeysEnum(C, enumDecl, caseIdentifier);
+          EnumDecl *caseCodingKeys;
+          if (!elt->hasAssociatedValues()) {
+            caseCodingKeys = lookupEvaluatedCodingKeysEnum(
+                C, enumDecl, emptyCodingKeysIdentifier(C));
+          } else {
+            auto caseIdentifier = caseCodingKeysIdentifier(C, elt);
+            caseCodingKeys =
+                lookupEvaluatedCodingKeysEnum(C, enumDecl, caseIdentifier);
+          }
 
           auto *nestedContainerDecl = createKeyedContainer(
               C, funcDC, C.getKeyedEncodingContainerDecl(),
@@ -1739,11 +1773,17 @@ deriveBodyDecodable_enum_init(AbstractFunctionDecl *initDecl, void *) {
             return std::make_tuple(codingKeyCase, body);
           }
 
-          llvm::SmallVector<ASTNode, 3> caseStatements;
-          auto caseIdentifier = caseCodingKeysIdentifier(C, elt);
-          auto *caseCodingKeys =
-              lookupEvaluatedCodingKeysEnum(C, targetEnum, caseIdentifier);
+          EnumDecl *caseCodingKeys;
+          if (!elt->hasAssociatedValues()) {
+            caseCodingKeys = lookupEvaluatedCodingKeysEnum(
+                C, targetEnum, emptyCodingKeysIdentifier(C));
+          } else {
+            auto caseIdentifier = caseCodingKeysIdentifier(C, elt);
+            caseCodingKeys =
+                lookupEvaluatedCodingKeysEnum(C, targetEnum, caseIdentifier);
+          }
 
+          llvm::SmallVector<ASTNode, 3> caseStatements;
           auto *nestedContainerDecl = createKeyedContainer(
               C, funcDC, C.getKeyedDecodingContainerDecl(),
               caseCodingKeys->getDeclaredInterfaceType(),

--- a/test/decl/protocol/special/coding/enum_codable_no_associated_values.swift
+++ b/test/decl/protocol/special/coding/enum_codable_no_associated_values.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// cases without associated values should not generate separate CodingKeys
+// implementations, but use a shared one instead.
+enum SimpleEnum : Codable {
+  case x
+  case y
+  case z
+}
+
+let _ = SimpleEnum.XCodingKeys.self // expected-error {{'XCodingKeys' is inaccessible due to 'private' protection level}}
+let _ = SimpleEnum.YCodingKeys.self // expected-error {{'YCodingKeys' is inaccessible due to 'private' protection level}}
+let _ = SimpleEnum.ZCodingKeys.self // expected-error {{'ZCodingKeys' is inaccessible due to 'private' protection level}}
+let _ = SimpleEnum.__empty__CodingKeys.self // expected-error {{'__empty__CodingKeys' is inaccessible due to 'private' protection level}}


### PR DESCRIPTION
…sociated values

rdar://151790784

The default Codable implementation for enums that are not RawRepresentable encodes them as objects containing the case as kay, pointing to the payload. For cases without associated values, we still need to encode the payload as empty objects, for forward compatibility reasons. So far we have been emitting one CodingKeys decl per case, but for all cases that don't have associated values, we can use a shared one to reduce code size.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
