### PR TITLE
[test] Fix IRGen/lto_autolink on Darwin arm64 platforms too

### DIFF
--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -19,8 +19,8 @@ import empty
 
 
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target %target-cpu-apple-macosx10.15 -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-MACHO-MERGE
-// RUN: %target-swift-emit-ir -target %target-cpu-apple-macosx10.15 -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-MACHO-MERGE
+// RUN: %target-swift-emit-ir -target %target-cpu-apple-macosx10.15 -lto=llvm-full -parse-stdlib -nostdimport -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-MACHO-MERGE
+// RUN: %target-swift-emit-ir -target %target-cpu-apple-macosx10.15 -lto=llvm-thin -parse-stdlib -nostdimport -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-MACHO-MERGE
 
 // CHECK-MACHO-MERGE-DAG: !llvm.linker.options = !{
 // CHECK-MACHO-MERGE-DAG: !{{[0-9]+}} = !{!"-lempty"}


### PR DESCRIPTION
@beccadax, I think this will fix the oss-swift_tools-RA_stdlib-DA_test-device-non_executable CI you asked about, please run it and see.