### PR TITLE
[6.2 :cherries:][cxx-interop] Fix assertion failure from unavailable typedef + enum pattern

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -846,13 +846,9 @@ static bool isPrintLikeMethod(DeclName name, const DeclContext *dc) {
 using MirroredMethodEntry =
   std::tuple<const clang::ObjCMethodDecl*, ProtocolDecl*, bool /*isAsync*/>;
 
-ImportedType findOptionSetType(clang::QualType type,
-                               ClangImporter::Implementation &Impl) {
-  ImportedType importedType;
-  auto fieldType = type;
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(fieldType))
-    fieldType = elaborated->desugar();
-  if (auto typedefType = dyn_cast<clang::TypedefType>(fieldType)) {
+ImportedType importer::findOptionSetEnum(clang::QualType type,
+                                         ClangImporter::Implementation &Impl) {
+  if (auto typedefType = dyn_cast<clang::TypedefType>(type)) {
     if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
       if (auto clangEnum =
               findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
@@ -862,13 +858,12 @@ ImportedType findOptionSetType(clang::QualType type,
             clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
             typedefType->getCanonicalTypeInternal());
         if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
-          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
-                          false};
+          return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
         }
       }
     }
   }
-  return importedType;
+  return {};
 }
 
 static bool areRecordFieldsComplete(const clang::CXXRecordDecl *decl) {
@@ -4540,8 +4535,8 @@ namespace {
           return nullptr;
       }
 
-      auto fieldType = decl->getType();
-      ImportedType importedType = findOptionSetType(fieldType, Impl);
+      auto fieldType = desugarIfElaborated(decl->getType());
+      ImportedType importedType = importer::findOptionSetEnum(fieldType, Impl);
 
       if (!importedType)
         importedType =
@@ -6133,8 +6128,8 @@ namespace {
         }
       }
 
-      auto fieldType = decl->getType();
-      ImportedType importedType = findOptionSetType(fieldType, Impl);
+      auto fieldType = desugarIfElaborated(decl->getType());
+      ImportedType importedType = importer::findOptionSetEnum(fieldType, Impl);
 
       if (!importedType)
         importedType = Impl.importPropertyType(decl, isInSystemModule(dc));
@@ -7098,8 +7093,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
       getAccessorPropertyType(getter, false, getterName.getSelfIndex());
   if (propertyType.isNull())
     return nullptr;
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(propertyType))
-    propertyType = elaborated->desugar();
+  propertyType = desugarIfElaborated(propertyType);
 
   // If there is a setter, check that the property it implies
   // matches that of the getter.
@@ -7125,24 +7119,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   if (dc->isTypeContext() && !getterName.getSelfIndex())
     isStatic = true;
 
-  ImportedType importedType;
-
-  // Sometimes we import unavailable typedefs as enums. If that's the case,
-  // use the enum, not the typedef here.
-  if (auto typedefType = dyn_cast<clang::TypedefType>(propertyType.getTypePtr())) {
-    if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
-          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
-                          false};
-        }
-      }
-    }
-  }
+  ImportedType importedType = importer::findOptionSetEnum(propertyType, Impl);
 
   if (!importedType) {
     // Compute the property type.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -846,26 +846,6 @@ static bool isPrintLikeMethod(DeclName name, const DeclContext *dc) {
 using MirroredMethodEntry =
   std::tuple<const clang::ObjCMethodDecl*, ProtocolDecl*, bool /*isAsync*/>;
 
-ImportedType importer::findOptionSetEnum(clang::QualType type,
-                                         ClangImporter::Implementation &Impl) {
-  if (auto typedefType = dyn_cast<clang::TypedefType>(type)) {
-    if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum =
-              findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(
-            clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-            typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
-          return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
-        }
-      }
-    }
-  }
-  return {};
-}
-
 static bool areRecordFieldsComplete(const clang::CXXRecordDecl *decl) {
   for (const auto *f : decl->fields()) {
     auto *fieldRecord = f->getType()->getAsCXXRecordDecl();

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -244,10 +244,7 @@ StringRef importer::getCommonPluralPrefix(StringRef singular,
 }
 
 const clang::Type *importer::getUnderlyingType(const clang::EnumDecl *decl) {
-  const clang::Type *underlyingType = decl->getIntegerType().getTypePtr();
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(underlyingType))
-    underlyingType = elaborated->desugar().getTypePtr();
-  return underlyingType;
+  return importer::desugarIfElaborated(decl->getIntegerType().getTypePtr());
 }
 
 /// Determine the prefix to be stripped from the names of the enum constants

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -253,11 +253,11 @@ ImportedType importer::findOptionSetEnum(clang::QualType type,
   if (!typedefType || !Impl.isUnavailableInSwift(typedefType->getDecl()))
     // If this isn't a typedef, or it is a typedef that is available in Swift,
     // then this definitely isn't used for {CF,NS}_OPTIONS.
-    return {};
+    return ImportedType();
 
   auto clangEnum = findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType);
   if (!clangEnum)
-    return {};
+    return ImportedType();
 
   // If this fails, it means that we need a stronger predicate for
   // determining the relationship between an enum and typedef.
@@ -267,7 +267,7 @@ ImportedType importer::findOptionSetEnum(clang::QualType type,
   if (auto *swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion))
     return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
 
-  return {};
+  return ImportedType();
 }
 
 /// Determine the prefix to be stripped from the names of the enum constants

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2255,10 +2255,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
     OptionalityOfReturn = OTK_ImplicitlyUnwrappedOptional;
   }
 
-  clang::QualType returnType = clangDecl->getReturnType();
-  if (auto elaborated =
-          dyn_cast<clang::ElaboratedType>(returnType))
-    returnType = elaborated->desugar();
+  clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
   // In C interop mode, the return type of library builtin functions
   // like 'memcpy' from headers like 'string.h' drops
   // any nullability specifiers from their return type, and preserves it on the
@@ -2296,19 +2293,9 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
           ->isTemplateTypeParmType())
     OptionalityOfReturn = OTK_None;
 
-  if (auto typedefType = dyn_cast<clang::TypedefType>(returnType)) {
-    if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
-        }
-      }
-    }
-  }
+  ImportedType optionSetEnum = importer::findOptionSetEnum(returnType, *this);
+  if (optionSetEnum)
+    return optionSetEnum;
 
   // Import the underlying result type.
   if (clangDecl) {
@@ -2376,27 +2363,11 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
 
   // Only eagerly import the return type if it's not too expensive (the current
   // heuristic for that is if it's not a record type).
-  ImportedType importedType;
   ImportDiagnosticAdder addDiag(*this, clangDecl,
                                 clangDecl->getSourceRange().getBegin());
-  clang::QualType returnType = clangDecl->getReturnType();
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(returnType))
-    returnType = elaborated->desugar();
+  clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
 
-  if (auto typedefType = dyn_cast<clang::TypedefType>(returnType)) {
-    if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
-                          false};
-        }
-      }
-    }
-  }
+  ImportedType importedType = importer::findOptionSetEnum(returnType, *this);
 
   if (auto templateType =
           dyn_cast<clang::TemplateTypeParmType>(returnType)) {
@@ -2460,9 +2431,7 @@ ClangImporter::Implementation::importParameterType(
     std::optional<unsigned> completionHandlerErrorParamIndex,
     ArrayRef<GenericTypeParamDecl *> genericParams,
     llvm::function_ref<void(Diagnostic &&)> addImportDiagnosticFn) {
-  auto paramTy = param->getType();
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(paramTy))
-    paramTy = elaborated->desugar();
+  auto paramTy = desugarIfElaborated(param->getType());
 
   ImportTypeKind importKind = paramIsCompletionHandler
                                   ? ImportTypeKind::CompletionHandlerParameter
@@ -2475,23 +2444,8 @@ ClangImporter::Implementation::importParameterType(
   bool isConsuming = false;
   bool isParamTypeImplicitlyUnwrapped = false;
 
-  // Sometimes we import unavailable typedefs as enums. If that's the case,
-  // use the enum, not the typedef here.
-  if (auto typedefType = dyn_cast<clang::TypedefType>(paramTy.getTypePtr())) {
-    if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum =
-              findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()
-                   ->getIntegerType()
-                   ->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          swiftParamTy = cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType();
-        }
-      }
-    }
+  if (auto optionSetEnum = importer::findOptionSetEnum(paramTy, *this)) {
+    swiftParamTy = optionSetEnum.getType();
   } else if (isa<clang::PointerType>(paramTy) &&
              isa<clang::TemplateTypeParmType>(paramTy->getPointeeType())) {
     auto pointeeType = paramTy->getPointeeType();
@@ -3211,26 +3165,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
 
   ImportDiagnosticAdder addImportDiag(*this, clangDecl,
                                       clangDecl->getLocation());
-  clang::QualType resultType = clangDecl->getReturnType();
-  if (auto elaborated = dyn_cast<clang::ElaboratedType>(resultType))
-    resultType = elaborated->desugar();
-
-  ImportedType importedType;
-  if (auto typedefType = dyn_cast<clang::TypedefType>(resultType.getTypePtr())) {
-    if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
-        // If this fails, it means that we need a stronger predicate for
-        // determining the relationship between an enum and typedef.
-        assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
-               typedefType->getCanonicalTypeInternal());
-        if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
-                          false};
-        }
-      }
-    }
-  }
-
+  clang::QualType resultType = desugarIfElaborated(clangDecl->getReturnType());
+  ImportedType importedType = importer::findOptionSetEnum(resultType, *this);
   if (!importedType)
     importedType = importType(resultType, resultKind, addImportDiag,
                               allowNSUIntegerAsIntInResult, Bridgeability::Full,
@@ -3478,9 +3414,6 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
           importedType.isImplicitlyUnwrapped()};
 }
 
-ImportedType findOptionSetType(clang::QualType type,
-                               ClangImporter::Implementation &Impl);
-
 ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
     const DeclContext *dc, const clang::ObjCPropertyDecl *property,
     const clang::ObjCMethodDecl *clangDecl, bool isFromSystemModule,
@@ -3506,11 +3439,11 @@ ImportedType ClangImporter::Implementation::importAccessorParamsAndReturnType(
   if (!origDC)
     return {Type(), false};
 
-  auto fieldType = isGetter ? clangDecl->getReturnType()
-                            : clangDecl->getParamDecl(0)->getType();
-
+  auto fieldType =
+      desugarIfElaborated(isGetter ? clangDecl->getReturnType()
+                                   : clangDecl->getParamDecl(0)->getType());
   // Import the property type, independent of what kind of accessor this is.
-  ImportedType importedType = findOptionSetType(fieldType, *this);
+  ImportedType importedType = importer::findOptionSetEnum(fieldType, *this);
   if (!importedType)
     importedType = importPropertyType(property, isFromSystemModule);
   if (!importedType)

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2083,6 +2083,27 @@ bool hasEscapableAttr(const clang::RecordDecl *decl);
 
 bool isViewType(const clang::CXXRecordDecl *decl);
 
+inline const clang::Type *desugarIfElaborated(const clang::Type *type) {
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(type))
+    return elaborated->desugar().getTypePtr();
+  return type;
+}
+
+inline clang::QualType desugarIfElaborated(clang::QualType type) {
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(type))
+    return elaborated->desugar();
+  return type;
+}
+
+/// Option set enums are sometimes imported as typedefs which assign a name to
+/// the type, but are unavailable in Swift.
+///
+/// If given such a typedef, this helper function retrieves and imports the
+/// underlying enum type. Returns an empty ImportedType otherwise.
+///
+/// If \a type is an elaborated type, it should be desugared first.
+ImportedType findOptionSetEnum(clang::QualType type,
+                               ClangImporter::Implementation &Impl);
 } // end namespace importer
 } // end namespace swift
 

--- a/test/Interop/Cxx/objc-correctness/ns-enum-with-unavailable-typedef.swift
+++ b/test/Interop/Cxx/objc-correctness/ns-enum-with-unavailable-typedef.swift
@@ -1,0 +1,60 @@
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t/include -module-name main
+// RUN: %target-swift-frontend -typecheck -verify %t/main.swift -I %t/include -module-name main -cxx-interoperability-mode=default
+// REQUIRES: objc_interop
+
+//--- include/module.modulemap
+module ObjCModule {
+    header "header.h"
+}
+
+//--- include/header.h
+#include <Foundation/Foundation.h>
+
+#define UNAVAILABLE API_UNAVAILABLE(macos)
+
+UNAVAILABLE
+typedef NS_ENUM(NSUInteger, MyUnavailableEnum) {
+    MyUnavailableEnumCase1 = 0,
+    MyUnavailableEnumCase2,
+};
+
+UNAVAILABLE
+void unavailableParam(MyUnavailableEnum e);
+
+UNAVAILABLE
+MyUnavailableEnum unavailableReturn(void);
+
+struct UNAVAILABLE UnavailableStruct {
+  MyUnavailableEnum field;
+};
+
+UNAVAILABLE
+@interface UnavailableClass
+@property (nonatomic, readonly) MyUnavailableEnum prop;
+@end
+
+UNAVAILABLE
+__attribute__((swift_name("getter:UnavailableStruct.iProp(self:)")))
+inline MyUnavailableEnum getUnavailableInjProp(struct UnavailableStruct s) {
+  return MyUnavailableEnumCase1;
+}
+
+//--- main.swift
+import Foundation
+import ObjCModule
+
+@available(*, unavailable)
+func useParam(_ e: MyUnavailableEnum) { unavailableParam(e) }
+
+@available(*, unavailable)
+func useReturn() -> MyUnavailableEnum { return unavailableReturn() }
+
+@available(*, unavailable)
+func useField(_ o: UnavailableStruct) -> MyUnavailableEnum { return o.field }
+
+@available(*, unavailable)
+func useIProp(_ o: UnavailableStruct) -> MyUnavailableEnum { return o.iProp }
+
+@available(*, unavailable)
+func useProp(_ o: UnavailableClass) -> MyUnavailableEnum { return o.prop }


### PR DESCRIPTION
Explanation: ClangImporter currently uses some pretty fragile heuristics to determine whether a typedef is involved in the definition of a `{CF,NS}_OPTIONS` type. Those heuristics lead it to mistakenly recognize unavailable `{CF,NS}_ENUM`s as `{CF,NS}_OPTIONS`. The resulting import logic turns out to work out all fine, except for the fact that there is an assertion that does not account for this possibility. This patch broadens that assertion slightly to also allow `{CF,NS}_ENUM`s along this code path.

Risk: Low, this patch set consists of some refactoring (to minimize the actual functional change) and then slightly broadens the scope of an assertion. This fixes an assertion failure that happens in internal CI.

Problem: rdar://150399978

Reviewed By: @egorzhdan 

Original PR: https://github.com/swiftlang/swift/pull/81625