### PR TITLE
InitializeStaticGlobals: handle `InlineArray.init(repeating:)` also for arm64_32

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
@@ -399,7 +399,7 @@ private extension StoreInst {
        let headerBr = vectorBase.parentBlock.terminator as? BranchInst,
        headerBr.targetBlock == parentBlock,
        let vectorSize = vectorBase.vector.type.builtinFixedArraySizeType.valueOfInteger,
-       let (start, loopCount, increment) = getLoopInductionInfo(of: indexAddr.index.lookThroughTruncOrBitCast),
+       let (start, loopCount, increment) = getLoopInductionInfo(of: indexAddr.index.lookThroughIndexScalarCast),
        start == 0, loopCount == vectorSize, increment == 1
     {
       return true

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPointerToAddress.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyPointerToAddress.swift
@@ -69,7 +69,7 @@ private func removeAddressToPointerToAddressPair(
 ///
 private func simplifyIndexRawPointer(of ptr2Addr: PointerToAddressInst, _ context: SimplifyContext) -> Bool {
   guard let indexRawPtr = ptr2Addr.pointer as? IndexRawPointerInst,
-        let tupleExtract = indexRawPtr.index.lookThroughTruncOrBitCast as? TupleExtractInst,
+        let tupleExtract = indexRawPtr.index.lookThroughIndexScalarCast as? TupleExtractInst,
         let strideMul = tupleExtract.tuple as? BuiltinInst, strideMul.id == .SMulOver,
         let (index, strideType) = strideMul.indexAndStrideOfMultiplication,
         strideType == ptr2Addr.type.objectType
@@ -314,9 +314,9 @@ private extension BuiltinInst {
 
 private extension Builder {
   func createCastIfNeeded(of index: Value, toIndexTypeOf indexRawPtr: IndexRawPointerInst) -> Value {
-    if let truncOrBitCast = indexRawPtr.index as? BuiltinInst {
-      assert(truncOrBitCast.id == .TruncOrBitCast)
-      return createBuiltin(name: truncOrBitCast.name, type: truncOrBitCast.type, arguments: [index])
+    if let cast = indexRawPtr.index as? BuiltinInst {
+      assert(cast.id == .TruncOrBitCast || cast.id == .SExtOrBitCast)
+      return createBuiltin(name: cast.name, type: cast.type, arguments: [index])
     }
     return index
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -45,9 +45,14 @@ extension Value {
     }
   }
 
-  var lookThroughTruncOrBitCast: Value {
-    if let truncOrBitCast = self as? BuiltinInst, truncOrBitCast.id == .TruncOrBitCast {
-      return truncOrBitCast.arguments[0]
+  var lookThroughIndexScalarCast: Value {
+    if let castBuiltin = self as? BuiltinInst {
+      switch castBuiltin.id {
+      case .TruncOrBitCast, .SExtOrBitCast:
+        return castBuiltin.arguments[0]
+      default:
+        return self
+      }
     }
     return self
   }


### PR DESCRIPTION
This needs matching a different builtin for scalar conversion for the `index_addr` index.

Fixes a test failure on watchos
rdar://151761870