### PR TITLE
[cxx-interop] Remove remnants of symbolic import mode

### DIFF
--- a/test/Interop/Cxx/class/inheritance/circular-inheritance-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/circular-inheritance-typechecker.swift
@@ -1,8 +1,4 @@
-// RUN: %empty-directory(%t/index)
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default -index-store-path %t/index
-//
-// Note that we specify an -index-store-path to ensure we also test importing symbolic C++ decls,
-// to exercise code that handles importing unspecialized class templates.
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=default
 
 import CircularInheritance
 


### PR DESCRIPTION
Symbolic import mode was removed in b51cfa5c. This removes a reference to it from a test.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
