### PR TITLE
🍒[cxx-interop] Relax a SILVerifier assertion for immortal reference types

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1047,7 +1047,13 @@ public:
     
     auto objectTy = value->getType().unwrapOptionalType();
     
-    require(objectTy.isReferenceCounted(F.getModule()),
+    // Immortal C++ foreign reference types are represented as trivially lowered
+    // types since they do not require retain/release calls.
+    bool isImmortalFRT = objectTy.isForeignReferenceType() &&
+                         objectTy.getASTType()->getReferenceCounting() ==
+                             ReferenceCounting::None;
+
+    require(objectTy.isReferenceCounted(F.getModule()) || isImmortalFRT,
             valueDescription + " must have reference semantics");
   }
   

--- a/test/Interop/Cxx/foreign-reference/unmanaged.swift
+++ b/test/Interop/Cxx/foreign-reference/unmanaged.swift
@@ -1,0 +1,20 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=default -Xfrontend -disable-availability-checking) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+import POD
+
+extension Empty {
+   public static func == (lhs: Empty, rhs: Empty) -> Bool {
+        Unmanaged.passUnretained(lhs).toOpaque() == Unmanaged.passUnretained(rhs).toOpaque()
+   }
+}
+
+let x = Empty.create()
+let y = Empty.create()
+
+print(x == y)
+// CHECK: false
+
+print(x == x)
+// CHECK: true


### PR DESCRIPTION
Immortal C++ foreign reference types get TrivialTypeLowering instead of ReferenceTypeLowering, since they do not have retain/release lifetime operations. This was tripping up an assertion in SILVerifier.

rdar://147251759 / resolves https://github.com/swiftlang/swift/issues/80065
(cherry picked from commit 2e3df1c0f32eeb8a99a230ba776fde3c0fc35e5d)
