### PR TITLE
🍒[cxx-interop] Temporarily disable a test for `std::function` on UBI 9

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -15,6 +15,7 @@
 // XFAIL: LinuxDistribution=rhel-9.3
 // XFAIL: LinuxDistribution=rhel-9.4
 // XFAIL: LinuxDistribution=rhel-9.5
+// XFAIL: LinuxDistribution=rhel-9.6
 // XFAIL: LinuxDistribution=fedora-39
 // XFAIL: LinuxDistribution=debian-12
 


### PR DESCRIPTION
This is a test-only change.

Similar to 0a4eeabd.

rdar://151476434
(cherry picked from commit 30649f239187cf6161cfbfda76feb77226cadc9c)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
