### PR TITLE
[cxx-interop] Fix ambiguous methods in long chains of inheritance

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -216,6 +216,9 @@ public:
                                           DeclContext *newContext,
                                           ClangInheritanceInfo inheritance) = 0;
 
+  /// Checks if \param decl is the original method or a clone from a base class
+  virtual bool isClonedMemberDecl(ValueDecl *decl) = 0;
+
   /// Emits diagnostics for any declarations named name
   /// whose direct declaration context is a TU.
   virtual void diagnoseTopLevelValue(const DeclName &name) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -657,6 +657,8 @@ public:
   ValueDecl *importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
                                   ClangInheritanceInfo inheritance) override;
 
+  bool isClonedMemberDecl(ValueDecl *decl) override;
+
   /// Emits diagnostics for any declarations named name
   /// whose direct declaration context is a TU.
   void diagnoseTopLevelValue(const DeclName &name) override;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6311,7 +6311,8 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
          cast<NominalTypeDecl>(recordDecl)->getCurrentMembersWithoutLoading()) {
       auto namedMember = dyn_cast<ValueDecl>(member);
       if (!namedMember || !namedMember->hasName() ||
-          namedMember->getName().getBaseName() != name)
+          namedMember->getName().getBaseName() != name ||
+          clangModuleLoader->isClonedMemberDecl(namedMember))
         continue;
 
       auto *imported = clangModuleLoader->importBaseMemberDecl(
@@ -7664,9 +7665,22 @@ ValueDecl *ClangImporter::Implementation::importBaseMemberDecl(
   if (known == clonedBaseMembers.end()) {
     ValueDecl *cloned = cloneBaseMemberDecl(decl, newContext, inheritance);
     known = clonedBaseMembers.insert({key, cloned}).first;
+    clonedMembers.insert(cloned);
   }
 
   return known->second;
+}
+
+bool ClangImporter::Implementation::isClonedMemberDecl(ValueDecl *decl) {
+  // If this is a cloned decl, we don't want to reclone it
+  // Otherwise, we may end up with multiple copies of the same method
+  if (!decl->hasClangNode()) {
+    // Skip decls with a clang node as those will never be a clone
+    auto result = clonedMembers.find(decl);
+    return result != clonedMembers.end();
+  }
+
+  return false;
 }
 
 size_t ClangImporter::Implementation::getImportedBaseMemberDeclArity(
@@ -7683,6 +7697,10 @@ ValueDecl *
 ClangImporter::importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
                                     ClangInheritanceInfo inheritance) {
   return Impl.importBaseMemberDecl(decl, newContext, inheritance);
+}
+
+bool ClangImporter::isClonedMemberDecl(ValueDecl *decl) {
+  return Impl.isClonedMemberDecl(decl);
 }
 
 void ClangImporter::diagnoseTopLevelValue(const DeclName &name) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -692,6 +692,9 @@ private:
   llvm::DenseMap<std::pair<ValueDecl *, DeclContext *>, ValueDecl *>
       clonedBaseMembers;
 
+  // Store all methods that result from cloning a base member
+  llvm::DenseSet<ValueDecl *> clonedMembers;
+
 public:
   llvm::DenseMap<const clang::ParmVarDecl*, FuncDecl*> defaultArgGenerators;
 
@@ -699,6 +702,8 @@ public:
 
   ValueDecl *importBaseMemberDecl(ValueDecl *decl, DeclContext *newContext,
                                   ClangInheritanceInfo inheritance);
+
+  bool isClonedMemberDecl(ValueDecl *decl);
 
   static size_t getImportedBaseMemberDeclArity(const ValueDecl *valueDecl);
 

--- a/test/Interop/Cxx/class/inheritance/inherited-lookup-executable.swift
+++ b/test/Interop/Cxx/class/inheritance/inherited-lookup-executable.swift
@@ -6,6 +6,20 @@ import StdlibUnittest
 
 var InheritedMemberTestSuite = TestSuite("Test if inherited lookup works")
 
+// The compiler handles 
+// - let iiiOne = IIIOne()
+// - struct Foo { let iiiOne : IIIOne } 
+// differently and because of that, by introducing the struct HasOne in this test, 
+// the function importBaseMemberDecl is called twice for each pair of parent-child structs. 
+// The second time, all the structs have a clone version of the method, 
+// which was triggering a "use of ambiguous method" error.
+struct HasOne {
+  let one: One
+  let iOne: IOne
+  let iiOne: IIOne
+  let iiiOne: IIIOne
+}
+
 InheritedMemberTestSuite.test("Regular methods resolve to base classes") {
   // No inheritance (sanity check)
   let one = One()


### PR DESCRIPTION
Let's suppose we have 3 structs, where `S3` inherits from `S2` and `S2` inherits from `S1`. If `S1` has a method `foo`, that is *not* overridden by their children structs, we would previously clone this method in `S3` twice: once from `S1` (the original method) and the other from `S2` (which would be a clone of a clone). This resulted in 2 definitions of the method `foo` in `S3`, which would be diagnosed as ambiguous methods. 

This fixes the above problem by making sure that we never clone a method that was already a clone. 

rdar://126229717
