### PR TITLE
DeadStoreElimination: don't assume that the operand of an `dealloc_stack` is an `alloc_stack`.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
@@ -256,7 +256,7 @@ private extension Deallocation {
 
 private extension DeallocStackInst {
   func isStackDeallocation(of base: AccessBase) -> Bool {
-    if case .stack(let allocStack) = base, allocstack == allocStack {
+    if case .stack(let allocStack) = base, operand.value == allocStack {
       return true
     }
     return false

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -647,11 +647,7 @@ extension Deallocation {
 }
 
 
-final public class DeallocStackInst : Instruction, UnaryInstruction, Deallocation {
-  public var allocstack: AllocStackInst {
-    return operand.value as! AllocStackInst
-  }
-}
+final public class DeallocStackInst : Instruction, UnaryInstruction, Deallocation {}
 
 final public class DeallocStackRefInst : Instruction, UnaryInstruction, Deallocation {
   public var allocRef: AllocRefInstBase { operand.value as! AllocRefInstBase }


### PR DESCRIPTION
It can also be a `partial_apply`.

Fixes a compiler crash

Fixes https://github.com/swiftlang/swift/issues/81698
rdar://151822502
