### PR TITLE
[TypeChecker] Improve diagnostics for access to actor-isolated values…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5629,6 +5629,9 @@ ERROR(actor_isolated_non_self_reference,none,
         "from a nonisolated autoclosure}2",
         (const ValueDecl *, unsigned, unsigned, Type,
          ActorIsolation))
+ERROR(actor_isolated_access_outside_of_actor_context,none,
+      "%0 %kind1 cannot be %select{accessed|called}2 from outside of the actor",
+      (ActorIsolation, const ValueDecl *, bool))
 ERROR(distributed_actor_isolated_non_self_reference,none,
       "distributed actor-isolated %kind0 can not be accessed from a "
       "nonisolated context",

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -168,7 +168,7 @@ func someAsyncFunc() async {
 
   _ = await a.deposit(b.withdraw(a.deposit(b.withdraw(b.balance()))))
 
-  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}{{3-3=await }} expected-note@+1 {{call is 'async'}}
+  // expected-error@+1 {{actor-isolated instance method 'testSelfBalance()' cannot be called from outside of the actor}} {{3-3=await }}
   a.testSelfBalance()
 
   await a.testThrowing() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
@@ -177,16 +177,16 @@ func someAsyncFunc() async {
   // effectful properties from outside the actor instance
 
   // expected-warning@+2 {{non-Sendable type 'Box' of property 'effPropA' cannot exit actor-isolated context}}
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
+  // expected-error@+1{{actor-isolated property 'effPropA' cannot be accessed from outside of the actor}} {{7-7=await }}
   _ = a.effPropA
 
   // expected-warning@+3 {{non-Sendable type 'Box' of property 'effPropT' cannot exit actor-isolated context}}
   // expected-error@+2{{property access can throw, but it is not marked with 'try' and the error is not handled}}
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
+  // expected-error@+1{{actor-isolated property 'effPropT' cannot be accessed from outside of the actor}} {{7-7=await }}
   _ = a.effPropT
 
   // expected-error@+2{{property access can throw, but it is not marked with 'try' and the error is not handled}}
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
+  // expected-error@+1{{actor-isolated property 'effPropAT' cannot be accessed from outside of the actor}} {{7-7=await }}
   _ = a.effPropAT
 
   // (mostly) corrected ones
@@ -204,9 +204,9 @@ func someAsyncFunc() async {
 
 extension BankAccount {
   func totalBalance(including other: BankAccount) async -> Int {
-    //expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{12-12=await }}
     return balance()
-          + other.balance()  // expected-note{{calls to instance method 'balance()' from outside of its actor context are implicitly asynchronous}}
+      + other.balance()
+    // expected-error@-1 {{actor-isolated instance method 'balance()' cannot be called from outside of the actor}}{{207:12-12=await }}
   }
 
   func breakAccounts(other: BankAccount) async {
@@ -223,11 +223,9 @@ func anotherAsyncFunc() async {
   let a = BankAccount(initialDeposit: 34)
   let b = BankAccount(initialDeposit: 35)
 
-  // expected-error@+2{{expression is 'async' but is not marked with 'await'}} {{7-7=await }}
-  // expected-note@+1{{calls to instance method 'deposit' from outside of its actor context are implicitly asynchronous}}
+  // expected-error@+1{{actor-isolated instance method 'deposit' cannot be called from outside of the actor}} {{7-7=await }}
   _ = a.deposit(1)
-  // expected-error@+2{{expression is 'async' but is not marked with 'await'}} {{7-7=await }}
-  // expected-note@+1{{calls to instance method 'balance()' from outside of its actor context are implicitly asynchronous}}
+  // expected-error@+1{{actor-isolated instance method 'balance()' cannot be called from outside of the actor}} {{7-7=await }}
   _ = b.balance()
 
   _ = b.balance // expected-error {{actor-isolated instance method 'balance()' can not be partially applied}}
@@ -235,7 +233,7 @@ func anotherAsyncFunc() async {
   // expected-error@+2{{actor-isolated property 'owner' can not be mutated from a nonisolated context}}
   // expected-note@+1{{consider declaring an isolated method on 'BankAccount' to perform the mutation}}
   a.owner = "cat"
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{7-7=await }} expected-note@+1{{property access is 'async'}}
+  // expected-error@+1{{actor-isolated property 'owner' cannot be accessed from outside of the actor}} {{7-7=await }}
   _ = b.owner
   _ = await b.owner == "cat"
 
@@ -334,7 +332,7 @@ func walkChain(chain : Chain) async {
 
 @OrangeActor func quinoa() async {
 
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }} expected-note@+1 {{call is 'async'}}
+  // expected-error@+1{{global actor 'BananaActor'-isolated global function 'rice()' cannot be called from outside of the actor}}{{3-3=await }}
   rice()
 }
 
@@ -458,21 +456,21 @@ func tryEffPropsFromSync() {
 }
 
 @OrangeActor func tryEffPropertiesFromGlobalActor() async throws {
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }} expected-note@+1 {{property access is 'async'}}
+  // expected-error@+1{{global actor 'BananaActor'-isolated var 'effPropA' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = effPropA
 
   // expected-note@+5{{did you mean to handle error as optional value?}}
   // expected-note@+4{{did you mean to use 'try'?}}
   // expected-note@+3{{did you mean to disable error propagation?}}
   // expected-error@+2{{property access can throw but is not marked with 'try'}}
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }} expected-note@+1 {{property access is 'async'}}
+  // expected-error@+1{{global actor 'BananaActor'-isolated var 'effPropT' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = effPropT
 
   // expected-note@+5{{did you mean to handle error as optional value?}}
   // expected-note@+4{{did you mean to use 'try'?}}
   // expected-note@+3{{did you mean to disable error propagation?}}
   // expected-error@+2{{property access can throw but is not marked with 'try'}}
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }} expected-note@+1 {{property access is 'async'}}
+  // expected-error@+1{{global actor 'BananaActor'-isolated var 'effPropAT' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = effPropAT
 
   _ = await effPropA
@@ -494,7 +492,7 @@ actor SubscriptA {
 
   func f() async {
 
-    // expected-error@+1{{expression is 'async' but is not marked with 'await'}} {{9-9=await }} expected-note@+1{{subscript access is 'async'}}
+    // expected-error@+1{{actor-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}} {{9-9=await }}
     _ = self[0]
   }
 }
@@ -543,7 +541,7 @@ actor SubscriptAT {
 }
 
 func tryTheActorSubscripts(a : SubscriptA, t : SubscriptT, at : SubscriptAT) async throws {
-  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }} expected-note@+1 {{subscript access is 'async'}}
+  // expected-error@+1 {{actor-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = a[0]
 
   _ = await a[0]
@@ -552,7 +550,7 @@ func tryTheActorSubscripts(a : SubscriptA, t : SubscriptT, at : SubscriptAT) asy
   // expected-note@+4{{did you mean to use 'try'?}}
   // expected-note@+3{{did you mean to disable error propagation?}}
   // expected-error@+2{{subscript access can throw but is not marked with 'try'}}
-  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }} expected-note@+1 {{subscript access is 'async'}}
+  // expected-error@+1 {{actor-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = t[0]
 
   _ = try await t[0]
@@ -563,7 +561,7 @@ func tryTheActorSubscripts(a : SubscriptA, t : SubscriptT, at : SubscriptAT) asy
   // expected-note@+4{{did you mean to use 'try'?}}
   // expected-note@+3{{did you mean to disable error propagation?}}
   // expected-error@+2{{subscript access can throw but is not marked with 'try'}}
-  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}{{7-7=await }} expected-note@+1 {{subscript access is 'async'}}
+  // expected-error@+1 {{actor-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = at[0]
 
   _ = try await at[0]
@@ -583,8 +581,7 @@ final class IsolatedOperator: @preconcurrency Equatable {
 
   nonisolated func callEqual() async -> Bool {
     let foo = await IsolatedOperator()
-    // expected-error@+2{{expression is 'async' but is not marked with 'await'}}
-    // expected-note@+1{{calls to operator function '==' from outside of its actor context are implicitly asynchronous}}
+    // expected-error@+1{{main actor-isolated operator function '==' cannot be called from outside of the actor}} {{12-12=await }}
     return foo == self
   }
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -117,8 +117,7 @@ func checkAsyncPropertyAccess() async {
   // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
 
   _ = act.point  // expected-warning{{non-Sendable type 'Point' of property 'point' cannot exit actor-isolated context}}
-  // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-2 {{property access is 'async'}}
+  // expected-warning@-1 {{actor-isolated property 'point' cannot be accessed from outside of the actor}} {{7-7=await }}
 }
 
 /// ------------------------------------------------------------------
@@ -270,8 +269,7 @@ extension MyActor {
     // Accesses on other actors can only reference immutable data synchronously,
     // otherwise the access is treated as async
     _ = otherActor.immutable // okay
-    _ = otherActor.mutable  // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{property access is 'async'}}
+    _ = otherActor.mutable  // expected-error{{actor-isolated property 'mutable' cannot be accessed from outside of the actor}}{{9-9=await }}
     _ = await otherActor.mutable
     otherActor.mutable = 0  // expected-error{{actor-isolated property 'mutable' can not be mutated on a nonisolated actor instance}}
     // expected-note@-1{{consider declaring an isolated method on 'MyActor' to perform the mutation}}
@@ -282,12 +280,12 @@ extension MyActor {
     await otherActor.mutable = 0
 
     _ = otherActor.synchronous()
-    // expected-error@-1{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-2{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+    // expected-error@-1{{actor-isolated instance method 'synchronous()' cannot be called from outside of the actor}}{{9-9=await }}
+
     _ = await otherActor.asynchronous()
     _ = otherActor.text[0]
-    // expected-error@-1{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-2{{property access is 'async'}}
+    // expected-error@-1{{actor-isolated property 'text' cannot be accessed from outside of the actor}}{{9-9=await }}
+
     _ = await otherActor.text[0] // okay
 
     // Global data is okay if it is immutable.
@@ -302,8 +300,7 @@ extension MyActor {
     Self.synchronousStatic()
 
     // Global actors
-    syncGlobalActorFunc() // expected-error{{expression is 'async' but is not marked with 'await'}}{{5-5=await }}
-    // expected-note@-1{{calls to global function 'syncGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
+    syncGlobalActorFunc() // expected-error{{global actor 'SomeGlobalActor'-isolated global function 'syncGlobalActorFunc()' cannot be called from outside of the actor}}{{5-5=await }}
 
     await asyncGlobalActorFunc()
 
@@ -483,8 +480,7 @@ func crossIsolationBoundary(_ closure: () -> Void) async {}
 func testGlobalActorClosures() {
   let _: Int = acceptAsyncClosure { @SomeGlobalActor in
     syncGlobalActorFunc()
-    syncOtherGlobalActorFunc() // expected-error{{expression is 'async' but is not marked with 'await'}}{{5-5=await }}
-    // expected-note@-1{{calls to global function 'syncOtherGlobalActorFunc()' from outside of its actor context are implicitly asynchronous}}
+    syncOtherGlobalActorFunc() // expected-error{{global actor 'SomeOtherGlobalActor'-isolated global function 'syncOtherGlobalActorFunc()' cannot be called from outside of the actor}}{{5-5=await }}
 
     await syncOtherGlobalActorFunc()
     return 17
@@ -514,54 +510,43 @@ extension MyActor {
     await asyncOtherGlobalActorFunc()
 
     _ = immutable
-    _ = mutable // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{property access is 'async'}}
+    _ = mutable // expected-error{{actor-isolated property 'mutable' cannot be accessed from outside of the actor}}{{9-9=await }}
     _ = await mutable
-    _ = synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+    _ = synchronous() // expected-error{{actor-isolated instance method 'synchronous()' cannot be called from outside of the actor}}{{9-9=await }}
     _ = await synchronous()
-    _ = text[0] // expected-error{{expression is 'async' but is not marked with 'await'}}
-    // expected-note@-1{{property access is 'async'}}
+    _ = text[0] // expected-error{{actor-isolated property 'text' cannot be accessed from outside of the actor}} {{9-9=await }}
 
     _ = await text[0]
 
     // Accesses on 'self' are only okay for immutable and asynchronous, because
     // we are outside of the actor instance.
     _ = self.immutable
-    _ = self.synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+    _ = self.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' cannot be called from outside of the actor}}{{9-9=await }}
     _ = await self.synchronous()
 
     _ = await self.asynchronous()
-    _ = self.text[0] // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{property access is 'async'}}
-    _ = self[0] // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{subscript access is 'async'}}
+    _ = self.text[0] // expected-error{{actor-isolated property 'text' cannot be accessed from outside of the actor}}{{9-9=await }}
+    _ = self[0] // expected-error{{actor-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{9-9=await }}
     _ = await self.text[0]
     _ = await self[0]
 
     // Accesses on 'super' are not okay without 'await'; we're outside of the actor.
-    _ = super.superState // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{property access is 'async'}}
+    _ = super.superState // expected-error{{actor-isolated property 'superState' cannot be accessed from outside of the actor}}{{9-9=await }}
     _ = await super.superState
-    super.superMethod() // expected-error{{expression is 'async' but is not marked with 'await'}}{{5-5=await }}
-  // expected-note@-1{{calls to instance method 'superMethod()' from outside of its actor context are implicitly asynchronous}}
+    super.superMethod() // expected-error{{actor-isolated instance method 'superMethod()' cannot be called from outside of the actor}}{{5-5=await }}
 
     await super.superMethod()
     await super.superAsyncMethod()
-    _ = super[0] // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{subscript access is 'async'}}
+    _ = super[0] // expected-error{{actor-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{9-9=await }}
     _ = await super[0]
 
     // Accesses on other actors can only reference immutable data or
     // call asynchronous methods
     _ = otherActor.immutable // okay
-    _ = otherActor.synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+    _ = otherActor.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' cannot be called from outside of the actor}}{{9-9=await }}
     _ = otherActor.synchronous  // expected-error{{actor-isolated instance method 'synchronous()' can not be partially applied}}
     _ = await otherActor.asynchronous()
-    _ = otherActor.text[0] // expected-error{{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-1{{property access is 'async'}}
+    _ = otherActor.text[0] // expected-error{{actor-isolated property 'text' cannot be accessed from outside of the actor}}{{9-9=await }}
     _ = await otherActor.text[0]
   }
 }
@@ -623,10 +608,8 @@ func testGlobalRestrictions(actor: MyActor) async {
   _ = actor.asynchronous
 
   // any kind of method can be called from outside the actor, so long as it's marked with 'await'
-  _ = actor.synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  // expected-note@-1{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
-  _ = actor.asynchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  // expected-note@-1{{call is 'async'}}
+  _ = actor.synchronous() // expected-error{{actor-isolated instance method 'synchronous()' cannot be called from outside of the actor}}{{7-7=await }}
+  _ = actor.asynchronous() // expected-error{{actor-isolated instance method 'asynchronous()' cannot be called from outside of the actor}}{{7-7=await }}
 
   _ = await actor.synchronous()
   _ = await actor.asynchronous()
@@ -634,14 +617,11 @@ func testGlobalRestrictions(actor: MyActor) async {
   // stored and computed properties can be accessed. Only immutable stored properties can be accessed without 'await'
   _ = actor.immutable
   _ = await actor.immutable // expected-warning {{no 'async' operations occur within 'await' expression}}
-  _ = actor.mutable  // expected-error{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  // expected-note@-1{{property access is 'async'}}
+  _ = actor.mutable  // expected-error{{actor-isolated property 'mutable' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = await actor.mutable
-  _ = actor.text[0] // expected-error{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  // expected-note@-1{{property access is 'async'}}
+  _ = actor.text[0] // expected-error{{actor-isolated property 'text' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = await actor.text[0]
-  _ = actor[0] // expected-error{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  // expected-note@-1{{subscript access is 'async'}}
+  _ = actor[0] // expected-error{{actor-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{7-7=await }}
   _ = await actor[0]
 
   // nonisolated declarations are permitted.
@@ -669,8 +649,7 @@ func testGlobalRestrictions(actor: MyActor) async {
     _ = i
   }
 
-  print("\(number)") //expected-error {{expression is 'async' but is not marked with 'await'}}{{12-12=await }}
-  //expected-note@-1{{property access is 'async'}}
+  print("\(number)") //expected-error {{global actor 'SomeGlobalActor'-isolated var 'number' cannot be accessed from outside of the actor}}{{12-12=await }}
 
 }
 
@@ -1053,8 +1032,7 @@ class SomeClassWithInits {
       // okay
       await self.isolated()
       self.isolated()
-      // expected-error@-1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-      // expected-note@-2{{calls to instance method 'isolated()' from outside of its actor context are implicitly asynchronous}}
+      // expected-error@-1{{main actor-isolated instance method 'isolated()' cannot be called from outside of the actor}}{{7-7=await }}
 
       print(await self.mutableState)
     }
@@ -1072,13 +1050,11 @@ func outsideSomeClassWithInits() { // expected-note 3 {{add '@MainActor' to make
 // nonisolated let and cross-module let
 // ----------------------------------------------------------------------
 func testCrossModuleLets(actor: OtherModuleActor) async {
-  _ = actor.a         // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{property access is 'async'}}
+  _ = actor.a         // expected-error{{actor-isolated property 'a' cannot be accessed from outside of the actor}} {{7-7=await }}
   _ = await actor.a   // okay
   _ = actor.b         // okay
-  _ = actor.c // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{property access is 'async'}}
-  // expected-warning@-2{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
+  _ = actor.c // expected-error{{actor-isolated property 'c' cannot be accessed from outside of the actor}} {{7-7=await }}
+  // expected-warning@-1{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
   _ = await actor.c // expected-warning{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
   _ = await actor.d // okay
 }
@@ -1108,13 +1084,11 @@ actor CrossModuleFromInitsActor {
   }
 
   init(v2 actor: OtherModuleActor) async {
-    _ = actor.a         // expected-error{{expression is 'async' but is not marked with 'await'}}
-    // expected-note@-1{{property access is 'async'}}
+    _ = actor.a         // expected-error{{actor-isolated property 'a' cannot be accessed from outside of the actor}} {{9-9=await }}
     _ = await actor.a   // okay
     _ = actor.b         // okay
-    _ = actor.c // expected-error{{expression is 'async' but is not marked with 'await'}}
-    // expected-note@-1{{property access is 'async'}}
-    // expected-warning@-2{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
+    _ = actor.c // expected-error{{actor-isolated property 'c' cannot be accessed from outside of the actor}} {{9-9=await }}
+    // expected-warning@-1{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
     _ = await actor.c // expected-warning{{non-Sendable type 'SomeClass' of property 'c' cannot exit actor-isolated context}}
     _ = await actor.d // okay
   }
@@ -1183,11 +1157,9 @@ func testCrossActorProtocol<T: P>(t: T) async {
   await t.f()
   await t.g()
   t.f()
-  // expected-error@-1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
-  // expected-note@-2{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  // expected-error@-1{{actor-isolated instance method 'f()' cannot be called from outside of the actor}}{{3-3=await }}
   t.g()
-  // expected-error@-1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
-  // expected-note@-2{{calls to instance method 'g()' from outside of its actor context are implicitly asynchronous}}
+  // expected-error@-1{{actor-isolated instance method 'g()' cannot be called from outside of the actor}}{{3-3=await }}
   ASP.s()
   ASPD.sd()
 }
@@ -1219,8 +1191,7 @@ extension MyActor {
     var counter = 0
 
     acceptAsyncSendableClosure {
-      _ = synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}
-      // expected-note@-1{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
+      _ = synchronous() // expected-error{{actor-isolated instance method 'synchronous()' cannot be called from outside of the actor}} {{11-11=await }}
 
       counter += 1 // expected-warning{{mutation of captured var 'counter' in concurrently-executing code}}
     }
@@ -1419,12 +1390,10 @@ func take(_ val: SelfParamIsolationNonMethod) {}
 
 actor SelfParamIsolationNonMethod {
   init(s0: Void) {
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{44-44=await }}
     acceptAsyncSendableClosureInheriting { self.f() }
 
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{34-34=await }}
     acceptAsyncSendableClosure { self.f() }
 
     // expected-error@+1 {{call to actor-isolated global function 'takeIsolated' in a synchronous nonisolated context}}
@@ -1434,20 +1403,17 @@ actor SelfParamIsolationNonMethod {
   }
 
   @MainActor init(s1: Void) {
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{44-44=await }}
     acceptAsyncSendableClosureInheriting { self.f() }
 
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{34-34=await }}
     acceptAsyncSendableClosure { self.f() }
   }
 
   init(a1: Void) async {
     acceptAsyncSendableClosureInheriting { self.f() }
 
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{34-34=await }}
     acceptAsyncSendableClosure { self.f() }
 
     takeIsolated(self)
@@ -1456,32 +1422,26 @@ actor SelfParamIsolationNonMethod {
   }
 
   @MainActor init(a2: Void) async {
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{44-44=await }}
     acceptAsyncSendableClosureInheriting { self.f() }
 
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{34-34=await }}
     acceptAsyncSendableClosure { self.f() }
   }
 
   nonisolated init(a3: Void) async {
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{44-44=await }}
     acceptAsyncSendableClosureInheriting { self.f() }
 
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{34-34=await }}
     acceptAsyncSendableClosure { self.f() }
   }
 
   deinit {
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{44-44=await }}
     acceptAsyncSendableClosureInheriting { self.f() }
 
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{34-34=await }}
     acceptAsyncSendableClosure { self.f() }
 
     // expected-error@+1 {{call to actor-isolated global function 'takeIsolated' in a synchronous nonisolated context}}
@@ -1498,18 +1458,15 @@ final class MainActorInit: Sendable {
   init() {
     acceptAsyncSendableClosureInheriting { self.f() }
 
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{34-34=await }}
     acceptAsyncSendableClosure { self.f() }
   }
 
   deinit {
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{44-44=await }}
     acceptAsyncSendableClosureInheriting { self.f() }
 
-    // expected-note@+2 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
-    // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-error@+1 {{actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{34-34=await }}
     acceptAsyncSendableClosure { self.f() }
   }
 
@@ -1679,9 +1636,8 @@ class ReferenceActor {
   init() async {
     self.a = ProtectNonSendable()
 
-    // expected-warning@+3 {{non-Sendable type 'NonSendable' of property 'ns' cannot exit actor-isolated context}}
-    // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
-    // expected-note@+1 {{property access is 'async'}}
+    // expected-warning@+2 {{non-Sendable type 'NonSendable' of property 'ns' cannot exit actor-isolated context}}
+    // expected-warning@+1 {{actor-isolated property 'ns' cannot be accessed from outside of the actor}} {{9-9=await }}
     _ = a.ns
   }
 }

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -100,8 +100,7 @@ extension A1 {
 
     // Across to a different actor, so Sendable restriction is enforced.
     _ = other.localLet // expected-warning{{non-Sendable type 'NotConcurrent' of property 'localLet' cannot exit actor-isolated context}}
-    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'}}
-    // expected-note@-2 {{property access is 'async'}}
+    // expected-warning@-1 {{actor-isolated property 'localLet' cannot be accessed from outside of the actor}} {{9-9=await }}
     _ = await other.synchronous() // expected-tns-warning {{non-Sendable 'NotConcurrent?'-typed result can not be returned from actor-isolated instance method 'synchronous()' to actor-isolated context}}
     _ = await other.asynchronous(nil)
   }
@@ -138,14 +137,12 @@ enum E {
 }
 
 func globalTest() async {
-  // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@+1 {{property access is 'async'}}
+  // expected-warning@+1 {{global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot be accessed from outside of the actor}} {{11-11=await }}
   let a = globalValue // expected-warning{{non-Sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
   await globalAsync(a)
   await globalSync(a)
 
-  // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@+1 {{property access is 'async'}}
+  // expected-warning@+1 {{global actor 'SomeGlobalActor'-isolated static property 'notSafe' cannot be accessed from outside of the actor}} {{11-11=await }}
   let _ = E.notSafe // expected-warning{{non-Sendable type 'NotConcurrent?' of static property 'notSafe' cannot exit global actor 'SomeGlobalActor'-isolated context}}
 
 #if ALLOW_TYPECHECKER_ERRORS
@@ -174,8 +171,7 @@ class ClassWithGlobalActorInits { // expected-tns-note 2{{class 'ClassWithGlobal
 
 @MainActor
 func globalTestMain(nc: NotConcurrent) async {
-  // expected-warning@+2 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@+1 {{property access is 'async'}}
+  // expected-warning@+1 {{global actor 'SomeGlobalActor'-isolated let 'globalValue' cannot be accessed from outside of the actor}} {{11-11=await }}
   let a = globalValue // expected-warning {{non-Sendable type 'NotConcurrent?' of let 'globalValue' cannot exit global actor 'SomeGlobalActor'-isolated context}}
   await globalAsync(a)
   await globalSync(a)

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -36,15 +36,15 @@ func referenceGlobalActor() async {
   let a = Alex()
   _ = a.method
   _ = a.const_memb
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  _ = a.mut_memb // expected-note{{property access is 'async'}}
+  // expected-error@+1{{global actor 'SomeGlobalActor'-isolated property 'mut_memb' cannot be accessed from outside of the actor}}{{7-7=await }}
+  _ = a.mut_memb
 
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  _ = a[1]  // expected-note{{subscript access is 'async'}}
+  // expected-error@+1{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{7-7=await }}
+  _ = a[1]
   a[0] = 1  // expected-error{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' can not be mutated from a nonisolated context}}
 
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  _ = 32 + a[1] // expected-note@:12{{subscript access is 'async'}}
+  // expected-error@+1{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{7-7=await }}
+  _ = 32 + a[1]
 }
 
 
@@ -122,11 +122,10 @@ func fromAsync() async {
   fn() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to let 'fn' from outside of its actor context are implicitly asynchronous}}
   _ = a.const_memb
-  _ = a.mut_memb  // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{property access is 'async'}}
+  _ = a.mut_memb  // expected-error{{global actor 'SomeGlobalActor'-isolated property 'mut_memb' cannot be accessed from outside of the actor}} {{7-7=await }}
 
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
-  _ = a[1]  // expected-note{{subscript access is 'async'}}
+  // expected-error@+1{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' cannot be accessed from outside of the actor}}{{7-7=await }}
+  _ = a[1]
   _ = await a[1]
   a[0] = 1  // expected-error{{global actor 'SomeGlobalActor'-isolated subscript 'subscript(_:)' can not be mutated from a nonisolated context}}
 }
@@ -144,7 +143,6 @@ topLevelSyncFunction(&value)
 
 class Sub: Super {
   func f() { }
-  // expected-note@-1 {{global actor 'SomeGlobalActor' isolation inferred from inheritance from class 'Super'}}
 
   func g() {
     Task.detached {
@@ -154,8 +152,7 @@ class Sub: Super {
 
   func g2() {
     Task.detached {
-      self.f() // expected-warning{{expression is 'async' but is not marked with 'await'}}
-      // expected-note@-1{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+      self.f() // expected-warning{{global actor 'SomeGlobalActor'-isolated instance method 'f()' cannot be called from outside of the actor}} {{7-7=await }}
     }
   }
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -282,8 +282,8 @@ class SubclassWithGlobalActors : SuperclassWithGlobalActors {
 @SomeGlobalActor func sibling() { foo() }
 
 func bar() async {
-  // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{3-3=await }}
-  foo() // expected-note{{calls to global function 'foo()' from outside of its actor context are implicitly asynchronous}}
+  // expected-error@+1{{global actor 'SomeGlobalActor'-isolated global function 'foo()' cannot be called from outside of the actor}}{{3-3=await }}
+  foo()
 }
 
 // expected-note@+1 {{add '@SomeGlobalActor' to make global function 'barSync()' part of global actor 'SomeGlobalActor'}} {{1-1=@SomeGlobalActor }}
@@ -645,8 +645,7 @@ func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable 
 
 @MainActor func testCallFromMainActor() {
   acceptAsyncSendableClosure {
-    onlyOnMainActor() // expected-error{{expression is 'async' but is not marked with 'await'}}
-    // expected-note@-1 {{calls to global function 'onlyOnMainActor()' from outside of its actor context are implicitly asynchronous}}
+    onlyOnMainActor() // expected-error{{main actor-isolated global function 'onlyOnMainActor()' cannot be called from outside of the actor}} {{5-5=await }}
   }
 
   acceptAsyncSendableClosure {

--- a/test/Concurrency/import_nsnotificationname_constants_as_nonisolated.swift
+++ b/test/Concurrency/import_nsnotificationname_constants_as_nonisolated.swift
@@ -34,8 +34,7 @@ extern NSNotificationName const TestIsolatedTrigger __attribute__((swift_name("T
 func testAsync() async {
   print(Test.didTrigger) // Ok (property is nonisolated)
   print(Test.isolatedTrigger)
-  // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
-  // expected-note@-2 {{property access is 'async'}}
+  // expected-warning@-1 {{main actor-isolated class property 'isolatedTrigger' cannot be accessed from outside of the actor}}
 }
 
 @MainActor

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -59,12 +59,10 @@ func nonisolatedCaller() {
 }
 
 func nonisolatedAsyncCaller() async {
-  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@+1 {{calls to global function 'mainActorDefaultArg(value:)' from outside of its actor context are implicitly asynchronous}}
+  // expected-error@+1 {{main actor-isolated global function 'mainActorDefaultArg(value:)' cannot be called from outside of the actor}} {{3-3=await }}
   mainActorDefaultArg()
 
-  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@+1 {{calls to global function 'mainActorClosure(closure:)' from outside of its actor context are implicitly asynchronous}}
+  // expected-error@+1 {{main actor-isolated global function 'mainActorClosure(closure:)' cannot be called from outside of the actor}} {{3-3=await }}
   mainActorClosure()
 
   await mainActorDefaultArg(value: requiresMainActor())
@@ -216,8 +214,7 @@ class C3 {
 
 class C4 {
   let task1 = Task {
-    // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
-    // expected-note@+1 {{calls to global function 'requiresMainActor()' from outside of its actor context are implicitly asynchronous}}
+    // expected-error@+1 {{main actor-isolated global function 'requiresMainActor()' cannot be called from outside of the actor}} {{5-5=await }}
     requiresMainActor()
   }
 
@@ -265,8 +262,7 @@ struct UseRequiresMain {
 }
 
 nonisolated func test() async {
-  // expected-warning@+2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
-  // expected-note@+1 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+  // expected-warning@+1 {{main actor-isolated initializer 'init()' cannot be called from outside of the actor; this is an error in the Swift 6 language mode}} {{7-7=await }}
   _ = UseRequiresMain()
 }
 

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -98,8 +98,7 @@ func testIsolatedParamCallsAsync(a: isolated A, b: A) async {
 
   #if ALLOW_TYPECHECKER_ERRORS
   globalFuncIsolated(a)
-  globalFuncIsolated(b) // expected-typechecker-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-typechecker-note@-1{{calls to global function 'globalFuncIsolated' from outside of its actor context are implicitly asynchronous}}
+  globalFuncIsolated(b) // expected-typechecker-error{{actor-isolated global function 'globalFuncIsolated' cannot be called from outside of the actor}} {{3-3=await }}
   await globalFuncIsolated(b)
   #endif
 }
@@ -309,8 +308,7 @@ func testExistentialIsolated(a: isolated P2, b: P2) async {
   a.m()
   await b.m()
   #if ALLOW_TYPECHECKER_ERRORS
-  b.m() // expected-typechecker-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-typechecker-note@-1{{calls to instance method 'm()' from outside of its actor context are implicitly asynchronous}}
+  b.m() // expected-typechecker-error{{actor-isolated instance method 'm()' cannot be called from outside of the actor}} {{3-3=await }}
   #endif
 }
 
@@ -443,9 +441,8 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
 
 #if ALLOW_TYPECHECKER_ERRORS
   optionalIsolatedSync(ns, to: myActor)
-  // expected-typechecker-error@-1 {{expression is 'async' but is not marked with 'await'}}
-  // expected-typechecker-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-warning@-3 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-typechecker-error@-1 {{actor-isolated global function 'optionalIsolatedSync(_:to:)' cannot be called from outside of the actor}} {{3-3=await }}
+  // expected-complete-warning@-2 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
   #endif
 }
 
@@ -466,9 +463,8 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
 
 #if ALLOW_TYPECHECKER_ERRORS
   optionalIsolatedSync(ns, to: myActor)
-  // expected-typechecker-error@-1 {{expression is 'async' but is not marked with 'await'}}
-  // expected-typechecker-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
-  // expected-complete-warning@-3 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-typechecker-error@-1 {{actor-isolated global function 'optionalIsolatedSync(_:to:)' cannot be called from outside of the actor}} {{3-3=await }}
+  // expected-complete-warning@-2 {{passing argument of non-Sendable type 'NotSendable' into actor-isolated context may introduce data races}}
 #endif
 }
 

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -111,16 +111,13 @@ func testCalls(x: X) {
 }
 
 func testCallsWithAsync() async {
-  onMainActorAlways() // expected-warning{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
+  onMainActorAlways() // expected-warning{{main actor-isolated global function 'onMainActorAlways()' cannot be called from outside of the actor}} {{3-3=await }}
 
   let _: () -> Void = onMainActorAlways // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
-  let c = MyModelClass() // expected-minimal-targeted-warning{{expression is 'async' but is not marked with 'await'}}
-  // expected-minimal-targeted-note@-1{{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+  let c = MyModelClass() // expected-minimal-targeted-warning{{main actor-isolated initializer 'init()' cannot be called from outside of the actor}} {{11-11=await }}
 
-  c.f() // expected-warning{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  c.f() // expected-warning{{main actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{3-3=await }}
 }
 
 // ---------------------------------------------------------------------------

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -73,15 +73,13 @@ func testCalls(x: X) {
 }
 
 func testCallsWithAsync() async {
-  onMainActorAlways() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
+  onMainActorAlways() // expected-error{{main actor-isolated global function 'onMainActorAlways()' cannot be called from outside of the actor}} {{3-3=await }}
 
   let _: () -> Void = onMainActorAlways // expected-error{{converting function value of type '@MainActor @Sendable () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
   let c = MyModelClass() // okay, synthesized init() is 'nonisolated'
 
-  c.f() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
+  c.f() // expected-error{{main actor-isolated instance method 'f()' cannot be called from outside of the actor}} {{3-3=await }}
 }
 
 // ---------------------------------------------------------------------------

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -459,9 +459,8 @@ struct DowngradeForPreconcurrency {
   func createStream() -> AsyncStream<NonSendable> {
     AsyncStream<NonSendable> {
       self.x
-      // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
-      // expected-note@-2 {{property access is 'async'}}
-      // expected-warning@-3 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
+      // expected-warning@-1 {{main actor-isolated property 'x' cannot be accessed from outside of the actor; this is an error in the Swift 6 language mode}} {{7-7=await }}
+      // expected-warning@-2 {{non-Sendable type 'NonSendable' of property 'x' cannot exit main actor-isolated context; this is an error in the Swift 6 language mode}}
     }
   }
 }

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -23,9 +23,8 @@ func nonIsolatedAsync() async {
     await print(a)
     a = a + 10
     // expected-warning@-1:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
-    // expected-warning@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
-    // expected-note@-3:9 {{property access is 'async'}}
-    // expected-note@-4 {{consider declaring an isolated method on 'MainActor' to perform the mutation}}
+    // expected-warning@-2:9 {{main actor-isolated var 'a' cannot be accessed from outside of the actor}}{{9-9=await }}
+    // expected-note@-3 {{consider declaring an isolated method on 'MainActor' to perform the mutation}}
 }
 
 @MainActor

--- a/test/Concurrency/toplevel/async-6-top-level.swift
+++ b/test/Concurrency/toplevel/async-6-top-level.swift
@@ -22,9 +22,8 @@ func nonIsolatedAsync() async {
     await print(a)
     a = a + 10
     // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
-    // expected-error@-2:9 {{expression is 'async' but is not marked with 'await'}}
-    // expected-note@-3:9 {{property access is 'async'}}
-    // expected-note@-4 {{consider declaring an isolated method on 'MainActor' to perform the mutation}}
+    // expected-error@-2:9 {{main actor-isolated var 'a' cannot be accessed from outside of the actor}} {{9-9=await }}
+    // expected-note@-3 {{consider declaring an isolated method on 'MainActor' to perform the mutation}}
 }
 
 @MainActor

--- a/test/Concurrency/toplevel/no-async-6-top-level.swift
+++ b/test/Concurrency/toplevel/no-async-6-top-level.swift
@@ -24,9 +24,8 @@ func isolatedSync() {
 func nonIsolatedAsync() async {
   await print(a)
   a = a + 10 // expected-error{{main actor-isolated var 'a' can not be mutated from a nonisolated context}}
-  // expected-note@-1{{property access is 'async'}}
-  // expected-error@-2{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-3{{consider declaring an isolated method on 'MainActor' to perform the mutation}}
+  // expected-error@-1{{main actor-isolated var 'a' cannot be accessed from outside of the actor}} {{7-7=await }}
+  // expected-note@-2{{consider declaring an isolated method on 'MainActor' to perform the mutation}}
 }
 
 @MainActor

--- a/test/Concurrency/toplevel/synchronous_mainactor.swift
+++ b/test/Concurrency/toplevel/synchronous_mainactor.swift
@@ -10,8 +10,7 @@ func unsafeAccess() { // expected-note{{add '@MainActor' to make global function
 }
 
 func unsafeAsyncAccess() async {
-    print(a) // expected-error@:5{{expression is 'async' but is not marked with 'await'}}{{5-5=await }}
-             // expected-note@-1:11{{property access is 'async'}}
+    print(a) // expected-error@:11{{main actor-isolated var 'a' cannot be accessed from outside of the actor}}{{5-5=await }}
 }
 
 @MainActor

--- a/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
+++ b/test/Distributed/distributed_actor_func_implicitly_async_throws.swift
@@ -25,66 +25,55 @@ distributed actor D {
 func test_not_distributed_funcs(distributed: D) async {
   distributed.hello() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
   distributed.helloAsync() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
-  // expected-error@-1{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-2{{call is 'async'}}
-  // {{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
+  // expected-error@-1{{actor-isolated instance method 'helloAsync()' cannot be called from outside of the actor}} {{3-3=await }}
   distributed.helloAsyncThrows() // expected-error{{only 'distributed' instance methods can be called on a potentially remote distributed actor}}
-  // expected-error@-1{{expression is 'async' but is not marked with 'await'}} // TODO: no need to diagnose this, it is impossible to call anyway
-  // expected-note@-2{{call is 'async'}}
-  // expected-error@-3{{call can throw, but it is not marked with 'try' and the error is not handled}} // TODO: no need to diagnose this, it is impossible to call anyway
+  // expected-error@-1{{actor-isolated instance method 'helloAsyncThrows()' cannot be called from outside of the actor}} // TODO: no need to diagnose this, it is impossible to call anyway
+  // expected-error@-2{{call can throw, but it is not marked with 'try' and the error is not handled}} // TODO: no need to diagnose this, it is impossible to call anyway
 }
 
 func test_outside(distributed: D) async throws {
-  distributed.distHello() // expected-error{{expression is 'async' but is not marked with 'await'}}
+  distributed.distHello() // expected-error{{actor-isolated distributed instance method 'distHello()' cannot be called from outside of the actor}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}
-  // expected-note@-2{{calls to distributed instance method 'distHello()' from outside of its actor context are implicitly asynchronous}}
-  // expected-note@-3{{did you mean to use 'try'?}}
-  // expected-note@-4{{did you mean to disable error propagation?}}
-  // expected-note@-5{{did you mean to handle error as optional value?}}
-  try distributed.distHello() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to distributed instance method 'distHello()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2{{did you mean to use 'try'?}}
+  // expected-note@-3{{did you mean to disable error propagation?}}
+  // expected-note@-4{{did you mean to handle error as optional value?}}
+  try distributed.distHello() // expected-error{{ctor-isolated distributed instance method 'distHello()' cannot be called from outside of the actor}}
   await distributed.distHello() // expected-error{{call can throw but is not marked with 'try'}}
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to disable error propagation?}}
   // expected-note@-3{{did you mean to handle error as optional value?}}
   try await distributed.distHello() // ok
 
-  distributed.distHelloAsync()// expected-error{{expression is 'async' but is not marked with 'await'}}
+  distributed.distHelloAsync()// expected-error{{actor-isolated distributed instance method 'distHelloAsync()' cannot be called from outside of the actor}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}
-  // expected-note@-2{{calls to distributed instance method 'distHelloAsync()' from outside of its actor context are implicitly asynchronous}}
-  // expected-note@-3{{did you mean to use 'try'?}}
-  // expected-note@-4{{did you mean to disable error propagation?}}
-  // expected-note@-5{{did you mean to handle error as optional value?}}
-  try distributed.distHelloAsync() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to distributed instance method 'distHelloAsync()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2{{did you mean to use 'try'?}}
+  // expected-note@-3{{did you mean to disable error propagation?}}
+  // expected-note@-4{{did you mean to handle error as optional value?}}
+  try distributed.distHelloAsync() // expected-error{{actor-isolated distributed instance method 'distHelloAsync()' cannot be called from outside of the actor}}
   await distributed.distHelloAsync() // expected-error{{call can throw but is not marked with 'try'}}
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to disable error propagation?}}
   // expected-note@-3{{did you mean to handle error as optional value?}}
   try await distributed.distHelloAsync() // ok
 
-  distributed.distHelloThrows() // expected-error{{expression is 'async' but is not marked with 'await'}}
+  distributed.distHelloThrows() // expected-error{{actor-isolated distributed instance method 'distHelloThrows()' cannot be called from outside of the actor}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}
-  // expected-note@-2{{calls to distributed instance method 'distHelloThrows()' from outside of its actor context are implicitly asynchronous}}
-  // expected-note@-3{{did you mean to use 'try'?}}
-  // expected-note@-4{{did you mean to disable error propagation?}}
-  // expected-note@-5{{did you mean to handle error as optional value?}}
-  try distributed.distHelloThrows() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to distributed instance method 'distHelloThrows()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2{{did you mean to use 'try'?}}
+  // expected-note@-3{{did you mean to disable error propagation?}}
+  // expected-note@-4{{did you mean to handle error as optional value?}}
+  try distributed.distHelloThrows() // expected-error{{actor-isolated distributed instance method 'distHelloThrows()' cannot be called from outside of the actor}}
   await distributed.distHelloThrows() // expected-error{{call can throw but is not marked with 'try'}}
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to disable error propagation?}}
   // expected-note@-3{{did you mean to handle error as optional value?}}
   try await distributed.distHelloThrows() // ok
 
-  distributed.distHelloAsyncThrows() // expected-error{{expression is 'async' but is not marked with 'await'}}
+  distributed.distHelloAsyncThrows() // expected-error{{actor-isolated distributed instance method 'distHelloAsyncThrows()' cannot be called from outside of the actor}}
   // expected-error@-1{{call can throw but is not marked with 'try'}}
-  // expected-note@-2{{calls to distributed instance method 'distHelloAsyncThrows()' from outside of its actor context are implicitly asynchronous}}
-  // expected-note@-3{{did you mean to use 'try'?}}
-  // expected-note@-4{{did you mean to disable error propagation?}}
-  // expected-note@-5{{did you mean to handle error as optional value?}}
-  try distributed.distHelloAsyncThrows() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to distributed instance method 'distHelloAsyncThrows()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-2{{did you mean to use 'try'?}}
+  // expected-note@-3{{did you mean to disable error propagation?}}
+  // expected-note@-4{{did you mean to handle error as optional value?}}
+  try distributed.distHelloAsyncThrows() // expected-error{{actor-isolated distributed instance method 'distHelloAsyncThrows()' cannot be called from outside of the actor}}
   await distributed.distHelloAsyncThrows() // expected-error{{call can throw but is not marked with 'try'}}
   // expected-note@-1{{did you mean to use 'try'?}}
   // expected-note@-2{{did you mean to disable error propagation?}}

--- a/test/Distributed/distributed_actor_isolation_and_tasks.swift
+++ b/test/Distributed/distributed_actor_isolation_and_tasks.swift
@@ -54,8 +54,7 @@ distributed actor Philosopher {
       // because we KNOW this is a local call -- and there is no system in
       // between that will throw.
       _ = await self.dist() // notice lack of 'try' even though 'distributed func'
-      _ = self.variable_fromDetach // expected-error{{expression is 'async' but is not marked with 'await'}}
-      // expected-note@-1{{property access is 'async'}}
+      _ = self.variable_fromDetach // expected-error{{actor-isolated property 'variable_fromDetach' cannot be accessed from outside of the actor}} {{11-11=await }}
       _ = await self.variable_fromDetach // okay, we know we're on the local node
     }
   }

--- a/test/Distributed/distributed_property_must_be_throws.swift
+++ b/test/Distributed/distributed_property_must_be_throws.swift
@@ -22,8 +22,7 @@ func test(da: MyDistributedActor) async throws {
   // expected-note@-2{{did you mean to handle error as optional value?}}
   // expected-note@-3{{did you mean to disable error propagation?}}
 
-  _ = try da.distributedProperty // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{property access is 'async'}}
+  _ = try da.distributedProperty // expected-error{{actor-isolated distributed property 'distributedProperty' cannot be accessed from outside of the actor}} {{11-11=await }}
 
   _ = try await da.distributedProperty // ok, implicitly async + throws
 }

--- a/test/Serialization/isolated-params.swift
+++ b/test/Serialization/isolated-params.swift
@@ -10,8 +10,7 @@ import def_isolated
 
 func test(a: A, a2: isolated A, s: S) async {
   await s.f(a: a)
-  s.f(a: a) // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to instance method 'f(a:)' from outside of its actor context are implicitly asynchronous}}
+  s.f(a: a) // expected-error{{actor-isolated instance method 'f(a:)' cannot be called from outside of the actor}} {{3-3=await }}
 
   s.f(a: a2)
 }

--- a/validation-test/Sema/SwiftUI/rdar76252310.swift
+++ b/validation-test/Sema/SwiftUI/rdar76252310.swift
@@ -41,13 +41,11 @@ func fromMainActor() async {
 func fromConcurrencyAware() async {
   let view = CoffeeTrackerView() // synthesized 'init' is 'nonisolated'
 
-  // expected-note@+3 {{property access is 'async'}}
   // expected-warning@+2 {{non-Sendable type 'some View' of property 'body' cannot exit main actor-isolated context}}
-  // expected-warning@+1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@+1 {{main actor-isolated property 'body' cannot be accessed from outside of the actor}} {{7-7=await }}
   _ = view.body
 
-  // expected-note@+2 {{property access is 'async'}}
-  // expected-warning@+1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@+1 {{main actor-isolated property 'showDrinkList' cannot be accessed from outside of the actor}} {{7-7=await }}
   _ = view.showDrinkList
 
   _ = view.storage


### PR DESCRIPTION
… outside of the actor

Replaces generic `expression is 'async' but is not marked with 'await` diagnostic with a tailed one for cases where there is an access to an actor-isolated value outside of its actor without `await` keyword.

This makes the diagnostics for async and sync contexts consistent and actually identifies a problem instead of simply pointing out the solution.

Resolves: rdar://151720646

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
