### PR TITLE
[6.2] [IDE] Better handle macro trailing closures

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -603,6 +603,13 @@ public:
   /// params in AbstractFunctionDecl and NominalTypeDecl.
   virtual bool shouldWalkIntoGenericParams() { return false; }
 
+  /// Whether the walker should walk into any attached CustomAttrs.
+  virtual bool shouldWalkIntoCustomAttrs() const {
+    // Default to false currently since some walkers don't handle this case
+    // well.
+    return false;
+  }
+
   /// This method configures how the walker should walk the initializers of
   /// lazy variables. These initializers are semantically different from other
   /// initializers in their context and so sometimes should be visited as part

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -458,7 +458,8 @@ public:
   void addEnumElementRef(const EnumElementDecl *EED, DeclVisibilityKind Reason,
                          DynamicLookupInfo dynamicLookupInfo,
                          bool HasTypeContext);
-  void addMacroCallArguments(const MacroDecl *MD, DeclVisibilityKind Reason);
+  void addMacroCallArguments(const MacroDecl *MD, DeclVisibilityKind Reason,
+                             bool forTrivialTrailingClosure = false);
   void addMacroExpansion(const MacroDecl *MD, DeclVisibilityKind Reason);
 
   void addKeyword(

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -458,6 +458,7 @@ public:
   void addEnumElementRef(const EnumElementDecl *EED, DeclVisibilityKind Reason,
                          DynamicLookupInfo dynamicLookupInfo,
                          bool HasTypeContext);
+  void addMacroCallArguments(const MacroDecl *MD, DeclVisibilityKind Reason);
   void addMacroExpansion(const MacroDecl *MD, DeclVisibilityKind Reason);
 
   void addKeyword(

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -120,6 +120,8 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   [[nodiscard]]
   bool visit(Decl *D) {
     SetParentRAII SetParent(Walker, D);
+    if (visitDeclCommon(D))
+      return true;
     return inherited::visit(D);
   }
 
@@ -137,6 +139,40 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   //===--------------------------------------------------------------------===//
   //                                 Decls
   //===--------------------------------------------------------------------===//
+
+  [[nodiscard]]
+  bool visitCustomAttr(CustomAttr *CA) {
+    auto *newTypeExpr = doIt(CA->getTypeExpr());
+    if (!newTypeExpr)
+      return true;
+
+    ASSERT(newTypeExpr == CA->getTypeExpr() &&
+           "Cannot change CustomAttr TypeExpr");
+
+    if (auto *args = CA->getArgs()) {
+      auto *newArgs = doIt(args);
+      if (!newArgs)
+        return true;
+
+      CA->setArgs(newArgs);
+    }
+    return false;
+  }
+
+  [[nodiscard]]
+  bool visitDeclCommon(Decl *D) {
+    if (Walker.shouldWalkIntoCustomAttrs()) {
+      for (auto *attr : D->getAttrs()) {
+        auto *CA = dyn_cast<CustomAttr>(attr);
+        if (!CA)
+          continue;
+
+        if (visitCustomAttr(CA))
+          return true;
+      }
+    }
+    return false;
+  }
 
   [[nodiscard]]
   bool visitGenericParamListIfNeeded(GenericContext *GC) {
@@ -2218,6 +2254,15 @@ bool Traversal::visitErrorTypeRepr(ErrorTypeRepr *T) {
 }
 
 bool Traversal::visitAttributedTypeRepr(AttributedTypeRepr *T) {
+  if (Walker.shouldWalkIntoCustomAttrs()) {
+    for (auto attr : T->getAttrs()) {
+      auto *CA = attr.dyn_cast<CustomAttr *>();
+      if (!CA)
+        continue;
+      if (visitCustomAttr(CA))
+        return true;
+    }
+  }
   return doIt(T->getTypeRepr());
 }
 

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1946,22 +1946,8 @@ static StringRef getTypeAnnotationString(const MacroDecl *MD,
   return {stash.data(), stash.size()};
 }
 
-void CompletionLookup::addMacroExpansion(const MacroDecl *MD,
-                                         DeclVisibilityKind Reason) {
-  if (!MD->hasName() || !MD->isAccessibleFrom(CurrDeclContext) ||
-      MD->shouldHideFromEditor())
-    return;
-
-  OptionSet<CustomAttributeKind> expectedKinds =
-      expectedTypeContext.getExpectedCustomAttributeKinds();
-  if (expectedKinds) {
-    CodeCompletionMacroRoles expectedRoles =
-        getCompletionMacroRoles(expectedKinds);
-    CodeCompletionMacroRoles roles = getCompletionMacroRoles(MD);
-    if (!(roles & expectedRoles))
-      return;
-  }
-
+void CompletionLookup::addMacroCallArguments(const MacroDecl *MD,
+                                             DeclVisibilityKind Reason) {
   CodeCompletionResultBuilder Builder =
       makeResultBuilder(CodeCompletionResultKind::Declaration,
                         getSemanticContext(MD, Reason, DynamicLookupInfo()));
@@ -1986,6 +1972,25 @@ void CompletionLookup::addMacroExpansion(const MacroDecl *MD,
     llvm::SmallVector<char, 0> stash;
     Builder.addTypeAnnotation(getTypeAnnotationString(MD, stash));
   }
+}
+
+void CompletionLookup::addMacroExpansion(const MacroDecl *MD,
+                                         DeclVisibilityKind Reason) {
+  if (!MD->hasName() || !MD->isAccessibleFrom(CurrDeclContext) ||
+      MD->shouldHideFromEditor())
+    return;
+
+  OptionSet<CustomAttributeKind> expectedKinds =
+      expectedTypeContext.getExpectedCustomAttributeKinds();
+  if (expectedKinds) {
+    CodeCompletionMacroRoles expectedRoles =
+        getCompletionMacroRoles(expectedKinds);
+    CodeCompletionMacroRoles roles = getCompletionMacroRoles(MD);
+    if (!(roles & expectedRoles))
+      return;
+  }
+
+  addMacroCallArguments(MD, Reason);
 }
 
 void CompletionLookup::addKeyword(StringRef Name, Type TypeAnnotation,

--- a/test/IDE/complete_macros.swift
+++ b/test/IDE/complete_macros.swift
@@ -21,6 +21,15 @@ public macro freestandingExprStringMacro() -> String
 @freestanding(expression)
 public macro freestandingExprTMacro<T>(_ value: T) -> T
 
+@freestanding(expression)
+public macro freestandingExprVoidClosureMacro(fn: () -> Void)
+
+@freestanding(expression)
+public macro freestandingExprIntClosureMacro(fn: () -> Int)
+
+@freestanding(declaration)
+public macro freestandingDeclVoidClosureMacro(fn: () -> Void)
+
 @freestanding(declaration)
 public macro freestandingDeclMacro()
 
@@ -158,8 +167,21 @@ func nestedFreestanding() {
 // ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprTMacro({#(value): T#})[#T#]; name=freestandingExprTMacro(:)
 // ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Expression Macro, Declaration Macro, Accessor Macro, Member Attribute Macro, Member Macro, Peer Macro, Extension Macro#]; name=EverythingMacro
 //
+// We offer a trailing closure completion for the Void case, but not the
+// Int case currently. Placeholder expansion will turn the latter into the
+// former though.
+//
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprVoidClosureMacro {|}[#Void#]; name=freestandingExprVoidClosureMacro
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprVoidClosureMacro({#fn: () -> Void##() -> Void#})[#Void#]; name=freestandingExprVoidClosureMacro(fn:)
+//
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingExprIntClosureMacro({#fn: () -> Int##() -> Int#})[#Void#]; name=freestandingExprIntClosureMacro(fn:)
+//
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingDeclVoidClosureMacro {|}[#Declaration Macro#]; name=freestandingDeclVoidClosureMacro
+// ALL_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingDeclVoidClosureMacro({#fn: () -> Void##() -> Void#})[#Declaration Macro#]; name=freestandingDeclVoidClosureMacro(fn:)
+//
 // ALL_FREESTANDING_NOT-NOT: Attached
 // ALL_FREESTANDING_NOT-NOT: BodyMacro
+// ALL_FREESTANDING_NOT-NOT: freestandingExprIntClosureMacro {|}
 
 func exprFreestanding(arg: Int) {
   _ = arg + ##^EXPR_FREESTANDING?check=EXPR_FREESTANDING;check=EXPR_FREESTANDING_NOT^#
@@ -180,6 +202,9 @@ struct NestedFreestanding {
 }
 // ITEM_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingDeclMacro[#Declaration Macro#]; name=freestandingDeclMacro
 // ITEM_FREESTANDING-DAG: Decl[Macro]/{{.*}}: EverythingMacro[#Expression Macro, Declaration Macro, Accessor Macro, Member Attribute Macro, Member Macro, Peer Macro, Extension Macro#]; name=EverythingMacro
+//
+// ITEM_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingDeclVoidClosureMacro {|}[#Declaration Macro#]; name=freestandingDeclVoidClosureMacro
+// ITEM_FREESTANDING-DAG: Decl[Macro]/{{.*}}: freestandingDeclVoidClosureMacro({#fn: () -> Void##() -> Void#})[#Declaration Macro#]; name=freestandingDeclVoidClosureMacro(fn:)
 //
 // ITEM_FREESTANDING_NOT-NOT: Attached
 // ITEM_FREESTANDING_NOT-NOT: freestandingExpr

--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -25,6 +25,10 @@ await foo(x: <#T##() -> Void#>)
 // CHECK-NEXT: <#code#>
 // CHECK-NEXT: }
 
+foo(bar(<#T##() -> Void#>))
+// CHECK:      foo(bar({
+// CHECK-NEXT: <#code#>
+// CHECK-NEXT: }))
 
 anArr.indexOfObjectPassingTest(<#T##predicate: ((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?##((AnyObject!, Int, UnsafePointer<ObjCBool>) -> Bool)?#>)
 // CHECK:      anArr.indexOfObjectPassingTest { <#AnyObject!#>, <#Int#>, <#UnsafePointer<ObjCBool>#> in
@@ -272,4 +276,42 @@ expandClosureWithInternalParameterNames {
   withtrail(<#T##callback: (Int, Int) -> Bool##(_ a: Int, _ b: Int) -> Bool#>)
 // CHECK: withtrail { a, b in
 // CHECK-NEXT: <#code#>
+}
+
+// CHECK-LABEL: func expandMacro()
+func expandMacro() {
+  #foo(<#T##() -> Int#>)
+  // CHECK:      #foo {
+  // CHECK-NEXT:   <#code#>
+  // CHECK-NEXT: }
+
+  #foo(bar: <#T##() -> ()#>)
+  // CHECK:      #foo {
+  // CHECK-NEXT:   <#code#>
+  // CHECK-NEXT: }
+
+  #foo(bar: <#T##() -> Int#>, baz: <#T##() -> ()#>)
+  // CHECK:      #foo {
+  // CHECK-NEXT:   <#code#>
+  // CHECK-NEXT: } baz: {
+  // CHECK-NEXT:   <#code#>
+  // CHECK-NEXT: }
+}
+
+// CHECK-LABEL: struct ExpandDeclMacro
+struct ExpandDeclMacro {
+  #foo(<#T##() -> ()#>)
+  // CHECK:      #foo {
+  // CHECK-NEXT:   <#code#>
+  // CHECK-NEXT: }
+
+  #foo(bar(<#T##() -> ()#>))
+  // CHECK:      #foo(bar({
+  // CHECK-NEXT:   <#code#>
+  // CHECK-NEXT: }))
+
+  #foo(#bar(<#T##() -> ()#>))
+  // CHECK:      #foo(#bar({
+  // CHECK-NEXT:   <#code#>
+  // CHECK-NEXT: }))
 }

--- a/test/SourceKit/CodeExpand/code-expand.swift
+++ b/test/SourceKit/CodeExpand/code-expand.swift
@@ -315,3 +315,23 @@ struct ExpandDeclMacro {
   // CHECK-NEXT:   <#code#>
   // CHECK-NEXT: }))
 }
+
+@Foo(<#Int#>)
+func testDeclAttr1() {}
+// CHECK: @Foo(<#Int#>)
+// CHECK-NEXT: func testDeclAttr1() {}
+
+@Foo(<#T##() -> ()#>)
+func testDeclAttr2() {}
+// CHECK:      @Foo({
+// CHECK-NEXT:   <#code#>
+// CHECK-NEXT: })
+// CHECK-NEXT: func testDeclAttr2() {}
+
+func testTypeAttr1(x: @Foo(<#Int#>) String) {}
+// CHECK: func testTypeAttr1(x: @Foo(<#Int#>) String) {}
+
+func testTypeAttr2(x: @Foo(<#T##() -> ()#>) Int) {}
+// CHECK: func testTypeAttr2(x: @Foo({
+// CHECK-NEXT:   <#code#>
+// CHECK-NEXT: }) Int) {}

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1679,34 +1679,65 @@ private:
     public:
       const SourceManager &SM;
       SourceLoc TargetLoc;
-      std::pair<Expr *, ArgumentList *> EnclosingCallAndArg;
+      std::pair<ASTNode, ArgumentList *> EnclosingCallAndArg;
       Expr *OuterExpr;
       Stmt *OuterStmt;
-      explicit CallExprFinder(const SourceManager &SM)
-        :SM(SM) { }
+      Decl *OuterDecl;
 
-      bool checkCallExpr(Expr *E) {
-        ArgumentList *Args = nullptr;
-        if (auto *CE = dyn_cast<CallExpr>(E)) {
-          // Call expression can have argument.
-          Args = CE->getArgs();
+      explicit CallExprFinder(const SourceManager &SM) : SM(SM) {}
+
+      void checkArgumentList(ArgumentList *Args) {
+        ASTNode Enclosing;
+        if (auto *E = Parent.getAsExpr()) {
+          // Must have a function call or macro parent.
+          if (!isa<CallExpr, MacroExpansionExpr>(E) ||
+              E->getArgs() != Args) {
+            return;
+          }
+          // If the outer expression is the call itself, disregard it.
+          if (OuterExpr == E)
+            OuterExpr = nullptr;
+
+          Enclosing = E;
         }
-        if (!Args)
-          return false;
-        if (EnclosingCallAndArg.first)
-          OuterExpr = EnclosingCallAndArg.first;
-        EnclosingCallAndArg = {E, Args};
-        return true;
+        if (auto *D = Parent.getAsDecl()) {
+          // Must have a macro decl parent.
+          auto *MED = dyn_cast<MacroExpansionDecl>(D);
+          if (!MED || MED->getArgs() != Args)
+            return;
+          Enclosing = D;
+        }
+        if (!Enclosing)
+          return;
+
+        // If we have an outer enclosing call, update the outer nodes if needed.
+        if (auto EnclosingCall = EnclosingCallAndArg.first) {
+          if (!OuterExpr)
+            OuterExpr = EnclosingCall.dyn_cast<Expr *>();
+          if (!OuterDecl)
+            OuterDecl = EnclosingCall.dyn_cast<Decl *>();
+        }
+
+        EnclosingCallAndArg = {Enclosing, Args};
       }
 
       MacroWalking getMacroWalkingBehavior() const override {
         return MacroWalking::Arguments;
       }
 
+      PreWalkResult<ArgumentList *>
+      walkToArgumentListPre(ArgumentList *ArgList) override {
+        auto SR = ArgList->getSourceRange();
+        if (SR.isValid() && SM.rangeContainsTokenLoc(SR, TargetLoc))
+          checkArgumentList(ArgList);
+
+        return Action::Continue(ArgList);
+      }
+
       PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
         auto SR = E->getSourceRange();
         if (SR.isValid() && SM.rangeContainsTokenLoc(SR, TargetLoc) &&
-            !checkCallExpr(E) && !EnclosingCallAndArg.first) {
+            !OuterExpr && !EnclosingCallAndArg.first) {
           if (!isa<TryExpr>(E) && !isa<AwaitExpr>(E) && !isa<UnsafeExpr>(E) &&
               !isa<PrefixUnaryExpr>(E)) {
             // We don't want to expand to trailing closures if the call is
@@ -1782,6 +1813,7 @@ private:
         EnclosingCallAndArg = {nullptr, nullptr};
         OuterExpr = nullptr;
         OuterStmt = nullptr;
+        OuterDecl = nullptr;
         TargetLoc = SL;
         SF.walk(*this);
         return EnclosingCallAndArg.second;
@@ -1791,14 +1823,9 @@ private:
     CallExprFinder CEFinder(SM);
     auto *Args = CEFinder.findEnclosingCallArg(SF, SL);
 
-    if (!Args)
-      return std::make_pair(Args, false);
-    if (CEFinder.OuterExpr)
-      return std::make_pair(Args, false);
-    if (CEFinder.OuterStmt)
-      return std::make_pair(Args, false);
-
-    return std::make_pair(Args, true);
+    auto HasOuterNode =
+        CEFinder.OuterExpr || CEFinder.OuterStmt || CEFinder.OuterDecl;
+    return std::make_pair(Args, /*useTrailingClosure*/ Args && !HasOuterNode);
   }
 
   struct ParamClosureInfo {

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1592,6 +1592,10 @@ private:
       return MacroWalking::Arguments;
     }
 
+    bool shouldWalkIntoCustomAttrs() const override {
+      return true;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (isa<EditorPlaceholderExpr>(E) && E->getStartLoc() == PlaceholderLoc) {
         Found = cast<EditorPlaceholderExpr>(E);


### PR DESCRIPTION
*6.2 cherry-pick of #81673*

- Explanation: Improves handling of trailing closure macro arguments in placeholder expansion and code completion 
- Scope: Affects placeholder expansion and completion
- Issue: rdar://150550747
- Risk: Low, only affects placeholder expansion and macro completion
- Testing: Added tests to test suite
- Reviewer: Rintaro Ishizaki