### PR TITLE
Skip stdlib private in bootstrap

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3184,6 +3184,7 @@ extra-swift-cmake-options=
   -DSWIFT_ENABLE_SWIFT_IN_SWIFT:BOOL=NO
   -DSWIFT_INCLUDE_DOCS:BOOL=NO
   -DSWIFT_BUILD_EXAMPLES:BOOL=OFF
+  -DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=NO
 
 build-subdir=%(build_subdir)s
 install-destdir=%(install_destdir)s
@@ -3217,8 +3218,11 @@ skip-build-benchmarks
 
 enable-experimental-concurrency=1
 
-extra-cmake-options=
+extra-llvm-cmake-options=
   -DLLVM_TARGETS_TO_BUILD=AArch64;X86
+
+extra-swift-cmake-options=
+  -DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=NO
 
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;toolchain-tools;license
 llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;compiler-rt;clang-features-file;lld
@@ -3248,6 +3252,8 @@ swiftpm
 swift-include-tests=0
 llvm-include-tests=0
 
+extra-swift-cmake-options=
+  -DSWIFT_STDLIB_BUILD_PRIVATE:BOOL=NO
 
 foundation
 libdispatch


### PR DESCRIPTION
We don't need to build the stdlib unittests as part of the bootstrap since we aren't running tests in the bootstrap steps. This should shave a couple minutes off of the bootstrapping times.