### PR TITLE
Disable tests that require arm64e slices for iOS sanitizers

### DIFF
--- a/test/Profiler/coverage_inlined_counters.swift
+++ b/test/Profiler/coverage_inlined_counters.swift
@@ -17,6 +17,7 @@
 // RUN: env SWIFT_USE_OLD_DRIVER=1 %target-build-swift %t/b.swift -profile-generate -profile-coverage-mapping -o %t/main -module-name B -I %t/out %t/out/a.swift.o
 
 // REQUIRES: profile_runtime
+// UNSUPPORTED: OS=ios && CPU=arm64e
 
 //--- a.swift
 @_transparent

--- a/validation-test/SILOptimizer/rdar133779160.swift
+++ b/validation-test/SILOptimizer/rdar133779160.swift
@@ -1,6 +1,7 @@
 // RUN: %target-build-swift %s -sanitize=thread
 
 // REQUIRES: tsan_runtime
+// UNSUPPORTED: OS=ios && CPU=arm64e
 
 class C {}
 func passC(_ b: consuming C) {


### PR DESCRIPTION
We started building iOS sanitizers when switching to `LLVM_ENABLE_RUNTIMES` to build compiler-rt, and turns out they currently provide only the arm64 slice.

Addresses rdar://151782340