### PR TITLE
[6.2][Driver] Add missing -default-isolation to the old driver

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -290,6 +290,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension_library);
   inputArgs.AddLastArg(arguments, options::OPT_enable_library_evolution);
+  inputArgs.AddLastArg(arguments, options::OPT_default_isolation);
+  inputArgs.AddLastArg(arguments, options::OPT_default_isolation_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_target);
   inputArgs.AddLastArg(arguments, options::OPT_require_explicit_availability_EQ);


### PR DESCRIPTION
- **Explanation**: Passes `-default-isolation` through to the frontend from the old driver (which sourcekitd is still using).
- **Scope**: Old driver (so really just sourcekitd)
- **Issues**: rdar://151643763
- **Original PRs**: https://github.com/swiftlang/swift/pull/81729
- **Risk**: Extremely low (if not none), just passes an existing flag through to the frontend (which is already the case for the new driver).
- **Testing**: Checked they are now passed through
- **Reviewers**: TBD