### PR TITLE
utils: make unify SDKSettings plist and json

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2284,15 +2284,6 @@ function Build-ExperimentalRuntime {
 
 function Write-SDKSettings([OS] $OS) {
   $SDKSettings = @{
-    DefaultProperties = @{
-    }
-  }
-  if ($OS -eq [OS]::Windows) {
-    $SDKSettings.DefaultProperties.DEFAULT_USE_RUNTIME = "MD"
-  }
-  Write-PList -Settings $SDKSettings -Path "$(Get-SwiftSDK $OS)\SDKSettings.plist"
-
-  $SDKSettings = @{
     CanonicalName = $OS.ToString().ToLowerInvariant()
     DisplayName = $OS.ToString()
     IsBaseSDK = "YES"
@@ -2328,6 +2319,7 @@ function Write-SDKSettings([OS] $OS) {
     }
   }
   $SDKSettings | ConvertTo-JSON -Depth 4 | Out-FIle -FilePath "$(Get-SwiftSDK $OS)\SDKSettings.json"
+  Write-PList -Settings $SDKSettings -Path "$(Get-SwiftSDK $OS)\SDKSettings.plist"
 }
 
 function Build-Dispatch([Hashtable] $Platform) {


### PR DESCRIPTION
Alter the PList and JSON to match contents. While the primary consumer for the PList is SPM, this synchronises the two just in case. This is in response to feedback from @jakepetroules.