### PR TITLE
[6.2] DeadStoreElimination: don't assume that the operand of an `dealloc_stack` is an `alloc_stack`.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/DeadStoreElimination.swift
@@ -256,7 +256,7 @@ private extension Deallocation {
 
 private extension DeallocStackInst {
   func isStackDeallocation(of base: AccessBase) -> Bool {
-    if case .stack(let allocStack) = base, allocstack == allocStack {
+    if case .stack(let allocStack) = base, operand.value == allocStack {
       return true
     }
     return false

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -647,11 +647,7 @@ extension Deallocation {
 }
 
 
-final public class DeallocStackInst : Instruction, UnaryInstruction, Deallocation {
-  public var allocstack: AllocStackInst {
-    return operand.value as! AllocStackInst
-  }
-}
+final public class DeallocStackInst : Instruction, UnaryInstruction, Deallocation {}
 
 final public class DeallocStackRefInst : Instruction, UnaryInstruction, Deallocation {
   public var allocRef: AllocRefInstBase { operand.value as! AllocRefInstBase }


### PR DESCRIPTION
* **Explanation**: This is a fix for a bug in DeadStoreElimination, which was there since a long time, but didn't get noticed because of a bug in IRGen (rdar://151462303), which let the program didn't trap when an unconditional cast fails. Now, as the IRGen bug is fixed, this caused a compiler crash when bootstrapping the compiler.
* **Risk**: Low. It is a simple, non-functional change
* **Testing**: Tested by lit tests.
* **Issue**: rdar://151822502, https://github.com/swiftlang/swift/issues/81698
* **Reviewer**:  @jckarter, @etcwilde
* **Main branch PR**: https://github.com/swiftlang/swift/pull/81717
