### PR TITLE
[cxx-interop] Ensure consistent checks for exportable fields

### DIFF
--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_IRGEN_STRUCTMETADATALAYOUT_H
 #define SWIFT_IRGEN_STRUCTMETADATALAYOUT_H
 
+#include "Field.h"
 #include "NominalMetadataVisitor.h"
 #include "swift/AST/IRGenOptions.h"
 
@@ -64,8 +65,7 @@ public:
     // Struct field offsets.
     asImpl().noteStartOfFieldOffsets();
     for (VarDecl *prop : Target->getStoredProperties()) {
-      if (!(prop->getClangDecl() &&
-            prop->getFormalAccess() == AccessLevel::Private))
+      if (isExportableField(prop))
         asImpl().addFieldOffset(prop);
     }
 


### PR DESCRIPTION
Small change requested [here](https://github.com/swiftlang/swift/pull/81740/files/d81d6547ba9d075b374e5d2514cc7373eb38fdf6#r2104328433) to make sure that we always go through `isExportableField` when determining if we should emit metadata for a field.

Follows https://github.com/swiftlang/swift/pull/81035