### PR TITLE
[6.2] Remove the note that suggests using `@unchecked`

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2771,9 +2771,6 @@ WARNING(remove_package_import,none,
 WARNING(public_decl_needs_sendable,none,
         "public %kind0 does not specify whether it is 'Sendable' or not",
         (const ValueDecl *))
-NOTE(explicit_unchecked_sendable,none,
-     "add '@unchecked Sendable' conformance to %kind0 if this type manually implements concurrency safety",
-     (const ValueDecl *))
 NOTE(explicit_disable_sendable,none,
      "make %kind0 explicitly non-Sendable to suppress this warning",
      (const ValueDecl *))

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1386,35 +1386,34 @@ void swift::diagnoseMissingExplicitSendable(NominalTypeDecl *nominal) {
         isUnchecked = true;
     }
 
-    auto note = nominal->diagnose(
-        isUnchecked ? diag::explicit_unchecked_sendable
-                    : diag::add_nominal_sendable_conformance,
-        nominal);
-    if (canMakeSendable && !requirements.empty()) {
-      // Produce a Fix-It containing a conditional conformance to Sendable,
-      // based on the requirements harvested from instance storage.
+    // If we can only make the type Sendable via @unchecked, don't provide a Fix-It.
+    if (!isUnchecked) {
+      auto note = nominal->diagnose(diag::add_nominal_sendable_conformance, nominal);
+      if (canMakeSendable && !requirements.empty()) {
+        // Produce a Fix-It containing a conditional conformance to Sendable,
+        // based on the requirements harvested from instance storage.
 
-      // Form the where clause containing all of the requirements.
-      SmallString<64> whereClause;
-      {
-        llvm::raw_svector_ostream out(whereClause);
-        llvm::interleaveComma(
-            requirements, out,
-            [&](const Requirement &req) {
-              out << req.getFirstType().getString() << ": "
-                  << req.getSecondType().getString();
-            });
+        // Form the where clause containing all of the requirements.
+        SmallString<64> whereClause;
+        {
+          llvm::raw_svector_ostream out(whereClause);
+          llvm::interleaveComma(
+              requirements, out,
+              [&](const Requirement &req) {
+                out << req.getFirstType().getString() << ": "
+                    << req.getSecondType().getString();
+              });
+        }
+
+        // Add a Fix-It containing the conditional extension text itself.
+        auto insertionLoc = nominal->getBraces().End;
+        note.fixItInsertAfter(
+            insertionLoc,
+            ("\n\nextension " + nominal->getName().str() + ": "
+             + "Sendable where " + whereClause + " { }\n").str());
+      } else {
+        addSendableFixIt(nominal, note, isUnchecked);
       }
-
-      // Add a Fix-It containing the conditional extension text itself.
-      auto insertionLoc = nominal->getBraces().End;
-      note.fixItInsertAfter(
-          insertionLoc,
-          ("\n\nextension " + nominal->getName().str() + ": "
-           + (isUnchecked? "@unchecked " : "") + "Sendable where " +
-           whereClause + " { }\n").str());
-    } else {
-      addSendableFixIt(nominal, note, isUnchecked);
     }
   }
 

--- a/test/Concurrency/objc_require_explicit_sendable.swift
+++ b/test/Concurrency/objc_require_explicit_sendable.swift
@@ -15,5 +15,4 @@ open class Y: X { }
 
 
 open class Z: NSObject { } // expected-warning{{public class 'Z' does not specify whether it is 'Sendable' or not}}
-// expected-note@-1{{add '@unchecked Sendable' conformance to class 'Z' if this type manually implements concurrency safety}}
-// expected-note@-2{{make class 'Z' explicitly non-Sendable to suppress this warning}}
+// expected-note@-1{{make class 'Z' explicitly non-Sendable to suppress this warning}}

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -13,7 +13,6 @@ public struct S1 { // expected-warning{{public struct 'S1' does not specify whet
 
 class C { }
 
-// expected-note@+2{{add '@unchecked Sendable' conformance to struct 'S2' if this type manually implements concurrency safety}}{{18-18=: @unchecked Sendable}}
 // expected-note@+1{{make struct 'S2' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension S2: Sendable { \}\n}}
 public struct S2 { // expected-warning{{public struct 'S2' does not specify whether it is 'Sendable' or not}}
   var c: C
@@ -25,7 +24,6 @@ final public class C1: P { // expected-warning{{public class 'C1' does not speci
   let str: String = ""
 }
 
-// expected-note@+2{{add '@unchecked Sendable' conformance to class 'C2' if this type manually implements concurrency safety}}{{17-17=: @unchecked Sendable}}
 // expected-note@+1{{make class 'C2' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension C2: Sendable { \}\n}}
 public class C2 { // expected-warning{{public class 'C2' does not specify whether it is 'Sendable' or not}}
   var str: String = ""
@@ -37,7 +35,6 @@ public struct S3<T> { // expected-warning{{public generic struct 'S3' does not s
   var t: T
 }
 
-// expected-note@+2{{add '@unchecked Sendable' conformance to generic struct 'S4' if this type manually implements concurrency safety}}{{+3:2-2=\n\nextension S4: @unchecked Sendable where T: Sendable { \}\n}}
 // expected-note@+1{{make generic struct 'S4' explicitly non-Sendable to suppress this warning}}{{+3:2-2=\n\n@available(*, unavailable)\nextension S4: Sendable { \}\n}}
 public struct S4<T> { // expected-warning{{public generic struct 'S4' does not specify whether it is 'Sendable' or not}}
   var t: T
@@ -92,8 +89,7 @@ public struct S9<T: P2 & Hashable> {
 }
 
 public struct S10 { // expected-warning{{public struct 'S10' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{add '@unchecked Sendable' conformance to struct 'S10' if this type manually implements concurrency safety}}
-  // expected-note@-2{{make struct 'S10' explicitly non-Sendable to suppress this warning}}
+  // expected-note@-1{{make struct 'S10' explicitly non-Sendable to suppress this warning}}
   var s7: S7
 }
 


### PR DESCRIPTION
- **Explanation**: A concurrency error about a non-`Sendable` type would suggest `@unchecked Sendable` with a Fix-It. This is almost always a bad idea, so stop suggesting it.
- **Scope**: Narrow. Removes a note associated with an existing diagnostic.
- **Original PRs**: https://github.com/swiftlang/swift/pull/81738
- **Risk**: Very low. Only removes a note.
- **Testing**: CI
