### PR TITLE
[6.2] Make `InferIsolatedConformances` and `StrictMemorySafety` migratable features

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8545,6 +8545,9 @@ GROUPED_ERROR(isolated_conformance_with_sendable_simple,IsolatedConformances,
 GROUPED_ERROR(isolated_conformance_wrong_domain,IsolatedConformances,none,
       "%0 conformance of %1 to %2 cannot be used in %3 context",
       (ActorIsolation, Type, DeclName, ActorIsolation))
+GROUPED_WARNING(isolated_conformance_will_become_nonisolated,IsolatedConformances,none,
+      "conformance of %0 to %1 should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'",
+      (const ValueDecl *, const ValueDecl *))
 
 //===----------------------------------------------------------------------===//
 // MARK: @_inheritActorContext

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -155,6 +155,11 @@
   #endif
 #endif
 
+#ifndef MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE
+  #define MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, Name)   \
+      OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, #Name)
+#endif
+
 #ifndef UPCOMING_FEATURE
   #define UPCOMING_FEATURE(FeatureName, SENumber, Version)                     \
     LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName)
@@ -290,7 +295,7 @@ MIGRATABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
 
 /// Diagnose uses of language constructs and APIs that can violate memory
 /// safety.
-OPTIONAL_LANGUAGE_FEATURE(StrictMemorySafety, 458, "Strict memory safety")
+MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE(StrictMemorySafety, 458, "Strict memory safety")
 
 // Experimental features
 
@@ -522,6 +527,7 @@ EXPERIMENTAL_FEATURE(CopyBlockOptimization, true)
 #undef UPCOMING_FEATURE
 #undef MIGRATABLE_UPCOMING_FEATURE
 #undef MIGRATABLE_EXPERIMENTAL_FEATURE
+#undef MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE
 #undef BASELINE_LANGUAGE_FEATURE
 #undef OPTIONAL_LANGUAGE_FEATURE
 #undef CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -283,7 +283,7 @@ UPCOMING_FEATURE(GlobalActorIsolatedTypesUsability, 0434, 6)
 MIGRATABLE_UPCOMING_FEATURE(ExistentialAny, 335, 7)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 7)
 UPCOMING_FEATURE(MemberImportVisibility, 444, 7)
-UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
+MIGRATABLE_UPCOMING_FEATURE(InferIsolatedConformances, 470, 7)
 MIGRATABLE_UPCOMING_FEATURE(NonisolatedNonsendingByDefault, 461, 7)
 
 // Optional language features / modes

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -872,7 +872,9 @@ namespace swift {
     FeatureState getFeatureState(Feature feature) const;
 
     /// Returns whether the given feature is enabled.
-    bool hasFeature(Feature feature) const;
+    ///
+    /// If allowMigration is set, also returns true when the feature has been enabled for migration.
+    bool hasFeature(Feature feature, bool allowMigration = false) const;
 
     /// Returns whether a feature with the given name is enabled. Returns
     /// `false` if a feature by this name is not known.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1018,6 +1018,10 @@ def strict_memory_safety : Flag<["-"], "strict-memory-safety">,
   Flags<[FrontendOption, ModuleInterfaceOptionIgnorable,
          SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
   HelpText<"Enable strict memory safety checking">;
+def strict_memory_safety_migrate : Flag<["-"], "strict-memory-safety:migrate">,
+  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable,
+         SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
+  HelpText<"Enable migration to strict memory safety checking">;
 
 def Rpass_EQ : Joined<["-"], "Rpass=">,
   Flags<[FrontendOption]>,

--- a/lib/Basic/Feature.cpp
+++ b/lib/Basic/Feature.cpp
@@ -73,6 +73,7 @@ bool Feature::isMigratable() const {
   switch (kind) {
 #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)
 #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
+#define MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, Name)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
   case Feature::FeatureName:
 #include "swift/Basic/Features.def"
@@ -81,6 +82,8 @@ bool Feature::isMigratable() const {
 #define MIGRATABLE_UPCOMING_FEATURE(FeatureName, SENumber, Version)            \
   case Feature::FeatureName:
 #define MIGRATABLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)          \
+  case Feature::FeatureName:
+#define MIGRATABLE_OPTIONAL_LANGUAGE_FEATURE(FeatureName, SENumber, Name)      \
   case Feature::FeatureName:
 #include "swift/Basic/Features.def"
     return true;

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -335,12 +335,16 @@ LangOptions::FeatureState LangOptions::getFeatureState(Feature feature) const {
   return state;
 }
 
-bool LangOptions::hasFeature(Feature feature) const {
-  if (featureStates.getState(feature).isEnabled())
+bool LangOptions::hasFeature(Feature feature, bool allowMigration) const {
+  auto state = featureStates.getState(feature);
+  if (state.isEnabled())
     return true;
 
   if (auto version = feature.getLanguageVersion())
     return isSwiftVersionAtLeast(*version);
+
+  if (allowMigration && state.isEnabledForMigration())
+    return true;
 
   return false;
 }

--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -52,7 +52,7 @@ void printSupportedFeatures(llvm::raw_ostream &out) {
       out << ", \"migratable\": true";
     }
     if (auto version = feature.getLanguageVersion()) {
-      out << ", \"enabled_in\": " << *version;
+      out << ", \"enabled_in\": \"" << *version << "\"";
     }
     out << " }";
   };

--- a/lib/Basic/SupportedFeatures.cpp
+++ b/lib/Basic/SupportedFeatures.cpp
@@ -27,7 +27,8 @@ namespace features {
 /// The subset of diagnostic groups (called categories by the diagnostic machinery) whose diagnostics should be
 /// considered to be part of the migration for this feature.
 ///
-///  When making a
+///  When making a feature migratable, ensure that all of the warnings that are used to drive the migration are
+///  part of a diagnostic group, and put that diagnostic group into the list for that feature here.
 static std::vector<DiagGroupID> migratableCategories(Feature feature) {
   switch (feature) {
     case Feature::InnerKind::ExistentialAny:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -284,7 +284,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
                                    options::OPT_disable_experimental_feature,
                                    options::OPT_enable_upcoming_feature,
                                    options::OPT_disable_upcoming_feature});
-  inputArgs.AddLastArg(arguments, options::OPT_strict_memory_safety);
+  inputArgs.AddLastArg(arguments, options::OPT_strict_memory_safety,
+                       options::OPT_strict_memory_safety_migrate);
   inputArgs.AddLastArg(arguments, options::OPT_warn_implicit_overrides);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -965,6 +965,8 @@ static bool ParseEnabledFeatureArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_strict_memory_safety))
     Opts.enableFeature(Feature::StrictMemorySafety);
+  else if (Args.hasArg(OPT_strict_memory_safety_migrate))
+    Opts.enableFeature(Feature::StrictMemorySafety, /*forMigration=*/true);
 
   return HadError;
 }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8172,7 +8172,7 @@ Expr *ExprRewriter::convertLiteralInPlace(
     Diag<> brokenProtocolDiag, Diag<> brokenBuiltinProtocolDiag) {
   // If coercing a literal to an unresolved type, we don't try to look up the
   // witness members, just do it.
-  if (type->is<UnresolvedType>()) {
+  if (type->is<UnresolvedType>() || type->is<ErrorType>()) {
     cs.setType(literal, type);
     return literal;
   }

--- a/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceDistributedActor.cpp
@@ -171,7 +171,7 @@ deriveBodyDistributed_doInvokeOnReturn(AbstractFunctionDecl *afd, void *arg) {
                          new (C) DeclRefExpr(ConcreteDeclRef(returnTypeParam),
                                              dloc, implicit))}));
 
-    if (C.LangOpts.hasFeature(Feature::StrictMemorySafety))
+    if (C.LangOpts.hasFeature(Feature::StrictMemorySafety, /*allowMigration=*/true))
       resultLoadCall = new (C) UnsafeExpr(sloc, resultLoadCall, Type(), true);
 
     auto resultPattern = NamedPattern::createImplicit(C, resultVar);

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -106,7 +106,7 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
     auto *argList = ArgumentList::forImplicitCallTo(functionRef->getName(),
                                                     {selfRef, typeExpr}, C);
     Expr *call = CallExpr::createImplicit(C, functionRef, argList);
-    if (C.LangOpts.hasFeature(Feature::StrictMemorySafety))
+    if (C.LangOpts.hasFeature(Feature::StrictMemorySafety, /*allowMigration=*/true))
       call = UnsafeExpr::createImplicit(C, SourceLoc(), call);
     auto *returnStmt = ReturnStmt::createImplicit(C, call);
     auto body = BraceStmt::create(C, SourceLoc(), ASTNode(returnStmt),

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2262,7 +2262,7 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
     diagnoseOverrideForAvailability(override, base);
   }
 
-  if (ctx.LangOpts.hasFeature(Feature::StrictMemorySafety)) {
+  if (ctx.LangOpts.hasFeature(Feature::StrictMemorySafety, /*allowMigration=*/true)) {
     // If the override is unsafe but the base declaration is not, then the
     // inheritance itself is unsafe.
     auto subs = SubstitutionMap::getOverrideSubstitutions(base, override);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2430,7 +2430,8 @@ public:
 
         // If strict memory safety checking is enabled, check the storage
         // of the nominal type.
-        if (Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety) &&
+        if (Ctx.LangOpts.hasFeature(
+                Feature::StrictMemorySafety, /*allowMigration=*/true) &&
             !isa<ProtocolDecl>(nominal)) {
           checkUnsafeStorage(nominal);
         }

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1187,8 +1187,7 @@ public:
     Classification result;
     bool considerAsync = !onlyEffect || *onlyEffect == EffectKind::Async;
     bool considerThrows = !onlyEffect || *onlyEffect == EffectKind::Throws;
-    bool considerUnsafe = (!onlyEffect || *onlyEffect == EffectKind::Unsafe) &&
-        ctx.LangOpts.hasFeature(Feature::StrictMemorySafety);
+    bool considerUnsafe = (!onlyEffect || *onlyEffect == EffectKind::Unsafe);
 
     // If we're tracking "unsafe" effects, compute them here.
     if (considerUnsafe) {
@@ -1710,8 +1709,7 @@ public:
         !fnType->isAsync() &&
         !E->isImplicitlyAsync() &&
         !hasAnyConformances &&
-        (fnRef.getExplicitSafety() == ExplicitSafety::Safe ||
-         !ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))) {
+        fnRef.getExplicitSafety() == ExplicitSafety::Safe) {
       return Classification();
     }
 
@@ -1932,7 +1930,6 @@ public:
     // If the safety of the callee is unspecified, check the safety of the
     // arguments specifically.
     if (hasUnspecifiedSafety &&
-        ctx.LangOpts.hasFeature(Feature::StrictMemorySafety) &&
         !(assumedSafeArguments && assumedSafeArguments->contains(E))) {
       classifyApplyEffect(EffectKind::Unsafe);
     }
@@ -4559,8 +4556,7 @@ private:
         Ctx.Diags.diagnose(S->getForLoc(), diag::for_unsafe_without_unsafe)
           .fixItInsert(insertionLoc, "unsafe ");
       }
-    } else if (S->getUnsafeLoc().isValid() &&
-               Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety)) {
+    } else if (S->getUnsafeLoc().isValid()) {
       // Extraneous "unsafe" on the sequence.
       Ctx.Diags.diagnose(S->getUnsafeLoc(), diag::no_unsafe_in_unsafe_for)
         .fixItRemove(S->getUnsafeLoc());
@@ -4605,9 +4601,6 @@ private:
   }
 
   void diagnoseRedundantUnsafe(UnsafeExpr *E) const {
-    if (!Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
-      return;
-
     // Silence this warning in the expansion of the _SwiftifyImport macro.
     // This is a hack because it's tricky to determine when to insert "unsafe".
     unsigned bufferID =

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4553,7 +4553,8 @@ private:
     if (classification.hasUnsafe()) {
       // If there is no such effect, complain.
       if (S->getUnsafeLoc().isInvalid() &&
-          Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety)) {
+          Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety,
+                                  /*allowMigration=*/true)) {
         auto insertionLoc = S->getPattern()->getStartLoc();
         Ctx.Diags.diagnose(S->getForLoc(), diag::for_unsafe_without_unsafe)
           .fixItInsert(insertionLoc, "unsafe ");
@@ -4880,7 +4881,7 @@ private:
 
   void diagnoseUncoveredUnsafeSite(
       const Expr *anchor, ArrayRef<UnsafeUse> unsafeUses) {
-    if (!Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
+    if (!Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety, /*allowMigration=*/true))
       return;
 
     const auto &[loc, insertText] = getFixItForUncoveredSite(anchor, "unsafe");

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2650,7 +2650,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
   // If we're enforcing strict memory safety and this conformance hasn't
   // opted out, look for safe/unsafe witness mismatches.
   if (conformance->getExplicitSafety() == ExplicitSafety::Unspecified &&
-      Context.LangOpts.hasFeature(Feature::StrictMemorySafety)) {
+      Context.LangOpts.hasFeature(Feature::StrictMemorySafety,
+                                  /*allowMigration=*/true)) {
     // Collect all of the unsafe uses for this conformance.
     SmallVector<UnsafeUse, 2> unsafeUses;
     for (auto requirement: Proto->getMembers()) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -6668,6 +6668,49 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
     }
   }
 
+  // If we are migrating to InferIsolatedConformances, and the
+  // nominal type is global-actor-isolated, look for conformances
+  // that are nonisolated but were not explicitly marked as such.
+  // These conformances will need to be marked 'nonisolated' to
+  // retain their current behavior.
+  if (Context.LangOpts
+          .getFeatureState(Feature::InferIsolatedConformances)
+            .isEnabledForMigration() &&
+      getActorIsolation(const_cast<NominalTypeDecl *>(nominal))
+          .isGlobalActor()) {
+    for (auto conformance : conformances) {
+      auto normal = dyn_cast<NormalProtocolConformance>(conformance);
+      if (!normal)
+        continue;
+
+      // Explicit nonisolated and @preconcurrency suppress this.
+      auto options = normal->getOptions();
+      if (options.contains(ProtocolConformanceFlags::Nonisolated) ||
+          options.contains(ProtocolConformanceFlags::Preconcurrency))
+        continue;
+
+      // Only consider conformances that were explicitly written in the source.
+      if (normal->getSourceKind() != ConformanceEntryKind::Explicit)
+        continue;
+
+      // Only consider conformances to non-marker, nonisolated protocols.
+      auto proto = normal->getProtocol();
+      if (proto->isMarkerProtocol() || getActorIsolation(proto).isActorIsolated())
+        continue;
+
+      // Only nonisolated conformances can be affected.
+      if (!conformance->getIsolation().isNonisolated())
+        continue;
+
+      auto nameLoc = normal->getProtocolNameLoc();
+      if (nameLoc.isValid()) {
+        Context.Diags.diagnose(
+            nameLoc, diag::isolated_conformance_will_become_nonisolated, nominal, proto)
+          .fixItInsert(nameLoc, "nonisolated ");
+      }
+    }
+  }
+
   if (Context.TypeCheckerOpts.DebugGenericSignatures &&
       !conformances.empty()) {
     // Now that they're filled out, print out information about the conformances

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -341,10 +341,6 @@ bool swift::enumerateUnsafeUses(ArrayRef<ProtocolConformanceRef> conformances,
     if (conformance.isInvalid())
       continue;
 
-    ASTContext &ctx = conformance.getProtocol()->getASTContext();
-    if (!ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
-      return false;
-
     if (!conformance.hasEffect(EffectKind::Unsafe))
       continue;
 
@@ -413,9 +409,6 @@ bool swift::isUnsafeInConformance(const ValueDecl *requirement,
 
 void swift::diagnoseUnsafeType(ASTContext &ctx, SourceLoc loc, Type type,
                                llvm::function_ref<void(Type)> diagnose) {
-  if (!ctx.LangOpts.hasFeature(Feature::StrictMemorySafety))
-    return;
-
   if (!type->isUnsafe())
     return;
 

--- a/test/Concurrency/isolated_conformance_migrate.swift
+++ b/test/Concurrency/isolated_conformance_migrate.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature InferIsolatedConformances:migrate %s
+
+// REQUIRES: concurrency
+
+
+protocol P { }
+protocol Q: P { }
+
+struct S: P { }
+
+struct S2: Q { }
+
+@MainActor
+struct MA1: P { }
+// expected-warning@-1{{conformance of 'MA1' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{13-13=nonisolated }}
+
+@MainActor
+struct MA2: Q { }
+// expected-warning@-1{{conformance of 'MA2' to 'Q' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{13-13=nonisolated }}
+
+@MainActor
+struct MA3 { }
+
+extension MA3: P, Q { }
+// expected-warning@-1{{conformance of 'MA3' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{16-16=nonisolated }}
+// expected-warning@-2{{conformance of 'MA3' to 'Q' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{19-19=nonisolated }}
+
+@MainActor
+struct MA4: @MainActor P { }
+
+@MainActor
+struct MA5: nonisolated P { }
+

--- a/test/Concurrency/isolated_conformance_migrate.swift
+++ b/test/Concurrency/isolated_conformance_migrate.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 -enable-upcoming-feature InferIsolatedConformances:migrate %s
 
 // REQUIRES: concurrency
-
+// REQUIRES: swift_feature_InferIsolatedConformances
 
 protocol P { }
 protocol Q: P { }

--- a/test/Constraints/issue-66553.swift
+++ b/test/Constraints/issue-66553.swift
@@ -4,7 +4,7 @@
 
 func baz(y: [Int], z: Int) -> Int {
   switch z {
-  case y[let z]: // expected-error {{'let' binding pattern cannot appear in an expression}}
+  case y[let z]: // expected-error 2{{'let' binding pattern cannot appear in an expression}}
     z
   default:
     z

--- a/test/Frontend/print-supported-features.swift
+++ b/test/Frontend/print-supported-features.swift
@@ -2,7 +2,7 @@
 
 // CHECK: "features": {
 // CHECK-NEXT:   "upcoming": [
-// CHECK:     { "name": "{{.*}}"{{, "migratable": true}}, "enabled_in": {{[0-9]+}} }
+// CHECK:     { "name": "{{.*}}"{{, "migratable": true}}, "enabled_in": "{{.*}}" }
 // CHECK:   ],
 // CHECK-NEXT:   "experimental": [
 // CHECK:     { "name": "{{.*}}" }

--- a/test/Frontend/print-supported-features.swift
+++ b/test/Frontend/print-supported-features.swift
@@ -2,9 +2,9 @@
 
 // CHECK: "features": {
 // CHECK-NEXT:   "upcoming": [
-// CHECK:     { "name": "{{.*}}"{{, "migratable": true}}, "enabled_in": "{{.*}}" }
+// CHECK:     { "name": "InferIsolatedConformances", "migratable": true, "categories": ["IsolatedConformances"], "enabled_in": "7" },
 // CHECK:   ],
-// CHECK-NEXT:   "experimental": [
+// CHECK:   "experimental": [
 // CHECK:     { "name": "{{.*}}" }
 // CHECK:   ]
 // CHECK: }

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -406,7 +406,7 @@ func testNonBinding5(_ x: Int, y: [Int]) {
 func testNonBinding6(y: [Int], z: Int) -> Int {
   switch 0 {
   // We treat 'z' here as a binding, which is invalid.
-  case let y[z]: // expected-error {{pattern variable binding cannot appear in an expression}}
+  case let y[z]: // expected-error 2{{pattern variable binding cannot appear in an expression}}
     z
   case y[z]: // This is fine
     0

--- a/test/Unsafe/migrate.swift
+++ b/test/Unsafe/migrate.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 6 -strict-memory-safety:migrate %s
+
+// REQUIRES: concurrency
+
+@preconcurrency import _Concurrency
+
+@unsafe func f() { }
+
+func g() {
+  f() // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{3-3=unsafe }}
+  // expected-note@-1{{reference to unsafe global function 'f()'}}
+}
+
+protocol P {
+  func f()
+}
+
+struct Conforming: P {
+  // expected-warning@-1{{conformance of 'Conforming' to protocol 'P' involves unsafe code; use '@unsafe' to indicate that the conformance is not memory-safe}}{{20-20=@unsafe }}
+  @unsafe func f() { } // expected-note{{unsafe instance method 'f()' cannot satisfy safe requirement}}
+}

--- a/test/Unsafe/unsafe_nonstrict.swift
+++ b/test/Unsafe/unsafe_nonstrict.swift
@@ -14,5 +14,5 @@ func acceptP<T: P>(_: T) { }
 func testItAll(ut: UnsafeType, x: X, i: Int) {
   _ = unsafe ut
   unsafe acceptP(x)
-  _ = unsafe i
+  _ = unsafe i // expected-warning{{no unsafe operations occur within 'unsafe' expression}}
 }

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -361,11 +361,11 @@ func testSequenceExpr() async throws(Never) {
 
   _ = unsafe await try! getIntAsync() + getIntAsync()
   // expected-warning@-1 {{'try' must precede 'await'}}
-
+  // expected-warning@-2{{no unsafe operations occur within 'unsafe' expression}}
   _ = try unsafe await try! getIntAsync() + getIntAsync()
   // expected-warning@-1 {{'try' must precede 'await'}}
   // expected-warning@-2 {{no calls to throwing functions occur within 'try' expression}}
-
+  // expected-warning@-3{{no unsafe operations occur within 'unsafe' expression}}
   try _ = (try! getInt()) + getInt()
   // expected-error@-1:29 {{thrown expression type 'any Error' cannot be converted to error type 'Never'}}
 


### PR DESCRIPTION
- **Explanation**: Both InferIsolatedConformances and StrictMemorySafety have an automatable migration path. Make both into migratable features. 
- **Scope**: Limited to these two features, behind the migration flags.
- **Issues**: rdar://151925275 & rdar://151925332
- **Original PRs**: https://github.com/swiftlang/swift/pull/81703
- **Risk**: Low. Only enabled by new compilation flags, only create new warnings or re-use existing ones.
- **Testing**: CI, here and for SwiftPM
- **Reviewers**: @xedin 
