### PR TITLE
utils: fix summary emission with caching

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -539,7 +539,7 @@ function Write-Summary {
 
   if ($EnableCaching) {
     Write-Host "SCCache:" -ForegroundColor Green
-    & sccache.exe --show-stats
+    Invoke-Program (Get-SCCache).Path --show-stats
   }
 
   $TotalTime = [TimeSpan]::Zero


### PR DESCRIPTION
This updates the SCCache invocation for the summary printing which needs to be adjusted for the use of the downloaded sccache.