### PR TITLE
[Swiftify] Support __sized_by on byte-sized pointee types

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9145,16 +9145,38 @@ struct CountedByExpressionValidator
 };
 } // namespace
 
-static bool SwiftifiableCAT(const clang::CountAttributedType *CAT) {
-  return CAT && CountedByExpressionValidator().Visit(CAT->getCountExpr());
-}
-
-static bool SwiftifiablePointerType(Type swiftType) {
-  // don't try to transform any Swift types that _SwiftifyImport doesn't know how to handle
+// don't try to transform any Swift types that _SwiftifyImport doesn't know how to handle
+static bool SwiftifiableCountedByPointerType(Type swiftType) {
   Type nonnullType = swiftType->lookThroughSingleOptionalType();
   PointerTypeKind PTK;
-  return nonnullType->isOpaquePointer() ||
-    (nonnullType->getAnyPointerElementType(PTK) && PTK != PTK_AutoreleasingUnsafeMutablePointer);
+  return nonnullType->getAnyPointerElementType(PTK) &&
+    (PTK == PTK_UnsafePointer || PTK == PTK_UnsafeMutablePointer);
+}
+static bool SwiftifiableSizedByPointerType(const clang::ASTContext &ctx,
+                                           Type swiftType,
+                                           const clang::CountAttributedType *CAT) {
+  Type nonnullType = swiftType->lookThroughSingleOptionalType();
+  if (nonnullType->isOpaquePointer())
+    return true;
+  PointerTypeKind PTK;
+  if (!nonnullType->getAnyPointerElementType(PTK))
+    return false;
+  if (PTK == PTK_UnsafeRawPointer || PTK == PTK_UnsafeMutableRawPointer)
+    return true;
+  if (PTK != PTK_UnsafePointer && PTK != PTK_UnsafeMutablePointer)
+    return false;
+  // We have a pointer to a type with a size. Verify that it is char-sized.
+  auto PtrT = CAT->getAs<clang::PointerType>();
+  auto PointeeT = PtrT->getPointeeType();
+  return ctx.getTypeSizeInChars(PointeeT).isOne();
+}
+static bool SwiftifiableCAT(const clang::ASTContext &ctx,
+                            const clang::CountAttributedType *CAT,
+                            Type swiftType) {
+  return CAT && CountedByExpressionValidator().Visit(CAT->getCountExpr()) &&
+    (CAT->isCountInBytes() ?
+       SwiftifiableSizedByPointerType(ctx, swiftType, CAT)
+     : SwiftifiableCountedByPointerType(swiftType));
 }
 
 void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
@@ -9194,7 +9216,7 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
     bool returnIsStdSpan = registerStdSpanTypeMapping(
         swiftReturnTy, ClangDecl->getReturnType());
     auto *CAT = ClangDecl->getReturnType()->getAs<clang::CountAttributedType>();
-    if (SwiftifiableCAT(CAT) && SwiftifiablePointerType(swiftReturnTy)) {
+    if (SwiftifiableCAT(getClangASTContext(), CAT, swiftReturnTy)) {
       printer.printCountedBy(CAT, SwiftifyInfoPrinter::RETURN_VALUE_INDEX);
       attachMacro = true;
     }
@@ -9211,7 +9233,7 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
       Type swiftParamTy = swiftParam->getInterfaceType();
       bool paramHasBoundsInfo = false;
       auto *CAT = clangParamTy->getAs<clang::CountAttributedType>();
-      if (SwiftifiableCAT(CAT) && SwiftifiablePointerType(swiftParamTy)) {
+      if (SwiftifiableCAT(getClangASTContext(), CAT, swiftParamTy)) {
         printer.printCountedBy(CAT, index);
         attachMacro = paramHasBoundsInfo = true;
       }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9145,7 +9145,8 @@ struct CountedByExpressionValidator
 };
 } // namespace
 
-// don't try to transform any Swift types that _SwiftifyImport doesn't know how to handle
+// Don't try to transform any Swift types that _SwiftifyImport doesn't know how
+// to handle.
 static bool SwiftifiableCountedByPointerType(Type swiftType) {
   Type nonnullType = swiftType->lookThroughSingleOptionalType();
   PointerTypeKind PTK;

--- a/test/Interop/C/swiftify-import/Inputs/sized-by-lifetimebound.h
+++ b/test/Interop/C/swiftify-import/Inputs/sized-by-lifetimebound.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <stdint.h>
+
+#ifndef __sized_by
 #define __sized_by(x) __attribute__((__sized_by__(x)))
+#endif
 #define __lifetimebound __attribute__((lifetimebound))
 
 const void * __sized_by(len) simple(int len, int len2, const void * __sized_by(len2) __lifetimebound p);
@@ -19,3 +23,9 @@ typedef struct foo opaque_t;
 opaque_t * __sized_by(len) opaque(int len, int len2, opaque_t * __sized_by(len2) __lifetimebound p);
 
 const void * __sized_by(len) nonsizedLifetime(int len, const void * __lifetimebound p);
+
+uint8_t *__sized_by(size)  bytesized(int size, const uint8_t *__sized_by(size) __lifetimebound);
+
+char *__sized_by(size) charsized(char *__sized_by(size) __lifetimebound, int size);
+
+const uint16_t *__sized_by(size)  doublebytesized(uint16_t *__sized_by(size) __lifetimebound, int size);

--- a/test/Interop/C/swiftify-import/Inputs/sized-by-noescape.h
+++ b/test/Interop/C/swiftify-import/Inputs/sized-by-noescape.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #define __sized_by(x) __attribute__((__sized_by__(x)))
 #define __noescape __attribute__((noescape))
 
@@ -23,3 +25,8 @@ const void * __sized_by(len) __noescape _Nonnull returnPointer(int len);
 typedef struct foo opaque_t;
 void opaque(int len, opaque_t * __sized_by(len) __noescape p);
 
+void bytesized(int size, const uint8_t *__sized_by(size) __noescape);
+
+void charsized(char *__sized_by(size) __noescape, int size);
+
+void doublebytesized(uint16_t *__sized_by(size) __noescape, int size);

--- a/test/Interop/C/swiftify-import/Inputs/sized-by.h
+++ b/test/Interop/C/swiftify-import/Inputs/sized-by.h
@@ -2,7 +2,9 @@
 
 #include <stdint.h>
 
+#ifndef __sized_by
 #define __sized_by(x) __attribute__((__sized_by__(x)))
+#endif
 
 void simple(int len, void * __sized_by(len) p);
 
@@ -24,8 +26,14 @@ void * __sized_by(len) returnPointer(int len);
 typedef struct foo opaque_t;
 void opaque(int len, opaque_t * __sized_by(len) p);
 
+typedef opaque_t *opaqueptr_t;
+void opaqueptr(int len, opaqueptr_t __sized_by(len) p);
+
 void charsized(char *__sized_by(size), int size);
 
 uint8_t *__sized_by(size) bytesized(int size);
 
 void doublebytesized(uint16_t *__sized_by(size), int size);
+
+typedef uint8_t * bytesizedptr_t;
+void aliasedBytesized(bytesizedptr_t __sized_by(size) p, int size);

--- a/test/Interop/C/swiftify-import/Inputs/sized-by.h
+++ b/test/Interop/C/swiftify-import/Inputs/sized-by.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #define __sized_by(x) __attribute__((__sized_by__(x)))
 
 void simple(int len, void * __sized_by(len) p);
@@ -21,3 +23,9 @@ void * __sized_by(len) returnPointer(int len);
 
 typedef struct foo opaque_t;
 void opaque(int len, opaque_t * __sized_by(len) p);
+
+void charsized(char *__sized_by(size), int size);
+
+uint8_t *__sized_by(size) bytesized(int size);
+
+void doublebytesized(uint16_t *__sized_by(size), int size);

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_LifetimeDependence
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByLifetimeboundClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByLifetimeboundClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByLifetimebound.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByLifetimebound.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __lifetimebound parameters and return values.
 
@@ -98,7 +98,7 @@ public func callSimple(_ p: inout MutableSpan<CInt>) {
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callNoncountedLifetime(_ p: UnsafeMutablePointer<CInt>) {
-  let _: MutableSpan<CInt> = noncountedLifetime(73, p)
+  let _: MutableSpan<CInt> = unsafe noncountedLifetime(73, p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/counted-by-no-swiftify.swift
+++ b/test/Interop/C/swiftify-import/counted-by-no-swiftify.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // REQUIRES: swift_feature_SafeInteropWrappers
 

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_LifetimeDependence
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by __noescape parameters.
 
@@ -150,14 +150,14 @@ public func callNullable(_ p: inout MutableSpan<CInt>?) {
 @lifetime(p: copy p)
 @inlinable
 public func callReturnLifetimeBound(_ p: inout MutableSpan<CInt>) {
-  let a: MutableSpan<CInt> = returnLifetimeBound(2, &p)
+  let _: MutableSpan<CInt> = returnLifetimeBound(2, &p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callReturnPointer() {
-  let a: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
-  let b: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
+  let _: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
+  let _: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
@@ -207,7 +207,7 @@ public func callFunc(_ p: inout MutableSpan<CInt>?) {
 @lifetime(p: copy p)
 @inlinable
 public func callFuncRenameKeyword(_ p: inout MutableSpan<CInt>?) {
-  funcRenamed(func: &p, extension: 1, init: 2, open: 3, var: 4, is: 5, as: 6, in: 7, guard: 8, where: 9)
+  let _ = funcRenamed(func: &p, extension: 1, init: 2, open: 3, var: 4, is: 5, as: 6, in: 7, guard: 8, where: 9)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedBy.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedBy.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by parameters.
 
@@ -67,73 +67,73 @@ import CountedByClang
 
 @inlinable
 public func callComplexExpr(_ p: UnsafeMutableBufferPointer<CInt>) {
-  complexExpr(CInt(p.count), 1, p)
+  unsafe complexExpr(CInt(p.count), 1, p)
 }
 
 @inlinable
 public func callConstInt(_ p: UnsafeMutableBufferPointer<CInt>) {
-  constInt(p)
+  unsafe constInt(p)
 }
 
 @inlinable
 public func callNonnull(_ p: UnsafeMutableBufferPointer<CInt>) {
-  nonnull(p)
+  unsafe nonnull(p)
 }
 
 @inlinable
 public func callNullUnspecified(_ p: UnsafeMutableBufferPointer<CInt>) {
-  nullUnspecified(p)
+  unsafe nullUnspecified(p)
 }
 
 @inlinable
 public func callNullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
-  nullable(p)
+  unsafe nullable(p)
 }
 
 @inlinable
 public func callOffByOne(_ p: UnsafeMutableBufferPointer<CInt>) {
-  offByOne(0, p)
+  unsafe offByOne(0, p)
 }
 
 @inlinable
 public func callReturnPointer() {
-  let a: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
-  let b: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
+  let _: UnsafeMutableBufferPointer<CInt>? = returnPointer(4) // call wrapper
+  let _: UnsafeMutablePointer<CInt>? = returnPointer(4) // call unsafe interop
 }
 
 @inlinable
 public func callScalar(_ p: UnsafeMutableBufferPointer<CInt>) {
-  scalar(4, 2, p)
+  unsafe scalar(4, 2, p)
 }
 
 @inlinable
 public func callShared(_ p: UnsafeMutableBufferPointer<CInt>, _ p2: UnsafeMutableBufferPointer<CInt>) {
-  shared(p, p2)
+  unsafe shared(p, p2)
 }
 
 @inlinable
 public func callSimple(_ p: UnsafeMutableBufferPointer<CInt>) {
-  simple(p)
+  unsafe simple(p)
 }
 
 @inlinable
 public func callSimpleIndirectOriginal(_ p: UnsafeMutablePointer<CInt>) {
-  let f = simple
-  f(13, p)
+  let f = unsafe simple
+  unsafe f(13, p)
 }
 
 @inlinable
 public func callSimpleIndirectOverload(_ p: UnsafeMutableBufferPointer<CInt>) {
-  let f: (UnsafeMutableBufferPointer<CInt>) -> Void = simple
-  f(p)
+  let f: (UnsafeMutableBufferPointer<CInt>) -> Void = unsafe simple
+  unsafe f(p)
 }
 
 @inlinable
 public func callSimpleFlipped(_ p: UnsafeMutableBufferPointer<CInt>) {
-  simpleFlipped(p)
+  unsafe simpleFlipped(p)
 }
 
 @inlinable
 public func callSwiftAttr(_ p: UnsafeMutableBufferPointer<CInt>) {
-  swiftAttr(p)
+  unsafe swiftAttr(p)
 }

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -13,6 +13,17 @@ import SizedByLifetimeboundClang
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(copy _bytesized_param1)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan) -> MutableRawSpan
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(copy _charsized_param0)
+// CHECK-NEXT: @lifetime(_charsized_param0: copy _charsized_param0)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_ _charsized_param0: inout MutableRawSpan) -> MutableRawSpan
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) -> RawSpan
 
@@ -92,4 +103,17 @@ public func callSimple(_ p: RawSpan) {
 @inlinable
 public func callNonsizedLifetime(_ p: UnsafeRawPointer) {
   let _: RawSpan = nonsizedLifetime(73, p)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@inlinable
+public func callBytesized(_ p: RawSpan) {
+  let _: MutableRawSpan = bytesized(p)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@inlinable
+@lifetime(p: copy p)
+public func callCharsized(_ p: inout MutableRawSpan) {
+  let _: MutableRawSpan = charsized(&p)
 }

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_LifetimeDependence
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByLifetimeboundClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByLifetimeboundClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByLifetimebound.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByLifetimebound.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -strict-memory-safety -warnings-as-errors -Xcc -Werror -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __lifetimebound parameters and return values.
 
@@ -102,7 +102,7 @@ public func callSimple(_ p: RawSpan) {
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callNonsizedLifetime(_ p: UnsafeRawPointer) {
-  let _: RawSpan = nonsizedLifetime(73, p)
+  let _: RawSpan = unsafe nonsizedLifetime(73, p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -1,10 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
+// REQUIRES: swift_feature_LifetimeDependence
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __noescape parameters.
 import SizedByNoEscapeClang
@@ -81,8 +82,8 @@ public func callNullable(_ p: RawSpan?) {
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
 public func callReturnPointer() {
-  let a: UnsafeRawBufferPointer? = returnPointer(4) // call wrapper
-  let b: UnsafeRawPointer? = returnPointer(4) // call unsafe interop
+  let _: UnsafeRawBufferPointer? = returnPointer(4) // call wrapper
+  let _: UnsafeRawPointer? = returnPointer(4) // call unsafe interop
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -12,6 +12,15 @@ import SizedByNoEscapeClang
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @lifetime(_charsized_param0: copy _charsized_param0)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_  _charsized_param0: inout MutableRawSpan)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: RawSpan)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -92,4 +101,17 @@ public func callSimple(_ p: RawSpan) {
 @inlinable
 public func callSwiftAttr(_ p: RawSpan) {
   swiftAttr(p)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@inlinable
+public func callBytesized(_ p: RawSpan) {
+  bytesized(p)
+}
+
+@available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+@inlinable
+@lifetime(p: copy p)
+public func callCharsized(_ p: inout MutableRawSpan) {
+  charsized(&p)
 }

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -1,9 +1,9 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by parameters.
 import SizedByClang
@@ -44,53 +44,53 @@ import SizedByClang
 
 @inlinable
 public func callComplexExpr(_ p: UnsafeMutableRawBufferPointer) {
-  complexExpr(CInt(p.count), 1, p)
+  unsafe complexExpr(CInt(p.count), 1, p)
 }
 
 @inlinable
 public func callNonnull(_ p: UnsafeMutableRawBufferPointer) {
-  nonnull(p)
+  unsafe nonnull(p)
 }
 
 @inlinable
 public func callNullUnspecified(_ p: UnsafeMutableRawBufferPointer) {
-  nullUnspecified(p)
+  unsafe nullUnspecified(p)
 }
 
 @inlinable
 public func callNullable(_ p: UnsafeMutableRawBufferPointer?) {
-  nullable(p)
+  unsafe nullable(p)
 }
 
 @inlinable
 public func callOpaque(_ p: UnsafeRawBufferPointer) {
-  opaque(p)
+  unsafe opaque(p)
 }
 
 @inlinable
 public func callReturnPointer() {
-  let a: UnsafeMutableRawBufferPointer? = returnPointer(4) // call wrapper
-  let b: UnsafeMutableRawPointer? = returnPointer(4) // call unsafe interop
+  let _: UnsafeMutableRawBufferPointer? = returnPointer(4) // call wrapper
+  let _: UnsafeMutableRawPointer? = returnPointer(4) // call unsafe interop
 }
 
 @inlinable
 public func callShared(_ p: UnsafeMutableRawBufferPointer, _ p2: UnsafeMutableRawBufferPointer) {
-  shared(p, p2)
+  unsafe shared(p, p2)
 }
 
 @inlinable
 public func callSimple(_ p: UnsafeMutableRawBufferPointer) {
-  simple(p)
+  unsafe simple(p)
 }
 
 @inlinable
 public func callSwiftAttr(_ p: UnsafeMutableRawBufferPointer) {
-  swiftAttr(p)
+  unsafe swiftAttr(p)
 }
 
 @inlinable
 public func callCharsized(_ p: UnsafeMutableRawBufferPointer) {
-  charsized(p)
+  unsafe charsized(p)
 }
 
 @inlinable

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -10,6 +10,9 @@ import SizedByClang
 
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func aliasedBytesized(_  p: UnsafeMutableRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func bytesized(_  size: Int{{.*}}) -> UnsafeMutableRawBufferPointer
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -29,6 +32,9 @@ import SizedByClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func opaque(_  p: UnsafeRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func opaqueptr(_  p: UnsafeRawBufferPointer)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnPointer(_ len: Int{{.*}}) -> UnsafeMutableRawBufferPointer
@@ -68,6 +74,11 @@ public func callOpaque(_ p: UnsafeRawBufferPointer) {
 }
 
 @inlinable
+public func callOpaqueptr(_ p: UnsafeRawBufferPointer) {
+  unsafe opaqueptr(p)
+}
+
+@inlinable
 public func callReturnPointer() {
   let _: UnsafeMutableRawBufferPointer? = returnPointer(4) // call wrapper
   let _: UnsafeMutableRawPointer? = returnPointer(4) // call unsafe interop
@@ -96,4 +107,9 @@ public func callCharsized(_ p: UnsafeMutableRawBufferPointer) {
 @inlinable
 public func callBytesized() {
   let _: UnsafeMutableRawBufferPointer = bytesized(37)
+}
+
+@inlinable
+public func callAliasedBytesized(_ p: UnsafeMutableRawBufferPointer) {
+  unsafe aliasedBytesized(p)
 }

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -3,14 +3,19 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=SizedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
-// RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedBy.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by parameters.
 import SizedByClang
 
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func bytesized(_  size: Int{{.*}}) -> UnsafeMutableRawBufferPointer
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_  _charsized_param0: UnsafeMutableRawBufferPointer)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int{{.*}}, _ offset: Int{{.*}}, _ p: UnsafeMutableRawBufferPointer)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -81,4 +86,14 @@ public func callSimple(_ p: UnsafeMutableRawBufferPointer) {
 @inlinable
 public func callSwiftAttr(_ p: UnsafeMutableRawBufferPointer) {
   swiftAttr(p)
+}
+
+@inlinable
+public func callCharsized(_ p: UnsafeMutableRawBufferPointer) {
+  charsized(p)
+}
+
+@inlinable
+public func callBytesized() {
+  let _: UnsafeMutableRawBufferPointer = bytesized(37)
 }

--- a/test/Macros/SwiftifyImport/MacroErrors/Pointee.swift
+++ b/test/Macros/SwiftifyImport/MacroErrors/Pointee.swift
@@ -2,18 +2,12 @@
 
 // RUN: %target-typecheck-verify-swift -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -verify
 
-// expected-error@+2{{SizedBy only supported for raw pointers}}
-@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
-func myFunc(_ ptr: UnsafePointer<Int>, _ size: CInt) {
-}
-
-// expected-error@+2{{raw pointers only supported for SizedBy}}
+// expected-error@+2{{void pointers not supported for countedBy}}
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "count"))
 func myFunc(_ ptr: UnsafeRawPointer, _ count: CInt) {
 }
 
-// expected-error@+2{{raw pointers only supported for SizedBy}}
+// expected-error@+2{{void pointers not supported for countedBy}}
 @_SwiftifyImport(.countedBy(pointer: .param(1), count: "count"))
 func myFunc(_ ptr: OpaquePointer, _ count: CInt) {
 }
-

--- a/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
@@ -1,0 +1,108 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: swift_feature_LifetimeDependence
+
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature LifetimeDependence -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
+func constParam(_ ptr: UnsafePointer<CChar>, _ size: CInt) {}
+
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
+func mutParam(_ ptr: UnsafeMutablePointer<UInt8>, _ size: CInt) {}
+
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size * count"))
+func exprParam(_ ptr: UnsafeMutablePointer<UInt8>, _ size: CInt, _ count: CInt) {}
+
+@_SwiftifyImport(.sizedBy(pointer: .return, size: "size"))
+func constReturn(_ size: CInt) -> UnsafePointer<CChar> {}
+
+@_SwiftifyImport(.sizedBy(pointer: .return, size: "size"))
+func mutReturn(_ size: CInt) -> UnsafeMutablePointer<UInt8> {}
+
+@_SwiftifyImport(.sizedBy(pointer: .return, size: "size * count"))
+func exprReturn(_ size: CInt, _ count: CInt) -> UnsafeMutablePointer<UInt8> {}
+
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"),
+                 .nonescaping(pointer: .param(1)))
+func constParamNoreturn(_ ptr: UnsafePointer<CChar>, _ size: CInt) {}
+
+@_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"),
+                 .nonescaping(pointer: .param(1)))
+func mutParamNoreturn(_ ptr: UnsafeMutablePointer<UInt8>, _ size: CInt) {}
+
+@_SwiftifyImport(.sizedBy(pointer: .param(2), size: "size"),
+                 .sizedBy(pointer: .return, size: "size"),
+                 .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy))
+func constReturnDependence(_ size: CInt, _ ptr: UnsafePointer<UInt8>) -> UnsafePointer<CChar> {}
+
+@_SwiftifyImport(.sizedBy(pointer: .param(2), size: "size"),
+                 .sizedBy(pointer: .return, size: "size"),
+                 .lifetimeDependence(dependsOn: .param(2), pointer: .return, type: .copy))
+func mutReturnDependence(_ size: CInt, _ ptr: UnsafeMutablePointer<UInt8>) -> UnsafeMutablePointer<UInt8> {}
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func constParam(_ ptr: UnsafeRawBufferPointer) {
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe constParam(ptr.baseAddress!.assumingMemoryBound(to: CChar.self), size)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func mutParam(_ ptr: UnsafeMutableRawBufferPointer) {
+// CHECK-NEXT:     let size = CInt(exactly: unsafe ptr.count)!
+// CHECK-NEXT:     return unsafe mutParam(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), size)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func exprParam(_ ptr: UnsafeMutableRawBufferPointer, _ size: CInt, _ count: CInt) {
+// CHECK-NEXT:     let _ptrCount = unsafe ptr.count
+// CHECK-NEXT:     if _ptrCount != size * count {
+// CHECK-NEXT:       fatalError("bounds check failure in exprParam: expected \(size * count) but got \(_ptrCount)")
+// CHECK-NEXT:     }
+// CHECK-NEXT:     return unsafe exprParam(ptr.baseAddress!.assumingMemoryBound(to: UInt8.self), size, count)
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func constReturn(_ size: CInt) -> UnsafeRawBufferPointer {
+// CHECK-NEXT:     return unsafe UnsafeRawBufferPointer(start: unsafe constReturn(size), count: Int(size))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func mutReturn(_ size: CInt) -> UnsafeMutableRawBufferPointer {
+// CHECK-NEXT:     return unsafe UnsafeMutableRawBufferPointer(start: unsafe mutReturn(size), count: Int(size))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func exprReturn(_ size: CInt, _ count: CInt) -> UnsafeMutableRawBufferPointer {
+// CHECK-NEXT:     return unsafe UnsafeMutableRawBufferPointer(start: unsafe exprReturn(size, count), count: Int(size * count))
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @_disfavoredOverload
+// CHECK-NEXT: func constParamNoreturn(_ ptr: RawSpan) {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
+// CHECK-NEXT:     return unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:       return unsafe constParamNoreturn(_ptrPtr.baseAddress!.assumingMemoryBound(to: CChar.self), size)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func mutParamNoreturn(_ ptr: inout MutableRawSpan) {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
+// CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
+// CHECK-NEXT:       return unsafe mutParamNoreturn(_ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self), size)
+// CHECK-NEXT:     }
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func constReturnDependence(_ ptr: RawSpan) -> RawSpan {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe ptr.withUnsafeBytes { _ptrPtr in
+// CHECK-NEXT:       return unsafe constReturnDependence(size, _ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self))
+// CHECK-NEXT:             }, byteCount: Int(size)), copying: ())
+// CHECK-NEXT: }
+
+// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK-NEXT: func mutReturnDependence(_ ptr: inout MutableRawSpan) -> MutableRawSpan {
+// CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
+// CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
+// CHECK-NEXT:       return unsafe mutReturnDependence(size, _ptrPtr.baseAddress!.assumingMemoryBound(to: UInt8.self))
+// CHECK-NEXT:             }, byteCount: Int(size)), copying: ())
+// CHECK-NEXT: }


### PR DESCRIPTION
[Swiftify] Support __sized_by on byte-sized pointee types

Previously we would emit a macro that would error on expansion when
trying to add a safe wrapper to a function with __sized_by on a type
that mapped to UnsafePointer<T> instead of UnsafeRawPointer or
OpaquePointer. __sized_by is acceptable when used on byte-sized pointee
types, so this adds machinery in the macro expansion to support that.
Meanwhile on the ClangImporter side, we add a check so that __sized_by
on pointee types with a size is ignored if that size is larger than 1
byte.

When _SwiftifyImport applies .sizedBy to a pointer of type
UnsafePointer<T> it will still map it to a
RawSpan/UnsafeRawBufferPointer in the safe overload. The assumption is
that any API using __sized_by is dealing with raw bytes, so raw pointers
are a better Swift abstraction than UnsafePointer<CChar> etc. It also
lets the user avoid doing a scary pointer cast from some potentially
larger-than-byte-sized pointer to a byte-sized pointer. Casts to
RawPointers are generally safer and more ergonomic.

rdar://150966684
rdar://150966021


[Swiftify] Enable warnings-as-errors in interop test cases (NFC)

This enables -strict-memory-safety -warnings-as-errors on the Swift side
to verify that the macro expansions don't cause any warnings and that
they use `unsafe` correctly. On the clang side it enables -Xcc -Werror.
To reduce noise in the test output and pass -Werror cleanly it also
enables -Xcc -Wno-nullability-completeness. This will make it easier to
detect mistakes when writing tests, because warnings stand out whereas
previously they've been drowned out in the noise.


