### PR TITLE
[6.2] Set the Compilation directory when generating the Skeleton CU

### DIFF
--- a/test/DebugInfo/comp-dir.swift
+++ b/test/DebugInfo/comp-dir.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/Globals.swiftmodule %S/Globals.swift
+// RUN: %target-swift-frontend -c -I %t -primary-file %s -g -parse-as-library -emit-module -emit-object -module-cache-path "./mc" -file-compilation-dir "." -debug-prefix-map "$(pwd)=." -o %t/test.o
+// RUN: %llvm-dwarfdump %t/test.o | %FileCheck %s
+
+// CHECK: DW_TAG_compile_unit
+
+// CHECK: DW_TAG_compile_unit
+// CHECK-NOT: NULL
+// CHECK: DW_AT_comp_dir	(".")
+// CHECK-NOT: NULL


### PR DESCRIPTION
Explanation: This change fixes a bug where if the `-file-compilation-dir` option was passed with a value, the DW_AT_comp_dir attribute was not set to the `-file-compilation-dir` passed in.

Scope: Narrow, only affects debug info

Risk: low, the change only affects the DW_AT_comp_dir attribute in the debug info in skeleton Compile units for imported modules, if the `-file-compilation-dir` option is passed.

Testing: automated testing via swift-ci smoke test, a new test was added for this patch

Issue: rdar://131726681

Reviewer: @adrian-prantl