### PR TITLE
IRGen: honour `-static-libclosure` in block creation

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1170,10 +1170,15 @@ llvm::Constant *swift::getRuntimeFn(
 
     if (IGM && useDllStorage(IGM->Triple) && IsExternal) {
       bool bIsImported = true;
+      swift::ASTContext &Context = IGM->Context;
       if (IGM->getSwiftModule()->getPublicModuleName(true).str() == ModuleName)
         bIsImported = false;
-      else if (ModuleDecl *MD = IGM->Context.getModuleByName(ModuleName))
+      else if (ModuleDecl *MD = Context.getModuleByName(ModuleName))
         bIsImported = !MD->isStaticLibrary();
+      else if (strcmp(ModuleName, "BlocksRuntime") == 0)
+        bIsImported =
+            !static_cast<ClangImporter *>(Context.getClangModuleLoader())
+                ->getCodeGenOpts().StaticClosure;
 
       if (bIsImported)
         fn->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);

--- a/test/IRGen/static-libclosure.swift
+++ b/test/IRGen/static-libclosure.swift
@@ -1,0 +1,9 @@
+// RUN: %swift_frontend_plain -target x86_64-unknown-windows-msvc -primary-file %s -parse-as-library -parse-stdlib -nostdimport -module-name M -emit-ir -Xcc -static-libclosure -o - | %FileCheck %s
+
+public let block: @convention(block) () -> () = {
+}
+
+// CHECK-NOT: @_NSConcreteStackBlock = external dllimport global
+// CHECK-NOT: declare dllimport ptr @_Block_copy(ptr)
+// CHECK: @_NSConcreteStackBlock = external global
+// CHECK: declare ptr @_Block_copy(ptr)


### PR DESCRIPTION
When creating a block, ensure that we correctly associate the DLL Storage on the `_NSConcreteStackBlock` root object declaration based upon whether we are generating code with `-static-libclosure` being passed to the clang importer or not.