### PR TITLE
[Concurrency] Correct the signing of priority escalation handler

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1745,7 +1745,7 @@ namespace SpecialPointerAuthDiscriminators {
   const uint16_t AsyncContextParent = 0xbda2; // = 48546
   const uint16_t AsyncContextResume = 0xd707; // = 55047
   const uint16_t AsyncContextYield = 0xe207; // = 57863
-  const uint16_t CancellationNotificationFunction = 0x2E3F; // = 11839 (TaskPriority, TaskPriority) -> Void
+  const uint16_t CancellationNotificationFunction = 0xf73; // = 3955 (TaskPriority, TaskPriority) -> Void
   const uint16_t EscalationNotificationFunction = 0x7861; // = 30817
   const uint16_t AsyncThinNullaryFunction = 0x0f08; // = 3848
   const uint16_t AsyncFutureFunction = 0x720f; // = 29199

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1817,7 +1817,7 @@ swift_task_addPriorityEscalationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(EscalationNotificationStatusRecord));
-  auto unsigned_handler = swift_auth_code(handler, 11839);
+  auto unsigned_handler = swift_auth_code(handler, 3955);
   auto *record = ::new (allocation)
       EscalationNotificationStatusRecord(unsigned_handler, context);
 


### PR DESCRIPTION
In https://github.com/swiftlang/swift/pull/81229 we used the wrong discriminator number: we used the witness table discriminator for the `TaskPriority`:

```
	mov	x17, x8
	movk	x17, #11839, lsl #48 <<<<< bad
	autda	x16, x17
```

while we should have used the one for the branch itself:

```
	stur	x1, [x29, #-32]
	bl	static Swift.TaskPriority.default.getter : Swift.TaskPriority
	mov	x0, x20
	bl	_swift_retain
	ldur	x8, [x29, #-88]
	ldur	x1, [x29, #-56]
	mov	x0, x1
	mov	x17, #3955 <<<<<< good
	blraa	x8, x17
```

This "actually" resolves rdar://150378890 which #81229 was intending to do