### PR TITLE
[Frontend][test] Minor changes from "-nostdimport and -nostdlibimport should remove the default framework search paths"

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -312,7 +312,8 @@ updateImplicitFrameworkSearchPaths(SearchPathOptions &SearchPathOpts,
   if (LangOpts.Target.isOSDarwin()) {
     if (!SearchPathOpts.SkipSDKImportPaths &&
         !SearchPathOpts.getSDKPath().empty()) {
-      StringRef SDKPath = SearchPathOpts.getSDKPath();
+      SmallString<128> SDKPath(SearchPathOpts.getSDKPath());
+
       SmallString<128> systemFrameworksScratch(SDKPath);
       llvm::sys::path::append(systemFrameworksScratch, "System", "Library",
                               "Frameworks");
@@ -321,6 +322,7 @@ updateImplicitFrameworkSearchPaths(SearchPathOptions &SearchPathOpts,
                               "SubFrameworks");
       SmallString<128> frameworksScratch(SDKPath);
       llvm::sys::path::append(frameworksScratch, "Library", "Frameworks");
+
       ImplicitFrameworkSearchPaths = {systemFrameworksScratch.str().str(),
                                       systemSubFrameworksScratch.str().str(),
                                       frameworksScratch.str().str()};

--- a/test/Frontend/default-search-paths.swift
+++ b/test/Frontend/default-search-paths.swift
@@ -1,7 +1,7 @@
 // UNSUPPORTED: OS=windows-msvc
 
 // Standard Apple paths.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -target arm64-apple-macos15.4 -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=APPLE %s
+// RUN: %swift_frontend_plain -target arm64-apple-macos15.4 %clang-importer-sdk-nosource -parse-stdlib -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=APPLE %s
 // APPLE: Implicit framework search paths:
 // APPLE-NEXT: [0] SOURCE_DIR/test/Inputs/clang-importer-sdk/System/Library/Frameworks
 // APPLE-NEXT: [1] SOURCE_DIR/test/Inputs/clang-importer-sdk/System/Library/SubFrameworks
@@ -12,7 +12,7 @@
 // APPLE-NEXT: (End of search path lists.)
 
 // Non-Apple platforms don't have any implicit framework search paths.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -target x86_64-unknown-linux-android -parse -parse-stdlib %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=ANDROID %s
+// RUN: %swift_frontend_plain -target x86_64-unknown-linux-android %clang-importer-sdk-nosource -parse-stdlib -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=ANDROID %s
 // ANDROID: Implicit framework search paths:
 // ANDROID-NEXT: Runtime library import search paths:
 // ANDROID-NEXT: [0] BUILD_DIR/lib/swift/android
@@ -22,20 +22,20 @@
 // ANDROID-NEXT: (End of search path lists.)
 
 // -nostdimport doesn't set up any standard import paths at all.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -target arm64-apple-macos15.4 -nostdimport -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=NOSTDIMPORT %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -target x86_64-unknown-linux-android -nostdimport -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=NOSTDIMPORT %s
+// RUN: %swift_frontend_plain -target arm64-apple-macos15.4 %clang-importer-sdk-nosource -parse-stdlib -nostdimport -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=NOSTDIMPORT %s
+// RUN: %swift_frontend_plain -target x86_64-unknown-linux-android %clang-importer-sdk-nosource -parse-stdlib -nostdimport -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=NOSTDIMPORT %s
 // NOSTDIMPORT: Implicit framework search paths:
 // NOSTDIMPORT-NEXT: Runtime library import search paths:
 // NOSTDIMPORT-NEXT: (End of search path lists.)
 
 // -nostdlibimport removes all of the standard imports from the SDK but leaves the toolchain ones.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -target arm64-apple-macos15.4 -nostdlibimport -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=APPLE-NOSTDLIBIMPORT %s
+// RUN: %swift_frontend_plain -target arm64-apple-macos15.4 %clang-importer-sdk-nosource -parse-stdlib -nostdlibimport -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=APPLE-NOSTDLIBIMPORT %s
 // APPLE-NOSTDLIBIMPORT: Implicit framework search paths:
 // APPLE-NOSTDLIBIMPORT-NEXT: Runtime library import search paths:
 // APPLE-NOSTDLIBIMPORT-NEXT: [0] BUILD_DIR/lib/swift/macosx
 // APPLE-NOSTDLIBIMPORT-NEXT: (End of search path lists.)
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -target x86_64-unknown-linux-android -nostdlibimport -parse -parse-stdlib %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=ANDROID-NOSTDLIBIMPORT %s
+// RUN: %swift_frontend_plain -target x86_64-unknown-linux-android %clang-importer-sdk-nosource -parse-stdlib -nostdlibimport -parse %s -Rmodule-loading 2>&1 | %FileCheck -check-prefix=ANDROID-NOSTDLIBIMPORT %s
 // ANDROID-NOSTDLIBIMPORT: Implicit framework search paths:
 // ANDROID-NOSTDLIBIMPORT-NEXT: Runtime library import search paths:
 // ANDROID-NOSTDLIBIMPORT-NEXT: [0] BUILD_DIR/lib/swift/android


### PR DESCRIPTION
Put the SDK path in a SmallString instead of a StringRef for ease of downstream merging. Simplify the command lines for the search path test.