### PR TITLE
utils: normalise the names as per expectations

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2407,7 +2407,7 @@ function Write-SDKSettings([OS] $OS) {
     LibrarySearchPaths = @();
     Toolchains = @( "${ToolchainIdentifier}" );
     DefaultProperties = @{
-      PLATFORM_NAME = $OS.ToString()
+      PLATFORM_NAME = $OS.ToString().ToLowerInvariant()
       DEFAULT_COMPILER = "${ToolchainIdentifier}"
     }
     SupportedTargets = @{


### PR DESCRIPTION
Adjust the platform identifier spelling to the expected case.