### PR TITLE
[test] lit.cfg: Wrap all substitutions with capture group refs in `SubstituteCaptures`

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1190,19 +1190,26 @@ def use_interpreter_for_simple_runs():
         # path.
         result += (
             'env SWIFT_INTERPRETER=%r %s %r %s -module-name main %s %s %s '
-            % (config.swift, xcrun_prefix, config.swift, target_options,
-               config.swift_test_options,
-               config.swift_driver_test_options,
-               swift_execution_tests_extra_flags))
+            % (
+                escape_for_substitute_captures(config.swift),
+                escape_for_substitute_captures(xcrun_prefix),
+                escape_for_substitute_captures(config.swift),
+                escape_for_substitute_captures(target_options),
+                escape_for_substitute_captures(config.swift_test_options),
+                escape_for_substitute_captures(config.swift_driver_test_options),
+                escape_for_substitute_captures(swift_execution_tests_extra_flags)
+            )
+        )
         if stdlib:
             result += '-Xfrontend -disable-access-control '
         if parameterized:
-            result += ' \\1 '
+            result += r' \1 '
         if gyb:
             result += '%t/main.swift'
         else:
             result += '%s'
-        return result
+        return SubstituteCaptures(result)
+
     config.target_run_stdlib_swiftgyb = make_simple_target_run(gyb=True)
     config.target_run_simple_swiftgyb = make_simple_target_run(gyb=True)
     config.target_run_stdlib_swift = make_simple_target_run(stdlib=True)
@@ -1597,11 +1604,12 @@ if run_vendor == 'apple':
         "%s %s %s" %
         (xcrun_prefix, config.clangxx, config.target_cc_options))
 
-    config.target_build_swift_dylib = (
-        "%s -parse-as-library -emit-library -o '\\1' "
-        "-Xlinker -install_name -Xlinker @executable_path/$(basename '\\1')"
-        % (config.target_build_swift))
-    config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
+    config.target_build_swift_dylib = SubstituteCaptures(
+        f"{escape_for_substitute_captures(config.target_build_swift)}"
+        r" -parse-as-library -emit-library -o '\1'"
+        r" -Xlinker -install_name -Xlinker @executable_path/$(basename '\1')"
+    )
+    config.target_add_rpath = SubstituteCaptures(r'-Xlinker -rpath -Xlinker \1')
 
     target_future = format('%s-apple-%s%s%s' % (run_cpu, run_os, target_future_version, run_environment))
 
@@ -1833,10 +1841,11 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
            config.swift_test_options, config.swift_driver_test_options,
            swift_execution_tests_extra_flags))
     config.target_codesign = "echo"
-    config.target_build_swift_dylib = (
-        "%s -parse-as-library -emit-library -o '\\1'"
-        % (config.target_build_swift))
-    config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
+    config.target_build_swift_dylib = SubstituteCaptures(
+        f"{escape_for_substitute_captures(config.target_build_swift)}"
+        r" -parse-as-library -emit-library -o '\1'"
+    )
+    config.target_add_rpath = SubstituteCaptures(r'-Xlinker -rpath -Xlinker \1')
     config.target_swift_frontend = (
         '%s -target %s %s %s %s %s '
         % (config.swift_frontend, config.variant_triple, config.resource_dir_opt, mcp_opt,
@@ -1926,11 +1935,11 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         config.resource_dir_opt, mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
-    config.target_build_swift_dylib = ' '.join([
-        config.target_build_swift,
-        '-parse-as-library', '-emit-library',
-        '-o', "'\\1'"])
-    config.target_add_rpath = r'-Xlinker -rpath -Xlinker \1'
+    config.target_build_swift_dylib = SubstituteCaptures(
+        f"{escape_for_substitute_captures(config.target_build_swift)}"
+        r" -parse-as-library -emit-library -o '\1'"
+    )
+    config.target_add_rpath = SubstituteCaptures(r'-Xlinker -rpath -Xlinker \1')
     config.target_swift_frontend = ' '.join([
         config.swift_frontend,
         '-target', config.variant_triple,
@@ -2010,9 +2019,10 @@ elif run_os == 'wasi':
         mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
-    config.target_build_swift_dylib = (
-        "%s -parse-as-library -emit-library -static -o '\\1'"
-        % (config.target_build_swift))
+    config.target_build_swift_dylib = SubstituteCaptures(
+        f"{escape_for_substitute_captures(config.target_build_swift)}"
+        r" -parse-as-library -emit-library -static -o '\1'"
+    )
     config.target_add_rpath = ''
     config.target_swift_frontend = ' '.join([
         config.swift_frontend,
@@ -2093,9 +2103,10 @@ elif config.external_embedded_platform:
         mcp_opt, config.swift_test_options,
         config.swift_driver_test_options, swift_execution_tests_extra_flags])
     config.target_codesign = "echo"
-    config.target_build_swift_dylib = (
-        "%s -parse-as-library -emit-library -static -o '\\1'"
-        % (config.target_build_swift))
+    config.target_build_swift_dylib = SubstituteCaptures(
+        f"{escape_for_substitute_captures(config.target_build_swift)}"
+        r" -parse-as-library -emit-library -static -o '\1'"
+    )
     config.target_add_rpath = ''
     config.target_swift_frontend = ' '.join([
         config.swift_frontend,
@@ -2965,8 +2976,7 @@ config.substitutions.insert(0, ('%target-static-library-name\(([^)]+)\)',
                                 SubstituteCaptures(r'%s\1%s' % (
                                     escape_for_substitute_captures(config.target_static_library_prefix),
                                     escape_for_substitute_captures(config.target_static_library_suffix)))))
-config.substitutions.append(('%target-rpath\(([^)]+)\)',
-                             SubstituteCaptures(config.target_add_rpath)))
+config.substitutions.append(('%target-rpath\(([^)]+)\)', config.target_add_rpath))
 
 config.substitutions.append(('%target-resilience-test', config.target_resilience_test))
 


### PR DESCRIPTION
Since https://github.com/llvm/llvm-project/pull/103042, backslashes in substitutions are consistently escaped on all platforms before feeding the substitutions to the regex engine. Make sure all substitutions containing capture group references are wrapped in `SubstituteCaptures` to suppress this behavior once main is rebranched.