### PR TITLE
[Diagnostics] A collection of diagnostic fixes/improvements

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3484,6 +3484,15 @@ public:
     return nullptr;
   }
 
+  Expr *getSemanticsProvidingParentExpr(Expr *expr) {
+    while (auto *parent = getParentExpr(expr)) {
+      if (parent->getSemanticsProvidingExpr() == parent)
+        return parent;
+      expr = parent;
+    }
+    return nullptr;
+  }
+
   /// Retrieve the depth of the given expression.
   std::optional<unsigned> getExprDepth(Expr *expr) {
     if (auto result = getExprDepthAndParent(expr))

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4311,6 +4311,15 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
             break;
           }
 
+          if ((isExpr<ArrayExpr>(anchor) || isExpr<DictionaryExpr>(anchor)) &&
+              last.is<LocatorPathElt::TupleElement>()) {
+            auto *fix = CollectionElementContextualMismatch::create(
+                *this, type1, type2, getConstraintLocator(anchor, path));
+            if (recordFix(fix, /*impact=*/2))
+              return getTypeMatchFailure(locator);
+            break;
+          }
+
           // TODO(diagnostics): If there are any requirement failures associated
           // with result types which are part of a function type conversion,
           // let's record general conversion mismatch in order for it to capture

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11438,6 +11438,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
             // `key path` constraint can't be retired until all components
             // are simplified.
             addTypeVariableConstraintsToWorkList(memberTypeVar);
+          } else if (locator->getAnchor().is<Expr *>() &&
+                     !getSemanticsProvidingParentExpr(
+                         getAsExpr(locator->getAnchor()))) {
+            // If there are no contextual expressions that could provide
+            // a type for the member type variable, let's default it to
+            // a placeholder eagerly so it could be propagated to the
+            // pattern if necessary.
+            recordTypeVariablesAsHoles(memberTypeVar);
           } else if (locator->isLastElement<LocatorPathElt::PatternMatch>()) {
             // Let's handle member patterns specifically because they use
             // equality instead of argument application constraint, so allowing

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4282,7 +4282,8 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
         if (!path.empty()) {
           auto last = path.back();
 
-          if (last.is<LocatorPathElt::ApplyArgToParam>()) {
+          if (last.is<LocatorPathElt::ApplyArgToParam>() ||
+              last.is<LocatorPathElt::AutoclosureResult>()) {
             auto proto = protoDecl->getDeclaredInterfaceType();
             // Impact is 2 here because there are two failures
             // 1 - missing conformance and 2 - incorrect argument type.

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -296,9 +296,9 @@ func rdar19836341(_ ns: NSString?, vns: NSString?) {
 
 // <rdar://problem/20029786> Swift compiler sometimes suggests changing "as!" to "as?!"
 func rdar20029786(_ ns: NSString?) {
-  var s: String = ns ?? "str" as String as String // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{19-19=(}} {{50-50=) as String}}
-  // expected-error@-1 {{cannot convert value of type 'String' to expected argument type 'NSString'}} {{50-50= as NSString}}
-  var s2 = ns ?? "str" as String as String // expected-error {{cannot convert value of type 'String' to expected argument type 'NSString'}}{{43-43= as NSString}}
+  var s: String = ns ?? "str" as String as String
+  // expected-error@-1 {{cannot convert value of type 'NSString?' to expected argument type 'String?'}} {{21-21= as String?}}
+  var s2 = ns ?? "str" as String as String // expected-error {{binary operator '??' cannot be applied to operands of type 'NSString?' and 'String'}}
 
   let s3: NSString? = "str" as String? // expected-error {{cannot convert value of type 'String?' to specified type 'NSString?'}}{{39-39= as NSString?}}
 

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1155,7 +1155,7 @@ struct R_76250381<Result, Failure: Error> {
 func rdar77022842(argA: Bool? = nil, argB: Bool? = nil) {
   if let a = argA ?? false, if let b = argB ?? {
     // expected-error@-1 {{initializer for conditional binding must have Optional type, not 'Bool'}}
-    // expected-error@-2 {{closure passed to parameter of type 'Bool?' that does not accept a closure}}
+    // expected-error@-2 {{cannot convert value of type 'Bool?' to expected argument type '(() -> ())?'}}
     // expected-error@-3 {{cannot convert value of type 'Void' to expected condition type 'Bool'}}
     // expected-error@-4 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
     // expected-error@-5 {{'if' must have an unconditional 'else' to be used as expression}}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1337,3 +1337,13 @@ func rdar143338891() {
     }
   }
 }
+
+do {
+  struct V {
+    init(value: @autoclosure @escaping () -> any Hashable) { }
+    init(other: @autoclosure @escaping () -> String) { }
+  }
+
+  let _ = V(value: { [Int]() }) // expected-error {{add () to forward '@autoclosure' parameter}} {{31-31=()}}
+  let _ = V(other: { [Int]() }) // expected-error {{cannot convert value of type '[Int]' to closure result type 'String'}}
+}

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -803,7 +803,6 @@ overloaded { print("hi"); print("bye") } // multiple expression closure without 
 // expected-error@-1 {{ambiguous use of 'overloaded'}}
 
 func not_overloaded(_ handler: () -> Int) {}
-// expected-note@-1 {{'not_overloaded' declared here}}
 
 not_overloaded { } // empty body
 // expected-error@-1 {{cannot convert value of type '()' to closure result type 'Int'}}
@@ -1346,4 +1345,24 @@ do {
 
   let _ = V(value: { [Int]() }) // expected-error {{add () to forward '@autoclosure' parameter}} {{31-31=()}}
   let _ = V(other: { [Int]() }) // expected-error {{cannot convert value of type '[Int]' to closure result type 'String'}}
+}
+
+// https://github.com/swiftlang/swift/issues/81770
+do {
+  func test(_: Int) {}
+  func test(_: Int = 42, _: (Int) -> Void) {}
+
+  test {
+    if let _ = $0.missing { // expected-error {{value of type 'Int' has no member 'missing'}}
+    }
+  }
+
+  test {
+    if let _ = (($0.missing)) { // expected-error {{value of type 'Int' has no member 'missing'}}
+    }
+  }
+
+  test { // expected-error {{invalid conversion from throwing function of type '(Int) throws -> Void' to non-throwing function type '(Int) -> Void'}}
+    try $0.missing // expected-error {{value of type 'Int' has no member 'missing'}}
+  }
 }

--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -705,6 +705,7 @@ func builderInClosure() {
 func testInvalidOptionalChainingInIfContext() {
   let v63796 = 1
   if v63796? {} // expected-error{{cannot use optional chaining on non-optional value of type 'Int'}}
+  // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
 }
 
 // https://github.com/swiftlang/swift/issues/79395

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -607,3 +607,14 @@ func testExtraQuestionMark(action: () -> Void, v: Int) {
   // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '() -> Void'}}
   // expected-error@-2 {{cannot use optional chaining on non-optional value of type 'Int'}}
 }
+
+func testPassingOptionalChainAsWrongArgument() {
+  class Test {
+    func fn(_ asdType: String?) {
+    }
+  }
+
+  func test(test: Test, arr: [Int]?) {
+    test.fn(arr?.first) // expected-error {{cannot convert value of type 'Int?' to expected argument type 'String?'}}
+  }
+}

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -435,7 +435,7 @@ func test_force_unwrap_not_being_too_eager() {
 // rdar://problem/57097401
 func invalidOptionalChaining(a: Any) {
   a == "="? // expected-error {{cannot use optional chaining on non-optional value of type 'String'}}
-  // expected-error@-1 {{binary operator '==' cannot be applied to operands of type 'Any' and 'String?'}}
+  // expected-error@-1 {{cannot convert value of type 'Any' to expected argument type 'String'}}
 }
 
 /// https://github.com/apple/swift/issues/54739
@@ -594,4 +594,16 @@ do {
   var x: Double = 42
   test(x!) // expected-error {{no exact matches in call to local function 'test'}}
   // expected-error@-1 {{cannot force unwrap value of non-optional type 'Double'}}
+}
+
+func testExtraQuestionMark(action: () -> Void, v: Int) {
+  struct Test {
+    init(action: () -> Void) {}
+  }
+
+  Test(action: action?)
+  // expected-error@-1 {{cannot use optional chaining on non-optional value of type '() -> Void'}}
+  Test(action: v?)
+  // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type '() -> Void'}}
+  // expected-error@-2 {{cannot use optional chaining on non-optional value of type 'Int'}}
 }

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -577,3 +577,11 @@ do {
 
   isFooableError(overloaded()) // Ok
 }
+
+do {
+  func takesFooables(_: [any Fooable]) {}
+
+  func test(v: String) {
+    takesFooables([v]) // expected-error {{cannot convert value of type 'String' to expected element type 'any Fooable'}}
+  }
+}

--- a/test/Constraints/rdar44770297.swift
+++ b/test/Constraints/rdar44770297.swift
@@ -10,6 +10,3 @@ func foo<T: P>(_: () throws -> T) -> T.A? { // expected-note {{where 'T' = 'Neve
 
 let _ = foo() {fatalError()} & nil
 // expected-error@-1 {{global function 'foo' requires that 'Never' conform to 'P'}}
-// expected-error@-2 {{value of optional type 'Never.A?' must be unwrapped to a value of type 'Never.A'}}
-// expected-note@-3 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-// expected-note@-4 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}

--- a/test/decl/func/typed_throws.swift
+++ b/test/decl/func/typed_throws.swift
@@ -192,7 +192,7 @@ enum G_E<T> {
 
 func testArrMap(arr: [String]) {
   _ = mapArray(arr, body: G_E<Int>.tuple)
-  // expected-error@-1{{cannot convert value of type '((x: Int, y: Int)) -> G_E<Int>' to expected argument type '(String) -> G_E<Int>'}}
+  // expected-error@-1{{conflicting arguments to generic parameter 'T' ('String' vs. '(x: Int, y: Int)')}}
 }
 
 // Shadowing of typed-throws Result.get() addresses a source compatibility

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -794,7 +794,7 @@ func testNilCoalescePrecedence(cond: Bool, a: Int?, r: ClosedRange<Int>?) {
 
   // ?? should have lower precedence than range and arithmetic operators.
   let r1 = r ?? (0...42) // ok
-  let r2 = (r ?? 0)...42 // not ok: expected-error {{binary operator '??' cannot be applied to operands of type 'ClosedRange<Int>?' and 'Int'}}
+  let r2 = (r ?? 0)...42 // not ok: expected-error {{cannot convert value of type 'ClosedRange<Int>?' to expected argument type 'Int?'}}
   let r3 = r ?? 0...42 // parses as the first one, not the second.
   
   

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -78,17 +78,14 @@ func unsafePointerConversionAvailability(
 
   _ = UnsafeMutablePointer<Int>(rp) // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
   _ = UnsafeMutablePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
-  // Two candidates here: OpaquePointer? and UnsafeMutablePointer<Int>?
+  // This is ambiguous because we have failable and non-failable initializers that accept the same argument type.
   _ = UnsafeMutablePointer<Int>(orp) // expected-error {{no exact matches in call to initializer}}
-  // Two candidates here: OpaquePointer? and UnsafeMutablePointer<Int>?
-  _ = UnsafeMutablePointer<Int>(omrp) // expected-error {{no exact matches in call to initializer}}
+  _ = UnsafeMutablePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
 
   _ = UnsafePointer<Int>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<Int>'}}
   _ = UnsafePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafePointer<Int>'}}
-  // Two candidates here: OpaquePointer? and UnsafeMutablePointer<Int>?
-  _ = UnsafePointer<Int>(orp)  // expected-error {{no exact matches in call to initializer}}
-  // Two candidates here: OpaquePointer? and UnsafeMutablePointer<Int>?
-  _ = UnsafePointer<Int>(omrp) // expected-error {{no exact matches in call to initializer}}
+  _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<Int>'}}
+  _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafePointer<Int>'}}
 
   _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'UnsafePointer<Int>'}}
   // expected-note@-1 {{arguments to generic parameter 'Pointee' ('String' and 'Int') are expected to be equal}}


### PR DESCRIPTION
This fixes deal with situations that previously caused a fallback diagnostic to be produced.

- Detect when generic argument mismatch applies to argument and produce a tailed fix
- Assign missing member eagerly when there is no context
- Diagnose existential mismatch in a literal collection element position
- Use argument mismatch fix for `@autoclosure` result positions
- Don't attempt to force unwrap invalid optional chaining in the argument position

Resolves: rdar://82971941
Resolves: rdar://152021264
Resolves: https://github.com/swiftlang/swift/issues/81770
Resolves: rdar://103045274
Resolves: rdar://110527062
Resolves: rdar://126080504

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
