### PR TITLE
[region-isolation] Add a test showing that we do not infer nonisolated(unsafe) onto named closures.

### DIFF
--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -1026,4 +1026,18 @@ func closureTests() async {
     // expected-note @-1 {{Passing value of non-Sendable type '() async -> ()' as a 'sending' argument to static method 'detached(priority:operation:)' risks causing races in between local and caller code}}
     Task.detached { _ = x4a; _ = x4b } // expected-note {{access can happen concurrently}}
   }
+
+  // The reason why this works is that we do not infer nonisolated(unsafe)
+  // passed the begin_borrow [var_decl] of y. So we think the closure is
+  // nonisolated(unsafe), but its uses via the begin_borrow [var_decl] is
+  // not.
+  func testNamedClosure() async {
+    nonisolated(unsafe) let x = NonSendableKlass()
+    let y = {
+      _ = x
+    }
+    sendingClosure(y) // expected-warning {{sending 'y' risks causing data races}}
+    // expected-note @-1 {{'y' used after being passed as a 'sending' parameter}}
+    sendingClosure(y) // expected-note {{access can happen concurrently}}
+  }
 }


### PR DESCRIPTION
The semantics we want is for nonisolated(unsafe) to be inferred onto anonymous closures. We already have that semantics since we do not look through move_value [var_decl] or begin_borrow [var_decl]. So even though the underlying partial_apply will be viewed as nonisolated(unsafe), we will not consider that when determining the nonisolated(unsafe) for the begin_borrow or move_value that defined the variable whose value is the partial_apply.
