### PR TITLE
[6.2][send-non-sendable] Recurse to the full underlying value computation instead of just the object one when computing the underlying object of an address.

### DIFF
--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -985,13 +985,12 @@ RegionAnalysisValueMap::getUnderlyingTrackedValueHelperAddress(
     // occur in the underlying DenseMap that backs getUnderlyingTrackedValue()
     // if we insert another entry into the DenseMap.
     if (!visitor.value)
-      return UnderlyingTrackedValueInfo(
-          getUnderlyingTrackedValueHelperObject(base));
+      return UnderlyingTrackedValueInfo(getUnderlyingTrackedValueHelper(base));
 
     // TODO: Should we us the base or value from
     // getUnderlyingTrackedValueHelperObject as our base?
     return UnderlyingTrackedValueInfo(
-        visitor.value, getUnderlyingTrackedValueHelperObject(base).value);
+        visitor.value, getUnderlyingTrackedValueHelper(base).value);
   }
 
   // Otherwise, we return the actorIsolation that our visitor found.

--- a/test/Concurrency/regionanalysis_trackable_value.sil
+++ b/test/Concurrency/regionanalysis_trackable_value.sil
@@ -56,6 +56,12 @@ class NonSendableKlassWithState {
 
 actor Custom {}
 
+enum MyEnum<T> {
+    case none
+    indirect case some(NonSendableKlass)
+    case some2(T)
+}
+
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
 sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
 sil @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
@@ -637,6 +643,42 @@ bb0(%0 : @owned $Struct2):
 
   destroy_addr %1
   dealloc_stack %1
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on indirect_enum_load_take: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:   Rep Value:   %1 = alloc_stack $MyEnum<T>
+// CHECK: end running test 1 of 1 on indirect_enum_load_take: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @indirect_enum_load_take : $@convention(thin) @async <T> (@in_guaranteed MyEnum<T>) -> () {
+bb0(%0 : $*MyEnum<T>):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %1 = alloc_stack $MyEnum<T>
+  copy_addr %0 to [init] %1
+  switch_enum_addr %1, case #MyEnum.some!enumelt: bb1, default bb2
+
+bb1:
+  %2 = unchecked_take_enum_data_addr %1, #MyEnum.some!enumelt
+  %3 = load [take] %2
+  %4 = project_box %3, 0
+  %5 = load_borrow %4
+  %6 = copy_value %5
+  debug_value [trace] %5
+  %7 = move_value [var_decl] %6
+  debug_value %5, let, name "x"
+  destroy_value %7
+  end_borrow %5
+  destroy_value %3
+  dealloc_stack %1
+  br bb3
+
+bb2:
+  destroy_addr %1
+  dealloc_stack %1
+  br bb3
+
+bb3:
   %9999 = tuple ()
   return %9999 : $()
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -93,6 +93,12 @@ struct SendableGenericStruct : Sendable {
   var x = SendableKlass()
 }
 
+enum MyEnum<T> {
+    case none
+    indirect case some(NonSendableKlass)
+    case more(T)
+}
+
 ////////////////////////////
 // MARK: Actor Self Tests //
 ////////////////////////////
@@ -2026,4 +2032,16 @@ func testIsolatedParamInference() {
       }
     }
   }
+}
+
+// We used to crash on this since we were not looking finding underlying objects
+// hard enough.
+func indirectEnumTestCase<T>(_ e: MyEnum<T>) async -> Bool {
+    switch e {
+    case .some(let x):
+      _ = x
+      return true
+    default:
+        return false
+    }
 }


### PR DESCRIPTION
Explanation: This PR ensures that we recurse further when determining the underlying value of an equivalence class.

Otherwise, depending on the exact value that we perform the underlying look up at... we will get different underlying values. To see this consider the following SIL:

```sil
  %1 = alloc_stack $MyEnum<T>
  copy_addr %0 to [init] %1
  %2 = unchecked_take_enum_data_addr %1, #MyEnum.some!enumelt
  %3 = load [take] %2
  %4 = project_box %3, 0
  %5 = load_borrow %4
  %6 = copy_value %5
```

If one were to perform an underlying object query on %4 or %3, one would get back an underlying object of %1. In contrast, if one performed the same operation on %5, then one would get back %3. The reason why this happens is that we first see we have an object but that it is from a load_borrow so we need to look through the load_borrow and perform the address underlying value computation. When we do that, we find project_box to be the value. project_box is special since it is the only address base we ever look through since from an underlying object perspective, we want to consider the box to be the underlying object rather than the projection. So thus we see that the result of the underlying address computation is that the underlying address is from a load [take]. Since we then pass in load [take] recursively into the underlying value object computation, we just return load [take]. In contrast, the correct behavior is to do the more general recurse that recognizes that we have a load [take] and that we need to look through it and perform the address computation.

Scope: This modifies one part of Region Based Isolation. It will not impact any other code.

Resolves: rdar://151598281

Main PR: https://github.com/swiftlang/swift/pull/81716

Risk: Low. This should only impact region based isolation code.

Testing: Added compiler tests

Reviewer: @rjmccall
