### PR TITLE
Build Swift-Testing with WMO

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swift_testing.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing.py
@@ -112,6 +112,8 @@ class SwiftTestingCMakeShim(cmake_product.CMakeProduct):
 
         self.cmake_options.define('CMAKE_BUILD_TYPE', self.args.build_variant)
 
+        self.cmake_options.define('CMAKE_Swift_COMPILATION_MODE', 'wholemodule')
+
         # FIXME: If we build macros for the builder, specify the path.
         self.cmake_options.define('SwiftTesting_MACRO', 'NO')
 


### PR DESCRIPTION
This tells build-script to build Swift-testing with WMO. This results in a faster build products, but is also necessary for configurations using the legacy swift driver, which would emit an invalid swift interface in non-WMO builds.

 - Explanation: The merge module job in the old Swift driver emits a broken textual swift interface resulting in a broken bootstrap build (`Testing.swiftinterface:413:2: error: '@_optimize(none)' attribute cannot be applied to stored properties`). Building swift-testing with WMO enabled results in a faster library and does not involve the broken merge-modules job.
 - Risk: Low. This is enabling WMO.
 - Original PR: https://github.com/swiftlang/swift/pull/81622
 - Reviewed by: @stmontgomery 
 - Resolves: rdar://151357567
 - Tests: PR testing, nightly toolchain, mainline bootstrap builds