### PR TITLE
fix calls to llvm prefix mapping functions to use space-separated opt…

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -499,7 +499,7 @@ public:
   bool SkipSDKImportPaths = false;
 
   /// Scanner Prefix Mapper.
-  std::vector<std::string> ScannerPrefixMapper;
+  std::vector<std::pair<std::string, std::string>> ScannerPrefixMapper;
 
   /// Verify resolved plugin is not changed.
   bool ResolvedPluginVerification = false;

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -755,12 +755,8 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   if (!ScannerPrefixMapper.empty()) {
     Mapper = std::make_unique<llvm::PrefixMapper>();
     SmallVector<llvm::MappedPrefix, 4> Prefixes;
-    if (auto E = llvm::MappedPrefix::transformJoined(ScannerPrefixMapper,
-                                                     Prefixes)) {
-      Instance.getDiags().diagnose(SourceLoc(), diag::error_prefix_mapping,
-                                   toString(std::move(E)));
-      return true;
-    }
+    llvm::MappedPrefix::transformPairs(ScannerPrefixMapper,
+                                       Prefixes);
     Mapper->addRange(Prefixes);
     Mapper->sort();
   }

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -40,8 +40,9 @@ using namespace clang::tooling::dependencies;
 static void addScannerPrefixMapperInvocationArguments(
     std::vector<std::string> &invocationArgStrs, ASTContext &ctx) {
   for (const auto &arg : ctx.SearchPathOpts.ScannerPrefixMapper) {
-    std::string prefixMapArg = "-fdepscan-prefix-map=" + arg;
-    invocationArgStrs.push_back(prefixMapArg);
+    invocationArgStrs.push_back("-fdepscan-prefix-map");
+    invocationArgStrs.push_back(arg.first);
+    invocationArgStrs.push_back(arg.second);
   }
 }
 


### PR DESCRIPTION
With [this PR](https://github.com/swiftlang/llvm-project/pull/10740) changing some of the prefix mapping API's in llvm, some build errors are triggered in swift. I fixed the API usage to prevent those build errors so that the llvm PR can pass CI tests.

PR for cross-repo testing: https://github.com/swiftlang/llvm-project/pull/10751
