### PR TITLE
[DebugInfo] Fix infinite recursion when opaque return type is defined inside function returning it

### DIFF
--- a/test/DebugInfo/nested_opaque.swift
+++ b/test/DebugInfo/nested_opaque.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -g -o - | %FileCheck %s
+
+protocol TheProtocol {
+}
+
+// CHECK: ![[FUNC_ID:[0-9]+]] = distinct !DISubprogram(name: "theFunction", 
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "TheType", scope: ![[FUNC_ID]]
+func theFunction() -> some TheProtocol {
+    struct TheType: TheProtocol {
+    }
+    return TheType()
+}
+
+theFunction()


### PR DESCRIPTION
A stack overflow would happen when the compiler tried emitting debug info for a function whose opaque return type was declared inside the function itself. This fixes the issue by emitting a forward declaration for the function before emitting it.

rdar://150313956

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
