### PR TITLE
[6.2][Distributed] account Distributed module use from DA declarations

### DIFF
--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -710,6 +710,18 @@ void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal
   if (!swift::ensureDistributedModuleLoaded(nominal))
     return;
 
+  auto &C = nominal->getASTContext();
+  auto loc = nominal->getLoc();
+  recordRequiredImportAccessLevelForDecl(
+    C.getDistributedActorDecl(), nominal, nominal->getEffectiveAccess(),
+    [&](AttributedImport<ImportedModule> attributedImport) {
+  ModuleDecl *importedVia = attributedImport.module.importedModule,
+             *sourceModule = nominal->getModuleContext();
+  C.Diags.diagnose(loc, diag::module_api_import, nominal, importedVia,
+                         sourceModule, importedVia == sourceModule,
+                         /*isImplicit*/ false);
+});
+
   // ==== Constructors
   // --- Get the default initializer
   // If applicable, this will create the default 'init(transport:)' initializer

--- a/test/Distributed/distributed_public_module_import.swift
+++ b/test/Distributed/distributed_public_module_import.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -target %target-swift-5.7-abi-triple %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.7-abi-triple -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// Should NOT produce a warning, we do use the module in a public declaration, see MyPublicDistributedActor
+public import Distributed
+import FakeDistributedActorSystems
+
+
+public distributed actor MyPublicDistributedActor {
+  public typealias ActorSystem = FakeActorSystem
+}


### PR DESCRIPTION
**Description**: 
When issuing warnings about an import not needing to be public, we did
not account for the Distributed module MUST be imported when a
distributed actor is declared. This also actually means that a public
distributed actor effectively is a public use of the DistributedActor
protocol

**Scope/Impact**: Import public diagnostics specifically about `distributed actor` declarations.
**Risk:** Low, only fixes a warning.
**Testing**: CI testing, added a test for this case.
**Reviewed by**: @xymus

**Original PR:** https://github.com/swiftlang/swift/pull/81797/
**Radar:** rdar://152129980 rdar://152063740
