### PR TITLE
[wasm] Unify WasmLLVMRuntimeLibs and WasmThreadsLLVMRuntimeLibs build directories

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -670,8 +670,6 @@ class BuildScriptInvocation(object):
                             is_enabled=self.args.build_wasmstdlib)
         builder.add_product(products.WasmLLVMRuntimeLibs,
                             is_enabled=self.args.build_wasmstdlib)
-        builder.add_product(products.WasmThreadsLLVMRuntimeLibs,
-                            is_enabled=self.args.build_wasmstdlib)
 
         builder.add_product(products.SwiftTestingMacros,
                             is_enabled=self.args.build_swift_testing_macros)

--- a/utils/swift_build_support/swift_build_support/products/__init__.py
+++ b/utils/swift_build_support/swift_build_support/products/__init__.py
@@ -42,7 +42,7 @@ from .swiftinspect import SwiftInspect
 from .swiftpm import SwiftPM
 from .swiftsyntax import SwiftSyntax
 from .tsan_libdispatch import TSanLibDispatch
-from .wasisysroot import WASILibc, WasmLLVMRuntimeLibs, WasmThreadsLLVMRuntimeLibs
+from .wasisysroot import WASILibc, WasmLLVMRuntimeLibs
 from .wasmkit import WasmKit
 from .wasmstdlib import WasmStdlib, WasmThreadsStdlib
 from .wasmswiftsdk import WasmSwiftSDK
@@ -88,7 +88,6 @@ __all__ = [
     'WasmLLVMRuntimeLibs',
     'WasmKit',
     'WasmStdlib',
-    'WasmThreadsLLVMRuntimeLibs',
     'WasmThreadsStdlib',
     'WasmSwiftSDK',
 ]

--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -130,53 +130,61 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
         return False
 
     def build(self, host_target):
-        self._build(host_target)
+        self._build(host_target, enable_wasi_threads=False,
+                    compiler_rt_os_dir='wasi', target_triple='wasm32-wasi')
+        self._build(host_target, enable_wasi_threads=True,
+                    compiler_rt_os_dir='wasip1', target_triple='wasm32-wasip1-threads')
 
-    def _build(self, host_target, enable_wasi_threads=False,
-               compiler_rt_os_dir='wasi', target_triple='wasm32-wasi'):
+    def _build(self, host_target, enable_wasi_threads, compiler_rt_os_dir, target_triple):
+        cmake = cmake_product.CMakeProduct(
+            args=self.args,
+            toolchain=self.toolchain,
+            source_dir=self.source_dir,
+            build_dir=os.path.join(self.build_dir, target_triple))
+
         build_root = os.path.dirname(self.build_dir)
         llvm_build_bin_dir = os.path.join(
             '..', build_root, '%s-%s' % ('llvm', host_target), 'bin')
-        llvm_tools_path = self.args.native_llvm_tools_path or llvm_build_bin_dir
-        clang_tools_path = self.args.native_clang_tools_path or llvm_build_bin_dir
+        llvm_tools_path = cmake.args.native_llvm_tools_path or llvm_build_bin_dir
+        clang_tools_path = cmake.args.native_clang_tools_path or llvm_build_bin_dir
 
         cmake_has_threads = 'TRUE' if enable_wasi_threads else 'FALSE'
 
-        self.cmake_options.define(
+        cmake.cmake_options.define(
             'CMAKE_SYSROOT:PATH',
             WASILibc.sysroot_build_path(build_root, host_target, target_triple))
         enable_runtimes = ['libcxx', 'libcxxabi', 'compiler-rt']
-        self.cmake_options.define('LLVM_ENABLE_RUNTIMES:STRING',
-                                  ';'.join(enable_runtimes))
+        cmake.cmake_options.define('LLVM_ENABLE_RUNTIMES:STRING',
+                                   ';'.join(enable_runtimes))
 
         libdir_suffix = '/' + target_triple
-        self.cmake_options.define('LIBCXX_LIBDIR_SUFFIX:STRING', libdir_suffix)
-        self.cmake_options.define('LIBCXXABI_LIBDIR_SUFFIX:STRING', libdir_suffix)
-        self.cmake_options.define('CMAKE_STAGING_PREFIX:PATH', '/')
+        cmake.cmake_options.define('LIBCXX_LIBDIR_SUFFIX:STRING', libdir_suffix)
+        cmake.cmake_options.define('LIBCXXABI_LIBDIR_SUFFIX:STRING', libdir_suffix)
+        cmake.cmake_options.define('CMAKE_STAGING_PREFIX:PATH', '/')
 
-        self.cmake_options.define('COMPILER_RT_DEFAULT_TARGET_ARCH:STRING', 'wasm32')
-        self.cmake_options.define('COMPILER_RT_DEFAULT_TARGET_ONLY:BOOL', 'TRUE')
-        self.cmake_options.define('COMPILER_RT_BAREMETAL_BUILD:BOOL', 'TRUE')
-        self.cmake_options.define('COMPILER_RT_BUILD_XRAY:BOOL', 'FALSE')
-        self.cmake_options.define('COMPILER_RT_BUILD_PROFILE:BOOL', 'TRUE')
-        self.cmake_options.define('COMPILER_RT_INCLUDE_TESTS:BOOL', 'FALSE')
-        self.cmake_options.define('COMPILER_RT_HAS_FPIC_FLAG:BOOL', 'FALSE')
-        self.cmake_options.define('COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN:BOOL', 'FALSE')
-        self.cmake_options.define('COMPILER_RT_OS_DIR:STRING', compiler_rt_os_dir)
+        cmake.cmake_options.define('COMPILER_RT_DEFAULT_TARGET_ARCH:STRING', 'wasm32')
+        cmake.cmake_options.define('COMPILER_RT_DEFAULT_TARGET_ONLY:BOOL', 'TRUE')
+        cmake.cmake_options.define('COMPILER_RT_BAREMETAL_BUILD:BOOL', 'TRUE')
+        cmake.cmake_options.define('COMPILER_RT_BUILD_XRAY:BOOL', 'FALSE')
+        cmake.cmake_options.define('COMPILER_RT_BUILD_PROFILE:BOOL', 'TRUE')
+        cmake.cmake_options.define('COMPILER_RT_INCLUDE_TESTS:BOOL', 'FALSE')
+        cmake.cmake_options.define('COMPILER_RT_HAS_FPIC_FLAG:BOOL', 'FALSE')
+        cmake.cmake_options.define('COMPILER_RT_EXCLUDE_ATOMIC_BUILTIN:BOOL', 'FALSE')
+        cmake.cmake_options.define('COMPILER_RT_OS_DIR:STRING', compiler_rt_os_dir)
 
-        self.cmake_options.define('CMAKE_C_COMPILER_WORKS:BOOL', 'TRUE')
-        self.cmake_options.define('CMAKE_CXX_COMPILER_WORKS:BOOL', 'TRUE')
+        cmake.cmake_options.define('CMAKE_C_COMPILER_WORKS:BOOL', 'TRUE')
+        cmake.cmake_options.define('CMAKE_CXX_COMPILER_WORKS:BOOL', 'TRUE')
 
-        self.cmake_options.define('CMAKE_SYSTEM_NAME:STRING', 'WASI')
-        self.cmake_options.define('CMAKE_SYSTEM_PROCESSOR:STRING', 'wasm32')
-        self.cmake_options.define('CMAKE_AR:FILEPATH',
-                                  os.path.join(llvm_tools_path, 'llvm-ar'))
-        self.cmake_options.define('CMAKE_RANLIB:FILEPATH',
-                                  os.path.join(llvm_tools_path, 'llvm-ranlib'))
-        self.cmake_options.define('CMAKE_C_COMPILER:FILEPATH',
-                                  os.path.join(clang_tools_path, 'clang'))
-        self.cmake_options.define('CMAKE_CXX_COMPILER:STRING',
-                                  os.path.join(clang_tools_path, 'clang++'))
+        cmake.cmake_options.define('CMAKE_SYSTEM_NAME:STRING', 'WASI')
+        cmake.cmake_options.define('CMAKE_SYSTEM_PROCESSOR:STRING', 'wasm32')
+        cmake.cmake_options.define('CMAKE_AR:FILEPATH',
+                                   os.path.join(llvm_tools_path, 'llvm-ar'))
+        cmake.cmake_options.define('CMAKE_RANLIB:FILEPATH',
+                                   os.path.join(llvm_tools_path, 'llvm-ranlib'))
+        cmake.cmake_options.define('CMAKE_C_COMPILER:FILEPATH',
+                                   os.path.join(clang_tools_path, 'clang'))
+        cmake.cmake_options.define('CMAKE_CXX_COMPILER:STRING',
+                                   os.path.join(clang_tools_path, 'clang++'))
 
         c_flags = []
         # Explicitly disable exceptions even though it's usually implicitly disabled by
@@ -187,51 +195,45 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
         if enable_wasi_threads:
             c_flags.append('-pthread')
             cxx_flags.append('-pthread')
-        self.cmake_options.define('CMAKE_C_FLAGS:STRING', ' '.join(c_flags))
-        self.cmake_options.define('CMAKE_CXX_FLAGS:STRING', ' '.join(cxx_flags))
+        cmake.cmake_options.define('CMAKE_C_FLAGS:STRING', ' '.join(c_flags))
+        cmake.cmake_options.define('CMAKE_CXX_FLAGS:STRING', ' '.join(cxx_flags))
 
-        self.cmake_options.define('CMAKE_C_COMPILER_TARGET:STRING', target_triple)
-        self.cmake_options.define('CMAKE_CXX_COMPILER_TARGET:STRING', target_triple)
+        cmake.cmake_options.define('CMAKE_C_COMPILER_TARGET:STRING', target_triple)
+        cmake.cmake_options.define('CMAKE_CXX_COMPILER_TARGET:STRING', target_triple)
 
-        self.cmake_options.define('CXX_SUPPORTS_CXX11:BOOL', 'TRUE')
+        cmake.cmake_options.define('CXX_SUPPORTS_CXX11:BOOL', 'TRUE')
 
-        self.cmake_options.define('LIBCXX_ENABLE_THREADS:BOOL', cmake_has_threads)
-        self.cmake_options.define('LIBCXX_HAS_PTHREAD_API:BOOL', cmake_has_threads)
-        self.cmake_options.define('LIBCXX_HAS_EXTERNAL_THREAD_API:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXX_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXX_HAS_WIN32_THREAD_API:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXX_ENABLE_SHARED:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXX_ENABLE_EXPERIMENTAL_LIBRARY:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXX_ENABLE_EXCEPTIONS:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXX_ENABLE_FILESYSTEM:BOOL', 'TRUE')
-        self.cmake_options.define('LIBCXX_CXX_ABI', 'libcxxabi')
-        self.cmake_options.define('LIBCXX_HAS_MUSL_LIBC:BOOL', 'TRUE')
+        cmake.cmake_options.define('LIBCXX_ENABLE_THREADS:BOOL', cmake_has_threads)
+        cmake.cmake_options.define('LIBCXX_HAS_PTHREAD_API:BOOL', cmake_has_threads)
+        cmake.cmake_options.define('LIBCXX_HAS_EXTERNAL_THREAD_API:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXX_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXX_HAS_WIN32_THREAD_API:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXX_ENABLE_SHARED:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXX_ENABLE_EXPERIMENTAL_LIBRARY:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXX_ENABLE_EXCEPTIONS:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXX_ENABLE_FILESYSTEM:BOOL', 'TRUE')
+        cmake.cmake_options.define('LIBCXX_CXX_ABI', 'libcxxabi')
+        cmake.cmake_options.define('LIBCXX_HAS_MUSL_LIBC:BOOL', 'TRUE')
 
-        self.cmake_options.define('LIBCXX_ABI_VERSION', '2')
-        self.cmake_options.define('LIBCXXABI_ENABLE_EXCEPTIONS:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXXABI_ENABLE_SHARED:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXXABI_USE_LLVM_UNWINDER:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXXABI_SILENT_TERMINATE:BOOL', 'TRUE')
-        self.cmake_options.define('LIBCXXABI_ENABLE_THREADS:BOOL', cmake_has_threads)
-        self.cmake_options.define('LIBCXXABI_HAS_PTHREAD_API:BOOL', cmake_has_threads)
-        self.cmake_options.define('LIBCXXABI_HAS_EXTERNAL_THREAD_API:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL',
-                                  'FALSE')
-        self.cmake_options.define('LIBCXXABI_HAS_WIN32_THREAD_API:BOOL', 'FALSE')
-        self.cmake_options.define('LIBCXXABI_ENABLE_PIC:BOOL', 'FALSE')
-        self.cmake_options.define('UNIX:BOOL', 'TRUE')
+        cmake.cmake_options.define('LIBCXX_ABI_VERSION', '2')
+        cmake.cmake_options.define('LIBCXXABI_ENABLE_EXCEPTIONS:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXXABI_ENABLE_SHARED:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXXABI_USE_LLVM_UNWINDER:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXXABI_SILENT_TERMINATE:BOOL', 'TRUE')
+        cmake.cmake_options.define('LIBCXXABI_ENABLE_THREADS:BOOL', cmake_has_threads)
+        cmake.cmake_options.define('LIBCXXABI_HAS_PTHREAD_API:BOOL', cmake_has_threads)
+        cmake.cmake_options.define('LIBCXXABI_HAS_EXTERNAL_THREAD_API:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL',
+                                   'FALSE')
+        cmake.cmake_options.define('LIBCXXABI_HAS_WIN32_THREAD_API:BOOL', 'FALSE')
+        cmake.cmake_options.define('LIBCXXABI_ENABLE_PIC:BOOL', 'FALSE')
+        cmake.cmake_options.define('UNIX:BOOL', 'TRUE')
 
-        self.build_with_cmake([], self.args.build_variant, [],
-                              prefer_native_toolchain=True)
-        self.install_with_cmake(
+        cmake.build_with_cmake([], cmake.args.build_variant, [],
+                               prefer_native_toolchain=True)
+        cmake.install_with_cmake(
             ["install"], WASILibc.sysroot_install_path(build_root, target_triple))
 
     @classmethod
     def get_dependencies(cls):
         return [WASILibc, llvm.LLVM]
-
-
-class WasmThreadsLLVMRuntimeLibs(WasmLLVMRuntimeLibs):
-    def build(self, host_target):
-        self._build(host_target, enable_wasi_threads=True,
-                    compiler_rt_os_dir='wasip1', target_triple='wasm32-wasip1-threads')

--- a/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmswiftsdk.py
@@ -110,8 +110,6 @@ class WasmSwiftSDK(product.Product):
 
     def build(self, host_target):
         build_root = os.path.dirname(self.build_dir)
-        llvm_runtime_libs_build_path = os.path.join(
-            build_root, '%s-%s' % ('wasmllvmruntimelibs', host_target))
 
         target_packages = []
         # NOTE: We have three types of target triples:
@@ -130,6 +128,9 @@ class WasmSwiftSDK(product.Product):
                 build_root, '%s-%s' % (build_basename, host_target))
             wasi_sysroot = wasisysroot.WASILibc.sysroot_install_path(
                 build_root, clang_multiarch_triple)
+            llvm_runtime_libs_build_path = os.path.join(
+                build_root, '%s-%s' % ('wasmllvmruntimelibs', host_target),
+                clang_multiarch_triple)
             package_path = self._build_target_package(
                 swift_host_triple, short_triple, stdlib_build_path,
                 llvm_runtime_libs_build_path, wasi_sysroot)


### PR DESCRIPTION
Having separate build product does not make sense and just adds complexity to manage build directory names.
