### PR TITLE
[6.1][Backtracing] Add warning suppression option, enable it for tests.

### DIFF
--- a/docs/Backtracing.rst
+++ b/docs/Backtracing.rst
@@ -113,6 +113,10 @@ follows:
 |                 |         | Otherwise, Swift will locate the binary relative |
 |                 |         | to the runtime library, or using ``SWIFT_ROOT``. |
 +-----------------+---------+--------------------------------------------------+
+| warnings        | enabled | Set to ``suppressed`` to disable warning output  |
+|                 |         | related to the state of the backtracer.  This is |
+|                 |         | sometimes useful for testing.                    |
++-----------------+---------+--------------------------------------------------+
 
 (*) On macOS, this defaults to ``no`` rather than ``yes``.
 

--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -127,6 +127,7 @@ struct BacktraceSettings {
   OutputTo         outputTo;
   Symbolication    symbolicate;
   OutputFormat     format;
+  bool             suppressWarnings;
   const char      *swiftBacktracePath;
   const char      *outputPath;
 };

--- a/test/IRGen/lit.local.cfg
+++ b/test/IRGen/lit.local.cfg
@@ -5,7 +5,7 @@ config.substitutions.insert(0, ('%build-irgen-test-overlays',
                                 '%target-swift-frontend -enable-objc-interop -disable-objc-attr-requires-foundation-module -emit-module -enable-library-evolution -o %t -sdk %S/Inputs %S/Inputs/ObjectiveC.swift && '
                                 '%target-swift-frontend -enable-objc-interop -emit-module -enable-library-evolution -o %t -sdk %S/Inputs %S/Inputs/Foundation.swift -I %t'))
 
-config.substitutions.insert(0, ('%build-irgen-test-overlays\(mock-sdk-directory: ([^)]+)\)',
+config.substitutions.insert(0, (r'%build-irgen-test-overlays\(mock-sdk-directory: ([^)]+)\)',
                              SubstituteCaptures(r'%target-swift-frontend -enable-objc-interop -disable-objc-attr-requires-foundation-module -emit-module -enable-library-evolution -o %t -sdk \1 \1/ObjectiveC.swift && '
                                 r'%target-swift-frontend -enable-objc-interop -emit-module -enable-library-evolution -o %t -sdk \1 \1/Foundation.swift -I %t')))
 

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -59,12 +59,12 @@ config.substitutions.insert(0, ('%target-interop-build-clang',  '%target-clang -
 config.substitutions.insert(0, ('%target-interop-build-clangxx', '%target-clangxx --std=gnu++14 ' + clang_opt))
 
 # Test parsing of the generated C++ header in different C++ language modes.
-config.substitutions.insert(0, ('%check-interop-cxx-header-in-clang\(([^)]+)\)',
+config.substitutions.insert(0, (r'%check-interop-cxx-header-in-clang\(([^)]+)\)',
                              SubstituteCaptures(r'%check-cxx-header-in-clang -std=c++14 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB ' + clang_compile_opt + r'\1 && '
                                                 r'%check-cxx-header-in-clang -std=c++17 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB ' + clang_compile_opt + r'\1 && '
                                                 r'%check-cxx-header-in-clang -std=c++20 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB ' + clang_compile_opt + r'\1')))
 
 # Test parsing of the generated C header in different C language modes.
-config.substitutions.insert(0, ('%check-interop-c-header-in-clang\(([^)]+)\)',
+config.substitutions.insert(0, (r'%check-interop-c-header-in-clang\(([^)]+)\)',
                              SubstituteCaptures(r'%check-c-header-in-clang -std=c99 -Wno-padded -Wno-c11-extensions -Wno-pre-c11-compat \1 && '
                                                 r'%check-c-header-in-clang -std=c11 -Wno-padded -Wno-pre-c11-compat \1')))

--- a/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/modulecache)
+// RUN: export SWIFT_BACKTRACE=
 
 // rdar://88830153
 // https://github.com/apple/swift/issues/58134

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -551,7 +551,7 @@ if backtracing is not None:
 
 backtrace_on_crash = lit_config.params.get('backtrace_on_crash', None)
 if backtrace_on_crash is not None:
-    config.environment['SWIFT_BACKTRACE'] = 'enable=on'
+    config.environment['SWIFT_BACKTRACE'] = 'enable=on,warnings=suppressed'
 
 # Make an explicit setting in the environment override whatever we did above
 swift_backtrace = os.environ.get('SWIFT_BACKTRACE')
@@ -2988,7 +2988,7 @@ if hasattr(config, 'target_link_sdk_future_version'):
     config.substitutions.append(('%target-link-sdk-future-version',
                                  config.target_link_sdk_future_version))
 
-run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --use-filecheck %s %s %s' % (
+run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitize SOURCE_DIR=%s --ignore-runtime-warnings --use-filecheck %s %s %s' % (
         shell_quote(sys.executable),
         shell_quote(config.PathSanitizingFileCheck),
         # LLVM Lit performs realpath with the config path, so all paths are relative

--- a/test/remote-run/exit-code.test-sh
+++ b/test/remote-run/exit-code.test-sh
@@ -1,5 +1,6 @@
 REQUIRES: shell
 
+RUN: export SWIFT_BACKTRACE=
 RUN: not %debug-remote-run false >%t.txt 2>%t.errs.txt
 RUN: test -f %t.txt -a ! -s %t.txt
 RUN: test -f %t.errs.txt -a ! -s %t.errs.txt

--- a/utils/PathSanitizingFileCheck
+++ b/utils/PathSanitizingFileCheck
@@ -61,6 +61,11 @@ constants.""")
              "to standard output",
         action="store_true")
 
+    parser.add_argument(
+        "--ignore-runtime-warnings",
+        help="Ignore warnings from the Swift runtime",
+        action="store_true")
+
     args, unknown_args = parser.parse_known_args()
 
     if args.enable_windows_compatibility:
@@ -81,6 +86,16 @@ constants.""")
         stdin = re.sub(re.sub(r'\\/' if sys.version_info[0] < 3 else r'/',
                               slashes_re, re.escape(pattern)),
                        replacement, stdin)
+
+    # Because we force the backtracer on in the tests, we can get runtime
+    # warnings about privileged programs.  Suppress those, and also the
+    # warning it might emit if backtracing isn't supported on the test platform.
+    # Additionally, suppress warnings about unknown backtracer options, since
+    # we might want to add new ones to the lit tests and we should ignore
+    # messages from the system copy of the runtime in that case.
+    if args.ignore_runtime_warnings:
+        stdin = re.sub(r'^swift runtime: (backtrace-on-crash is not '
+                       r'supported|unknown) .*\n', "", stdin, flags=re.M)
 
     if args.dry_run:
         print(stdin)

--- a/validation-test/BuildSystem/swift-xcodegen.test
+++ b/validation-test/BuildSystem/swift-xcodegen.test
@@ -3,6 +3,7 @@
 # RUN: %empty-directory(%t/out)
 # RUN: export PATH="%original_path_env"
 # RUN: export SWIFTCI_USE_LOCAL_DEPS=1
+# RUN: export SWIFT_BACKTRACE=
 
 # REQUIRES: OS=macosx
 # REQUIRES: standalone_build

--- a/validation-test/Python/line-directive.swift
+++ b/validation-test/Python/line-directive.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
+// RUN: export SWIFT_BACKTRACE=
 
 // RUN: %{python} %utils/line-directive
 // RUN: %{python} %utils/line-directive -- %{python} %t/unicode.py

--- a/validation-test/Python/update_checkout.swift
+++ b/validation-test/Python/update_checkout.swift
@@ -4,5 +4,6 @@
 // than once for each supported Apple device.
 
 // REQUIRES: OS=macosx
+// RUN: export SWIFT_BACKTRACE=
 
 // RUN: %{python} %utils/update_checkout/run_tests.py


### PR DESCRIPTION
[Backtracing] Add warning suppression option, enable it for tests.

The backtracing code will warn you if you attempt to forcibly enable backtracing for a privileged executable. This is apparently upsetting the Driver/filelists.swift test.

Since we want to force it on for tests, so that we will definitely get backtraces, add an option to suppress warning messages, and turn that on for tests as well.

rdar://152074531