### PR TITLE
[Diagnostics] Add fix-it to `@main` struct without main static function.

### DIFF
--- a/test/attr/ApplicationMain/attr_main_instance.swift
+++ b/test/attr/ApplicationMain/attr_main_instance.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck -parse-as-library -verify %s
 
-@main // expected-error{{'MyBase' is annotated with '@main' and must provide a main static function}}
+@main // expected-error{{'MyBase' is annotated with '@main' and must provide a main static function}} {{4:15-15=\n    static func main() {\n        <#code#>\n    }\n}} {{4:15-15=\n    static func main() throws {\n        <#code#>\n    }\n}} {{4:15-15=\n    static func main() async {\n        <#code#>\n    }\n}} {{4:15-15=\n    static func main() async throws {\n        <#code#>\n    }\n}}
 class MyBase {
   func main() {
   }


### PR DESCRIPTION
Resolves https://github.com/swiftlang/swift/issues/58518

It will create four different fix-its:

```swift
    static func main() {
        <#code#>
    }
 
    static func main() throws {
        <#code#>
    }
 
    static func main() async {
        <#code#>
    }
 
    static func main() async throws {
        <#code#>
    }
```