### PR TITLE
[IRGen] This ArtificialLoc requires a debug scope.

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -5023,8 +5023,11 @@ static void emitRetconCoroutineEntry(
   for (auto *arg : finalArguments) {
     arguments.push_back(arg);
   }
-  ArtificialLocation Loc(IGF.getDebugScope(), IGF.IGM.DebugInfo.get(),
-                         IGF.Builder);
+  std::optional<ArtificialLocation> Loc;
+  if (IGF.getDebugScope()) {
+    Loc.emplace(IGF.getDebugScope(), IGF.IGM.DebugInfo.get(),
+                           IGF.Builder);
+  }
   llvm::Value *id = IGF.Builder.CreateIntrinsicCall(idIntrinsic, arguments);
 
   // Call 'llvm.coro.begin', just for consistency with the normal pattern.


### PR DESCRIPTION
An `IRGenFunction` may not have a debug scope--for example, a dispatch thunk--but creating an `AritificalLocation` requires one.  Only create an `ArtificalLocation` here if the `IRGenFunction` has one.

Unfortunately, I don't have an isolated test case.  Fixes a compiler crash.
