### PR TITLE
[6.2] Disable layout_string_witnesses_dynamic.swift

### DIFF
--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -17,7 +17,7 @@
 // UNSUPPORTED: back_deployment_runtime
 
 // test disabled until rdar://151476435 is fixed
-// REQUIRES: rdar://151476435
+// REQUIRES: rdar151476435
 
 import Swift
 import layout_string_witnesses_types

--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -16,6 +16,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// test disabled until rdar://151476435 is fixed
+// REQUIRES: rdar://151476435
+
 import Swift
 import layout_string_witnesses_types
 import layout_string_witnesses_types_resilient


### PR DESCRIPTION
Explanation:
Cherry-pick disabling of layout_string_witnesses_dynamic.swift to 6.2 branch

Scope:
Minimal risk, disabling a failing test being investigated.

Issues:
rdar://151476435

Original PRs:
https://github.com/swiftlang/swift/pull/81629

Risk:
Failing test is blocking 6.2 nightlies

Testing:

Reviewers:
@drexin @shahmishal 