### PR TITLE
[6.2] [cxx-interop] Temporarily disable a test for `std::function` on UBI 9

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -15,6 +15,7 @@
 // XFAIL: LinuxDistribution=rhel-9.3
 // XFAIL: LinuxDistribution=rhel-9.4
 // XFAIL: LinuxDistribution=rhel-9.5
+// XFAIL: LinuxDistribution=rhel-9.6
 // XFAIL: LinuxDistribution=fedora-39
 // XFAIL: LinuxDistribution=debian-12
 


### PR DESCRIPTION

Explanation:
Cherry-pick disabling of use-std-function.swift on 6.2 branch

Scope:
Minimal risk, disabling a failing test being investigated.

Issues:

 rdar://151476434

Original PRs:

https://github.com/swiftlang/swift/pull/81708

Risk:
Failing test is blocking 6.2 nightlies

Testing:

This test has been already disabled on main and 6.1. Temp disabling it for UBI9 in 6.2 as well

Reviewers:
@egorzhdan  @shahmishal 