### PR TITLE
Add %target-codesign to executables and dylibs in newly added AutoDiff tests

### DIFF
--- a/test/AutoDiff/validation-test/always_emit_into_client/multi_file.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/multi_file.swift
@@ -7,6 +7,7 @@
 // RUN:   -emit-module -emit-module-path %t/MultiFileModule.swiftmodule -module-name MultiFileModule
 
 // RUN: %target-build-swift -I%t %s -o %t/a.out %target-rpath(%t)
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 
 // RUN: %target-build-swift -I%t %s -emit-ir | %FileCheck %s

--- a/test/AutoDiff/validation-test/always_emit_into_client/multi_module.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/multi_module.swift
@@ -5,11 +5,14 @@
 /// symbols because all the functions in the module are marked as @_alwaysEmitIntoClient.
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModule1)) %S/Inputs/MultiModule/file1.swift \
 // RUN:   -emit-module -emit-module-path %t/MultiModule1.swiftmodule -module-name MultiModule1
+// RUN: %target-codesign %t/%target-library-name(MultiModule1)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModule2)) %S/Inputs/MultiModule/file2.swift \
 // RUN:   -emit-module -emit-module-path %t/MultiModule2.swiftmodule -module-name MultiModule2 -I%t %target-rpath(%t)
+// RUN: %target-codesign %t/%target-library-name(MultiModule2)
 
 // RUN: %target-build-swift -I%t %s -o %t/a.out %target-rpath(%t)
-// RUN: %target-run %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out %t/%target-library-name(MultiModule1) %t/%target-library-name(MultiModule2)
 
 // RUN: %target-build-swift -I%t %s -emit-ir | %FileCheck %s
 

--- a/test/AutoDiff/validation-test/always_emit_into_client/multi_module_protocol.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/multi_module_protocol.swift
@@ -3,6 +3,7 @@
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModuleProtocol1)) %S/Inputs/MultiModuleProtocol/file1.swift \
 // RUN:   -emit-module -emit-module-path %t/MultiModuleProtocol1.swiftmodule -module-name MultiModuleProtocol1
+// RUN: %target-codesign %t/%target-library-name(MultiModuleProtocol1)
 
 /// Note: we build just a module without a library since it would not contain any exported
 /// symbols because all the functions in the module are marked as @_alwaysEmitIntoClient.
@@ -11,12 +12,14 @@
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModuleProtocol3)) %S/Inputs/MultiModuleProtocol/file3.swift \
 // RUN:   -emit-module -emit-module-path %t/MultiModuleProtocol3.swiftmodule -module-name MultiModuleProtocol3 -I%t -L%t -lMultiModuleProtocol1 %target-rpath(%t)
+// RUN: %target-codesign %t/%target-library-name(MultiModuleProtocol3)
 
 /// Note: we enable forward-mode differentiation to automatically generate JVP for `foo`.
 /// It wraps `Protocol.sum` that has custom JVP defined in MultiModuleProtocol2, so we can test it.
 // RUN: %target-build-swift -Xfrontend -enable-experimental-forward-mode-differentiation \
 // RUN:   -I%t -L%t %s -lMultiModuleProtocol1 -lMultiModuleProtocol3 -o %t/a.out %target-rpath(%t)
-// RUN: %target-run %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out %t/%target-library-name(MultiModuleProtocol1) %t/%target-library-name(MultiModuleProtocol3)
 
 // RUN: %target-build-swift -I%t %s -emit-ir | %FileCheck %s
 

--- a/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct.swift
@@ -3,14 +3,17 @@
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModuleStruct1)) %S/Inputs/MultiModuleStruct/file1.swift \
 // RUN:   -emit-module -emit-module-path %t/MultiModuleStruct1.swiftmodule -module-name MultiModuleStruct1
+// RUN: %target-codesign %t/%target-library-name(MultiModuleStruct1)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModuleStruct2)) %S/Inputs/MultiModuleStruct/file2.swift \
 // RUN:   -emit-module -emit-module-path %t/MultiModuleStruct2.swiftmodule -module-name MultiModuleStruct2 -I%t -L%t -lMultiModuleStruct1 %target-rpath(%t)
+// RUN: %target-codesign %t/%target-library-name(MultiModuleStruct2)
 
 /// Note: we enable forward-mode differentiation to automatically generate JVP for `foo`.
 /// It wraps `Struct.sum` that has custom JVP defined in MultiModuleStruct2, so we can test it.
 // RUN: %target-build-swift -Xfrontend -enable-experimental-forward-mode-differentiation \
 // RUN:   -I%t -L%t %s -lMultiModuleStruct1 -lMultiModuleStruct2 -o %t/a.out %target-rpath(%t)
-// RUN: %target-run %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out %t/%target-library-name(MultiModuleStruct1) %t/%target-library-name(MultiModuleStruct2)
 
 // RUN: %target-build-swift -I%t %s -emit-ir | %FileCheck %s
 

--- a/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/multi_module_struct_no_jvp.swift
@@ -3,14 +3,17 @@
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModuleStruct1)) %S/Inputs/MultiModuleStruct/file1.swift \
 // RUN:   -emit-module -emit-module-path %t/MultiModuleStruct1.swiftmodule -module-name MultiModuleStruct1
+// RUN: %target-codesign %t/%target-library-name(MultiModuleStruct1)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(MultiModuleStruct2NoJVP)) %S/Inputs/MultiModuleStruct/file2_no_jvp.swift \
 // RUN:   -emit-module -emit-module-path %t/MultiModuleStruct2NoJVP.swiftmodule -module-name MultiModuleStruct2NoJVP -I%t -L%t -lMultiModuleStruct1 %target-rpath(%t)
+// RUN: %target-codesign %t/%target-library-name(MultiModuleStruct2NoJVP)
 
 /// Note: we enable forward-mode differentiation to automatically generate JVP for `foo`.
 /// It wraps `Struct.sum` that has custom JVP defined in MultiModuleStruct2, so we can test it.
 // RUN: %target-build-swift -Xfrontend -enable-experimental-forward-mode-differentiation \
 // RUN:   -I%t -L%t %s -lMultiModuleStruct1 -lMultiModuleStruct2NoJVP -o %t/a.out %target-rpath(%t)
-// RUN: %target-run %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out %t/%target-library-name(MultiModuleStruct1) %t/%target-library-name(MultiModuleStruct2NoJVP)
 
 // RUN: %target-build-swift -I%t %s -emit-ir | %FileCheck %s
 

--- a/test/AutoDiff/validation-test/always_emit_into_client/single_file.swift
+++ b/test/AutoDiff/validation-test/always_emit_into_client/single_file.swift
@@ -7,6 +7,7 @@
 // RUN:   -emit-module-path %t/SingleFileModule.swiftmodule -module-name SingleFileModule
 
 // RUN: %target-build-swift -I%t %s -o %t/a.out %target-rpath(%t)
+// RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 
 // RUN: %target-build-swift -I%t %s -emit-ir | %FileCheck %s


### PR DESCRIPTION
There tests were failing in device testing due to code signing and missing dylibs.
