### PR TITLE
[Concurrency] Fix races/overflows in TaskGroup implementation.

### DIFF
--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -80,7 +80,7 @@ public func withDiscardingTaskGroup<GroupResult>(
     discardResults: true
   )
 
-  let _group = Builtin.createTaskGroupWithFlags(flags, GroupResult.self)
+  let _group = Builtin.createTaskGroupWithFlags(flags, Void.self)
   var group = DiscardingTaskGroup(group: _group)
   defer { Builtin.destroyTaskGroup(_group) }
 
@@ -108,7 +108,7 @@ public func _unsafeInheritExecutor_withDiscardingTaskGroup<GroupResult>(
     discardResults: true
   )
 
-  let _group = Builtin.createTaskGroupWithFlags(flags, GroupResult.self)
+  let _group = Builtin.createTaskGroupWithFlags(flags, Void.self)
   var group = DiscardingTaskGroup(group: _group)
   defer { Builtin.destroyTaskGroup(_group) }
 
@@ -347,7 +347,7 @@ public func withThrowingDiscardingTaskGroup<GroupResult>(
       discardResults: true
   )
 
-  let _group = Builtin.createTaskGroupWithFlags(flags, GroupResult.self)
+  let _group = Builtin.createTaskGroupWithFlags(flags, Void.self)
   var group = ThrowingDiscardingTaskGroup<Error>(group: _group)
   defer { Builtin.destroyTaskGroup(_group) }
 
@@ -378,7 +378,7 @@ public func _unsafeInheritExecutor_withThrowingDiscardingTaskGroup<GroupResult>(
       discardResults: true
   )
 
-  let _group = Builtin.createTaskGroupWithFlags(flags, GroupResult.self)
+  let _group = Builtin.createTaskGroupWithFlags(flags, Void.self)
   var group = ThrowingDiscardingTaskGroup<Error>(group: _group)
   defer { Builtin.destroyTaskGroup(_group) }
 

--- a/test/Concurrency/Runtime/async_taskgroup_cancellation_race.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_cancellation_race.swift
@@ -1,0 +1,59 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: freestanding
+
+func unorderedResults<R>(
+    _ fns: [@Sendable () async -> R]) -> (Task<(), Never>, AsyncStream<R>) {
+        var capturedContinuation: AsyncStream<R>.Continuation? = nil
+        let stream = AsyncStream<R> { continuation in
+            capturedContinuation = continuation
+        }
+
+        guard let capturedContinuation = capturedContinuation else {
+            fatalError("failed to capture continuation")
+        }
+
+        let task = Task.detached {
+            await withTaskGroup(of: Void.self) { group in
+                for fn in fns {
+                    group.addTask {
+                        let _ = capturedContinuation.yield(await fn())
+                    }
+                }
+                await group.waitForAll()
+            }
+            capturedContinuation.finish()
+        }
+
+        let result = (task, stream)
+
+        return result
+    }
+
+var fns: [@Sendable () async -> String] = [
+    {
+      try? await Task.sleep(nanoseconds: .random(in: 0..<50000))
+      return "hello"
+    }
+]
+
+fns.append(fns[0])
+fns.append(fns[0])
+
+// This is a race that will crash or trigger an assertion failure if there's an
+// issue. If we get to the end then we pass.
+for _ in 0..<1000 {
+  let (t, s) = unorderedResults(fns)
+
+  for try await x in s {
+    _ = x
+    if Bool.random() { t.cancel() }
+  }
+}

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift
@@ -85,9 +85,24 @@ func test_discardingTaskGroup_neverConsume(sleepBeforeGroupWaitAll: Duration) as
   print("all tasks: \(allTasks)")
 }
 
+func test_discardingTaskGroup_bigReturn() async {
+  print(">>> \(#function)")
+
+  // Test returning a very large value to ensure we don't overflow memory.
+  let array = await withDiscardingTaskGroup { group in
+    group.addTask {}
+    try? await Task.sleep(until: .now + .milliseconds(100), clock: .continuous)
+    return InlineArray<32768, Int>(repeating: 12345)
+  }
+
+  // CHECK: Huge return value produced: 12345 12345
+  print("Huge return value produced:", array[0], array[32767])
+}
+
 @main struct Main {
   static func main() async {
     await test_discardingTaskGroup_neverConsume()
     await test_discardingTaskGroup_neverConsume(sleepBeforeGroupWaitAll: .milliseconds(500))
+    await test_discardingTaskGroup_bigReturn()
   }
 }


### PR DESCRIPTION
statusCompletePendingReadyWaiting(), offer(), and poll() did a one-off compare_exchange_strong which could fail if the group was concurrently cancelled. Put these into loops so that they are retried when needed.

DiscardingTaskGroup creation passed the group result type as the task result type. waitAll() would then use the group result type when collecting task results. Since the task result type is always Void in this case, this would overflow the result buffer if the group result type was larger. This often works as it writes into the free space of the task allocator, but can crash if it happens to be at the end of a page or the group result type is particularly large.

rdar://151663730