### PR TITLE
Basic: Adjust condition for include after macro removal in upstream LLVM

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -33,7 +33,7 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#ifdef HAVE_SYS_RESOURCE_H
+#if HAVE_GETRUSAGE && !defined(__HAIKU__)
 #include <sys/resource.h>
 #endif
 #ifdef HAVE_PROC_PID_RUSAGE
@@ -383,7 +383,7 @@ void UnifiedStatsReporter::recordJobMaxRSS(long rss) {
 }
 
 int64_t UnifiedStatsReporter::getChildrenMaxResidentSetSize() {
-#if defined(HAVE_GETRUSAGE) && !defined(__HAIKU__)
+#if HAVE_GETRUSAGE && !defined(__HAIKU__)
   struct rusage RU;
   ::getrusage(RUSAGE_CHILDREN, &RU);
   int64_t M = static_cast<int64_t>(RU.ru_maxrss);


### PR DESCRIPTION
`HAVE_SYS_RESOURCE_H` was removed in https://github.com/llvm/llvm-project/pull/123288, so this header is no longer included at this particular location on rebranch, which breaks the Linux build, where it is not transitively included either.

Use the same condition as in the use site (`getChildrenMaxResidentSetSize`) instead.

Also, don't wrap `HAVE_GETRUSAGE` in `defined()` in case it does get defined to 0.