### PR TITLE
[6.2][Runtime] Add ptrauth attribute to TargetGlobalActorReference conformance pointer.

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -2792,11 +2792,22 @@ using ResilientWitnessesHeader = TargetResilientWitnessesHeader<InProcess>;
 /// global actor protocol.
 template<typename Runtime>
 struct TargetGlobalActorReference {
+private:
+  using SignedDescriptorPointer =
+      const TargetProtocolConformanceDescriptor<Runtime>
+          *__ptrauth_swift_protocol_conformance_descriptor;
+
+public:
   /// The type of the global actor.
   RelativeDirectPointer<const char, /*nullable*/ false> type;
 
   /// The conformance of the global actor to the GlobalActor protocol.
-  TargetRelativeProtocolConformanceDescriptorPointer<Runtime> conformance;
+  RelativeIndirectablePointer<
+      const TargetProtocolConformanceDescriptor<Runtime>,
+      /*nullable*/ false,
+      /*offset*/ int32_t,
+      /*indirect type*/ SignedDescriptorPointer>
+      conformance;
 };
 
 /// Describes the context of a protocol conformance that is relevant when

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -272,6 +272,9 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_type_descriptor \
   __ptrauth(ptrauth_key_process_independent_data, 1, \
             SpecialPointerAuthDiscriminators::TypeDescriptor)
+#define __ptrauth_swift_protocol_conformance_descriptor \
+  __ptrauth(ptrauth_key_process_independent_data, 1, \
+            SpecialPointerAuthDiscriminators::ProtocolConformanceDescriptor)
 #define __ptrauth_swift_dynamic_replacement_key                                \
   __ptrauth(ptrauth_key_process_independent_data, 1,                           \
             SpecialPointerAuthDiscriminators::DynamicReplacementKey)
@@ -365,6 +368,7 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_runtime_function_entry_strip(__fn) (__fn)
 #define __ptrauth_swift_heap_object_destructor
 #define __ptrauth_swift_type_descriptor
+#define __ptrauth_swift_protocol_conformance_descriptor
 #define __ptrauth_swift_nonunique_extended_existential_type_shape
 #define __ptrauth_swift_dynamic_replacement_key
 #define swift_ptrauth_sign_opaque_read_resume_function(__fn, __buffer) (__fn)


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/81824 to `release/6.2`.

**Explanation**: Adds a necessary ptrauth attribute to GlobalActorReference's indirect pointer type.
**Scope**: Affects ARM64e processes that take this runtime path.
**Issue**: rdar://151945202
**Risk**: Low. This adds a ptrauth attribute to a pointer, which is needed on ARM64e to not crash, and does nothing on all other targets.
**Testing**: Verified that an example crashes with a ptrauth failure without this fix, and works with it.
**Reviewer**: @ktoso

When the TargetGlobalActorReference conformance is an indirect pointer, the indirect pointer is signed when ptrauth is enabled.

rdar://151945202