### PR TITLE
[6.2] LifetimeDependenceInsertion: allow dependency on Builtin.addressof()

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -413,6 +413,11 @@ struct VariableIntroducerUseDefWalker : LifetimeDependenceUseDefValueWalker, Lif
   }
  
   mutating func introducer(_ value: Value, _ owner: Value?) -> WalkResult {
+    if let addrToPtr = value as? AddressToPointerInst {
+      // AddressToPointer introduces the value dependence. To handle Builtin.addressOfBorrow, follow the address that
+      // the pointer is derived from.
+      return walkUp(address: addrToPtr.address)
+    }
     return visitorClosure(value)
   }
 


### PR DESCRIPTION
This mostly makes it easier to test dependency corner cases. The analysis still
doesn't recognize UnsafeRawPointer.init(), so regular users still need to use
_overrideLifetime.

Fixes rdar://137608270 ([borrows] Add Builtin.addressof() support
for @addressable arguments)

(cherry picked from commit 51090b62bb2f33eb127c5824d8b64bd44febe391)

main PR: https://github.com/swiftlang/swift/pull/81837
