### PR TITLE
Re-add UNSUPPORTED for watchos arm64_32 in lto_autolink.swift.

### DIFF
--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -43,4 +43,5 @@ import AutolinkElfCPragma
 import AutolinkModuleMapLink
 #endif
 
+// UNSUPPORTED: OS=watchos && (CPU=arm64_32 || CPU=armv7k)
 // UNSUPPORTED: CPU=wasm32


### PR DESCRIPTION
Tests are failing with:

<unknown>:0: error: unknown target triple 'arm64_32-unknown-linux-gnu'
<unknown>:0: error: clang importer creation failed

