### PR TITLE
[test] Enable Serialization/runtime-import-from-sdk on non-Darwin platforms

### DIFF
--- a/test/Serialization/module_defining_interface.swift
+++ b/test/Serialization/module_defining_interface.swift
@@ -2,7 +2,6 @@
 // RUN: %empty-directory(%t/inputs)
 // RUN: %empty-directory(%t/test-sdk)
 // RUN: %empty-directory(%t/test-sdk/usr/lib/swift)
-// RUN: cp -r %platform-module-dir/Swift.swiftmodule %t/test-sdk/usr/lib/swift/Swift.swiftmodule
 
 // RUN: %empty-directory(%t/test-sdk/usr/lib/Foo.swiftmodule)
 // RUN: split-file %s %t

--- a/test/Serialization/module_defining_interface_client.swift
+++ b/test/Serialization/module_defining_interface_client.swift
@@ -6,7 +6,6 @@
 // RUN: %empty-directory(%t/test-sdk/usr/lib/Bar.swiftmodule)
 // RUN: %empty-directory(%t/test-sdk/usr/lib/_Foo_Bar.swiftmodule)
 // RUN: %empty-directory(%t/test-sdk/usr/lib/Foo.swiftcrossimport)
-// RUN: cp -r %platform-module-dir/Swift.swiftmodule %t/test-sdk/usr/lib/swift/Swift.swiftmodule
 
 // RUN: split-file %s %t
 


### PR DESCRIPTION
Also, remove Swift runtime modules from Serialization/module_defining_interface,_client that are unused.

This seems to vary by platform today, so see what the CI finds...