### PR TITLE
[cxx-interop] Do not crash when emitting layout of `std::string`

### DIFF
--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -83,4 +83,21 @@ inline int takesZeroSizedInCpp(HasZeroSizedField x) {
   return x.a;
 }
 
+/// Not imported into Swift.
+struct EmptyNotImported {
+  char : 0;
+
+  EmptyNotImported() = default;
+  EmptyNotImported(const EmptyNotImported &) = delete;
+  EmptyNotImported(EmptyNotImported &&) = delete;
+};
+
+struct LastFieldNoUniqueAddress {
+  char c;
+  [[no_unique_address]] EmptyNotImported p0;
+
+  LastFieldNoUniqueAddress(const LastFieldNoUniqueAddress &other) {}
+  LastFieldNoUniqueAddress(LastFieldNoUniqueAddress &&other) {}
+};
+
 #endif

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -83,4 +83,14 @@ FieldsTestSuite.test("Non-standard-layout field padding in templated class reuse
   expectEqual(s2.get_c(), 6)
 }
 
+FieldsTestSuite.test("Last field is no unique address") {
+  var s = LastFieldNoUniqueAddress()
+
+  s.c = 5
+  expectEqual(s.c, 5)
+
+  s.c = 6
+  expectEqual(s.c, 6)
+}
+
 runAllTests()


### PR DESCRIPTION
If a `[[no_unique_address]]` field has zero size according to Clang, and field has a type that isn't representable in Swift, Swift would previously try to add an opaque field of size 1 for it.

This is wrong and was causing crashes for `std::string` while emitting a padding field:
```
_LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T1> _LIBCPP_CONCAT3(__padding1_, __LINE__, _);
```

rdar://151941799

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
