### PR TITLE
[6.2] [SourceKit] Properly handle cursor info range for macro expansions

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -434,10 +434,18 @@ public:
   /// \c nullptr if the source location isn't in this module.
   SourceFile *getSourceFileContainingLocation(SourceLoc loc);
 
+  // Retrieve the buffer ID and source range of the outermost node that
+  // caused the generation of the buffer containing \p range. \p range and its
+  // buffer if it isn't in a generated buffer or has no original range.
+  std::pair<unsigned, SourceRange> getOriginalRange(SourceRange range) const;
+
   // Retrieve the buffer ID and source location of the outermost location that
   // caused the generation of the buffer containing \p loc. \p loc and its
   // buffer if it isn't in a generated buffer or has no original location.
-  std::pair<unsigned, SourceLoc> getOriginalLocation(SourceLoc loc) const;
+  std::pair<unsigned, SourceLoc> getOriginalLocation(SourceLoc loc) const {
+    auto [buffer, range] = getOriginalRange(loc);
+    return std::make_pair(buffer, range.Start);
+  }
 
   /// Creates a map from \c #filePath strings to corresponding \c #fileID
   /// strings, diagnosing any conflicts.

--- a/test/SourceKit/Macros/expansion_decl_cursor_info.swift
+++ b/test/SourceKit/Macros/expansion_decl_cursor_info.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// REQUIRES: swift_swift_parser
+
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %t/MacroDefinition.swift -g -no-toolchain-stdlib-rpath
+
+//--- MacroDefinition.swift
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct AddFuncMacro: DeclarationMacro, PeerMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> [DeclSyntax] {
+    ["func foo(_ x: String) {}"]
+  }
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    ["func foo(_ x: Int) {}"]
+  }
+}
+
+//--- main.swift
+
+@attached(peer, names: named(foo))
+macro AddFuncPeer(x: Int) = #externalMacro(module: "MacroDefinition", type: "AddFuncMacro")
+
+@freestanding(declaration, names: named(foo))
+macro AddFunc(x: Int) = #externalMacro(module: "MacroDefinition", type: "AddFuncMacro")
+
+@AddFuncPeer(x: 0)
+#AddFunc(x: 0)
+
+foo(0)
+// RUN: %sourcekitd-test -req=cursor %t/main.swift -pos=%(line-1):1 -- %t/main.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser | %FileCheck --check-prefix PEER %s
+// PEER: source.lang.swift.ref.function.free ([[@LINE-5]]:1-[[@LINE-5]]:19)
+
+foo("")
+// RUN: %sourcekitd-test -req=cursor %t/main.swift -pos=%(line-1):1 -- %t/main.swift -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser | %FileCheck --check-prefix FREESTANDING %s
+// FREESTANDING: source.lang.swift.ref.function.free ([[@LINE-8]]:1-[[@LINE-8]]:15)


### PR DESCRIPTION
*6.2 cherry-pick of #81809*

- Explanation: Fixes an issue where cursor info would report an incorrect range length for a macro expansion decl when highlighting the macro in the outer buffer
- Scope: Affects cursor info
- Issue: rdar://151411756
- Risk: Low, only affects cursor info
- Testing: Added tests to test suite
- Reviewer: Ben Barham