### PR TITLE
[Basic] Always dump message to stderr in `_abortWithMessage`

### DIFF
--- a/lib/Basic/Assertions.cpp
+++ b/lib/Basic/Assertions.cpp
@@ -123,9 +123,9 @@ static void _abortWithMessage(llvm::StringRef message) {
   // crash reporter.
   PrettyStackTraceMultilineString trace(message);
 
-  // If pretty backtracing is disabled, fall back to dumping to stderr.
-  if (!llvm::SavePrettyStackState())
-    llvm::errs() << message << '\n';
+  // Also dump to stderr in case pretty backtracing is disabled, and to
+  // allow the message to be seen while attached with a debugger.
+  llvm::errs() << message << '\n';
 
   abort();
 }

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -16,7 +16,7 @@ public class Sub: Base {
 // CHECK-CRASH: error: fatal error encountered while reading from module 'Lib'; please submit a bug report (https://swift.org/contributing/#reporting-bugs){{$}}
 // CHECK-CRASH-4: Compiling with effective version 4.1.50
 // CHECK-CRASH-4_2: Compiling with effective version 4.2
-// CHECK-CRASH: While loading members for 'Sub' (in module 'Lib')
+// CHECK-CRASH-LABEL: While loading members for 'Sub' (in module 'Lib')
 // CHECK-CRASH-LABEL: *** DESERIALIZATION FAILURE ***
 // CHECK-CRASH-LABEL: *** If any module named here was modified in the SDK, please delete the ***
 // CHECK-CRASH-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***


### PR DESCRIPTION
This allows it to be seen while e.g attached with a debugger.