### PR TITLE
[TypeCheckEffects] Fix `AbstractFunction::getType` to look through al…

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -386,7 +386,7 @@ public:
   Type getType() const {
     switch (getKind()) {
     case Kind::Opaque:
-      return getOpaqueFunction()->getType()->lookThroughSingleOptionalType();
+      return getOpaqueFunction()->getType()->lookThroughAllOptionalTypes();
     case Kind::Function: {
       auto *AFD = getFunction();
       if (AFD->hasImplicitSelfDecl() && AppliedSelf)
@@ -395,8 +395,7 @@ public:
     }
     case Kind::Closure: return getClosure()->getType();
     case Kind::Parameter:
-      return getParameter()->getInterfaceType()
-          ->lookThroughSingleOptionalType();
+      return getParameter()->getInterfaceType()->lookThroughAllOptionalTypes();
     }
     llvm_unreachable("bad kind");
   }

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar151943924.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar151943924.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+@propertyWrapper
+struct Weak<Value> {
+    var wrappedValue: Value? { fatalError() }
+}
+
+struct WeakStorage<Item: Hashable> {
+    @Weak var action: ((Set<Item>) -> Void)??
+}
+
+final class Test {
+    var storage: WeakStorage<AnyHashable> = .init()
+
+    func test(items: Set<AnyHashable>) {
+        storage.action??(items)
+    }
+}


### PR DESCRIPTION
…l levels of optional

A member and a parameter could be wrapped in an arbitrary number of `Optional`, we need to look through all of them to get to the underlying function type.

Resolves: rdar://151943924

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
