### PR TITLE
Effects: Treat #selector as covering throws/async effects in its operand

### DIFF
--- a/test/expr/primary/selector/selector.swift
+++ b/test/expr/primary/selector/selector.swift
@@ -172,3 +172,11 @@ extension SomeProtocol {
 func test() -> Selector {
   #selector(OverloadedFuncAndProperty.f)
 }
+
+@objc protocol HasThrows {
+  @objc optional func doSomething(to object: AnyObject) throws -> Void
+}
+
+func testWithThrowing(obj: AnyObject) {
+  _ = #selector(HasThrows.doSomething(to:))
+}


### PR DESCRIPTION
Fixes rdar://151968656