### PR TITLE
[DestroyAddrHoisting] Don't destructure NE aggs.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1281,7 +1281,7 @@ struct AccessPathWithBase {
 //
 // Returns false if the access path couldn't be computed.
 bool visitProductLeafAccessPathNodes(
-    SILValue address, TypeExpansionContext tec, SILModule &module,
+    SILValue address, TypeExpansionContext tec, SILFunction &function,
     std::function<void(AccessPath::PathNode, SILType)> visitor);
 
 inline AccessPath AccessPath::compute(SILValue address) {

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1461,7 +1461,7 @@ bool swift::visitProductLeafAccessPathNodes(
         visitor(AccessPath::PathNode(node), silType);
         continue;
       }
-      if (decl->isCxxNonTrivial()) {
+      if (decl->isCxxNonTrivial() || !silType.isEscapable(function)) {
         visitor(AccessPath::PathNode(node), silType);
         continue;
       }

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1437,7 +1437,7 @@ AccessPathWithBase AccessPathWithBase::computeInScope(SILValue address) {
 }
 
 bool swift::visitProductLeafAccessPathNodes(
-    SILValue address, TypeExpansionContext tec, SILModule &module,
+    SILValue address, TypeExpansionContext tec, SILFunction &function,
     std::function<void(AccessPath::PathNode, SILType)> visitor) {
   auto rootPath = AccessPath::compute(address);
   if (!rootPath.isValid()) {
@@ -1469,7 +1469,8 @@ bool swift::visitProductLeafAccessPathNodes(
       for (auto *field : decl->getStoredProperties()) {
         auto *fieldNode = node->getChild(index);
         worklist.push_back(
-            {silType.getFieldType(field, module, tec), fieldNode});
+            {silType.getFieldType(field, function.getModule(), tec),
+             fieldNode});
         ++index;
       }
     } else {

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1461,7 +1461,8 @@ bool swift::visitProductLeafAccessPathNodes(
         visitor(AccessPath::PathNode(node), silType);
         continue;
       }
-      if (decl->isCxxNonTrivial() || !silType.isEscapable(function)) {
+      if (decl->isCxxNonTrivial() || !silType.isEscapable(function) ||
+          silType.isMoveOnly()) {
         visitor(AccessPath::PathNode(node), silType);
         continue;
       }

--- a/lib/SILOptimizer/Transforms/DestroyAddrHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/DestroyAddrHoisting.cpp
@@ -604,7 +604,7 @@ bool HoistDestroys::foldBarrier(SILInstruction *barrier,
   SmallPtrSet<AccessPath::PathNode, 16> trivialLeaves;
 
   bool succeeded = visitProductLeafAccessPathNodes(
-      storageRoot, typeExpansionContext, module,
+      storageRoot, typeExpansionContext, *function,
       [&](AccessPath::PathNode node, SILType ty) {
         if (ty.isTrivial(*function))
           return;
@@ -765,7 +765,7 @@ bool HoistDestroys::checkFoldingBarrier(
     bool alreadySawLeaf = false;
     bool alreadySawTrivialSubleaf = false;
     auto succeeded = visitProductLeafAccessPathNodes(
-        address, typeExpansionContext, module,
+        address, typeExpansionContext, *function,
         [&](AccessPath::PathNode node, SILType ty) {
           if (ty.isTrivial(*function)) {
             bool inserted = !trivialLeaves.insert(node).second;

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1,9 +1,10 @@
-// RUN: %target-sil-opt -sil-print-types -opt-mode=none  -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB --check-prefix=CHECK-DEB
-// RUN: %target-sil-opt -sil-print-types -opt-mode=speed -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT --check-prefix=CHECK-OPT
+// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature LifetimeDependence -opt-mode=none  -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB --check-prefix=CHECK-DEB
+// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature LifetimeDependence -opt-mode=speed -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT --check-prefix=CHECK-OPT
 //
 // TODO: migrate the remaining tests from destroy_hoisting.sil.
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_LifetimeDependence
 
 sil_stage canonical
 
@@ -1223,4 +1224,34 @@ bb0(%0 : @owned $Nontrivial):
   destroy_value %0 : $Nontrivial
   %14 = tuple ()
   return %14 : $()
+}
+
+struct Regular {
+  var storage: Builtin.NativeObject
+}
+struct NEGutless: ~Escapable {
+  let ptr: UnsafeRawPointer?
+}
+struct NEMarker : ~Escapable {}
+struct NEAggregate: ~Escapable {
+  var ne: NEGutless
+  let regular: Regular
+
+  @lifetime(copy ne) init(ne: NEMarker)
+}
+
+// CHECK-LABEL: sil [ossa] @no_destructure_nonescapable : {{.*}} {
+// CHECK:       bb0([[AGGREGATE:%[^,]+]] :
+// CHECK:       destroy_addr [[AGGREGATE]]
+// CHECK-LABEL: } // end sil function 'no_destructure_nonescapable'
+sil [ossa] @no_destructure_nonescapable : $@convention(method) (@in NEAggregate) -> () {
+bb0(%aggregate : $*NEAggregate):
+  %regular = struct_element_addr %aggregate, #NEAggregate.regular
+  %regular_copy = alloc_stack $Regular
+  copy_addr %regular to [init] %regular_copy
+  destroy_addr %regular_copy
+  dealloc_stack %regular_copy
+  destroy_addr %aggregate
+  %retval = tuple ()
+  return %retval
 }

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1255,3 +1255,28 @@ bb0(%aggregate : $*NEAggregate):
   %retval = tuple ()
   return %retval
 }
+
+struct NCGutless: ~Copyable {
+  let ptr: UnsafeRawPointer?
+}
+struct NCAggregate: ~Copyable {
+  var ne: NCGutless
+  let regular: Regular
+  deinit {}
+}
+
+// CHECK-LABEL: sil [ossa] @no_destructure_noncopyable : {{.*}} {
+// CHECK:       bb0([[AGGREGATE:%[^,]+]] :
+// CHECK:       destroy_addr [[AGGREGATE]]
+// CHECK-LABEL: } // end sil function 'no_destructure_noncopyable'
+sil [ossa] @no_destructure_noncopyable : $@convention(method) (@in NCAggregate) -> () {
+bb0(%aggregate : $*NCAggregate):
+  %regular = struct_element_addr %aggregate, #NCAggregate.regular
+  %regular_copy = alloc_stack $Regular
+  copy_addr %regular to [init] %regular_copy
+  destroy_addr %regular_copy
+  dealloc_stack %regular_copy
+  destroy_addr %aggregate
+  %retval = tuple ()
+  return %retval
+}


### PR DESCRIPTION
When hoisting destroys of aggregates, an attempt is made to fold the destroys of individual fields into the foregoing instructions.  If the aggregate is nonescapable, this transformation is illegal.  Fixes a verifier error.  While here, also block the transformation for noncopyable aggregates.

rdar://152195094
