### PR TITLE
[embedded] Resolve a circular dependency problem in SwiftShims when using pico-libc

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -513,6 +513,10 @@ void importer::getNormalInvocationArguments(
       "-isystem", searchPathOpts.RuntimeResourcePath,
   });
 
+  if (LangOpts.hasFeature(Feature::Embedded)) {
+    invocationArgStrs.insert(invocationArgStrs.end(), {"-D__swift_embedded__"});
+  }
+
   // Enable Position Independence.  `-fPIC` is not supported on Windows, which
   // is implicitly position independent.
   if (!triple.isOSWindows())

--- a/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
+++ b/stdlib/public/SwiftShims/swift/shims/SwiftStdint.h
@@ -24,7 +24,7 @@
 
 // Clang has been defining __INTxx_TYPE__ macros for a long time.
 // __UINTxx_TYPE__ are defined only since Clang 3.5.
-#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__)
+#if !defined(__APPLE__) && !defined(__linux__) && !defined(__OpenBSD__) && !defined(__wasi__) && !defined(__swift_embedded__)
 #include <stdint.h>
 typedef int64_t __swift_int64_t;
 typedef uint64_t __swift_uint64_t;

--- a/test/embedded/builtin-float.swift
+++ b/test/embedded/builtin-float.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/include
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -target armv7em-none-none-eabi -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: embedded_stdlib_cross_compiling
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN Main.swift
+
+print("hello")
+
+// BEGIN include/stdint.h
+
+#include <float.h>
+typedef __INTPTR_TYPE__ intptr_t;
+typedef __UINTPTR_TYPE__ uintptr_t;
+typedef __INT64_TYPE__ int64_t;
+typedef __UINT64_TYPE__ uint64_t;
+typedef __INT32_TYPE__ int32_t;
+typedef __UINT32_TYPE__ uint32_t;
+typedef __INT16_TYPE__ int16_t;
+typedef __UINT16_TYPE__ uint16_t;
+typedef __INT8_TYPE__ int8_t;
+typedef __UINT8_TYPE__ uint8_t;


### PR DESCRIPTION
Since we started building Builtin_Float overlay for Embedded Swift and including it in the nightly toolchains (under lib/swift/embedded), we broke building agains the pico libc -- this is a popular libc distributed for example by the official LLVM embedded ARM toolchain as well. The problem is that for non-Linux ARM embedded targets, SwiftShims includes stdint.h, and in pico libc that transitively includes float.h which triggers a dependency on the overlay. See <https://github.com/swiftlang/swift/issues/81594>:

> When updating swift-embedded-examples to main-snapshots from May, we see a new issue trying to use the llvm toolchain: error: circular dependency between modules 'Swift' and '_Builtin_float'

Let's simply avoid depending on stdint.h from SwiftShims because we already have other platforms avoiding that (for possibly a similar or same reason).

Fixes https://github.com/swiftlang/swift/issues/81594.