### PR TITLE
introduce @_manualOwnership performance attribute

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -293,6 +293,7 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     case noRuntime
     case noExistentials
     case noObjCRuntime
+    case manualOwnership
   }
 
   public var performanceConstraints: PerformanceConstraints {
@@ -303,6 +304,7 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
       case .NoRuntime: return .noRuntime
       case .NoExistentials: return .noExistentials
       case .NoObjCBridging: return .noObjCRuntime
+      case .ManualOwnership: return .manualOwnership
       default: fatalError("unknown performance constraint")
     }
   }

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -815,7 +815,10 @@ SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
   UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   155)
 
-// Unused '156': Used to be `_distributedThunkTarget` but completed implementation in Swift 6.0 does not need it after all
+SIMPLE_DECL_ATTR(_manualOwnership, ManualOwnership,
+  OnAbstractFunction | OnSubscript,
+  UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
+  156)
 
 DECL_ATTR(_allowFeatureSuppression, AllowFeatureSuppression,
   OnAnyDecl,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -428,6 +428,8 @@ ERROR(wrong_linkage_for_serialized_function,none,
       "function has wrong linkage to be called from %0", (StringRef))
 NOTE(performance_called_from,none,
       "called from here", ())
+ERROR(manualownership_copy,none,
+      "explicit 'copy' required here", ())
 
 // 'transparent' diagnostics
 ERROR(circular_transparent,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2145,6 +2145,10 @@ ERROR(attr_static_exclusive_only_mutating,none,
 ERROR(attr_static_exclusive_no_setters,none,
       "variable of type %0 must not have a setter", (Type))
 
+// @_manualOwnership
+ERROR(attr_manual_ownership_experimental,none,
+      "'@_manualOwnership' requires '-enable-experimental-feature ManualOwnership'", ())
+
 // @extractConstantsFromMembers
 ERROR(attr_extractConstantsFromMembers_experimental,none,
       "'@extractConstantsFromMembers' requires "

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -447,6 +447,9 @@ EXPERIMENTAL_FEATURE(LifetimeDependence, true)
 /// Enable the `@_staticExclusiveOnly` attribute.
 EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)
 
+/// Enable the `@_manualOwnership` attribute.
+EXPERIMENTAL_FEATURE(ManualOwnership, false)
+
 /// Enable the @extractConstantsFromMembers attribute.
 EXPERIMENTAL_FEATURE(ExtractConstantsFromMembers, false)
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -463,7 +463,8 @@ struct BridgedFunction {
     NoLocks = 2,
     NoRuntime = 3,
     NoExistentials = 4,
-    NoObjCBridging = 5
+    NoObjCBridging = 5,
+    ManualOwnership = 6,
   };
 
   enum class InlineStrategy {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -280,6 +280,14 @@ public:
     return false;
   }
 
+  /// If we have a SILFunction, return true if it has a ManualOwnership
+  /// PerformanceConstraint, which corresponds to an attribute on the FuncDecl.
+  bool hasManualOwnershipAttr() const {
+    if (F)
+      return F->getPerfConstraints() == PerformanceConstraints::ManualOwnership;
+    return false;
+  }
+
   //===--------------------------------------------------------------------===//
   // Insertion Point Management
   //===--------------------------------------------------------------------===//

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -93,7 +93,8 @@ enum class PerformanceConstraints : uint8_t {
   NoLocks = 2,
   NoRuntime = 3,
   NoExistentials = 4,
-  NoObjCBridging = 5
+  NoObjCBridging = 5,
+  ManualOwnership = 6,
 };
 
 class SILSpecializeAttr final {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -5030,6 +5030,7 @@ public:
   TRIVIAL_ATTR_PRINTER(NoLocks, no_locks)
   TRIVIAL_ATTR_PRINTER(NoMetadata, no_metadata)
   TRIVIAL_ATTR_PRINTER(NoObjCBridging, no_objc_bridging)
+  TRIVIAL_ATTR_PRINTER(ManualOwnership, manual_ownership)
   TRIVIAL_ATTR_PRINTER(NoRuntime, no_runtime)
   TRIVIAL_ATTR_PRINTER(NonEphemeral, non_ephemeral)
   TRIVIAL_ATTR_PRINTER(NonEscapable, non_escapable)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -138,6 +138,7 @@ static bool usesFeatureInlineArrayTypeSugar(Decl *D) {
 }
 
 UNINTERESTING_FEATURE(StaticExclusiveOnly)
+UNINTERESTING_FEATURE(ManualOwnership)
 UNINTERESTING_FEATURE(ExtractConstantsFromMembers)
 UNINTERESTING_FEATURE(GroupActorErrors)
 UNINTERESTING_FEATURE(SameElementRequirements)

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -265,6 +265,7 @@ extension ASTGenVisitor {
         .LexicalLifetimes,
         .LLDBDebuggerFunction,
         .MainType,
+        .ManualOwnership,
         .Marker,
         .MoveOnly,
         .NeverEmitIntoClient,

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -203,6 +203,8 @@ void SILFunctionBuilder::addFunctionAttributes(
     F->setPerfConstraints(PerformanceConstraints::NoExistentials);
   } else if (Attrs.hasAttribute<NoObjCBridgingAttr>()) {
     F->setPerfConstraints(PerformanceConstraints::NoObjCBridging);
+  } else if (Attrs.hasAttribute<ManualOwnershipAttr>()) {
+    F->setPerfConstraints(PerformanceConstraints::ManualOwnership);
   }
 
   if (Attrs.hasAttribute<LexicalLifetimesAttr>()) {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3658,6 +3658,7 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     case PerformanceConstraints::NoRuntime:      OS << "[no_runtime] "; break;
     case PerformanceConstraints::NoExistentials: OS << "[no_existentials] "; break;
     case PerformanceConstraints::NoObjCBridging: OS << "[no_objc_bridging] "; break;
+    case PerformanceConstraints::ManualOwnership: OS << "[manual_ownership] "; break;
   }
 
   if (isPerformanceConstraint())

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -783,6 +783,8 @@ static bool parseDeclSILOptional(
       *perfConstraints = PerformanceConstraints::NoExistentials;
     else if (perfConstraints && SP.P.Tok.getText() == "no_objc_bridging")
       *perfConstraints = PerformanceConstraints::NoObjCBridging;
+    else if (perfConstraints && SP.P.Tok.getText() == "manual_ownership")
+      *perfConstraints = PerformanceConstraints::ManualOwnership;
     else if (isPerformanceConstraint && SP.P.Tok.getText() == "perf_constraint")
       *isPerformanceConstraint = true;
     else if (markedAsUsed && SP.P.Tok.getText() == "used")

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -186,6 +186,7 @@ static_assert((int)BridgedFunction::PerformanceConstraints::NoLocks == (int)swif
 static_assert((int)BridgedFunction::PerformanceConstraints::NoRuntime == (int)swift::PerformanceConstraints::NoRuntime);
 static_assert((int)BridgedFunction::PerformanceConstraints::NoExistentials == (int)swift::PerformanceConstraints::NoExistentials);
 static_assert((int)BridgedFunction::PerformanceConstraints::NoObjCBridging == (int)swift::PerformanceConstraints::NoObjCBridging);
+static_assert((int)BridgedFunction::PerformanceConstraints::ManualOwnership == (int)swift::PerformanceConstraints::ManualOwnership);
 
 static_assert((int)BridgedFunction::InlineStrategy::InlineDefault == (int)swift::InlineDefault);
 static_assert((int)BridgedFunction::InlineStrategy::NoInline == (int)swift::NoInline);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -475,6 +475,11 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
             diag::copy_expression_cannot_be_used_with_noncopyable_types);
       }
 
+      /// FIXME: there really is no reason for the restriction on copy not being
+      ///   permitted on fields, other than needing tests to ensure it works.
+      if (Ctx.LangOpts.hasFeature(ManualOwnership))
+        return;
+
       // We only allow for copy_expr to be applied directly to lvalues. We do
       // not allow currently for it to be applied to fields.
       auto *subExpr = copyExpr->getSubExpr();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -470,6 +470,7 @@ public:
   void visitUnsafeNonEscapableResultAttr(UnsafeNonEscapableResultAttr *attr);
 
   void visitStaticExclusiveOnlyAttr(StaticExclusiveOnlyAttr *attr);
+  void visitManualOwnershipAttr(ManualOwnershipAttr *attr);
   void visitWeakLinkedAttr(WeakLinkedAttr *attr);
   void visitSILGenNameAttr(SILGenNameAttr *attr);
   void visitLifetimeAttr(LifetimeAttr *attr);
@@ -8356,6 +8357,13 @@ void AttributeChecker::visitStaticExclusiveOnlyAttr(
   if (structDecl->canBeCopyable() != TypeDecl::CanBeInvertible::Never) {
     diagnoseAndRemoveAttr(attr, diag::attr_static_exclusive_only_noncopyable);
   }
+}
+
+void AttributeChecker::visitManualOwnershipAttr(ManualOwnershipAttr *attr) {
+  if (Ctx.LangOpts.hasFeature(Feature::ManualOwnership))
+    return;
+
+  diagnoseAndRemoveAttr(attr, diag::attr_manual_ownership_experimental);
 }
 
 void AttributeChecker::visitWeakLinkedAttr(WeakLinkedAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1621,6 +1621,7 @@ namespace  {
     UNINTERESTING_ATTR(NoRuntime)
     UNINTERESTING_ATTR(NoExistentials)
     UNINTERESTING_ATTR(NoObjCBridging)
+    UNINTERESTING_ATTR(ManualOwnership)
     UNINTERESTING_ATTR(Inlinable)
     UNINTERESTING_ATTR(Effects)
     UNINTERESTING_ATTR(Expose)

--- a/test/SIL/manual_ownership.swift
+++ b/test/SIL/manual_ownership.swift
@@ -1,0 +1,154 @@
+// RUN: %target-swift-frontend %s -emit-sil -verify -enable-experimental-feature ManualOwnership
+
+// REQUIRES: swift_feature_ManualOwnership
+
+// MARK: types
+
+public class Whatever {
+  var a = Pair(x: 0, y: 0)
+}
+
+public struct Pair {
+  var x: Int
+  var y: Int
+
+  consuming func midpoint(_ other: borrowing Pair) -> Pair {
+    return Pair(x: (x + other.x) / 2, y: (y + other.y) / 2)
+  }
+}
+
+public class Triangle {
+  var a = Pair(x: 0, y: 0)
+  var b = Pair(x: 0, y: 1)
+  var c = Pair(x: 1, y: 1)
+
+  var nontrivial = Whatever()
+
+  consuming func consuming() {}
+  borrowing func borrowing() {}
+}
+
+/// MARK: return statements
+
+@_manualOwnership
+public func basic_return1() -> Triangle {
+  let x = Triangle()
+  return x // expected-error {{explicit 'copy' required here}}
+}
+@_manualOwnership
+public func basic_return1_fixed() -> Triangle {
+  let x = Triangle()
+  return copy x
+}
+
+
+@_manualOwnership
+public func basic_return2(t: Triangle) -> Triangle {
+  return t // expected-error {{explicit 'copy' required here}}
+}
+@_manualOwnership
+public func basic_return2_fixed(t: Triangle) -> Triangle {
+  return copy t
+}
+
+@_manualOwnership
+public func basic_return3() -> Triangle {
+  return Triangle()
+}
+
+/// MARK: method calls
+
+@_manualOwnership
+func basic_methods_borrowing(_ t1: Triangle) {
+  let t2 = Triangle()
+  t1.borrowing()
+  t2.borrowing()
+}
+
+@_manualOwnership
+func basic_methods_consuming(_ t1: Triangle) {
+  let t2 = Triangle()
+  t1.consuming() // expected-error {{explicit 'copy' required here}}
+  t2.consuming() // expected-error {{explicit 'copy' required here}}
+}
+@_manualOwnership
+func basic_methods_consuming_fixed(_ t1: Triangle) {
+  let t2 = Triangle()
+  var t3 = Triangle()
+  t3 = Triangle()
+
+  (copy t1).consuming()
+  (copy t2).consuming()
+  (copy t3).consuming()
+}
+
+func consumingFunc(_ t0: consuming Triangle) {}
+func plainFunc(_ t0: Triangle) {}
+
+@_manualOwnership
+func basic_function_call(_ t1: Triangle) {
+  consumingFunc(t1) // expected-error {{explicit 'copy' required here}}
+  consumingFunc(copy t1)
+  plainFunc(t1)
+}
+
+/// MARK: control-flow
+
+
+// FIXME: var's and assignments are a little busted
+
+// @_manualOwnership
+// func reassignments_1() {
+//   var t3 = Triangle()
+//   t3 = Triangle()
+//   t3.borrowing()
+// }
+// @_manualOwnership
+// func ressignments_2() {
+//   var t3 = Triangle()
+//   t3 = Triangle()
+//   t3.consuming()
+// }
+
+@_manualOwnership
+public func basic_loop_trivial_values(_ t: Triangle, _ xs: [Triangle]) {
+  var p: Pair = t.a
+  for x in xs { // expected-error {{explicit 'copy' required here}}
+    p = p.midpoint(x.a)
+  }
+  t.a = p
+}
+@_manualOwnership
+public func basic_loop_trivial_values_fixed(_ t: Triangle, _ xs: [Triangle]) {
+  var p: Pair = t.a
+  for x in copy xs {
+    p = p.midpoint(x.a)
+  }
+  t.a = p
+}
+
+// FIXME: the only reason for so many copies below is because
+// `Triangle.nontrivial` only exposes get/set rather than read/modify by default
+//
+// We should figure out when the coroutine accessors are generated, and ensure
+// that when it is available, it is used without copying the result, rather than
+// calling the get/set
+
+@_manualOwnership
+public func basic_loop_nontrivial_values(_ t: Triangle, _ xs: [Triangle]) {
+  var p: Pair = t.nontrivial.a // expected-error {{explicit 'copy' required here}}
+  for x in xs { // expected-error {{explicit 'copy' required here}}
+    p = p.midpoint(x.nontrivial.a) // expected-error {{explicit 'copy' required here}}
+  }
+  t.nontrivial.a = p // expected-error {{explicit 'copy' required here}}
+}
+
+// FIXME: there should be no copies required in the below, other than what's already written.
+@_manualOwnership
+public func basic_loop_nontrivial_values_fixed(_ t: Triangle, _ xs: [Triangle]) {
+  var p: Pair = (copy t.nontrivial).a  // expected-error {{explicit 'copy' required here}}
+  for x in copy xs {
+    p = p.midpoint((copy x.nontrivial).a) // expected-error {{explicit 'copy' required here}}
+  }
+  (copy t.nontrivial).a = p // expected-error {{explicit 'copy' required here}}
+}


### PR DESCRIPTION
This attribute forces programmers to acknowledge every copy that is required in the body of a function. The copies that are "required" to be acknowledged are those that are implicit according to Swift's core language implementation rules. For example,

```swift
func consumingFunc(_ t0: consuming Triangle) {}

@_manualOwnership
func basic_function_call(_ t1: Triangle) {
  consumingFunc(t1)  // error: explicit 'copy' required here
}
```

passing a value to a consuming parameter does not require explicitly copying the argument in the source language, but by the ownership rules a copy will happen. Acknowledging copies does not impact performance and these copies are a superset of all copies that will happen in the function; they are still eligible be eliminated by optimizations.

The way this is implemented is to flag every implicitly-created copy in such functions as an error. This ensures programmers and the compiler are in sync about what copies are actually happening. This motivates performance conscious programmers to write their code in such a way to avoid copies. It also motivates fixes in the compiler for cases where it is emitting a copy that is useless according to the language.

Related to rdar://151323307
