### PR TITLE
[MacrosOnImports][Swiftify] Copy module imports from clang node's module to its Swift macro SourceFile

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -643,6 +643,9 @@ namespace swift {
     /// Enables dumping macro expansions.
     bool DumpMacroExpansions = false;
 
+    /// Enables dumping imports for each SourceFile.
+    bool DumpSourceFileImports = false;
+
     /// The model of concurrency to be used.
     ConcurrencyModel ActiveConcurrencyModel = ConcurrencyModel::Standard;
 

--- a/include/swift/Basic/Located.h
+++ b/include/swift/Basic/Located.h
@@ -71,7 +71,7 @@ struct DenseMapInfo<swift::Located<T>> {
   }
 
   static unsigned getHashValue(const swift::Located<T> &LocatedVal) {
-    return combineHashValue(DenseMapInfo<T>::getHashValue(LocatedVal.Item),
+    return detail::combineHashValue(DenseMapInfo<T>::getHashValue(LocatedVal.Item),
                             DenseMapInfo<swift::SourceLoc>::getHashValue(LocatedVal.Loc));
   }
 
@@ -81,5 +81,13 @@ struct DenseMapInfo<swift::Located<T>> {
   }
 };
 } // namespace llvm
+
+namespace swift {
+  template<typename T>
+  llvm::hash_code hash_value(const Located<T> &LocatedVal) {
+    return llvm::DenseMapInfo<Located<T>>::getHashValue(LocatedVal);
+  }
+} // namespace swift
+
 
 #endif // SWIFT_BASIC_LOCATED_H

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -702,6 +702,12 @@ bool isCxxStdModule(const clang::Module *module);
 /// (std_vector, std_iosfwd, etc).
 bool isCxxStdModule(StringRef moduleName, bool IsSystem);
 
+/// Build the path corresponding to the Swift wrapper for a clang module.
+/// Returns ImportPath::Builder to leave control over if and where to clone the
+/// path to the caller.
+ImportPath::Builder getSwiftModulePath(ASTContext &SwiftContext,
+                                       const clang::Module *M);
+
 /// Returns the pointee type if the given type is a C++ `const`
 /// reference type, `None` otherwise.
 std::optional<clang::QualType>

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -702,12 +702,6 @@ bool isCxxStdModule(const clang::Module *module);
 /// (std_vector, std_iosfwd, etc).
 bool isCxxStdModule(StringRef moduleName, bool IsSystem);
 
-/// Build the path corresponding to the Swift wrapper for a clang module.
-/// Returns ImportPath::Builder to leave control over if and where to clone the
-/// path to the caller.
-ImportPath::Builder getSwiftModulePath(ASTContext &SwiftContext,
-                                       const clang::Module *M);
-
 /// Returns the pointee type if the given type is a C++ `const`
 /// reference type, `None` otherwise.
 std::optional<clang::QualType>

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -433,6 +433,9 @@ def dump_macro_expansions : Flag<["-"], "dump-macro-expansions">,
 def emit_macro_expansion_files : Separate<["-"], "emit-macro-expansion-files">,
   HelpText<"Specify when to emit macro expansion file: 'none', 'debug', or 'diagnostics'">;
 
+def dump_source_file_imports : Flag<["-"], "dump-source-file-imports">,
+  HelpText<"Dumps the list of imports for each source file">;
+
 def analyze_request_evaluator : Flag<["-"], "analyze-request-evaluator">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
   HelpText<"Print out request evaluator cache statistics at the end of the compilation job">;

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -125,9 +125,7 @@ namespace swift {
 
   /// Resolve imports for a source file generated to adapt a given
   /// Clang module.
-  void performImportResolutionForClangMacroBuffer(
-    SourceFile &SF, ModuleDecl *clangModule
-  );
+  void performImportResolutionForClangMacroBuffer(SourceFile &SF);
 
   /// Once type-checking is complete, this instruments code with calls to an
   /// intrinsic that record the expected values of local variables so they can

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -125,7 +125,8 @@ namespace swift {
 
   /// Resolve imports for a source file generated to adapt a given
   /// Clang module.
-  void performImportResolutionForClangMacroBuffer(SourceFile &SF);
+  void performImportResolutionForClangMacroBuffer(
+      SourceFile &SF, ModuleDecl *explicitOriginModule);
 
   /// Once type-checking is complete, this instruments code with calls to an
   /// intrinsic that record the expected values of local variables so they can

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2665,6 +2665,11 @@ void
 SourceFile::setImports(ArrayRef<AttributedImport<ImportedModule>> imports) {
   assert(!Imports && "Already computed imports");
   Imports = getASTContext().AllocateCopy(imports);
+  if (getASTContext().LangOpts.DumpSourceFileImports) {
+    llvm::errs() << "imports for " << getFilename() << ":\n";
+    for (auto Import : imports)
+      llvm::errs() << "\t" << Import.module.importedModule->getName() << "\n";
+  }
 }
 
 std::optional<AttributedImport<ImportedModule>>

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -8770,11 +8770,12 @@ bool importer::isCxxStdModule(StringRef moduleName, bool IsSystem) {
 }
 
 ImportPath::Builder importer::getSwiftModulePath(ASTContext &SwiftContext, const clang::Module *M) {
-  if (isCxxStdModule(M))
-    return ImportPath::Builder(SwiftContext.Id_CxxStdlib);
   ImportPath::Builder builder;
   while (M) {
-    builder.push_back(SwiftContext.getIdentifier(M->Name));
+    if (!M->isSubModule() && isCxxStdModule(M))
+      builder.push_back(SwiftContext.Id_CxxStdlib);
+    else
+      builder.push_back(SwiftContext.getIdentifier(M->Name));
     M = M->Parent;
   }
   std::reverse(builder.begin(), builder.end());

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2838,9 +2838,10 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
     // Make sure that synthesized Swift code in the clang module wrapper
     // (e.g. _SwiftifyImport macro expansions) can access the same symbols as
     // if it were actually in the clang module
-    StringRef moduleName = isCxxStdModule(I) ? SwiftContext.Id_CxxStdlib.str() :
+    std::string swiftModuleName = isCxxStdModule(I) ?
+      static_cast<std::string>(SwiftContext.Id_CxxStdlib) :
       I->getFullModuleName();
-    ImportPath::Builder importPath(SwiftContext, moduleName, '.');
+    ImportPath::Builder importPath(SwiftContext, swiftModuleName, '.');
     UnloadedImportedModule importedModule(importPath.copyTo(SwiftContext), ImportKind::Module);
     implicitImportInfo.AdditionalUnloadedImports.push_back(importedModule);
   }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2834,6 +2834,14 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
   if (auto mainModule = SwiftContext.MainModule) {
     implicitImportInfo = mainModule->getImplicitImportInfo();
   }
+  for (auto *I : underlying->Imports) {
+    // Make sure that synthesized Swift code in the clang module wrapper
+    // (e.g. _SwiftifyImport macro expansions) can access the same symbols as
+    // if it were actually in the clang module
+    ImportPath::Builder importPath(SwiftContext, I->getFullModuleName(), '.');
+    UnloadedImportedModule importedModule(importPath.copyTo(SwiftContext), ImportKind::Module);
+    implicitImportInfo.AdditionalUnloadedImports.push_back(importedModule);
+  }
   ClangModuleUnit *file = nullptr;
   auto wrapper = ModuleDecl::create(name, SwiftContext, implicitImportInfo,
                                     [&](ModuleDecl *wrapper, auto addFile) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2838,7 +2838,9 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
     // Make sure that synthesized Swift code in the clang module wrapper
     // (e.g. _SwiftifyImport macro expansions) can access the same symbols as
     // if it were actually in the clang module
-    ImportPath::Builder importPath(SwiftContext, I->getFullModuleName(), '.');
+    StringRef moduleName = isCxxStdModule(I) ? SwiftContext.Id_CxxStdlib.str() :
+      I->getFullModuleName();
+    ImportPath::Builder importPath(SwiftContext, moduleName, '.');
     UnloadedImportedModule importedModule(importPath.copyTo(SwiftContext), ImportKind::Module);
     implicitImportInfo.AdditionalUnloadedImports.push_back(importedModule);
   }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1278,6 +1278,8 @@ public:
   /// \returns The named module, or null if the module has not been imported.
   ModuleDecl *getNamedModule(StringRef name);
 
+  ImportPath::Builder getSwiftModulePath(const clang::Module *M);
+
   /// Returns the "Foundation" module, if it can be loaded.
   ///
   /// After this has been called, the Foundation module will or won't be loaded

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1730,6 +1730,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.DumpMacroExpansions = Args.hasArg(
       OPT_dump_macro_expansions);
 
+  Opts.DumpSourceFileImports = Args.hasArg(
+      OPT_dump_source_file_imports);
+
   if (const Arg *A = Args.getLastArg(OPT_debug_requirement_machine))
     Opts.DebugRequirementMachine = A->getValue();
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -327,9 +327,7 @@ void swift::performImportResolution(SourceFile &SF) {
 }
 
 void swift::performImportResolutionForClangMacroBuffer(SourceFile &SF) {
-  // If we've already performed import resolution, bail.
-  if (SF.ASTStage == SourceFile::ImportsResolved)
-    return;
+  assert(SF.ASTStage == SourceFile::Unprocessed);
 
   // `getWrapperForModule` has already declared all the implicit clang module
   // imports we need

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -334,12 +334,6 @@ void swift::performImportResolutionForClangMacroBuffer(SourceFile &SF) {
   // `getWrapperForModule` has already declared all the implicit clang module
   // imports we need
   ImportResolver resolver(SF);
-
-  // FIXME: This is a hack that we shouldn't need, but be sure that we can
-  // see the Swift standard library.
-  if (auto stdlib = SF.getASTContext().getStdlibModule())
-    resolver.addImplicitImport(stdlib);
-
   SF.setImports(resolver.getFinishedImports());
   SF.setImportedUnderlyingModule(resolver.getUnderlyingClangModule());
 

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -321,15 +321,14 @@ void swift::performImportResolution(SourceFile &SF) {
   verify(SF);
 }
 
-void swift::performImportResolutionForClangMacroBuffer(
-    SourceFile &SF, ModuleDecl *clangModule
-) {
+void swift::performImportResolutionForClangMacroBuffer(SourceFile &SF) {
   // If we've already performed import resolution, bail.
   if (SF.ASTStage == SourceFile::ImportsResolved)
     return;
 
+  // `getWrapperForModule` has already declared all the implicit clang module
+  // imports we need
   ImportResolver resolver(SF);
-  resolver.addImplicitImport(clangModule);
 
   // FIXME: This is a hack that we shouldn't need, but be sure that we can
   // see the Swift standard library.

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1060,10 +1060,8 @@ createMacroSourceFile(std::unique_ptr<llvm::MemoryBuffer> buffer,
       /*parsingOpts=*/{}, /*isPrimary=*/false);
   if (auto parentSourceFile = dc->getParentSourceFile())
     macroSourceFile->setImports(parentSourceFile->getImports());
-  else if (auto clangModuleUnit =
-               dyn_cast<ClangModuleUnit>(dc->getModuleScopeContext())) {
-    auto clangModule = clangModuleUnit->getParentModule();
-    performImportResolutionForClangMacroBuffer(*macroSourceFile, clangModule);
+  else if (isa<ClangModuleUnit>(dc->getModuleScopeContext())) {
+    performImportResolutionForClangMacroBuffer(*macroSourceFile);
   }
   return macroSourceFile;
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1061,7 +1061,12 @@ createMacroSourceFile(std::unique_ptr<llvm::MemoryBuffer> buffer,
   if (auto parentSourceFile = dc->getParentSourceFile())
     macroSourceFile->setImports(parentSourceFile->getImports());
   else if (isa<ClangModuleUnit>(dc->getModuleScopeContext())) {
-    performImportResolutionForClangMacroBuffer(*macroSourceFile);
+    ModuleDecl *originModule = nullptr;
+    // FIXME: remove this workaround once namespace contents are imported into
+    // their corresponding modules
+    if (macroSourceFile->getParentModule()->isClangHeaderImportModule())
+      originModule = cast<Decl *>(target)->getModuleContextForNameLookup();
+    performImportResolutionForClangMacroBuffer(*macroSourceFile, originModule);
   }
   return macroSourceFile;
 }

--- a/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-a.h
+++ b/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-a.h
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef int a_t;

--- a/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-b.h
+++ b/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-b.h
@@ -1,0 +1,3 @@
+#pragma once
+
+typedef int b_t;

--- a/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-c.h
+++ b/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-c.h
@@ -1,0 +1,2 @@
+#pragma once
+typedef int c_t;

--- a/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-d.h
+++ b/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-d.h
@@ -1,0 +1,2 @@
+#pragma once
+typedef int d_t;

--- a/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-e.h
+++ b/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module-e.h
@@ -1,0 +1,2 @@
+#pragma once
+typedef int e_t;

--- a/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module.modulemap
+++ b/test/Interop/C/swiftify-import/Inputs/TransitiveModules/module.modulemap
@@ -1,0 +1,24 @@
+module ModuleA {
+    header "module-a.h"
+    export *
+}
+module ModuleB {
+    header "module-b.h"
+}
+module ModuleOuter {
+    module ModuleC {
+        header "module-c.h"
+        export *
+    }
+    explicit module ModuleD {
+         header "module-d.h"
+         export *
+    }
+}
+module ModuleDeep {
+    module ModuleDeepNested {
+        module ModuleDeepNestedNested {
+            header "module-e.h"
+        }
+    }
+}

--- a/test/Interop/C/swiftify-import/Inputs/clang-includes.h
+++ b/test/Interop/C/swiftify-import/Inputs/clang-includes.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "TransitiveModules/module-a.h"
+#include "TransitiveModules/module-b.h"
+#include "TransitiveModules/module-c.h"
+#include "TransitiveModules/module-d.h"
+#include "TransitiveModules/module-e.h"
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
+
+void basic_include(const a_t *__counted_by(len) p __noescape, a_t len);
+
+void non_exported_include(const b_t *__counted_by(len) p __noescape, b_t len);
+
+void submodule_include(const c_t *__counted_by(len) p __noescape, c_t len);
+
+void explicit_submodule_include(const d_t *__counted_by(len) p __noescape, d_t len);
+
+void deep_submodule_noexport(const e_t *__counted_by(len) p __noescape, e_t len);

--- a/test/Interop/C/swiftify-import/Inputs/module.modulemap
+++ b/test/Interop/C/swiftify-import/Inputs/module.modulemap
@@ -26,3 +26,10 @@ module CommentsClang {
     header "comments.h"
     export *
 }
+module ClangIncludesModule {
+    header "clang-includes.h"
+    export *
+}
+module ClangIncludesNoExportModule {
+    header "clang-includes.h"
+}

--- a/test/Interop/C/swiftify-import/clang-includes-aliasing-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-aliasing-imports.swift
@@ -1,0 +1,93 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-A1 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A2 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-A2 --implicit-check-not=import --match-full-lines
+
+//--- test.swift
+import A1
+
+import A2
+
+public func callUnsafe(_ p: UnsafeMutableRawPointer) {
+  let _ = a1(p, 13)
+  let _ = a2(p, 13)
+}
+
+public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
+  let _ = a1(p)
+  let _ = a2(p)
+}
+
+//--- Inputs/module.modulemap
+module A1 {
+  header "A1.h"
+  explicit module Aliasing {
+    // Make sure that the full module path is taken into account
+    // and not just the module name
+    header "Aliasing1.h"
+    explicit module Aliasing {
+      header "Aliasing2.h"
+    }
+  }
+}
+module A2 {
+  header "A2.h"
+}
+module A3 {
+  explicit module Aliasing {
+    header "Aliasing3.h"
+  }
+}
+module A4 {
+  explicit module Aliasing {
+    header "Aliasing4.h"
+  }
+}
+
+//--- Inputs/A1.h
+#pragma once
+
+#include "Aliasing1.h"
+#include "Aliasing2.h"
+
+// CHECK-A1: import A1.Aliasing
+// CHECK-A1: import A1.Aliasing.Aliasing
+
+#define __sized_by(s) __attribute__((__sized_by__(s)))
+
+aliasing1_t a1(void * _Nonnull __sized_by(size), aliasing2_t size);
+
+//--- Inputs/Aliasing1.h
+#pragma once
+
+typedef int aliasing1_t;
+
+//--- Inputs/Aliasing2.h
+#pragma once
+
+typedef int aliasing2_t;
+
+//--- Inputs/Aliasing3.h
+#pragma once
+
+typedef int aliasing3_t;
+
+//--- Inputs/Aliasing4.h
+#pragma once
+
+typedef int aliasing4_t;
+
+//--- Inputs/A2.h
+#pragma once
+
+#include "Aliasing3.h"
+#include "Aliasing4.h"
+
+// CHECK-A2-NOT: import
+
+#define __sized_by(s) __attribute__((__sized_by__(s)))
+
+aliasing3_t a2(void * _Nonnull __sized_by(size), aliasing4_t size);

--- a/test/Interop/C/swiftify-import/clang-includes-aliasing-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-aliasing-imports.swift
@@ -3,6 +3,9 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+// RUN: %target-swift-frontend -dump-source-file-imports -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift 2>&1 | %FileCheck %s --check-prefix DUMP
+// RUN: %target-swift-frontend -dump-source-file-imports -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift -cxx-interoperability-mode=default 2>&1 | %FileCheck %s --check-prefix DUMP --check-prefix DUMP-CXX
+
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-A1 --implicit-check-not=import --match-full-lines
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A2 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-A2 --implicit-check-not=import --match-full-lines
 
@@ -10,6 +13,17 @@
 import A1
 
 import A2
+
+// DUMP: imports for {{.*}}/test.swift:
+// DUMP-NEXT:   Swift
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   A2
 
 public func callUnsafe(_ p: UnsafeMutableRawPointer) {
   let _ = a1(p, 13)
@@ -60,6 +74,19 @@ module A4 {
 
 aliasing1_t a1(void * _Nonnull __sized_by(size), aliasing2_t size);
 
+// DUMP-NEXT: imports for A1.a1:
+// DUMP-NEXT: imports for @__swiftmacro_So2a115_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   Aliasing
+// DUMP-NEXT:   Aliasing
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
 //--- Inputs/Aliasing1.h
 #pragma once
 
@@ -91,3 +118,20 @@ typedef int aliasing4_t;
 #define __sized_by(s) __attribute__((__sized_by__(s)))
 
 aliasing3_t a2(void * _Nonnull __sized_by(size), aliasing4_t size);
+
+// DUMP-NEXT: imports for A2.a2:
+// DUMP-NEXT: imports for @__swiftmacro_So2a215_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   Aliasing
+// DUMP-NEXT:   A4
+// DUMP-NEXT:   Aliasing
+// DUMP-NEXT:   A3
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
+// DUMP-NOT: imports

--- a/test/Interop/C/swiftify-import/clang-includes-aliasing-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-aliasing-imports.swift
@@ -85,7 +85,6 @@ aliasing1_t a1(void * _Nonnull __sized_by(size), aliasing2_t size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/Aliasing1.h
 #pragma once
@@ -132,6 +131,5 @@ aliasing3_t a2(void * _Nonnull __sized_by(size), aliasing4_t size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 // DUMP-NOT: imports

--- a/test/Interop/C/swiftify-import/clang-includes-explicit.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-explicit.swift
@@ -1,0 +1,57 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift
+
+//--- test.swift
+import A1.B1.C1.D1
+
+public func callUnsafe(_ p: UnsafeMutableRawPointer) {
+  let _ = foo(p, 13)
+}
+
+public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
+  let _ = foo(p)
+}
+
+//--- Inputs/module.modulemap
+module A1 {
+  explicit module B1 {
+    explicit module C1 {
+      explicit module D1 {
+        header "D1.h"
+      }
+    }
+  }
+}
+
+module A2 {
+ explicit module B2 {
+    header "B2.h"
+    export C2
+
+    explicit module C2 {
+      header "C2.h"
+    }
+  }
+}
+
+//--- Inputs/D1.h
+#pragma once
+
+#include "B2.h"
+#define __sized_by(s) __attribute__((__sized_by__(s)))
+
+c2_t foo(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/B2.h
+#pragma once
+
+#include "C2.h"
+
+//--- Inputs/C2.h
+#pragma once
+
+typedef int c2_t;

--- a/test/Interop/C/swiftify-import/clang-includes-explicit.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-explicit.swift
@@ -4,6 +4,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift -cxx-interoperability-mode=default
 
 //--- test.swift
 import A1.B1.C1.D1

--- a/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
@@ -1,0 +1,93 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-B1 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1.C1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-C1 --implicit-check-not=import --match-full-lines
+
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A2.B2 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-B2 --implicit-check-not=import --match-full-lines
+
+//--- test.swift
+import A1.B1
+import A2.B2
+
+public func callUnsafe(_ p: UnsafeMutableRawPointer) {
+  let _ = b1b(p, 13)
+  let _ = b1c(p, 13)
+  let _ = b1d(p, 13)
+  let _ = b2b(p, 13)
+  let _ = b2c(p, 13)
+  let _ = b2d(p, 13)
+}
+
+public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
+  let _ = b1b(p)
+  let _ = b1c(p)
+  let _ = b1d(p)
+  let _ = b2b(p)
+  let _ = b2c(p)
+  let _ = b2d(p)
+}
+//--- Inputs/module.modulemap
+module A1 {
+  explicit module B1 {
+    header "B1.h"
+    explicit module C1 {
+      header "C1.h"
+      explicit module D1 {
+        header "D1.h"
+      }
+    }
+  }
+}
+module A2 {
+  explicit module B2 {
+    header "B2.h"
+  }
+}
+
+//--- Inputs/B1.h
+#pragma once
+
+#include "C1.h"
+#include "D1.h"
+
+// CHECK-B1: import A1.B1.C1
+// CHECK-B1: import A1.B1.C1.D1
+
+typedef int b1_t;
+
+b1_t b1b(void * _Nonnull __sized_by(size), int size);
+c1_t b1c(void * _Nonnull __sized_by(size), int size);
+d1_t b1d(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/C1.h
+#pragma once
+
+#include "D1.h"
+
+// CHECK-C1: import A1.B1.C1.D1
+
+typedef int c1_t;
+
+
+//--- Inputs/D1.h
+#pragma once
+
+#define __sized_by(s) __attribute__((__sized_by__(s)))
+
+typedef int d1_t;
+
+//--- Inputs/B2.h
+#pragma once
+
+#include "B1.h"
+#include "C1.h"
+#include "D1.h"
+
+// CHECK-B2-NOT: import
+
+b1_t b2b(void * _Nonnull __sized_by(size), int size);
+c1_t b2c(void * _Nonnull __sized_by(size), int size);
+d1_t b2d(void * _Nonnull __sized_by(size), int size);

--- a/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
@@ -83,7 +83,6 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for @__swiftmacro_So3b1b15_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
@@ -97,7 +96,6 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for @__swiftmacro_So3b1c15_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
@@ -110,7 +108,6 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A1.b1d:
 // DUMP-NEXT: imports for @__swiftmacro_So3b1d15_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   D1
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
 // DUMP-CXX-NEXT:   CxxShim

--- a/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
@@ -6,7 +6,6 @@
 // RUN: %target-swift-frontend -dump-source-file-imports -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift 2>&1 | %FileCheck %s --check-prefix DUMP
 // RUN: %target-swift-frontend -dump-source-file-imports -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift -cxx-interoperability-mode=default 2>&1 | %FileCheck %s --check-prefix DUMP --check-prefix DUMP-CXX
 
-
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-B1 --implicit-check-not=import --match-full-lines
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1.C1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-C1 --implicit-check-not=import --match-full-lines
 
@@ -84,6 +83,7 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -97,6 +97,7 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -110,6 +111,7 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -157,6 +159,7 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   A1
+// DUMP-NEXT:   B2
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -174,6 +177,7 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   A1
+// DUMP-NEXT:   B2
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -191,6 +195,7 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   A1
+// DUMP-NEXT:   B2
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing

--- a/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
@@ -90,7 +90,6 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 // DUMP-NEXT: imports for A1.b1c:
 // DUMP-NEXT: imports for @__swiftmacro_So3b1c15_SwiftifyImportfMp_.swift:
@@ -104,7 +103,6 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 // DUMP-NEXT: imports for A1.b1d:
 // DUMP-NEXT: imports for @__swiftmacro_So3b1d15_SwiftifyImportfMp_.swift:
@@ -118,7 +116,6 @@ d1_t b1d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/C1.h
 #pragma once
@@ -164,7 +161,6 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 // DUMP-NEXT: imports for A2.b2c:
 // DUMP-NEXT: imports for @__swiftmacro_So3b2c15_SwiftifyImportfMp_.swift:
@@ -180,7 +176,6 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 // DUMP-NEXT: imports for A2.b2d:
 // DUMP-NEXT: imports for @__swiftmacro_So3b2d15_SwiftifyImportfMp_.swift:
@@ -196,6 +191,5 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 // DUMP-NOT: imports

--- a/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
@@ -3,6 +3,10 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+// RUN: %target-swift-frontend -dump-source-file-imports -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift 2>&1 | %FileCheck %s --check-prefix DUMP
+// RUN: %target-swift-frontend -dump-source-file-imports -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift -cxx-interoperability-mode=default 2>&1 | %FileCheck %s --check-prefix DUMP --check-prefix DUMP-CXX
+
+
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-B1 --implicit-check-not=import --match-full-lines
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1.C1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-C1 --implicit-check-not=import --match-full-lines
 
@@ -11,6 +15,19 @@
 //--- test.swift
 import A1.B1
 import A2.B2
+
+// DUMP: imports for {{.*}}/test.swift:
+// DUMP-NEXT:   Swift
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B2
+// DUMP-NEXT:   A2
 
 public func callUnsafe(_ p: UnsafeMutableRawPointer) {
   let _ = b1b(p, 13)
@@ -62,6 +79,48 @@ b1_t b1b(void * _Nonnull __sized_by(size), int size);
 c1_t b1c(void * _Nonnull __sized_by(size), int size);
 d1_t b1d(void * _Nonnull __sized_by(size), int size);
 
+// DUMP-NEXT: imports for A1.b1b:
+// DUMP-NEXT: imports for @__swiftmacro_So3b1b15_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
+// DUMP-NEXT: imports for A1.b1c:
+// DUMP-NEXT: imports for @__swiftmacro_So3b1c15_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
+// DUMP-NEXT: imports for A1.b1d:
+// DUMP-NEXT: imports for @__swiftmacro_So3b1d15_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
 //--- Inputs/C1.h
 #pragma once
 
@@ -91,3 +150,56 @@ typedef int d1_t;
 b1_t b2b(void * _Nonnull __sized_by(size), int size);
 c1_t b2c(void * _Nonnull __sized_by(size), int size);
 d1_t b2d(void * _Nonnull __sized_by(size), int size);
+
+// DUMP-NEXT: imports for A2.b2b:
+// DUMP-NEXT: imports for @__swiftmacro_So3b2b15_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
+// DUMP-NEXT: imports for A2.b2c:
+// DUMP-NEXT: imports for @__swiftmacro_So3b2c15_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
+// DUMP-NEXT: imports for A2.b2d:
+// DUMP-NEXT: imports for @__swiftmacro_So3b2d15_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
+// DUMP-NOT: imports

--- a/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-indirect-explicit-modules.swift
@@ -156,9 +156,7 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B2
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
@@ -174,9 +172,7 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B2
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
@@ -192,9 +188,7 @@ d1_t b2d(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B2
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx

--- a/test/Interop/C/swiftify-import/clang-includes-noexport.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-noexport.swift
@@ -4,6 +4,7 @@
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesNoExport.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesNoExport.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s -cxx-interoperability-mode=default
 
 import ClangIncludesNoExportModule
 

--- a/test/Interop/C/swiftify-import/clang-includes-noexport.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-noexport.swift
@@ -19,23 +19,23 @@ import ClangIncludesNoExportModule
 // CHECK-NEXT: func deep_submodule_noexport(_ p: UnsafePointer<e_t>!, _ len: e_t)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func basic_include(_ p: Span<a_t>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func deep_submodule_noexport(_ p: Span<e_t>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func explicit_submodule_include(_ p: Span<d_t>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func non_exported_include(_ p: Span<b_t>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func submodule_include(_ p: Span<c_t>)
 
 public func callBasicInclude(_ p: Span<CInt>) {

--- a/test/Interop/C/swiftify-import/clang-includes-noexport.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-noexport.swift
@@ -1,0 +1,59 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClangIncludesNoExportModule -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+
+// swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesNoExport.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+
+import ClangIncludesNoExportModule
+
+// CHECK:      import ModuleA
+// CHECK-NEXT: import ModuleB
+// CHECK-NOT:  import
+// CHECK-EMPTY:
+
+// CHECK-NEXT: func basic_include(_ p: UnsafePointer<a_t>!, _ len: a_t)
+// CHECK-NEXT: func non_exported_include(_ p: UnsafePointer<b_t>!, _ len: b_t)
+// CHECK-NEXT: func submodule_include(_ p: UnsafePointer<c_t>!, _ len: c_t)
+// CHECK-NEXT: func explicit_submodule_include(_ p: UnsafePointer<d_t>!, _ len: d_t)
+// CHECK-NEXT: func deep_submodule_noexport(_ p: UnsafePointer<e_t>!, _ len: e_t)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func basic_include(_ p: Span<a_t>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func deep_submodule_noexport(_ p: Span<e_t>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func explicit_submodule_include(_ p: Span<d_t>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func non_exported_include(_ p: Span<b_t>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func submodule_include(_ p: Span<c_t>)
+
+public func callBasicInclude(_ p: Span<CInt>) {
+  basic_include(p)
+}
+
+public func callNonExported(_ p: Span<CInt>) {
+  non_exported_include(p)
+}
+
+public func callSubmoduleInclude(_ p: Span<CInt>) {
+  submodule_include(p)
+}
+
+public func callExplicitSubmoduleInclude(_ p: Span<CInt>) {
+  explicit_submodule_include(p)
+}
+
+public func callDeepSubmoduleNoexport(_ p: Span<CInt>) {
+  deep_submodule_noexport(p)
+}

--- a/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
@@ -1,0 +1,215 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-A1 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-B1 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1.C1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-C1 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1.C1.D1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-D1 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.E1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-E1 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.E1.F1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-F1 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.E1.G1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-G1 --implicit-check-not=import --match-full-lines
+
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A2.B2 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-B2 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A2.B2.C2 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-C2 --implicit-check-not=import --match-full-lines
+// RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A2.B2.C2.D2 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-D2 --implicit-check-not=import --match-full-lines
+
+//--- test.swift
+import A1
+import A1.B1
+import A1.B1.C1
+import A1.B1.C1.D1
+import A1.E1
+
+import A2.B2
+import A2.B2.C2
+
+public func callUnsafe(_ p: UnsafeMutableRawPointer) {
+  let _ = a1(p, 13)
+  let _ = b1(p, 13)
+  let _ = c1(p, 13)
+  let _ = d1(p, 13)
+  let _ = e1_1(p, 13)
+  let _ = e1_2(p, 13)
+  let _ = b2_1(p, 13)
+  let _ = b2_2(p, 13)
+  let _ = c2(p, 13)
+  let _ = d2(p, 13)
+}
+
+public func callSafe(_ p: UnsafeMutableRawBufferPointer) {
+  let _ = a1(p)
+  let _ = b1(p)
+  let _ = c1(p)
+  let _ = d1(p)
+  let _ = e1_1(p)
+  let _ = e1_2(p)
+  let _ = b2_1(p)
+  let _ = b2_2(p)
+  let _ = c2(p)
+  let _ = d2(p)
+}
+
+//--- Inputs/module.modulemap
+module A1 {
+  header "A1.h"
+  explicit module B1 {
+    header "B1.h"
+    module C1 {
+      header "C1.h"
+      export D1
+      explicit module D1 {
+        header "D1.h"
+      }
+    }
+  }
+  module E1 {
+    header "E1.h"
+
+    // F1 and G1 are not imported directly from Swift - G1 is implicitly
+    // reexported by E1, but F1 ust be implicitly loaded for its decl to be visible
+    explicit module F1 {
+      header "F1.h"
+    }
+    module G1 {
+      header "G1.h"
+    }
+  }
+}
+module A2 {
+  module B2 {
+    header "B2.h"
+
+    explicit module C2 {
+      header "C2.h"
+
+      module D2 {
+        header "D2.h"
+
+        module E2 {
+          header "E2.h"
+        }
+      }
+    }
+  }
+}
+
+//--- Inputs/A1.h
+#pragma once
+
+#include "E1.h"
+#include "B1.h"
+
+// CHECK-A1: import A1.B1
+// CHECK-A1: @_exported import A1.E1
+
+f1_t  a1(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/B1.h
+#pragma once
+
+#include "A1.h"
+#include "F1.h"
+#include "C1.h"
+
+// CHECK-B1: import A1
+// CHECK-B1: @_exported import A1.B1.C1
+
+c1_t  b1(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/C1.h
+#pragma once
+
+typedef int c1_t;
+#include "D1.h"
+
+// CHECK-C1: @_exported import A1.B1.C1.D1
+
+f1_t  c1(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/D1.h
+#pragma once
+
+#include "F1.h"
+
+// CHECK-D1-NOT: import
+
+f1_t d1(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/E1.h
+#pragma once
+
+#include "A1.h"
+#include "B1.h"
+#include "C1.h"
+#include "D1.h"
+#include "G1.h"
+
+// CHECK-E1: import A1
+// CHECK-E1: import A1.E1.F1
+// CHECK-E1: @_exported import A1.E1.G1
+
+f1_t e1_1(void * _Nonnull __sized_by(size), int size);
+g1_t e1_2(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/F1.h
+#pragma once
+
+// CHECK-F1-NOT: import
+
+#define __sized_by(s) __attribute__((__sized_by__(s)))
+
+typedef int f1_t;
+
+//--- Inputs/G1.h
+#pragma once
+
+// CHECK-G1-NOT: import
+
+typedef int g1_t;
+
+//--- Inputs/B2.h
+#pragma once
+
+#include "A1.h"
+#include "B1.h"
+#include "C1.h"
+#include "C2.h"
+#include "D1.h"
+
+// CHECK-B2: import A1
+// CHECK-B2: import A2.B2.C2
+
+
+c1_t b2_1(void * _Nonnull __sized_by(size), int size);
+c2_t b2_2(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/C2.h
+#pragma once
+
+#include "D2.h"
+#include "B1.h"
+#include "C1.h"
+
+// CHECK-C2: @_exported import A2.B2.C2.D2
+
+typedef int c2_t;
+
+e2_t c2(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/D2.h
+#pragma once
+
+#include "E2.h"
+
+// CHECK-D2: @_exported import A2.B2.C2.D2.E2
+
+e2_t d2(void * _Nonnull __sized_by(size), int size);
+
+//--- Inputs/E2.h
+#pragma once
+
+#define __sized_by(s) __attribute__((__sized_by__(s)))
+
+typedef int e2_t;

--- a/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
@@ -138,7 +138,6 @@ f1_t  a1(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/B1.h
 #pragma once
@@ -164,7 +163,6 @@ c1_t  b1(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/C1.h
 #pragma once
@@ -188,7 +186,6 @@ f1_t  c1(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/D1.h
 #pragma once
@@ -211,7 +208,6 @@ f1_t d1(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/E1.h
 #pragma once
@@ -241,7 +237,6 @@ g1_t e1_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 // DUMP-NEXT: imports for A1.e1_2:
 // DUMP-NEXT: imports for @__swiftmacro_So4e1_215_SwiftifyImportfMp_.swift:
@@ -255,7 +250,6 @@ g1_t e1_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/F1.h
 #pragma once
@@ -303,7 +297,6 @@ c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 // DUMP-NEXT: imports for A2.b2_2:
 // DUMP-NEXT: imports for @__swiftmacro_So4b2_215_SwiftifyImportfMp_.swift:
@@ -319,7 +312,6 @@ c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/C2.h
 #pragma once
@@ -348,7 +340,6 @@ e2_t c2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/D2.h
 #pragma once
@@ -373,7 +364,6 @@ e2_t d2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   _SwiftConcurrencyShims
 // DUMP-NEXT:   _Concurrency
 // DUMP-NEXT:   SwiftOnoneSupport
-// DUMP-NEXT:   Swift
 
 //--- Inputs/E2.h
 #pragma once

--- a/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
@@ -3,6 +3,9 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+// RUN: %target-swift-frontend -dump-source-file-imports -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift 2>&1 | %FileCheck %s --check-prefix DUMP
+// RUN: %target-swift-frontend -dump-source-file-imports -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludesExplicit.swiftmodule -I %t/Inputs -enable-experimental-feature SafeInteropWrappers %t/test.swift -cxx-interoperability-mode=default 2>&1 | %FileCheck %s --check-prefix DUMP --check-prefix DUMP-CXX
+
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-A1 --implicit-check-not=import --match-full-lines
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-B1 --implicit-check-not=import --match-full-lines
 // RUN: %target-swift-ide-test -print-module -module-print-hidden -module-to-print=A1.B1.C1 -plugin-path %swift-plugin-dir -I %t -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s --check-prefix CHECK-C1 --implicit-check-not=import --match-full-lines
@@ -24,6 +27,28 @@ import A1.E1
 
 import A2.B2
 import A2.B2.C2
+
+// DUMP: imports for {{.*}}/test.swift:
+// DUMP-NEXT:   Swift
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   E1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B2
+// DUMP-NEXT:   A2
+// DUMP-NEXT:   C2
+// DUMP-NEXT:   A2
 
 public func callUnsafe(_ p: UnsafeMutableRawPointer) {
   let _ = a1(p, 13)
@@ -106,6 +131,29 @@ module A2 {
 
 f1_t  a1(void * _Nonnull __sized_by(size), int size);
 
+// DUMP-NEXT: imports for A1.a1:
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2a115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2a115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: imports for @__swiftmacro_So2a115_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   G1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   E1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
 //--- Inputs/B1.h
 #pragma once
 
@@ -118,6 +166,29 @@ f1_t  a1(void * _Nonnull __sized_by(size), int size);
 
 c1_t  b1(void * _Nonnull __sized_by(size), int size);
 
+// DUMP-NEXT: imports for A1.b1:
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2b115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2b115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: imports for @__swiftmacro_So2b115_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   G1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   E1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
 //--- Inputs/C1.h
 #pragma once
 
@@ -128,6 +199,29 @@ typedef int c1_t;
 
 f1_t  c1(void * _Nonnull __sized_by(size), int size);
 
+// DUMP-NEXT: imports for A1.c1:
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2c115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2c115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: imports for @__swiftmacro_So2c115_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   G1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   E1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
 //--- Inputs/D1.h
 #pragma once
 
@@ -136,6 +230,29 @@ f1_t  c1(void * _Nonnull __sized_by(size), int size);
 // CHECK-D1-NOT: import
 
 f1_t d1(void * _Nonnull __sized_by(size), int size);
+
+// DUMP-NEXT: imports for A1.d1:
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2d115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2d115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: imports for @__swiftmacro_So2d115_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   G1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   E1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
 
 //--- Inputs/E1.h
 #pragma once
@@ -152,6 +269,52 @@ f1_t d1(void * _Nonnull __sized_by(size), int size);
 
 f1_t e1_1(void * _Nonnull __sized_by(size), int size);
 g1_t e1_2(void * _Nonnull __sized_by(size), int size);
+
+// DUMP-NEXT: imports for A1.e1_1:
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So4e1_115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So4e1_115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: imports for @__swiftmacro_So4e1_115_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   G1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   E1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
+// DUMP-NEXT: imports for A1.e1_2:
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So4e1_215_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So4e1_215_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
+// DUMP-NEXT: imports for @__swiftmacro_So4e1_215_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   F1
+// DUMP-NEXT:   G1
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   E1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
 
 //--- Inputs/F1.h
 #pragma once
@@ -185,6 +348,56 @@ typedef int g1_t;
 c1_t b2_1(void * _Nonnull __sized_by(size), int size);
 c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 
+// DUMP-NEXT: imports for A2.b2_1:
+// DUMP-NEXT: imports for @__swiftmacro_So4b2_115_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   E2
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   D2
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   C2
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   A1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
+// DUMP-NEXT: imports for A2.b2_2:
+// DUMP-NEXT: imports for @__swiftmacro_So4b2_215_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   E2
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   D2
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   C2
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   A1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
 //--- Inputs/C2.h
 #pragma once
 
@@ -198,6 +411,31 @@ typedef int c2_t;
 
 e2_t c2(void * _Nonnull __sized_by(size), int size);
 
+// DUMP-NEXT: imports for A2.c2:
+// DUMP-NEXT: imports for @__swiftmacro_So2c215_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   E2
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   D2
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   C2
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   A1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
 //--- Inputs/D2.h
 #pragma once
 
@@ -207,9 +445,36 @@ e2_t c2(void * _Nonnull __sized_by(size), int size);
 
 e2_t d2(void * _Nonnull __sized_by(size), int size);
 
+// DUMP-NEXT: imports for A2.d2:
+// DUMP-NEXT: imports for @__swiftmacro_So2d215_SwiftifyImportfMp_.swift:
+// DUMP-NEXT:   Swift
+// DUMP-NEXT:   E2
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   D2
+// DUMP-NEXT:   D1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   C2
+// DUMP-NEXT:   C1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   B1
+// DUMP-NEXT:   A1
+// DUMP-NEXT:   A1
+// DUMP-CXX-NEXT:   CxxShim
+// DUMP-CXX-NEXT:   Cxx
+// DUMP-NEXT:   _StringProcessing
+// DUMP-NEXT:   _SwiftConcurrencyShims
+// DUMP-NEXT:   _Concurrency
+// DUMP-NEXT:   SwiftOnoneSupport
+// DUMP-NEXT:   Swift
+
 //--- Inputs/E2.h
 #pragma once
 
 #define __sized_by(s) __attribute__((__sized_by__(s)))
 
 typedef int e2_t;
+
+// DUMP-NOT: imports

--- a/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
@@ -38,17 +38,12 @@ import A2.B2.C2
 // DUMP-NEXT:   SwiftOnoneSupport
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   E1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B2
 // DUMP-NEXT:   A2
 // DUMP-NEXT:   C2
-// DUMP-NEXT:   A2
 
 public func callUnsafe(_ p: UnsafeMutableRawPointer) {
   let _ = a1(p, 13)
@@ -301,10 +296,7 @@ c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
-// DUMP-NEXT:   A1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -320,10 +312,7 @@ c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
-// DUMP-NEXT:   A1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -352,10 +341,7 @@ e2_t c2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
-// DUMP-NEXT:   A1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -380,10 +366,7 @@ e2_t d2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
-// DUMP-NEXT:   A1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing

--- a/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
@@ -132,18 +132,12 @@ module A2 {
 f1_t  a1(void * _Nonnull __sized_by(size), int size);
 
 // DUMP-NEXT: imports for A1.a1:
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2a115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2a115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
 // DUMP-NEXT: imports for @__swiftmacro_So2a115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   F1
 // DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   B1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   E1
 // DUMP-CXX-NEXT:   CxxShim
@@ -167,18 +161,12 @@ f1_t  a1(void * _Nonnull __sized_by(size), int size);
 c1_t  b1(void * _Nonnull __sized_by(size), int size);
 
 // DUMP-NEXT: imports for A1.b1:
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2b115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2b115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
 // DUMP-NEXT: imports for @__swiftmacro_So2b115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   F1
 // DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   B1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   E1
 // DUMP-CXX-NEXT:   CxxShim
@@ -200,18 +188,12 @@ typedef int c1_t;
 f1_t  c1(void * _Nonnull __sized_by(size), int size);
 
 // DUMP-NEXT: imports for A1.c1:
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2c115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2c115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
 // DUMP-NEXT: imports for @__swiftmacro_So2c115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   F1
 // DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   B1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   E1
 // DUMP-CXX-NEXT:   CxxShim
@@ -232,18 +214,12 @@ f1_t  c1(void * _Nonnull __sized_by(size), int size);
 f1_t d1(void * _Nonnull __sized_by(size), int size);
 
 // DUMP-NEXT: imports for A1.d1:
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2d115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So2d115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
 // DUMP-NEXT: imports for @__swiftmacro_So2d115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   F1
 // DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   B1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   E1
 // DUMP-CXX-NEXT:   CxxShim
@@ -271,18 +247,12 @@ f1_t e1_1(void * _Nonnull __sized_by(size), int size);
 g1_t e1_2(void * _Nonnull __sized_by(size), int size);
 
 // DUMP-NEXT: imports for A1.e1_1:
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So4e1_115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So4e1_115_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
 // DUMP-NEXT: imports for @__swiftmacro_So4e1_115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   F1
 // DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   B1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   E1
 // DUMP-CXX-NEXT:   CxxShim
@@ -294,18 +264,12 @@ g1_t e1_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT:   Swift
 
 // DUMP-NEXT: imports for A1.e1_2:
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So4e1_215_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
-// DUMP-NEXT: <unknown>:0: warning: file '@__swiftmacro_So4e1_215_SwiftifyImportfMp_.swift' is part of module 'A1'; ignoring import
 // DUMP-NEXT: imports for @__swiftmacro_So4e1_215_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   F1
 // DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   C1
-// DUMP-NEXT:   B1
 // DUMP-NEXT:   B1
 // DUMP-NEXT:   E1
 // DUMP-CXX-NEXT:   CxxShim
@@ -352,10 +316,6 @@ c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for @__swiftmacro_So4b2_115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   E2
-// DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
-// DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   D2
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
@@ -377,10 +337,6 @@ c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for @__swiftmacro_So4b2_215_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   E2
-// DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
-// DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   D2
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
@@ -415,10 +371,6 @@ e2_t c2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for @__swiftmacro_So2c215_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   E2
-// DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
-// DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   D2
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
@@ -449,10 +401,6 @@ e2_t d2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for @__swiftmacro_So2d215_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
 // DUMP-NEXT:   E2
-// DUMP-NEXT:   C1
-// DUMP-NEXT:   A1
-// DUMP-NEXT:   B1
-// DUMP-NEXT:   A1
 // DUMP-NEXT:   D2
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1

--- a/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
+++ b/test/Interop/C/swiftify-import/clang-includes-redundant-imports.swift
@@ -134,12 +134,9 @@ f1_t  a1(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A1.a1:
 // DUMP-NEXT: imports for @__swiftmacro_So2a115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   E1
+// DUMP-NEXT:   F1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -163,12 +160,9 @@ c1_t  b1(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A1.b1:
 // DUMP-NEXT: imports for @__swiftmacro_So2b115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   E1
+// DUMP-NEXT:   F1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -190,12 +184,9 @@ f1_t  c1(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A1.c1:
 // DUMP-NEXT: imports for @__swiftmacro_So2c115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   E1
+// DUMP-NEXT:   F1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -216,12 +207,9 @@ f1_t d1(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A1.d1:
 // DUMP-NEXT: imports for @__swiftmacro_So2d115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   E1
+// DUMP-NEXT:   F1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -249,12 +237,9 @@ g1_t e1_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A1.e1_1:
 // DUMP-NEXT: imports for @__swiftmacro_So4e1_115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   E1
+// DUMP-NEXT:   F1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -266,12 +251,9 @@ g1_t e1_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A1.e1_2:
 // DUMP-NEXT: imports for @__swiftmacro_So4e1_215_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   F1
-// DUMP-NEXT:   G1
 // DUMP-NEXT:   D1
-// DUMP-NEXT:   C1
 // DUMP-NEXT:   B1
-// DUMP-NEXT:   E1
+// DUMP-NEXT:   F1
 // DUMP-CXX-NEXT:   CxxShim
 // DUMP-CXX-NEXT:   Cxx
 // DUMP-NEXT:   _StringProcessing
@@ -315,11 +297,9 @@ c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A2.b2_1:
 // DUMP-NEXT: imports for @__swiftmacro_So4b2_115_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   E2
-// DUMP-NEXT:   D2
+// DUMP-NEXT:   C2
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
-// DUMP-NEXT:   C2
 // DUMP-NEXT:   C1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
@@ -336,11 +316,9 @@ c2_t b2_2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A2.b2_2:
 // DUMP-NEXT: imports for @__swiftmacro_So4b2_215_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   E2
-// DUMP-NEXT:   D2
+// DUMP-NEXT:   C2
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
-// DUMP-NEXT:   C2
 // DUMP-NEXT:   C1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
@@ -370,11 +348,9 @@ e2_t c2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A2.c2:
 // DUMP-NEXT: imports for @__swiftmacro_So2c215_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   E2
-// DUMP-NEXT:   D2
+// DUMP-NEXT:   C2
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
-// DUMP-NEXT:   C2
 // DUMP-NEXT:   C1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   B1
@@ -400,11 +376,9 @@ e2_t d2(void * _Nonnull __sized_by(size), int size);
 // DUMP-NEXT: imports for A2.d2:
 // DUMP-NEXT: imports for @__swiftmacro_So2d215_SwiftifyImportfMp_.swift:
 // DUMP-NEXT:   Swift
-// DUMP-NEXT:   E2
-// DUMP-NEXT:   D2
+// DUMP-NEXT:   C2
 // DUMP-NEXT:   D1
 // DUMP-NEXT:   A1
-// DUMP-NEXT:   C2
 // DUMP-NEXT:   C1
 // DUMP-NEXT:   A1
 // DUMP-NEXT:   B1

--- a/test/Interop/C/swiftify-import/clang-includes.swift
+++ b/test/Interop/C/swiftify-import/clang-includes.swift
@@ -4,6 +4,7 @@
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludes.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludes.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s -cxx-interoperability-mode=default
 
 import ClangIncludesModule
 

--- a/test/Interop/C/swiftify-import/clang-includes.swift
+++ b/test/Interop/C/swiftify-import/clang-includes.swift
@@ -1,0 +1,59 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClangIncludesModule -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers | %FileCheck %s
+
+// swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/ClangIncludes.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers %s
+
+import ClangIncludesModule
+
+// CHECK:      @_exported import ModuleA
+// CHECK-NEXT: @_exported import ModuleB
+// CHECK-NOT:  import
+// CHECK-EMPTY:
+
+// CHECK-NEXT: func basic_include(_ p: UnsafePointer<a_t>!, _ len: a_t)
+// CHECK-NEXT: func non_exported_include(_ p: UnsafePointer<b_t>!, _ len: b_t)
+// CHECK-NEXT: func submodule_include(_ p: UnsafePointer<c_t>!, _ len: c_t)
+// CHECK-NEXT: func explicit_submodule_include(_ p: UnsafePointer<d_t>!, _ len: d_t)
+// CHECK-NEXT: func deep_submodule_noexport(_ p: UnsafePointer<e_t>!, _ len: e_t)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func basic_include(_ p: Span<a_t>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func deep_submodule_noexport(_ p: Span<e_t>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func explicit_submodule_include(_ p: Span<d_t>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func non_exported_include(_ p: Span<b_t>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func submodule_include(_ p: Span<c_t>)
+
+public func callBasicInclude(_ p: Span<CInt>) {
+  basic_include(p)
+}
+
+public func callNonExported(_ p: Span<CInt>) {
+  non_exported_include(p)
+}
+
+public func callSubmoduleInclude(_ p: Span<CInt>) {
+  submodule_include(p)
+}
+
+public func callExplicitSubmoduleInclude(_ p: Span<CInt>) {
+  explicit_submodule_include(p)
+}
+
+public func callDeepSubmoduleNoexport(_ p: Span<CInt>) {
+  deep_submodule_noexport(p)
+}

--- a/test/Interop/C/swiftify-import/clang-includes.swift
+++ b/test/Interop/C/swiftify-import/clang-includes.swift
@@ -19,23 +19,23 @@ import ClangIncludesModule
 // CHECK-NEXT: func deep_submodule_noexport(_ p: UnsafePointer<e_t>!, _ len: e_t)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func basic_include(_ p: Span<a_t>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func deep_submodule_noexport(_ p: Span<e_t>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func explicit_submodule_include(_ p: Span<d_t>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func non_exported_include(_ p: Span<b_t>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func submodule_include(_ p: Span<c_t>)
 
 public func callBasicInclude(_ p: Span<CInt>) {

--- a/test/Interop/Cxx/stdlib/Inputs/check-libcxx-version.cpp
+++ b/test/Interop/Cxx/stdlib/Inputs/check-libcxx-version.cpp
@@ -6,7 +6,9 @@ int main() {
   return 1;
 #endif
 
-#if _LIBCPP_VERSION >= 170004
+  // the libc++ module was split into multiple top-level modules in Clang 17,
+  // and then re-merged into one module with submodules in Clang 20
+#if _LIBCPP_VERSION >= 170004 && _LIBCPP_VERSION < 200000
   return 0;
 #else
   return 1;

--- a/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
@@ -1,4 +1,4 @@
-// Only run this test with older libc++, before the top-level std module got split into multiple top-level modules.
+// Don't run this test with libc++ versions 17-19, when the top-level std module was split into multiple top-level modules.
 // RUN: %empty-directory(%t)
 // RUN: %target-clangxx %S/Inputs/check-libcxx-version.cpp -o %t/check-libcxx-version
 // RUN: %target-codesign %t/check-libcxx-version

--- a/test/Interop/Cxx/swiftify-import/counted-by-in-namespace.swift
+++ b/test/Interop/Cxx/swiftify-import/counted-by-in-namespace.swift
@@ -1,28 +1,66 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Namespace -source-filename=x | %FileCheck %s
-// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/namespace.swift -dump-macro-expansions -typecheck -verify
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/namespace.swift -emit-module -verify
+// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Namespace -source-filename=x > %t/interface.txt
+// RUN: diff %t/interface.txt %t/interface.txt.expected
 
-// CHECK: enum foo {
-// CHECK:  static func bar(_ p: UnsafeMutableBufferPointer<Float>)
+//--- interface.txt.expected
+@_exported import Namespace.Baz
 
+enum foo {
+  static func foo_func(_ p: UnsafeMutablePointer<Float>!, _ len: Int32)
+  /// This is an auto-generated wrapper for safer interop
+  @_alwaysEmitIntoClient @_disfavoredOverload public static func foo_func(_ p: UnsafeMutableBufferPointer<Float>)
+  static func foo_func2(_ p: UnsafePointer<baz_t>!, _ len: baz_t)
+  /// This is an auto-generated wrapper for safer interop
+  @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+  @_alwaysEmitIntoClient @_disfavoredOverload public static func foo_func2(_ p: Span<baz_t>)
+  enum bar {
+    static func bar_func(_ p: UnsafePointer<baz_t>!, _ len: baz_t)
+    /// This is an auto-generated wrapper for safer interop
+    @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+    @_alwaysEmitIntoClient @_disfavoredOverload public static func bar_func(_ p: Span<baz_t>)
+  }
+}
 //--- Inputs/module.modulemap
 module Namespace {
     header "namespace.h"
     requires cplusplus
+    module Baz {
+      header "baz.h"
+    }
 }
 
 //--- Inputs/namespace.h
+#include "baz.h"
+
+#define __counted_by(x) __attribute__((__counted_by__(x)))
+#define __noescape __attribute__((noescape))
 
 namespace foo {
-   __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))"))) void bar(float *p, int len);
+  __attribute__((swift_attr("@_SwiftifyImport(.countedBy(pointer: .param(1), count: \"len\"))"))) void foo_func(float *p, int len);
+  void foo_func2(const baz_t * __counted_by(len) p __noescape, baz_t len);
+  namespace bar {
+    void bar_func(const baz_t * __counted_by(len) p __noescape, baz_t len);
+  }
 }
+
+//--- Inputs/baz.h
+typedef int baz_t;
 
 //--- namespace.swift
 import Namespace
-  
+
 func test(s: UnsafeMutableBufferPointer<Float>) {
-  foo.bar(s)
-}    
+  foo.foo_func(s)
+}
+
+func test2(s: Span<CInt>) {
+  foo.foo_func2(s)
+}
+
+func test3(s: Span<CInt>) {
+  foo.bar.bar_func(s)
+}

--- a/test/SourceKit/InterfaceGen/gen_clang_libcxx_sdk_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_libcxx_sdk_module.swift
@@ -1,6 +1,19 @@
-// RUN: %sourcekitd-test -req=interface-gen -module CxxStdlib -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -cxx-interoperability-mode=default -target %target-triple -sdk %sdk | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %target-clangxx %S/../../Interop/Cxx/stdlib/Inputs/check-libcxx-version.cpp -o %t/check-libcxx-version
+// RUN: %target-codesign %t/check-libcxx-version
+
+// Since this test runs check-libcxx-version, it requires execution.
+// REQUIRES: executable_test
+
+// RUN: %target-run %t/check-libcxx-version || %sourcekitd-test -req=interface-gen -module CxxStdlib -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -cxx-interoperability-mode=default -target %target-triple -sdk %sdk | %FileCheck %s --check-prefix CHECK-MONO
+// RUN: not %target-run %t/check-libcxx-version || %sourcekitd-test -req=interface-gen -module CxxStdlib -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -cxx-interoperability-mode=default -target %target-triple -sdk %sdk | %FileCheck %s --check-prefix CHECK-SPLIT
 
 // REQUIRES: OS=macosx
 
-// CHECK: import {{CxxStdlib.vector|std_vector}}
-// CHECK: extension std.basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>> {
+// CHECK-MONO-NOT: import CxxStdlib{{$}}
+// CHECK-MONO: import CxxStdlib.vector
+// CHECK-MONO: extension std.basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>> {
+
+// CHECK-SPLIT-NOT: import CxxStdlib{{$}}
+// CHECK-SPLIT: import std_vector
+// CHECK-SPLIT: extension std.basic_string<CChar, std.__1.char_traits<CChar>, std.__1.allocator<CChar>> {

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3793,9 +3793,14 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
       llvm::outs() << ":\n";
 
       scratch.clear();
-      next.importedModule->getImportedModules(
-          scratch, ModuleDecl::ImportFilterKind::Exported);
-      // FIXME: ImportFilterKind::ShadowedByCrossImportOverlay?
+      if (options::ModulePrintHidden) {
+        next.importedModule->getImportedModules(
+            scratch, ModuleDecl::getImportFilterAll());
+      } else {
+        next.importedModule->getImportedModules(
+            scratch, ModuleDecl::ImportFilterKind::Exported);
+        // FIXME: ImportFilterKind::ShadowedByCrossImportOverlay?
+      }
       for (auto &import : scratch) {
         llvm::outs() << "\t" << import.importedModule->getName();
         for (auto accessPathPiece : import.accessPath) {


### PR DESCRIPTION
Since the _SwiftifyImport peer macro expansion reuses the function signature of the original imported function, it needs to import the same modules as the module where the original clang node resides, to ensure visibility of any symbols that may appear in the signature.

rdar://151611573