### PR TITLE
[AutoDiff] Define derivative for concrete SIMD.init(repeating:)

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -141,6 +141,20 @@ void SILLinkerVisitor::maybeAddFunctionToWorklist(
       // are also set to IsSerialized.
       Worklist.push_back(F);
     }
+
+    if (F->markedAsAlwaysEmitIntoClient()) {
+      // For @_alwaysEmitIntoClient functions, we need to lookup its
+      // differentiability witness and, if present, ask SILLoader to obtain its
+      // definition. Otherwise, a linker error would occur due to undefined
+      // reference to these symbols.
+      for (SILDifferentiabilityWitness *witness :
+           F->getModule().lookUpDifferentiabilityWitnessesForFunction(
+               F->getName())) {
+        F->getModule().getSILLoader()->lookupDifferentiabilityWitness(
+            witness->getKey());
+      }
+    }
+
     return;
   }
 

--- a/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
@@ -456,12 +456,8 @@ where
   }
 }
 
-%for (Scalar, bits) in [('Float16',16), ('Float',32), ('Double',64)]:
+%for (Scalar, bits) in [('Float',32), ('Double',64)]:
 % for n in vectorscalarCounts:
-%  if bits == 16:
-#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
-@available(SwiftStdlib 5.3, *)
-%  end
 extension SIMD${n} where Scalar == ${Scalar} {
   @inlinable
   @_alwaysEmitIntoClient
@@ -481,8 +477,5 @@ extension SIMD${n} where Scalar == ${Scalar} {
     return (Self(repeating: value), { v in Self(repeating: v) })
   }
 }
-%  if bits == 16:
-#endif
-%  end
 % end
 %end

--- a/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/SIMDDifferentiation.swift.gyb
@@ -455,3 +455,34 @@ where
     return (Self(repeating: value), { v in Self(repeating: v) })
   }
 }
+
+%for (Scalar, bits) in [('Float16',16), ('Float',32), ('Double',64)]:
+% for n in vectorscalarCounts:
+%  if bits == 16:
+#if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
+@available(SwiftStdlib 5.3, *)
+%  end
+extension SIMD${n} where Scalar == ${Scalar} {
+  @inlinable
+  @_alwaysEmitIntoClient
+  @derivative(of: init(repeating:))
+  static func _vjpInit(repeating value: Scalar)
+    -> (value: Self, pullback: (TangentVector) -> Scalar.TangentVector)
+  {
+    return (Self(repeating: value), { v in v.sum() })
+  }
+
+  @inlinable
+  @_alwaysEmitIntoClient
+  @derivative(of: init(repeating:))
+  static func _jvpInit(repeating value: Scalar)
+    -> (value: Self, differential: (Scalar.TangentVector) -> TangentVector)
+  {
+    return (Self(repeating: value), { v in Self(repeating: v) })
+  }
+}
+%  if bits == 16:
+#endif
+%  end
+% end
+%end

--- a/stdlib/public/core/SIMDFloatConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDFloatConcreteOperations.swift.gyb
@@ -34,8 +34,6 @@ extension SIMD${n} where Scalar == ${Scalar} {
     _storage = ${Scalar}.SIMD${storageN}Storage(_builtin)
   }
   
-  /* Breaks differentiation testing, commented out while we figure out
-     what to do about that.
   @_alwaysEmitIntoClient @_transparent
   public init(repeating scalar: ${Scalar}) {
     let asVector = Builtin.insertelement_${Builtin}_FPIEEE${bits}_Int32(
@@ -52,7 +50,6 @@ extension SIMD${n} where Scalar == ${Scalar} {
     ))
 %end
   }
-  */
   
 %  if n >= 4:
   @_alwaysEmitIntoClient @_transparent

--- a/test/stdlib/SIMDFloatInitializers.swift.gyb
+++ b/test/stdlib/SIMDFloatInitializers.swift.gyb
@@ -14,10 +14,6 @@
 // RUN: %target-swift-frontend -primary-file %t/SIMDFloatInitializers.swift -S | %FileCheck %t/SIMDFloatInitializers.swift --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECKOnone-%target-cpu
 // RUN: %target-swift-frontend -primary-file %t/SIMDFloatInitializers.swift -S -O | %FileCheck %t/SIMDFloatInitializers.swift --check-prefix=CHECK --check-prefix=CHECK-%target-cpu --check-prefix=CHECKO-%target-cpu
 
-// Disable this test for now because aEIC/transparent functions still are not
-// correctly differentiable, and so these inits are suppressed in the stdlib.
-// REQUIRES: differentiable-aEIC-transparent
-
 import Swift
 
 %for bits in [16,32,64]:


### PR DESCRIPTION
The PR #81766 introduced some concrete SIMD operations, but `init(repeating:)` was temporarily disabled due to differentiation testing break. See:

https://github.com/stephentyrone/swift/commit/7a006190652a4f28ec88f2601dcd1100441c6b37

This PR contains two changes:

1. Define custom derivatives for concrete `init(repeating:)` so we do not fall into non-differentiability error diagnostic.

2. Add a fix to SIL linker so differentiability witness lookup is done when the original function has both `@_alwaysEmitIntoClient` and `@_transparent`. Similar changes were introduced previously in #78908, but they only handled `@_alwaysEmitIntoClient` without `@_transparent`.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
