### PR TITLE
🍒 [cxx-interop] Ensure field offset vector matches the structs/fields metadata

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3157,7 +3157,7 @@ emitInitializeFieldOffsetVector(SILType T, llvm::Value *metadata,
   }
 
   // Collect the stored properties of the type.
-  unsigned numFields = getNumFields(target);
+  unsigned numFields = countExportableFields(IGM, target);
 
   // Fill out an array with the field type metadata records.
   Address fields = createAlloca(
@@ -3170,6 +3170,9 @@ emitInitializeFieldOffsetVector(SILType T, llvm::Value *metadata,
   forEachField(IGM, target, [&](Field field) {
     assert(field.isConcrete() &&
            "initializing offset vector for type with missing member?");
+    if (!isExportableField(field))
+      return;
+
     SILType propTy = field.getType(IGM, T);
     llvm::Value *fieldLayout = emitTypeLayoutRef(*this, propTy, collector);
     Address fieldLayoutAddr =
@@ -3277,7 +3280,7 @@ static void emitInitializeFieldOffsetVectorWithLayoutString(
       emitAddressOfFieldOffsetVector(IGF, metadata, target).getAddress();
 
   // Collect the stored properties of the type.
-  unsigned numFields = getNumFields(target);
+  unsigned numFields = countExportableFields(IGM, target);
 
   // Ask the runtime to lay out the struct or class.
   auto numFieldsV = IGM.getSize(Size(numFields));
@@ -3300,6 +3303,9 @@ static void emitInitializeFieldOffsetVectorWithLayoutString(
   forEachField(IGM, target, [&](Field field) {
     assert(field.isConcrete() &&
            "initializing offset vector for type with missing member?");
+    if (!isExportableField(field))
+      return;
+
     SILType propTy = field.getType(IGM, T);
     llvm::Value *fieldMetatype;
     llvm::Value *fieldTag;

--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_IRGEN_STRUCTMETADATALAYOUT_H
 #define SWIFT_IRGEN_STRUCTMETADATALAYOUT_H
 
+#include "Field.h"
 #include "NominalMetadataVisitor.h"
 #include "swift/AST/IRGenOptions.h"
 
@@ -64,8 +65,7 @@ public:
     // Struct field offsets.
     asImpl().noteStartOfFieldOffsets();
     for (VarDecl *prop : Target->getStoredProperties()) {
-      if (!(prop->getClangDecl() &&
-            prop->getFormalAccess() == AccessLevel::Private))
+      if (isExportableField(prop))
         asImpl().addFieldOffset(prop);
     }
 


### PR DESCRIPTION
  - **Explanation**: The field offset vector should be consistent with the type metadata emitted for structs and fields. If we don't emit metadata for private C++ fields (https://github.com/swiftlang/swift/pull/81740), then the field offset vector shouldn't include these fields.
  - **Scope**: Changes the fields added to the field offset vector
  - **Related**: This is a follow-up to https://github.com/swiftlang/swift/pull/81740
  - **Original PRs**: https://github.com/swiftlang/swift/pull/81838 and https://github.com/swiftlang/swift/pull/81742
  - **Risk**: Low, we filter the fields in the field offset vector the same way we filter them in the metadata, to ensure consistency.
  - **Reviewers**: @egorzhdan, @j-hui
