### PR TITLE
[Windows] Fix building Swift on a Windows ARM64 machine

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -260,6 +260,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND NOT SWIFT_WASI_SYSROOT_PATH)
       # generate valid COFF object files.
       "i686    i686-unknown-windows-msvc   i686-unknown-windows-msvc"
       "x86_64  x86_64-unknown-windows-msvc x86_64-unknown-windows-msvc"
+      "aarch64  aarch64-unknown-windows-msvc aarch64-unknown-windows-msvc"
     )
   endif()
 endif()

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1279,10 +1279,9 @@ function Build-CMakeProject {
     # Add additional defines (unless already present)
     $Defines = $Defines.Clone()
 
-    if (($Platform.OS -ne [OS]::Windows) -or ($Platform.Architecture.CMakeName -ne $BuildPlatform.Architecture.CMakeName)) {
-      Add-KeyValueIfNew $Defines CMAKE_SYSTEM_NAME $Platform.OS.ToString()
-      Add-KeyValueIfNew $Defines CMAKE_SYSTEM_PROCESSOR $Platform.Architecture.CMakeName
-    }
+    # CMAKE_SYSTEM_PROCESSOR detection is broken on Windows: https://gitlab.kitware.com/cmake/cmake/-/issues/15170
+    Add-KeyValueIfNew $Defines CMAKE_SYSTEM_NAME $Platform.OS.ToString()
+    Add-KeyValueIfNew $Defines CMAKE_SYSTEM_PROCESSOR $Platform.Architecture.CMakeName
 
     if ($AddAndroidCMakeEnv) {
       # Set generic android options if we need to build an Android runtime component


### PR DESCRIPTION
Partially resolves https://github.com/swiftlang/swift/issues/81836.

This patch forces the value of `CMAKE_SYSTEM_PROCESSOR` to the platform we are building for. This variable is broken on Windows and is not detected correctly on an ARM64 machine **if you are not installing MSVC through the "C++ Development workload"**, or if you don't use Visual Studio's CMake.


We also have to override `CMAKE_SYSTEM_NAME` [because CMake will override `CMAKE_SYSTEM_PROCESSOR` otherwise.](https://github.com/Kitware/CMake/blob/26460454b762f19e6bf185363cbdce875c55398e/Modules/CMakeDetermineSystem.cmake#L173).

We also add `aarch64-unknown-windows-msvc` to `EMBEDDED_STDLIB_TARGET_TRIPLES` otherwise it does not build either.