### PR TITLE
[6.2, stdlib] fix an extraneous symbol exported by MutableSpan

### DIFF
--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -55,8 +55,7 @@ extension MutableSpan: @unchecked Sendable where Element: Sendable {}
 extension MutableSpan where Element: ~Copyable {
 
   @unsafe
-  @_unsafeNonescapableResult
-  @usableFromInline
+  @_alwaysEmitIntoClient
   @lifetime(borrow elements)
   internal init(
     _unchecked elements: UnsafeMutableBufferPointer<Element>

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -946,7 +946,6 @@ Added: _$ss11MutableSpanVMa
 Added: _$ss11MutableSpanVMn
 Added: _$ss11MutableSpanVsRi_zrlE6_countSivg
 Added: _$ss11MutableSpanVsRi_zrlE8_pointerSvSgvg
-Added: _$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC
 Added: _$ss14MutableRawSpanV6_countSivg
 Added: _$ss14MutableRawSpanV8_pointerSvSgvg
 Added: _$ss14MutableRawSpanVMa
@@ -1090,7 +1089,6 @@ Added: __swift_stdlib_CreateIndirectTaggedPointerString
 // Span backward deployment
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVMa$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVMn$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVsRi_zrlE6_countSivg$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVsRi_zrlE8_pointerSvSgvg$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss14MutableRawSpanV6_countSivg$

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -947,7 +947,6 @@ Added: _$ss11MutableSpanVMa
 Added: _$ss11MutableSpanVMn
 Added: _$ss11MutableSpanVsRi_zrlE6_countSivg
 Added: _$ss11MutableSpanVsRi_zrlE8_pointerSvSgvg
-Added: _$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC
 Added: _$ss14MutableRawSpanV6_countSivg
 Added: _$ss14MutableRawSpanV8_pointerSvSgvg
 Added: _$ss14MutableRawSpanVMa
@@ -1087,11 +1086,9 @@ Added: _$ss18EnumeratedSequenceVyxGSKsSkRzrlMc
 // Indirect tagged string creation
 Added: __swift_stdlib_CreateIndirectTaggedPointerString
 
-
 // Span backward deployment
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVMa$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVMn$
-Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVsRi_zrlE10_uncheckedAByxGSryxG_tcfC$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVsRi_zrlE6_countSivg$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss11MutableSpanVsRi_zrlE8_pointerSvSgvg$
 Added: $ld$previous$@rpath/libswiftCompatibilitySpan.dylib$$1$10.14$15.0$_$ss14MutableRawSpanV6_countSivg$


### PR DESCRIPTION
Explanation: In https://github.com/swiftlang/swift/pull/79650, one of the initializers was not marked `@_alwaysEmitIntoClient`, by mistake. This fixes the mistake, and adjusts the list of ABI symbols accordingly.

Scope: Binaries which construct `MutableSpan` instances
Original PR: https://github.com/swiftlang/swift/pull/81816
Risk: Low; type has very little adoption so far.
Testing: CI
Reviewed by: @azoy
