### PR TITLE
🍒[cxx-interop] Do not crash when emitting layout of `std::string`

### DIFF
--- a/test/Interop/Cxx/class/Inputs/member-variables.h
+++ b/test/Interop/Cxx/class/Inputs/member-variables.h
@@ -83,4 +83,21 @@ inline int takesZeroSizedInCpp(HasZeroSizedField x) {
   return x.a;
 }
 
+/// Not imported into Swift.
+struct EmptyNotImported {
+  char : 0;
+
+  EmptyNotImported() = default;
+  EmptyNotImported(const EmptyNotImported &) = delete;
+  EmptyNotImported(EmptyNotImported &&) = delete;
+};
+
+struct LastFieldNoUniqueAddress {
+  char c;
+  [[no_unique_address]] EmptyNotImported p0;
+
+  LastFieldNoUniqueAddress(const LastFieldNoUniqueAddress &other) {}
+  LastFieldNoUniqueAddress(LastFieldNoUniqueAddress &&other) {}
+};
+
 #endif

--- a/test/Interop/Cxx/class/zero-sized-field.swift
+++ b/test/Interop/Cxx/class/zero-sized-field.swift
@@ -83,4 +83,14 @@ FieldsTestSuite.test("Non-standard-layout field padding in templated class reuse
   expectEqual(s2.get_c(), 6)
 }
 
+FieldsTestSuite.test("Last field is no unique address") {
+  var s = LastFieldNoUniqueAddress()
+
+  s.c = 5
+  expectEqual(s.c, 5)
+
+  s.c = 6
+  expectEqual(s.c, 6)
+}
+
 runAllTests()


### PR DESCRIPTION
  - **Explanation**: If a `[[no_unique_address]]` field has zero size according to Clang, and field has a type that isn't representable in Swift, Swift would previously try to add an opaque field of size 1 for it.
  This is wrong and was causing crashes for `std::string` while emitting a padding field:
```
_LIBCPP_NO_UNIQUE_ADDRESS ::std::__compressed_pair_padding<T1> _LIBCPP_CONCAT3(__padding1_, __LINE__, _);
```
  - **Scope**: This changes the type lowering logic for Clang types with `[[no_unique_address]]` fields.
  - **Issues**: rdar://151941799
  - **Original PRs**: https://github.com/swiftlang/swift/pull/81844
  - **Risk**: Low, this changes the code path that would previously cause a crash.
  - **Testing**: Added a compiler test.
  - **Reviewers**: @hnrklssn @j-hui 
