### PR TITLE
[6.2] Add the distribution tag to `-print-target-info`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,8 @@ set(SWIFT_COMPILER_VERSION "" CACHE STRING
     "The internal version of the Swift compiler")
 set(CLANG_COMPILER_VERSION "" CACHE STRING
     "The internal version of the Clang compiler")
+set(SWIFT_TOOLCHAIN_VERSION "" CACHE STRING
+    "The Swift compiler tag")
 
 option(SWIFT_DISABLE_DEAD_STRIPPING
       "Turn off Darwin-specific dead stripping for Swift host tools." FALSE)

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -171,11 +171,6 @@ std::string getSwiftFullVersion(Version effectiveLanguageVersion =
 /// this Swift was built.
 StringRef getSwiftRevision();
 
-/// Is the running compiler built with a version tag for distribution?
-/// When true, \c version::getCurrentCompilerVersion returns a valid version
-/// and \c getCurrentCompilerTag returns the version tuple in string format.
-bool isCurrentCompilerTagged();
-
 /// Retrieves the distribution tag of the running compiler, if any.
 StringRef getCurrentCompilerTag();
 

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -134,10 +134,8 @@ if(NOT "${SWIFT_VENDOR}" STREQUAL "")
       " -DSWIFT_VENDOR=\"\\\"${SWIFT_VENDOR}\\\"\"")
 endif()
 
-set(SWIFT_COMPILER_VERSION "" CACHE STRING
-    "The string that identifies the SCM commit(s) for this build")
-
 message(STATUS "Swift compiler version: ${SWIFT_COMPILER_VERSION}")
+message(STATUS "Swift toolchain version: ${SWIFT_TOOLCHAIN_VERSION}")
 message(STATUS "Embedded clang compiler version: ${CLANG_COMPILER_VERSION}")
 
 if(SWIFT_COMPILER_VERSION)
@@ -150,3 +148,7 @@ if(CLANG_COMPILER_VERSION)
     " -DCLANG_COMPILER_VERSION=\"\\\"${CLANG_COMPILER_VERSION}\\\"\"")
 endif()
 
+if(SWIFT_TOOLCHAIN_VERSION)
+  set_property(SOURCE Version.cpp APPEND_STRING PROPERTY COMPILE_FLAGS
+    " -DSWIFT_TOOLCHAIN_VERSION=\"\\\"${SWIFT_TOOLCHAIN_VERSION}\\\"\"")
+endif()

--- a/lib/Basic/TargetInfo.cpp
+++ b/lib/Basic/TargetInfo.cpp
@@ -65,6 +65,14 @@ void printTargetInfo(const CompilerInvocation &invocation,
   writeEscaped(version::getSwiftFullVersion(version::Version::getCurrentLanguageVersion()), out);
   out << "\",\n";
 
+  // Distribution tag, if any.
+  StringRef tag = version::getCurrentCompilerTag();
+  if (!tag.empty()) {
+    out << "  \"swiftCompilerTag\": \"";
+    writeEscaped(tag, out);
+    out << "\",\n";
+  }
+
   // Target triple and target variant triple.
   auto runtimeVersion =
     invocation.getIRGenOptions().AutolinkRuntimeCompatibilityLibraryVersion;

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -304,17 +304,9 @@ StringRef getSwiftRevision() {
 #endif
 }
 
-bool isCurrentCompilerTagged() {
-#ifdef SWIFT_COMPILER_VERSION
-  return true;
-#else
-  return false;
-#endif
-}
-
 StringRef getCurrentCompilerTag() {
-#ifdef SWIFT_COMPILER_VERSION
-  return SWIFT_COMPILER_VERSION;
+#ifdef SWIFT_TOOLCHAIN_VERSION
+  return SWIFT_TOOLCHAIN_VERSION;
 #else
   return StringRef();
 #endif

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -932,7 +932,7 @@ class ModuleInterfaceLoaderImpl {
           return std::make_error_code(std::errc::not_supported);
         } else if (isInResourceDir(adjacentMod) &&
                    loadMode == ModuleLoadingMode::PreferSerialized &&
-                   !version::isCurrentCompilerTagged() &&
+                   version::getCurrentCompilerSerializationTag().empty() &&
                    rebuildInfo.getOrInsertCandidateModule(adjacentMod)
                            .serializationStatus !=
                        serialization::Status::SDKMismatch &&

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -395,7 +395,7 @@ static ValidationInfo validateControlBlock(
       // env var is set (for testing).
       static const char* forceDebugPreSDKRestriction =
         ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_PER_SDK");
-      if (!version::isCurrentCompilerTagged() &&
+      if (version::getCurrentCompilerSerializationTag().empty() &&
           !forceDebugPreSDKRestriction) {
         break;
       }
@@ -436,10 +436,12 @@ static ValidationInfo validateControlBlock(
         ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
 
       StringRef moduleRevision = blobData;
+      StringRef serializationTag =
+          version::getCurrentCompilerSerializationTag();
       if (forcedDebugRevision ||
-          (requiresRevisionMatch && version::isCurrentCompilerTagged())) {
-        StringRef compilerRevision = forcedDebugRevision ?
-          forcedDebugRevision : version::getCurrentCompilerSerializationTag();
+          (requiresRevisionMatch && !serializationTag.empty())) {
+        StringRef compilerRevision =
+            forcedDebugRevision ? forcedDebugRevision : serializationTag;
         if (moduleRevision != compilerRevision) {
           // The module versions are mismatching, record it and diagnose later.
           result.problematicRevision = moduleRevision;


### PR DESCRIPTION
- **Explanation**: Adds a new `swiftCompilerTag` to `-print-target-info` that contains *just* the tag.
- **Scope**: `swift -print-target-info`
- **Original PRs**: https://github.com/swiftlang/swift/pull/81697
- **Risk**: The main risk here is the removal of `isCurrentCompilerTagged` and corresponding serialization changes. Happy to remove those for 6.2 if we feel it's necessary. The change is otherwise just adding a new field to some command line output, so zero risk there.
- **Testing**: Prints out the tag when it's provided
- **Reviewers**: @shahmishal 