### PR TITLE
[RemoteMirror] Strip protocol descriptor pointers when reading the conformance cache.

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1389,7 +1389,7 @@ public:
 
     for (StoredSize i = 0; i < Count; i++) {
       auto &Element = ElementsData[i];
-      Call(Element.Type, Element.Proto);
+      Call(Element.Type, stripSignedPointer(Element.Proto));
     }
   }
 

--- a/include/swift/RemoteInspection/RuntimeInternals.h
+++ b/include/swift/RemoteInspection/RuntimeInternals.h
@@ -58,7 +58,7 @@ template <typename Runtime> struct ConcurrentHashMap {
 
 template <typename Runtime> struct ConformanceCacheEntry {
   typename Runtime::StoredPointer Type;
-  typename Runtime::StoredPointer Proto;
+  typename Runtime::StoredSignedPointer Proto;
   typename Runtime::StoredPointer Witness;
 };
 


### PR DESCRIPTION
Protocol descriptor pointers may be signed. Mark this as a StoredSignedPointer and strip it before handing it back to clients.