### PR TITLE
[6.2 🍒][Dependency Scanning] Bridge diagnostics emitted during bridging header scanning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2334,6 +2334,7 @@ NOTE(dependency_as_imported_by_main_module,none,
 NOTE(dependency_as_imported_by, none,
      "a dependency of %select{Swift|Clang}2 module '%0': '%1'", (StringRef, StringRef, bool))
 ERROR(clang_dependency_scan_error, none, "Clang dependency scanner failure: %0", (StringRef))
+ERROR(clang_header_dependency_scan_error, none, "Bridging header dependency scan failure: %0", (StringRef))
 
 // Enum annotations
 ERROR(indirect_case_without_payload,none,

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -420,7 +420,7 @@ bool ModuleDependencyScanningWorker::scanHeaderDependenciesOfSwiftModule(
     };
 
     auto dependencies = clangScanningTool.getTranslationUnitDependencies(
-        /*ACTODO:*/ inputSpecificClangScannerCommand(clangScanningBaseCommandLineArgs, headerPath),
+        inputSpecificClangScannerCommand(clangScanningBaseCommandLineArgs, headerPath),
         clangScanningWorkingDirectoryPath,
         cache.getAlreadySeenClangModules(), lookupModuleOutput, sourceBuffer);
     if (!dependencies)
@@ -450,11 +450,9 @@ bool ModuleDependencyScanningWorker::scanHeaderDependenciesOfSwiftModule(
   // - Binary module dependnecies may have arbitrary header inputs.
   auto clangModuleDependencies = scanHeaderDependencies();
   if (!clangModuleDependencies) {
-    // FIXME: Route this to a normal diagnostic.
-    llvm::logAllUnhandledErrors(clangModuleDependencies.takeError(),
-                                llvm::errs());
-    ctx.Diags.diagnose(SourceLoc(), diag::clang_dependency_scan_error,
-                       "failed to scan header dependencies");
+    auto errorStr = toString(clangModuleDependencies.takeError());
+    workerASTContext->Diags.diagnose(
+            SourceLoc(), diag::clang_header_dependency_scan_error, errorStr);
     return true;
   }
 

--- a/test/ScanDependencies/bridging_header_error.swift
+++ b/test/ScanDependencies/bridging_header_error.swift
@@ -1,0 +1,7 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %s -o %t/deps.json -import-objc-header %t/does-this-header-even-exist.h &> %t/diagnostic_output.txt
+// RUN: cat %t/diagnostic_output.txt | %FileCheck %s
+// CHECK: error: Bridging header dependency scan failure: error: no such file or directory: '{{.*}}does-this-header-even-exist.h'

--- a/test/ScanDependencies/clang_scan_error.swift
+++ b/test/ScanDependencies/clang_scan_error.swift
@@ -6,7 +6,7 @@
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -o %t/deps.json -I %t -swift-version 5 2>&1 | %FileCheck %s
 
-// CHECK: error: Clang dependency scanner failure: failed to scan header dependencies
+// CHECK: error: Bridging header dependency scan failure: {{.*}}bridging.h:1:10: fatal error: 'do-not-exist.h' file not found
 
 //--- bridging.h
 #include "do-not-exist.h"


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/81850
---------------------------------------

- **Explanation**: The Swift dependency scanner collects diagnostics as it performs a scan, including those emitted by the integrated Clang dependency scanner. Such diagnostics are then presented to the client, most-likely the `swift-driver` or another build system. This change adds such diagnostic handling to those emitted by the clang dependency scanner when scanning the bridging header file. 

- **Scope**: Specifically dependency scanning actions (as part of a build with explicitly-built modules) which involve scanning a bridging header file and emitting diagnostics during said header scan.

- **Risk**: Low, the code-path this changes affects only how Clang scanner-emitted diagnostics are handled by collecting them into the scanner's diagnostic handler, like any other diagnostics, instead of just dumping them to stderr. 

- **Problem**: rdar://151993075

- **Reviewed By**: @cachemeifyoucan

- **Original PR**: https://github.com/swiftlang/swift/pull/81850
