### PR TITLE
[6.2] Change InlineArray sugar separator `x` -> `of`

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -594,7 +594,7 @@ struct PrintOptions {
   bool AlwaysDesugarArraySliceTypes = false;
 
   /// Whether to always desugar inline array types from
-  /// `[<count> x <element>]` to `InlineArray<count, element>`
+  /// `[<count> of <element>]` to `InlineArray<count, element>`
   bool AlwaysDesugarInlineArrayTypes = false;
 
   /// Whether to always desugar dictionary types

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -641,7 +641,7 @@ private:
   friend class TypeRepr;
 };
 
-/// An InlineArray type e.g `[2 x Foo]`, sugar for `InlineArray<2, Foo>`.
+/// An InlineArray type e.g `[2 of Foo]`, sugar for `InlineArray<2, Foo>`.
 class InlineArrayTypeRepr : public TypeRepr {
   TypeRepr *Count;
   TypeRepr *Element;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6289,7 +6289,7 @@ public:
   }
 };
 
-/// An InlineArray type e.g `[2 x Foo]`, sugar for `InlineArray<2, Foo>`.
+/// An InlineArray type e.g `[2 of Foo]`, sugar for `InlineArray<2, Foo>`.
 class InlineArrayType : public SyntaxSugarType {
   Type Count;
   Type Elt;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -507,7 +507,7 @@ EXPERIMENTAL_FEATURE(ExtensibleEnums, true)
 /// Syntax sugar features for concurrency.
 EXPERIMENTAL_FEATURE(ConcurrencySyntaxSugar, true)
 
-/// Enable syntax sugar type '[3 x Int]' for Inline Array
+/// Enable syntax sugar type '[3 of Int]' for Inline Array
 EXPERIMENTAL_FEATURE(InlineArrayTypeSugar, false)
 
 /// Allow declaration of compile-time values

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7104,7 +7104,7 @@ public:
     } else {
       Printer << "[";
       visit(T->getCountType());
-      Printer << " x ";
+      Printer << " of ";
       visit(T->getElementType());
       Printer << "]";
     }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -484,7 +484,7 @@ void InlineArrayTypeRepr::printImpl(ASTPrinter &Printer,
                                     const PrintOptions &Opts) const {
   Printer << "[";
   printTypeRepr(getCount(), Printer, Opts);
-  Printer << " x ";
+  Printer << " of ";
   printTypeRepr(getElement(), Printer, Opts);
   Printer << "]";
 }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -3316,7 +3316,7 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
   case Node::Kind::SugaredInlineArray: {
     Printer << "[";
     print(Node->getChild(0), depth + 1);
-    Printer << " x ";
+    Printer << " of ";
     print(Node->getChild(1), depth + 1);
     Printer << "]";
     return nullptr;

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1322,13 +1322,13 @@ ParserResult<TypeRepr> Parser::parseTypeInlineArray(SourceLoc lSquare) {
 
   ParserStatus status;
 
-  // 'isStartOfInlineArrayTypeBody' means we should at least have a type and 'x'
-  // to start with.
+  // 'isStartOfInlineArrayTypeBody' means we should at least have a type and
+  // 'of' to start with.
   auto count = parseTypeOrValue();
   auto *countTy = count.get();
   status |= count;
 
-  // 'x'
+  // 'of'
   consumeToken(tok::identifier);
 
   // Allow parsing a value for better recovery, Sema will diagnose any
@@ -1827,16 +1827,16 @@ bool Parser::canParseStartOfInlineArrayType() {
   if (!Context.LangOpts.hasFeature(Feature::InlineArrayTypeSugar))
     return false;
 
-  // We must have at least '[<type> x', which cannot be any other kind of
+  // We must have at least '[<type> of', which cannot be any other kind of
   // expression or type. We specifically look for any type, not just integers
-  // for better recovery in e.g cases where the user writes '[Int x 2]'. We
-  // only do type-scalar since variadics would be ambiguous e.g 'Int...x'.
+  // for better recovery in e.g cases where the user writes '[Int of 2]'. We
+  // only do type-scalar since variadics would be ambiguous e.g 'Int...of'.
   if (!canParseTypeScalar())
     return false;
 
   // For now we don't allow multi-line since that would require
   // disambiguation.
-  if (Tok.isAtStartOfLine() || !Tok.isContextualKeyword("x"))
+  if (Tok.isAtStartOfLine() || !Tok.isContextualKeyword("of"))
     return false;
 
   consumeToken();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5393,7 +5393,7 @@ TypeResolver::resolveInlineArrayType(InlineArrayTypeRepr *repr,
   auto argOptions = options.withoutContext().withContext(
       TypeResolverContext::ValueGenericArgument);
 
-  // It's possible the user accidentally wrote '[Int x 4]', correct that here.
+  // It's possible the user accidentally wrote '[Int of 4]', correct that here.
   auto *countRepr = repr->getCount();
   auto *eltRepr = repr->getElement();
   if (!isa<IntegerTypeRepr>(countRepr) && isa<IntegerTypeRepr>(eltRepr)) {

--- a/test/ASTGen/types.swift
+++ b/test/ASTGen/types.swift
@@ -84,10 +84,10 @@ let optionalIntArray: Array<_> = [42]
 
 @available(SwiftStdlib 9999, *)
 func testInlineArray() {
-  let _: [3 x Int] = [1, 2, 3]
-  let _: [_ x _] = [1, 2]
-  let _ = [3 x Int](repeating: 0)
-  let _ = [3 x _](repeating: 0)
+  let _: [3 of Int] = [1, 2, 3]
+  let _: [_ of _] = [1, 2]
+  let _ = [3 of Int](repeating: 0)
+  let _ = [3 of _](repeating: 0)
 }
 
 func testNamedOpaqueReturnTy() -> <T> T { return () }

--- a/test/DebugInfo/sugar_inline_array.swift
+++ b/test/DebugInfo/sugar_inline_array.swift
@@ -2,14 +2,14 @@
 
 // REQUIRES: swift_feature_InlineArrayTypeSugar
 
-let a: ([3 x Int], InlineArray<3, Int>) = ([1, 2, 3], [1, 2, 3])
-let b: ([3 x [1 x String]], InlineArray<3, InlineArray<1, String>>) = ([[""], [""], [""]], [[""], [""], [""]])
+let a: ([3 of Int], InlineArray<3, Int>) = ([1, 2, 3], [1, 2, 3])
+let b: ([3 of [1 of String]], InlineArray<3, InlineArray<1, String>>) = ([[""], [""], [""]], [[""], [""], [""]])
 
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$s$2_SiXSA_s11InlineArrayVy$2_SiGtD", {{.*}})
 // CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$s$2_$0_SSXSAXSA_s11InlineArrayVy$2_ABy$0_SSGGtD", {{.*}})
 
 // RUN: swift-demangle 's$2_SiXSA_s11InlineArrayVy$2_SiGtD' | %FileCheck %s --check-prefix SIMPLE
-// SIMPLE: ([3 x Swift.Int], Swift.InlineArray<3, Swift.Int>)
+// SIMPLE: ([3 of Swift.Int], Swift.InlineArray<3, Swift.Int>)
 
 // RUN: swift-demangle 's$2_$0_SSXSAXSA_s11InlineArrayVy$2_ABy$0_SSGGtD' | %FileCheck %s --check-prefix NESTED
-// NESTED: ([3 x [1 x Swift.String]], Swift.InlineArray<3, Swift.InlineArray<1, Swift.String>>)
+// NESTED: ([3 of [1 of Swift.String]], Swift.InlineArray<3, Swift.InlineArray<1, Swift.String>>)

--- a/test/IDE/complete_inline_array.swift
+++ b/test/IDE/complete_inline_array.swift
@@ -4,6 +4,6 @@
 
 struct FooBar {}
 
-[3 x #^COMPLETE_TOPLEVEL?check=COMPLETE^#
-let _: [3 x #^COMPLETE_TYPE?check=COMPLETE^#
+[3 of #^COMPLETE_TOPLEVEL?check=COMPLETE^#
+let _: [3 of #^COMPLETE_TYPE?check=COMPLETE^#
 // COMPLETE: Decl[Struct]/CurrModule: FooBar[#FooBar#]; name=FooBar

--- a/test/Sema/inline_array_availability.swift
+++ b/test/Sema/inline_array_availability.swift
@@ -7,7 +7,7 @@ func foo(x: InlineArray<3, Int>) {}
 // expected-error@-1 {{'InlineArray' is only available in}}
 // expected-note@-2 {{add '@available' attribute to enclosing global function}}
 
-func bar(x: [3 x Int]) {}
+func bar(x: [3 of Int]) {}
 // expected-error@-1 {{'InlineArray' is only available in}}
 // expected-note@-2 {{add '@available' attribute to enclosing global function}}
 
@@ -15,4 +15,4 @@ func bar(x: [3 x Int]) {}
 func baz(x: InlineArray<3, Int>) {}
 
 @available(SwiftStdlib 9999, *)
-func qux(x: [3 x Int]) {}
+func qux(x: [3 of Int]) {}

--- a/test/Sema/inlinearray.swift
+++ b/test/Sema/inlinearray.swift
@@ -13,26 +13,26 @@ let f: InlineArray<_, Int> = ["hello"] // expected-error {{cannot convert value 
 
 let g: InlineArray<1, 1> // expected-error {{cannot use value type '1' for generic argument 'Element'}}
 
-let _: [3 x Int] = [1, 2, 3]  // Ok, InlineArray<3, Int>
-let _: [_ x Int] = [1, 2, 3]  // Ok, InlineArray<3, Int>
-let _: [3 x _] = [1, 2, 3]    // Ok, InlineArray<3, Int>
-let _: [_ x _] = ["", "", ""] // Ok, InlineArray<3, String>
+let _: [3 of Int] = [1, 2, 3]  // Ok, InlineArray<3, Int>
+let _: [_ of Int] = [1, 2, 3]  // Ok, InlineArray<3, Int>
+let _: [3 of _] = [1, 2, 3]    // Ok, InlineArray<3, Int>
+let _: [_ of _] = ["", "", ""] // Ok, InlineArray<3, String>
 
-let _: [3 x [3 x Int]] = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-let _: [3 x [3 x Int]] = [[1, 2], [3, 4, 5, 6]]
+let _: [3 of [3 of Int]] = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+let _: [3 of [3 of Int]] = [[1, 2], [3, 4, 5, 6]]
 // expected-error@-1 {{'3' elements in inline array literal, but got '2'}}
-// expected-error@-2 2{{cannot convert value of type '[Int]' to expected element type '[3 x Int]'}}
+// expected-error@-2 2{{cannot convert value of type '[Int]' to expected element type '[3 of Int]'}}
 
-let _ = [3 x [3 x Int]](repeating: [1, 2]) // expected-error {{expected '3' elements in inline array literal, but got '2'}}
-let _ = [3 x [_ x Int]](repeating: [1, 2])
+let _ = [3 of [3 of Int]](repeating: [1, 2]) // expected-error {{expected '3' elements in inline array literal, but got '2'}}
+let _ = [3 of [_ of Int]](repeating: [1, 2])
 
-let _: [Int x 10] = [1, 2] // expected-error {{element count must precede inline array element type}} {{15-17=Int}} {{9-12=10}}
+let _: [Int of 10] = [1, 2] // expected-error {{element count must precede inline array element type}} {{16-18=Int}} {{9-12=10}}
 // expected-error@-1 {{expected '10' elements in inline array literal, but got '2'}}
 
-let _: [4 x _] = [1, 2, 3]   // expected-error {{expected '4' elements in inline array literal, but got '3'}}
-let _: [3 x Int] = [1, 2, 3, 4] // expected-error {{expected '3' elements in inline array literal, but got '4'}}
-let _: [3 x String] = [1, 2, 3] // expected-error 3{{cannot convert value of type 'Int' to expected element type 'String'}}
-let _: [3 x String] = [1] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
+let _: [4 of _] = [1, 2, 3]   // expected-error {{expected '4' elements in inline array literal, but got '3'}}
+let _: [3 of Int] = [1, 2, 3, 4] // expected-error {{expected '3' elements in inline array literal, but got '4'}}
+let _: [3 of String] = [1, 2, 3] // expected-error 3{{cannot convert value of type 'Int' to expected element type 'String'}}
+let _: [3 of String] = [1] // expected-error {{cannot convert value of type 'Int' to expected element type 'String'}}
 // expected-error@-1 {{expected '3' elements in inline array literal, but got '1'}}
 
 func takeVectorOf2<T>(_: InlineArray<2, T>) {}
@@ -63,10 +63,10 @@ takeVectorOf2Int(["hello", "world"]) // expected-error {{cannot convert value of
 
 takeVectorOf2Int(["hello", "world", "!"]) // expected-error {{cannot convert value of type '[String]' to expected argument type 'InlineArray<2, Int>'}}
 
-func takeSugarVectorOf2<T>(_: [2 x T], ty: T.Type = T.self) {}
+func takeSugarVectorOf2<T>(_: [2 of T], ty: T.Type = T.self) {}
 takeSugarVectorOf2([1, 2])
 takeSugarVectorOf2(["hello"]) // expected-error {{expected '2' elements in inline array literal, but got '1'}}
-takeSugarVectorOf2(["hello"], ty: Int.self) // expected-error {{cannot convert value of type '[String]' to expected argument type '[2 x Int]'}}
+takeSugarVectorOf2(["hello"], ty: Int.self) // expected-error {{cannot convert value of type '[String]' to expected argument type '[2 of Int]'}}
 takeSugarVectorOf2(["hello", "hi"], ty: Int.self) // expected-error 2{{cannot convert value of type 'String' to expected element type 'Int'}}
 
 
@@ -112,15 +112,15 @@ extension InlineArray where Element: ~Copyable {
   }
 }
 
-extension [3 x Int] { // expected-note 2{{where 'count' = '2'}} expected-note {{where 'Element' = 'String'}}
+extension [3 of Int] { // expected-note 2{{where 'count' = '2'}} expected-note {{where 'Element' = 'String'}}
   func methodOnSugar() {}
 }
 
 func testExtension(
-  _ a: [3 x Int],
+  _ a: [3 of Int],
   _ b: InlineArray<3, Int>,
-  _ c: [2 x Int],
-  _ d: [2 x String]
+  _ c: [2 of Int],
+  _ d: [2 of String]
 ) {
   a.enumerated { _, _ in }
   a.methodOnSugar()
@@ -133,23 +133,23 @@ func testExtension(
 }
 
 func redecl(_ x: InlineArray<2, Int>) {} // expected-note {{'redecl' previously declared here}}
-func redecl(_ x: [2 x Int]) {} // expected-error {{invalid redeclaration of 'redecl'}}
+func redecl(_ x: [2 of Int]) {} // expected-error {{invalid redeclaration of 'redecl'}}
 
 func noRedecl(_ x: InlineArray<2, Int>) {}
-func noRedecl(_ x: [3 x Int]) {}
-func noRedecl(_ x: [2 x String]) {}
-func noRedecl(_ x: [3 x String]) {}
+func noRedecl(_ x: [3 of Int]) {}
+func noRedecl(_ x: [2 of String]) {}
+func noRedecl(_ x: [3 of String]) {}
 
-func testMismatches(_ x: [3 x Int], _ y: InlineArray<3, Int>) {
+func testMismatches(_ x: [3 of Int], _ y: InlineArray<3, Int>) {
   let _: InlineArray<3, Int> = x
-  let _: InlineArray<4, Int> = x // expected-error {{cannot assign value of type '[3 x Int]' to type 'InlineArray<4, Int>'}}
+  let _: InlineArray<4, Int> = x // expected-error {{cannot assign value of type '[3 of Int]' to type 'InlineArray<4, Int>'}}
   // expected-note@-1 {{arguments to generic parameter 'count' ('3' and '4') are expected to be equal}}
-  let _: InlineArray<3, String> = x  // expected-error {{cannot assign value of type '[3 x Int]' to type 'InlineArray<3, String>'}}
+  let _: InlineArray<3, String> = x  // expected-error {{cannot assign value of type '[3 of Int]' to type 'InlineArray<3, String>'}}
   // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
 
-  let _: [3 x Int] = y
-  let _: [4 x Int] = y // expected-error {{cannot assign value of type 'InlineArray<3, Int>' to type '[4 x Int]'}}
+  let _: [3 of Int] = y
+  let _: [4 of Int] = y // expected-error {{cannot assign value of type 'InlineArray<3, Int>' to type '[4 of Int]'}}
   // expected-note@-1 {{arguments to generic parameter 'count' ('3' and '4') are expected to be equal}}
-  let _: [3 x String] = y  // expected-error {{cannot assign value of type 'InlineArray<3, Int>' to type '[3 x String]'}}
+  let _: [3 of String] = y  // expected-error {{cannot assign value of type 'InlineArray<3, Int>' to type '[3 of String]'}}
   // expected-note@-1 {{arguments to generic parameter 'Element' ('Int' and 'String') are expected to be equal}}
 }

--- a/test/Serialization/value_generics.swift
+++ b/test/Serialization/value_generics.swift
@@ -22,5 +22,5 @@ extension Vector where Count == 2 {
 // CHECK: func something<let N : Int>(_: borrowing Vector<Int, N>)
 func something<let N: Int>(_: borrowing Vector<Int, N>) {}
 
-// CHECK: func hello(_: [4 x Int])
-func hello(_: [4 x Int]) {}
+// CHECK: func hello(_: [4 of Int])
+func hello(_: [4 of Int]) {}

--- a/test/type/inline_array.swift
+++ b/test/type/inline_array.swift
@@ -2,48 +2,48 @@
 
 // REQUIRES: swift_feature_InlineArrayTypeSugar
 
-let _: [3 x Int]
-let _ = [3 x Int](repeating: 0)
-let _ = [3 x [3 x Int]](repeating: [1, 2, 3])
+let _: [3 of Int]
+let _ = [3 of Int](repeating: 0)
+let _ = [3 of [3 of Int]](repeating: [1, 2, 3])
 
-let _ = [[3 x Int] x Int]() // expected-error {{cannot pass type '[3 x Int]' as a value for generic value 'count'}}
+let _ = [[3 of Int] of Int]() // expected-error {{cannot pass type '[3 of Int]' as a value for generic value 'count'}}
 
 do {
-  let _: [3 x
+  let _: [3 of
   // expected-error@-1 {{expected type}}
 }
 
 do {
-  let _: [3 x Int // expected-note {{to match this opening '['}}
+  let _: [3 of Int // expected-note {{to match this opening '['}}
 } // expected-error {{expected ']' in inline array type}}
 
 // We don't currently allow multi-line.
-func testMultiline(_ x: Int) {
+func testMultiline(_ of: Int) {
   let _ = [ // expected-error {{cannot call value of non-function type '[Int]'}}
     3 // expected-error {{expected ',' separator}}
-    x
+    of
     Int
   ](repeating: 0)
 
   let _ = [3
-    x
+    of
     Int
   ](repeating: 0)
   // expected-error@-4 {{expected ',' separator}}
   // expected-error@-5 {{cannot call value of non-function type '[Int]'}}
 
   let _ = [3
-           x Int](repeating: 0)
+           of Int](repeating: 0)
   // expected-error@-2 {{cannot call value of non-function type '[Int]'}}
   // expected-error@-3 {{expected ',' separator}}
 
   // This is okay.
-  let _ = [3 x
+  let _ = [3 of
              Int](repeating: 0)
 
   // So's this
   let _ = [
-    3 x Int
+    3 of Int
   ](repeating: 0)
 }
 
@@ -52,58 +52,58 @@ protocol Q {}
 
 struct S<T> {}
 
-let _ = S<[3 x Int]>()
-let _ = S<[[3 x Int]]>()
+let _ = S<[3 of Int]>()
+let _ = S<[[3 of Int]]>()
 
 // Make sure we can recover for different type productions as the LHS.
-let _ = S<[[Int x 3]]>()
+let _ = S<[[Int of 3]]>()
 // expected-error@-1 {{element count must precede inline array element type}}
-let _ = S<[@escaping () -> Int x 3]>()
+let _ = S<[@escaping () -> Int of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 // expected-error@-2 {{'@escaping' may only be used in function parameter position}}
-let _ = S<[Int.Type x 3]>()
+let _ = S<[Int.Type of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
-let _ = S<[sending P & Q x 3]>()
+let _ = S<[sending P & Q of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 // expected-error@-2 {{'sending' may only be used on parameters and results}}
-let _ = S<[some P & Q -> Int x 3]>()
+let _ = S<[some P & Q -> Int of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 // expected-error@-2 {{single argument function types require parentheses}}
 // expected-error@-3 {{'some' types are only permitted in properties, subscripts, and functions}}
-let _ = S<[~P x 3]>()
+let _ = S<[~P of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 // expected-error@-2 {{type 'P' cannot be suppressed}}
-let _ = S<[(Int, String) x 3]>()
+let _ = S<[(Int, String) of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
-let _ = S<[[3 x Int] x 3]>()
+let _ = S<[[3 of Int] of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
-let _ = S<[[Int] x 3]>()
+let _ = S<[[Int] of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
-let _ = S<[Array<Int> x 3]>()
+let _ = S<[Array<Int> of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
-let _ = S<[_ x 3]>()
-// expected-error@-1 {{element count must precede inline array element type}}
-// expected-error@-2 {{could not infer type for placeholder}}
-let _ = S<[_? x 3]>()
+let _ = S<[_ of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 // expected-error@-2 {{could not infer type for placeholder}}
-let _ = S<[_?x 3]>()
+let _ = S<[_? of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 // expected-error@-2 {{could not infer type for placeholder}}
-let _ = S<[_! x 3]>()
+let _ = S<[_?of 3]>()
+// expected-error@-1 {{element count must precede inline array element type}}
+// expected-error@-2 {{could not infer type for placeholder}}
+let _ = S<[_! of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 // expected-warning@-2 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}
 // expected-note@-3 {{use '?' instead}}
 // expected-error@-4 {{could not infer type for placeholder}}
-let _ = S<[_!x 3]>()
+let _ = S<[_!of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 // expected-warning@-2 {{using '!' here is deprecated; this is an error in the Swift 5 language mode}}
 // expected-note@-3 {{use '?' instead}}
 // expected-error@-4 {{could not infer type for placeholder}}
-let _ = S<[Int?x 3]>()
+let _ = S<[Int?of 3]>()
 // expected-error@-1 {{element count must precede inline array element type}}
 
-func testEllipsis(_ x: Int) {
-  // Make sure this isn't parsed as '<variadic-type> x <missing type>'
-  let _ = [x...x]
+func testEllipsis(_ of: Int) {
+  // Make sure this isn't parsed as '<variadic-type> of <missing type>'
+  let _ = [of...of]
 }

--- a/test/type/inline_array_disabled.swift
+++ b/test/type/inline_array_disabled.swift
@@ -3,17 +3,17 @@
 // Make sure InlineArray type sugar is disabled by default.
 // FIXME: The recovery here really isn't great.
 do {
-  let _: [3 x Int] // expected-note {{to match this opening '['}}
+  let _: [3 of Int] // expected-note {{to match this opening '['}}
   // expected-error@-1 4{{expected}}
   // expected-error@-2 4{{consecutive statements on a line must be separated by ';'}}
   // expected-warning@-3 2{{is unused}}
-  // expected-error@-4 {{cannot find 'x' in scope}}
+  // expected-error@-4 {{cannot find 'of' in scope}}
   // expected-note@-5 {{add arguments after the type to construct a value of the type}}
   // expected-note@-6 {{use '.self' to reference the type object}}
 }
 do {
-  let _ = [3 x Int]()
+  let _ = [3 of Int]()
   // expected-error@-1 {{cannot call value of non-function type '[Int]'}}
   // expected-error@-2 {{expected ',' separator}}
-  // expected-error@-3 {{cannot find 'x' in scope}}
+  // expected-error@-3 {{cannot find 'of' in scope}}
 }


### PR DESCRIPTION
*6.2 cherry-pick of #81868*

- Explanation: Updates the InlineArray type sugar separator from `x` to `of`
- Scope: Affects parsing of the (currently experimental) InlineArray type sugar
- Issue: rdar://152334289
- Risk: Low, the syntax is currently disabled by default, and the patch just swaps one identifier for another
- Testing: Updated tests in test suite
- Reviewer: Ben Barham