### PR TITLE
[6.2][Concurrency] Fix a false-positive metatype capture diagnostic.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4839,8 +4839,6 @@ bool ActorIsolationChecker::mayExecuteConcurrentlyWith(
   if (useContext == defContext)
     return false;
 
-  bool isolatedStateMayEscape = false;
-
   auto useIsolation = getActorIsolationOfContext(
       const_cast<DeclContext *>(useContext), getClosureActorIsolation);
   if (useIsolation.isActorIsolated()) {
@@ -4858,16 +4856,6 @@ bool ActorIsolationChecker::mayExecuteConcurrentlyWith(
     if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability) &&
         regionIsolationEnabled && useIsolation.isGlobalActor())
       return false;
-
-    // If the local function is not Sendable, its isolation differs
-    // from that of the context, and both contexts are actor isolated,
-    // then capturing non-Sendable values allows the closure to stash
-    // those values into actor isolated state. The original context
-    // may also stash those values into isolated state, enabling concurrent
-    // access later on.
-    isolatedStateMayEscape =
-        (!regionIsolationEnabled &&
-        useIsolation.isActorIsolated() && defIsolation.isActorIsolated());
   }
 
   // Walk the context chain from the use to the definition.
@@ -4877,17 +4865,12 @@ bool ActorIsolationChecker::mayExecuteConcurrentlyWith(
       if (closure->isSendable())
         return true;
 
-      if (isolatedStateMayEscape)
-        return true;
     }
 
     if (auto func = dyn_cast<FuncDecl>(useContext)) {
       if (func->isLocalCapture()) {
         // If the function is @Sendable... it can be run concurrently.
         if (func->isSendable())
-          return true;
-
-        if (isolatedStateMayEscape)
           return true;
       }
     }

--- a/test/Concurrency/sendable_metatype_typecheck.swift
+++ b/test/Concurrency/sendable_metatype_typecheck.swift
@@ -175,3 +175,16 @@ extension TestUnapplied {
 func testUnappliedWithOpetator<T: Comparable>(v: TestUnapplied<T>) {
   v<=>(>) // expected-error {{converting non-Sendable function value to '@Sendable (T, T) -> Bool' may introduce data races}}
 }
+
+protocol P {}
+
+func acceptClosure(_: () -> Void) {}
+
+@MainActor
+func f<T: P>(_: T.Type) {
+  acceptClosure {
+    Task {
+      _ = T.self // okay to capture T.Type in this closure.
+    }
+  }
+}


### PR DESCRIPTION
  - **Explanation**: `sending` closures that are isolated to the same actor as the enclosing context don't execute concurrently with the context. Concurrency checking for local captures accounts for this, but there was a bug in the strict `Sendable` metatype logic from SE-0470 that diagnosed non-`Sendable` metatypes in `sending` closures that did not execute concurrently. This change fixes that so that the following pattern is safe:

```swift
protocol P {}

func acceptClosure(_: () -> Void) {}

@MainActor
func f<T: P>(_: T.Type) {
  acceptClosure {
    Task {
      _ = T.self // okay to capture T.Type in this closure.
    }
  }
}
```

  - **Scope**: Only impacts strict concurrency diagnostics when using non-`Sendable` metatypes in `sending` closures that are isolated.
  - **Issues**: rdar://152185495
  - **Original PRs**: https://github.com/swiftlang/swift/pull/81860
  - **Risk**: Low; the only effect is skipping diagnostics when checking local captures in the actor isolation checker.
  - **Testing**: Added tests.
  - **Reviewers**: @DougGregor