### PR TITLE
[Strict memory safety] Improve Fix-Its for implied conformances

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2695,10 +2695,28 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
     }
 
     if (!unsafeUses.empty()) {
-      Context.Diags.diagnose(
+      // Primary diagnostic along with a Fix-It to add @unsafe in the appropriate
+      // place.
+      {
+        auto diag = Context.Diags.diagnose(
           conformance->getLoc(), diag::conformance_involves_unsafe,
-          conformance->getType(), Proto)
-      .fixItInsert(conformance->getProtocolNameLoc(), "@unsafe ");
+          conformance->getType(), Proto);
+        
+        // Find the original explicit conformance, where we can add the Fix-It.
+        auto explicitConformance = conformance;
+        while (explicitConformance->getSourceKind() ==
+                  ConformanceEntryKind::Implied) {
+          explicitConformance =
+            explicitConformance->ProtocolConformance::getImplyingConformance();
+        }
+        
+        if (explicitConformance->getSourceKind() ==
+              ConformanceEntryKind::Explicit) {
+          diag.fixItInsert(explicitConformance->getProtocolNameLoc(),
+                           "@unsafe ");
+        }
+      }
+
       for (const auto& unsafeUse : unsafeUses)
         diagnoseUnsafeUse(unsafeUse);
     }

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -349,3 +349,17 @@ func testSwitch(se: SomeEnum) {
   default: break
   }
 }
+
+@unsafe class SomeClass {}
+@unsafe class SomeClassWrapper { }
+
+protocol Associated {
+    associatedtype Associated
+}
+
+protocol CustomAssociated: Associated { }
+
+// expected-warning@+1{{conformance of 'SomeClass' to protocol 'Associated' involves unsafe code}}{{22-22=@unsafe }}
+extension SomeClass: CustomAssociated {
+  typealias Associated = SomeClassWrapper // expected-note{{unsafe type 'SomeClass.Associated' (aka 'SomeClassWrapper') cannot satisfy safe associated type 'Associated'}}
+}


### PR DESCRIPTION
- **Explanation**: The Fix-It produced to add `@unsafe` for an implied protocol conformance would end up on the extension rather than the conformance, which is incorrect. Make sure we apply @unsafe at the right location for the explicit conformance.
- **Scope**: Limited to one warning when strict memory safety is enabled.
- **Issues**: rdar://151800162
- **Original PRs**: https://github.com/swiftlang/swift/pull/81882
- **Risk**: Low. Improves the source location for a fix-it within strict memory safety mode.
- **Testing**: CI
