### PR TITLE
[Sema] Downgrade multi-param default inference diag for methods

### DIFF
--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -278,7 +278,7 @@ func testInferenceFromClosureVarInvalid<T>(x: T = { let x = "" as Int; return x 
 // https://github.com/swiftlang/swift/issues/72199
 enum S72199_1 {
   func testS72199_1<T>(_: T = 42, _: [T]) {}
-  // expected-error@-1 {{cannot use default expression for inference of 'T' because it is inferrable from parameters #0, #1}}
+  // expected-warning@-1 {{cannot use default expression for inference of 'T' because it is inferrable from parameters #0, #1; this will be an error in a future Swift language mode}}
 }
 
 func testS72199_2<T: P>(x: T.X, y: T = S()) { } // Ok

--- a/test/Constraints/type_inference_from_default_exprs_swift7.swift
+++ b/test/Constraints/type_inference_from_default_exprs_swift7.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -swift-version 7
+// REQUIRES: swift7
+
+// https://github.com/swiftlang/swift/issues/72199
+enum S72199_1 {
+  func testS72199_1<T>(_: T = 42, _: [T]) {}
+  // expected-error@-1 {{cannot use default expression for inference of 'T' because it is inferrable from parameters #0, #1}}
+}
+
+func testS72199<T>(_: T = 42, _: [T]) {}
+// expected-error@-1 {{cannot use default expression for inference of 'T' because it is inferrable from parameters #0, #1}}


### PR DESCRIPTION
We recently started enforcing this rule for methods (#79989), downgrade to a warning until the next language mode to avoid source compatibility breakage.