### PR TITLE
AST: honour `throws` in `AccessorDecl::createImplicit`

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11102,7 +11102,7 @@ AccessorDecl *AccessorDecl::createImplicit(ASTContext &ctx,
       ctx, /*declLoc=*/SourceLoc(),
       /*accessorKeywordLoc=*/SourceLoc(), accessorKind,
       storage, async, /*asyncLoc=*/SourceLoc(),
-      /*throws=*/true, /*throwsLoc=*/SourceLoc(),
+      /*throws=*/throws, /*throwsLoc=*/SourceLoc(),
       thrownType, parent,
       /*clangNode=*/ClangNode());
   D->setImplicit();


### PR DESCRIPTION
We would previously unconditionally create the accessor as a throwing accessor irrespective of the parameter. This seems like an oversight and results in an incorrect accessor being formed. This was caught while trying to improve the ClangImporter's handling of aliasing macros.