### PR TITLE
[Concurrency] Don't disable priority escalation tests on arm64e

### DIFF
--- a/test/Concurrency/async_task_escalate_priority.swift
+++ b/test/Concurrency/async_task_escalate_priority.swift
@@ -19,9 +19,6 @@
 // UNSUPPORTED: DARWIN_SIMULATOR=ios
 // UNSUPPORTED: DARWIN_SIMULATOR=tvos
 
-// rdar://107390341 - Because task escalation tests seem disabled on this platform
-// UNSUPPORTED: CPU=arm64e
-
 import Darwin
 @preconcurrency import Dispatch
 


### PR DESCRIPTION
We carried over all unsupported: marks from task_priority test which seems to have had just racy behavior for ages. This test should be fine on arm64e, and especially, we must run it to verify the pointer auth of these APIs.

This allowed a pointer auth issue to slip through, so let's remedy this by actually running the test on those platforms.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
