### PR TITLE
[cxx-interop] Fix compilation failure in rebranch

### DIFF
--- a/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
+++ b/test/Interop/Cxx/class/nonescapable-lifetimebound.swift
@@ -73,7 +73,7 @@ View getViewFromEither(View view1 [[clang::lifetimebound]], View view2 [[clang::
 struct SWIFT_NONESCAPABLE TestAnnotationTranslation {
     TestAnnotationTranslation() : member(nullptr) {}
     TestAnnotationTranslation(const int *p [[clang::lifetimebound]]) : member(p) {}
-    TestAnnotationTranslation(const TestAnnotationTranslation& [[clang::lifetimebound]]) = default;
+    TestAnnotationTranslation(const TestAnnotationTranslation& other [[clang::lifetimebound]]) = default;
 private:
     const int *member;
 };


### PR DESCRIPTION
It looks like in the latest version of clang, it needs parameters to be named for the lifetimebound attribute to be applicable.

rdar://151918181