### PR TITLE
[6.2][Concurrency] Correct priority cancellation handler signing

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1745,7 +1745,7 @@ namespace SpecialPointerAuthDiscriminators {
   const uint16_t AsyncContextParent = 0xbda2; // = 48546
   const uint16_t AsyncContextResume = 0xd707; // = 55047
   const uint16_t AsyncContextYield = 0xe207; // = 57863
-  const uint16_t CancellationNotificationFunction = 0xf73; // = 3955 (TaskPriority, TaskPriority) -> Void
+  const uint16_t CancellationNotificationFunction = 0x0f08; // = 3848
   const uint16_t EscalationNotificationFunction = 0x7861; // = 30817
   const uint16_t AsyncThinNullaryFunction = 0x0f08; // = 3848
   const uint16_t AsyncFutureFunction = 0x720f; // = 29199

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -269,7 +269,7 @@ public:
 /// subsequently used.
 class EscalationNotificationStatusRecord : public TaskStatusRecord {
 public:
-  using FunctionType = SWIFT_CC(swift) void(JobPriority, JobPriority, SWIFT_CONTEXT void *);
+  using FunctionType = SWIFT_CC(swift) void(uint8_t, uint8_t, SWIFT_CONTEXT void *);
 
 private:
   FunctionType *__ptrauth_swift_escalation_notification_function Function;
@@ -282,7 +282,10 @@ public:
   }
 
   void run(JobPriority oldPriority, JobPriority newPriority) {
-    Function(oldPriority, newPriority, Argument);
+    Function(
+      static_cast<size_t>(oldPriority),
+      static_cast<size_t>(newPriority),
+      Argument);
   }
 
   static bool classof(const TaskStatusRecord *record) {

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1816,7 +1816,7 @@ swift_task_addPriorityEscalationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(EscalationNotificationStatusRecord));
-  auto unsigned_handler = swift_auth_code(handler, 3955);
+  auto unsigned_handler = swift_auth_code(handler, 30817);
   auto *record = ::new (allocation)
       EscalationNotificationStatusRecord(unsigned_handler, context);
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1763,7 +1763,8 @@ swift_task_addCancellationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(CancellationNotificationStatusRecord));
-  auto unsigned_handler = swift_auth_code(handler, 3848);
+  auto unsigned_handler = swift_auth_code_function(handler,
+      SpecialPointerAuthDiscriminators::CancellationNotificationFunction);
   auto *record = ::new (allocation)
       CancellationNotificationStatusRecord(unsigned_handler, context);
 
@@ -1816,7 +1817,8 @@ swift_task_addPriorityEscalationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(EscalationNotificationStatusRecord));
-  auto unsigned_handler = swift_auth_code(handler, 30817);
+  auto unsigned_handler = swift_auth_code_function(handler,
+      SpecialPointerAuthDiscriminators::EscalationNotificationFunction);
   auto *record = ::new (allocation)
       EscalationNotificationStatusRecord(unsigned_handler, context);
 

--- a/test/Concurrency/async_task_escalate_priority.swift
+++ b/test/Concurrency/async_task_escalate_priority.swift
@@ -19,9 +19,6 @@
 // UNSUPPORTED: DARWIN_SIMULATOR=ios
 // UNSUPPORTED: DARWIN_SIMULATOR=tvos
 
-// rdar://107390341 - Because task escalation tests seem disabled on this platform
-// UNSUPPORTED: CPU=arm64e
-
 import Darwin
 @preconcurrency import Dispatch
 


### PR DESCRIPTION
**Description**: We previously corrected the descriminator we're signing with, but the signing was still incorrect due to the type of the function we're using. We must matche exactly the incoming function from Swift, which is: `  handler: (UInt8, UInt8) -> Void`.

This patch corrects the signature and confirms the signing is entirely correct now. Specifically, we sign using the right signature:

```
	add	x16, x16, closure #1 (Swift.UInt8, Swift.UInt8) -> () in main.makeit() -> @convention(thin) (Swift.UInt8, Swift.UInt8) -> ()@PAGEOFF
	mov	x17, #30817
	pacia	x16, x17
```

and we now _store_ and on the C++ side also use the same signature; otherwise there was a mismatch and auth failures ensured.


**Scope/Impact**: Pointer auth fix; this feature didn't yet land in a functional way as we didn't get the exact signing right until now.

**Risk:** Low, corrects the handler signing for the specific `withTaskPriorityEscalation` handler API

**Testing**: Manually verified using `arm64e` build and tests that this indeed is the right signing combination
**Reviewed by**: @mikeash

**Original PR:** https://github.com/swiftlang/swift/pull/81899
**Radar:** rdar://150378890