### PR TITLE
[CS] Check `hasType` in `isPlaceholderVar`

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2744,11 +2744,13 @@ Type constraints::isPlaceholderVar(PatternBindingDecl *PB) {
     return Type();
 
   auto *pattern = PB->getPattern(0);
-  if (auto *typedPattern = dyn_cast<TypedPattern>(pattern)) {
-    auto type = typedPattern->getType();
-    if (type && type->hasPlaceholder())
-      return type;
-  }
+  auto *typedPattern = dyn_cast<TypedPattern>(pattern);
+  if (!typedPattern || !typedPattern->hasType())
+    return Type();
 
-  return Type();
+  auto type = typedPattern->getType();
+  if (!type->hasPlaceholder())
+    return Type();
+
+  return type;
 }

--- a/test/Constraints/rdar146383201.swift
+++ b/test/Constraints/rdar146383201.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/a.swift %t/b.swift -plugin-path %swift-plugin-dir
+
+//--- a.swift
+
+func foo() {
+  _ = {
+    let i = 0
+    $bar.withValue(i) {}
+  }
+}
+
+//--- b.swift
+
+@TaskLocal
+var bar: Int?


### PR DESCRIPTION
Patterns assert that a type is set in `getType`, check `hasType` before querying.

rdar://146383201
