### PR TITLE
Optimize `[U]Int.init(bitPattern:)` for optional pointer conversions

### DIFF
--- a/stdlib/public/core/Pointer.swift
+++ b/stdlib/public/core/Pointer.swift
@@ -343,11 +343,7 @@ extension Int {
   @safe
   @_transparent
   public init<P: _Pointer>(bitPattern pointer: P?) {
-    if let pointer = pointer {
-      self = Int(Builtin.ptrtoint_Word(pointer._rawValue))
-    } else {
-      self = 0
-    }
+    self = unsafe unsafeBitCast(pointer, to: Self.self)
   }
 }
 
@@ -362,11 +358,7 @@ extension UInt {
   @safe
   @_transparent
   public init<P: _Pointer>(bitPattern pointer: P?) {
-    if let pointer = pointer {
-      self = UInt(Builtin.ptrtoint_Word(pointer._rawValue))
-    } else {
-      self = 0
-    }
+    self = unsafe unsafeBitCast(pointer, to: Self.self)
   }
 }
 


### PR DESCRIPTION
The `[U]Int.init(bitPattern:)` initializers for optional pointer types currently result in suboptimal machine code. These conversions are semantically simple—reinterpreting the bit pattern of an optional pointer as an integer—but the current implementation introduces conditional branching, which penalizes idiomatic use in performance-sensitive code. Swift’s current runtime representation uses a zero bit pattern to represent `Optional<Unsafe*Pointer>.none`. If this representation is stable and guaranteed, we can use `unsafeBitCast(_:to:)` to eliminate branching entirely.

#### Benchmark: Compiler Explorer Outputs

This section shows some assembly for the current (foo) and the proposed (bar) approach:

```swift
func foo(pointer: Optional<UnsafeRawPointer>, plus distance: Int) -> Optional<UnsafeRawPointer> {
    let x  = Int(bitPattern: pointer)
    return UnsafeRawPointer(bitPattern: x &+ distance)
}

func bar(pointer: Optional<UnsafeRawPointer>, plus distance: Int) -> Optional<UnsafeRawPointer> {
    let x = Swift.unsafeBitCast(pointer, to: Int.self)
    return UnsafeRawPointer(bitPattern: x &+ distance)
}
```

[aarch64 swiftc 6.1:](https://swift.godbolt.org/z/Ge53fK46W)

```
output.foo(pointer: Swift.UnsafeRawPointer?, plus: Swift.Int) -> Swift.UnsafeRawPointer?:
        mov     x8, x0
        mov     x0, x1
        cbz     x8, .LBB1_2
        adds    x0, x0, x8
.LBB1_2:
        ret

output.bar(pointer: Swift.UnsafeRawPointer?, plus: Swift.Int) -> Swift.UnsafeRawPointer?:
        add     x0, x1, x0
        ret
```

[x86-64 swiftc 6.1:](https://swift.godbolt.org/z/3cqcTzKqx)

```
output.foo(pointer: Swift.UnsafeRawPointer?, plus: Swift.Int) -> Swift.UnsafeRawPointer?:
        mov     rax, rsi
        test    rdi, rdi
        je      .LBB1_1
        add     rax, rdi
        je      .LBB1_3
.LBB1_4:
        ret
.LBB1_1:
        test    rax, rax
        jne     .LBB1_4
.LBB1_3:
        xor     eax, eax
        ret

output.bar(pointer: Swift.UnsafeRawPointer?, plus: Swift.Int) -> Swift.UnsafeRawPointer?:
        lea     rax, [rdi + rsi]
        ret
```

#### Risk & Open Questions

The key question is whether the zero bit pattern representation of `Optional<Unsafe*Pointer>.none` is a formal guarantee of the Swift ABI or an implementation detail subject to change. If this layout is not formally guaranteed by the Swift ABI, then this optimization might introduce undefined behavior in future Swift versions.