### PR TITLE
[6.2] SILGen: Establish an addressability scope for closure captures.

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -2542,6 +2542,8 @@ SILGenFunction::getLocalVariableAddressableBuffer(VarDecl *decl,
   SILValue reabstraction, allocStack, storeBorrow;
   {
     SavedInsertionPointRAII save(B);
+    ASSERT(AddressableBuffers.find(decl) != AddressableBuffers.end()
+           && "local variable did not have an addressability scope set");
     auto insertPoint = AddressableBuffers[decl].insertPoint;
     B.setInsertionPoint(insertPoint);
     auto allocStackTy = fullyAbstractedTy;

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -543,7 +543,9 @@ public:
     
     PreparedAddressableBuffer(SILInstruction *insertPoint)
       : insertPoint(insertPoint)
-    {}
+    {
+      ASSERT(insertPoint && "null insertion point provided");
+    }
     
     PreparedAddressableBuffer(PreparedAddressableBuffer &&other)
       : insertPoint(other.insertPoint)

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1406,6 +1406,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
   }
 
   SGF.VarLocs[VD] = SILGenFunction::VarLoc(arg, enforcement, box);
+  SGF.enterLocalVariableAddressableBufferScope(VD);
   SILDebugVariable DbgVar(VD->isLet(), ArgNo);
   if (auto *AllocStack = dyn_cast<AllocStackInst>(arg)) {
     AllocStack->setArgNo(ArgNo);

--- a/test/SILGen/dependency_through_closure.swift
+++ b/test/SILGen/dependency_through_closure.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-emit-silgen -verify -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes %s
+
+// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_AddressableTypes
+
+@_addressableForDependencies
+struct Owner {
+    @lifetime(borrow self)
+    func reference() -> Reference { fatalError() }
+}
+
+struct Reference: ~Escapable {
+    @lifetime(immortal)
+    init() { fatalError() }
+
+    func use() {}
+}
+
+func closure(_: () -> Void) {}
+
+func dependencyThroughClosure(from owner: borrowing Owner) {
+    closure { owner.reference().use() }
+}

--- a/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
+++ b/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
@@ -253,15 +253,12 @@ public struct NoncopyableSelfAccessors : ~Copyable & ~Escapable {
     _modify
   }
   
-  // FIXME: rdar://150073405 ([SILGen] support synthesized _modify on top of borrowed getters with library evolution)
-  /*
   public var neComputedBorrow: lifetime_depend_infer.NE {
     @lifetime(borrow self)
     get
     @lifetime(&self)
     set
   }
-  */
   
   public var neYieldedBorrow: lifetime_depend_infer.NE {
     @lifetime(borrow self)


### PR DESCRIPTION
Explanation: Fixes a bug when invoking a Span-returning API on a value captured inside of a closure.

Scope: Bug fix.

Issue: rdar://150479326

Original PR: https://github.com/swiftlang/swift/pull/81878

Risk: Low, corrects an oversight where closure captures did not get a scope set for their `@_addressable` dependency.

Testing: Swift CI, test case from issue

Reviewers: @atrick 