### PR TITLE
update_checkout: bump s-a-p to 1.5.1

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -137,7 +137,7 @@
                 "swift-toolchain-sqlite": "1.0.1",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
-                "swift-argument-parser": "1.4.0",
+                "swift-argument-parser": "1.5.1",
                 "swift-atomics": "1.2.0",
                 "swift-collections": "1.1.3",
                 "swift-crypto": "3.0.0",


### PR DESCRIPTION
Update swift-argument-parser to 1.5.1. This is motivated by a change to the build system in 1.5.1 that is required to build swift-argument-parser as part of swift-driver to enable static linking on Windows. Pulling in this change will enable us to make further progress towards enabling the early swift driver on Windows.