### PR TITLE
[C++Interop] Do not query C++ Standard Library Swift overlays when building Swift modules which were built without C++ interop

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -45,6 +45,7 @@ namespace swift {
 
   struct DiagnosticBehavior;
   class DiagnosticEngine;
+  class FrontendOptions;
 
   /// Kind of implicit platform conditions.
   enum class PlatformConditionKind {
@@ -339,7 +340,8 @@ namespace swift {
     std::optional<version::Version> FormalCxxInteropMode;
 
     void setCxxInteropFromArgs(llvm::opt::ArgList &Args,
-                               swift::DiagnosticEngine &Diags);
+                               swift::DiagnosticEngine &Diags,
+                               const FrontendOptions &FrontendOpts);
 
     /// The C++ standard library used for the current build. This can differ
     /// from the default C++ stdlib on a particular platform when `-Xcc

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4388,7 +4388,14 @@ ModuleDecl *ClangModuleUnit::getOverlayModule() const {
     // FIXME: Include proper source location.
     ModuleDecl *M = getParentModule();
     ASTContext &Ctx = M->getASTContext();
-    auto overlay = Ctx.getOverlayModule(this);
+
+    ModuleDecl *overlay = nullptr;
+    // During compilation of a textual interface with no formal C++ interop mode,
+    // i.e. it was built without C++ interop, avoid querying the 'CxxStdlib' overlay
+    // for it, since said overlay was not used during compilation of this module.
+    if (!importer::isCxxStdModule(clangModule) || Ctx.LangOpts.FormalCxxInteropMode)
+      overlay = Ctx.getOverlayModule(this);
+
     if (overlay) {
       Ctx.addLoadedModule(overlay);
     } else {
@@ -4408,7 +4415,8 @@ ModuleDecl *ClangModuleUnit::getOverlayModule() const {
     // If this Clang module is a part of the C++ stdlib, and we haven't loaded
     // the overlay for it so far, it is a split libc++ module (e.g. std_vector).
     // Load the CxxStdlib overlay explicitly.
-    if (!overlay && importer::isCxxStdModule(clangModule)) {
+    if (!overlay && importer::isCxxStdModule(clangModule) &&
+        Ctx.LangOpts.FormalCxxInteropMode) {
       ImportPath::Module::Builder builder(Ctx.Id_CxxStdlib);
       overlay = owner.loadModule(SourceLoc(), std::move(builder).get());
     }

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -1478,7 +1478,13 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependenciesForModule(
 
     // If the textual interface was built without C++ interop, do not query
     // the C++ Standard Library Swift overlay for its compilation.
-    if (llvm::find(commandLine, "-formal-cxx-interoperability-mode=off") ==
+    //
+    // FIXME: We always declare the 'Darwin' module as formally having been built
+    // without C++Interop, for compatibility with prior versions. Once we are certain
+    // that we are only building against modules built with support of
+    // '-formal-cxx-interoperability-mode', this hard-coded check should be removed.
+    if (moduleID.ModuleName != "Darwin" &&
+        llvm::find(commandLine, "-formal-cxx-interoperability-mode=off") ==
         commandLine.end()) {
       for (const auto &clangDepName : allClangDependencies) {
         // If this Clang module is a part of the C++ stdlib, and we haven't

--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -214,7 +214,8 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
     Options.AvailabilityIsBlockList = A->getOption().matches(OPT_block_availability_platforms);
   }
 
-  Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags);
+  Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags,
+                                                    Invocation.getFrontendOptions());
 
   std::string InstanceSetupError;
   if (CI.setup(Invocation, InstanceSetupError)) {

--- a/lib/DriverTool/swift_synthesize_interface_main.cpp
+++ b/lib/DriverTool/swift_synthesize_interface_main.cpp
@@ -133,7 +133,8 @@ int swift_synthesize_interface_main(ArrayRef<const char *> Args,
   Invocation.setImportSearchPaths(ImportSearchPaths);
 
   Invocation.getLangOptions().EnableObjCInterop = Target.isOSDarwin();
-  Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags);
+  Invocation.getLangOptions().setCxxInteropFromArgs(ParsedArgs, Diags,
+                                                    Invocation.getFrontendOptions());
 
   std::string ModuleCachePath = "";
   if (auto *A = ParsedArgs.getLastArg(OPT_module_cache_path)) {

--- a/test/Interop/Cxx/modules/no-cxx-overlay-for-non-interop-interface.swift
+++ b/test/Interop/Cxx/modules/no-cxx-overlay-for-non-interop-interface.swift
@@ -6,8 +6,13 @@
 // RUN: %target-swift-frontend -typecheck %t/clientWithInteropDep.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -module-cache-path %t/module-cache &> %t/interop_dep.txt
 // RUN: cat %t/interop_dep.txt | %FileCheck %s -check-prefix=ENABLE-CHECK
 
-// RUN: %target-swift-frontend -typecheck -o %t/deps_no_interop_dep.json %t/clientNoInteropDep.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -module-cache-path %t/module-cache &> %t/no_interop_dep.txt
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %target-swift-frontend -typecheck %t/clientNoInteropDep.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -module-cache-path %t/module-cache &> %t/no_interop_dep.txt
 // RUN: cat %t/no_interop_dep.txt | %FileCheck %s -check-prefix=DISABLE-CHECK
+
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %target-swift-frontend -typecheck %t/clientDarwin.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -module-cache-path %t/module-cache &> %t/darwin_dep.txt
+// RUN: cat %t/darwin_dep.txt | %FileCheck %s -check-prefix=DISABLE-CHECK
 
 // ENABLE-CHECK: remark: loaded module 'CxxStdlib' (overlay for a clang dependency)
 // DISABLE-CHECK-NOT: remark: loaded module 'CxxStdlib' (overlay for a clang dependency)
@@ -43,9 +48,19 @@ public struct Foo1 {}
 import Bar
 public struct Foo2 {}
 
+//--- deps/Darwin.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Darwin -enable-library-evolution
+// swift-module-flags-ignorable: -Rmodule-loading
+import Bar
+public struct Foo2 {}
+
 //--- clientWithInteropDep.swift
 import Foo
 
 //--- clientNoInteropDep.swift
 import FooNoInterop
+
+//--- clientDarwin.swift
+import Darwin
 

--- a/test/Interop/Cxx/modules/no-cxx-overlay-for-non-interop-interface.swift
+++ b/test/Interop/Cxx/modules/no-cxx-overlay-for-non-interop-interface.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/deps)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/clientWithInteropDep.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -module-cache-path %t/module-cache &> %t/interop_dep.txt
+// RUN: cat %t/interop_dep.txt | %FileCheck %s -check-prefix=ENABLE-CHECK
+
+// RUN: %target-swift-frontend -typecheck -o %t/deps_no_interop_dep.json %t/clientNoInteropDep.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -module-cache-path %t/module-cache &> %t/no_interop_dep.txt
+// RUN: cat %t/no_interop_dep.txt | %FileCheck %s -check-prefix=DISABLE-CHECK
+
+// ENABLE-CHECK: remark: loaded module 'CxxStdlib' (overlay for a clang dependency)
+// DISABLE-CHECK-NOT: remark: loaded module 'CxxStdlib' (overlay for a clang dependency)
+
+//--- deps/bar.h
+#include "std_bar.h"
+void bar(void);
+
+//--- deps/std_bar.h
+void std_bar(void);
+
+//--- deps/module.modulemap
+module std_Bar [system] {
+  header "std_bar.h"
+  export *
+}
+
+module Bar [system] {
+  header "bar.h"
+  export *    
+}
+
+//--- deps/Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo -enable-library-evolution -Rmodule-loading
+import Bar
+public struct Foo1 {}
+
+//--- deps/FooNoInterop.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name FooNoInterop -enable-library-evolution
+// swift-module-flags-ignorable: -formal-cxx-interoperability-mode=off -Rmodule-loading
+import Bar
+public struct Foo2 {}
+
+//--- clientWithInteropDep.swift
+import Foo
+
+//--- clientNoInteropDep.swift
+import FooNoInterop
+


### PR DESCRIPTION
Similarly to how this was fixed in https://github.com/swiftlang/swift/pull/81415 in the Dependency Scanner for builds using Explicitly-Built modules, this change causes Implicitly-Built module code path to also forego querying Swift overlay `CxxStdlib` when the compiler is building a module with no declared "[formal C++ interop mode](https://github.com/swiftlang/swift/pull/79984)". 

This change also temporarily hard-codes the `Darwin` module to always have no formal C++ interop mode, for the sake of compatibility with `Darwin` Swift module textual interfaces which were constructed prior to the introduction of the `-formal-cxx-interoperability-mode=` option. 