### PR TITLE
[rbi] Lookthrough an invocation of DistributedActor.asLocalActor when determining actor instances.

### DIFF
--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -13,6 +13,7 @@
 #include "swift/SILOptimizer/Utils/SILIsolationInfo.h"
 
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/DistributedDecl.h"
 #include "swift/AST/Expr.h"
 #include "swift/SIL/AddressWalker.h"
 #include "swift/SIL/ApplySite.h"
@@ -1413,6 +1414,30 @@ SILValue ActorInstance::lookThroughInsts(SILValue value) {
             ei->getFunction()->getASTContext().getOptionalDecl()) {
           value = lookThroughInsts(ei->getOperand());
           continue;
+        }
+      }
+    }
+
+    // See if this is distributed asLocalActor. In such a case, we want to
+    // consider the result actor to be the same actor as the input isolated
+    // parameter.
+    if (auto fas = FullApplySite::isa(svi)) {
+      if (auto *functionRef = fas.getReferencedFunctionOrNull()) {
+        if (auto declRef = functionRef->getDeclRef()) {
+          if (auto *accessor =
+                  dyn_cast_or_null<AccessorDecl>(declRef.getFuncDecl())) {
+            if (auto asLocalActorDecl =
+                    getDistributedActorAsLocalActorComputedProperty(
+                        functionRef->getDeclContext()->getParentModule())) {
+              if (auto asLocalActorGetter =
+                      asLocalActorDecl->getAccessor(AccessorKind::Get);
+                  asLocalActorGetter && asLocalActorGetter == accessor) {
+                value = lookThroughInsts(
+                    fas.getIsolatedArgumentOperandOrNullPtr()->get());
+                continue;
+              }
+            }
+          }
         }
       }
     }

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -65,6 +65,19 @@ distributed actor MyDistributedActor {
       // expected-note @-1 {{'self'-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
+
+
+  func doSomething() async { }
+
+  // Make sure that we consider asLocalActor's result to be the same actor as
+  // its actor parameter.
+  func testAsLocalActorForwards() async {
+    await withTaskGroup { group in
+      group.addTask {
+        await self.doSomething()
+      }
+    }
+  }
 }
 
 /////////////////////////////////


### PR DESCRIPTION
In this case, what is happening is that in SILGen, we insert implicit DistributedActor.asLocalActor calls to convert a distributed actor to its local any Actor typed form. The intention is that the actor parameter and result are considered the same... but there is nothing at the SIL level to enforce that. In this commit, I change ActorInstance (the utility that defines actor identity at a value level) to look through such a call.

I implemented this by just recognizing the decl directly. We already do this in parts of SILGen, so I don't really see a problem with doing this. It also provides a nice benefit that we do not have to modify SILFunctionType to represent this or put a @_semantic attribute on the getter.

NOTE: Generally, Sema prevents us from mixing together different actors. In this case, Sema does not help us since this call is inserted implicitly by the distributed actor implementation in SILGen. So this is not a problem in general.

rdar://152436817

