### PR TITLE
[Strict memory safety] Adjust "unsafe" location for string interpolations

### DIFF
--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -376,3 +376,9 @@ protocol CustomAssociated: Associated { }
 extension SomeClass: CustomAssociated {
   typealias Associated = SomeClassWrapper // expected-note{{unsafe type 'SomeClass.Associated' (aka 'SomeClassWrapper') cannot satisfy safe associated type 'Associated'}}
 }
+
+func testInterpolation(ptr: UnsafePointer<Int>) {
+  _ = "Hello \(unsafe ptr)" // expected-warning{{expression uses unsafe constructs but is not marked with 'unsafe'}}{{7-7=unsafe }}
+  // expected-note@-1{{reference to unsafe type 'UnsafePointer<Int>'}}
+  // expected-note@-2{{argument #0 in call to instance method 'appendInterpolation' has unsafe type 'UnsafePointer<Int>'}}
+}


### PR DESCRIPTION
String interpolations can end up being unsafe in the call to appendInterpolation when it's provided with unsafe types. Move the location of the proposed "unsafe" out to the string interpolation itself in these cases, which properly suppresses the warning.

Fixes rdar://151799777.