### PR TITLE
AST: Fix crash when type parameter is fixed to an existential

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -753,7 +753,9 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
 SubstitutionMap TypeBase::getContextSubstitutionMap(
     const DeclContext *dc,
     GenericEnvironment *genericEnv) {
-  if (dc == getAnyNominal() && genericEnv == nullptr)
+  auto *nominal = getAnyNominal();
+  if (dc == nominal && !isa<ProtocolDecl>(nominal) &&
+      genericEnv == nullptr)
     return getContextSubstitutionMap();
 
   auto genericSig = dc->getGenericSignatureOfContext();

--- a/test/Generics/concrete_contraction_existential.swift
+++ b/test/Generics/concrete_contraction_existential.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P1 {
+  associatedtype Value
+}
+
+protocol P2 {
+  typealias A = Int
+}
+
+struct G<T: P1> where T.Value == any Collection, T.Value.Element: P2 {}
+// expected-error@-1 {{cannot access associated type 'Element' from 'any Collection'; use a concrete type or generic parameter base instead}}
+


### PR DESCRIPTION
getContextSubstitutionMap() didn't handle the case where getAnyNominal() returns a ProtocolDecl. This should not take the "fast path", which is only suitable for concrete nominals.

This manifested as a crash-on-invalid -- the user probably meant to write "T.Value: Collection" rather than "T.Value == Collection".

Fixes rdar://151479861.