### PR TITLE
[6.2][flow-isolation] Allow for initialization of fields of a Global Actor isolated class in its nonisolated inits

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7873,6 +7873,19 @@ ActorReferenceResult ActorReferenceResult::forReference(
         (!actorInstance || actorInstance->isSelf())) {
       auto type = fromDC->mapTypeIntoContext(decl->getInterfaceType());
       if (!type->isSendableType()) {
+        // If we have an actor instance and our declIsolation is global actor
+        // isolated, but our context isolation is nonisolated... defer to flow
+        // isolation for additional checking.
+        //
+        // NOTE: We also require this to pass additional restrictions validated
+        // by checkedByFlowIsolation (e.x.: the initializer's nominal type has
+        // to be isolated).
+        if (actorInstance &&
+            declIsolation.isGlobalActor() && contextIsolation.isNonisolated() &&
+            checkedByFlowIsolation(fromDC, *actorInstance, decl, declRefLoc, useKind)) {
+          return forSameConcurrencyDomain(declIsolation, options);
+        }
+
         // Treat the decl isolation as 'preconcurrency' to downgrade violations
         // to warnings, because violating Sendable here is accepted by the
         // Swift 5.9 compiler.

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -32,6 +32,13 @@ struct Money {
   }
 }
 
+actor OtherActorBackingActor { }
+
+@globalActor
+struct OtherActor {
+  static let shared = OtherActorBackingActor()
+}
+
 @available(SwiftStdlib 5.1, *)
 func takeBob(_ b: Bob) {}
 
@@ -832,17 +839,78 @@ func testActorWithInitAccessorInit() {
 
 @available(SwiftStdlib 5.1, *)
 actor TestNonisolatedUnsafe {
-  private nonisolated(unsafe) var child: OtherActor!
+  private nonisolated(unsafe) var child: MyOtherActor!
   init() {
-    child = OtherActor(parent: self)
+    child = MyOtherActor(parent: self)
   }
 }
 
 @available(SwiftStdlib 5.1, *)
-actor OtherActor {
+actor MyOtherActor {
   unowned nonisolated let parent: any Actor
 
   init(parent: any Actor) {
     self.parent = parent
+  }
+}
+
+func globalActorNonIsolatedInitializerTests() {
+  @MainActor
+  class C {
+    let ns: NonSendableType
+
+    nonisolated init() {
+      self.ns = NonSendableType()
+    }
+
+    nonisolated init(x: NonSendableType) {
+      self.ns = x
+    }
+
+    nonisolated func doSomething() {}
+
+    nonisolated init(x2 x: NonSendableType) {
+      self.ns = x
+      doSomething() // expected-note {{after calling instance method 'doSomething()', only nonisolated properties of 'self' can be accessed from this init}}
+      print(self.ns) // expected-warning {{cannot access property 'ns' here in nonisolated initializer}}
+    }
+  }
+
+  // Make sure this does not apply in cases where self is not actor isolated.
+  class D {
+    @MainActor let ns: NonSendableType // expected-note {{mutation of this property is only permitted within the actor}}
+
+    nonisolated init() {
+      self.ns = NonSendableType() // expected-warning {{main actor-isolated property 'ns' can not be mutated from a nonisolated context}}
+    }
+  }
+
+  actor A {
+    @MainActor let ns: NonSendableType
+
+    init() {
+      self.ns = NonSendableType()
+    }
+  }
+
+  @MainActor
+  class C2 {
+    @OtherActor let ns: NonSendableType
+
+    nonisolated init() {
+      self.ns = NonSendableType()
+    }
+
+    nonisolated init(_ x: NonSendableType) {
+      self.ns = x
+    }
+
+    nonisolated func doSomething() {}
+
+    nonisolated init(x2 x: NonSendableType) {
+      self.ns = x
+      doSomething() // expected-note {{after calling instance method 'doSomething()', only nonisolated properties of 'self' can be accessed from this init}}
+      print(self.ns) // expected-warning {{cannot access property 'ns' here in nonisolated initializer}}
+    }
   }
 }


### PR DESCRIPTION
Explanation: This PR loosens some checks in the type checker so that we stop erroring when we access a field of a global actor isolated type in a nonisolated initializer. We do this so that we can instead just rely on flow sensitive isolation. This ensures that we can now initialize fields of global actor isolated nominal types in nonisolated initializers as long as self has not "escaped" the initializer.

Scope: This eliminates an error in the type checker that prevented flow sensitive isolation (a SIL pass) from running on code.

Resolves: rdar://131136194

Main PR: https://github.com/swiftlang/swift/pull/81851

Risk: Low. This will only impact global actor isolated nominal types with nonisolated initializers. Only risk is potentially a bug in flow sensitive isolation. But it has been tested/used on actor types for a while.

Testing: Added compiler tests

Reviewer: @xedin
