### PR TITLE
[6.2] Fix diagnostic messages for some cases of invalid lifetime depenndencies

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8203,8 +8203,8 @@ ERROR(lifetime_dependence_immortal_alone, none,
       "cannot specify any other dependence source along with immortal", ())
 ERROR(lifetime_dependence_invalid_inherit_escapable_type, none,
       "cannot copy the lifetime of an Escapable type, use "
-      "'@lifetime(borrow %0)' instead",
-      (StringRef))
+      "'@lifetime(%1%0)' instead",
+      (StringRef, StringRef))
 ERROR(lifetime_dependence_cannot_use_parsed_borrow_consuming, none,
       "invalid use of %0 dependence with %1 ownership",
       (StringRef, StringRef))

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -665,8 +665,18 @@ protected:
   case ParsedLifetimeDependenceKind::Inherit:
     // @lifetime(copy x) is only invalid for Escapable types.
     if (type->isEscapable()) {
-      diagnose(loc, diag::lifetime_dependence_invalid_inherit_escapable_type,
-               descriptor.getString());
+      if (loweredOwnership == ValueOwnership::Shared) {
+        diagnose(loc, diag::lifetime_dependence_invalid_inherit_escapable_type,
+                 descriptor.getString(), "borrow ");
+      } else if (loweredOwnership == ValueOwnership::InOut) {
+        diagnose(loc, diag::lifetime_dependence_invalid_inherit_escapable_type,
+                 descriptor.getString(), "&");
+      } else {
+        diagnose(
+            loc,
+            diag::lifetime_dependence_cannot_use_default_escapable_consuming,
+            getOwnershipSpelling(loweredOwnership));
+      }
       return std::nullopt;
     }
     return LifetimeDependenceKind::Inherit;

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -69,3 +69,18 @@ func inoutLifetimeDependence(_ ne: inout NE) -> NE {
   ne
 }
 
+@lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&k)' instead}}
+func dependOnEscapable(_ k: inout Klass) -> NE {
+  NE()
+}
+
+@lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow k)' instead}}
+func dependOnEscapable(_ k: borrowing Klass) -> NE { 
+  NE()
+}
+
+@lifetime(copy k) // expected-error{{invalid lifetime dependence on an Escapable value with consuming ownership}}
+func dependOnEscapable(_ k: consuming Klass) -> NE { 
+  NE()
+}
+

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -84,7 +84,7 @@ struct EscapableTrivialSelf {
   @lifetime(self) // OK
   mutating func mutatingMethodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
+  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&self)' instead}}
   mutating func mutatingMethodNoParamCopy() -> NEImmortal { NEImmortal() }
 
   @lifetime(borrow self)
@@ -106,7 +106,7 @@ struct EscapableTrivialSelf {
   @lifetime(self)
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
+  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&self)' instead}}
   mutating func mutatingMethodOneParamCopy(_: Int) -> NEImmortal { NEImmortal() }
 
   @lifetime(borrow self)
@@ -138,7 +138,7 @@ struct EscapableNonTrivialSelf {
   @lifetime(self)
   mutating func mutatingMethodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
+  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&self)' instead}}
   mutating func mutatingMethodNoParamCopy() -> NEImmortal { NEImmortal() }
 
   @lifetime(&self)
@@ -160,7 +160,7 @@ struct EscapableNonTrivialSelf {
   @lifetime(self)
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
+  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&self)' instead}}
   mutating func mutatingMethodOneParamCopy(_: Int) -> NEImmortal { NEImmortal() }
 
   @lifetime(&self)


### PR DESCRIPTION
Explanation: This PR fixes some diagnostic messages involving lifetime dependencies that were misleading and suggested an invalid alternative.

Scope: Limited to LifetimeDependence experimental feature

Resolves: rdar://151810577 

Main PR: https://github.com/swiftlang/swift/pull/81893

Risk: None. Rephrasing diagnostic messages

Testing: Added compiler tests

Reviewer: @atrick 

