### PR TITLE
AST: Fix crash when type parameter is substituted with an existential [6.2]

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -747,7 +747,9 @@ TypeBase::getContextSubstitutions(const DeclContext *dc,
 SubstitutionMap TypeBase::getContextSubstitutionMap(
     const DeclContext *dc,
     GenericEnvironment *genericEnv) {
-  if (dc == getAnyNominal() && genericEnv == nullptr)
+  auto *nominal = getAnyNominal();
+  if (dc == nominal && !isa<ProtocolDecl>(nominal) &&
+      genericEnv == nullptr)
     return getContextSubstitutionMap();
 
   auto genericSig = dc->getGenericSignatureOfContext();

--- a/test/Generics/concrete_contraction_existential.swift
+++ b/test/Generics/concrete_contraction_existential.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P1 {
+  associatedtype Value
+}
+
+protocol P2 {
+  typealias A = Int
+}
+
+struct G<T: P1> where T.Value == any Collection, T.Value.Element: P2 {}
+// expected-error@-1 {{cannot access associated type 'Element' from 'any Collection'; use a concrete type or generic parameter base instead}}
+


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/81913

* **Description:** getContextSubstitutionMap() would crash on an invalid input instead of returning a substitution map with an invalid conformance. This manifested as a crash-on-invalid where the user wrote "T.Value: Collection" rather than "T.Value == Collection".
* **Origination:** This is a regression from https://github.com/swiftlang/swift/pull/75068.
* **Risk:** Low. This just skips a "fast path" that was incorrect for the given inputs.
* **Radar:** Fixes rdar://151479861.
* **Reviewed by:** @DougGregor 