### PR TITLE
[6.2][Frontend] -Isystem doesn't work everywhere -I does

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -261,7 +261,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     arguments.push_back("-color-diagnostics");
   }
 
-  inputArgs.AddAllArgs(arguments, options::OPT_I);
+  inputArgs.addAllArgs(arguments, {options::OPT_I, options::OPT_Isystem});
   inputArgs.addAllArgs(arguments, {options::OPT_F, options::OPT_Fsystem});
   inputArgs.AddAllArgs(arguments, options::OPT_vfsoverlay);
 


### PR DESCRIPTION
- **Explanation**: This change fixes the legacy driver to handle `-Isystem`
- **Scope**: Only affects clients trying to use the new `-Isystem` flag with the legacy driver.
- **Original PRs**: https://github.com/swiftlang/swift/pull/81914
- **Risk**: None anticipated.
- **Testing**: CI.