### PR TITLE
[6.2, cmake] InoutLifetimeDependence should be enabled

### DIFF
--- a/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake
+++ b/Runtimes/Core/cmake/modules/ExperimentalFeatures.cmake
@@ -4,6 +4,7 @@ add_compile_options(
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature SE427NoInferenceOnExtension>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature NonescapableTypes>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependence>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature InoutLifetimeDependence>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature LifetimeDependenceMutableAccessors>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature MemberImportVisibility>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature TypedThrows>"


### PR DESCRIPTION
Explanation: This enables the InoutLifetimeDependence flag when building a toolchain with the new build system. As a result the flag will be enabled in the swift core module's swiftinterface file. (It's already enabled when building with the older system, which generates the OSS toolchains.)

Scope: Binaries which use MutableSpan instances
Original PR: https://github.com/swiftlang/swift/pull/81923
Risk: Very low; CI toolchains have this flag turned on.
Testing: CI
Reviewed by: @etcwilde

Addresses rdar://152467655