### PR TITLE
IRGen: add an option `-min-valid-pointer-value` to override the target's LeastValidPointerValue

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -603,6 +603,8 @@ ERROR(objc_with_embedded,none,
       "Objective-C interoperability cannot be enabled with embedded Swift.", ())
 ERROR(no_allocations_without_embedded,none,
       "-no-allocations is only applicable with embedded Swift.", ())
+ERROR(min_ptr_value_without_embedded,none,
+      "-min-valid-pointer-value is only applicable with embedded Swift.", ())
 ERROR(no_swift_sources_with_embedded,none,
       "embedded swift cannot be enabled in a compiler built without Swift sources", ())
 

--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -566,6 +566,9 @@ public:
   /// Pointer authentication.
   PointerAuthOptions PointerAuth;
 
+  // If not 0, this overrides the value defined by the target.
+  uint64_t CustomLeastValidPointerValue = 0;
+
   /// The different modes for dumping IRGen type info.
   enum class TypeInfoDumpFilter {
     All,

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1187,6 +1187,10 @@ def enable_cond_fail_message_annotation : Flag<["-"], "enable-cond-fail-message-
 def disable_cond_fail_message_annotation : Flag<["-"], "dissable-cond-fail-message-annotation">,
   HelpText<"Disable cond_fail message annotation.">;
 
+def min_valid_pointer_value : Joined<["-"], "min-valid-pointer-value=">,
+  MetaVarName<"<value>">,
+  HelpText<"Overrides the target's least valid pointer value.'">;
+
 let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOptionIgnorable] in {
   def enable_pack_metadata_stack_promotion :
     Joined<["-"], "enable-pack-metadata-stack-promotion=">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3506,6 +3506,21 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
 
   Opts.DebugInfoForProfiling |= Args.hasArg(OPT_debug_info_for_profiling);
 
+
+  if (const Arg *A = Args.getLastArg(OPT_min_valid_pointer_value)) {
+    // The LeastValidPointerValue is hard-coded in the runtime. Therefore it
+    // can only safely customized in embedded swift - which doesn't have a runtime.
+    if (!LangOpts.hasFeature(Feature::Embedded)) {
+      Diags.diagnose(SourceLoc(), diag::min_ptr_value_without_embedded);
+      return true;
+    }
+    if (StringRef(A->getValue()).getAsInteger(0, Opts.CustomLeastValidPointerValue)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      return true;
+    }
+  }
+
   Opts.PrintInlineTree |= Args.hasArg(OPT_print_llvm_inline_tree);
   // Always producing all outputs when caching is enabled.
   Opts.AlwaysCompile |= Args.hasArg(OPT_always_compile_output_files) ||

--- a/lib/IRGen/SwiftTargetInfo.cpp
+++ b/lib/IRGen/SwiftTargetInfo.cpp
@@ -263,6 +263,9 @@ SwiftTargetInfo SwiftTargetInfo::get(IRGenModule &IGM) {
     break;
   }
 
+  if (IGM.getOptions().CustomLeastValidPointerValue != 0)
+    target.LeastValidPointerValue = IGM.getOptions().CustomLeastValidPointerValue;
+
   return target;
 }
 

--- a/test/embedded/min-pointer-value-option.swift
+++ b/test/embedded/min-pointer-value-option.swift
@@ -1,0 +1,21 @@
+
+// RUN: %target-swift-emit-ir %s -module-name main -parse-as-library -enable-experimental-feature Embedded -O -min-valid-pointer-value=0x200  | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: swift_feature_Embedded
+
+public func testit(_ s: S?) -> Bool {
+  return s != nil
+}
+
+class C {}
+
+public struct S {
+  var a = InlineArray<57, UInt8>(repeating: 0)
+  var b = C()
+  var c = InlineArray<49, UInt8>(repeating: 0)
+}
+
+// CHECK-LABEL: define {{.*}} @"$e4main1SVSgWOg"(ptr %0)
+// CHECK:         icmp {{.*}}, 511
+// CHECK-LABEL: }


### PR DESCRIPTION
The LeastValidPointerValue is hard-coded in the runtime. Therefore this option is only available in embedded swift - which doesn't have a runtime.

rdar://151755654
