### PR TITLE
[CSSimplify] Fix `matchDeepEqualityTypes` to allow fixing of optionals

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -560,6 +560,11 @@ public:
     return false;
   }
 
+  template <typename E>
+  bool directlyAt() const {
+    return getLocator()->directlyAt<E>();
+  }
+
   void print(llvm::raw_ostream &Out) const;
 
   SWIFT_DEBUG_DUMP;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1114,7 +1114,12 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
   if (!diagnostic)
     return false;
 
-  emitDiagnosticAt(::getLoc(anchor), *diagnostic, fromType, toType);
+  {
+    auto diag =
+        emitDiagnosticAt(::getLoc(anchor), *diagnostic, fromType, toType);
+    (void)tryFixIts(diag);
+  }
+
   emitNotesForMismatches();
   return true;
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4039,6 +4039,12 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
       getConstraintLocator(locator, {LocatorPathElt::GenericType(type1),
           LocatorPathElt::GenericType(type2)});
 
+    // Optionals have a lot of special diagnostics and only one
+    // generic argument so if we're dealing with one, let's allow
+    // `repairFailures` to take care of it.
+    if (bound1->getDecl()->isOptionalDecl())
+      return matchDeepTypeArguments(*this, subflags, args1, args2, baseLoc);
+
     auto argMatchingFlags = subflags;
     // Allow the solver to produce separate fixes while matching
     // key path's root/value to a contextual type instead of the
@@ -4048,13 +4054,6 @@ ConstraintSystem::matchDeepEqualityTypes(Type type1, Type type2,
       argMatchingFlags |= TMF_ApplyingFix;
       argMatchingFlags |= TMF_MatchingGenericArguments;
     }
-
-    // Optionals have a lot of special diagnostics and only one
-    // generic argument so if we' re dealing with one, don't produce generic
-    // arguments mismatch fixes.
-    if (bound1->getDecl()->isOptionalDecl())
-      return matchDeepTypeArguments(*this, argMatchingFlags, args1, args2,
-                                    baseLoc);
 
     SmallVector<unsigned, 4> mismatches;
     auto result = matchDeepTypeArguments(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15696,6 +15696,22 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
     unsigned impact = 1;
     if (type1->isMarkerExistential() || type2->isMarkerExistential())
       ++impact;
+
+    // If generic arguments mismatch ends up being recorded on the result
+    // of the chain or a try expression it means that there is a contextual 
+    // conversion mismatch.
+    //
+    // For optional conversions the solver currently generates a disjunction
+    // with two choices - bind and optional-to-optional conversion which is
+    // anchored on the contextual expression. If we can get a fix recorded
+    // there that would result in a better diagnostic. It's only possible
+    // for optional-to-optional choice because it doesn't bind the
+    // variable immediately, so we need to downgrade direct fixes to prevent
+    // `bind` choice from considered better.
+    if (fix->directlyAt<OptionalEvaluationExpr>() ||
+        fix->directlyAt<AnyTryExpr>())
+      impact += 2;
+
     return recordFix(fix, impact) ? SolutionKind::Error : SolutionKind::Solved;
   }
 

--- a/test/ClangImporter/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header.swift
@@ -66,11 +66,13 @@ func testProtocolNamingConflict() {
   let a: ConflictingName1?
   var b: ConflictingName1Protocol?
   b = a // expected-error {{cannot assign value of type 'ConflictingName1?' to type '(any ConflictingName1Protocol)?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('ConflictingName1' and 'any ConflictingName1Protocol') are expected to be equal}}
   _ = b
 
   let c: ConflictingName2?
   var d: ConflictingName2Protocol?
   d = c // expected-error {{cannot assign value of type 'ConflictingName2?' to type '(any ConflictingName2Protocol)?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('ConflictingName2' and 'any ConflictingName2Protocol') are expected to be equal}}
   _ = d
 }
 

--- a/test/ClangImporter/cf.swift
+++ b/test/ClangImporter/cf.swift
@@ -118,6 +118,7 @@ func testOutParametersGood() {
 func testOutParametersBad() {
   let fridge: CCRefrigerator?
   CCRefrigeratorCreateIndirect(fridge) // expected-error {{cannot convert value of type 'CCRefrigerator?' to expected argument type 'UnsafeMutablePointer<CCRefrigerator?>?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('CCRefrigerator' and 'UnsafeMutablePointer<CCRefrigerator?>') are expected to be equal}}
 
   let power: CCPowerSupply?
   CCRefrigeratorGetPowerSupplyIndirect(0, power)
@@ -128,13 +129,16 @@ func testOutParametersBad() {
   CCRefrigeratorGetItemUnaudited(0, 0, item)
   // expected-error@-1:34 {{cannot convert value of type 'Int' to expected argument type 'CCRefrigerator'}}
   // expected-error@-2:40 {{cannot convert value of type 'CCItem?' to expected argument type 'UnsafeMutablePointer<Unmanaged<CCItem>?>?'}}
+  // expected-note@-3 {{arguments to generic parameter 'Wrapped' ('CCItem' and 'UnsafeMutablePointer<Unmanaged<CCItem>?>') are expected to be equal}}
 }
 
 func nameCollisions() {
   var objc: MyProblematicObject?
   var cf: MyProblematicObjectRef?
   cf = objc // expected-error {{cannot assign value of type 'MyProblematicObject?' to type 'MyProblematicObjectRef?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('MyProblematicObject' and 'MyProblematicObjectRef') are expected to be equal}}
   objc = cf // expected-error {{cannot assign value of type 'MyProblematicObjectRef?' to type 'MyProblematicObject?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('MyProblematicObjectRef' and 'MyProblematicObject') are expected to be equal}}
 
   var cfAlias: MyProblematicAliasRef?
   cfAlias = cf // okay
@@ -142,7 +146,9 @@ func nameCollisions() {
 
   var otherAlias: MyProblematicAlias?
   otherAlias = cfAlias // expected-error {{cannot assign value of type 'MyProblematicAliasRef?' (aka 'Optional<MyProblematicObjectRef>') to type 'MyProblematicAlias?' (aka 'Optional<Float>')}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('MyProblematicAliasRef' (aka 'MyProblematicObjectRef') and 'MyProblematicAlias' (aka 'Float')) are expected to be equal}}
   cfAlias = otherAlias // expected-error {{cannot assign value of type 'MyProblematicAlias?' (aka 'Optional<Float>') to type 'MyProblematicAliasRef?' (aka 'Optional<MyProblematicObjectRef>')}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('MyProblematicAlias' (aka 'Float') and 'MyProblematicAliasRef' (aka 'MyProblematicObjectRef')) are expected to be equal}}
 
   func isOptionalFloat(_: inout Optional<Float>) {}
   isOptionalFloat(&otherAlias) // okay

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -214,6 +214,7 @@ func testFunctionPointers() {
 
   useFunctionPointer2(anotherFP)
   sizedFP = fp // expected-error {{cannot assign value of type 'fptr?' (aka 'Optional<@convention(c) (Int32) -> Int32>') to type '(@convention(c) (CInt, CInt, UnsafeMutableRawPointer?) -> Void)?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('fptr' (aka '@convention(c) (Int32) -> Int32') and '@convention(c) (CInt, CInt, UnsafeMutableRawPointer?) -> Void'}}
 }
 
 func testStructDefaultInit() {

--- a/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
+++ b/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
@@ -62,7 +62,7 @@ func bridgeNSNumberBackToSpecificType(object: ${ObjectType},
   _ = object as? ${Type}
   _ = object as! ${Type}
 
-  _ = optional as ${Type}? // expected-error{{is not convertible to}} expected-note {{use 'as!'}}
+  _ = optional as ${Type}? // expected-error{{cannot convert value of type '${ObjectType}?' to type '${Type}?' in coercion}} expected-note {{arguments to generic parameter 'Wrapped' ('${ObjectType}' and '${Type}') are expected to be equal}}
   _ = optional is ${Type}?
   _ = optional as? ${Type}?
   _ = optional as! ${Type}?

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -283,13 +283,17 @@ func rdar19831698() {
 // <rdar://problem/19836341> Incorrect fixit for NSString? to String? conversions
 func rdar19836341(_ ns: NSString?, vns: NSString?) {
   var vns = vns
-  let _: String? = ns // expected-error{{cannot convert value of type 'NSString?' to specified type 'String?'}}{{22-22= as String?}}
-  var _: String? = ns // expected-error{{cannot convert value of type 'NSString?' to specified type 'String?'}}{{22-22= as String?}}
+  let _: String? = ns // expected-error{{cannot assign value of type 'NSString?' to type 'String?'}}{{22-22= as String?}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('NSString' and 'String') are expected to be equal}}
+  var _: String? = ns // expected-error{{cannot assign value of type 'NSString?' to type 'String?'}}{{22-22= as String?}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('NSString' and 'String') are expected to be equal}}
 
   // Important part about below diagnostic is that from-type is described as
   // 'NSString?' and not '@lvalue NSString?':
-  let _: String? = vns // expected-error{{cannot convert value of type 'NSString?' to specified type 'String?'}}{{23-23= as String?}}
-  var _: String? = vns // expected-error{{cannot convert value of type 'NSString?' to specified type 'String?'}}{{23-23= as String?}}
+  let _: String? = vns // expected-error{{cannot assign value of type 'NSString?' to type 'String?'}}{{23-23= as String?}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('NSString' and 'String') are expected to be equal}}
+  var _: String? = vns // expected-error{{cannot assign value of type 'NSString?' to type 'String?'}}{{23-23= as String?}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('NSString' and 'String') are expected to be equal}}
 
   vns = ns
 }
@@ -300,7 +304,8 @@ func rdar20029786(_ ns: NSString?) {
   // expected-error@-1 {{cannot convert value of type 'NSString?' to expected argument type 'String?'}} {{21-21= as String?}}
   var s2 = ns ?? "str" as String as String // expected-error {{binary operator '??' cannot be applied to operands of type 'NSString?' and 'String'}}
 
-  let s3: NSString? = "str" as String? // expected-error {{cannot convert value of type 'String?' to specified type 'NSString?'}}{{39-39= as NSString?}}
+  let s3: NSString? = "str" as String? // expected-error {{cannot assign value of type 'String?' to type 'NSString?'}}{{39-39= as NSString?}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('String' and 'NSString') are expected to be equal}}
 
   var s4: String = ns ?? "str" // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}} {{20-20=(}} {{31-31=) as String}}
   var s5: String = (ns ?? "str") as String // fixed version
@@ -308,7 +313,8 @@ func rdar20029786(_ ns: NSString?) {
 
 // Make sure more complicated cast has correct parenthesization
 func castMoreComplicated(anInt: Int?) {
-  let _: (NSObject & NSCopying)? = anInt // expected-error{{cannot convert value of type 'Int?' to specified type '(any NSObject & NSCopying)?'}}{{41-41= as (any NSObject & NSCopying)?}}
+  let _: (NSObject & NSCopying)? = anInt // expected-error{{cannot assign value of type 'Int?' to type '(any NSObject & NSCopying)?'}}{{41-41= as (any NSObject & NSCopying)?}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('Int' and 'any NSObject & NSCopying') are expected to be equal}}
 }
 
 

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -82,8 +82,8 @@ func optionalityMismatchingCasts(f: CGFloat, n: NSNumber, fooo: CGFloat???,
                                  nooo: NSNumber???) {
   _ = f as NSNumber?
   _ = f as NSNumber??
-  let _ = fooo as NSNumber?? // expected-error{{'CGFloat???' is not convertible to 'NSNumber??'}}
-  //expected-note@-1 {{did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
+  let _ = fooo as NSNumber?? // expected-error{{cannot convert value of type 'CGFloat???' to type 'NSNumber??' in coercion}}
+  //expected-note@-1 {{arguments to generic parameter 'Wrapped' ('CGFloat?' and 'NSNumber') are expected to be equal}}
   let _ = fooo as NSNumber???? // okay: injects extra optionals
 }
 

--- a/test/Constraints/fixes.swift
+++ b/test/Constraints/fixes.swift
@@ -158,16 +158,14 @@ struct Q {
   let s: String?
 }
 let q = Q(s: nil)
-let a: Int? = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
-// expected-error@-1 {{cannot convert value of type 'String.UTF8View?' to specified type 'Int?'}}
-// expected-note@-2{{chain the optional using '?'}}{{18-18=?}}
-let b: Int = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
+let a: Int? = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}} expected-note {{chain the optional using '?'}}{{18-18=?}}
+// expected-error@-1 {{cannot assign value of type 'String.UTF8View?' to type 'Int?'}}
+// expected-note@-2 {{arguments to generic parameter 'Wrapped' ('String.UTF8View' and 'Int') are expected to be equal}}
+let b: Int = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}} expected-note {{chain the optional using '?'}}{{17-17=?}} expected-note {{force-unwrap using '!'}}{{17-17=!}}
 // expected-error@-1 {{cannot convert value of type 'String.UTF8View' to specified type 'Int'}}
-// expected-note@-2{{chain the optional using '?'}}{{17-17=?}}
-// expected-note@-3{{force-unwrap using '!'}}{{17-17=!}}
-let d: Int! = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
-// expected-error@-1 {{cannot convert value of type 'String.UTF8View?' to specified type 'Int?'}}
-// expected-note@-2{{chain the optional using '?'}}{{18-18=?}}
+let d: Int! = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}} expected-note {{chain the optional using '?'}}{{18-18=?}}
+// expected-error@-1 {{cannot assign value of type 'String.UTF8View?' to type 'Int?'}}
+// expected-note@-2 {{arguments to generic parameter 'Wrapped' ('String.UTF8View' and 'Int') are expected to be equal}}
 let c = q.s.utf8 // expected-error{{value of optional type 'String?' must be unwrapped to refer to member 'utf8' of wrapped base type 'String'}}
 // expected-note@-1{{chain the optional using '?' to access member 'utf8' only for non-'nil' base values}}{{12-12=?}}
 // expected-note@-2{{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}{{12-12=!}}

--- a/test/Constraints/invalid_implicit_conversions.swift
+++ b/test/Constraints/invalid_implicit_conversions.swift
@@ -29,7 +29,7 @@ func test(
 
   takesAutoclosure(rawPtr, a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafeRawPointer'}}
   takesAutoclosure(ptr, a) // expected-error {{cannot perform pointer conversion of value of type '[Int]' to autoclosure result type 'UnsafePointer<Int>'}}
-  takesAutoclosure(optPtr, b) // expected-error {{cannot perform pointer conversion of value of type '[Int]?' to autoclosure result type 'UnsafePointer<Int>?'}}
+  takesAutoclosure(optPtr, b) // expected-error {{conflicting arguments to generic parameter 'T' ('UnsafePointer<Int>?' vs. '[Int]?')}}
 
   takesAutoclosure(rawPtr, s) // expected-error {{cannot perform pointer conversion of value of type 'String' to autoclosure result type 'UnsafeRawPointer'}}
   takesAutoclosure(ptrI8, s) // expected-error {{cannot perform pointer conversion of value of type 'String' to autoclosure result type 'UnsafePointer<Int8>'}}

--- a/test/Constraints/issue-81023.swift
+++ b/test/Constraints/issue-81023.swift
@@ -1,0 +1,30 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/81023
+
+protocol MyPublisher {
+  associatedtype Output
+  associatedtype Failure: Error
+  func eraseToAnyPublisher() -> MyAnyPublisher<Output, Failure>
+}
+
+extension MyPublisher {
+  func eraseToAnyPublisher() -> MyAnyPublisher<Output, Failure> {
+    fatalError()
+  }
+}
+
+struct MyAnyPublisher<Output, Failure: Error>: MyPublisher {}
+struct MyJust<Output>: MyPublisher {
+  typealias Failure = Never
+  init(_ value: Output) {}
+}
+
+extension MyPublisher where Output == (any Collection)? { // expected-note {{where 'Self.Output' = '[Int]?'}}
+  func mapCount() -> MyAnyPublisher<Int, Failure> { fatalError() }
+}
+
+func test(myPub: MyAnyPublisher<[Int]?, Never>) {
+  myPub.mapCount()
+  // expected-error@-1 {{referencing instance method 'mapCount()' on 'MyPublisher' requires the types '[Int]?' and '(any Collection)?' be equivalent}}
+}

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -216,7 +216,8 @@ let _ = (returnsIUO as () -> Int)() // expected-error {{cannot convert value of 
 // Make sure we only permit an IUO unwrap on the first application.
 func returnsIUOFn() -> (() -> Int?)! { nil }
 let _: (() -> Int?)? = returnsIUOFn()
-let _: (() -> Int)? = returnsIUOFn() // expected-error {{cannot convert value of type '(() -> Int?)?' to specified type '(() -> Int)?'}}
+let _: (() -> Int)? = returnsIUOFn() // expected-error {{cannot assign value of type '(() -> Int?)?' to type '(() -> Int)?'}}
+// expected-note@-1 {{arguments to generic parameter 'Wrapped' ('() -> Int?' and '() -> Int') are expected to be equal}}
 let _: () -> Int? = returnsIUOFn()
 let _: () -> Int = returnsIUOFn() // expected-error {{cannot convert value of type '(() -> Int?)?' to specified type '() -> Int'}}
 let _: Int? = returnsIUOFn()()

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -34,7 +34,7 @@ class Demo {
 
 let some = Some(keyPath: \Demo.here)
 // expected-error@-1 {{cannot convert value of type 'KeyPath<Demo, (() -> Void)?>' to expected argument type 'KeyPath<Demo, ((V) -> Void)?>'}}
-// expected-note@-2 {{arguments to generic parameter 'Value' ('(() -> Void)?' and '((V) -> Void)?') are expected to be equal}}
+// expected-note@-2 {{arguments to generic parameter 'Wrapped' ('() -> Void' and '(V) -> Void') are expected to be equal}}
 // expected-error@-3 {{generic parameter 'V' could not be inferred}}
 // expected-note@-4 {{explicitly specify the generic arguments to fix this issue}}
 

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -278,6 +278,7 @@ func rdar60727310() {
   func myAssertion<T>(_ a: T, _ op: ((T,T)->Bool), _ b: T) {}
   var e: Error? = nil
   myAssertion(e, ==, nil) // expected-error {{cannot convert value of type '(any Error)?' to expected argument type '(any (~Copyable & ~Escapable).Type)?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('any Error' and 'any (~Copyable & ~Escapable).Type') are expected to be equal}}
 }
 
 // https://github.com/apple/swift/issues/54877

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -113,6 +113,7 @@ let squares = [ 1, 2, 3 ].reduce([:]) { (dict, n) in
 func r23670252(_ dictionary: [String : AnyObject], someObject: AnyObject) {
   let color : String?
   color = dictionary["color"]  // expected-error {{cannot assign value of type 'AnyObject?' to type 'String?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('AnyObject' and 'String') are expected to be equal}}
   _ = color
 }
 

--- a/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
+++ b/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
@@ -59,7 +59,7 @@ func test_${TestPtrSize}_bit_ptrs(sptr: UnsafePointer<Int${TestPtrSize}>,
   % end
 
   % for pointer in ['osptr', 'ouptr']:
-    opt_char_ptr_func(${pointer}) // expected-error {{}}
+    opt_char_ptr_func(${pointer}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
     const_opt_char_ptr_func(${pointer}) // Ok
     unsigned_opt_char_ptr_func(${pointer}) // expected-error {{}}
     const_opt_unsigned_char_ptr_func(${pointer}) // Ok
@@ -96,13 +96,13 @@ func test_${TestPtrSize}_bit_ptrs(sptr: UnsafePointer<Int${TestPtrSize}>,
   % for pointer in ['osptr', 'ouptr']:
     % for Size in ['16', '32', '64']:
       % if Size == TestPtrSize:
-        opt_int_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
-        opt_uint_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}}
+        opt_int_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
+        opt_uint_${TestPtrSize}_ptr_func(${pointer}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
         const_opt_int_${TestPtrSize}_ptr_func(${pointer}) // Ok
         const_opt_uint_${TestPtrSize}_ptr_func(${pointer}) // Ok
       % else:
-        opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}}
-        opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}}
+        opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
+        opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
         const_opt_int_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
         const_opt_uint_${Size}_ptr_func(${pointer}) // expected-error {{}} expected-note {{}}
       % end
@@ -215,7 +215,7 @@ func test_raw_ptr_value_to_optional_promotion(
 func test_raw_ptr_optional_to_optional_conversion(
   riptr: UnsafeRawPointer?,
   rmptr: UnsafeMutableRawPointer?) {
-  opt_char_ptr_func(riptr) // expected-error {{}}
+  opt_char_ptr_func(riptr) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
   const_opt_char_ptr_func(riptr) // Ok
 
   opt_char_ptr_func(rmptr) // Ok
@@ -226,11 +226,11 @@ func test_raw_ptr_optional_to_optional_conversion(
 
   % for Ptr in ['riptr', 'rmptr']:
     % for Size in ['16', '32', '64']:
-      opt_int_${Size}_ptr_func(${Ptr}) // expected-error {{}}
-      opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+      opt_int_${Size}_ptr_func(${Ptr}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
+      opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
 
-      const_opt_int_${Size}_ptr_func(${Ptr}) // expected-error {{}}
-      const_opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}}
+      const_opt_int_${Size}_ptr_func(${Ptr}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
+      const_opt_uint_${Size}_ptr_func(${Ptr}) // expected-error {{}} expected-note {{arguments to generic parameter 'Wrapped'}}
     % end
   % end
 }

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -340,6 +340,7 @@ var optionalTuple3: (UInt64, Int)? = (bignum, 1) // expected-error {{cannot conv
 optionalTuple = (bignum, 1) // expected-error {{cannot assign value of type '(Int64, Int)' to type '(Int, Int)'}}
 // Optional to Optional
 optionalTuple = optionalTuple2 // expected-error {{cannot assign value of type '(Int64, Int)?' to type '(Int, Int)?'}}
+// expected-note@-1 {{arguments to generic parameter 'Wrapped' ('(Int64, Int)' and '(Int, Int)') are expected to be equal}}
 
 func testTupleLabelMismatchFuncConversion(fn1: @escaping ((x: Int, y: Int)) -> Void,
                                           fn2: @escaping () -> (x: Int, Int)) {

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1660,6 +1660,7 @@ do {
   func foo(_: (() -> Void)?) {}
   func bar() -> ((()) -> Void)? { return nil }
   foo(bar()) // expected-error {{cannot convert value of type '((()) -> Void)?' to expected argument type '(() -> Void)?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('(()) -> Void' and '() -> Void') are expected to be equal}}
 }
 
 // https://github.com/apple/swift/issues/49059
@@ -1699,6 +1700,7 @@ do {
   func log<T>() -> ((T) -> Void)? { return nil }
 
   f(a: log() as ((()) -> Void)?) // expected-error {{cannot convert value of type '((()) -> Void)?' to expected argument type '(() -> Void)?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('(()) -> Void' and '() -> Void') are expected to be equal}}
 
   func logNoOptional<T>() -> (T) -> Void { }
   f(a: logNoOptional() as ((()) -> Void)) // expected-error {{cannot convert value of type '(()) -> Void' to expected argument type '() -> Void'}}

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -237,12 +237,14 @@ struct ThingProducer {
 }
 
 let optProducer: ThingProducer? = ThingProducer()
-let _: Int? = try? optProducer?.produceInt() // expected-error {{value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?}}
+let _: Int? = try? optProducer?.produceInt() // expected-error {{cannot assign value of type 'Int??' to type 'Int?'}}
+// expected-note@-1 {{arguments to generic parameter 'Wrapped' ('Int?' and 'Int') are expected to be equal}}
 let _: Int = try? optProducer?.produceInt() // expected-error {{cannot convert value of type 'Int??' to specified type 'Int'}}
 let _: String = try? optProducer?.produceInt() // expected-error {{cannot convert value of type 'Int??' to specified type 'String'}}
 let _: Int?? = try? optProducer?.produceInt() // good
 
-let _: Int? = try? optProducer?.produceIntNoThrowing() // expected-error {{value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?}}
+let _: Int? = try? optProducer?.produceIntNoThrowing() // expected-error {{cannot assign value of type 'Int??' to type 'Int?'}}
+// expected-note@-1 {{arguments to generic parameter 'Wrapped' ('Int?' and 'Int') are expected to be equal}}
 let _: Int?? = try? optProducer?.produceIntNoThrowing() // expected-warning {{no calls to throwing functions occur within 'try' expression}}
 
 let _: Int? = (try? optProducer?.produceAny()) as? Int // good

--- a/test/Sema/clang_fn_type_mismatch.swift
+++ b/test/Sema/clang_fn_type_mismatch.swift
@@ -12,10 +12,12 @@ let _ : @convention(c) (Int) -> Int = f1!
 // expected-error@-1{{cannot convert value of type '@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int' to specified type '@convention(c) (Int) -> Int'}}
 
 let _ : (@convention(c) (Int) -> Int)? = f1
-// expected-error@-1{{cannot convert value of type '(@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?' to specified type '(@convention(c) (Int) -> Int)?'}}
+// expected-error@-1{{cannot assign value of type '(@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?' to type '(@convention(c) (Int) -> Int)?'}}
+// expected-note@-2 {{arguments to generic parameter 'Wrapped' ('@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int' and '@convention(c) (Int) -> Int') are expected to be equal}}
 
 let _ : (@convention(c, cType: "void *(*)(void *)") (Int) -> Int)? = f1
-// expected-error@-1{{cannot convert value of type '(@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?' to specified type '(@convention(c, cType: "void *(*)(void *)") (Int) -> Int)?'}}
+// expected-error@-1{{cannot assign value of type '(@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int)?' to type '(@convention(c, cType: "void *(*)(void *)") (Int) -> Int)?'}}
+// expected-note@-2 {{arguments to generic parameter 'Wrapped' ('@convention(c, cType: "size_t (*)(size_t)") (Int) -> Int' and '@convention(c, cType: "void *(*)(void *)") (Int) -> Int') are expected to be equal}}
 
 
 // Converting from @convention(c) -> @convention(swift) works

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -45,11 +45,13 @@ public func testVTableBuilding(user: User) {
 
 #if VERIFY
 let _: String = useAssoc(ImportedType.self) // expected-error {{cannot convert value of type 'Int32?' to specified type 'String'}}
-let _: Bool? = useAssoc(ImportedType.self) // expected-error {{cannot convert value of type 'Int32?' to specified type 'Bool?'}}
+let _: Bool? = useAssoc(ImportedType.self) // expected-error {{cannot assign value of type 'Int32?' to type 'Bool?'}}
+// expected-note@-1 {{arguments to generic parameter 'Wrapped' ('Int32' and 'Bool') are expected to be equal}}
 let _: Int32? = useAssoc(ImportedType.self)
 
 let _: String = useAssoc(AnotherType.self) // expected-error {{cannot convert value of type 'AnotherType.Assoc?' (aka 'Optional<Int32>') to specified type 'String'}}
-let _: Bool? = useAssoc(AnotherType.self) // expected-error {{cannot convert value of type 'AnotherType.Assoc?' (aka 'Optional<Int32>') to specified type 'Bool?'}}
+let _: Bool? = useAssoc(AnotherType.self) // expected-error {{cannot assign value of type 'AnotherType.Assoc?' (aka 'Optional<Int32>') to type 'Bool?'}}
+// expected-note@-1 {{arguments to generic parameter 'Wrapped' ('AnotherType.Assoc' (aka 'Int32') and 'Bool') are expected to be equal}}
 let _: Int32? = useAssoc(AnotherType.self)
 
 let _ = wrapped // expected-error {{cannot find 'wrapped' in scope}}

--- a/test/decl/class/circular_inheritance_2.swift
+++ b/test/decl/class/circular_inheritance_2.swift
@@ -4,5 +4,6 @@
 class Foo {}
 class Bar: Bar {} // expected-error{{'Bar' inherits from itself}}
 func foo(_ o: AnyObject) -> Foo? {
-    return o as? Bar // expected-error{{cannot convert return expression of type 'Bar?' to return type 'Foo?'}}
+  return o as? Bar // expected-error{{cannot convert return expression of type 'Bar?' to return type 'Foo?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('Bar' and 'Foo') are expected to be equal}}
 }

--- a/test/expr/cast/optional.swift
+++ b/test/expr/cast/optional.swift
@@ -45,5 +45,6 @@ func implicitCastOfLiteralToOptional() {
 // https://github.com/apple/swift/issues/46093
 func castUnrelatedOptionalTypes(x: Int?) {
   let _ = x as String? // expected-error {{cannot convert value}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('Int' and 'String') are expected to be equal}}
   let _ = x as? String? // no-warning
 }

--- a/test/expr/conversions/RawRepresentable_fixits.swift
+++ b/test/expr/conversions/RawRepresentable_fixits.swift
@@ -85,22 +85,28 @@ do {
 
     // FIXME: No fix-it. Could be 'int_o.map { Mask(rawValue: UInt64($0)) }'.
     let _: Mask? = int_o
-    // expected-error@-1:20 {{cannot convert value of type 'Int?' to specified type 'Mask?'}}{{none}}
+    // expected-error@-1:20 {{cannot assign value of type 'Int?' to type 'Mask?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Int' and 'Mask') are expected to be equal}}
     takeMask_o(int_o)
     // expected-error@-1:16 {{cannot convert value of type 'Int?' to expected argument type 'Mask?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Int' and 'Mask') are expected to be equal}}
 
     // FIXME: No fix-it. Could be 'uint64_o.map(Mask(rawValue:))' or 'uint64_o.map { Mask(rawValue: $0) }'.
     let _: Mask? = uint64_o
-    // expected-error@-1:20 {{cannot convert value of type 'UInt64?' to specified type 'Mask?'}}{{none}}
+    // expected-error@-1:20 {{cannot assign value of type 'UInt64?' to type 'Mask?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('UInt64' and 'Mask') are expected to be equal}}
     takeMask_o(uint64_o)
     // expected-error@-1:16 {{cannot convert value of type 'UInt64?' to expected argument type 'Mask?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('UInt64' and 'Mask') are expected to be equal}}
 
     // FIXME: No fix-it. Could be '(anything as? Int).map { Mask(rawValue: UInt64($0)) }'.
     let anything: Any
     let _: Mask? = anything as? Int
-    // expected-error@-1:29 {{cannot convert value of type 'Int?' to specified type 'Mask?'}}{{none}}
+    // expected-error@-1:29 {{cannot assign value of type 'Int?' to type 'Mask?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Int' and 'Mask') are expected to be equal}}
     takeMask_o(anything as? Int)
     // expected-error@-1:25 {{cannot convert value of type 'Int?' to expected argument type 'Mask?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Int' and 'Mask') are expected to be equal}}
   }
 
   // Try a nested OptionSet.
@@ -162,15 +168,18 @@ do {
 
     // FIXME: No fix-it. Could be 'mask_o.map { Int($0.rawValue) }'.
     let _: Int? = mask_o
-    // expected-error@-1:19 {{cannot convert value of type 'Mask?' to specified type 'Int?'}}{{none}}
+    // expected-error@-1:19 {{cannot assign value of type 'Mask?' to type 'Int?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Mask' and 'Int') are expected to be equal}}
     takeInt_o(mask_o)
     // expected-error@-1:15 {{cannot convert value of type 'Mask?' to expected argument type 'Int?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Mask' and 'Int') are expected to be equal}}
 
     // FIXME: No fix-it. Could be 'mask_o?.rawValue' or 'mask_o.map { $0.rawValue }'.
     let _: UInt64? = mask_o
     // expected-error@-1:22 {{cannot convert value of type 'Mask?' to specified type 'UInt64?'}}{{28-28=?.rawValue}}
     takeUInt64_o(mask_o)
     // expected-error@-1:18 {{cannot convert value of type 'Mask?' to expected argument type 'UInt64?'}}{{none}}
+    // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Mask' and 'UInt64') are expected to be equal}}
   }
 }
 
@@ -202,7 +211,7 @@ do {
     takeAnyObject(iuo)
     // expected-error@-1:19 {{argument type 'ClassWrapper?' expected to be an instance of a class or class-constrained type}}{{none}}
     takeAnyObjectOpt(iuo)
-    // expected-error@-1:22 {{argument type 'ClassWrapper' expected to be an instance of a class or class-constrained type}}{{none}}
+    // expected-error@-1:22 {{argument type 'ClassWrapper?' expected to be an instance of a class or class-constrained type}}{{none}}
 
     let _: ClassWrapper = subClass
     // expected-error@-1:27 {{cannot convert value of type 'SubClass' to specified type 'ClassWrapper'}}{{27-27=ClassWrapper(rawValue: }} {{35-35=) ?? <#default value#>}}

--- a/test/stdlib/UnsafePointerDiagnostics.swift
+++ b/test/stdlib/UnsafePointerDiagnostics.swift
@@ -80,12 +80,14 @@ func unsafePointerConversionAvailability(
   _ = UnsafeMutablePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
   // This is ambiguous because we have failable and non-failable initializers that accept the same argument type.
   _ = UnsafeMutablePointer<Int>(orp) // expected-error {{no exact matches in call to initializer}}
-  _ = UnsafeMutablePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafeMutablePointer<Int>'}}
+  // Two candidates here: OpaquePointer? and UnsafeMutablePointer<Int>?
+  _ = UnsafeMutablePointer<Int>(omrp) // expected-error {{no exact matches in call to initializer}}
 
   _ = UnsafePointer<Int>(rp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<Int>'}}
   _ = UnsafePointer<Int>(mrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafePointer<Int>'}}
-  _ = UnsafePointer<Int>(orp)  // expected-error {{cannot convert value of type 'UnsafeRawPointer' to expected argument type 'UnsafePointer<Int>'}}
-  _ = UnsafePointer<Int>(omrp) // expected-error {{cannot convert value of type 'UnsafeMutableRawPointer' to expected argument type 'UnsafePointer<Int>'}}
+  // Two candidates here: OpaquePointer? and UnsafeMutablePointer<Int>?
+  _ = UnsafePointer<Int>(orp)  // expected-error {{no exact matches in call to initializer}}
+  _ = UnsafePointer<Int>(omrp) // expected-error {{no exact matches in call to initializer}}
 
   _ = UnsafePointer<Int>(ups) // expected-error {{cannot convert value of type 'UnsafePointer<String>' to expected argument type 'UnsafePointer<Int>'}}
   // expected-note@-1 {{arguments to generic parameter 'Pointee' ('String' and 'Int') are expected to be equal}}
@@ -123,6 +125,7 @@ func unsafeRawBufferPointerConversions(
   _ = UnsafeMutableRawBufferPointer(start: omrp, count: 1)
   _ = UnsafeRawBufferPointer(start: omrp, count: 1)
   _ = UnsafeMutableRawBufferPointer(start: orp, count: 1) // expected-error {{cannot convert value of type 'UnsafeRawPointer?' to expected argument type 'UnsafeMutableRawPointer?'}}
+  // expected-note@-1 {{arguments to generic parameter 'Wrapped' ('UnsafeRawPointer' and 'UnsafeMutableRawPointer') are expected to be equal}}
   _ = UnsafeRawBufferPointer(start: orp, count: 1)
 }
 

--- a/test/stmt/if_while_var.swift
+++ b/test/stmt/if_while_var.swift
@@ -64,7 +64,8 @@ if case let x? = nonOptionalEnum() { _ = x } // expected-error{{'?' pattern cann
 if let x { _ = x } // expected-error{{cannot find 'x' in scope}}
 
 if let optional: String { _ = optional }
-if let optional: Int { _ = optional } // expected-error{{cannot convert value of type 'String?' to specified type 'Int?'}}
+if let optional: Int { _ = optional } // expected-error{{cannot assign value of type 'String?' to type 'Int?'}}
+// expected-note@-1 {{arguments to generic parameter 'Wrapped' ('String' and 'Int') are expected to be equal}}
 
 class B {} // expected-note * {{did you mean 'B'?}}
 class D : B {}// expected-note * {{did you mean 'D'?}}

--- a/validation-test/compiler_crashers_2_fixed/issue-54093.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-54093.swift
@@ -13,11 +13,12 @@ class Test1 {
 }
 
 @propertyWrapper 
-struct Wrapper2 { // expected-note {{property wrapper type 'Wrapper2' declared here}}
+struct Wrapper2 {
   var wrappedValue: Int??
 }
 
 class Test2 {
   @Wrapper2 var user: Int? 
-  // expected-error@-1 {{property type 'Int?' does not match that of the 'wrappedValue' property of its wrapper type 'Wrapper2'}}
+  // expected-error@-1 {{property type 'Int?' does not match 'wrappedValue' type 'Int??'}}
+  // expected-note@-2 {{arguments to generic parameter 'Wrapped' ('Int' and 'Int?') are expected to be equal}}
 }


### PR DESCRIPTION
Attempting to propagate generic argument failures up is not always
reliable, `matchDeepEqualityTypes` should avoid using `TMF_ApplyingFix`
while dealing with optionals and instead let `repairFailures` decide
whether to use generic arguments mismatch fix to a more general one.

`GenericArgument` handling is updated to:

- Produce a tailored fix for a mismatch in tuple element position
- Produce a tailored fixes in situations where optional object type is not a class and matched against `AnyObject`
- Increase impact if mismatch is contextual (to help prefer a fix at a better location)

Resolves: https://github.com/swiftlang/swift/issues/81023
Resolves: rdar://149843877

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
