### PR TITLE
Rename SwiftStdlibCurrentOS to StdlibDeploymentTarget.

### DIFF
--- a/Runtimes/Core/cmake/modules/AvailabilityMacros.cmake
+++ b/Runtimes/Core/cmake/modules/AvailabilityMacros.cmake
@@ -7,13 +7,13 @@ foreach(def ${availability_defs})
   add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"${def}\">")
 
   if("${def}" MATCHES "SwiftStdlib .*")
-    # For each SwiftStdlib x.y, also define SwiftStdlibCurrentOS x.y, which,
+    # For each SwiftStdlib x.y, also define StdlibDeploymentTarget x.y, which,
     # will expand to the current `-target` platform if the macro defines a
     # newer platform as its availability.
     #
     # There is a setting, SwiftCore_ENABLE_STRICT_AVAILABILITY, which if set
     # ON will cause us to use the "proper" availability instead.
-    string(REPLACE "SwiftStdlib" "SwiftStdlibCurrentOS" current "${def}")
+    string(REPLACE "SwiftStdlib" "StdlibDeploymentTarget" current "${def}")
     if(NOT SwiftCore_ENABLE_STRICT_AVAILABILITY AND SwiftCore_SWIFT_AVAILABILITY_PLATFORM)
       if("${SwiftCore_SWIFT_AVAILABILITY_PLATFORM}" STREQUAL "macOS" AND "${SwiftCore_VARIANT_AVAILABILITY_PLATFORM}" STREQUAL "iOS")
         string(REGEX MATCH "iOS ([0-9]+(\.[0-9]+)+)" ios_platform_version "${def}")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1005,13 +1005,13 @@ function(add_swift_target_library_single target name)
     list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS "-Xfrontend" "-define-availability" "-Xfrontend" "${def}")
 
     if("${def}" MATCHES "SwiftStdlib .*")
-      # For each SwiftStdlib x.y, also define SwiftStdlibCurrentOS x.y, which,
+      # For each SwiftStdlib x.y, also define StdlibDeploymentTarget x.y, which,
       # will expand to the current `-target` platform if the macro defines a
       # newer platform as its availability.
       #
       # There is a setting, SWIFT_STDLIB_ENABLE_STRICT_AVAILABILITY, which if set
       # ON will cause us to use the "proper" availability instead.
-      string(REPLACE "SwiftStdlib" "SwiftStdlibCurrentOS" current "${def}")
+      string(REPLACE "SwiftStdlib" "StdlibDeploymentTarget" current "${def}")
       if(NOT SWIFT_STDLIB_ENABLE_STRICT_AVAILABILITY AND SWIFT_SDK_${SWIFTLIB_SINGLE_SDK}_AVAILABILITY_NAME)
         if(SWIFTLIB_SINGLE_SDK STREQUAL "OSX" AND SWIFTLIB_SINGLE_MACCATALYST_BUILD_FLAVOR STREQUAL "ios-like")
           string(REGEX MATCH "iOS ([0-9]+(\.[0-9]+)+)" platform_version "${def}")

--- a/stdlib/public/Concurrency/CFExecutor.swift
+++ b/stdlib/public/Concurrency/CFExecutor.swift
@@ -43,7 +43,7 @@ enum CoreFoundation {
 
 // .. Main Executor ............................................................
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public final class CFMainExecutor: DispatchMainExecutor, @unchecked Sendable {
 
   override public func run() throws {
@@ -58,7 +58,7 @@ public final class CFMainExecutor: DispatchMainExecutor, @unchecked Sendable {
 
 // .. Task Executor ............................................................
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public final class CFTaskExecutor: DispatchGlobalTaskExecutor,
                                    @unchecked Sendable {
 

--- a/stdlib/public/Concurrency/Clock.swift
+++ b/stdlib/public/Concurrency/Clock.swift
@@ -30,7 +30,7 @@ import Swift
 ///
 /// For more information about specific clocks see `ContinuousClock` and
 /// `SuspendingClock`.
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 public protocol Clock<Duration>: Sendable {
   associatedtype Duration
   associatedtype Instant: InstantProtocol where Instant.Duration == Duration
@@ -43,7 +43,7 @@ public protocol Clock<Duration>: Sendable {
 #endif
 
   /// The traits associated with this clock instance.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   var traits: ClockTraits { get }
 
   /// Convert a Clock-specific Duration to a Swift Duration
@@ -59,7 +59,7 @@ public protocol Clock<Duration>: Sendable {
   ///
   /// Returns: A `Swift.Duration` representing the equivalent duration, or
   ///          `nil` if this function is not supported.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   func convert(from duration: Duration) -> Swift.Duration?
 
   /// Convert a Swift Duration to a Clock-specific Duration
@@ -70,7 +70,7 @@ public protocol Clock<Duration>: Sendable {
   ///
   /// Returns: A `Duration` representing the equivalent duration, or
   ///          `nil` if this function is not supported.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   func convert(from duration: Swift.Duration) -> Duration?
 
   /// Convert an `Instant` from some other clock's `Instant`
@@ -82,12 +82,12 @@ public protocol Clock<Duration>: Sendable {
   ///
   /// Returns: An `Instant` representing the equivalent instant, or
   ///          `nil` if this function is not supported.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   func convert<OtherClock: Clock>(instant: OtherClock.Instant,
                                   from clock: OtherClock) -> Instant?
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Clock {
   /// Measure the elapsed time to execute a closure.
   ///
@@ -95,7 +95,7 @@ extension Clock {
   ///       let elapsed = clock.measure {
   ///          someWork()
   ///       }
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public func measure(_ work: () throws -> Void) rethrows -> Instant.Duration {
     let start = now
     try work()
@@ -109,7 +109,7 @@ extension Clock {
   ///       let elapsed = await clock.measure {
   ///          await someWork()
   ///       }
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
   public func measure(
     isolation: isolated (any Actor)? = #isolation,
@@ -127,7 +127,7 @@ extension Clock {
   //
   // This function also doubles as an ABI-compatibility shim predating the
   // introduction of #isolation.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @_silgen_name("$ss5ClockPsE7measurey8DurationQzyyYaKXEYaKF")
   @_unsafeInheritExecutor // for ABI compatibility
   public func _unsafeInheritExecutor_measure(
@@ -140,7 +140,7 @@ extension Clock {
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension Clock {
   // For compatibility, return `nil` if this is not implemented
   public func convert(from duration: Duration) -> Swift.Duration? {
@@ -171,7 +171,7 @@ extension Clock {
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension Clock where Duration == Swift.Duration {
   public func convert(from duration: Duration) -> Duration? {
     return duration
@@ -179,13 +179,13 @@ extension Clock where Duration == Swift.Duration {
 }
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Clock {
   /// Suspends for the given duration.
   ///
   /// Prefer to use the `sleep(until:tolerance:)` method on `Clock` if you have
   /// access to an absolute instant.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @_alwaysEmitIntoClient
   public func sleep(
     for duration: Instant.Duration,
@@ -207,7 +207,7 @@ extension Clock {
 /// clocks best matches the clock that the user is trying to specify a
 /// time or delay in.  Executors are expected to do this on a best effort
 /// basis.
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct ClockTraits: OptionSet {
   public let rawValue: UInt32
 
@@ -225,10 +225,10 @@ public struct ClockTraits: OptionSet {
   public static let wallTime = ClockTraits(rawValue: 1 << 2)
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension Clock {
   /// The traits associated with this clock instance.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public var traits: ClockTraits {
     return []
   }
@@ -239,21 +239,21 @@ enum _ClockID: Int32 {
   case suspending = 2
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_silgen_name("swift_get_time")
 internal func _getTime(
   seconds: UnsafeMutablePointer<Int64>,
   nanoseconds: UnsafeMutablePointer<Int64>,
   clock: CInt)
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_silgen_name("swift_get_clock_res")
 internal func _getClockRes(
   seconds: UnsafeMutablePointer<Int64>,
   nanoseconds: UnsafeMutablePointer<Int64>,
   clock: CInt)
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_sleep")
 internal func _sleep(
   seconds: Int64,

--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -20,7 +20,7 @@ import Swift
 /// only comparable locally during the execution of a program.
 ///
 /// This clock is suitable for high resolution measurements of execution.
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 public struct ContinuousClock: Sendable {
   /// A continuous point in time used for `ContinuousClock`.
@@ -36,12 +36,12 @@ public struct ContinuousClock: Sendable {
 }
 
 #if !$Embedded
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension ContinuousClock.Instant: Codable {
 }
 #endif
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration {
   internal init(_seconds s: Int64, nanoseconds n: Int64) {
     let (secHi, secLo) = s.multipliedFullWidth(by: 1_000_000_000_000_000_000)
@@ -56,7 +56,7 @@ extension Duration {
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension Clock where Self == ContinuousClock {
   /// A clock that measures time that always increments but does not stop
@@ -64,11 +64,11 @@ extension Clock where Self == ContinuousClock {
   ///
   ///       try await Task.sleep(until: .now + .seconds(3), clock: .continuous)
   ///
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static var continuous: ContinuousClock { return ContinuousClock() }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension ContinuousClock: Clock {
   /// The current continuous instant.
@@ -101,7 +101,7 @@ extension ContinuousClock: Clock {
   }
 
   /// The continuous clock is continuous and monotonic
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public var traits: ClockTraits {
     return [.continuous, .monotonic]
   }
@@ -119,7 +119,7 @@ extension ContinuousClock: Clock {
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    if #available(SwiftStdlibCurrentOS 6.2, *) {
+    if #available(StdlibDeploymentTarget 6.2, *) {
       try await Task._sleep(until: deadline,
                             tolerance: tolerance,
                             clock: self)
@@ -128,7 +128,7 @@ extension ContinuousClock: Clock {
     }
   }
 #else
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
@@ -138,7 +138,7 @@ extension ContinuousClock: Clock {
 #endif
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension ContinuousClock {
   @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/Concurrency/CooperativeExecutor.swift
+++ b/stdlib/public/Concurrency/CooperativeExecutor.swift
@@ -17,7 +17,7 @@ import Swift
 // Store the Timestamp in the executor private data, if it will fit; otherwise,
 // use the allocator to allocate space for it and stash a pointer in the private
 // data area.
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension ExecutorJob {
   fileprivate var cooperativeExecutorTimestampIsIndirect: Bool {
     return MemoryLayout<(Int, Int)>.size
@@ -99,7 +99,7 @@ extension ExecutorJob {
 
 /// A co-operative executor that can be used as the main executor or as a
 /// task executor.
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 class CooperativeExecutor: Executor, @unchecked Sendable {
   var runQueue: PriorityQueue<UnownedJob>
   var waitQueue: PriorityQueue<UnownedJob>
@@ -179,7 +179,7 @@ class CooperativeExecutor: Executor, @unchecked Sendable {
   public var asSchedulable: any SchedulableExecutor { self }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension CooperativeExecutor: SchedulableExecutor {
   var currentTime: Timestamp {
     var now: Timestamp = .zero
@@ -202,7 +202,7 @@ extension CooperativeExecutor: SchedulableExecutor {
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension CooperativeExecutor: RunLoopExecutor {
   public func run() throws {
     try runUntil { false }
@@ -249,13 +249,13 @@ extension CooperativeExecutor: RunLoopExecutor {
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension CooperativeExecutor: SerialExecutor {}
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension CooperativeExecutor: TaskExecutor {}
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension CooperativeExecutor: MainExecutor {}
 
 #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY

--- a/stdlib/public/Concurrency/DispatchExecutor.swift
+++ b/stdlib/public/Concurrency/DispatchExecutor.swift
@@ -23,7 +23,7 @@ import Swift
 
 // .. Main Executor ............................................................
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public class DispatchMainExecutor: RunLoopExecutor, @unchecked Sendable {
   var threaded = false
 
@@ -43,7 +43,7 @@ public class DispatchMainExecutor: RunLoopExecutor, @unchecked Sendable {
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension DispatchMainExecutor: SerialExecutor {
 
   public func enqueue(_ job: consuming ExecutorJob) {
@@ -57,7 +57,7 @@ extension DispatchMainExecutor: SerialExecutor {
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension DispatchMainExecutor: SchedulableExecutor {
   public var asSchedulable: SchedulableExecutor? {
     return self
@@ -85,12 +85,12 @@ extension DispatchMainExecutor: SchedulableExecutor {
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension DispatchMainExecutor: MainExecutor {}
 
 // .. Task Executor ............................................................
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public class DispatchGlobalTaskExecutor: TaskExecutor, SchedulableExecutor,
                                          @unchecked Sendable {
   public init() {}
@@ -130,7 +130,7 @@ public class DispatchGlobalTaskExecutor: TaskExecutor, SchedulableExecutor,
 ///
 /// It is used to help convert instants and durations from arbitrary `Clock`s
 /// to Dispatch's time base.
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 protocol DispatchExecutorProtocol: Executor {
 
   /// Convert an `Instant` from the specified clock to a tuple identifying
@@ -158,7 +158,7 @@ enum DispatchClockID: CInt {
   case suspending = 2
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension DispatchExecutorProtocol {
 
   func clamp(_ components: (seconds: Int64, attoseconds: Int64))
@@ -201,11 +201,11 @@ extension DispatchExecutorProtocol {
 
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension DispatchGlobalTaskExecutor: DispatchExecutorProtocol {
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension DispatchMainExecutor: DispatchExecutorProtocol {
 }
 

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -26,24 +26,24 @@ public protocol Executor: AnyObject, Sendable {
   // Cannot introduce these methods in SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   // since it lacks move-only type support.
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   @available(*, deprecated, message: "Implement 'enqueue(_: consuming ExecutorJob)' instead")
   func enqueue(_ job: consuming Job)
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   func enqueue(_ job: consuming ExecutorJob)
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
   #if !$Embedded
   /// `true` if this is the main executor.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   var isMainExecutor: Bool { get }
   #endif
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public protocol SchedulableExecutor: Executor {
 
   #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
@@ -63,7 +63,7 @@ public protocol SchedulableExecutor: Executor {
   /// - tolerance: The maximum additional delay permissible before the
   ///              job is executed.  `nil` means no limit.
   /// - clock:     The clock used for the delay.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   func enqueue<C: Clock>(_ job: consuming ExecutorJob,
                          after delay: C.Duration,
                          tolerance: C.Duration?,
@@ -83,7 +83,7 @@ public protocol SchedulableExecutor: Executor {
   /// - tolerance: The maximum additional delay permissible before the
   ///              job is executed.  `nil` means no limit.
   /// - clock:     The clock used for the delay..
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   func enqueue<C: Clock>(_ job: consuming ExecutorJob,
                          at instant: C.Instant,
                          tolerance: C.Duration?,
@@ -125,7 +125,7 @@ extension Executor {
   /// Executors that implement SchedulableExecutor should provide their
   /// own copy of this method, which will allow the compiler to avoid a
   /// potentially expensive runtime cast.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   var asSchedulable: SchedulableExecutor? {
     return self as? SchedulableExecutor
   }
@@ -148,19 +148,19 @@ extension Executor {
   #if !$Embedded
   // This defaults to `false` so that existing third-party Executor
   // implementations will work as expected.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public var isMainExecutor: Bool { false }
   #endif
 
 }
 
 // Delay support
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension SchedulableExecutor {
 
   #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public func enqueue<C: Clock>(_ job: consuming ExecutorJob,
                                 after delay: C.Duration,
                                 tolerance: C.Duration? = nil,
@@ -171,7 +171,7 @@ extension SchedulableExecutor {
             tolerance: tolerance, clock: clock)
   }
 
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public func enqueue<C: Clock>(_ job: consuming ExecutorJob,
                                 at instant: C.Instant,
                                 tolerance: C.Duration? = nil,
@@ -275,7 +275,7 @@ public protocol SerialExecutor: Executor {
   // avoid drilling down to the base conformance just for the basic
   // work-scheduling operation.
   @_nonoverride
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   @available(*, deprecated, message: "Implement 'enqueue(_: consuming ExecutorJob)' instead")
   func enqueue(_ job: consuming Job)
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
@@ -286,7 +286,7 @@ public protocol SerialExecutor: Executor {
   // avoid drilling down to the base conformance just for the basic
   // work-scheduling operation.
   @_nonoverride
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   func enqueue(_ job: consuming ExecutorJob)
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
@@ -317,7 +317,7 @@ public protocol SerialExecutor: Executor {
   /// - Returns: `true`, if `self` and the `other` executor actually are
   ///            mutually exclusive and it is safe–from a concurrency
   ///            perspective–to execute code assuming one on the other.
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   func isSameExclusiveExecutionContext(other: Self) -> Bool
 
   /// Last resort "fallback" isolation check, called when the concurrency runtime
@@ -340,7 +340,7 @@ public protocol SerialExecutor: Executor {
   ///
   /// - Warning: This method must crash and halt program execution if unable
   ///     to prove the isolation of the calling context.
-  @available(SwiftStdlibCurrentOS 6.0, *)
+  @available(StdlibDeploymentTarget 6.0, *)
   func checkIsolated()
 
   /// Checks if the current execution context is isolated by this executor.
@@ -360,20 +360,20 @@ public protocol SerialExecutor: Executor {
   /// The default implementation returns `nil` is used to indicate that it is "unknown" if the current context is
   /// isolated by this serial executor. The runtime then _may_ proceed to invoke `checkIsolated()` as a last-resort
   /// attempt to verify the isolation of the current context.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   func isIsolatingCurrentContext() -> Bool?
 
 }
 
-@available(SwiftStdlibCurrentOS 6.0, *)
+@available(StdlibDeploymentTarget 6.0, *)
 extension SerialExecutor {
 
   #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public var isMainExecutor: Bool { return MainActor.executor._isSameExecutor(self) }
   #endif
 
-  @available(SwiftStdlibCurrentOS 6.0, *)
+  @available(StdlibDeploymentTarget 6.0, *)
   public func checkIsolated() {
     #if !$Embedded
     fatalError("Unexpected isolation context, expected to be executing on \(Self.self)")
@@ -383,13 +383,13 @@ extension SerialExecutor {
   }
 
   #if SWIFT_CONCURRENCY_USES_DISPATCH
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   private var _dispatchQueue: OpaquePointer? {
     return unsafe _getDispatchQueueForExecutor(self.asUnownedSerialExecutor())
   }
   #endif
 
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   internal func _isSameExecutor(_ rhs: some SerialExecutor) -> Bool {
     if rhs === self {
       return true
@@ -409,10 +409,10 @@ extension SerialExecutor {
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension SerialExecutor {
 
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public func isIsolatingCurrentContext() -> Bool? {
     return nil
   }
@@ -435,7 +435,7 @@ extension SerialExecutor {
 /// the provided task executor.
 ///
 /// Unstructured tasks do not inherit the task executor.
-@available(SwiftStdlibCurrentOS 6.0, *)
+@available(StdlibDeploymentTarget 6.0, *)
 public protocol TaskExecutor: Executor {
   // This requirement is repeated here as a non-override so that we
   // get a redundant witness-table entry for it.  This allows us to
@@ -466,7 +466,7 @@ public protocol TaskExecutor: Executor {
   func asUnownedTaskExecutor() -> UnownedTaskExecutor
 }
 
-@available(SwiftStdlibCurrentOS 6.0, *)
+@available(StdlibDeploymentTarget 6.0, *)
 extension TaskExecutor {
   public func asUnownedTaskExecutor() -> UnownedTaskExecutor {
     unsafe UnownedTaskExecutor(ordinary: self)
@@ -474,7 +474,7 @@ extension TaskExecutor {
 }
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 extension Executor {
 
   // Delegation goes like this:
@@ -494,28 +494,28 @@ extension Executor {
 }
 #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 extension SerialExecutor {
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     unsafe UnownedSerialExecutor(ordinary: self)
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 extension SerialExecutor {
 
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   public func isSameExclusiveExecutionContext(other: Self) -> Bool {
     return self === other
   }
 
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension SerialExecutor where Self: Equatable {
 
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public func isSameExclusiveExecutionContext(other: Self) -> Bool {
     return self == other
   }
@@ -527,7 +527,7 @@ extension SerialExecutor where Self: Equatable {
 /// The idea here is that some executors may work by running a loop
 /// that processes events of some sort; we want a way to enter that loop,
 /// and we would also like a way to trigger the loop to exit.
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public protocol RunLoopExecutor: Executor {
   /// Run the executor's run loop.
   ///
@@ -558,7 +558,7 @@ public protocol RunLoopExecutor: Executor {
   func stop()
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension RunLoopExecutor {
 
   public func runUntil(_ condition: () -> Bool) throws {
@@ -570,14 +570,14 @@ extension RunLoopExecutor {
 
 /// The main executor must conform to these three protocols; we have to
 /// make this a protocol for compatibility with Embedded Swift.
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public protocol MainExecutor: RunLoopExecutor, SerialExecutor {
 }
 
 
 /// An ExecutorFactory is used to create the default main and task
 /// executors.
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public protocol ExecutorFactory {
   #if !$Embedded
   /// Constructs and returns the main executor, which is started implicitly
@@ -590,10 +590,10 @@ public protocol ExecutorFactory {
   static var defaultExecutor: any TaskExecutor { get }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 typealias DefaultExecutorFactory = PlatformExecutorFactory
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_createExecutors")
 public func _createExecutors<F: ExecutorFactory>(factory: F.Type) {
   #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
@@ -612,7 +612,7 @@ func _createDefaultExecutors() {
 
 #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 extension MainActor {
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   static var _executor: (any MainExecutor)? = nil
 
   /// The main executor, which is started implicitly by the `async main`
@@ -620,7 +620,7 @@ extension MainActor {
   ///
   /// Attempting to set this after the first `enqueue` on the main
   /// executor is a fatal error.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public static var executor: any MainExecutor {
     // It would be good if there was a Swift way to do this
     _createDefaultExecutorsOnce()
@@ -630,7 +630,7 @@ extension MainActor {
 #endif // !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
 extension Task where Success == Never, Failure == Never {
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   static var _defaultExecutor: (any TaskExecutor)? = nil
 
   /// The default or global executor, which is the default place in which
@@ -638,7 +638,7 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// Attempting to set this after the first `enqueue` on the global
   /// executor is a fatal error.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public static var defaultExecutor: any TaskExecutor {
     // It would be good if there was a Swift way to do this
     _createDefaultExecutorsOnce()
@@ -658,7 +658,7 @@ extension Task where Success == Never, Failure == Never {
   ///   3. The task executor for the current thread
   ///
   ///  If none of these exist, returns the default executor.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   @_unavailableInEmbedded
   public static var currentExecutor: any Executor {
     if let activeExecutor = unsafe _getActiveExecutor().asSerialExecutor() {
@@ -672,7 +672,7 @@ extension Task where Success == Never, Failure == Never {
   }
 
   /// Get the preferred executor for the current `Task`, if any.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public static var preferredExecutor: (any TaskExecutor)? {
     if let taskExecutor = unsafe _getPreferredTaskExecutor().asTaskExecutor() {
       return taskExecutor
@@ -684,7 +684,7 @@ extension Task where Success == Never, Failure == Never {
   ///
   /// This follows the same logic as `currentExecutor`, except that it ignores
   /// any executor that isn't a `SchedulableExecutor`.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   @_unavailableInEmbedded
   public static var currentSchedulableExecutor: (any SchedulableExecutor)? {
     if let activeExecutor = unsafe _getActiveExecutor().asSerialExecutor(),
@@ -776,14 +776,14 @@ public struct UnownedSerialExecutor: Sendable {
     unsafe _executor_isComplexEquality(self)
   }
 
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public func asSerialExecutor() -> (any SerialExecutor)? {
     return unsafe unsafeBitCast(executor, to: (any SerialExecutor)?.self)
   }
 }
 
 
-@available(SwiftStdlibCurrentOS 6.0, *)
+@available(StdlibDeploymentTarget 6.0, *)
 @unsafe
 @frozen
 public struct UnownedTaskExecutor: Sendable {
@@ -813,7 +813,7 @@ public struct UnownedTaskExecutor: Sendable {
     unsafe self.executor = Builtin.buildOrdinaryTaskExecutorRef(executor)
   }
 
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public func asTaskExecutor() -> (any TaskExecutor)? {
     return unsafe unsafeBitCast(executor, to: (any TaskExecutor)?.self)
   }
@@ -876,7 +876,7 @@ func _checkExpectedExecutor(_filenameStart: Builtin.RawPointer,
 /// otherwise returns only the job's 32bit Id.
 ///
 /// - Returns: the Id stored in this ExecutorJob or Task, for purposes of debug printing
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 @_silgen_name("swift_task_getJobTaskId")
 internal func _getJobTaskId(_ job: UnownedJob) -> UInt64
 
@@ -930,7 +930,7 @@ internal func _task_taskExecutor_getTaskExecutorRef<E>(_ taskExecutor: E) -> Bui
 internal func _enqueueOnExecutor<E>(job unownedJob: UnownedJob, executor: E)
 where E: SerialExecutor {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  if #available(SwiftStdlibCurrentOS 5.9, *) {
+  if #available(StdlibDeploymentTarget 5.9, *) {
     executor.enqueue(ExecutorJob(context: unownedJob._context))
   } else {
     fatalError("we shouldn't get here; if we have, availability is broken")

--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -17,19 +17,19 @@
 
 import Swift
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("_swift_exit")
 internal func _exit(result: CInt)
 
 #if !$Embedded
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("_swift_task_isMainExecutorSwift")
 internal func _isMainExecutor<E>(_ executor: E) -> Bool where E: SerialExecutor {
   return executor.isMainExecutor
 }
 #endif
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("_swift_task_checkIsolatedSwift")
 internal func checkIsolated<E>(executor: E) where E: SerialExecutor {
   executor.checkIsolated()
@@ -40,7 +40,7 @@ internal func checkIsolated<E>(executor: E) where E: SerialExecutor {
 ///     -1: unknown
 ///      0: not isolated
 ///      1: isolated
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("_swift_task_isIsolatingCurrentContextSwift")
 internal func isIsolatingCurrentContext<E>(executor: E) -> Int8
   where E: SerialExecutor {
@@ -51,37 +51,37 @@ internal func isIsolatingCurrentContext<E>(executor: E) -> Int8
   }
 }
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("_swift_getActiveExecutor")
 internal func _getActiveExecutor() -> UnownedSerialExecutor
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("_swift_getCurrentTaskExecutor")
 internal func _getCurrentTaskExecutor() -> UnownedTaskExecutor
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("_swift_getPreferredTaskExecutor")
 internal func _getPreferredTaskExecutor() -> UnownedTaskExecutor
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_job_allocate")
 internal func _jobAllocate(_ job: Builtin.Job,
                            _ capacity: Int) -> UnsafeMutableRawPointer
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_job_deallocate")
 internal func _jobDeallocate(_ job: Builtin.Job,
                              _ address: UnsafeMutableRawPointer)
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_job_getPriority")
 internal func _jobGetPriority(_ job: Builtin.Job) -> UInt8
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_job_getKind")
 internal func _jobGetKind(_ job: Builtin.Job) -> UInt8
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_job_getExecutorPrivateData")
 internal func _jobGetExecutorPrivateData(
   _ job: Builtin.Job
@@ -89,32 +89,32 @@ internal func _jobGetExecutorPrivateData(
 
 #if !$Embedded
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_getMainExecutor")
 internal func _getMainExecutor() -> any SerialExecutor {
   return MainActor.executor
 }
 #else
 // For task-to-thread model, this is implemented in C++
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_getMainExecutor")
 internal func _getMainExecutor() -> any SerialExecutor
 #endif // SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 #endif // !$Embedded
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_dispatchMain")
 internal func _dispatchMain()
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_dispatchEnqueueMain")
 internal func _dispatchEnqueueMain(_ job: UnownedJob)
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_dispatchEnqueueGlobal")
 internal func _dispatchEnqueueGlobal(_ job: UnownedJob)
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_dispatchEnqueueWithDeadline")
 internal func _dispatchEnqueueWithDeadline(_ global: CBool,
                                            _ sec: CLongLong,
@@ -124,7 +124,7 @@ internal func _dispatchEnqueueWithDeadline(_ global: CBool,
                                            _ clock: CInt,
                                            _ job: UnownedJob)
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_dispatchAssertMainQueue")
 internal func _dispatchAssertMainQueue()
 

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -34,7 +34,7 @@ import Swift
 @_unavailableInEmbedded
 public var globalConcurrentExecutor: any TaskExecutor {
   get {
-    if #available(SwiftStdlibCurrentOS 6.2, *) {
+    if #available(StdlibDeploymentTarget 6.2, *) {
       return Task.defaultExecutor
     } else {
       fatalError("we shouldn't get here; if we have, availability is broken")

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -33,14 +33,14 @@ internal func _swiftJobRun(_ job: UnownedJob,
                            _ executor: UnownedSerialExecutor) -> ()
 
 @_unavailableInEmbedded
-@available(SwiftStdlibCurrentOS 6.0, *)
+@available(StdlibDeploymentTarget 6.0, *)
 @_silgen_name("swift_job_run_on_task_executor")
 @usableFromInline
 internal func _swiftJobRunOnTaskExecutor(_ job: UnownedJob,
                                          _ executor: UnownedTaskExecutor) -> ()
 
 @_unavailableInEmbedded
-@available(SwiftStdlibCurrentOS 6.0, *)
+@available(StdlibDeploymentTarget 6.0, *)
 @_silgen_name("swift_job_run_on_serial_and_task_executor")
 @usableFromInline
 internal func _swiftJobRunOnTaskExecutor(_ job: UnownedJob,
@@ -63,14 +63,14 @@ public struct UnownedJob: Sendable {
   private var context: Builtin.Job
 
   @usableFromInline
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   internal init(context: Builtin.Job) {
     self.context = context
   }
 
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   /// Create an `UnownedJob` whose lifetime must be managed carefully until it is run exactly once.
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   public init(_ job: __owned Job) { // must remain '__owned' in order to not break ABI
     self.context = job.context
   }
@@ -78,17 +78,17 @@ public struct UnownedJob: Sendable {
 
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   /// Create an `UnownedJob` whose lifetime must be managed carefully until it is run exactly once.
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   public init(_ job: __owned ExecutorJob) { // must remain '__owned' in order to not break ABI
     self.context = job.context
   }
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
   /// The priority of this job.
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   public var priority: JobPriority {
     let raw: UInt8
-    if #available(SwiftStdlibCurrentOS 6.2, *) {
+    if #available(StdlibDeploymentTarget 6.2, *) {
       raw = _jobGetPriority(context)
     } else {
       fatalError("we shouldn't get here; if we have, availability is broken")
@@ -96,7 +96,7 @@ public struct UnownedJob: Sendable {
     return JobPriority(rawValue: raw)
   }
 
-  @available(SwiftStdlibCurrentOS 5.9, *)
+  @available(StdlibDeploymentTarget 5.9, *)
   internal var _context: Builtin.Job {
     context
   }
@@ -143,7 +143,7 @@ public struct UnownedJob: Sendable {
   ///
   /// - SeeAlso: ``runSynchronously(isolatedTo:taskExecutor:)``
   @_unavailableInEmbedded
-  @available(SwiftStdlibCurrentOS 6.0, *)
+  @available(StdlibDeploymentTarget 6.0, *)
   @_alwaysEmitIntoClient
   @inlinable
   public func runSynchronously(on executor: UnownedTaskExecutor) {
@@ -171,7 +171,7 @@ public struct UnownedJob: Sendable {
   ///
   /// - SeeAlso: ``runSynchronously(on:)``
   @_unavailableInEmbedded
-  @available(SwiftStdlibCurrentOS 6.0, *)
+  @available(StdlibDeploymentTarget 6.0, *)
   @_alwaysEmitIntoClient
   @inlinable
   public func runSynchronously(isolatedTo serialExecutor: UnownedSerialExecutor,
@@ -206,7 +206,7 @@ extension UnownedJob: CustomStringConvertible {
 ///
 /// Unless you're implementing a scheduler,
 /// you don't generally interact with jobs directly.
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 @available(*, deprecated, renamed: "ExecutorJob")
 @frozen
 public struct Job: Sendable, ~Copyable {
@@ -227,7 +227,7 @@ public struct Job: Sendable, ~Copyable {
 
   public var priority: JobPriority {
     let raw: UInt8
-    if #available(SwiftStdlibCurrentOS 6.2, *) {
+    if #available(StdlibDeploymentTarget 6.2, *) {
       raw = _jobGetPriority(self.context)
     } else {
       fatalError("we shouldn't get here; if we have, availability is broken")
@@ -280,7 +280,7 @@ extension Job {
 ///
 /// Unless you're implementing a scheduler,
 /// you don't generally interact with jobs directly.
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 @frozen
 public struct ExecutorJob: Sendable, ~Copyable {
   internal var context: Builtin.Job
@@ -300,7 +300,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
 
   public var priority: JobPriority {
     let raw: UInt8
-    if #available(SwiftStdlibCurrentOS 6.2, *) {
+    if #available(StdlibDeploymentTarget 6.2, *) {
       raw = _jobGetPriority(self.context)
     } else {
       fatalError("we shouldn't get here; if we have, availability is broken")
@@ -316,7 +316,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
   /// - body: The closure to execute.
   ///
   /// Returns the result of executing the closure.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public func withUnsafeExecutorPrivateData<R, E>(body: (UnsafeMutableRawBufferPointer) throws(E) -> R) throws(E) -> R {
     let base = _jobGetExecutorPrivateData(self.context)
     let size = unsafe 2 * MemoryLayout<OpaquePointer>.stride
@@ -325,7 +325,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
   }
 
   /// Kinds of schedulable jobs
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   @frozen
   public struct Kind: Sendable, RawRepresentable {
     public typealias RawValue = UInt8
@@ -346,7 +346,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
   }
 
   /// What kind of job this is.
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public var kind: Kind {
     return Kind(rawValue: _jobGetKind(self.context))!
   }
@@ -367,7 +367,7 @@ public struct ExecutorJob: Sendable, ~Copyable {
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 extension ExecutorJob {
 
   /// Run this job on the passed in executor.
@@ -409,7 +409,7 @@ extension ExecutorJob {
   ///
   /// - SeeAlso: ``runSynchronously(isolatedTo:taskExecutor:)``
   @_unavailableInEmbedded
-  @available(SwiftStdlibCurrentOS 6.0, *)
+  @available(StdlibDeploymentTarget 6.0, *)
   @_alwaysEmitIntoClient
   @inlinable
   __consuming public func runSynchronously(on executor: UnownedTaskExecutor) {
@@ -432,7 +432,7 @@ extension ExecutorJob {
   ///
   /// - SeeAlso: ``runSynchronously(on:)``
   @_unavailableInEmbedded
-  @available(SwiftStdlibCurrentOS 6.0, *)
+  @available(StdlibDeploymentTarget 6.0, *)
   @_alwaysEmitIntoClient
   @inlinable
   __consuming public func runSynchronously(isolatedTo serialExecutor: UnownedSerialExecutor,
@@ -442,7 +442,7 @@ extension ExecutorJob {
 }
 
 // Stack-disciplined job-local allocator support
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 extension ExecutorJob {
 
   /// Obtain a stack-disciplined job-local allocator.
@@ -533,7 +533,7 @@ extension ExecutorJob {
 /// however, since not all jobs are tasks, represented as separate type.
 ///
 /// Conversions between the two priorities are available as initializers on the respective types.
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 @frozen
 public struct JobPriority: Sendable {
   public typealias RawValue = UInt8
@@ -557,7 +557,7 @@ extension TaskPriority {
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 extension JobPriority: Equatable {
   public static func == (lhs: JobPriority, rhs: JobPriority) -> Bool {
     lhs.rawValue == rhs.rawValue
@@ -568,7 +568,7 @@ extension JobPriority: Equatable {
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.9, *)
+@available(StdlibDeploymentTarget 5.9, *)
 extension JobPriority: Comparable {
   public static func < (lhs: JobPriority, rhs: JobPriority) -> Bool {
     lhs.rawValue < rhs.rawValue

--- a/stdlib/public/Concurrency/PlatformExecutorCooperative.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorCooperative.swift
@@ -13,7 +13,7 @@
 import Swift
 
 // This platform uses a single, global, CooperativeExecutor
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   static let executor = CooperativeExecutor()
   public static var mainExecutor: any MainExecutor { executor }

--- a/stdlib/public/Concurrency/PlatformExecutorDarwin.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorDarwin.swift
@@ -14,7 +14,7 @@
 
 import Swift
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static var mainExecutor: any MainExecutor {
     if CoreFoundation.isPresent {

--- a/stdlib/public/Concurrency/PlatformExecutorLinux.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorLinux.swift
@@ -15,7 +15,7 @@
 import Swift
 
 // The default executors for now are Dispatch-based
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
   public static let defaultExecutor: any TaskExecutor

--- a/stdlib/public/Concurrency/PlatformExecutorNone.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorNone.swift
@@ -12,7 +12,7 @@
 
 import Swift
 
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = DummyMainExecutor()
   public static let defaultExecutor: any TaskExecutor = DummyTaskExecutor()

--- a/stdlib/public/Concurrency/PlatformExecutorWindows.swift
+++ b/stdlib/public/Concurrency/PlatformExecutorWindows.swift
@@ -15,7 +15,7 @@
 import Swift
 
 // The default executors for now are Dispatch-based
-@available(SwiftStdlibCurrentOS 6.2, *)
+@available(StdlibDeploymentTarget 6.2, *)
 public struct PlatformExecutorFactory: ExecutorFactory {
   public static let mainExecutor: any MainExecutor = DispatchMainExecutor()
   public static let defaultExecutor: any TaskExecutor =

--- a/stdlib/public/Concurrency/SuspendingClock.swift
+++ b/stdlib/public/Concurrency/SuspendingClock.swift
@@ -20,7 +20,7 @@ import Swift
 /// only comparable on the same machine in the same booted session.
 ///
 /// This clock is suitable for high resolution measurements of execution.
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 public struct SuspendingClock: Sendable {
   public struct Instant: Sendable {
@@ -35,12 +35,12 @@ public struct SuspendingClock: Sendable {
 }
 
 #if !$Embedded
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension SuspendingClock.Instant: Codable {
 }
 #endif
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension Clock where Self == SuspendingClock {
   /// A clock that measures time that always increments but stops incrementing
@@ -48,21 +48,21 @@ extension Clock where Self == SuspendingClock {
   ///
   ///       try await Task.sleep(until: .now + .seconds(3), clock: .suspending)
   ///
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static var suspending: SuspendingClock { return SuspendingClock() }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension SuspendingClock: Clock {
   /// The current instant accounting for machine suspension.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public var now: SuspendingClock.Instant {
     SuspendingClock.now
   }
 
   /// The current instant accounting for machine suspension.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static var now: SuspendingClock.Instant {
     var seconds = Int64(0)
     var nanoseconds = Int64(0)
@@ -76,7 +76,7 @@ extension SuspendingClock: Clock {
   }
 
   /// The minimum non-zero resolution between any two calls to `now`.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public var minimumResolution: Swift.Duration {
     var seconds = Int64(0)
     var nanoseconds = Int64(0)
@@ -88,7 +88,7 @@ extension SuspendingClock: Clock {
   }
 
   /// The suspending clock is monotonic
-  @available(SwiftStdlibCurrentOS 6.2, *)
+  @available(StdlibDeploymentTarget 6.2, *)
   public var traits: ClockTraits {
     return [.monotonic]
   }
@@ -103,11 +103,11 @@ extension SuspendingClock: Clock {
   /// `CancellationError`.
   ///
   /// This function doesn't block the underlying thread.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
   ) async throws {
-    if #available(SwiftStdlibCurrentOS 6.2, *) {
+    if #available(StdlibDeploymentTarget 6.2, *) {
       try await Task._sleep(until: deadline,
                             tolerance: tolerance,
                             clock: self)
@@ -116,7 +116,7 @@ extension SuspendingClock: Clock {
     }
   }
 #else
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public func sleep(
     until deadline: Instant, tolerance: Swift.Duration? = nil
@@ -126,7 +126,7 @@ extension SuspendingClock: Clock {
 #endif
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension SuspendingClock {
   @available(SwiftStdlib 5.7, *)

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -637,7 +637,7 @@ extension Task where Success == Never, Failure == Never {
           continuation: continuation)
 
       #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-      if #available(SwiftStdlibCurrentOS 6.2, *) {
+      if #available(StdlibDeploymentTarget 6.2, *) {
         let executor = Task.currentExecutor
 
         executor.enqueue(ExecutorJob(context: job))
@@ -822,7 +822,7 @@ func _enqueueJobGlobalWithDelay(_ delay: UInt64, _ task: UnownedJob) {
   return _enqueueJobGlobalWithDelay(delay, task._context)
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_silgen_name("swift_task_enqueueGlobalWithDeadline")
 @usableFromInline
 func _enqueueJobGlobalWithDeadline(_ seconds: Int64, _ nanoseconds: Int64,
@@ -898,7 +898,7 @@ internal func _runAsyncMain(_ asyncFun: @Sendable @escaping () async throws -> (
   }
 
   let job = Builtin.convertTaskToJob(theTask)
-  if #available(SwiftStdlibCurrentOS 6.2, *) {
+  if #available(StdlibDeploymentTarget 6.2, *) {
     MainActor.executor.enqueue(ExecutorJob(context: job))
   } else {
     fatalError("we shouldn't get here; if we have, availability is broken")

--- a/stdlib/public/Concurrency/TaskSleep.swift
+++ b/stdlib/public/Concurrency/TaskSleep.swift
@@ -28,7 +28,7 @@ extension Task where Success == Never, Failure == Never {
           priority: Int(Task.currentPriority.rawValue),
           continuation: continuation)
 
-      if #available(SwiftStdlibCurrentOS 6.2, *) {
+      if #available(StdlibDeploymentTarget 6.2, *) {
         #if !$Embedded
         if let executor = Task.currentSchedulableExecutor {
           executor.enqueue(ExecutorJob(context: job),
@@ -272,7 +272,7 @@ extension Task where Success == Never, Failure == Never {
 
               let job = Builtin.convertTaskToJob(sleepTask)
 
-              if #available(SwiftStdlibCurrentOS 6.2, *) {
+              if #available(StdlibDeploymentTarget 6.2, *) {
                 #if !$Embedded
                 if let executor = Task.currentSchedulableExecutor {
                   executor.enqueue(ExecutorJob(context: job),

--- a/stdlib/public/Concurrency/TaskSleepDuration.swift
+++ b/stdlib/public/Concurrency/TaskSleepDuration.swift
@@ -13,11 +13,11 @@
 import Swift
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 fileprivate func timestamp<C: Clock>(for instant: C.Instant, clock: C)
   -> (clockID: _ClockID, seconds: Int64, nanoseconds: Int64) {
   var clockID: _ClockID
-  if #available(SwiftStdlibCurrentOS 6.2, *) {
+  if #available(StdlibDeploymentTarget 6.2, *) {
     if clock.traits.contains(.continuous) {
       clockID = .continuous
     } else {
@@ -34,7 +34,7 @@ fileprivate func timestamp<C: Clock>(for instant: C.Instant, clock: C)
                   clock: clockID.rawValue)
 
   let delta: Swift.Duration
-  if #available(SwiftStdlibCurrentOS 6.2, *) {
+  if #available(StdlibDeploymentTarget 6.2, *) {
     delta = clock.convert(from: clock.now.duration(to: instant))!
   } else {
     fatalError("we shouldn't get here; if we have, availability is broken")
@@ -54,10 +54,10 @@ fileprivate func timestamp<C: Clock>(for instant: C.Instant, clock: C)
           nanoseconds: Int64(nanoseconds))
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension Task where Success == Never, Failure == Never {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   internal static func _sleep<C: Clock>(
     until instant: C.Instant,
     tolerance: C.Duration?,
@@ -97,7 +97,7 @@ extension Task where Success == Never, Failure == Never {
 
               let job = Builtin.convertTaskToJob(sleepTask)
 
-              if #available(SwiftStdlibCurrentOS 6.2, *) {
+              if #available(StdlibDeploymentTarget 6.2, *) {
                 #if !$Embedded
                 if let executor = Task.currentSchedulableExecutor {
                   executor.enqueue(ExecutorJob(context: job),
@@ -117,7 +117,7 @@ extension Task where Success == Never, Failure == Never {
                                                               clock: clock)
               let toleranceSeconds: Int64
               let toleranceNanoseconds: Int64
-              if #available(SwiftStdlibCurrentOS 6.2, *) {
+              if #available(StdlibDeploymentTarget 6.2, *) {
                 if let tolerance = tolerance,
                    let components = clock.convert(from: tolerance)?.components {
                   toleranceSeconds = components.seconds
@@ -130,7 +130,7 @@ extension Task where Success == Never, Failure == Never {
                 fatalError("we shouldn't get here; if we have, availability is broken")
               }
 
-              if #available(SwiftStdlibCurrentOS 5.9, *) {
+              if #available(StdlibDeploymentTarget 5.9, *) {
                 _enqueueJobGlobalWithDeadline(
                   seconds, nanoseconds,
                   toleranceSeconds, toleranceNanoseconds,

--- a/stdlib/public/core/Duration.swift
+++ b/stdlib/public/core/Duration.swift
@@ -31,7 +31,7 @@
 /// temporal measurement component; specifically leap seconds should be 
 /// represented as an additional accessor since that is specific only to certain
 /// clock implementations.
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @frozen
 public struct Duration: Sendable {
   /// The low 64 bits of a 128-bit signed integer value counting attoseconds.
@@ -86,13 +86,13 @@ public struct Duration: Sendable {
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration {
   /// The composite components of the `Duration`.
   ///
   /// This is intended for facilitating conversions to existing time types. The
   /// attoseconds value will not exceed 1e18 or be lower than -1e18.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public var components: (seconds: Int64, attoseconds: Int64) {
     let (seconds, attoseconds) = _attoseconds.dividedBy1e18()
     return (Int64(seconds), Int64(attoseconds))
@@ -129,7 +129,7 @@ extension Duration {
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration {
   /// Construct a `Duration` given a number of seconds represented as a 
   /// `BinaryInteger`.
@@ -137,7 +137,7 @@ extension Duration {
   ///       let d: Duration = .seconds(77)
   ///
   /// - Returns: A `Duration` representing a given number of seconds.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @inlinable
   public static func seconds<T: BinaryInteger>(_ seconds: T) -> Duration {
     guard let high = Int64(exactly: seconds >> 64) else { fatalError() }
@@ -170,7 +170,7 @@ extension Duration {
   ///       let d: Duration = .seconds(22.93)
   ///
   /// - Returns: A `Duration` representing a given number of seconds.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func seconds(_ seconds: Double) -> Duration {
     Duration(seconds, scale: 1_000_000_000_000_000_000)
   }
@@ -181,7 +181,7 @@ extension Duration {
   ///       let d: Duration = .milliseconds(645)
   ///
   /// - Returns: A `Duration` representing a given number of milliseconds.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @inlinable
   public static func milliseconds<T: BinaryInteger>(
     _ milliseconds: T
@@ -199,7 +199,7 @@ extension Duration {
   ///       let d: Duration = .milliseconds(88.3)
   ///
   /// - Returns: A `Duration` representing a given number of milliseconds.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func milliseconds(_ milliseconds: Double) -> Duration {
     Duration(milliseconds, scale: 1_000_000_000_000_000)
   }
@@ -210,7 +210,7 @@ extension Duration {
   ///       let d: Duration = .microseconds(12)
   ///
   /// - Returns: A `Duration` representing a given number of microseconds.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @inlinable
   public static func microseconds<T: BinaryInteger>(
     _ microseconds: T
@@ -228,7 +228,7 @@ extension Duration {
   ///       let d: Duration = .microseconds(382.9)
   ///
   /// - Returns: A `Duration` representing a given number of microseconds.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func microseconds(_ microseconds: Double) -> Duration {
     Duration(microseconds, scale: 1_000_000_000_000)
   }
@@ -239,7 +239,7 @@ extension Duration {
   ///       let d: Duration = .nanoseconds(1929)
   ///
   /// - Returns: A `Duration` representing a given number of nanoseconds.
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   @inlinable
   public static func nanoseconds<T: BinaryInteger>(
     _ nanoseconds: T
@@ -263,10 +263,10 @@ extension Duration {
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension Duration: Codable {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public init(from decoder: Decoder) throws {
     var container = try decoder.unkeyedContainer()
     let high = try container.decode(Int64.self)
@@ -274,7 +274,7 @@ extension Duration: Codable {
     self.init(_high: high, low: low)
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public func encode(to encoder: Encoder) throws {
     var container = encoder.unkeyedContainer()
     try container.encode(_high)
@@ -282,112 +282,112 @@ extension Duration: Codable {
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration: Hashable {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_attoseconds)
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration: Equatable {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func == (_ lhs: Duration, _ rhs: Duration) -> Bool {
     return lhs._attoseconds == rhs._attoseconds
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration: Comparable {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func < (_ lhs: Duration, _ rhs: Duration) -> Bool {
     return lhs._attoseconds < rhs._attoseconds
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration: AdditiveArithmetic {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static var zero: Duration { Duration(_attoseconds: 0) }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func + (_ lhs: Duration, _ rhs: Duration) -> Duration {
     return Duration(_attoseconds: lhs._attoseconds + rhs._attoseconds)
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func - (_ lhs: Duration, _ rhs: Duration) -> Duration {
     return Duration(_attoseconds: lhs._attoseconds - rhs._attoseconds)
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func += (_ lhs: inout Duration, _ rhs: Duration) {
     lhs = lhs + rhs
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func -= (_ lhs: inout Duration, _ rhs: Duration) {
     lhs = lhs - rhs
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func / (_ lhs: Duration, _ rhs: Double) -> Duration {
     return Duration(_attoseconds:
       _Int128(Double(lhs._attoseconds) / rhs))
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func /= (_ lhs: inout Duration, _ rhs: Double) {
     lhs = lhs / rhs
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func / <T: BinaryInteger>(
     _ lhs: Duration, _ rhs: T
   ) -> Duration {
     Duration(_attoseconds: lhs._attoseconds / _Int128(rhs))
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func /= <T: BinaryInteger>(_ lhs: inout Duration, _ rhs: T) {
     lhs = lhs / rhs
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func / (_ lhs: Duration, _ rhs: Duration) -> Double {
     Double(lhs._attoseconds) / Double(rhs._attoseconds)
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func * (_ lhs: Duration, _ rhs: Double) -> Duration {
     Duration(_attoseconds: _Int128(Double(lhs._attoseconds) * rhs))
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func * <T: BinaryInteger>(
     _ lhs: Duration, _ rhs: T
   ) -> Duration {
     Duration(_attoseconds: lhs._attoseconds * _Int128(rhs))
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func *= <T: BinaryInteger>(_ lhs: inout Duration, _ rhs: T) {
     lhs = lhs * rhs
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 @_unavailableInEmbedded
 extension Duration: CustomStringConvertible {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public var description: String {
     return (Double(_attoseconds) / 1e18).description + " seconds"
   }
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension Duration: DurationProtocol { }

--- a/stdlib/public/core/DurationProtocol.swift
+++ b/stdlib/public/core/DurationProtocol.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 /// A type that defines a duration for a given `InstantProtocol` type.
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 public protocol DurationProtocol: Comparable, AdditiveArithmetic, Sendable {
   static func / (_ lhs: Self, _ rhs: Int) -> Self
   static func /= (_ lhs: inout Self, _ rhs: Int)
@@ -21,14 +21,14 @@ public protocol DurationProtocol: Comparable, AdditiveArithmetic, Sendable {
   static func / (_ lhs: Self, _ rhs: Self) -> Double
 }
 
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 extension DurationProtocol {
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func /= (_ lhs: inout Self, _ rhs: Int) {
     lhs = lhs / rhs
   }
 
-  @available(SwiftStdlibCurrentOS 5.7, *)
+  @available(StdlibDeploymentTarget 5.7, *)
   public static func *= (_ lhs: inout Self, _ rhs: Int) {
     lhs = lhs * rhs
   }

--- a/stdlib/public/core/Instant.swift
+++ b/stdlib/public/core/Instant.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 // A type that defines a specific point in time for a given `Clock`.
-@available(SwiftStdlibCurrentOS 5.7, *)
+@available(StdlibDeploymentTarget 5.7, *)
 public protocol InstantProtocol<Duration>: Comparable, Hashable, Sendable {
   associatedtype Duration: DurationProtocol
   func advanced(by duration: Duration) -> Self

--- a/test/Concurrency/custom_executor_enqueue_availability.swift
+++ b/test/Concurrency/custom_executor_enqueue_availability.swift
@@ -28,7 +28,7 @@ final class OldExecutorOldStdlib: SerialExecutor {
 final class BothExecutorOldStdlib: SerialExecutor {
   func enqueue(_ job: UnownedJob) {}
 
-  // This no longer warns, because of the use of SwiftStdlibCurrentOS in the
+  // This no longer warns, because of the use of StdlibDeploymentTarget in the
   // runtime.
   @available(SwiftStdlib 5.9, *)
   func enqueue(_ job: __owned ExecutorJob) {}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -541,7 +541,7 @@ def version_gt(a, b):
     b_int += [0] * (vlen - len(b_int))
   return a_int > b_int
 
-# Returns a SwiftStdlibCurrentOS macro given a SwiftStdlib macro
+# Returns a StdlibDeploymentTarget macro given a SwiftStdlib macro
 def availability_macro_to_current(macro):
     matches = re.search(r'^\s*SwiftStdlib\s+([0-9\.]*)\s*:\s*(.*)', macro)
     if not matches:
@@ -568,9 +568,9 @@ def availability_macro_to_current(macro):
       ver = platform.mac_ver()[0]
 
       if version_gt(orig_vers, ver):
-        return f"SwiftStdlibCurrentOS {stdlib_vers}:{platform_name} {ver}"
+        return f"StdlibDeploymentTarget {stdlib_vers}:{platform_name} {ver}"
 
-    return f"SwiftStdlibCurrentOS {stdlib_vers}:{orig_spec}"
+    return f"StdlibDeploymentTarget {stdlib_vers}:{orig_spec}"
 
 # Add availability macros to the default frontend/driver flags and create target
 # triple substitutions for each stdlib version.

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -15,14 +15,13 @@
 # Each of the remaining lines must define an availability macro in the same
 # format used by the `-define-availability` frontend command line option.
 
-# NOTE: The build system will define another macro, SwiftStdlibCurrentOS,
-#       for each SwiftStdlib macro defined in this file.  The difference
-#       between the two is the the CurrentOS macro will never be set to a
+# NOTE: The build system will define another macro, StdlibDeploymentTarget, for
+#       each SwiftStdlib macro defined in this file.  The difference between the
+#       two is the the StdlibDeploymentTarget macro will never be set to a
 #       higher version than the machine on which we are building.
 #
-#       This is to allow for use of new functions and types within the
-#       standard libraries, in such a way that these usages will work on
-#       our CI machines.
+#       This is to allow for use of new functions and types within the standard
+#       libraries, in such a way that these usages will work on our CI machines.
 
 # 9999 is the generic unknown future Swift release. It always needs to resolve
 # to the special placeholder version numbers 9999.


### PR DESCRIPTION
`StdlibDeploymentTarget` seems to be a better name.

rdar://152498657
