### PR TITLE
[AST] Remove `getSemanticAttrs`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -396,9 +396,6 @@ protected:
     /// lldb.
     Hoisted : 1,
 
-    /// Whether the set of semantic attributes has been computed.
-    SemanticAttrsComputed : 1,
-
     /// True if \c ObjCInterfaceAndImplementationRequest has been computed
     /// and did \em not find anything. This is the fast path where we can bail
     /// out without checking other caches or computing anything.
@@ -1027,11 +1024,6 @@ public:
   /// attribute macro expansion.
   DeclAttributes getExpandedAttrs() const;
 
-  /// Returns all semantic attributes attached to this declaration,
-  /// including attributes that are generated as the result of member
-  /// attribute macro expansion.
-  DeclAttributes getSemanticAttrs() const;
-
   /// Register the relationship between \c this and \p attr->abiDecl , assuming
   /// that \p attr is attached to \c this . This is necessary for
   /// \c ABIRoleInfo::ABIRoleInfo() to determine that \c attr->abiDecl
@@ -1236,14 +1228,6 @@ private:
   }
 
 public:
-  bool getSemanticAttrsComputed() const {
-    return Bits.Decl.SemanticAttrsComputed;
-  }
-
-  void setSemanticAttrsComputed(bool Computed) {
-    Bits.Decl.SemanticAttrsComputed = Computed;
-  }
-
   /// \returns the unparsed comment attached to this declaration.
   RawComment getRawComment() const;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4994,25 +4994,6 @@ public:
   void cacheResult(bool isSkipped) const;
 };
 
-class SemanticDeclAttrsRequest
-    : public SimpleRequest<SemanticDeclAttrsRequest,
-                           DeclAttributes(const Decl *),
-                           RequestFlags::SeparatelyCached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  DeclAttributes evaluate(Evaluator &evaluator, const Decl *) const;
-
-public:
-  // Separate caching.
-  bool isCached() const { return true; }
-  std::optional<DeclAttributes> getCachedResult() const;
-  void cacheResult(DeclAttributes) const;
-};
-
 class UniqueUnderlyingTypeSubstitutionsRequest
     : public SimpleRequest<UniqueUnderlyingTypeSubstitutionsRequest,
                            std::optional<SubstitutionMap>(

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -572,9 +572,6 @@ SWIFT_REQUEST(TypeChecker, IsFunctionBodySkippedRequest,
 SWIFT_REQUEST(TypeChecker, IsCCompatibleFuncDeclRequest,
               bool(const FuncDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, SemanticDeclAttrsRequest,
-              DeclAttributes(const Decl *),
-              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, UniqueUnderlyingTypeSubstitutionsRequest,
               std::optional<SubstitutionMap>(const Decl *),
               SeparatelyCached, NoLocationInfo)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1273,7 +1273,7 @@ void PrintAST::printAttributes(const Decl *D) {
 
   // Force semantic attrs to be computed if appropriate.
   if (shouldPrintAllSemanticDetails(Options))
-    (void)D->getSemanticAttrs();
+    (void)D->getExpandedAttrs();
 
   auto attrs = D->getAttrs();
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -417,12 +417,6 @@ DeclAttributes Decl::getExpandedAttrs() const {
   return getAttrs();
 }
 
-DeclAttributes Decl::getSemanticAttrs() const {
-  (void)evaluateOrDefault(getASTContext().evaluator,
-                          SemanticDeclAttrsRequest{this}, {});
-  return getAttrs();
-}
-
 void Decl::attachParsedAttrs(DeclAttributes attrs) {
   ASSERT(getAttrs().isEmpty() && "attaching when there are already attrs?");
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2535,45 +2535,6 @@ void ExpandPeerMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
 }
 
 //----------------------------------------------------------------------------//
-// SemanticDeclAttrsRequest computation.
-//----------------------------------------------------------------------------//
-
-DeclAttributes SemanticDeclAttrsRequest::evaluate(Evaluator &evaluator,
-                                                  const Decl *decl) const {
-  // Expand attributes contributed by attached macros.
-  auto mutableDecl = const_cast<Decl *>(decl);
-  (void)evaluateOrDefault(evaluator, ExpandMemberAttributeMacros{mutableDecl},
-                          {});
-
-  // Trigger requests that cause additional semantic attributes to be added.
-  if (auto vd = dyn_cast<ValueDecl>(mutableDecl)) {
-    (void)getActorIsolation(vd);
-    (void)vd->isDynamic();
-    (void)vd->isFinal();
-  }
-  if (auto afd = dyn_cast<AbstractFunctionDecl>(decl)) {
-    (void)afd->isTransparent();
-  } else if (auto asd = dyn_cast<AbstractStorageDecl>(decl)) {
-    (void)asd->hasStorage();
-  }
-
-  return decl->getAttrs();
-}
-
-std::optional<DeclAttributes>
-SemanticDeclAttrsRequest::getCachedResult() const {
-  auto decl = std::get<0>(getStorage());
-  if (decl->getSemanticAttrsComputed())
-    return decl->getAttrs();
-  return std::nullopt;
-}
-
-void SemanticDeclAttrsRequest::cacheResult(DeclAttributes attrs) const {
-  auto decl = std::get<0>(getStorage());
-  const_cast<Decl *>(decl)->setSemanticAttrsComputed(true);
-}
-
-//----------------------------------------------------------------------------//
 // UniqueUnderlyingTypeSubstitutionsRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -728,7 +728,7 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
 
   ModuleDecl *MD = D->getModuleContext();
   for (auto *customAttr :
-       D->getSemanticAttrs().getAttributes<CustomAttr, true>()) {
+       D->getExpandedAttrs().getAttributes<CustomAttr, true>()) {
     SourceFile *SF =
         MD->getSourceFileContainingLocation(customAttr->getLocation());
     ASTNode expansion = SF ? SF->getMacroExpansion() : nullptr;


### PR DESCRIPTION
After https://github.com/swiftlang/swift/pull/69578, the only users of `getSemanticAttrs` after that PR are the AST printer and `SemaAnnotator`, all other calls were switched to `getExpandedAttrs`. This caused the `SemanticDeclAttrsRequest` to only get evaluated during indexing, which ends up doing semantic analysis in the pass that writes out the index data. Neither the AST printer nor indexing should report data that is unavailable during compilation and so both of these should use `getExpandedAttrs`.
