### PR TITLE
tests: require 64-bit pointersize for SILOptimizer/enum-comparison.swift

### DIFF
--- a/test/SILOptimizer/enum-comparison.swift
+++ b/test/SILOptimizer/enum-comparison.swift
@@ -5,6 +5,7 @@
 // RUN: %target-run %t/a.out | %FileCheck %s --check-prefix=OUT
 
 // REQUIRES: executable_test,optimized_stdlib
+// REQUIRES: PTRSIZE=64
 
 enum E: String {
   case a, b, c, long_case_name_for_testing, d, e


### PR DESCRIPTION
rdar://152175197
