### PR TITLE
Platform: Windows SDK 26100.3916 module map update

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -19,10 +19,39 @@ module _complex [system] [no_undeclared_includes] {
   export *
 }
 
+module _fenv [system] [no_undeclared_includes] {
+  use _float
+  use corecrt
+  header "fenv.h"
+  export *
+}
+
+module _float [system] [no_undeclared_includes] {
+  use corecrt
+  header "float.h"
+  export *
+}
+
+module _malloc [system] [no_undeclared_includes] {
+  use corecrt
+  header "malloc.h"
+  export *
+}
+
+module _stdlib [system] [no_undeclared_includes] {
+  use corecrt
+  header "stdlib.h"
+  export *
+}
+
 module ucrt [system] {
 
   module C {
     export _complex
+    export _fenv
+    export _float
+    export _malloc
+    export _stdlib
 
     module ctype {
       header "ctype.h"


### PR DESCRIPTION
A minor update to the Windows SDK broke our module maps. This fixes the issue by re-separating a few modules. For backward-compatibility and proper export of symbols, the split headers are also included in the main `ucrt` module.
