### PR TITLE
[stdlib] Add explict import to ReflectionTest to avoid name conflicts in stdlib and Darwin

### DIFF
--- a/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
+++ b/stdlib/private/SwiftReflectionTest/SwiftReflectionTest.swift
@@ -32,6 +32,9 @@ let RequestPointerSize = "p"
 internal import MachO
 internal import Darwin
 internal import var Darwin.errno
+internal import var Darwin.stdout
+internal import var Darwin.stderr
+internal import var Darwin.stdin
 
 #if arch(x86_64) || arch(arm64)
 typealias MachHeader = mach_header_64


### PR DESCRIPTION
Similar to #77155 , we disambiguate stdin, stdout, and stderr now.