### PR TITLE
SILOptimizer: change SIL linkage for prespecializations

### DIFF
--- a/Runtimes/Core/cmake/modules/DefaultSettings.cmake
+++ b/Runtimes/Core/cmake/modules/DefaultSettings.cmake
@@ -76,7 +76,9 @@ elseif(WIN32)
   set(SwiftCore_ENABLE_CONCURRENCY_default NO)
   set(SwiftCore_ENABLE_REMOTE_MIRROR_default NO)
   set(SwiftCore_THREADING_PACKAGE_default "WIN32")
-  set(SwiftCore_ENABLE_PRESPECIALIZATION_default ON)
+  # FIXME(swiftlang/swift#84780) - generic prespecialization seems to cause
+  # errors
+  set(SwiftCore_ENABLE_PRESPECIALIZATION_default OFF)
   set(SwiftCore_CONCURRENCY_GLOBAL_EXECUTOR_default "dispatch")
 
   set(SwiftCore_ENABLE_VECTOR_TYPES_default ON)


### PR DESCRIPTION
Give prespecialised functions `shared` SIL linkage rather than `public` SIL linkage when building a static library. This changes the IR linkage from `external, default visibility, dll export storage` to `linkonce ODR, default visibility, default storage`, effectively internalizing and enable link once ODR semantics allowing collapsing multiple definitions _across_ modules. This is important for `-Onone` builds with static libraries. As an example,
`$sSMsSKRzrlE14_insertionSort6within9sortedEnd2byySny5IndexSlQzG_AFSb7ElementSTQz_AItKXEtKFSrySSG_Tg5` was being emitted multiply across SwiftOnoneSupport and FoundationEssentials (in Locale.swift). This would then fail when static linking was used with `-Onone` (the default SPM level) on Windows.