### PR TITLE
[Runtime] Don't redeclare os_unfair_recursive_lock et al if the SDK has them.

### DIFF
--- a/include/swift/Threading/Impl/Darwin.h
+++ b/include/swift/Threading/Impl/Darwin.h
@@ -131,7 +131,9 @@ inline void lazy_mutex_unsafe_unlock(lazy_mutex_handle &handle) {
 
 // .. Recursive mutex support .................................................
 
-// The os_unfair_recursive_lock interface is stable, but not in the SDK. Bring
+#if OS_LOCK_API_VERSION < 20250601
+
+// The os_unfair_recursive_lock interface is stable, but not in this SDK. Bring
 // our own definitions for what we need.
 
 #define OS_UNFAIR_RECURSIVE_LOCK_INIT                                          \
@@ -150,6 +152,8 @@ os_unfair_recursive_lock_lock_with_options(os_unfair_recursive_lock_t lock,
 
 extern "C" void
 os_unfair_recursive_lock_unlock(os_unfair_recursive_lock_t lock);
+
+#endif // OS_UNFAIR_RECURSIVE_LOCK_INIT
 
 inline void recursive_mutex_init(recursive_mutex_handle &handle,
                                  bool checked = false) {


### PR DESCRIPTION
rdar://152340726