### PR TITLE
[Distributed] More IRGenMangler fixes for distributed thunks

### DIFF
--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -51,6 +51,8 @@ public:
     beginMangling();
     appendEntity(func);
     appendOperator("Tj");
+    if (func->isDistributedThunk())
+      appendSymbolKind(SymbolKind::DistributedThunk);
     return finalize();
   }
 


### PR DESCRIPTION
We also need to mangle the dispatch thunks to distributed thunks uniquely.

This is a follow up to https://github.com/swiftlang/swift/pull/81805 in order to resolve similar issues and TBD validation uncovered in large scale testing.

rdar://144568615 rdar://125628060