### PR TITLE
[Option] Add a feature flag for -Isystem

### DIFF
--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -47,6 +47,9 @@
     },
     {
        "name": "experimental-package-interface-load"
+    },
+    {
+       "name": "Isystem"
     }
   ]
 }


### PR DESCRIPTION
swift-build needs a flag to know if -Isystem is available.

rdar://152540225