### PR TITLE
utils: Add llvm-symbolizer to install_components_with_clang presets

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -19,7 +19,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;libexec;
 [preset: mixin_buildbot_install_components_with_clang]
 
 swift-install-components=autolink-driver;back-deployment;compiler;clang-resource-dir-symlink;libexec;stdlib;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;libclang;dsymutil;LTO;clang-features-file;lld
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;libclang;dsymutil;LTO;clang-features-file;lld
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.
@@ -848,7 +848,7 @@ no-swift-stdlib-assertions
 [preset: mixin_linux_install_components_with_clang]
 
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;libexec;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;libclang;lld;LTO;clang-features-file
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;libclang;lld;LTO;clang-features-file
 
 [preset: mixin_linux_installation]
 mixin-preset=


### PR DESCRIPTION
llvm-symbolizer is critical to ASAN/LSAN properly reading and applying allowlists and suppressions. Without properly symbolized backtraces, the tools cannot match stack traces to suppression lists, leading to false negatives in leak detection and other issues.

Ensure that it's installed in the toolchain presets.

ref: https://github.com/swiftlang/swiftly/issues/368

cc @FranzBusch 