### PR TITLE
[6.2][Option] Add a feature flag for -Isystem

### DIFF
--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -47,6 +47,9 @@
     },
     {
        "name": "experimental-package-interface-load"
+    },
+    {
+       "name": "Isystem"
     }
   ]
 }


### PR DESCRIPTION
- **Explanation**: This change adds a feature flag for `swift-build` to detect `-Isystem` support.
- **Scope**: New feature flag for an already implemented feature.
- **Original PRs**: https://github.com/swiftlang/swift/pull/81964
- **Risk**: None anticipated.
- **Testing**: CI, tested in coordination with https://github.com/swiftlang/swift-build/pull/555