### PR TITLE
[6.2] Add optional language features to the supported features output

### DIFF
--- a/test/Frontend/print-supported-features.swift
+++ b/test/Frontend/print-supported-features.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend -print-supported-features | %FileCheck %s
 
 // CHECK: "features": {
+// CHECK-NEXT:   "optional": [
+// CHECK: { "name": "StrictMemorySafety", "migratable": true, "categories": ["StrictMemorySafety"], "flag_name": "-strict-memory-safety" }
+// CHECK-NEXT: ],
 // CHECK-NEXT:   "upcoming": [
 // CHECK:     { "name": "InferIsolatedConformances", "migratable": true, "categories": ["IsolatedConformances"], "enabled_in": "7" },
 // CHECK:   ],


### PR DESCRIPTION
Follow-up to https://github.com/swiftlang/swift/pull/81744

- Explanation:

  One commit got lost while cherry-picking https://github.com/swiftlang/swift/pull/81703 to 6.2:

  Optional language features don't have a specific "-enable-*" flag, because they're rare and don't fit the same upcoming/experimental distinction. Add a flag_name field to provide the flag name as well.

- Main Branch PR: https://github.com/swiftlang/swift/pull/81703 (specifically one commit - 414adb55ca09c088a45740132da487aab301df5f)

- Risk: Low. Only enabled by new compilation flags, only create new warnings or re-use existing ones.

- Reviewed By: @DougGregor 

- Testing: Updated existing test-case.

(cherry picked from commit 414adb55ca09c088a45740132da487aab301df5f)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
