### PR TITLE
[cxx-interop] Only swiftify template instantiations behind type aliases

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -62,8 +62,9 @@
 #include "clang/AST/DeclObjCCommon.h"
 #include "clang/AST/Expr.h"
 #include "clang/AST/PrettyPrinter.h"
-#include "clang/AST/StmtVisitor.h"
 #include "clang/AST/RecordLayout.h"
+#include "clang/AST/RecursiveASTVisitor.h"
+#include "clang/AST/StmtVisitor.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetInfo.h"
@@ -9180,6 +9181,25 @@ static bool SwiftifiableCAT(const clang::ASTContext &ctx,
      : SwiftifiableCountedByPointerType(swiftType));
 }
 
+namespace {
+
+// Searches for template instantiations that are not behind type aliases.
+// FIXME: make sure the generated code compiles for template
+// instantiations that are not behind type aliases.
+struct UnaliasedInstantiationVisitor
+    : clang::RecursiveASTVisitor<UnaliasedInstantiationVisitor> {
+  bool hasUnaliasedInstantiation = false;
+
+  bool TraverseTypedefType(const clang::TypedefType *) { return true; }
+
+  bool
+  VisitTemplateSpecializationType(const clang::TemplateSpecializationType *) {
+    hasUnaliasedInstantiation = true;
+    return false;
+  }
+};
+} // namespace
+
 void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
   if (!SwiftContext.LangOpts.hasFeature(Feature::SafeInteropWrappers))
     return;
@@ -9190,6 +9210,13 @@ void ClangImporter::Implementation::swiftify(AbstractFunctionDecl *MappedDecl) {
 
   if (ClangDecl->getNumParams() != MappedDecl->getParameters()->size())
     return;
+
+  {
+    UnaliasedInstantiationVisitor visitor;
+    visitor.TraverseType(ClangDecl->getType());
+    if (visitor.hasUnaliasedInstantiation)
+      return;
+  }
 
   llvm::SmallString<128> MacroString;
   // We only attach the macro if it will produce an overload. Any __counted_by

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -165,12 +165,20 @@ inline SpanOfInt MixedFuncWithMutableSafeWrapper7(int * __counted_by(len) p, int
   return SpanOfInt(p, len);
 }
 
+template <typename X>
+struct S {};
+
 struct SpanWithoutTypeAlias {
   std::span<const int> bar() [[clang::lifetimebound]];
   void foo(std::span<const int> s [[clang::noescape]]);
+  void otherTemplatedType(ConstSpanOfInt copy [[clang::noescape]], S<int>);
+  void otherTemplatedType2(ConstSpanOfInt copy [[clang::noescape]], S<int> *);
 };
 
 inline void func(ConstSpanOfInt copy [[clang::noescape]]) {}
 inline void mutableKeyword(SpanOfInt copy [[clang::noescape]]) {}
+
+inline void spanWithoutTypeAlias(std::span<const int> s [[clang::noescape]]) {}
+inline void mutableSpanWithoutTypeAlias(std::span<int> s [[clang::noescape]]) {}
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -3,7 +3,7 @@
 // RUN: %FileCheck %s < %t/interface.swift
 
 // Make sure we trigger typechecking and SIL diagnostics
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -strict-memory-safety -warnings-as-errors -Xcc -std=c++20 %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -strict-memory-safety -warnings-as-errors -verify -Xcc -std=c++20 %s
 
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_LifetimeDependence
@@ -34,15 +34,10 @@ import CxxStdlib
 // CHECK-NEXT: }
 // CHECK: struct SpanWithoutTypeAlias {
 // CHECK-NEXT:   init()
-// CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:   @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT:   @lifetime(borrow self)
-// CHECK-NEXT:   @_alwaysEmitIntoClient @_disfavoredOverload public mutating func bar() -> Span<CInt>
 // CHECK-NEXT:   mutating func bar() -> std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>
-// CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:   @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT:   @_alwaysEmitIntoClient @_disfavoredOverload public mutating func foo(_ s: Span<CInt>)
 // CHECK-NEXT:   mutating func foo(_ s: std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>)
+// CHECK-NEXT:   mutating func otherTemplatedType(_ copy: ConstSpanOfInt, _: S<CInt>)
+// CHECK-NEXT:   mutating func otherTemplatedType2(_ copy: ConstSpanOfInt, _: UnsafeMutablePointer<S<CInt>>!)
 // CHECK-NEXT: }
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
@@ -150,7 +145,7 @@ func callMethodWithSafeWrapper(_ x: inout X, s: Span<CInt>) {
 }
 
 func callFooBar(_ x: inout SpanWithoutTypeAlias, _ s: ConstSpanOfInt) {
-    let _: Span<CInt> = x.bar()
+    let _: Span<CInt> = x.bar() // expected-error {{cannot convert value of type}}
     unsafe x.foo(s)
 }
 
@@ -241,4 +236,12 @@ func callMixedFuncWithSafeWrapper7(_ p: UnsafeBufferPointer<CInt>) {
 @lifetime(span: copy span)
 func callMutableKeyword(_ span: inout MutableSpan<CInt>) {
     mutableKeyword(&span)
+}
+
+func callSpanWithoutTypeAlias(_ span: Span<CInt>) {
+  spanWithoutTypeAlias(span) // expected-error {{cannot convert value of type}}
+}
+
+func callMutableSpanWithoutTypeAlias(_ span: consuming MutableSpan<CInt>) {
+  mutableSpanWithoutTypeAlias(&span) // expected-error {{cannot convert value of type}}
 }


### PR DESCRIPTION
While I could not trigger a scenario where the generated macro triggers a compilation error, the generated code is definitely not valid Swift.

rdar://151422108
