### PR TITLE
[IDE] Pass a `SourceRange` instead of a `CharSourceRange` in `SemaAnnotator::passReference`

### DIFF
--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -140,7 +140,7 @@ public:
   /// refers to.
   /// \param ExtTyRef this is set when the entity is a reference to a type loc
   /// in \c ExtensionDecl.
-  virtual bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
+  virtual bool visitDeclReference(ValueDecl *D, SourceRange Range,
                                   TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
                                   Type T, ReferenceMetaData Data);
 
@@ -156,7 +156,7 @@ public:
   /// \param Data whether this is a read, write or read/write access, etc.
   /// \param IsOpenBracket this is \c true when the method is called on an
   /// open bracket.
-  virtual bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
+  virtual bool visitSubscriptReference(ValueDecl *D, SourceRange Range,
                                        ReferenceMetaData Data,
                                        bool IsOpenBracket);
 
@@ -167,7 +167,7 @@ public:
   /// \param D the referenced decl.
   /// \param Range the source range of the source reference.
   /// \param Data whether this is a read, write or read/write access, etc.
-  virtual bool visitCallAsFunctionReference(ValueDecl *D, CharSourceRange Range,
+  virtual bool visitCallAsFunctionReference(ValueDecl *D, SourceRange Range,
                                             ReferenceMetaData Data);
 
   /// This method is called for each keyword argument in a call expression.

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -829,9 +829,9 @@ bool swift::emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
 class ObjcMethodReferenceCollector: public SourceEntityWalker {
   unsigned CurrentFileID;
   llvm::DenseMap<const clang::ObjCMethodDecl*, unsigned> results;
-  bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef,
-                          Type T, ReferenceMetaData Data) override {
+  bool visitDeclReference(ValueDecl *D, SourceRange Range, TypeDecl *CtorTyRef,
+                          ExtensionDecl *ExtTyRef, Type T,
+                          ReferenceMetaData Data) override {
     if (!Range.isValid())
       return true;
     if (auto *clangD = dyn_cast_or_null<clang::ObjCMethodDecl>(D->getClangDecl()))

--- a/lib/Refactoring/ExtractExprBase.cpp
+++ b/lib/Refactoring/ExtractExprBase.cpp
@@ -26,8 +26,8 @@ struct ReferenceCollector : public SourceEntityWalker {
   SmallVector<ValueDecl *, 4> References;
 
   ReferenceCollector(Expr *E) { walk(E); }
-  bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
+  bool visitDeclReference(ValueDecl *D, SourceRange Range, TypeDecl *CtorTyRef,
+                          ExtensionDecl *ExtTyRef, Type T,
                           ReferenceMetaData Data) override {
     References.emplace_back(D);
     return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1203,21 +1203,24 @@ public:
     return true;
   }
 
-  bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type Ty,
+  bool visitDeclReference(ValueDecl *D, SourceRange Range, TypeDecl *CtorTyRef,
+                          ExtensionDecl *ExtTyRef, Type Ty,
                           ReferenceMetaData Data) override {
     if (Data.isImplicit || !Range.isValid())
       return true;
     // Ignore things that don't come from this buffer.
-    if (!SM.getRangeForBuffer(BufferID).contains(Range.getStart()))
+    if (!SM.getRangeForBuffer(BufferID).contains(Range.Start))
       return true;
 
-    unsigned StartOffset = getOffset(Range.getStart());
-    References.emplace_back(D, StartOffset, Range.getByteLength(), Ty);
+    CharSourceRange CharRange = Lexer::getCharSourceRangeFromSourceRange(
+        D->getASTContext().SourceMgr, Range);
+
+    unsigned StartOffset = getOffset(CharRange.getStart());
+    References.emplace_back(D, StartOffset, CharRange.getByteLength(), Ty);
     return true;
   }
 
-  bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
+  bool visitSubscriptReference(ValueDecl *D, SourceRange Range,
                                ReferenceMetaData Data,
                                bool IsOpenBracket) override {
     // Treat both open and close brackets equally

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -990,8 +990,8 @@ public:
     }
   }
 
-  bool visitDeclReference(ValueDecl *D, CharSourceRange Range,
-                          TypeDecl *CtorTyRef, ExtensionDecl *ExtTyRef, Type T,
+  bool visitDeclReference(ValueDecl *D, SourceRange Range, TypeDecl *CtorTyRef,
+                          ExtensionDecl *ExtTyRef, Type T,
                           ReferenceMetaData Data) override {
     if (Data.isImplicit)
       return true;
@@ -1004,9 +1004,12 @@ public:
     if (D->isUnavailable())
       return true;
 
+    CharSourceRange CharRange = Lexer::getCharSourceRangeFromSourceRange(
+        D->getASTContext().SourceMgr, Range);
+
     auto &SM = D->getASTContext().SourceMgr;
     if (D == D->getASTContext().getOptionalNoneDecl() &&
-        SM.extractText(Range, BufferID) == "nil") {
+        SM.extractText(CharRange, BufferID) == "nil") {
       // If a 'nil' literal occurs in a swift-case statement, it gets replaced
       // by a reference to 'Optional.none' in the AST. We want to continue
       // highlighting 'nil' as a keyword and not as an enum element.
@@ -1015,11 +1018,11 @@ public:
 
     if (CtorTyRef)
       D = CtorTyRef;
-    annotate(D, /*IsRef=*/true, Range);
+    annotate(D, /*IsRef=*/true, CharRange);
     return true;
   }
 
-  bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
+  bool visitSubscriptReference(ValueDecl *D, SourceRange Range,
                                ReferenceMetaData Data,
                                bool IsOpenBracket) override {
     // We should treat both open and close brackets equally


### PR DESCRIPTION
Most `SemaAnnotator`s don’t actually care about the char source range. Instead, they only care about the start location of the reference, which is also included in `SourceRange`. Computing a `CharSourceRange` from a `SourceRange` is kind of expensive because it needs to start a new lexer.

To avoid this overhead, pass `SourceRange` to `SemaAnnotator::passReference` and related functions and let the clients compute the `CharSourceRange` when needed.

This reduces the overhead of index-while-building by about 10%.
