### PR TITLE
[cmake] add SINGLE_THREADED_MODE option to Synchronization

### DIFF
--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -58,6 +58,8 @@ option(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION "Generate ABI resilient runtime 
 option(${PROJECT_NAME}_ENABLE_PRESPECIALIZATION "Enable generic metadata prespecialization"
   ${SwiftCore_ENABLE_PRESPECIALIZATION})
 
+option(${PROJECT_NAME}_SINGLE_THREADED_MODE "Build Synchronization assuming it will be used in an environment with only a single thread" OFF)
+
 add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
@@ -95,12 +97,19 @@ add_library(swiftSynchronization
   Atomics/WordPair.swift
   Atomics/AtomicStorage.swift
   Atomics/AtomicIntegers.swift
-  Cell.swift
-  Mutex/Mutex.swift
-  $<$<PLATFORM_ID:Darwin>:Mutex/DarwinImpl.swift>
-  $<$<PLATFORM_ID:Android,Linux>:Mutex/LinuxImpl.swift>
-  $<$<PLATFORM_ID:Android,WASI>:Mutex/SpinLoopHint.swift>
-  $<$<PLATFORM_ID:Windows>:Mutex/WindowsImpl.swift>)
+  Cell.swift)
+
+# Determine Mutex definition
+if(${PROJECT_NAME}_SINGLE_THREADED_MODE)
+  target_sources(swiftSynchronization PRIVATE Mutex/MutexUnavailable.swift)
+else()
+  target_sources(swiftSynchronization PRIVATE
+    Mutex/Mutex.swift
+    $<$<PLATFORM_ID:Darwin>:Mutex/DarwinImpl.swift>
+    $<$<PLATFORM_ID:Android,Linux>:Mutex/LinuxImpl.swift>
+    $<$<PLATFORM_ID:Android,WASI>:Mutex/SpinLoopHint.swift>
+    $<$<PLATFORM_ID:Windows>:Mutex/WindowsImpl.swift>)
+endif()
 
 set_target_properties(swiftSynchronization PROPERTIES
   Swift_MODULE_NAME Synchronization)

--- a/Runtimes/Supplemental/Synchronization/cmake/caches/Vendors/Apple/arm64-BridgeOS.cmake
+++ b/Runtimes/Supplemental/Synchronization/cmake/caches/Vendors/Apple/arm64-BridgeOS.cmake
@@ -9,5 +9,6 @@ set(CMAKE_Swift_COMPILER_TARGET "arm64-apple-bridgeos${CMAKE_OSX_DEPLOYMENT_TARG
 set(SwiftSynchronization_ARCH_SUBDIR arm64 CACHE STRING "")
 set(SwiftSynchronization_PLATFORM_SUBDIR freestanding CACHE STRING "")
 set(CMAKE_BUILD_TYPE MinSizeRel CACHE STRING "")
+set(SwiftSynchronization_SINGLE_THREADED_MODE YES CACHE BOOL "")
 
 include("${CMAKE_CURRENT_LIST_DIR}/apple-common.cmake")


### PR DESCRIPTION
Add `SwiftSynchronization_FORCE_EMPTY_MUTEX_IMPLEMENTATION` flag to use empty mutex definition for certain apple platforms. This brings Synchronization in line with the current build systems functionality

We will revisit this in the future to determine if we can add a mutex definition for all Darwin platforms 