### PR TITLE
[IDE] Use `getExpandedAttrs` instead of `getSemanticAttrs` to get custom attributes of a declaration

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -728,7 +728,7 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
 
   ModuleDecl *MD = D->getModuleContext();
   for (auto *customAttr :
-       D->getSemanticAttrs().getAttributes<CustomAttr, true>()) {
+       D->getExpandedAttrs().getAttributes<CustomAttr, true>()) {
     SourceFile *SF =
         MD->getSourceFileContainingLocation(customAttr->getLocation());
     ASTNode expansion = SF ? SF->getMacroExpansion() : nullptr;


### PR DESCRIPTION
`getSemanticAttrs` runs a couple queries that we don’t actually need to run to get all the custom attributes, such as getting the actor isolation of the declaration. Running these things can amount to 5%-7% of the index-while-building overhead. Just running `getExpandedAttrs` should be sufficient here.