### PR TITLE
Only emit the non-sendable metatype capture diagnostic under region-based isolation

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3052,7 +3052,8 @@ namespace {
         }
       }
 
-      if (mayExecuteConcurrentlyWith(
+      if (ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation) &&
+          mayExecuteConcurrentlyWith(
               localFunc.getAsDeclContext(), getDeclContext(),
               /*includeSending*/true)) {
         auto innermostGenericDC = localFunc.getAsDeclContext();

--- a/test/Concurrency/sendable_metatype_swift5.swift
+++ b/test/Concurrency/sendable_metatype_swift5.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// REQUIRES: concurrency
+
+protocol P {
+  static func doSomething()
+}
+
+func doSomethingStatic<T: P>(_: T.Type) {
+  Task { @concurrent in
+    T.doSomething()
+  }
+}


### PR DESCRIPTION
We effectively suppress sendable diagnostics when region-based isolation is disabled, and RBI is enabled whenever strict concurrency checking is enabled. So, suppress this diagnostic when RBI is enabled.

Fixes rdar://152583759.