### PR TITLE
Make (Raw)ConformanceIsolation requests work on the normal protocol conformance

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -148,7 +148,7 @@ protected:
       Kind : bitmax(NumProtocolConformanceKindBits, 8),
 
       /// Whether the "raw" conformance isolation is "inferred", which applies to most conformances.
-      IsRawConformanceInferred : 1,
+      IsRawIsolationInferred : 1,
 
       /// Whether the computed actor isolation is nonisolated.
       IsComputedNonisolated : 1
@@ -205,16 +205,16 @@ protected:
   ProtocolConformance(ProtocolConformanceKind kind, Type conformingType)
     : ConformingType(conformingType) {
     Bits.ProtocolConformance.Kind = unsigned(kind);
-    Bits.ProtocolConformance.IsRawConformanceInferred = false;
+    Bits.ProtocolConformance.IsRawIsolationInferred = false;
     Bits.ProtocolConformance.IsComputedNonisolated = false;
   }
 
-  bool isRawConformanceInferred() const {
-    return Bits.ProtocolConformance.IsRawConformanceInferred;
+  bool isRawIsolationInferred() const {
+    return Bits.ProtocolConformance.IsRawIsolationInferred;
   }
 
   void setRawConformanceInferred(bool value = true) {
-    Bits.ProtocolConformance.IsRawConformanceInferred = value;
+    Bits.ProtocolConformance.IsRawIsolationInferred = value;
   }
 
   bool isComputedNonisolated() const {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -477,7 +477,7 @@ public:
 
 class RawConformanceIsolationRequest :
     public SimpleRequest<RawConformanceIsolationRequest,
-                         std::optional<ActorIsolation>(ProtocolConformance *),
+                         std::optional<ActorIsolation>(NormalProtocolConformance *),
                          RequestFlags::SeparatelyCached |
                          RequestFlags::SplitCached> {
 public:
@@ -488,7 +488,7 @@ private:
 
   // Evaluation.
   std::optional<ActorIsolation>
-  evaluate(Evaluator &evaluator, ProtocolConformance *conformance) const;
+  evaluate(Evaluator &evaluator, NormalProtocolConformance *conformance) const;
 
 public:
   // Separate caching.
@@ -499,7 +499,7 @@ public:
 
 class ConformanceIsolationRequest :
     public SimpleRequest<ConformanceIsolationRequest,
-                         ActorIsolation(ProtocolConformance *),
+                         ActorIsolation(NormalProtocolConformance *),
                          RequestFlags::SeparatelyCached |
                          RequestFlags::SplitCached> {
 public:
@@ -510,7 +510,7 @@ private:
 
   // Evaluation.
   ActorIsolation
-  evaluate(Evaluator &evaluator, ProtocolConformance *conformance) const;
+  evaluate(Evaluator &evaluator, NormalProtocolConformance *conformance) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -407,11 +407,11 @@ SWIFT_REQUEST(TypeChecker, ConformanceHasEffectRequest,
               bool(EffectKind, ProtocolConformanceRef),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RawConformanceIsolationRequest,
-              std::optional<ActorIsolation>(ProtocolConformance *),
+              std::optional<ActorIsolation>(NormalProtocolConformance *),
               SeparatelyCached | SplitCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ConformanceIsolationRequest,
-              ActorIsolation(ProtocolConformance *),
+              ActorIsolation(NormalProtocolConformance *),
               SeparatelyCached | SplitCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeRequest,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1378,7 +1378,7 @@ RawConformanceIsolationRequest::getCachedResult() const {
   auto conformance = std::get<0>(getStorage());
 
   // Was actor isolation non-isolated?
-  if (conformance->isRawConformanceInferred())
+  if (conformance->isRawIsolationInferred())
     return std::optional<ActorIsolation>();
 
   ASTContext &ctx = conformance->getDeclContext()->getASTContext();


### PR DESCRIPTION
Reduce the burden on the evaluator's caching mechanism by handling the unwrapping of a conformance down to its normal protocol conformance outside of these requests. Thanks, Slava!