### PR TITLE
[SIL] Generalize CastingIsolatedConformances to CheckedCastInstOptions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyAllocStack.swift
@@ -213,14 +213,14 @@ private extension AllocStackInst {
         builder.createCheckedCastAddrBranch(
           source: newAlloc, sourceFormalType: concreteFormalType,
           destination: cab.destination, targetFormalType: cab.targetFormalType,
-          isolatedConformances: cab.isolatedConformances,
+          options: cab.checkedCastOptions,
           consumptionKind: cab.consumptionKind,
           successBlock: cab.successBlock, failureBlock: cab.failureBlock)
         context.erase(instruction: cab)
       case let ucca as UnconditionalCheckedCastAddrInst:
         let builder = Builder(before: ucca, context)
         builder.createUnconditionalCheckedCastAddr(
-          isolatedConformances: ucca.isolatedConformances,
+          options: ucca.checkedCastOptions,
           source: newAlloc, sourceFormalType: concreteFormalType,
           destination: ucca.destination, targetFormalType: ucca.targetFormalType)
         context.erase(instruction: ucca)

--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -180,7 +180,7 @@ public struct Builder {
   public func createCheckedCastAddrBranch(
     source: Value, sourceFormalType: CanonicalType,
     destination: Value, targetFormalType: CanonicalType,
-    isolatedConformances: CastingIsolatedConformances,
+    options: CheckedCastInstOptions,
     consumptionKind: CheckedCastAddrBranchInst.CastConsumptionKind,
     successBlock: BasicBlock,
     failureBlock: BasicBlock
@@ -195,7 +195,7 @@ public struct Builder {
 
     let cast = bridged.createCheckedCastAddrBranch(source.bridged, sourceFormalType.bridged,
                                                    destination.bridged, targetFormalType.bridged,
-                                                   isolatedConformances.bridged,
+                                                   options.bridged,
                                                    bridgedConsumption,
                                                    successBlock.bridged, failureBlock.bridged)
     return notifyNew(cast.getAs(CheckedCastAddrBranchInst.self))
@@ -203,13 +203,12 @@ public struct Builder {
 
   @discardableResult
   public func createUnconditionalCheckedCastAddr(
-    isolatedConformances: CastingIsolatedConformances,
+    options: CheckedCastInstOptions,
     source: Value, sourceFormalType: CanonicalType,
     destination: Value, targetFormalType: CanonicalType
   ) -> UnconditionalCheckedCastAddrInst {
     let cast = bridged.createUnconditionalCheckedCastAddr(
-        isolatedConformances.bridged, source.bridged,
-        sourceFormalType.bridged,
+        options.bridged, source.bridged, sourceFormalType.bridged,
         destination.bridged, targetFormalType.bridged
     )
     return notifyNew(cast.getAs(UnconditionalCheckedCastAddrInst.self))

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -546,12 +546,8 @@ final public class UnconditionalCheckedCastAddrInst : Instruction, SourceDestAdd
   public var isInitializationOfDestination: Bool { true }
   public override var mayTrap: Bool { true }
 
-  public var isolatedConformances: CastingIsolatedConformances {
-    switch bridged.UnconditionalCheckedCastAddr_getIsolatedConformances() {
-    case .Allow: .allow
-    case .Prohibit: .prohibit
-    @unknown default: fatalError("Unhandled CastingIsolatedConformances")
-    }
+  public var checkedCastOptions: CheckedCastInstOptions {
+     .init(storage: bridged.UnconditionalCheckedCastAddr_getCheckedCastOptions().storage)
   }
 }
 
@@ -1060,12 +1056,8 @@ class UnconditionalCheckedCastInst : SingleValueInstruction, UnaryInstruction {
     CanonicalType(bridged: bridged.UnconditionalCheckedCast_getTargetFormalType())
   }
 
-  public var isolatedConformances: CastingIsolatedConformances {
-    switch bridged.UnconditionalCheckedCast_getIsolatedConformances() {
-    case .Allow: .allow
-    case .Prohibit: .prohibit
-    @unknown default: fatalError("Unhandled CastingIsolatedConformances")
-    }
+  public var checkedCastOptions: CheckedCastInstOptions {
+     .init(storage: bridged.UnconditionalCheckedCast_getCheckedCastOptions().storage)
   }
 }
 
@@ -1793,16 +1785,21 @@ final public class DynamicMethodBranchInst : TermInst {
 final public class AwaitAsyncContinuationInst : TermInst, UnaryInstruction {
 }
 
+public struct CheckedCastInstOptions {
+  var storage: UInt8 = 0
+  
+  var bridged: BridgedInstruction.CheckedCastInstOptions {
+    .init(storage: storage)
+  }
+  
+  var isolatedConformances: CastingIsolatedConformances {
+    return (storage & 0x01) != 0 ? .prohibit : .allow
+  }
+}
+
 public enum CastingIsolatedConformances {
   case allow
   case prohibit
-
-  var bridged: BridgedInstruction.CastingIsolatedConformances {
-    switch self {
-    case .allow: return .Allow
-    case .prohibit: return .Prohibit
-    }
-  }
 }
 
 final public class CheckedCastBranchInst : TermInst, UnaryInstruction {
@@ -1814,12 +1811,8 @@ final public class CheckedCastBranchInst : TermInst, UnaryInstruction {
     bridged.CheckedCastBranch_updateSourceFormalTypeFromOperandLoweredType()
   }
 
-  public var isolatedConformances: CastingIsolatedConformances {
-    switch bridged.CheckedCastBranch_getIsolatedConformances() {
-    case .Allow: return .allow
-    case .Prohibit: return .prohibit
-    default: fatalError("Bad CastingIsolatedConformances value")
-    }
+  public var checkedCastOptions: CheckedCastInstOptions {
+     .init(storage: bridged.CheckedCastBranch_getCheckedCastOptions().storage)
   }
 }
 
@@ -1862,12 +1855,8 @@ final public class CheckedCastAddrBranchInst : TermInst {
     }
   }
 
-  public var isolatedConformances: CastingIsolatedConformances {
-    switch bridged.CheckedCastAddrBranch_getIsolatedConformances() {
-    case .Allow: .allow
-    case .Prohibit: .prohibit
-    @unknown default: fatalError("Unhandled CastingIsolatedConformances")
-    }
+  public var checkedCastOptions: CheckedCastInstOptions {
+     .init(storage: bridged.CheckedCastAddrBranch_getCheckedCastOptions().storage)
   }
 }
 

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -148,7 +148,7 @@ protected:
       Kind : bitmax(NumProtocolConformanceKindBits, 8),
 
       /// Whether the "raw" conformance isolation is "inferred", which applies to most conformances.
-      IsRawConformanceInferred : 1,
+      IsRawIsolationInferred : 1,
 
       /// Whether the computed actor isolation is nonisolated.
       IsComputedNonisolated : 1
@@ -205,16 +205,16 @@ protected:
   ProtocolConformance(ProtocolConformanceKind kind, Type conformingType)
     : ConformingType(conformingType) {
     Bits.ProtocolConformance.Kind = unsigned(kind);
-    Bits.ProtocolConformance.IsRawConformanceInferred = false;
+    Bits.ProtocolConformance.IsRawIsolationInferred = false;
     Bits.ProtocolConformance.IsComputedNonisolated = false;
   }
 
-  bool isRawConformanceInferred() const {
-    return Bits.ProtocolConformance.IsRawConformanceInferred;
+  bool isRawIsolationInferred() const {
+    return Bits.ProtocolConformance.IsRawIsolationInferred;
   }
 
   void setRawConformanceInferred(bool value = true) {
-    Bits.ProtocolConformance.IsRawConformanceInferred = value;
+    Bits.ProtocolConformance.IsRawIsolationInferred = value;
   }
 
   bool isComputedNonisolated() const {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -477,7 +477,7 @@ public:
 
 class RawConformanceIsolationRequest :
     public SimpleRequest<RawConformanceIsolationRequest,
-                         std::optional<ActorIsolation>(ProtocolConformance *),
+                         std::optional<ActorIsolation>(NormalProtocolConformance *),
                          RequestFlags::SeparatelyCached |
                          RequestFlags::SplitCached> {
 public:
@@ -488,7 +488,7 @@ private:
 
   // Evaluation.
   std::optional<ActorIsolation>
-  evaluate(Evaluator &evaluator, ProtocolConformance *conformance) const;
+  evaluate(Evaluator &evaluator, NormalProtocolConformance *conformance) const;
 
 public:
   // Separate caching.
@@ -499,7 +499,7 @@ public:
 
 class ConformanceIsolationRequest :
     public SimpleRequest<ConformanceIsolationRequest,
-                         ActorIsolation(ProtocolConformance *),
+                         ActorIsolation(NormalProtocolConformance *),
                          RequestFlags::SeparatelyCached |
                          RequestFlags::SplitCached> {
 public:
@@ -510,7 +510,7 @@ private:
 
   // Evaluation.
   ActorIsolation
-  evaluate(Evaluator &evaluator, ProtocolConformance *conformance) const;
+  evaluate(Evaluator &evaluator, NormalProtocolConformance *conformance) const;
 
 public:
   // Separate caching.

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -407,11 +407,11 @@ SWIFT_REQUEST(TypeChecker, ConformanceHasEffectRequest,
               bool(EffectKind, ProtocolConformanceRef),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, RawConformanceIsolationRequest,
-              std::optional<ActorIsolation>(ProtocolConformance *),
+              std::optional<ActorIsolation>(NormalProtocolConformance *),
               SeparatelyCached | SplitCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ConformanceIsolationRequest,
-              ActorIsolation(ProtocolConformance *),
+              ActorIsolation(NormalProtocolConformance *),
               SeparatelyCached | SplitCached,
               NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeRequest,

--- a/include/swift/SIL/DynamicCasts.h
+++ b/include/swift/SIL/DynamicCasts.h
@@ -107,7 +107,7 @@ bool canIRGenUseScalarCheckedCastInstructions(SILModule &M,
 /// using a scalar cast operation.
 void emitIndirectConditionalCastWithScalar(
     SILBuilder &B, ModuleDecl *M, SILLocation loc,
-    CastingIsolatedConformances isolatedConformances,
+    CheckedCastInstOptions options,
     CastConsumptionKind consumption, SILValue src, CanType sourceType,
     SILValue dest, CanType targetType, SILBasicBlock *trueBB,
     SILBasicBlock *falseBB, ProfileCounter TrueCount = ProfileCounter(),
@@ -458,18 +458,18 @@ public:
         getModule(), getSourceFormalType(), getTargetFormalType());
   }
 
-  CastingIsolatedConformances getIsolatedConformances() const {
+  CheckedCastInstOptions getCheckedCastOptions() const {
     switch (getKind()) {
     case SILDynamicCastKind::CheckedCastAddrBranchInst:
-      return cast<CheckedCastAddrBranchInst>(inst)->getIsolatedConformances();
+      return cast<CheckedCastAddrBranchInst>(inst)->getCheckedCastOptions();
     case SILDynamicCastKind::CheckedCastBranchInst:
-      return cast<CheckedCastBranchInst>(inst)->getIsolatedConformances();
+      return cast<CheckedCastBranchInst>(inst)->getCheckedCastOptions();
     case SILDynamicCastKind::UnconditionalCheckedCastAddrInst:
       return cast<UnconditionalCheckedCastAddrInst>(inst)
-          ->getIsolatedConformances();
+          ->getCheckedCastOptions();
     case SILDynamicCastKind::UnconditionalCheckedCastInst:
       return cast<UnconditionalCheckedCastInst>(inst)
-          ->getIsolatedConformances();
+          ->getCheckedCastOptions();
     }
   }
 };

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -716,9 +716,8 @@ struct BridgedInstruction {
     CopyOnSuccess
   };
 
-  enum class CastingIsolatedConformances {
-    Allow,
-    Prohibit
+  struct CheckedCastInstOptions {
+    uint8_t storage;
   };
 
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef CondFailInst_getMessage() const;
@@ -831,22 +830,22 @@ struct BridgedInstruction {
   BRIDGED_INLINE void LoadInst_setOwnership(SwiftInt ownership) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType UnconditionalCheckedCast_getSourceFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType UnconditionalCheckedCast_getTargetFormalType() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CastingIsolatedConformances
-      UnconditionalCheckedCast_getIsolatedConformances() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CheckedCastInstOptions
+      UnconditionalCheckedCast_getCheckedCastOptions() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType UnconditionalCheckedCastAddr_getSourceFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType UnconditionalCheckedCastAddr_getTargetFormalType() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CastingIsolatedConformances
-      UnconditionalCheckedCastAddr_getIsolatedConformances() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CheckedCastInstOptions
+      UnconditionalCheckedCastAddr_getCheckedCastOptions() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastBranch_getSuccessBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastBranch_getFailureBlock() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CastingIsolatedConformances
-      CheckedCastBranch_getIsolatedConformances() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CheckedCastInstOptions
+      CheckedCastBranch_getCheckedCastOptions() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType CheckedCastAddrBranch_getSourceFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedCanType CheckedCastAddrBranch_getTargetFormalType() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastAddrBranch_getSuccessBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastAddrBranch_getFailureBlock() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CastingIsolatedConformances
-      CheckedCastAddrBranch_getIsolatedConformances() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE CheckedCastInstOptions
+      CheckedCastAddrBranch_getCheckedCastOptions() const;
   BRIDGED_INLINE void CheckedCastBranch_updateSourceFormalTypeFromOperandLoweredType() const;
   BRIDGED_INLINE CastConsumptionKind CheckedCastAddrBranch_getConsumptionKind() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap ApplySite_getSubstitutionMap() const;
@@ -1176,11 +1175,11 @@ struct BridgedBuilder{
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createCheckedCastAddrBranch(
       BridgedValue source, BridgedCanType sourceFormalType,
       BridgedValue destination, BridgedCanType targetFormalType,
-      BridgedInstruction::CastingIsolatedConformances isolatedConformances,
+      BridgedInstruction::CheckedCastInstOptions options,
       BridgedInstruction::CastConsumptionKind consumptionKind,
       BridgedBasicBlock successBlock, BridgedBasicBlock failureBlock) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUnconditionalCheckedCastAddr(
-        BridgedInstruction::CastingIsolatedConformances isolatedConformances,
+        BridgedInstruction::CheckedCastInstOptions options,
         BridgedValue source, BridgedCanType sourceFormalType,
         BridgedValue destination, BridgedCanType targetFormalType) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createUncheckedOwnershipConversion(

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1564,10 +1564,11 @@ BridgedCanType BridgedInstruction::UnconditionalCheckedCast_getTargetFormalType(
   return {getAs<swift::UnconditionalCheckedCastInst>()->getTargetFormalType()};    
 }
 
-BridgedInstruction::CastingIsolatedConformances
-BridgedInstruction::UnconditionalCheckedCast_getIsolatedConformances() const {
-  return static_cast<BridgedInstruction::CastingIsolatedConformances>(
-      getAs<swift::UnconditionalCheckedCastInst>()->getIsolatedConformances());
+BridgedInstruction::CheckedCastInstOptions
+BridgedInstruction::UnconditionalCheckedCast_getCheckedCastOptions() const {
+  return BridgedInstruction::CheckedCastInstOptions{
+      getAs<swift::UnconditionalCheckedCastInst>()->getCheckedCastOptions()
+        .getStorage()};
 }
 
 BridgedCanType BridgedInstruction::UnconditionalCheckedCastAddr_getSourceFormalType() const {
@@ -1578,10 +1579,11 @@ BridgedCanType BridgedInstruction::UnconditionalCheckedCastAddr_getTargetFormalT
   return {getAs<swift::UnconditionalCheckedCastAddrInst>()->getTargetFormalType()};    
 }
 
-BridgedInstruction::CastingIsolatedConformances
-BridgedInstruction::UnconditionalCheckedCastAddr_getIsolatedConformances() const {
-  return static_cast<BridgedInstruction::CastingIsolatedConformances>(
-      getAs<swift::UnconditionalCheckedCastAddrInst>()->getIsolatedConformances());
+BridgedInstruction::CheckedCastInstOptions
+BridgedInstruction::UnconditionalCheckedCastAddr_getCheckedCastOptions() const {
+  return BridgedInstruction::CheckedCastInstOptions{
+      getAs<swift::UnconditionalCheckedCastAddrInst>()->getCheckedCastOptions()
+        .getStorage()};
 }
 
 BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getSuccessBlock() const {
@@ -1592,10 +1594,11 @@ BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getFailureBlock() const 
   return {getAs<swift::CheckedCastBranchInst>()->getFailureBB()};
 }
 
-BridgedInstruction::CastingIsolatedConformances
-BridgedInstruction::CheckedCastBranch_getIsolatedConformances() const {
-  return static_cast<BridgedInstruction::CastingIsolatedConformances>(
-      getAs<swift::CheckedCastBranchInst>()->getIsolatedConformances());
+BridgedInstruction::CheckedCastInstOptions
+BridgedInstruction::CheckedCastBranch_getCheckedCastOptions() const {
+  return BridgedInstruction::CheckedCastInstOptions{
+      getAs<swift::CheckedCastBranchInst>()->getCheckedCastOptions()
+        .getStorage()};
 }
 
 BridgedCanType BridgedInstruction::CheckedCastAddrBranch_getSourceFormalType() const {
@@ -1626,10 +1629,11 @@ BridgedInstruction::CastConsumptionKind BridgedInstruction::CheckedCastAddrBranc
            getAs<swift::CheckedCastAddrBranchInst>()->getConsumptionKind());
 }
 
-BridgedInstruction::CastingIsolatedConformances
-BridgedInstruction::CheckedCastAddrBranch_getIsolatedConformances() const {
-  return static_cast<BridgedInstruction::CastingIsolatedConformances>(
-      getAs<swift::CheckedCastAddrBranchInst>()->getIsolatedConformances());
+BridgedInstruction::CheckedCastInstOptions
+BridgedInstruction::CheckedCastAddrBranch_getCheckedCastOptions() const {
+  return BridgedInstruction::CheckedCastInstOptions{
+      getAs<swift::CheckedCastAddrBranchInst>()->getCheckedCastOptions()
+        .getStorage()};
 }
 
 BridgedSubstitutionMap BridgedInstruction::ApplySite_getSubstitutionMap() const {
@@ -2190,13 +2194,13 @@ BridgedInstruction BridgedBuilder::createUpcast(BridgedValue op, BridgedType typ
 BridgedInstruction BridgedBuilder::createCheckedCastAddrBranch(
     BridgedValue source, BridgedCanType sourceFormalType,
     BridgedValue destination, BridgedCanType targetFormalType,
-    BridgedInstruction::CastingIsolatedConformances isolatedConformances,
+    BridgedInstruction::CheckedCastInstOptions options,
     BridgedInstruction::CastConsumptionKind consumptionKind,
     BridgedBasicBlock successBlock, BridgedBasicBlock failureBlock) const
 {
   return {unbridged().createCheckedCastAddrBranch(
             regularLoc(),
-            (swift::CastingIsolatedConformances)isolatedConformances,
+            swift::CheckedCastInstOptions(options.storage),
             (swift::CastConsumptionKind)consumptionKind,
             source.getSILValue(), sourceFormalType.unbridged(),
             destination.getSILValue(), targetFormalType.unbridged(),
@@ -2204,13 +2208,13 @@ BridgedInstruction BridgedBuilder::createCheckedCastAddrBranch(
 }
 
 BridgedInstruction BridgedBuilder::createUnconditionalCheckedCastAddr(
-    BridgedInstruction::CastingIsolatedConformances isolatedConformances,
+    BridgedInstruction::CheckedCastInstOptions options,
     BridgedValue source, BridgedCanType sourceFormalType,
     BridgedValue destination, BridgedCanType targetFormalType) const
 {
   return {unbridged().createUnconditionalCheckedCastAddr(
             regularLoc(),
-            (swift::CastingIsolatedConformances)isolatedConformances,
+            swift::CheckedCastInstOptions(options.storage),
             source.getSILValue(), sourceFormalType.unbridged(),
             destination.getSILValue(), targetFormalType.unbridged())};
 }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1554,33 +1554,33 @@ public:
 
   UnconditionalCheckedCastInst *
   createUnconditionalCheckedCast(SILLocation Loc,
-                                 CastingIsolatedConformances isolatedConformances,
+                                 CheckedCastInstOptions options,
                                  SILValue op,
                                  SILType destLoweredTy,
                                  CanType destFormalTy) {
-    return createUnconditionalCheckedCast(Loc, isolatedConformances, op,
+    return createUnconditionalCheckedCast(Loc, options, op,
                                           destLoweredTy, destFormalTy,
                                           op->getOwnershipKind());
   }
 
   UnconditionalCheckedCastInst *
   createUnconditionalCheckedCast(SILLocation Loc,
-                                 CastingIsolatedConformances isolatedConformances,
+                                 CheckedCastInstOptions options,
                                  SILValue op,
                                  SILType destLoweredTy, CanType destFormalTy,
                                  ValueOwnershipKind forwardingOwnershipKind) {
     return insert(UnconditionalCheckedCastInst::create(
-        getSILDebugLocation(Loc), isolatedConformances, op, destLoweredTy,
+        getSILDebugLocation(Loc), options, op, destLoweredTy,
         destFormalTy, getFunction(), forwardingOwnershipKind));
   }
 
   UnconditionalCheckedCastAddrInst *
   createUnconditionalCheckedCastAddr(SILLocation Loc,
-                                     CastingIsolatedConformances isolatedConformances,
+                                     CheckedCastInstOptions options,
                                      SILValue src, CanType sourceFormalType,
                                      SILValue dest, CanType targetFormalType) {
     return insert(UnconditionalCheckedCastAddrInst::create(
-        getSILDebugLocation(Loc), isolatedConformances, src, sourceFormalType,
+        getSILDebugLocation(Loc), options, src, sourceFormalType,
         dest, targetFormalType, getFunction()));
   }
 
@@ -2779,7 +2779,7 @@ public:
 
   CheckedCastBranchInst *
   createCheckedCastBranch(SILLocation Loc, bool isExact,
-                          CastingIsolatedConformances isolatedConformances,
+                          CheckedCastInstOptions options,
                           SILValue op,
                           CanType srcFormalTy, SILType destLoweredTy,
                           CanType destFormalTy, SILBasicBlock *successBB,
@@ -2789,7 +2789,7 @@ public:
 
   CheckedCastBranchInst *
   createCheckedCastBranch(SILLocation Loc, bool isExact,
-                          CastingIsolatedConformances isolatedConformances,
+                          CheckedCastInstOptions options,
                           SILValue op,
                           CanType srcFormalTy, SILType destLoweredTy,
                           CanType destFormalTy, SILBasicBlock *successBB, 
@@ -2800,7 +2800,7 @@ public:
 
   CheckedCastAddrBranchInst *
   createCheckedCastAddrBranch(SILLocation Loc,
-                              CastingIsolatedConformances isolatedConformances,
+                              CheckedCastInstOptions options,
                               CastConsumptionKind consumption,
                               SILValue src, CanType sourceFormalType,
                               SILValue dest, CanType targetFormalType,
@@ -2809,7 +2809,7 @@ public:
                               ProfileCounter Target1Count = ProfileCounter(),
                               ProfileCounter Target2Count = ProfileCounter()) {
     return insertTerminator(CheckedCastAddrBranchInst::create(
-        getSILDebugLocation(Loc), isolatedConformances, consumption, src,
+        getSILDebugLocation(Loc), options, consumption, src,
         sourceFormalType, dest, targetFormalType, successBB, failureBB,
         Target1Count, Target2Count, getFunction()));
   }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2022,7 +2022,7 @@ SILCloner<ImplClass>::visitUnconditionalCheckedCastInst(
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst,
                           getBuilder().createUnconditionalCheckedCast(
-                              OpLoc, Inst->getIsolatedConformances(), OpValue,
+                              OpLoc, Inst->getCheckedCastOptions(), OpValue,
                               OpLoweredType, OpFormalType,
                               getBuilder().hasOwnership()
                                   ? Inst->getForwardingOwnershipKind()
@@ -2041,7 +2041,7 @@ SILCloner<ImplClass>::visitUnconditionalCheckedCastAddrInst(
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   recordClonedInstruction(Inst,
                           getBuilder().createUnconditionalCheckedCastAddr(
-                              OpLoc, Inst->getIsolatedConformances(),
+                              OpLoc, Inst->getCheckedCastOptions(),
                               SrcValue, SrcType, DestValue, TargetType));
 }
 
@@ -3452,7 +3452,7 @@ SILCloner<ImplClass>::visitCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
   recordClonedInstruction(
       Inst, getBuilder().createCheckedCastBranch(
                 getOpLocation(Inst->getLoc()), Inst->isExact(),
-                Inst->getIsolatedConformances(),
+                Inst->getCheckedCastOptions(),
                 getOpValue(Inst->getOperand()),
                 getOpASTType(Inst->getSourceFormalType()),
                 getOpType(Inst->getTargetLoweredType()),
@@ -3474,7 +3474,7 @@ void SILCloner<ImplClass>::visitCheckedCastAddrBranchInst(
   auto FalseCount = Inst->getFalseBBCount();
   recordClonedInstruction(Inst, getBuilder().createCheckedCastAddrBranch(
                                     getOpLocation(Inst->getLoc()),
-                                    Inst->getIsolatedConformances(),
+                                    Inst->getCheckedCastOptions(),
                                     Inst->getConsumptionKind(), SrcValue,
                                     SrcType, DestValue, TargetType, OpSuccBB,
                                     OpFailBB, TrueCount, FalseCount));

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -247,7 +247,7 @@ protected:
     if (canSILUseScalarCheckedCastInstructions(B.getModule(),
                                                sourceType, targetType)) {
       emitIndirectConditionalCastWithScalar(
-          B, SwiftMod, loc, inst->getIsolatedConformances(),
+          B, SwiftMod, loc, inst->getCheckedCastOptions(),
           inst->getConsumptionKind(), src, sourceType, dest,
           targetType, succBB, failBB, TrueCount, FalseCount);
       return;
@@ -255,7 +255,7 @@ protected:
 
     // Otherwise, use the indirect cast.
     B.createCheckedCastAddrBranch(loc,
-                                  inst->getIsolatedConformances(),
+                                  inst->getCheckedCastOptions(),
                                   inst->getConsumptionKind(),
                                   src, sourceType,
                                   dest, targetType,

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1378,7 +1378,7 @@ RawConformanceIsolationRequest::getCachedResult() const {
   auto conformance = std::get<0>(getStorage());
 
   // Was actor isolation non-isolated?
-  if (conformance->isRawConformanceInferred())
+  if (conformance->isRawIsolationInferred())
     return std::optional<ActorIsolation>();
 
   ASTContext &ctx = conformance->getDeclContext()->getASTContext();

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -45,7 +45,7 @@ using namespace irgen;
 static DynamicCastFlags getDynamicCastFlags(
     CastConsumptionKind consumptionKind,
     CheckedCastMode mode,
-    CastingIsolatedConformances isolatedConformances
+    CheckedCastInstOptions options
 ) {
   DynamicCastFlags flags = DynamicCastFlags::Default;
 
@@ -56,7 +56,7 @@ static DynamicCastFlags getDynamicCastFlags(
   if (shouldTakeOnSuccess(consumptionKind))
     flags |= DynamicCastFlags::TakeOnSuccess;
 
-  switch (isolatedConformances) {
+  switch (options.isolatedConformances()) {
   case CastingIsolatedConformances::Allow:
     break;
   case CastingIsolatedConformances::Prohibit:
@@ -75,11 +75,10 @@ llvm::Value *irgen::emitCheckedCast(IRGenFunction &IGF,
                                     CanType targetType,
                                     CastConsumptionKind consumptionKind,
                                     CheckedCastMode mode,
-                            CastingIsolatedConformances isolatedConformances) {
+                                    CheckedCastInstOptions options) {
   // TODO: attempt to specialize this based on the known types.
 
-  DynamicCastFlags flags = getDynamicCastFlags(consumptionKind, mode,
-                                               isolatedConformances);
+  DynamicCastFlags flags = getDynamicCastFlags(consumptionKind, mode, options);
 
   // Cast both addresses to opaque pointer type.
   dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.OpaqueTy);
@@ -860,7 +859,7 @@ void irgen::emitScalarCheckedCast(IRGenFunction &IGF,
                                   SILType targetLoweredType,
                                   CanType targetFormalType,
                                   CheckedCastMode mode,
-                              CastingIsolatedConformances isolatedConformances,
+                                  CheckedCastInstOptions options,
                                   Explosion &out) {
   assert(sourceLoweredType.isObject());
   assert(targetLoweredType.isObject());
@@ -990,7 +989,7 @@ void irgen::emitScalarCheckedCast(IRGenFunction &IGF,
                                                src, sourceFormalType,
                                                dest, targetFormalType,
                                                CastConsumptionKind::TakeAlways,
-                                               mode, isolatedConformances);
+                                               mode, options);
         llvm::Value *successResult = IGF.Builder.CreateLoad(dest);
         llvm::Value *failureResult = llvm::ConstantPointerNull::get(destPtrType);
         llvm::Value *result = IGF.Builder.CreateSelect(success, successResult, failureResult);

--- a/lib/IRGen/GenCast.h
+++ b/lib/IRGen/GenCast.h
@@ -28,7 +28,7 @@ namespace swift {
   class SILType;
   class ProtocolDecl;
   enum class CastConsumptionKind : unsigned char;
-  enum class CastingIsolatedConformances: uint8_t;
+  class CheckedCastInstOptions;
 
 namespace irgen {
   class Address;
@@ -48,7 +48,7 @@ namespace irgen {
                                CanType toType,
                                CastConsumptionKind consumptionKind,
                                CheckedCastMode mode,
-                              CastingIsolatedConformances isolatedConformances);
+                               CheckedCastInstOptions options);
 
   void emitScalarCheckedCast(IRGenFunction &IGF, Explosion &value,
                              SILType sourceLoweredType,
@@ -56,7 +56,7 @@ namespace irgen {
                              SILType targetLoweredType,
                              CanType targetFormalType,
                              CheckedCastMode mode,
-                             CastingIsolatedConformances isolatedConformances,
+                             CheckedCastInstOptions options,
                              Explosion &out);
 
   llvm::Value *emitFastClassCastIfPossible(

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7248,7 +7248,7 @@ visitUncheckedRefCastAddrInst(swift::UncheckedRefCastAddrInst *i) {
                   dest, i->getTargetFormalType(),
                   CastConsumptionKind::TakeAlways,
                   CheckedCastMode::Unconditional,
-                  CastingIsolatedConformances::Allow);
+                  CheckedCastInstOptions());
 }
 
 void IRGenSILFunction::visitUncheckedAddrCastInst(
@@ -7478,7 +7478,7 @@ void IRGenSILFunction::visitUnconditionalCheckedCastInst(
                         i->getTargetLoweredType(),
                         i->getTargetFormalType(),
                         CheckedCastMode::Unconditional,
-                        i->getIsolatedConformances(),
+                        i->getCheckedCastOptions(),
                         ex);
   setLoweredExplosion(i, ex);
 }
@@ -7668,7 +7668,7 @@ void IRGenSILFunction::visitUnconditionalCheckedCastAddrInst(
                   dest, i->getTargetFormalType(),
                   CastConsumptionKind::TakeAlways,
                   CheckedCastMode::Unconditional,
-                  i->getIsolatedConformances());
+                  i->getCheckedCastOptions());
 }
 
 void IRGenSILFunction::visitCheckedCastBranchInst(
@@ -7689,7 +7689,7 @@ void IRGenSILFunction::visitCheckedCastBranchInst(
                           i->getTargetLoweredType(),
                           i->getTargetFormalType(),
                           CheckedCastMode::Conditional,
-                          i->getIsolatedConformances(),
+                          i->getCheckedCastOptions(),
                           ex);
     auto val = ex.claimNext();
     castResult.casted = val;
@@ -7728,7 +7728,7 @@ void IRGenSILFunction::visitCheckedCastAddrBranchInst(
                     src, i->getSourceFormalType(),
                     dest, i->getTargetFormalType(),
                     i->getConsumptionKind(), CheckedCastMode::Conditional,
-                    i->getIsolatedConformances());
+                    i->getCheckedCastOptions());
   Builder.CreateCondBr(castSucceeded,
                        getLoweredBB(i->getSuccessBB()).bb,
                        getLoweredBB(i->getFailureBB()).bb);

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -780,7 +780,7 @@ SwitchEnumInst *SILBuilder::createSwitchEnum(
 
 CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
     SILLocation Loc, bool isExact,
-    CastingIsolatedConformances isolatedConformances,
+    CheckedCastInstOptions options,
     SILValue op, CanType srcFormalTy,
     SILType destLoweredTy, CanType destFormalTy, SILBasicBlock *successBB,
     SILBasicBlock *failureBB, ProfileCounter target1Count,
@@ -788,14 +788,14 @@ CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
   auto forwardingOwnership =
       deriveForwardingOwnership(op, destLoweredTy, getFunction());
   return createCheckedCastBranch(
-      Loc, isExact, isolatedConformances, op, srcFormalTy, destLoweredTy,
+      Loc, isExact, options, op, srcFormalTy, destLoweredTy,
       destFormalTy, successBB,
       failureBB, forwardingOwnership, target1Count, target2Count);
 }
 
 CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
     SILLocation Loc, bool isExact,
-    CastingIsolatedConformances isolatedConformances,
+    CheckedCastInstOptions options,
     SILValue op, CanType srcFormalTy,
     SILType destLoweredTy, CanType destFormalTy, SILBasicBlock *successBB,
     SILBasicBlock *failureBB, ValueOwnershipKind forwardingOwnershipKind,
@@ -805,7 +805,7 @@ CheckedCastBranchInst *SILBuilder::createCheckedCastBranch(
          "failureBB's argument doesn't match incoming argument type");
 
   return insertTerminator(CheckedCastBranchInst::create(
-      getSILDebugLocation(Loc), isExact, isolatedConformances, op, srcFormalTy,
+      getSILDebugLocation(Loc), isExact, options, op, srcFormalTy,
       destLoweredTy, destFormalTy, successBB, failureBB, getFunction(),
       target1Count, target2Count, forwardingOwnershipKind));
 }

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -1441,15 +1441,16 @@ UncheckedRefCastAddrInst::create(SILDebugLocation Loc, SILValue src,
 }
 
 UnconditionalCheckedCastAddrInst::UnconditionalCheckedCastAddrInst(
-    SILDebugLocation Loc, CastingIsolatedConformances isolatedConformances,
+    SILDebugLocation Loc, CheckedCastInstOptions options,
     SILValue src, CanType srcType, SILValue dest,
     CanType targetType, ArrayRef<SILValue> TypeDependentOperands)
     : AddrCastInstBase(Loc, src, srcType, dest, targetType,
         TypeDependentOperands),
-      IsolatedConformances(isolatedConformances) {}
+      Options(options) {}
 
 UnconditionalCheckedCastAddrInst *
-UnconditionalCheckedCastAddrInst::create(SILDebugLocation Loc, CastingIsolatedConformances isolatedConformances, SILValue src,
+UnconditionalCheckedCastAddrInst::create(SILDebugLocation Loc,
+        CheckedCastInstOptions options, SILValue src,
         CanType srcType, SILValue dest, CanType targetType, SILFunction &F) {
   SILModule &Mod = F.getModule();
   SmallVector<SILValue, 4> allOperands;
@@ -1458,12 +1459,12 @@ UnconditionalCheckedCastAddrInst::create(SILDebugLocation Loc, CastingIsolatedCo
       totalSizeToAlloc<swift::Operand>(2 + allOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(UnconditionalCheckedCastAddrInst));
   return ::new (Buffer) UnconditionalCheckedCastAddrInst(
-    Loc, isolatedConformances, src, srcType, dest, targetType, allOperands);
+    Loc, options, src, srcType, dest, targetType, allOperands);
 }
 
 CheckedCastAddrBranchInst::CheckedCastAddrBranchInst(
   SILDebugLocation DebugLoc,
-  CastingIsolatedConformances isolatedConformances,
+  CheckedCastInstOptions options,
   CastConsumptionKind consumptionKind,
   SILValue src, CanType srcType, SILValue dest, CanType targetType,
   ArrayRef<SILValue> TypeDependentOperands,
@@ -1472,14 +1473,14 @@ CheckedCastAddrBranchInst::CheckedCastAddrBranchInst(
       : AddrCastInstBase(DebugLoc, src, srcType, dest,
             targetType, TypeDependentOperands, consumptionKind,
             successBB, failureBB, Target1Count, Target2Count),
-        IsolatedConformances(isolatedConformances) {
+        Options(options) {
   assert(consumptionKind != CastConsumptionKind::BorrowAlways &&
          "BorrowAlways is not supported on addresses");
 }
 
 CheckedCastAddrBranchInst *
 CheckedCastAddrBranchInst::create(SILDebugLocation DebugLoc,
-         CastingIsolatedConformances isolatedConformances,
+         CheckedCastInstOptions options,
          CastConsumptionKind consumptionKind,
          SILValue src, CanType srcType, SILValue dest, CanType targetType,
          SILBasicBlock *successBB, SILBasicBlock *failureBB,
@@ -1492,7 +1493,7 @@ CheckedCastAddrBranchInst::create(SILDebugLocation DebugLoc,
       totalSizeToAlloc<swift::Operand>(2 + allOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(CheckedCastAddrBranchInst));
   return ::new (Buffer) CheckedCastAddrBranchInst(
-    DebugLoc, isolatedConformances, consumptionKind,
+    DebugLoc, options, consumptionKind,
     src, srcType, dest, targetType, allOperands,
     successBB, failureBB, Target1Count, Target2Count);
 }
@@ -2691,7 +2692,7 @@ UncheckedBitwiseCastInst::create(SILDebugLocation DebugLoc, SILValue Operand,
 }
 
 UnconditionalCheckedCastInst *UnconditionalCheckedCastInst::create(
-    SILDebugLocation DebugLoc, CastingIsolatedConformances isolatedConformances,
+    SILDebugLocation DebugLoc, CheckedCastInstOptions options,
     SILValue Operand, SILType DestLoweredTy,
     CanType DestFormalTy, SILFunction &F,
     ValueOwnershipKind forwardingOwnershipKind) {
@@ -2702,13 +2703,13 @@ UnconditionalCheckedCastInst *UnconditionalCheckedCastInst::create(
       totalSizeToAlloc<swift::Operand>(1 + TypeDependentOperands.size());
   void *Buffer = Mod.allocateInst(size, alignof(UnconditionalCheckedCastInst));
   return ::new (Buffer) UnconditionalCheckedCastInst(
-      DebugLoc, isolatedConformances, Operand, TypeDependentOperands,
+      DebugLoc, options, Operand, TypeDependentOperands,
       DestLoweredTy, DestFormalTy, forwardingOwnershipKind);
 }
 
 CheckedCastBranchInst *CheckedCastBranchInst::create(
     SILDebugLocation DebugLoc, bool IsExact,
-    CastingIsolatedConformances isolatedConformances, SILValue Operand,
+    CheckedCastInstOptions options, SILValue Operand,
     CanType SrcFormalTy, SILType DestLoweredTy, CanType DestFormalTy,
     SILBasicBlock *SuccessBB, SILBasicBlock *FailureBB, SILFunction &F,
     ProfileCounter Target1Count, ProfileCounter Target2Count,
@@ -2722,7 +2723,7 @@ CheckedCastBranchInst *CheckedCastBranchInst::create(
       totalSizeToAlloc<swift::Operand>(3 + TypeDependentOperands.size());
   void *Buffer = module.allocateInst(size, alignof(CheckedCastBranchInst));
   return ::new (Buffer) CheckedCastBranchInst(
-      DebugLoc, IsExact, isolatedConformances, Operand, SrcFormalTy,
+      DebugLoc, IsExact, options, Operand, SrcFormalTy,
       TypeDependentOperands,
       DestLoweredTy, DestFormalTy, SuccessBB, FailureBB, Target1Count,
       Target2Count, forwardingOwnershipKind, preservesOwnership);

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1040,8 +1040,8 @@ public:
 
   //===--------------------------------------------------------------------===//
   // SILInstruction Printing Logic
-  void printCastingIsolatedConformancesIfNeeded(CastingIsolatedConformances flag) {
-    switch (flag) {
+  void printCheckedCastInstOptions(CheckedCastInstOptions options) {
+    switch (options.isolatedConformances()) {
     case CastingIsolatedConformances::Allow:
       break;
 
@@ -2107,13 +2107,13 @@ public:
   }
 
   void visitUnconditionalCheckedCastInst(UnconditionalCheckedCastInst *CI) {
-    printCastingIsolatedConformancesIfNeeded(CI->getIsolatedConformances());
+    printCheckedCastInstOptions(CI->getCheckedCastOptions());
     *this << getIDAndType(CI->getOperand()) << " to " << CI->getTargetFormalType();
     printForwardingOwnershipKind(CI, CI->getOperand());
   }
   
   void visitCheckedCastBranchInst(CheckedCastBranchInst *CI) {
-    printCastingIsolatedConformancesIfNeeded(CI->getIsolatedConformances());
+    printCheckedCastInstOptions(CI->getCheckedCastOptions());
     if (CI->isExact())
       *this << "[exact] ";
     *this << CI->getSourceFormalType() << " in ";
@@ -2128,14 +2128,14 @@ public:
   }
 
   void visitUnconditionalCheckedCastAddrInst(UnconditionalCheckedCastAddrInst *CI) {
-    printCastingIsolatedConformancesIfNeeded(CI->getIsolatedConformances());
+    printCheckedCastInstOptions(CI->getCheckedCastOptions());
     *this << CI->getSourceFormalType() << " in " << getIDAndType(CI->getSrc())
           << " to " << CI->getTargetFormalType() << " in "
           << getIDAndType(CI->getDest());
   }
 
   void visitCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *CI) {
-    printCastingIsolatedConformancesIfNeeded(CI->getIsolatedConformances());
+    printCheckedCastInstOptions(CI->getCheckedCastOptions());
     *this << getCastConsumptionKindName(CI->getConsumptionKind()) << ' '
           << CI->getSourceFormalType() << " in " << getIDAndType(CI->getSrc())
           << " to " << CI->getTargetFormalType() << " in "

--- a/lib/SIL/Parser/SILParser.h
+++ b/lib/SIL/Parser/SILParser.h
@@ -413,6 +413,9 @@ public:
     else
       P.diagnose(loc, diag::unknown_attr_name, name);
   }
+  
+  /// Parse into checked cast options, such as [prohibit_isolated_conformances].
+  CheckedCastInstOptions parseCheckedCastInstOptions(bool *isExact);
 };
 
 } // namespace swift

--- a/lib/SIL/Utils/DynamicCasts.cpp
+++ b/lib/SIL/Utils/DynamicCasts.cpp
@@ -1322,7 +1322,7 @@ bool swift::emitSuccessfulIndirectUnconditionalCast(
     }
 
     B.createUnconditionalCheckedCastAddr(loc,
-                                         CastingIsolatedConformances::Allow,
+                                         CheckedCastInstOptions(),
                                          src, sourceFormalType,
                                          dest, targetFormalType);
     return true;
@@ -1428,7 +1428,7 @@ bool swift::canIRGenUseScalarCheckedCastInstructions(SILModule &M,
 /// using a scalar cast operation.
 void swift::emitIndirectConditionalCastWithScalar(
     SILBuilder &B, ModuleDecl *M, SILLocation loc,
-    CastingIsolatedConformances isolatedConformances,
+    CheckedCastInstOptions options,
     CastConsumptionKind consumption,
     SILValue srcAddr, CanType sourceFormalType,
     SILValue destAddr, CanType targetFormalType,
@@ -1467,7 +1467,7 @@ void swift::emitIndirectConditionalCastWithScalar(
   })();
 
   auto *ccb = B.createCheckedCastBranch(
-      loc, /*exact*/ false, isolatedConformances, srcValue, sourceFormalType,
+      loc, /*exact*/ false, options, srcValue, sourceFormalType,
       targetLoweredType, targetFormalType, scalarSuccBB, scalarFailBB,
       TrueCount, FalseCount);
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -625,10 +625,10 @@ ManagedValue SILGenBuilder::createEnum(SILLocation loc, ManagedValue payload,
 }
 
 ManagedValue SILGenBuilder::createUnconditionalCheckedCast(
-    SILLocation loc, CastingIsolatedConformances isolatedConformances,
+    SILLocation loc, CheckedCastInstOptions options,
     ManagedValue op, SILType destLoweredTy, CanType destFormalTy) {
   SILValue result =
-      createUnconditionalCheckedCast(loc, isolatedConformances,
+      createUnconditionalCheckedCast(loc, options,
                                      op.forward(SGF),
                                      destLoweredTy, destFormalTy);
   return SGF.emitManagedRValueWithCleanup(result);
@@ -636,7 +636,7 @@ ManagedValue SILGenBuilder::createUnconditionalCheckedCast(
 
 void SILGenBuilder::createCheckedCastBranch(
     SILLocation loc, bool isExact,
-    CastingIsolatedConformances isolatedConformances,
+    CheckedCastInstOptions options,
     ManagedValue op,
     CanType sourceFormalTy,
     SILType destLoweredTy,
@@ -650,7 +650,7 @@ void SILGenBuilder::createCheckedCastBranch(
                                          destFormalTy)) {
     op = op.ensurePlusOne(SGF, loc);
   }
-  createCheckedCastBranch(loc, isExact, isolatedConformances,
+  createCheckedCastBranch(loc, isExact, options,
                           op.forward(SGF), sourceFormalTy,
                           destLoweredTy, destFormalTy, trueBlock, falseBlock,
                           Target1Count, Target2Count);

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -309,14 +309,14 @@ public:
   using SILBuilder::createUnconditionalCheckedCast;
   ManagedValue createUnconditionalCheckedCast(
       SILLocation loc,
-      CastingIsolatedConformances isolatedConformances,
+      CheckedCastInstOptions options,
       ManagedValue op,
       SILType destLoweredTy,
       CanType destFormalTy);
 
   using SILBuilder::createCheckedCastBranch;
   void createCheckedCastBranch(SILLocation loc, bool isExact,
-                               CastingIsolatedConformances isolatedConformances,
+                               CheckedCastInstOptions options,
                                ManagedValue op,
                                CanType sourceFormalTy,
                                SILType destLoweredTy,

--- a/lib/SILOptimizer/Differentiation/JVPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/JVPCloner.cpp
@@ -949,7 +949,7 @@ public:
     auto tanDest = getTangentBuffer(bb, uccai->getDest());
 
     diffBuilder.createUnconditionalCheckedCastAddr(
-       loc, uccai->getIsolatedConformances(),
+       loc, uccai->getCheckedCastOptions(),
         tanSrc, tanSrc->getType().getASTType(),
         tanDest, tanDest->getType().getASTType());
   }

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -1826,7 +1826,7 @@ public:
     auto adjSrc = getAdjointBuffer(bb, uccai->getSrc());
     auto castBuf = builder.createAllocStack(uccai->getLoc(), adjSrc->getType());
     builder.createUnconditionalCheckedCastAddr(
-        uccai->getLoc(), uccai->getIsolatedConformances(),
+        uccai->getLoc(), uccai->getCheckedCastOptions(),
         adjDest, adjDest->getType().getASTType(), castBuf,
         adjSrc->getType().getASTType());
     addToAdjointBuffer(bb, uccai->getSrc(), castBuf, uccai->getLoc());

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -424,7 +424,7 @@ public:
     auto *pbTupleVal = buildPullbackValueTupleValue(ccbi);
     // Create a new `checked_cast_branch` instruction.
     getBuilder().createCheckedCastBranch(
-        ccbi->getLoc(), ccbi->isExact(), ccbi->getIsolatedConformances(),
+        ccbi->getLoc(), ccbi->isExact(), ccbi->getCheckedCastOptions(),
         getOpValue(ccbi->getOperand()),
         getOpASTType(ccbi->getSourceFormalType()),
         getOpType(ccbi->getTargetLoweredType()),
@@ -441,7 +441,7 @@ public:
     // Create a new `checked_cast_addr_branch` instruction.
     getBuilder().createCheckedCastAddrBranch(
         ccabi->getLoc(),
-        ccabi->getIsolatedConformances(),
+        ccabi->getCheckedCastOptions(),
         ccabi->getConsumptionKind(),
         getOpValue(ccabi->getSrc()), getOpASTType(ccabi->getSourceFormalType()),
         getOpValue(ccabi->getDest()),

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2924,7 +2924,7 @@ public:
     }
 
     termBuilder.createCheckedCastAddrBranch(
-        castLoc, ccb->getIsolatedConformances(),
+        castLoc, ccb->getCheckedCastOptions(),
         CastConsumptionKind::TakeOnSuccess, srcAddr,
         ccb->getSourceFormalType(), destAddr, ccb->getTargetFormalType(),
         successBB, failureBB, ccb->getTrueBBCount(), ccb->getFalseBBCount());
@@ -3021,7 +3021,7 @@ static UnconditionalCheckedCastAddrInst *rewriteUnconditionalCheckedCastInst(
   }
   assert(destAddr);
   auto *uccai = builder.createUnconditionalCheckedCastAddr(
-      uncondCheckedCast->getLoc(), uncondCheckedCast->getIsolatedConformances(),
+      uncondCheckedCast->getLoc(), uncondCheckedCast->getCheckedCastOptions(),
       srcAddr, srcAddr->getType().getASTType(),
       destAddr, destAddr->getType().getASTType());
   auto afterBuilder =

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -163,7 +163,7 @@ static FullApplySite speculateMonomorphicTarget(SILPassManager *pm, FullApplySit
   // class instance is identical to the SILType.
 
   CCBI = Builder.createCheckedCastBranch(AI.getLoc(), /*exact*/ true,
-                                      CastingIsolatedConformances::Allow,
+                                      CheckedCastInstOptions(),
                                       CMI->getOperand(),
                                       CMI->getOperand()->getType().getASTType(),
                                       SILType::getPrimitiveObjectType(SubType),

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -108,7 +108,7 @@ convertObjectToLoadableBridgeableType(SILBuilderWithScope &builder,
     // ty. We return the cast as our value and as our new cast instruction.
     auto *cast =
         builder.createUnconditionalCheckedCast(
-          loc, dynamicCast.getIsolatedConformances(), load, silBridgedTy,
+          loc, dynamicCast.getCheckedCastOptions(), load, silBridgedTy,
           dynamicCast.getBridgedTargetType());
     return {cast, cast};
   }
@@ -144,7 +144,7 @@ convertObjectToLoadableBridgeableType(SILBuilderWithScope &builder,
   // Ok, we need to perform the full cast optimization. This means that we are
   // going to replace the cast terminator in inst_block with a checked_cast_br.
   auto *ccbi = builder.createCheckedCastBranch(loc, false,
-                                               dynamicCast.getIsolatedConformances(),
+                                               dynamicCast.getCheckedCastOptions(),
                                                load,
                                                dynamicCast.getBridgedSourceType(),
                                                silBridgedTy,
@@ -567,7 +567,7 @@ static SILValue computeFinalCastedValue(SILBuilderWithScope &builder,
     // fails since we will trap.
     if (!isConditional) {
       return builder.createUnconditionalCheckedCast(
-          loc, dynamicCast.getIsolatedConformances(), newAI,
+          loc, dynamicCast.getCheckedCastOptions(), newAI,
           destLoweredTy, destFormalTy);
     }
 
@@ -592,7 +592,7 @@ static SILValue computeFinalCastedValue(SILBuilderWithScope &builder,
         newAI->getFunction()->createBasicBlockAfter(newAI->getParent());
     condBrSuccessBB->createPhiArgument(destLoweredTy, OwnershipKind::Owned);
     builder.createCheckedCastBranch(loc, /* isExact*/ false,
-                                    dynamicCast.getIsolatedConformances(),
+                                    dynamicCast.getCheckedCastOptions(),
                                     newAI,
                                     sourceFormalTy, destLoweredTy, destFormalTy,
                                     condBrSuccessBB, failureBB);
@@ -1075,7 +1075,7 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
       if (!CastedValue)
         CastedValue =
             Builder.createUnconditionalCheckedCast(
-              Loc, Inst->getIsolatedConformances(), Op, TargetLoweredType,
+              Loc, Inst->getCheckedCastOptions(), Op, TargetLoweredType,
               TargetFormalType);
     }
 
@@ -1166,7 +1166,7 @@ SILInstruction *CastOptimizer::optimizeCheckedCastAddrBranchInst(
           SILBuilderWithScope B(Inst, builderContext);
           auto NewI = B.createCheckedCastBranch(
               Loc, false /*isExact*/,
-              Inst->getIsolatedConformances(),
+              Inst->getCheckedCastOptions(),
               MI,
               Inst->getSourceFormalType(),
               Inst->getTargetLoweredType().getObjectType(),
@@ -1211,7 +1211,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
     }
     return B.createCheckedCastBranch(
         dynamicCast.getLocation(), false /*isExact*/,
-        dynamicCast.getIsolatedConformances(),
+        dynamicCast.getCheckedCastOptions(),
         mi,
         // The cast is now from the MetatypeInst, so get the source formal
         // type from it.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7991,16 +7991,34 @@ bool swift::diagnoseNonSendableFromDeinit(
 }
 
 std::optional<ActorIsolation> ProtocolConformance::getRawIsolation() const {
+  // Only normal protocol conformances can be isolated.
+  auto rootNormal =
+      dyn_cast<NormalProtocolConformance>(this->getRootConformance());
+  if (!rootNormal)
+    return ActorIsolation::forNonisolated(false);
+
+  if (this != rootNormal)
+    return rootNormal->getRawIsolation();
+
   ASTContext &ctx = getDeclContext()->getASTContext();
-  auto conformance = const_cast<ProtocolConformance *>(this);
+  auto conformance = const_cast<NormalProtocolConformance *>(rootNormal);
   return evaluateOrDefault(
       ctx.evaluator, RawConformanceIsolationRequest{conformance},
       ActorIsolation());
 }
 
 ActorIsolation ProtocolConformance::getIsolation() const {
+  // Only normal protocol conformances can be isolated.
+  auto rootNormal =
+      dyn_cast<NormalProtocolConformance>(this->getRootConformance());
+  if (!rootNormal)
+    return ActorIsolation::forNonisolated(false);
+
+  if (this != rootNormal)
+    return rootNormal->getIsolation();
+
   ASTContext &ctx = getDeclContext()->getASTContext();
-  auto conformance = const_cast<ProtocolConformance *>(this);
+  auto conformance = const_cast<NormalProtocolConformance *>(rootNormal);
   return evaluateOrDefault(
       ctx.evaluator, ConformanceIsolationRequest{conformance},
       ActorIsolation());
@@ -8008,29 +8026,20 @@ ActorIsolation ProtocolConformance::getIsolation() const {
 
 std::optional<ActorIsolation>
 RawConformanceIsolationRequest::evaluate(
-    Evaluator &evaluator, ProtocolConformance *conformance
+    Evaluator &evaluator, NormalProtocolConformance *conformance
 ) const {
-  // Only normal protocol conformances can be isolated.
-  auto rootNormal =
-      dyn_cast<NormalProtocolConformance>(conformance->getRootConformance());
-  if (!rootNormal)
-    return ActorIsolation::forNonisolated(false);
-
-  if (conformance != rootNormal)
-    return rootNormal->getRawIsolation();
-
   // If the conformance is explicitly non-isolated, report that.
-  if (rootNormal->getOptions().contains(ProtocolConformanceFlags::Nonisolated))
+  if (conformance->getOptions().contains(ProtocolConformanceFlags::Nonisolated))
     return ActorIsolation::forNonisolated(false);
 
   // If there is an explicitly-specified global actor on the isolation,
   // resolve it and report it.
-  if (auto globalActorTypeExpr = rootNormal->getExplicitGlobalActorIsolation()) {
+  if (auto globalActorTypeExpr = conformance->getExplicitGlobalActorIsolation()) {
     // If we don't already have a resolved global actor type, resolve it now.
     Type globalActorType = globalActorTypeExpr->getInstanceType();
     if (!globalActorType) {
       const auto resolution = TypeResolution::forInterface(
-          rootNormal->getDeclContext(), std::nullopt,
+          conformance->getDeclContext(), std::nullopt,
           /*unboundTyOpener*/ nullptr,
           /*placeholderHandler*/ nullptr,
           /*packElementOpener*/ nullptr);
@@ -8048,9 +8057,9 @@ RawConformanceIsolationRequest::evaluate(
     return ActorIsolation::forGlobalActor(globalActorType);
   }
 
-  auto dc = rootNormal->getDeclContext();
+  auto dc = conformance->getDeclContext();
   ASTContext &ctx = dc->getASTContext();
-  auto proto = rootNormal->getProtocol();
+  auto proto = conformance->getProtocol();
 
   // If the protocol itself is isolated, don't infer isolation for the
   // conformance.
@@ -8064,7 +8073,7 @@ RawConformanceIsolationRequest::evaluate(
     return ActorIsolation::forNonisolated(false);
 
   // @preconcurrency disables isolation inference.
-  if (rootNormal->isPreconcurrency())
+  if (conformance->isPreconcurrency())
     return ActorIsolation::forNonisolated(false);
 
   return std::nullopt;
@@ -8129,25 +8138,15 @@ ActorIsolation swift::inferConformanceIsolation(
 
 ActorIsolation
 ConformanceIsolationRequest::evaluate(
-    Evaluator &evaluator, ProtocolConformance *conformance
+    Evaluator &evaluator, NormalProtocolConformance *conformance
 ) const {
   // If there is raw isolation, use that.
   if (auto rawIsolation = conformance->getRawIsolation())
     return *rawIsolation;
 
   // Otherwise, we may infer isolation.
-
-  // Only normal protocol conformances can be isolated.
-  auto rootNormal =
-      dyn_cast<NormalProtocolConformance>(conformance->getRootConformance());
-  if (!rootNormal)
-    return ActorIsolation::forNonisolated(false);
-
-  if (conformance != rootNormal)
-    return rootNormal->getIsolation();
-
   return inferConformanceIsolation(
-      rootNormal, /*hasKnownIsolatedWitness=*/false);
+      conformance, /*hasKnownIsolatedWitness=*/false);
 }
 
 namespace {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3052,7 +3052,8 @@ namespace {
         }
       }
 
-      if (mayExecuteConcurrentlyWith(
+      if (ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation) &&
+          mayExecuteConcurrentlyWith(
               localFunc.getAsDeclContext(), getDeclContext(),
               /*includeSending*/true)) {
         auto innermostGenericDC = localFunc.getAsDeclContext();

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 953; // update LifetimeDependence layout
+const uint16_t SWIFTMODULE_VERSION_MINOR = 954; // Checked cast inst options
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2236,9 +2236,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   // Checked Conversion instructions.
   case SILInstructionKind::UnconditionalCheckedCastInst: {
     auto CI = cast<UnconditionalCheckedCastInst>(&SI);
-    unsigned flags = 0;
-    if (CI->getIsolatedConformances() == CastingIsolatedConformances::Prohibit)
-      flags |= 0x01;
+    unsigned flags = CI->getCheckedCastOptions().getStorage();
     ValueID listOfValues[] = {
       addValueRef(CI->getOperand()),
       S.addTypeRef(CI->getSourceLoweredType().getRawASTType()),
@@ -2257,9 +2255,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   }
   case SILInstructionKind::UnconditionalCheckedCastAddrInst: {
     auto CI = cast<UnconditionalCheckedCastAddrInst>(&SI);
-    unsigned flags = 0;
-    if (CI->getIsolatedConformances() == CastingIsolatedConformances::Prohibit)
-      flags |= 0x01;
+    unsigned flags = CI->getCheckedCastOptions().getStorage();
     ValueID listOfValues[] = {
       S.addTypeRef(CI->getSourceFormalType()),
       addValueRef(CI->getSrc()),
@@ -2780,8 +2776,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned flags = 0;
     if (CBI->isExact())
       flags |= 0x01;
-    if (CBI->getIsolatedConformances() == CastingIsolatedConformances::Prohibit)
-      flags |= 0x02;
+    flags |= (CBI->getCheckedCastOptions().getStorage() << 1);
     ValueID listOfValues[] = {
       flags,
       S.addTypeRef(CBI->getSourceFormalType()),
@@ -2805,9 +2800,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
   case SILInstructionKind::CheckedCastAddrBranchInst: {
     auto CBI = cast<CheckedCastAddrBranchInst>(&SI);
     unsigned flags =
-      toStableCastConsumptionKind(CBI->getConsumptionKind()) << 1;
-    if (CBI->getIsolatedConformances() == CastingIsolatedConformances::Prohibit)
-      flags |= 0x01;
+      toStableCastConsumptionKind(CBI->getConsumptionKind()) << 8;
+    flags |= CBI->getCheckedCastOptions().getStorage();
     ValueID listOfValues[] = {
       flags,
       S.addTypeRef(CBI->getSourceFormalType()),

--- a/test/Concurrency/sendable_metatype_swift5.swift
+++ b/test/Concurrency/sendable_metatype_swift5.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// REQUIRES: concurrency
+
+protocol P {
+  static func doSomething()
+}
+
+func doSomethingStatic<T: P>(_: T.Type) {
+  Task { @concurrent in
+    T.doSomething()
+  }
+}


### PR DESCRIPTION
We are going to need to add more flags to the various checked cast
instructions. Generalize the CastingIsolatedConformances bit in all of
these SIL instructions to an "options" struct that's easier to extend.

Precursor to rdar://152335805.