### PR TITLE
[6.2][Distributed] Fix computed properties in protocols on arm64e

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -273,10 +273,11 @@ static Flags getMethodDescriptorFlags(ValueDecl *fn) {
       return {Flags::Kind::ModifyCoroutine, false};
     case AccessorKind::Modify2:
       return {Flags::Kind::ModifyCoroutine, true};
+    case AccessorKind::DistributedGet:
+      return {Flags::Kind::Getter, false};
 #define OPAQUE_ACCESSOR(ID, KEYWORD)
 #define ACCESSOR(ID) \
     case AccessorKind::ID:
-    case AccessorKind::DistributedGet:
 #include "swift/AST/AccessorKinds.def"
       llvm_unreachable("these accessors never appear in protocols or v-tables");
     }
@@ -1070,13 +1071,6 @@ namespace {
       }
 
       for (auto &entry : pi.getWitnessEntries()) {
-        if (entry.isFunction() &&
-            entry.getFunction().getDecl()->isDistributedGetAccessor()) {
-          // We avoid emitting _distributed_get accessors, as they cannot be
-          // referred to anyway
-          continue;
-        }
-
         if (Resilient) {
           if (entry.isFunction()) {
             // Define the method descriptor.

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -3,6 +3,11 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
+// Run again with library evolution:
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -enable-library-evolution -I %t %s -plugin-path %swift-plugin-dir -o %t/evo.out
+// RUN: %target-codesign %t/evo.out
+// RUN: %target-run %t/evo.out | %FileCheck %s --color
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -14,9 +14,6 @@
 // rdar://90373022
 // UNSUPPORTED: OS=watchos
 
-// rdar://125628060
-// UNSUPPORTED: CPU=arm64e
- 
 import Distributed
 
 @Resolvable

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol_variable.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol_variable.swift
@@ -3,6 +3,11 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
+// Run again with library evolution:
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -enable-library-evolution -I %t %s -plugin-path %swift-plugin-dir -o %t/evo.out
+// RUN: %target-codesign %t/evo.out
+// RUN: %target-run %t/evo.out | %FileCheck %s --color
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol_variable.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol_variable.swift
@@ -14,9 +14,6 @@
 // rdar://90373022
 // UNSUPPORTED: OS=watchos
 
-// rdar://125628060
-// UNSUPPORTED: CPU=arm64e
- 
 import Distributed
 
 @Resolvable

--- a/test/Distributed/Runtime/distributed_actor_localSystem_generic_system.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_generic_system.swift
@@ -3,6 +3,11 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
+// Run again with library evolution:
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -enable-library-evolution -I %t %s -plugin-path %swift-plugin-dir -o %t/evo.out
+// RUN: %target-codesign %t/evo.out
+// RUN: %target-run %t/evo.out | %FileCheck %s --color
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed

--- a/test/Distributed/Runtime/distributed_actor_localSystem_manual_conformance.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_manual_conformance.swift
@@ -3,6 +3,11 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
+// Run again with library evolution:
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -enable-library-evolution -I %t %s -plugin-path %swift-plugin-dir -o %t/evo.out
+// RUN: %target-codesign %t/evo.out
+// RUN: %target-run %t/evo.out | %FileCheck %s --color
+
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: distributed

--- a/test/Distributed/Runtime/distributed_actor_localSystem_manual_conformance.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_manual_conformance.swift
@@ -14,9 +14,6 @@
 // rdar://90373022
 // UNSUPPORTED: OS=watchos
 
-// rdar://125628060
-// UNSUPPORTED: CPU=arm64e
-
 import Distributed
 
 @available(SwiftStdlib 6.0, *)


### PR DESCRIPTION
**Description**: 
This actually manifested as an pointer auth crash, but the real reason being is that we messed up the order of elements in the witness table. If we'd skip the accessor like this, the types we sign/auth with would no longer align and manifest in a crash.

There is no real reason to skip this entry so we just bring it back, and avoid making this special in any way.

**Scope/Impact**: Computed distributed properties in distributed protocols were not usable on arm64e before this change. Causing trouble to some protocols being adopted to distributed actors.

**Risk:** Low, the change removes a special case that was not necessary specifically in distributed computed property accessor entries in witness tables. No impact on other code.

**Testing**: CI testing, verified the arm64e issue specifically locally
**Reviewed by**: @xedin 

**Original PR:** https://github.com/swiftlang/swift/pull/82009
**Radar:** rdar://125628060