### PR TITLE
[stdlib] adjust addressable attribute on String type family

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -17,6 +17,7 @@ import SwiftShims
 // functionality and guidance for efficiently working with Strings.
 //
 @frozen
+@_addressableForDependencies
 public // SPI(corelibs-foundation)
 struct _StringGuts: @unchecked Sendable {
   @usableFromInline

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -89,7 +89,6 @@ extension String {
   ///     print(String(s1.utf8.prefix(15))!)
   ///     // Prints "They call me 'B"
   @frozen
-  @_addressableForDependencies
   public struct UTF8View: Sendable {
     @usableFromInline
     internal var _guts: _StringGuts

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -630,7 +630,6 @@ extension Substring: LosslessStringConvertible {
 
 extension Substring {
   @frozen
-  @_addressableForDependencies
   public struct UTF8View: Sendable {
     @usableFromInline
     internal var _slice: Slice<String.UTF8View>

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -417,7 +417,7 @@ public func testTrivialInoutBorrow(p: inout UnsafePointer<Int>) -> Span<Int> {
 
 private let immortalInt = 0
 
-private let immortalString = ""
+private let immortalStrings: [String] = []
 
 @lifetime(immortal)
 func testImmortalInt() -> Span<Int> {
@@ -427,10 +427,10 @@ func testImmortalInt() -> Span<Int> {
 }
 
 @lifetime(immortal)
-func testImmortalString() -> Span<String> {
-  let nilBasedBuffer = UnsafeBufferPointer<String>(start: nil, count: 0)
+func testImmortalStrings() -> Span<[String]> {
+  let nilBasedBuffer = UnsafeBufferPointer<[String]>(start: nil, count: 0)
   let span = Span(base: nilBasedBuffer.baseAddress, count: nilBasedBuffer.count)
-  return _overrideLifetime(span, borrowing: immortalString)
+  return _overrideLifetime(span, borrowing: immortalStrings)
 }
 
 let ptr = UnsafePointer<Int>(bitPattern: 1)!

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -363,8 +363,6 @@ Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without rethrows
 
 // Adoption of @_addressableForDependencies
 Struct CollectionOfOne is now with @_addressableForDependencies
-Struct String.UTF8View is now with @_addressableForDependencies
-Struct Substring.UTF8View is now with @_addressableForDependencies
 
 Protocol CodingKey has added inherited protocol SendableMetatype
 Protocol Error has added inherited protocol SendableMetatype

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -825,8 +825,7 @@ Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has mangled name changing f
 Struct String.Index has added a conformance to an existing protocol CustomDebugStringConvertible
 
 Struct CollectionOfOne is now with @_addressableForDependencies
-Struct String.UTF8View is now with @_addressableForDependencies
-Struct Substring.UTF8View is now with @_addressableForDependencies
+Struct _StringGuts is now with @_addressableForDependencies
 
 Enum _SwiftifyInfo is a new API without '@available'
 Enum _SwiftifyExpr is a new API without '@available'


### PR DESCRIPTION
This rearranges the `@_addressableForDependencies` attributes in the `String` family to be applied to `_StringGuts`, which is where the information is located. Other types inherit the characteristic transitively.

Addresses rdar://152615917
