### PR TITLE
SIL: handle `drop_deinit` in WalkUtils

### DIFF
--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -23,6 +23,12 @@ class X {
   @_hasStorage var s: Str
 }
 
+struct NonCopyable: ~Copyable {
+  var a: Int
+
+  deinit
+}
+
 class D: X {}
 
 struct Container {
@@ -52,6 +58,7 @@ struct NE : ~Escapable {}
 
 sil @no_arguments : $@convention(thin) () -> ()
 sil @indirect_argument : $@convention(thin) (@in Int) -> ()
+sil @consume_nc : $@convention(thin) (@in NonCopyable) -> ()
 sil @indirect_struct_argument : $@convention(thin) (@in Str) -> ()
 sil @direct_argument : $@convention(thin) (Int) -> ()
 sil @class_argument : $@convention(thin) (@guaranteed X) -> ()
@@ -870,7 +877,7 @@ bb2(%17 : $Error):
 }
 
 // CHECK-LABEL: Address escape information for test_store_borrow:
-// CHECK:       value:  %2 = store_borrow %0 to %1 : $*X                // users: %4, %3
+// CHECK:       value:  %2 = store_borrow %0 to %1 : $*X
 // CHECK-NEXT:  End function test_store_borrow
 sil [ossa] @test_store_borrow : $@convention(thin) (@guaranteed X) -> () {
 bb0(%0 :  @guaranteed $X):
@@ -881,6 +888,26 @@ bb0(%0 :  @guaranteed $X):
   dealloc_stack %1 : $*X
   %3 = tuple ()
   return %3 : $()
+}
+
+// CHECK-LABEL: Address escape information for test_drop_deinit:
+// CHECK:       value:  %1 = alloc_stack $NonCopyable
+// CHECK-NEXT:    -     %6 = apply %5() : $@convention(thin) () -> ()
+// CHECK-NEXT:    ==>   %8 = apply %7(%3) : $@convention(thin) (@in NonCopyable) -> ()
+// CHECK-NEXT:  End function test_drop_deinit
+sil [ossa] @test_drop_deinit : $@convention(thin) (@owned NonCopyable) -> () {
+bb0(%0 :  @owned $NonCopyable):
+  %1 = alloc_stack $NonCopyable
+  store %0 to [init] %1
+  %3 = drop_deinit %1
+  fix_lifetime %1
+  %5 = function_ref @no_arguments : $@convention(thin) () -> ()
+  %6 = apply %5() : $@convention(thin) () -> ()
+  %7 = function_ref @consume_nc : $@convention(thin) (@in NonCopyable) -> ()
+  %8 = apply %7(%3) : $@convention(thin) (@in NonCopyable) -> ()
+  dealloc_stack %1
+  %10 = tuple ()
+  return %10 : $()
 }
 
 // CHECK-LABEL: Address escape information for noescape_via_independent_addressable:
@@ -956,3 +983,4 @@ bb0(%0 : $Int):
   %9 = tuple ()
   return %9 : $()
 }
+

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -404,15 +404,14 @@ bb0:
 // Test that initializing LifetimeDependence.Scope from an unidentified enclosing access scope does not
 // unwrap nil.
 //
-// TODO: the mark_dependence should redirect to the drop_deinit, not the struct_element_addr, but AccessBase does not
-// currently preserve the address of an unidentified base.
-//
 // CHECK-LABEL: sil hidden [ossa] @testUnidentified : $@convention(method) (@owned B) -> () {
-// CHECK: [[DD:%.*]] = drop_deinit
+// CHECK: [[AS:%.*]] = alloc_stack $B
+// CHECK: [[MU:%.*]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[AS]]
+// CHECK: [[DD:%.*]] = drop_deinit [[MU]]
 // CHECK: [[SE:%.*]] = struct_element_addr [[DD]], #B.ne
 // CHECK: [[LB:%.*]] = load_borrow
 // CHECK: apply %{{.*}} : $@convention(thin) (@guaranteed NE) -> UnsafePointer<A>
-// CHECK: mark_dependence [unresolved] %{{.*}} on [[SE]]
+// CHECK: mark_dependence [unresolved] %{{.*}} on [[AS]]
 // CHECK-LABEL: } // end sil function 'testUnidentified'
 sil hidden [ossa] @testUnidentified : $@convention(method) (@owned B) -> () {
 bb0(%0 : @owned $B):

--- a/test/SILOptimizer/optimal_arc.swift
+++ b/test/SILOptimizer/optimal_arc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -module-name test -O -emit-sil -O -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name test -O -emit-sil -primary-file %s | %FileCheck %s
 
 // REQUIRES: optimized_stdlib,swift_stdlib_no_asserts
 
@@ -50,5 +50,25 @@ struct TestCollection: RandomAccessCollection, RangeReplaceableCollection {
   }
 }
 
+class C {
+  func foo() {}
+}
+
+struct S: ~Copyable {
+  var c: C
+
+  // Check that there is only a single release in the deinit.
+
+  // CHECK-LABEL: sil hidden @$s4test1SVfD :
+  // CHECK-NOT:     retain
+  // CHECK-NOT:     release
+  // CHECK:         apply
+  // CHECK:         release
+  // CHECK-NOT:     release
+  // CHECK:       } // end sil function '$s4test1SVfD'
+  deinit {
+    c.foo()
+  }
+}
 
 


### PR DESCRIPTION
Also, handle some other missing instructions in the AddressDefUseWalker, which are visited in the AddressUseDefWalker.

This enables various optimizations, like copy elimination, in the presence of `drop_deinit`.

rdar://152307747
