### PR TITLE
Sema: Never record argument label mismatches for unlabeled trailing closures

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6665,12 +6665,6 @@ bool isSIMDOperator(ValueDecl *value);
 
 std::string describeGenericType(ValueDecl *GP, bool includeName = false);
 
-/// Whether the given parameter requires an argument.
-bool parameterRequiresArgument(
-    ArrayRef<AnyFunctionType::Param> params,
-    const ParameterListInfo &paramInfo,
-    unsigned paramIdx);
-
 } // end namespace swift
 
 namespace llvm {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -373,8 +373,15 @@ static bool matchCallArgumentsImpl(
   auto claim = [&](Identifier expectedName, unsigned argIdx,
                    bool ignoreNameClash = false)  -> unsigned {
     // Make sure we can claim this argument.
-    assert(argIdx != numArgs && "Must have a valid index to claim");
-    assert(!claimedArgs[argIdx] && "Argument already claimed");
+    ASSERT(argIdx != numArgs && "Must have a valid index to claim");
+    ASSERT(!claimedArgs[argIdx] && "Argument already claimed");
+
+    // Prevent recording of an argument label mismatche for an unlabeled
+    // trailing closure. An unlabeled trailing closure is necessarily the first
+    // one and vice versa, per language syntax.
+    if (unlabeledTrailingClosureArgIndex == argIdx) {
+      expectedName = Identifier();
+    }
 
     if (!actualArgNames.empty()) {
       // We're recording argument names; record this one.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -279,10 +279,9 @@ static ConstraintSystem::TypeMatchOptions getDefaultDecompositionOptions(
 }
 
 /// Whether the given parameter requires an argument.
-bool swift::parameterRequiresArgument(
-    ArrayRef<AnyFunctionType::Param> params,
-    const ParameterListInfo &paramInfo,
-    unsigned paramIdx) {
+static bool parameterRequiresArgument(ArrayRef<AnyFunctionType::Param> params,
+                                      const ParameterListInfo &paramInfo,
+                                      unsigned paramIdx) {
   return !paramInfo.hasDefaultArgument(paramIdx)
       && !params[paramIdx].isVariadic();
 }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2701,8 +2701,10 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
     }
   }
 
+  ASSERT((numMissing + numExtra + numWrong > 0) &&
+         "Should not call this function with nothing to diagnose");
+
   // Emit the diagnostic.
-  assert(numMissing > 0 || numExtra > 0 || numWrong > 0);
   llvm::SmallString<16> haveBuffer; // note: diagOpt has references to this
   llvm::SmallString<16> expectedBuffer; // note: diagOpt has references to this
 

--- a/validation-test/compiler_crashers_2_fixed/34a73a7299992de3.swift
+++ b/validation-test/compiler_crashers_2_fixed/34a73a7299992de3.swift
@@ -1,4 +1,3 @@
 // {"signature":"(anonymous namespace)::OpaqueUnderlyingTypeChecker::check()"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend -typecheck %s
 Array {


### PR DESCRIPTION
Fixes a crash on invalid. The previous logic was causing a label mismatch constraint fix to be recorded for an unlabeled trailing closure argument matching a variadic paramater after a late recovery argument claim in `matchCallArgumentsImpl`, because the recovery claiming skips arguments matching defaulted parameters, but not variadic ones. We may want to reconsider that last part, but currently it regresses the quality of some diagnostics, and this is a targeted fix.
                                      
The previous behavior is fine because the diagnosis routine associate with the constraint fix (`diagnoseArgumentLabelError`) skips unlabeled trailing closures when tallying labeling issues — *unless* there are no other issues and the tally is zero, which we assert it is not.

Minimal crasher:
```swift
func f(x: Int...) {}
f { return () }
```

Fixes rdar://152313388.