### PR TITLE
[6.2] Windows module maps update

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -12,12 +12,6 @@
 
 // The following modules have to be standalone top-level modules to deal with
 // version 10.0.26100 of the Windows SDK.
-module _malloc [system] [no_undeclared_includes] {
-  use corecrt
-  header "malloc.h"
-  export *
-}
-
 module _complex [system] [no_undeclared_includes] {
   use corecrt
   use std
@@ -25,24 +19,10 @@ module _complex [system] [no_undeclared_includes] {
   export *
 }
 
-module _stddef [system] [no_undeclared_includes] {
-  header "stddef.h"
-  export *
-}
-
-module _stdlib [system] [no_undeclared_includes] {
-  use corecrt
-  header "stdlib.h"
-  export *
-}
-
 module ucrt [system] {
-  export _malloc
 
   module C {
     export _complex
-    export _stddef
-    export _stdlib
 
     module ctype {
       header "ctype.h"
@@ -50,7 +30,7 @@ module ucrt [system] {
     }
 
     module errno {
-      header "errno.h"
+      textual header "errno.h"
       export *
     }
 
@@ -74,6 +54,11 @@ module ucrt [system] {
       export *
     }
 
+    module malloc {
+      header "malloc.h"
+      export *
+    }
+
     module math {
       header "math.h"
       export *
@@ -81,6 +66,16 @@ module ucrt [system] {
 
     module signal {
       header "signal.h"
+      export *
+    }
+
+    module stdalign {
+      header "stdalign.h"
+      export  *
+    }
+
+    module stddef {
+      textual header "stddef.h"
       export *
     }
 
@@ -98,6 +93,11 @@ module ucrt [system] {
 
     module stdlib {
       header "stdlib.h"
+      export *
+    }
+
+    module stdnoreturn {
+      textual header "stdnoreturn.h"
       export *
     }
 
@@ -187,8 +187,14 @@ module corecrt [system] {
     export *
   }
 
+  module direct {
+    header "corecrt_wdirect.h"
+    export *
+  }
+
   module io {
     header "corecrt_io.h"
+    header "corecrt_wio.h"
     export *
   }
 
@@ -202,8 +208,33 @@ module corecrt [system] {
     export *
   }
 
+  module memory {
+    header "corecrt_memory.h"
+    export *
+  }
+
+  module memcpy {
+    header "corecrt_memcpy_s.h"
+    export *
+  }
+
+  module process {
+    header "corecrt_wprocess.h"
+    export *
+  }
+
+  module search {
+    header "corecrt_search.h"
+    export *
+  }
+
   module share {
     header "corecrt_share.h"
+    export *
+  }
+
+  module ctype {
+    header "corecrt_wctype.h"
     export *
   }
 
@@ -227,4 +258,3 @@ module corecrt [system] {
     export *
   }
 }
-

--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -19,10 +19,39 @@ module _complex [system] [no_undeclared_includes] {
   export *
 }
 
+module _fenv [system] [no_undeclared_includes] {
+  use _float
+  use corecrt
+  header "fenv.h"
+  export *
+}
+
+module _float [system] [no_undeclared_includes] {
+  use corecrt
+  header "float.h"
+  export *
+}
+
+module _malloc [system] [no_undeclared_includes] {
+  use corecrt
+  header "malloc.h"
+  export *
+}
+
+module _stdlib [system] [no_undeclared_includes] {
+  use corecrt
+  header "stdlib.h"
+  export *
+}
+
 module ucrt [system] {
 
   module C {
     export _complex
+    export _fenv
+    export _float
+    export _malloc
+    export _stdlib
 
     module ctype {
       header "ctype.h"

--- a/stdlib/public/Platform/vcruntime.modulemap
+++ b/stdlib/public/Platform/vcruntime.modulemap
@@ -100,13 +100,43 @@ module vcruntime [system] {
 
   header "vcruntime.h"
 
+  module iso646 {
+    header "iso646.h"
+    export *
+  }
+
+  module limits {
+    header "limits.h"
+    export *
+  }
+
   module setjmp {
     header "setjmp.h"
     export *
   }
 
+  module stdarg {
+    header "stdarg.h"
+    export *
+  }
+
+  module stdbool {
+    header "stdbool.h"
+    export  *
+  }
+
   module stdint {
     header "stdint.h"
+    export *
+  }
+
+  module string {
+    header "vcruntime_string.h"
+    export *
+  }
+
+  module vadefs {
+    header "vadefs.h"
     export *
   }
 }


### PR DESCRIPTION
- **Explanation**:
  Update the Windows module maps to build with the static SDK and the most recent version of the Windows SDK (10.0.26100.3916)
- **Scope**:
  Limited to the module maps for the VC Runtime and Windows SDK.
- **Issues**:
  N/A
- **Original PRs**:
  #81826
  #81951
- **Risk**:
  Limited, this has been tested on main. CI should notify of breakages.
- **Testing**:
  Tested locally with a recent Windows SDK installed.
- **Reviewers**:
  @compnerd, @stephentyrone