### PR TITLE
[6.2] LoopRotate: Fix a by reference map bug under reallocation

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -428,7 +428,8 @@ static bool rotateLoop(SILLoop *loop, DominanceInfo *domInfo,
 
   for (auto &inst : *header) {
     if (auto *bfi = dyn_cast<BorrowedFromInst>(&inst)) {
-      valueMap[bfi] = valueMap[bfi->getBorrowedValue()];
+      auto mappedValue = valueMap[bfi->getBorrowedValue()];
+      valueMap[bfi] = mappedValue;
     } else if (SILInstruction *cloned = inst.clone(preheaderBranch)) {
       mapOperands(cloned, valueMap);
 


### PR DESCRIPTION
Issue:
When using a densemap subscript expression on both sides of an assignment in the same statement of the same map we run into the issue that the map can reallocate because of the assignment but we are referencing the value of the RHS map subscript by reference -- i.e we can reference deallocated memory.

Not good.

Scope: A "silent" memory error that one might run into including the reporter of the bug.

Risk: Extremely, low. The fix is spliting an assignment from a map value to a map entry into: A value assignment of the map value to a local. And then storing the local in the map entry forgoing the reference of reallocated memory bug.

```
  valueMap[bfi] = valueMap[bfi->getBorrowedValue()];

=>

  auto mappedMValue = valueMap[bfi->getBorrowedValue()];
  valueMap[bfi] = mappedValue;
```

Reviewed by: Meghana G, Erik E., Joe G.

Testing: The fix was tested on the reporting project.

Original PR: https://github.com/swiftlang/swift/pull/81995

rdar://151031297