### PR TITLE
line-directive: Actually stop expanding response files

### DIFF
--- a/utils/line-directive
+++ b/utils/line-directive
@@ -682,7 +682,7 @@ def run():
         # delegates to the Win32 CreateProcess API. Unix systems handle
         # non-normalized paths, so don't have this problem.
         # Arguments passed to the process are normalized by the process.
-        command_args = expand_response_files(sys.argv[dashes + 1:])
+        command_args = sys.argv[dashes + 1:]
         command_args[0] = os.path.normpath(command_args[0])
 
         try:


### PR DESCRIPTION
The changes in #81996 fixed the response file format but failed to actually make `line-directive` stop expanding the response files in the compiler invocation. These changes fix that.