### PR TITLE
[silgen] Teach SILGen how to emit a forced dynamic member ref given nonisolated(nonsending) casts.

### DIFF
--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -133,6 +133,9 @@ typedef void (^NonsendableCompletionHandler)(NSString * _Nullable, NSString * _N
                           (void (^)(NSString *__nullable value,
                                     NSError *__nullable error))completionHandler
     MAIN_ACTOR;
+
+- (void)startAt:(__nullable NSDate *)value
+     completion:(void (^_Nonnull)(void))completion;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -360,3 +360,31 @@ extension SlowServer: @retroactive FailableFloatLoader {
 // CHECK-NEXT:    [[ZERO_FLOAT:%.*]] = builtin "zeroInitializer"() : $Float
 // CHECK-NEXT:    [[BORROWED_SOME_NSERROR:%.*]] = begin_borrow [[SOME_NSERROR]] :
 // CHECK-NEXT:    apply [[BORROWED_BLOCK]]([[ZERO_FLOAT]], [[BORROWED_SOME_NSERROR]])
+
+// CHECK-LABEL: sil hidden [ossa] @$s10objc_async13testAnyObjectyySo10SlowServerCYaF : $@convention(thin) @async (@guaranteed SlowServer) -> () {
+// CHECK: bb0([[SLOWSERVER:%.*]] : @guaranteed $SlowServer):
+// CHECK: [[SLOWSERVER_C:%.*]] = copy_value [[SLOWSERVER]]
+// CHECK: [[SLOWSERVER_ANYOBJECT:%.*]] = init_existential_ref [[SLOWSERVER_C]]
+// CHECK: [[SLOWSERVER_ANYOBJECT_M:%.*]] = move_value [lexical] [var_decl] [[SLOWSERVER_ANYOBJECT]]
+// CHECK: debug_value [[SLOWSERVER_ANYOBJECT_M]] : $AnyObject, let, name "anyObjectSlowServer"
+// CHECK: [[SLOWSERVER_ANYOBJECT_M_B:%.*]] = begin_borrow [[SLOWSERVER_ANYOBJECT_M]]
+// CHECK: [[SLOWSERVER_ANYOBJECT_M_B_O:%.*]] = open_existential_ref [[SLOWSERVER_ANYOBJECT_M_B]]
+// CHECK: [[SLOWSERVER_ANYOBJECT_M_B_O_C:%.*]] = copy_value [[SLOWSERVER_ANYOBJECT_M_B_O]]
+// CHECK: [[METHOD:%.*]] = objc_method [[SLOWSERVER_ANYOBJECT_M_B_O_C]] : $@opened("{{.*}}", AnyObject) Self, #SlowServer.start!foreign : (SlowServer) -> (NSDate?) async -> (), $@convention(objc_method) (Optional<NSDate>, @convention(block) @Sendable () -> (), @opened("{{.*}}", AnyObject) Self) -> ()
+// CHECK: [[CONT:%.*]] = get_async_continuation_addr ()
+// CHECK: [[UNSAFE_CONT:%.*]] = struct $UnsafeContinuation<(), Never> ([[CONT]] : $Builtin.RawUnsafeContinuation)
+// CHECK: [[BLOCK:%.*]] = alloc_stack $@block_storage Any
+// CHECK: [[BLOCK_PROJECT:%.*]] = project_block_storage [[BLOCK]]
+// CHECK: [[BLOCK_PROJECT_EX:%.*]] = init_existential_addr [[BLOCK_PROJECT]]
+// CHECK: store [[UNSAFE_CONT]] to [trivial] [[BLOCK_PROJECT_EX]]
+// CHECK: merge_isolation_region [[BLOCK]] : $*@block_storage Any,
+// CHECK: [[CONT_HANDLER:%.*]] = function_ref @$sIeyBh_ytTz_ : $@convention(c) @Sendable (@inout_aliasable @block_storage Any) -> ()
+// CHECK: [[INIT_BLOCK_STORAGE_HEADER:%.*]] = init_block_storage_header [[BLOCK]] : $*@block_storage Any, invoke [[CONT_HANDLER]]
+// CHECK: merge_isolation_region [[SLOWSERVER_ANYOBJECT_M_B_O_C]] : $@opened("{{.*}}", AnyObject) Self, [[BLOCK]]
+// CHECK: apply [[METHOD]]({{%.*}}, [[INIT_BLOCK_STORAGE_HEADER]], [[SLOWSERVER_ANYOBJECT_M_B_O_C]])
+// CHECK: await_async_continuation [[CONT]] : $Builtin.RawUnsafeContinuation, resume bb1
+// CHECK: } // end sil function '$s10objc_async13testAnyObjectyySo10SlowServerCYaF'
+func testAnyObject(_ slowServer: SlowServer) async {
+  let anyObjectSlowServer: AnyObject = slowServer
+  await anyObjectSlowServer.start(at: nil)
+}


### PR DESCRIPTION
Specifically, I taught SILGen how to emit an AST like the following:

```
(force_value_expr implicit type="nonisolated(nonsending) (Date?) async -> Void" implicit_iuo_unwrap
  (open_existential_expr implicit type="(nonisolated(nonsending) (Date?) async  -> Void)?"
    (opaque_value_expr implicit type="AnyObject")
    (declref_expr type="AnyObject" decl="test.(file).repro().anyObject@test.swift:6:7" function_ref=unapplied)
    (optional_evaluation_expr type="(nonisolated(nonsending) (Date?) async -> Void)?"
      (inject_into_optional type="(nonisolated(nonsending) (Date?) async -> Void)?"
        (function_conversion_expr type="nonisolated(nonsending) (Date?) async -> Void"
          (bind_optional_expr type="(Date?) async -> Void" depth=0
            (dynamic_member_ref_expr type="((Date?) async -> Void)?" decl="__ObjC.(file).Foo.start(at:)"
              (opaque_value_expr type="AnyObject"))))))))
```

Since we are emitting an objc async function, there isn't an extra implicit parameter like if we were using a swift async function. So, I just reused code that was already used locally to look through these sorts of conversions. I just had to add to that code support for conversions that add nonisolated(nonsending). Previously it only supported looking through global actor conversions.

rdar://152596823