### PR TITLE
Resolve unit test link error due to a build cycle

### DIFF
--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -6,7 +6,8 @@ target_link_libraries(swiftSIL PRIVATE
   swiftAST
   swiftClangImporter
   swiftSema
-  swiftSerialization)
+  swiftSerialization
+  swiftSILOptimizer)
 
 add_subdirectory(IR)
 add_subdirectory(Utils)


### PR DESCRIPTION
We currently hit the following errors when attempting to link unit tests:
```
Undefined symbols for architecture arm64:
  "swift::ConstExprEvaluator::ConstExprEvaluator(swift::SymbolicValueAllocator&, unsigned int, bool)", referenced from:
      BridgedConstExprFunctionState::create() in libswiftSIL.a[63](SILBridging.cpp.o)
  "swift::ConstExprEvaluator::~ConstExprEvaluator()", referenced from:
      BridgedConstExprFunctionState::deinitialize() in libswiftSIL.a[63](SILBridging.cpp.o)
  "swift::ConstExprFunctionState::getConstantValue(swift::SILValue)", referenced from:
      BridgedConstExprFunctionState::isConstantValue(BridgedValue) in libswiftSIL.a[63](SILBridging.cpp.o)
  "swift::ConstExprFunctionState::ConstExprFunctionState(swift::ConstExprEvaluator&, swift::SILFunction*, swift::SubstitutionMap, unsigned int&, bool)", referenced from:
      BridgedConstExprFunctionState::create() in libswiftSIL.a[63](SILBridging.cpp.o)
```

There is an implicit cyclic dependency here between `libswiftSIL` and `libswiftSILOptimizer`, which is okay to have at link time as long as these are static archives and as long as respective archives are specified explicitly on the linker invocation. This change achives that.

Resolves rdar://150944677
