### PR TITLE
[Runtimes][CMake] Refactor FindSwiftCore to put focus on targets...

### DIFF
--- a/Runtimes/Supplemental/cmake/modules/PlatformInfo.cmake
+++ b/Runtimes/Supplemental/cmake/modules/PlatformInfo.cmake
@@ -1,3 +1,5 @@
+include_guard(GLOBAL)
+
 if(NOT ${PROJECT_NAME}_SIZEOF_POINTER)
   set(${PROJECT_NAME}_SIZEOF_POINTER "${CMAKE_SIZEOF_VOID_P}" CACHE STRING "Size of a pointer in bytes")
   message(CONFIGURE_LOG "Stdlib Pointer size: ${CMAKE_SIZEOF_VOID_P}")


### PR DESCRIPTION
Notable changes/flags:
* Append to variables controlling paths and names, to allow for user
  configuration
* add `SwiftCore_USE_STATIC_LIBS` to generate static archives
* use PlatformInfo variables to get the platform and arch subfolders
  (where appropriate)
* add include guards to ensure PlatformInfo and FindSwiftCore are
    included once in a project
* search for the appropriate static or import library under Windows

Addresses rdar://152838903