### PR TITLE
PrintAsClang: Introduce `@cdecl` enums

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -365,7 +365,7 @@ SIMPLE_DECL_ATTR(_show_in_interface, ShowInInterface,
   62)
 
 DECL_ATTR(_cdecl, CDecl,
-  OnFunc | OnAccessor,
+  OnFunc | OnAccessor | OnEnum,
   LongAttribute | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   63)
 DECL_ATTR_ALIAS(cdecl, CDecl)

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3758,9 +3758,9 @@ ERROR(enum_with_raw_type_case_with_argument,none,
 NOTE(enum_raw_type_here,none,
      "declared raw type %0 here", (Type))
 ERROR(objc_enum_no_raw_type,none,
-      "'@objc' enum must declare an integer raw type", ())
+      "'%0' enum must declare an integer raw type", (DeclAttribute))
 ERROR(objc_enum_raw_type_not_integer,none,
-      "'@objc' enum raw type %0 is not an integer type", (Type))
+      "'%0' enum raw type %1 is not an integer type", (DeclAttribute, Type))
 ERROR(enum_non_integer_raw_value_auto_increment,none,
       "enum case must declare a raw value when the preceding raw value is not an integer", ())
 ERROR(enum_non_integer_convertible_raw_type_no_value,none,
@@ -6615,6 +6615,10 @@ NOTE(not_objc_swift_struct,none,
      (ForeignLanguage))
 NOTE(not_objc_swift_enum,none,
       "non-'@objc' enums cannot be represented in Objective-C", ())
+NOTE(not_cdecl_or_objc_swift_enum,none,
+     "Swift enums not marked '@cdecl'%select{| or '@objc'}0 cannot be "
+     "represented in %" FOREIGN_LANG_SELECT "0",
+     (ForeignLanguage))
 NOTE(not_objc_generic_type_param,none,
      "generic type parameters cannot be represented in "
      "%" FOREIGN_LANG_SELECT "0", (ForeignLanguage))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2078,6 +2078,9 @@ ERROR(cdecl_empty_name,none,
       "%0 symbol name cannot be empty", (DeclAttribute))
 ERROR(cdecl_throws,none,
       "raising errors from %0 functions is not supported", (DeclAttribute))
+ERROR(cdecl_incompatible_with_objc,none,
+      "cannot apply both '@cdecl' and '@objc' to %kindonly0",
+      (const Decl *))
 ERROR(cdecl_feature_required,none,
       "'@cdecl' requires '-enable-experimental-feature CDecl'",
       ())

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4853,9 +4853,9 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Check @cdecl-style attributes for compatibility with the foreign language.
-class TypeCheckCDeclAttributeRequest
-    : public SimpleRequest<TypeCheckCDeclAttributeRequest,
+/// Check @cdecl functions for compatibility with the foreign language.
+class TypeCheckCDeclFunctionRequest
+    : public SimpleRequest<TypeCheckCDeclFunctionRequest,
                            evaluator::SideEffect(FuncDecl *FD,
                                                  CDeclAttr *attr),
                            RequestFlags::Cached> {
@@ -4867,6 +4867,25 @@ private:
 
   evaluator::SideEffect
   evaluate(Evaluator &evaluator, FuncDecl *FD, CDeclAttr *attr) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
+/// Check @cdecl enums for compatibility with C.
+class TypeCheckCDeclEnumRequest
+    : public SimpleRequest<TypeCheckCDeclEnumRequest,
+                           evaluator::SideEffect(EnumDecl *ED,
+                                                 CDeclAttr *attr),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  evaluator::SideEffect
+  evaluate(Evaluator &evaluator, EnumDecl *ED, CDeclAttr *attr) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -550,8 +550,11 @@ SWIFT_REQUEST(TypeChecker, IsNonUserModuleRequest,
 SWIFT_REQUEST(TypeChecker, TypeCheckObjCImplementationRequest,
               unsigned(ExtensionDecl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, TypeCheckCDeclAttributeRequest,
-              evaluator::SideEffect(FuncDecl *, CDeclAttr *),
+SWIFT_REQUEST(TypeChecker, TypeCheckCDeclFunctionRequest,
+              evaluator::SideEffect(FunctionDecl *, CDeclAttr *),
+              Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, TypeCheckCDeclEnumRequest,
+              evaluator::SideEffect(EnumDecl *, CDeclAttr *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, HasInitAccessorRequest,
               bool(AbstractStorageDecl *), Cached,

--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -176,19 +176,36 @@ CLANG_MACRO_CONDITIONAL("SWIFT_ENUM_ATTR", "(_extensibility)", \
                         "__attribute__((enum_extensibility(_extensibility)))")
 
 CLANG_MACRO_BODY("SWIFT_ENUM", \
-    "# define SWIFT_ENUM(_type, _name, _extensibility) " \
+    "# if (defined(__cplusplus) && __cplusplus >= 201103L) || " \
+    "     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || " \
+    "     __has_feature(objc_fixed_enum)\n" \
+    "#  define SWIFT_ENUM(_type, _name, _extensibility) " \
         "enum _name : _type _name; " \
         "enum SWIFT_ENUM_ATTR(_extensibility) SWIFT_ENUM_EXTRA _name : _type\n" \
-    "# if __has_feature(generalized_swift_name)\n" \
-    "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, _extensibility) " \
-        "enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); " \
-        "enum SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_ENUM_ATTR(_extensibility) " \
-            "SWIFT_ENUM_EXTRA _name : _type\n" \
+    "#  if __has_feature(generalized_swift_name)\n" \
+    "#   define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, _extensibility) " \
+         "enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); " \
+         "enum SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_ENUM_ATTR(_extensibility) " \
+             "SWIFT_ENUM_EXTRA _name : _type\n" \
+    "#  else\n" \
+    "#   define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, _extensibility) " \
+         "SWIFT_ENUM(_type, _name, _extensibility)\n" \
+    "#  endif\n" \
     "# else\n" \
+    "#  define SWIFT_ENUM(_type, _name, _extensibility) _type _name; enum \n" \
     "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, _extensibility) " \
         "SWIFT_ENUM(_type, _name, _extensibility)\n" \
     "# endif")
 CLANG_MACRO_DEFINED("SWIFT_ENUM_NAMED")
+
+CLANG_MACRO_BODY("SWIFT_ENUM_TAG", \
+    "# if (defined(__cplusplus) && __cplusplus >= 201103L) || " \
+    "     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || " \
+    "     __has_feature(objc_fixed_enum)\n" \
+    "#  define SWIFT_ENUM_TAG enum\n" \
+    "# else\n" \
+    "#  define SWIFT_ENUM_TAG\n" \
+    "# endif")
 
 CLANG_MACRO("SWIFT_UNAVAILABLE", , "__attribute__((unavailable))")
 CLANG_MACRO("SWIFT_UNAVAILABLE_MSG", "(msg)", "__attribute__((unavailable(msg)))")

--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -207,6 +207,15 @@ CLANG_MACRO_BODY("SWIFT_ENUM_TAG", \
     "#  define SWIFT_ENUM_TAG\n" \
     "# endif")
 
+CLANG_MACRO_BODY("SWIFT_ENUM_FWD_DECL", \
+    "# if (defined(__cplusplus) && __cplusplus >= 201103L) || " \
+    "     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L) || " \
+    "     __has_feature(objc_fixed_enum)\n" \
+    "#  define SWIFT_ENUM_FWD_DECL(_type, _name) enum _name : _type _name;\n" \
+    "# else\n" \
+    "#  define SWIFT_ENUM_FWD_DECL(_type, _name) _type _name;\n" \
+    "# endif")
+
 CLANG_MACRO("SWIFT_UNAVAILABLE", , "__attribute__((unavailable))")
 CLANG_MACRO("SWIFT_UNAVAILABLE_MSG", "(msg)", "__attribute__((unavailable(msg)))")
 

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/LazyResolver.h"
@@ -47,6 +48,9 @@ getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
       return name->getSelectorPieces().front().str();
     }
   }
+
+  if (auto cdeclAttr = VD->getAttrs().getAttribute<CDeclAttr>())
+    return cdeclAttr->Name;
 
   if (customNamesOnly)
     return StringRef();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3082,6 +3082,12 @@ getForeignRepresentable(Type type, ForeignLanguage language,
       // Imported classes and protocols are not representable in C.
       if (isa<ClassDecl>(nominal) || isa<ProtocolDecl>(nominal))
         return failure();
+
+      // @objc enums are not representable in C, @cdecl ones and imported ones
+      // are ok.
+      if (!nominal->hasClangNode())
+        return failure();
+
       LLVM_FALLTHROUGH;
 
     case ForeignLanguage::ObjectiveC:
@@ -3118,6 +3124,11 @@ getForeignRepresentable(Type type, ForeignLanguage language,
 
       return { ForeignRepresentableKind::Trivial, nullptr };
     }
+  }
+
+  // @cdecl enums are representable in C and Objective-C.
+  if (nominal->getAttrs().getAttribute<CDeclAttr>()) {
+    return { ForeignRepresentableKind::Trivial, nullptr };
   }
 
   // Pointers may be representable in ObjC.

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -457,6 +457,14 @@ public:
       }
     }
 
+    if (isa<EnumDecl>(D) && !D->hasClangNode() &&
+        outputLangMode != OutputLanguageMode::Cxx) {
+      // We don't want to add an import for a @cdecl or @objc enum declared
+      // in Swift. We either do nothing for special enums like Optional as
+      // done in the prologue here, or we forward declare them.
+      return false;
+    }
+
     imports.insert(otherModule);
     return true;
   }
@@ -530,16 +538,20 @@ public:
   }
 
   void forwardDeclare(const EnumDecl *ED) {
-    // Don't forward declare C enums.
-    if (ED->getAttrs().getAttribute<CDeclAttr>())
-      return;
-
-    assert(ED->isObjC() || ED->hasClangNode());
+    assert(ED->isObjC() || ED->getAttrs().getAttribute<CDeclAttr>() ||
+           ED->hasClangNode());
     
     forwardDeclare(ED, [&]{
-      os << "enum " << getNameForObjC(ED) << " : ";
-      printer.print(ED->getRawType());
-      os << ";\n";
+      if (ED->getASTContext().LangOpts.hasFeature(Feature::CDecl)) {
+        // Forward declare in a way to be compatible with older C standards.
+        os << "typedef SWIFT_ENUM_FWD_DECL(";
+        printer.print(ED->getRawType());
+        os << ", " << getNameForObjC(ED) << ")\n";
+      } else {
+        os << "enum " << getNameForObjC(ED) << " : ";
+        printer.print(ED->getRawType());
+        os << ";\n";
+      }
     });
   }
 
@@ -608,6 +620,7 @@ public:
     } else if (addImport(TD)) {
       return;
     } else if (auto ED = dyn_cast<EnumDecl>(TD)) {
+      // Treat this after addImport to filter out special enums from the stdlib.
       forwardDeclare(ED);
     } else if (isa<GenericTypeParamDecl>(TD)) {
       llvm_unreachable("should not see generic parameters here");

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -530,6 +530,10 @@ public:
   }
 
   void forwardDeclare(const EnumDecl *ED) {
+    // Don't forward declare C enums.
+    if (ED->getAttrs().getAttribute<CDeclAttr>())
+      return;
+
     assert(ED->isObjC() || ED->hasClangNode());
     
     forwardDeclare(ED, [&]{
@@ -864,7 +868,7 @@ public:
 
     SmallVector<ProtocolConformance *, 1> conformances;
     auto errorTypeProto = ctx.getProtocol(KnownProtocolKind::Error);
-    if (outputLangMode != OutputLanguageMode::Cxx
+    if (outputLangMode == OutputLanguageMode::ObjC
         && ED->lookupConformance(errorTypeProto, conformances)) {
       bool hasDomainCase = std::any_of(ED->getAllElements().begin(),
                                        ED->getAllElements().end(),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2398,6 +2398,12 @@ void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
                attr->Name);
   }
 
+  // @_cdecl was never accepted on enums. Keep the previous diagnostic.
+  if (isa<EnumDecl>(D) && attr->Underscored) {
+    diagnose(attr->getLocation(), diag::attr_only_one_decl_kind,
+             attr, "func");
+  }
+
   if (!attr->Underscored &&
       !Ctx.LangOpts.hasFeature(Feature::CDecl)) {
     Ctx.Diags.diagnose(attr->getLocation(), diag::cdecl_feature_required);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2404,9 +2404,15 @@ void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
              attr, "func");
   }
 
+  // Reject using both @cdecl and @objc on the same decl.
+  if (D->getAttrs().getAttribute<ObjCAttr>()) {
+    diagnose(attr->getLocation(), diag::cdecl_incompatible_with_objc, D);
+  }
+
+  // @cdecl needs to be enabled via a feature flag.
   if (!attr->Underscored &&
       !Ctx.LangOpts.hasFeature(Feature::CDecl)) {
-    Ctx.Diags.diagnose(attr->getLocation(), diag::cdecl_feature_required);
+    diagnose(attr->getLocation(), diag::cdecl_feature_required);
   }
 }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -223,9 +223,17 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
 
   // Special diagnostic for enums.
   if (T->is<EnumType>()) {
-    diags.diagnose(TypeRange.Start, diag::not_objc_swift_enum)
-        .highlight(TypeRange)
-        .limitBehavior(behavior);
+    if (DC->getASTContext().LangOpts.hasFeature(Feature::CDecl)) {
+      // New dialog mentioning @cdecl.
+      diags.diagnose(TypeRange.Start, diag::not_cdecl_or_objc_swift_enum,
+                     language)
+          .highlight(TypeRange)
+          .limitBehavior(behavior);
+    } else {
+      diags.diagnose(TypeRange.Start, diag::not_objc_swift_enum)
+          .highlight(TypeRange)
+          .limitBehavior(behavior);
+    }
     return;
   }
 
@@ -1766,19 +1774,18 @@ static bool isCIntegerType(Type type) {
 }
 
 /// Determine whether the given enum should be @objc.
-static bool isEnumObjC(EnumDecl *enumDecl) {
+static bool isEnumObjC(EnumDecl *enumDecl, DeclAttribute *attr) {
   // FIXME: Use shouldMarkAsObjC once it loses it's TypeChecker argument.
 
-  // If there is no @objc attribute, it's not @objc.
-  auto attr = enumDecl->getAttrs().getAttribute<ObjCAttr>();
+  // If there is no @objc or @cdecl attribute, skip it.
   if (!attr)
     return false;
 
   Type rawType = enumDecl->getRawType();
 
-  // @objc enums must have a raw type.
+  // @objc/@cdecl enums must have a raw type.
   if (!rawType) {
-    enumDecl->diagnose(diag::objc_enum_no_raw_type);
+    enumDecl->diagnose(diag::objc_enum_no_raw_type, attr);
     return false;
   }
 
@@ -1791,7 +1798,7 @@ static bool isEnumObjC(EnumDecl *enumDecl) {
     SourceRange errorRange;
     if (!enumDecl->getInherited().empty())
       errorRange = enumDecl->getInherited().getEntry(0).getSourceRange();
-    enumDecl->diagnose(diag::objc_enum_raw_type_not_integer, rawType)
+    enumDecl->diagnose(diag::objc_enum_raw_type_not_integer, attr, rawType)
       .highlight(errorRange);
     return false;
   }
@@ -1801,7 +1808,8 @@ static bool isEnumObjC(EnumDecl *enumDecl) {
     enumDecl->diagnose(diag::empty_enum_raw_type);
   }
 
-  checkObjCNameValidity(enumDecl, attr);
+  if (auto objcAttr = dyn_cast<ObjCAttr>(attr))
+    checkObjCNameValidity(enumDecl, objcAttr);
   return true;
 }
 
@@ -1842,9 +1850,9 @@ bool IsObjCRequest::evaluate(Evaluator &evaluator, ValueDecl *VD) const {
   } else if (auto enumDecl = dyn_cast<EnumDecl>(VD)) {
     // Enums can be @objc so long as they have a raw type that is representable
     // as an arithmetic type in C.
-    if (isEnumObjC(enumDecl))
-      isObjC = objCReasonForObjCAttr(
-                                 enumDecl->getAttrs().getAttribute<ObjCAttr>());
+    auto attr = enumDecl->getAttrs().getAttribute<ObjCAttr>();
+    if (attr && isEnumObjC(enumDecl, attr))
+      isObjC = objCReasonForObjCAttr(attr);
   } else if (auto enumElement = dyn_cast<EnumElementDecl>(VD)) {
     // Enum elements can be @objc so long as the containing enum is @objc.
     if (enumElement->getParentEnum()->isObjC()) {
@@ -4209,9 +4217,9 @@ evaluate(Evaluator &evaluator, Decl *D) const {
 }
 
 evaluator::SideEffect
-TypeCheckCDeclAttributeRequest::evaluate(Evaluator &evaluator,
-                                         FuncDecl *FD,
-                                         CDeclAttr *attr) const {
+TypeCheckCDeclFunctionRequest::evaluate(Evaluator &evaluator,
+                                        FuncDecl *FD,
+                                        CDeclAttr *attr) const {
   auto &ctx = FD->getASTContext();
 
   auto lang = FD->getCDeclKind();
@@ -4236,6 +4244,14 @@ TypeCheckCDeclAttributeRequest::evaluate(Evaluator &evaluator,
   } else {
     reason.setAttrInvalid();
   }
+  return {};
+}
 
+evaluator::SideEffect
+TypeCheckCDeclEnumRequest::evaluate(Evaluator &evaluator,
+                                    EnumDecl *ED,
+                                    CDeclAttr *attr) const {
+  // Apply @objc's logic.
+  isEnumObjC(ED, attr);
   return {};
 }

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -192,6 +192,7 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
   if (auto *CD = T->getClassOrBoundGenericClass()) {
     if (language == ForeignLanguage::C) {
       diags.diagnose(TypeRange.Start, diag::cdecl_incompatible_with_classes)
+          .highlight(TypeRange)
           .limitBehavior(behavior);
       return;
     }
@@ -233,6 +234,7 @@ static void diagnoseTypeNotRepresentableInObjC(const DeclContext *DC,
     // No protocol is representable in C.
     if (language == ForeignLanguage::C) {
       diags.diagnose(TypeRange.Start, diag::cdecl_incompatible_with_protocols)
+          .highlight(TypeRange)
           .limitBehavior(behavior);
       return;
     }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3280,6 +3280,13 @@ public:
       }
     }
 
+    // If the enum is exported to C, it must be representable in C.
+    if (auto CDeclAttr = ED->getAttrs().getAttribute<swift::CDeclAttr>()) {
+      evaluateOrDefault(Ctx.evaluator,
+                        TypeCheckCDeclEnumRequest{ED, CDeclAttr},
+                        {});
+    }
+
     // -----
     // NonCopyableChecks
     //
@@ -3813,7 +3820,7 @@ public:
     // If the function is exported to C, it must be representable in (Obj-)C.
     if (auto CDeclAttr = FD->getAttrs().getAttribute<swift::CDeclAttr>()) {
       evaluateOrDefault(Ctx.evaluator,
-                        TypeCheckCDeclAttributeRequest{FD, CDeclAttr},
+                        TypeCheckCDeclFunctionRequest{FD, CDeclAttr},
                         {});
     }
 

--- a/test/PrintAsObjC/cdecl-enum-reference.swift
+++ b/test/PrintAsObjC/cdecl-enum-reference.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build CoreLib defining a @cdecl enum.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %t/CoreLib.swift -emit-module -verify -o %t \
+// RUN:   -emit-clang-header-path %t/CoreLib.h \
+// RUN:   -enable-experimental-feature CDecl
+// RUN: %check-in-clang-c %t/CoreLib.h -I %t
+
+/// Build MiddleLib using the @cdecl enum in API.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %t/MiddleLib.swift -emit-module -verify -o %t -I %t \
+// RUN:   -emit-clang-header-path %t/MiddleLib.h \
+// RUN:   -enable-experimental-feature CDecl
+// RUN: %FileCheck %s --input-file %t/MiddleLib.h
+// RUN: %check-in-clang-c %t/MiddleLib.h -I %t
+
+/// Build a client.
+// RUN: %clang-no-modules -c %t/Client.c -I %t \
+// RUN:   -F %S/../Inputs/clang-importer-sdk-path/frameworks \
+// RUN:   -I %clang-include-dir -Werror \
+// RUN:   -isysroot %S/../Inputs/clang-importer-sdk
+
+// REQUIRES: swift_feature_CDecl
+
+//--- CoreLib.swift
+@cdecl("CEnum")
+public enum CEnum: CInt { case A, B }
+
+//--- MiddleLib.swift
+import CoreLib
+
+@cdecl("CFunc")
+public func CFunc(e: CEnum) {}
+// CHECK: typedef SWIFT_ENUM_FWD_DECL(int, CEnum)
+// CHECK: SWIFT_EXTERN void CFunc(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT;
+
+//--- Client.c
+#include "CoreLib.h"
+#include "MiddleLib.h"
+
+int main() {
+    CFunc(CEnumA);
+}

--- a/test/PrintAsObjC/cdecl-enums.swift
+++ b/test/PrintAsObjC/cdecl-enums.swift
@@ -1,0 +1,126 @@
+/// Variant of PrintAsObjC/enums.swift for @cdecl enums.
+
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import \
+// RUN:   -emit-module -emit-module-doc -o %t %s \
+// RUN:   -import-objc-header %S/Inputs/enums.h \
+// RUN:   -emit-objc-header-path %t/enums.h \
+// RUN:   -disable-objc-attr-requires-foundation-module \
+// RUN:   -enable-experimental-feature CDecl
+
+// RUN: %FileCheck %s --input-file %t/enums.h
+// RUN: %FileCheck -check-prefix=NEGATIVE %s --input-file %t/enums.h
+// RUN: %check-in-clang %t/enums.h
+
+// REQUIRES: swift_feature_CDecl
+// REQUIRES: objc_interop
+
+import Foundation
+
+// NEGATIVE-NOT: enum EnumNamed
+
+/// No error domains in C mode.
+// NEGATIVE-NOT: @"main.
+
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, ObjcEnumNamed, "EnumNamed", closed) {
+// CHECK-NEXT:   ObjcEnumNamedA = 0,
+// CHECK-NEXT:   ObjcEnumNamedB = 1,
+// CHECK-NEXT:   ObjcEnumNamedC = 2,
+// CHECK-NEXT:   ObjcEnumNamedD = 3,
+// CHECK-NEXT:   ObjcEnumNamedHelloDolly = 4,
+// CHECK-NEXT: };
+
+@cdecl("ObjcEnumNamed") enum EnumNamed: Int {
+  case A, B, C, d, helloDolly
+}
+
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(unsigned int, ExplicitValues, "ExplicitValues", closed) {
+// CHECK-NEXT:   ExplicitValuesZim = 0,
+// CHECK-NEXT:   ExplicitValuesZang = 219,
+// CHECK-NEXT:   ExplicitValuesZung = 220,
+// CHECK-NEXT: };
+// NEGATIVE-NOT: ExplicitValuesDomain
+
+@cdecl("ExplicitValues") enum ExplicitValues: CUnsignedInt {
+  case Zim, Zang = 219, Zung
+
+  func methodNotExportedToC() {}
+}
+
+// CHECK: /// Foo: A feer, a female feer.
+// CHECK-NEXT: typedef SWIFT_ENUM_NAMED(int, FooComments, "FooComments", closed) {
+// CHECK: /// Zim: A zeer, a female zeer.
+// CHECK-NEXT:   FooCommentsZim = 0,
+// CHECK-NEXT:   FooCommentsZang = 1,
+// CHECK-NEXT:   FooCommentsZung = 2,
+// CHECK-NEXT: }
+
+/// Foo: A feer, a female feer.
+@cdecl("FooComments") public enum FooComments: CInt {
+  /// Zim: A zeer, a female zeer.
+  case Zim
+  case Zang, Zung
+}
+
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(int16_t, NegativeValues, "NegativeValues", closed) {
+// CHECK-NEXT:   Zang = -219,
+// CHECK-NEXT:   Zung = -218,
+// CHECK-NEXT: };
+@cdecl("NegativeValues") enum NegativeValues: Int16 {
+  case Zang = -219, Zung
+
+  func methodNotExportedToC() {}
+}
+
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, SomeError, "SomeError", closed) {
+// CHECK-NEXT:   SomeErrorBadness = 9001,
+// CHECK-NEXT:   SomeErrorWorseness = 9002,
+// CHECK-NEXT: };
+@cdecl("SomeError") enum SomeError: Int, Error {
+  case Badness = 9001
+  case Worseness
+}
+
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, SomeOtherError, "SomeOtherError", closed) {
+// CHECK-NEXT:   SomeOtherErrorDomain = 0,
+// CHECK-NEXT: };
+@cdecl("SomeOtherError") enum SomeOtherError: Int, Error {
+  case Domain
+}
+
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, ObjcErrorType, "SomeRenamedErrorType", closed) {
+// CHECK-NEXT:   ObjcErrorTypeBadStuff = 0,
+// CHECK-NEXT: };
+@cdecl("ObjcErrorType") enum SomeRenamedErrorType: Int, Error {
+  case BadStuff
+}
+
+@cdecl("acceptMemberImported") func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
+// CHECK-LABEL: SWIFT_EXTERN void acceptMemberImported(enum MemberRaw a, enum MemberEnum b, MemberOptions c, enum MemberTypedef d, MemberAnon e, MemberAnon2 ee) SWIFT_NOEXCEPT;
+
+@cdecl("acceptPlainEnum") func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
+// CHECK-LABEL: SWIFT_EXTERN void acceptPlainEnum(enum NSMalformedEnumMissingTypedef) SWIFT_NOEXCEPT;
+
+@cdecl("acceptTopLevelImported") func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
+// CHECK-LABEL: SWIFT_EXTERN void acceptTopLevelImported(enum TopLevelRaw a, TopLevelEnum b, TopLevelOptions c, TopLevelTypedef d, TopLevelAnon e) SWIFT_NOEXCEPT;
+
+@cdecl("takeAndReturnEnumC") func takeAndReturnEnumC(_ foo: FooComments) -> NegativeValues {
+  return .Zung
+}
+// CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG NegativeValues takeAndReturnEnumC(SWIFT_ENUM_TAG FooComments foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+@cdecl("takeAndReturnRenamedEnum") func takeAndReturnRenamedEnum(_ foo: EnumNamed) -> EnumNamed {
+  return .A
+}
+// CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG ObjcEnumNamed takeAndReturnRenamedEnum(SWIFT_ENUM_TAG ObjcEnumNamed foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+/// Objective-C user.
+
+// CHECK-LABEL: SWIFT_ENUM_FWD_DECL(int, FooComments)
+// CHECK-LABEL: SWIFT_ENUM_FWD_DECL(int16_t, NegativeValues)
+
+// CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG NegativeValues takeAndReturnEnumObjC(SWIFT_ENUM_TAG FooComments foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+@_cdecl("takeAndReturnEnumObjC") func takeAndReturnEnumObjC(_ foo: FooComments) -> NegativeValues {
+  return .Zung
+}

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -27,6 +27,22 @@
 // CHECK: extern "C" {
 // CHECK: #endif
 
+// CHECK: /// Enums
+// CHECK: typedef SWIFT_ENUM_NAMED(int, CEnum, "CEnum", closed) {
+// CHECK:   CEnumA = 0,
+// CHECK:   CEnumB = 1,
+// CHECK: };
+
+// CHECK: typedef SWIFT_ENUM_NAMED(long, CEnumRenamed_CName, "CEnumRenamed", closed) {
+// CHECK:   CEnumRenamed_CNameA = 0,
+// CHECK:   CEnumRenamed_CNameB = 1,
+// CHECK: };
+
+// CHECK: typedef SWIFT_ENUM_NAMED(char, zCEnumDefinedLate, "zCEnumDefinedLate", closed) {
+// CHECK:   CEnumDefinedLateA = 0,
+// CHECK:   CEnumDefinedLateB = 1,
+// CHECK: };
+
 /// My documentation
 @cdecl("simple")
 func a_simple(x: Int, bar y: Int) -> Int { return x }
@@ -62,6 +78,30 @@ func g_nullablePointers(_ x: UnsafeMutableRawPointer,
                           z: UnsafeMutableRawPointer!) {}
 // CHECK: SWIFT_EXTERN void nullable_pointers(void * _Nonnull x, void * _Nullable y, void * _Null_unspecified z) SWIFT_NOEXCEPT;
 
+/// Enums
+
+@cdecl("CEnum")
+enum CEnum: CInt { case A, B }
+
+@cdecl("CEnumRenamed_CName")
+enum CEnumRenamed: CLong { case A, B }
+
+@cdecl("use_enum")
+func h_useCEnum(e: CEnum) -> CEnum { return e }
+// CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG CEnum use_enum(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+@cdecl("use_enum_renamed")
+func i_useCEnumLong(e: CEnumRenamed) -> CEnumRenamed { return e }
+// CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG CEnumRenamed_CName use_enum_renamed(SWIFT_ENUM_TAG CEnumRenamed_CName e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+@cdecl("use_enum_late")
+func j_useCEnumChar(e: zCEnumDefinedLate) -> zCEnumDefinedLate { return e }
+// CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG zCEnumDefinedLate use_enum_late(SWIFT_ENUM_TAG zCEnumDefinedLate e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
+/// Declare this enum late in the source file and in alphabetical order.
+@cdecl("zCEnumDefinedLate")
+enum zCEnumDefinedLate: CChar { case A, B }
+
 // CHECK:      #if defined(__cplusplus)
 // CHECK-NEXT: }
 // CHECK-NEXT: #endif
@@ -74,5 +114,10 @@ int main() {
     ptrdiff_t x = simple(42, 43);
     primitiveTypes(1, 2, 3, 'a', 1.0f, 2.0, true);
     has_keyword_arg_names(1, 2);
+
+    (void)use_enum(CEnumA);
+    (void)use_enum_renamed(CEnumRenamed_CNameB);
+    (void)use_enum_late(zCEnumDefinedLateA);
+
     return_never();
 }

--- a/test/attr/attr_cdecl.swift
+++ b/test/attr/attr_cdecl.swift
@@ -8,7 +8,7 @@ func emptyName(x: Int) -> Int { return x }
 @_cdecl("noBody")
 func noBody(x: Int) -> Int // expected-error{{expected '{' in body of function}}
 
-@_cdecl("property") // expected-error{{may only be used on 'func' declarations}}
+@_cdecl("property") // expected-error{{'@_cdecl' attribute cannot be applied to this declaration}}
 var property: Int
 
 var computed: Int {
@@ -23,6 +23,9 @@ enum SwiftEnum { case A, B }
 #else
 @objc enum CEnum: Int { case A, B }
 #endif
+
+@_cdecl("enum") // expected-error {{@_cdecl may only be used on 'func' declarations}}
+enum UnderscoreCDeclEnum: Int { case A, B }
 
 @_cdecl("swiftStruct")
 func swiftStruct(x: SwiftStruct) {} // expected-error{{cannot be represented}} expected-note{{Swift struct}}
@@ -40,10 +43,10 @@ class Foo {
   @_cdecl("Foo_foo_2") // expected-error{{can only be applied to global functions}}
   static func foo(x: Int) -> Int { return x }
 
-  @_cdecl("Foo_init") // expected-error{{may only be used on 'func'}}
+  @_cdecl("Foo_init") // expected-error{{'@_cdecl' attribute cannot be applied to this declaration}}
   init() {}
 
-  @_cdecl("Foo_deinit") // expected-error{{may only be used on 'func'}}
+  @_cdecl("Foo_deinit") // expected-error{{'@_cdecl' attribute cannot be applied to this declaration}}
   deinit {}
 }
 

--- a/test/attr/attr_cdecl.swift
+++ b/test/attr/attr_cdecl.swift
@@ -25,7 +25,7 @@ enum SwiftEnum { case A, B }
 #endif
 
 @_cdecl("enum") // expected-error {{@_cdecl may only be used on 'func' declarations}}
-enum UnderscoreCDeclEnum: Int { case A, B }
+enum UnderscoreCDeclEnum: CInt { case A, B }
 
 @_cdecl("swiftStruct")
 func swiftStruct(x: SwiftStruct) {} // expected-error{{cannot be represented}} expected-note{{Swift struct}}

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -27,11 +27,18 @@ func noBody(x: inout Int) { } // expected-error{{global function cannot be marke
 
 struct SwiftStruct { var x, y: Int }
 enum SwiftEnum { case A, B }
+
 #if os(Windows) && (arch(x86_64) || arch(arm64))
-@objc enum CEnum: Int32 { case A, B }
+@cdecl("CEnum") enum CEnum: Int32 { case A, B }
 #else
-@objc enum CEnum: Int { case A, B }
+@cdecl("CEnum") enum CEnum: Int { case A, B }
 #endif
+
+@cdecl("CEnumNoRawType") enum CEnumNoRawType { case A, B }
+// expected-error @-1 {{'@cdecl' enum must declare an integer raw type}}
+
+@cdecl("CEnumStringRawType") enum CEnumStringRawType: String { case A, B }
+// expected-error @-1 {{'@cdecl' enum raw type 'String' is not an integer type}}
 
 @cdecl("swiftStruct")
 func swiftStruct(x: SwiftStruct) {}
@@ -39,14 +46,16 @@ func swiftStruct(x: SwiftStruct) {}
 // expected-note @-2 {{Swift structs cannot be represented in C}}
 
 @cdecl("swiftEnum")
-func swiftEnum(x: SwiftEnum) {} // expected-error{{cannot be represented}} expected-note{{non-'@objc' enum}}
+func swiftEnum(x: SwiftEnum) {}
+// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-note @-2 {{Swift enums not marked '@cdecl' cannot be represented in C}}
 
 @cdecl("cEnum")
 func cEnum(x: CEnum) {}
 
 @cdecl("CDeclAndObjC") // expected-error {{cannot apply both '@cdecl' and '@objc' to enum}}
 @objc
-enum CDeclAndObjC: Int { case A, B }
+enum CDeclAndObjC: CInt { case A, B }
 
 @cdecl("TwoCDecls") // expected-note {{attribute already specified here}}
 @_cdecl("TwoCDecls") // expected-error {{duplicate attribute}}

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -14,7 +14,7 @@ func emptyName(x: Int) -> Int { return x }
 @cdecl("noBody")
 func noBody(x: Int) -> Int // expected-error{{expected '{' in body of function}}
 
-@cdecl("property") // expected-error{{may only be used on 'func' declarations}}
+@cdecl("property") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
 var property: Int
 
 var computed: Int {
@@ -51,10 +51,10 @@ class Foo {
   @cdecl("Foo_foo_2") // expected-error{{@cdecl can only be applied to global functions}}
   static func foo(x: Int) -> Int { return x }
 
-  @cdecl("Foo_init") // expected-error{{@cdecl may only be used on 'func'}}
+  @cdecl("Foo_init") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
   init() {}
 
-  @cdecl("Foo_deinit") // expected-error{{@cdecl may only be used on 'func'}}
+  @cdecl("Foo_deinit") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
   deinit {}
 }
 

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -44,6 +44,14 @@ func swiftEnum(x: SwiftEnum) {} // expected-error{{cannot be represented}} expec
 @cdecl("cEnum")
 func cEnum(x: CEnum) {}
 
+@cdecl("CDeclAndObjC") // expected-error {{cannot apply both '@cdecl' and '@objc' to enum}}
+@objc
+enum CDeclAndObjC: Int { case A, B }
+
+@cdecl("TwoCDecls") // expected-note {{attribute already specified here}}
+@_cdecl("TwoCDecls") // expected-error {{duplicate attribute}}
+func TwoCDecls() {}
+
 class Foo {
   @cdecl("Foo_foo") // expected-error{{@cdecl can only be applied to global functions}}
   func foo(x: Int) -> Int { return x }

--- a/test/attr/attr_cdecl_official_with_objc.swift
+++ b/test/attr/attr_cdecl_official_with_objc.swift
@@ -24,3 +24,19 @@ protocol ObjCProtocol {}
 @cdecl("objcProtocol") func objcProtocol(a: ObjCProtocol) { }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
+
+@objc
+enum ObjCEnum: Int { case A, B }
+@cdecl("objcEnumUseInCDecl") func objcEnumUseInCDecl(a: ObjCEnum) { }
+// expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
+// expected-note @-2 {{Swift enums not marked '@cdecl' cannot be represented in C}}
+
+/// Objective-C accepts @cdecl enums.
+@cdecl("CEnum")
+enum CEnum: Int { case A, B }
+@_cdecl("cdeclEnumUseInObjc") func cdeclEnumUseInObjc(a: CEnum) { }
+
+enum SwiftEnum { case A, B }
+@_cdecl("swiftEnumUseInObjc") func swiftEnumUseInObjc(a: SwiftEnum) { }
+// expected-error @-1 {{global function cannot be marked '@_cdecl' because the type of the parameter cannot be represented in Objective-C}}
+// expected-note @-2 {{Swift enums not marked '@cdecl' or '@objc' cannot be represented in Objective-C}}


### PR DESCRIPTION
Introduce `@cdecl` enums, enums declared in Swift and representable in C. These enums must have an integer raw type and can be referenced from `@cdecl` functions and `@objc` methods.

`@cdecl` enums are printed in the compatibility header using a macro that ensures compatibility with different C language modes. They can also be forward declared when referenced from the compatibility header of a client.

`@cdecl` and `@objc` enums mostly have the same restrictions on their declarations. There are differences on how they are printed in the compatibility header, each are in the corresponding language section and only `@objc` enums supports error domains.

 This is guarded behind the `CDecl` feature flag.