### PR TITLE
[NFC] Silence some unused variable warnings

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -236,12 +236,12 @@ public:
         paramIndicesLength = inheritLifetimeParamIndices->getCapacity();
       }
       if (scopeLifetimeParamIndices) {
-        assert(paramIndicesLength == 0 ||
+        ASSERT(paramIndicesLength == 0 ||
                paramIndicesLength == scopeLifetimeParamIndices->getCapacity());
         paramIndicesLength = scopeLifetimeParamIndices->getCapacity();
       }
       if (addressableParamIndices) {
-        assert(paramIndicesLength == 0 ||
+        ASSERT(paramIndicesLength == 0 ||
                paramIndicesLength == addressableParamIndices->getCapacity());
         paramIndicesLength = addressableParamIndices->getCapacity();
       }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3583,13 +3583,13 @@ protected:
     Bits.AnyFunctionType.NumParams = NumParams;
     assert(Bits.AnyFunctionType.NumParams == NumParams && "Params dropped!");
     
-    if (Info) {
+    if (Info && CONDITIONAL_ASSERT_enabled()) {
       unsigned maxLifetimeTarget = NumParams + 1;
       if (auto outputFn = Output->getAs<AnyFunctionType>()) {
         maxLifetimeTarget += outputFn->getNumParams();
       }
       for (auto &dep : Info->getLifetimeDependencies()) {
-        assert(dep.getTargetIndex() < maxLifetimeTarget);
+        ASSERT(dep.getTargetIndex() < maxLifetimeTarget);
       }
     }
   }


### PR DESCRIPTION
This patch addresses some warnings that come from variables that seem unused outside of recently-added `assert()` statements. Those warnings come from header files that are used by many translation units. This patch replaces them with `ASSERT()` to "use" the variables.