### PR TITLE
[TypeLowering] Record pack used in aggregate signature.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2742,6 +2742,7 @@ namespace {
     template <class LoadableLoweringClass>
     TypeLowering *handleAggregateByProperties(CanType type,
                                               RecursiveProperties props) {
+      props = mergeHasPack(HasPack_t(type->hasAnyPack()), props);
       if (props.isAddressOnly()) {
         return handleAddressOnly(type, props);
       }

--- a/validation-test/IRGen/rdar152580661.swift
+++ b/validation-test/IRGen/rdar152580661.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -target %target-swift-5.9-abi-triple -emit-ir
+
+struct H<T> {
+  var packs: [Pack<T>] {
+      id(_packs)
+  }
+  let _packs: [Pack<T>]
+}
+
+struct Pack<each T> {}
+
+func id<T>(_ t: T) -> T {
+  return t
+}


### PR DESCRIPTION
Every `LowerType::visit*` function eventually calls through to a `LowerType::handle*` function.  After https://github.com/swiftlang/swift/pull/81581 , every `LowerType::handle*` needs to set the `hasPack` flag based on the passed-in type by calling `mergeHasPack`.  Add the missing call in the `handleAggregateByProperties` function.

rdar://152580661
