### PR TITLE
6.2: [TypeLowering] Record pack used in aggregate signature.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2742,6 +2742,7 @@ namespace {
     template <class LoadableLoweringClass>
     TypeLowering *handleAggregateByProperties(CanType type,
                                               RecursiveProperties props) {
+      props = mergeHasPack(HasPack_t(type->hasAnyPack()), props);
       if (props.isAddressOnly()) {
         return handleAddressOnly(type, props);
       }

--- a/validation-test/IRGen/rdar152580661.swift
+++ b/validation-test/IRGen/rdar152580661.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend %s -target %target-swift-5.9-abi-triple -emit-ir
+
+struct H<T> {
+  var packs: [Pack<T>] {
+      id(_packs)
+  }
+  let _packs: [Pack<T>]
+}
+
+struct Pack<each T> {}
+
+func id<T>(_ t: T) -> T {
+  return t
+}


### PR DESCRIPTION
**Explanation**: Fix an assertion failure involving a generic, non-variadic-generic, type into which a variadic generic type is substituted.

Metadata packs are stored on the stack as an optimization. These allocations must obey stack discipline. This is enforced via the `PackMetadataMarkerInserter` pass. That pass inserts `alloc_pack_metadata` marker instructions before each instruction which may allocate an on-stack pack and inserts `dealloc_pack_metadata` instructions to indicate where those packs should be deallocated (the `StackNesting` utility ensures proper nesting, reflowing all stack deallocating instructions as needed). The pass relies on knowing whether an instruction may allocate an on-stack pack. This is determined by a recursive walk over the fields of each type of each operand of the instruction. That walk is done in `TypeLowering`.

Prior to https://github.com/swiftlang/swift/pull/81659 , whether a type involved a pack in its signature was not considered by `TypeLowering`.  Only whether the outermost type's signature involved a pack was considered by the `typeOrLayoutInvolvesPack` helper function called by the pass.  This was incorrect.  After that PR, whether any type visited recursively involved a pack in its signature was considered.  This was achieved by adding merging the pack-ness of each intermediate and leaf type's signature into the outermost type's pack-ness.  Specifically, this merging was done in each `LowerType::handle*` in `TypeLowering.cpp`--these functions are the final step in computing each type's properties, so one will be called for every single type that's visited along the way.

But I missed one of the `LowerType::handle*` functions.  This in combination with the removal (correct) of the check in `typeOrLayoutInvolvesPack` of whether the outermost type involved a pack in its signature led to a regression in certain cases such as that in the included test case.

The solution, implemented here, is to merge in the pack-ness in the one `LowerType::handle*` function from which it was missing.  This addresses the regression without reintroducing the wrong approach of checking the outermost type's signature which happened to work in some simple cases.
**Scope**: Variadic generics.
**Issue**: rdar://152580661
**Original PR**: https://github.com/swiftlang/swift/pull/82043
**Risk**: Low, this completes the pattern set in the previous PR, ensuring that all types merge pack-ness from their signatures.
**Testing**: Added test.
**Reviewer**: Arnold Schawighofer ( @aschwaighofer)