### PR TITLE
AST: Fix iOS -> visionOS version remap for `@backDeployed` attrs

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -365,7 +365,8 @@ bool AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
     const BackDeployedAttr *attr, const ASTContext &ctx,
     AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
   bool hasRemap = false;
-  auto remappedDomain = domain.getRemappedDomain(ctx, hasRemap);
+  auto remappedDomain = AvailabilityDomain::forPlatform(attr->Platform)
+                            .getRemappedDomain(ctx, hasRemap);
   if (!hasRemap)
     return false;
 

--- a/test/SILGen/back_deployed_attr_func_visionos.swift
+++ b/test/SILGen/back_deployed_attr_func_visionos.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-xros1.0 -verify
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-xros1.0 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -Xllvm -sil-print-types -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-xros1.0 | %FileCheck %s
 
 // REQUIRES: OS=xros
 
@@ -10,7 +10,7 @@
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy11trivialFuncyyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy11trivialFuncyyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 0
@@ -45,7 +45,7 @@ public func trivialFunc() {}
 // CHECK:   return [[RESULT]] : $()
 
 // -- Back deployment thunk for trivialFunc_iOS()
-// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy15trivialFunc_iOSyyFTwb : $@convention(thin) () -> ()
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy15trivialFunc_iOSyyFTwb : $@convention(thin) () -> ()
 // CHECK: bb0:
 // CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 1
 // CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 1

--- a/test/attr/attr_backDeployed_availability_visionos.swift
+++ b/test/attr/attr_backDeployed_availability_visionos.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -parse-as-library
-
-// REQUIRES: OS=xros
+// RUN: %empty-directory(%t/mock-sdk)
+// RUN: cp %S/../Inputs/MockPlatformRemapSDKConfig/SDKSettings.json %t/mock-sdk/SDKSettings.json
+// RUN: %swift -typecheck -verify -parse-stdlib -target arm64-apple-xros1.0 %s -sdk %t/mock-sdk
 
 @backDeployed(before: visionOS 2) // Ok, introduced availability is inferred to be visionOS epoch
 public func topLevelFunc() {}
@@ -51,7 +51,7 @@ public func availableSameVersionAsBackDeploymentAndAlsoAvailableEarlierOniOS() {
 @backDeployed(before: visionOS 2) // expected-error {{'@backDeployed' has no effect because 'availableAfterBackDeployment()' is not available before visionOS 2}}
 public func availableAfterBackDeployment() {}
 
-@available(iOS 99, *) // expected-note {{'availableOniOSAfterBackDeploymentOniOS()' was introduced in visionOS 99}}
+@available(iOS 99, *) // expected-note {{'availableOniOSAfterBackDeploymentOniOS()' was introduced in iOS 99}}
 @backDeployed(before: iOS 17.4) // expected-error {{'@backDeployed' has no effect because 'availableOniOSAfterBackDeploymentOniOS()' is not available before visionOS 1.1}}
 public func availableOniOSAfterBackDeploymentOniOS() {}
 


### PR DESCRIPTION
The version remapping for `@backDeployed` regressed due to a bug introduced by https://github.com/swiftlang/swift/pull/81922.

Also, fix some visionOS tests that have gotten out of date because we don't seem to be running them in CI.

Resolves rdar://152542983.
