### PR TITLE
ASTPrinter: Fix printing of let properties inside @objc @implementation extensions

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3508,11 +3508,13 @@ void PrintAST::visitPatternBindingDecl(PatternBindingDecl *decl) {
   if (decl->isStatic())
     printStaticKeyword(decl->getCorrectStaticSpelling());
 
+  bool printAsVar = false;
   if (anyVar) {
-    Printer << (anyVar->isSettable(anyVar->getDeclContext()) ? "var " : "let ");
-  } else {
-    Printer << "let ";
+    printAsVar = (anyVar->isSettable(anyVar->getDeclContext()) ||
+                  isInObjCImpl(anyVar));
   }
+
+  Printer << (printAsVar ? "var " : "let ");
 
   bool isFirst = true;
   for (auto idx : range(decl->getNumPatternEntries())) {
@@ -3958,9 +3960,9 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
     // Map all non-let specifiers to 'var'.  This is not correct, but
     // SourceKit relies on this for info about parameter decls.
     
-    Printer.printIntroducerKeyword(
-      introducer == VarDecl::Introducer::Let ? "let" : "var",
-      Options, " ");
+    bool printAsVar = (introducer != VarDecl::Introducer::Let ||
+                       isInObjCImpl(decl));
+    Printer.printIntroducerKeyword(printAsVar ? "var" : "let", Options, " ");
   }
   printContextIfNeeded(decl);
   recordDeclLoc(decl,

--- a/test/ModuleInterface/Inputs/objc_implementation/objc_implementation.h
+++ b/test/ModuleInterface/Inputs/objc_implementation/objc_implementation.h
@@ -4,6 +4,7 @@
 
 - (nonnull instancetype)init;
 
+@property (readonly) int letProperty1;
 @property (assign) int implProperty;
 
 - (void)mainMethod:(int)param;

--- a/test/ModuleInterface/objc_implementation.swift
+++ b/test/ModuleInterface/objc_implementation.swift
@@ -42,6 +42,12 @@ import Foundation
     didSet { print(implProperty) }
   }
 
+  // CHECK-NOT: var letProperty1:
+  @objc public let letProperty1: Int32
+
+  // CHECK-DAG: @nonobjc public var letProperty2: Swift.Int32 { get }
+  @nonobjc public let letProperty2: Int32
+
   // CHECK-DAG: final public var implProperty2: ObjectiveC.NSObject? { get set }
   public final var implProperty2: NSObject?
 


### PR DESCRIPTION
A `let` here is really just a `var` with a `{ get }`.

Fixes rdar://problem/127120469.