### PR TITLE
[6.2] ASTPrinter: Fix printing of let properties inside @objc @implementation extensions

### DIFF
--- a/test/ModuleInterface/Inputs/objc_implementation/objc_implementation.h
+++ b/test/ModuleInterface/Inputs/objc_implementation/objc_implementation.h
@@ -4,6 +4,7 @@
 
 - (nonnull instancetype)init;
 
+@property (readonly) int letProperty1;
 @property (assign) int implProperty;
 
 - (void)mainMethod:(int)param;

--- a/test/ModuleInterface/objc_implementation.swift
+++ b/test/ModuleInterface/objc_implementation.swift
@@ -42,6 +42,12 @@ import Foundation
     didSet { print(implProperty) }
   }
 
+  // CHECK-NOT: var letProperty1:
+  @objc public let letProperty1: Int32
+
+  // CHECK-DAG: @nonobjc public var letProperty2: Swift.Int32 { get }
+  @nonobjc public let letProperty2: Int32
+
   // CHECK-DAG: final public var implProperty2: ObjectiveC.NSObject? { get set }
   public final var implProperty2: NSObject?
 


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82048

* **Description:** Fix an edge case where we emit a broken module interface file for a `@objc @implementation extension`.

* **Risk:** Should be pretty safe. In the worst case the new output is wrong, but the old output didn't parse at all.

* **Radar:** Fixes rdar://problem/127120469.

* **Reviewed by:** @tshortli 