### PR TITLE
[6.2][Indexing] Don't verify mangling of USRs

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1006,7 +1006,7 @@ ASTMangler::mangleAnyDecl(const ValueDecl *Decl,
 
   // We have a custom prefix, so finalize() won't verify for us. If we're not
   // in invalid code (coming from an IDE caller) verify manually.
-  if (!Decl->isInvalid())
+  if (CONDITIONAL_ASSERT_enabled() && !prefix && !Decl->isInvalid())
     verify(Storage.str(), Flavor);
   return finalize();
 }
@@ -1026,7 +1026,7 @@ std::string ASTMangler::mangleAccessorEntityAsUSR(AccessorKind kind,
   appendAccessorEntity(getCodeForAccessorKind(kind), decl, isStatic);
   // We have a custom prefix, so finalize() won't verify for us. If we're not
   // in invalid code (coming from an IDE caller) verify manually.
-  if (!decl->isInvalid())
+  if (CONDITIONAL_ASSERT_enabled() && !decl->isInvalid())
     verify(Storage.str().drop_front(USRPrefix.size()), Flavor);
   return finalize();
 }


### PR DESCRIPTION
- **Explanation**: Verifying USR mangling adds ~30% overhead to indexing times. We don’t verify the mangled names that we use for code generation and the USRs we create are less correctness-critical. Save those 30% when asserts are disabled.
- **Scope**: Indexing
- **Issue**: n/a
- **Original PR**: https://github.com/swiftlang/swift/pull/81941
- **Risk**: Very low, this disables a check that might have crashed the compiler
- **Testing**: Builds and passes tests
- **Reviewer**: @bnbarham @hamishknight 


