### PR TITLE
[Diagnostics] Add fix-its for missing `set` and `)` after access modifier

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -690,6 +690,13 @@ public:
     return Context.LangOpts.EnableExperimentalConcurrency;
   }
 
+  /// Returns true if a a Swift declaration starts after the current token, otherwise returns false.
+  bool isNextStartOfSwiftDecl() {
+    BacktrackingScope backtrack(*this);
+    consumeToken();
+    return isStartOfSwiftDecl();
+  }
+
 public:
   InFlightDiagnostic diagnose(SourceLoc Loc, DiagRef Diag) {
     if (Diags.isDiagnosticPointsToFirstBadToken(Diag.getID()) &&

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -690,7 +690,8 @@ public:
     return Context.LangOpts.EnableExperimentalConcurrency;
   }
 
-  /// Returns true if a a Swift declaration starts after the current token, otherwise returns false.
+  /// Returns true if a Swift declaration starts after the current token,
+  /// otherwise returns false.
   bool isNextStartOfSwiftDecl() {
     BacktrackingScope backtrack(*this);
     consumeToken();

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -69,32 +69,38 @@ package(set) // expected-note {{previous modifier specified here}}
 public(set) // expected-error {{multiple incompatible access-level modifiers specified}}
 public var customSetterDuplicateAttr3 = 0
 
-private(get) // expected-error{{expected 'set' as subject of 'private' modifier}}
+private(get) // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-12=set}}
 var invalidSubject = 0
 
-private(42) // expected-error{{expected 'set' as subject of 'private' modifier}}
+private(42) // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-11=set}}
 var invalidSubject2 = 0
 
 private(a bunch of random tokens) // expected-error{{expected 'set' as subject of 'private' modifier}} expected-error{{expected declaration}}
 var invalidSubject3 = 0
 
 
-package(get) // expected-error{{expected 'set' as subject of 'package' modifier}}
+package(get) // expected-error{{expected 'set' as subject of 'package' modifier}} {{9-12=set}}
 var invalidSubject4 = 0
 
-package(42) // expected-error{{expected 'set' as subject of 'package' modifier}}
+package(42) // expected-error{{expected 'set' as subject of 'package' modifier}} {{9-11=set}}
 var invalidSubject5 = 0
 
-private(set // expected-error{{expected ')' in 'private' modifier}}
+private((())) // expected-error{{expected 'set' as subject of 'private' modifier}} expected-error{{expected declaration}}
+var invalidSubject6 = 0
+
+private( missingFunc(_ x: Int) -> Bool // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-9=set)}} expected-error{{expected declaration}}
+let independentVar1 = 0
+
+private(set // expected-error{{expected ')' in 'private' modifier}} {{12-12=)}}
 var unterminatedSubject = 0
 
-private(42 // expected-error{{expected 'set' as subject of 'private' modifier}} expected-error{{expected declaration}}
+private(42 // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-11=set)}} expected-error{{expected declaration}}
 var unterminatedInvalidSubject = 0
 
-private() // expected-error{{expected 'set' as subject of 'private' modifier}}
+private() // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-9=set}}
 var emptySubject = 0
 
-private( // expected-error{{expected 'set' as subject of 'private' modifier}}
+private( // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-9=set)}}
 var unterminatedEmptySubject = 0
 
 // Check that the parser made it here.

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -347,3 +347,10 @@ package extension PkgGenericStruct where Param: InternalProto {} // expected-err
 extension PkgGenericStruct where Param: InternalProto {
   package func foo() {} // expected-error {{cannot declare a package instance method in an extension with internal requirements}} {{3-10=internal}}
 }
+
+func f() {}
+private( // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-9=set)}}
+if true { // expected-error{{expected declaration}} {{none}}
+  f()
+}
+var unrelatedVar = "Swift"

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -94,7 +94,7 @@ let independentVar1 = 0
 private(set // expected-error{{expected ')' in 'private' modifier}} {{12-12=)}}
 var unterminatedSubject = 0
 
-private(42 // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-11=set)}} expected-error{{expected declaration}}
+private(42 // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-11=set)}}
 var unterminatedInvalidSubject = 0
 
 private() // expected-error{{expected 'set' as subject of 'private' modifier}} {{9-9=set}}


### PR DESCRIPTION
## Summary

Added fix-its missing `set` subject and `)` for access control modifiers. The added fix-its handle the following cases:

- `private(set` inserts `)` to become `private(set)`
- `private()` inserts `set` to become `private(set)`
- `private(<unexpected>)` replaces `<unexpected>` with `set` to become `private(set)`
- `private( <declaration>` inserts `set)` to become `private(set) <declaration>`
- `private(<unexpected> <declaration>` replaces `<unexpected>` with `set)` to become `private(set) <declaration>`
