### PR TITLE
IRGen: Disable indirect symbol replacement with GOTPCREL for AArch64/ELF

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -132,6 +132,9 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
   // FIXME: We should do this entirely through Clang, for consistency.
   TargetOptions TargetOpts;
 
+  // Linker support for this is not widespread enough.
+  TargetOpts.SupportIndirectSymViaGOTPCRel_AArch64_ELF = false;
+
   // Explicitly request debugger tuning for LLDB which is the default
   // on Darwin platforms but not on others.
   TargetOpts.DebuggerTuning = llvm::DebuggerKind::LLDB;


### PR DESCRIPTION
The linkers in our Linux environments do not support this option and fail to link the standard library.

See:
- https://github.com/swiftlang/llvm-project/pull/9339
- https://github.com/llvm/llvm-project/pull/78003

Paired with https://github.com/swiftlang/llvm-project/pull/10795.