### PR TITLE
[windows] fix missing environment variables when running check-lldb

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1894,8 +1894,7 @@ function Test-Compilers([Hashtable] $Platform, [switch] $TestClang, [switch] $Te
       Write-Host "Copying '$RuntimeBinaryCache\bin\swiftCore.dll' to '$(Get-ProjectBinaryCache $BuildPlatform Compilers)\bin'"
       Copy-Item "$RuntimeBinaryCache\bin\swiftCore.dll" "$(Get-ProjectBinaryCache $BuildPlatform Compilers)\bin"
 
-      $PythonRoot = "$(Get-PythonPath $BuildPlatform)\tools"
-      $env:Path = "$PythonRoot;$env:Path"
+      $env:Path = "$(Get-PythonPath $BuildPlatform)\tools;$env:Path"
 
       $TestingDefines += @{
         LLDB_INCLUDE_TESTS = "YES";

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1894,12 +1894,15 @@ function Test-Compilers([Hashtable] $Platform, [switch] $TestClang, [switch] $Te
       Write-Host "Copying '$RuntimeBinaryCache\bin\swiftCore.dll' to '$(Get-ProjectBinaryCache $BuildPlatform Compilers)\bin'"
       Copy-Item "$RuntimeBinaryCache\bin\swiftCore.dll" "$(Get-ProjectBinaryCache $BuildPlatform Compilers)\bin"
 
+      $PythonRoot = "$(Get-PythonPath $BuildPlatform)\tools"
+      $env:Path = "$PythonRoot;$env:Path"
+
       $TestingDefines += @{
         LLDB_INCLUDE_TESTS = "YES";
         # Check for required Python modules in CMake
         LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS = "YES";
         # No watchpoint support on windows: https://github.com/llvm/llvm-project/issues/24820
-        LLDB_TEST_USER_ARGS = "--skip-category=watchpoint";
+        LLDB_TEST_USER_ARGS = "--env PYTHONHOME=$PythonRoot --skip-category=watchpoint";
         # gtest sharding breaks llvm-lit's --xfail and LIT_XFAIL inputs: https://github.com/llvm/llvm-project/issues/102264
         LLVM_LIT_ARGS = "-v --no-gtest-sharding --time-tests";
         # LLDB Unit tests link against this library

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1902,7 +1902,7 @@ function Test-Compilers([Hashtable] $Platform, [switch] $TestClang, [switch] $Te
         # Check for required Python modules in CMake
         LLDB_ENFORCE_STRICT_TEST_REQUIREMENTS = "YES";
         # No watchpoint support on windows: https://github.com/llvm/llvm-project/issues/24820
-        LLDB_TEST_USER_ARGS = "--env PYTHONHOME=$PythonRoot --skip-category=watchpoint";
+        LLDB_TEST_USER_ARGS = "--skip-category=watchpoint";
         # gtest sharding breaks llvm-lit's --xfail and LIT_XFAIL inputs: https://github.com/llvm/llvm-project/issues/102264
         LLVM_LIT_ARGS = "-v --no-gtest-sharding --time-tests";
         # LLDB Unit tests link against this library


### PR DESCRIPTION
Currently when running `build.ps1` at desk to build and test LLDB, the tests will fail because `python39.dll` is not in the Path and because `PYTHONHOME` is not set.

This PR adds `python39.dll` to the `Path` before running the tests and passes `PYTHONHOME` to `lit` through `LLDB_TEST_USER_ARGS`. Simply setting the `PYTHONHOME` env variable is not enough as `lit` reset the env before running the tests.