### PR TITLE
[stdlibUnittest] generalize `expectNotNil(_:)`

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -752,11 +752,14 @@ public func expectNil<T>(_ value: T?,
 }
 
 @discardableResult
-public func expectNotNil<T>(_ value: T?,
+@lifetime(copy value)
+public func expectNotNil<T: ~Copyable & ~Escapable>(
+  _ value: consuming T?,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) -> T? {
+  file: String = #file, line: UInt = #line
+) -> T? {
   if value == nil {
     expectationFailure("expected optional to be non-nil", trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))

--- a/test/stdlib/OptionalGeneralizations.swift
+++ b/test/stdlib/OptionalGeneralizations.swift
@@ -92,3 +92,23 @@ suite.test("Initializer references") {
     expectTrue(r != nil)
   }
 }
+
+suite.test("expectNotNil()") {
+  func opt1<T: ~Copyable>(_ t: consuming T) -> T? { Optional.some(t) }
+  _ = expectNotNil(opt1(TrivialStruct()))
+  _ = expectNotNil(opt1(NoncopyableStruct()))
+  _ = expectNotNil(opt1(RegularClass()))
+#if $NonescapableTypes
+  @lifetime(copy t)
+  func opt2<T: ~Copyable & ~Escapable>(_ t: consuming T) -> T? { t }
+
+  let ne = NonescapableStruct()
+  _ = expectNotNil(opt2(ne))
+
+  let ncne = NoncopyableNonescapableStruct()
+  _ = expectNotNil(opt2(ncne))
+
+  let nent = NonescapableNontrivialStruct()
+  _ = expectNotNil(opt2(nent))
+#endif
+}


### PR DESCRIPTION
Generalize StdlibUnittest's `expectNotNil(_:)` function for non-copyable and non-escapable parameter types.

Useful for testing failable `UTF8Span` initializers, for example.