### PR TITLE
ClangImporter: import SwiftShims properly for static linking

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -321,6 +321,8 @@ namespace swift {
     /// Flags for use by tests
     ///
 
+    bool UseStaticStandardLibrary = false;
+
     /// Enable Objective-C Runtime interop code generation and build
     /// configuration options.
     bool EnableObjCInterop = true;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -682,6 +682,9 @@ void importer::getNormalInvocationArguments(
     }
   }
 
+  if (LangOpts.UseStaticStandardLibrary)
+    invocationArgStrs.push_back("-DSWIFT_STATIC_STDLIB");
+
   // If we support SendingArgsAndResults, set the -D flag to signal that it
   // is supported.
   if (LangOpts.hasFeature(Feature::SendingArgsAndResults))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1571,6 +1571,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     ModuleInterfaceOpts.PublicFlags.IgnorableFlags +=
         " " + printFormalCxxInteropVersion(Opts);
 
+  Opts.UseStaticStandardLibrary = Args.hasArg(OPT_use_static_resource_dir);
   Opts.EnableObjCInterop =
       Args.hasFlag(OPT_enable_objc_interop, OPT_disable_objc_interop,
                    Target.isOSDarwin() && !Opts.hasFeature(Feature::Embedded));

--- a/test/ClangImporter/static_stdlib.swift
+++ b/test/ClangImporter/static_stdlib.swift
@@ -1,0 +1,5 @@
+// RUN: %swift_frontend_plain -parse-stdlib -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-DYNAMIC
+// RUN: %swift_frontend_plain -parse-stdlib -use-static-resource-dir -typecheck %s -dump-clang-diagnostics 2>&1 | %FileCheck %s -check-prefix CHECK-STATIC
+
+// CHECK-DYNAMIC-NOT: clang importer cc1 args: {{.*}} '-D' 'SWIFT_STATIC_STDLIB'
+// CHECK-STATIC: clang importer cc1 args: {{.*}} '-D' 'SWIFT_STATIC_STDLIB'


### PR DESCRIPTION
When building against the static standard library, we should define `SWIFT_STATIC_STDLIB` to indicate to the shims that the declarations should be giving hidden visibility and default DLL storage. This is required to ensure that these symbols are known to be `dso_local` when compiling to avoid an unnecessary look up through the PLT/GOT or the indirection through the synthesized `__imp_` symbol and the IAT. This corrects a number of incorrect code generation cases on Windows with the static standard library.