### PR TITLE
[Build] Pass the toolchain version through to Swift's compilation

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1828,6 +1828,7 @@ function Get-CompilersDefines([Hashtable] $Platform, [switch] $Test) {
     Python3_INCLUDE_DIR = "$PythonRoot\include";
     Python3_LIBRARY = "$PythonRoot\libs\$PythonLibName.lib";
     Python3_ROOT_DIR = $PythonRoot;
+    SWIFT_TOOLCHAIN_VERSION = "${ToolchainIdentifier}";
     SWIFT_BUILD_SWIFT_SYNTAX = "YES";
     SWIFT_CLANG_LOCATION = (Get-PinnedToolchainToolsDir);
     SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY = "YES";

--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -10,6 +10,8 @@
 #
 # ----------------------------------------------------------------------------
 
+import os
+
 from build_swift.build_swift.constants import SWIFT_REPO_NAME
 
 from . import cmark
@@ -170,6 +172,11 @@ updated without updating swift.py?")
         if self.args.clang_compiler_version is not None:
             clang_compiler_version = self.args.clang_compiler_version
             r.define('CLANG_COMPILER_VERSION', str(clang_compiler_version))
+
+        toolchain_version = os.environ.get('TOOLCHAIN_VERSION')
+        if toolchain_version:
+            r.define('SWIFT_TOOLCHAIN_VERSION', toolchain_version)
+
         return r
 
     @property


### PR DESCRIPTION
Passes the value of the environment variable `TOOLCHAIN_VERSION` through to Swift's `SWIFT_TOOLCHAIN_VERSION` for use in eg. `-print-target-info` (and some day, `--version`).