### PR TITLE
Shorten command line lengths

### DIFF
--- a/Runtimes/Core/cmake/modules/AvailabilityMacros.cmake
+++ b/Runtimes/Core/cmake/modules/AvailabilityMacros.cmake
@@ -4,7 +4,7 @@ configure_file("${SwiftCore_SWIFTC_SOURCE_DIR}/utils/availability-macros.def"
 file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/availability-macros.def" availability_defs)
 list(FILTER availability_defs EXCLUDE REGEX "^\\s*(#.*)?$")
 foreach(def ${availability_defs})
-  add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"${def}\">")
+  list(APPEND availability_definitions "-Xfrontend -define-availability -Xfrontend \"${def}\"")
 
   if("${def}" MATCHES "SwiftStdlib .*")
     # For each SwiftStdlib x.y, also define StdlibDeploymentTarget x.y, which,
@@ -31,6 +31,12 @@ foreach(def ${availability_defs})
         endif()
       endif()
     endif()
-    add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -define-availability -Xfrontend \"${current}\">")
+    list(APPEND availability_definitions "-Xfrontend -define-availability -Xfrontend \"${current}\"")
   endif()
 endforeach()
+
+list(JOIN availability_definitions "\n" availability_definitions)
+file(GENERATE
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/availability-macros.rsp"
+  CONTENT "${availability_definitions}")
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:${CMAKE_Swift_RESPONSE_FILE_FLAG}${CMAKE_CURRENT_BINARY_DIR}/availability-macros.rsp>")

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2338,6 +2338,7 @@ function Build-ExperimentalRuntime {
         CMAKE_Swift_COMPILER_WORKS = "YES";
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
         CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
+        CMAKE_NINJA_FORCE_RESPONSE_FILE = "YES";
 
         # NOTE(compnerd) we can get away with this currently because we only
         # use the C portion of the dispatch build, which is always built


### PR DESCRIPTION
This PR works on shortening up the command line lengths, specifically for Windows.
With the landing of the new availability values, we've leapt over the 32k character limit by about a thousand characters resulting in build failures.

The first patch tells CMake to move source files into a response file. I believe this only takes effect when CMP0157 is enabled, which means that it won't do anything on the Windows CI today since the old Swift driver breaks in that mode. It will shorten things going forward once we have the full swift driver available when building the compiler.

The second patch moves the availability defines to a generated response file.
https://github.com/swiftlang/swift/pull/81440 doubled the number that we are passing to the compiler, resulting in roughly 2k additional characters being passed on the command line. Prior to this, we were at around 31k, so the 2k put us 1k over the `CreateProcessW` limit.

This should fix the Windows CI command line length limit issues for now.