### PR TITLE
[stdlib] fix utf8Span accessors for small strings

### DIFF
--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -109,13 +109,8 @@ suite.test("UTF8Span from Span")
   let span1 = s.span
   guard let utf8 = expectNotNil(try? UTF8Span(validating: span1)) else { return }
 
-  expectEqual(utf8.count, span1.count)
   let span2 = utf8.span
   expectTrue(span1.isIdentical(to: span2))
-  expectEqual(span1.count, span2.count)
-  for (i,j) in zip(span1.indices, span2.indices) {
-    expectEqual(span1[i], span2[j])
-  }
 }
 
 suite.test("Span from Substring.utf8Span")

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -85,3 +85,35 @@ suite.test("Span from Large Native String's Substring")
     expectEqual(span[i], u[i])
   }
 }
+
+suite.test("Span from UTF8Span")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = String(200)
+  let utf8span = s.utf8Span
+  let span1 = utf8span.span
+  let utf8view = s.utf8
+  let span2 = utf8view.span
+  expectEqual(span1.count, span2.count)
+  for (i,j) in zip(span1.indices, span2.indices) {
+    expectEqual(span1[i], span2[j])
+  }
+}
+
+suite.test("UTF8Span from Span")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = String(200).utf8
+  let span1 = s.span
+  guard let utf8 = expectNotNil(try? UTF8Span(validating: span1)) else { return }
+
+  expectEqual(utf8.count, span1.count)
+  let span2 = utf8.span
+  expectTrue(span1.isIdentical(to: span2))
+  expectEqual(span1.count, span2.count)
+  for (i,j) in zip(span1.indices, span2.indices) {
+    expectEqual(span1[i], span2[j])
+  }
+}

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -86,7 +86,7 @@ suite.test("Span from Large Native String's Substring")
   }
 }
 
-suite.test("Span from UTF8Span")
+suite.test("Span from String.utf8Span")
 .require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
 
@@ -112,6 +112,21 @@ suite.test("UTF8Span from Span")
   expectEqual(utf8.count, span1.count)
   let span2 = utf8.span
   expectTrue(span1.isIdentical(to: span2))
+  expectEqual(span1.count, span2.count)
+  for (i,j) in zip(span1.indices, span2.indices) {
+    expectEqual(span1[i], span2[j])
+  }
+}
+
+suite.test("Span from Substring.utf8Span")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = String(22000).dropFirst().dropLast()
+  let utf8span = s.utf8Span
+  let span1 = utf8span.span
+  let utf8view = s.utf8
+  let span2 = utf8view.span
   expectEqual(span1.count, span2.count)
   for (i,j) in zip(span1.indices, span2.indices) {
     expectEqual(span1[i], span2[j])


### PR DESCRIPTION
Re-implements the `String.utf8Span` and `Substring.utf8Span` accessors to properly return views on small (inline-stored) strings.

Addresses rdar://152615664 and https://github.com/swiftlang/swift/issues/82024