### PR TITLE
[6.2][silgen] Teach SILGen how to emit a forced dynamic member ref given nonisolated(nonsending) casts.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1718,6 +1718,37 @@ public:
     return false;
   }
 
+  static bool addsNonIsolatedNonSendingToAsyncFn(FunctionConversionExpr *fce) {
+    CanType oldTy = fce->getSubExpr()->getType()->getCanonicalType();
+    CanType newTy = fce->getType()->getCanonicalType();
+
+    if (auto oldFnTy = dyn_cast<AnyFunctionType>(oldTy)) {
+      if (auto newFnTy = dyn_cast<AnyFunctionType>(newTy)) {
+        // old type and new type MUST both be async
+        if (!oldFnTy->hasEffect(EffectKind::Async) ||
+            !newFnTy->hasEffect(EffectKind::Async))
+          return false;
+
+        // old type MUST NOT have nonisolated(nonsending).
+        if (oldFnTy->getIsolation().isNonIsolatedCaller())
+          return false;
+
+        // new type MUST nonisolated(nonsending)
+        if (!newFnTy->getIsolation().isNonIsolatedCaller())
+          return false;
+
+        // See if setting isolation of old type to nonisolated(nonsending)
+        // yields the new type.
+        auto addedNonIsolatedNonSending = oldFnTy->getExtInfo().withIsolation(
+            FunctionTypeIsolation::forNonIsolatedCaller());
+
+        return oldFnTy->withExtInfo(addedNonIsolatedNonSending) == newFnTy;
+      }
+    }
+
+    return false;
+  }
+
   /// Ignore parentheses and implicit conversions.
   static Expr *ignoreParensAndImpConversions(Expr *expr) {
     while (true) {
@@ -1737,6 +1768,8 @@ public:
           // skip over a specific, known no-op function conversion, if it exists
           if (auto funcConv = dyn_cast<FunctionConversionExpr>(nextSubExpr)) {
             if (addsGlobalActorToAsyncFn(funcConv))
+              nextSubExpr = funcConv->getSubExpr();
+            else if (addsNonIsolatedNonSendingToAsyncFn(funcConv))
               nextSubExpr = funcConv->getSubExpr();
           }
 
@@ -1775,7 +1808,7 @@ public:
 
     auto openExistential = dyn_cast<OpenExistentialExpr>(arg);
     if (openExistential)
-      arg = openExistential->getSubExpr();
+      arg = ignoreParensAndImpConversions(openExistential->getSubExpr());
 
     auto dynamicMemberRef = dyn_cast<DynamicMemberRefExpr>(arg);
     if (!dynamicMemberRef)

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -133,6 +133,9 @@ typedef void (^NonsendableCompletionHandler)(NSString * _Nullable, NSString * _N
                           (void (^)(NSString *__nullable value,
                                     NSError *__nullable error))completionHandler
     MAIN_ACTOR;
+
+- (void)startAt:(__nullable NSDate *)value
+     completion:(void (^_Nonnull)(void))completion;
 @end
 
 @protocol RefrigeratorDelegate<NSObject>

--- a/test/SILGen/objc_async.swift
+++ b/test/SILGen/objc_async.swift
@@ -360,3 +360,31 @@ extension SlowServer: @retroactive FailableFloatLoader {
 // CHECK-NEXT:    [[ZERO_FLOAT:%.*]] = builtin "zeroInitializer"() : $Float
 // CHECK-NEXT:    [[BORROWED_SOME_NSERROR:%.*]] = begin_borrow [[SOME_NSERROR]] :
 // CHECK-NEXT:    apply [[BORROWED_BLOCK]]([[ZERO_FLOAT]], [[BORROWED_SOME_NSERROR]])
+
+// CHECK-LABEL: sil hidden [ossa] @$s10objc_async13testAnyObjectyySo10SlowServerCYaF : $@convention(thin) @async (@guaranteed SlowServer) -> () {
+// CHECK: bb0([[SLOWSERVER:%.*]] : @guaranteed $SlowServer):
+// CHECK: [[SLOWSERVER_C:%.*]] = copy_value [[SLOWSERVER]]
+// CHECK: [[SLOWSERVER_ANYOBJECT:%.*]] = init_existential_ref [[SLOWSERVER_C]]
+// CHECK: [[SLOWSERVER_ANYOBJECT_M:%.*]] = move_value [lexical] [var_decl] [[SLOWSERVER_ANYOBJECT]]
+// CHECK: debug_value [[SLOWSERVER_ANYOBJECT_M]] : $AnyObject, let, name "anyObjectSlowServer"
+// CHECK: [[SLOWSERVER_ANYOBJECT_M_B:%.*]] = begin_borrow [[SLOWSERVER_ANYOBJECT_M]]
+// CHECK: [[SLOWSERVER_ANYOBJECT_M_B_O:%.*]] = open_existential_ref [[SLOWSERVER_ANYOBJECT_M_B]]
+// CHECK: [[SLOWSERVER_ANYOBJECT_M_B_O_C:%.*]] = copy_value [[SLOWSERVER_ANYOBJECT_M_B_O]]
+// CHECK: [[METHOD:%.*]] = objc_method [[SLOWSERVER_ANYOBJECT_M_B_O_C]] : $@opened("{{.*}}", AnyObject) Self, #SlowServer.start!foreign : (SlowServer) -> (NSDate?) async -> (), $@convention(objc_method) (Optional<NSDate>, @convention(block) @Sendable () -> (), @opened("{{.*}}", AnyObject) Self) -> ()
+// CHECK: [[CONT:%.*]] = get_async_continuation_addr ()
+// CHECK: [[UNSAFE_CONT:%.*]] = struct $UnsafeContinuation<(), Never> ([[CONT]] : $Builtin.RawUnsafeContinuation)
+// CHECK: [[BLOCK:%.*]] = alloc_stack $@block_storage Any
+// CHECK: [[BLOCK_PROJECT:%.*]] = project_block_storage [[BLOCK]]
+// CHECK: [[BLOCK_PROJECT_EX:%.*]] = init_existential_addr [[BLOCK_PROJECT]]
+// CHECK: store [[UNSAFE_CONT]] to [trivial] [[BLOCK_PROJECT_EX]]
+// CHECK: merge_isolation_region [[BLOCK]] : $*@block_storage Any,
+// CHECK: [[CONT_HANDLER:%.*]] = function_ref @$sIeyBh_ytTz_ : $@convention(c) @Sendable (@inout_aliasable @block_storage Any) -> ()
+// CHECK: [[INIT_BLOCK_STORAGE_HEADER:%.*]] = init_block_storage_header [[BLOCK]] : $*@block_storage Any, invoke [[CONT_HANDLER]]
+// CHECK: merge_isolation_region [[SLOWSERVER_ANYOBJECT_M_B_O_C]] : $@opened("{{.*}}", AnyObject) Self, [[BLOCK]]
+// CHECK: apply [[METHOD]]({{%.*}}, [[INIT_BLOCK_STORAGE_HEADER]], [[SLOWSERVER_ANYOBJECT_M_B_O_C]])
+// CHECK: await_async_continuation [[CONT]] : $Builtin.RawUnsafeContinuation, resume bb1
+// CHECK: } // end sil function '$s10objc_async13testAnyObjectyySo10SlowServerCYaF'
+func testAnyObject(_ slowServer: SlowServer) async {
+  let anyObjectSlowServer: AnyObject = slowServer
+  await anyObjectSlowServer.start(at: nil)
+}


### PR DESCRIPTION
Explanation: This PR teaches SILGen how to emit a forced dynamic member ref given AST casts to nonisolated(nonsending) that occurs when emitting calls to objective-c methods through an AnyObject casted object. Specifically, I taught SILGen how to emit an AST like the following:

```
(force_value_expr implicit type="nonisolated(nonsending) (Date?) async -> Void" implicit_iuo_unwrap
  (open_existential_expr implicit type="(nonisolated(nonsending) (Date?) async  -> Void)?"
    (opaque_value_expr implicit type="AnyObject")
    (declref_expr type="AnyObject" decl="test.(file).repro().anyObject@test.swift:6:7" function_ref=unapplied)
    (optional_evaluation_expr type="(nonisolated(nonsending) (Date?) async -> Void)?"
      (inject_into_optional type="(nonisolated(nonsending) (Date?) async -> Void)?"
        (function_conversion_expr type="nonisolated(nonsending) (Date?) async -> Void"
          (bind_optional_expr type="(Date?) async -> Void" depth=0
            (dynamic_member_ref_expr type="((Date?) async -> Void)?" decl="__ObjC.(file).Foo.start(at:)"
              (opaque_value_expr type="AnyObject"))))))))
```

Since we are emitting an objc async function, there isn't an extra implicit parameter like if we were using a swift async function. So, I just reused code that was already used locally to look through these sorts of conversions. I just had to add to that code support for conversions that add nonisolated(nonsending). Previously it only supported looking through global actor conversions.

Scope: This changes how SILGen emits dynamic member given a cast in the AST which only occurs if a user casts an objective-c class to AnyObject and invokes the method. The implementation is similar to how we already handle casts to/form global actor so the change is not doing anything novel. It will not impact code that does not cast classes to AnyObject. So code that uses classes directly will not be impacted.

Resolves: rdar://152596823

Main PR: https://github.com/swiftlang/swift/pull/82029

Risk: Low. This can only impact code that casts an imported objc class that is cast to an AnyObject and then whose methods are then invoked.

Testing: Added compiler tests

Reviewer: @rjmccall 