### PR TITLE
[test] Compiler crasher only seem to happen in asserts mode

### DIFF
--- a/validation-test/compiler_crashers_2/6a33401772c7458.swift
+++ b/validation-test/compiler_crashers_2/6a33401772c7458.swift
@@ -1,5 +1,6 @@
 // {"signature":"swift::constraints::GenericArgumentsMismatchFailure::GenericArgumentsMismatchFailure(swift::constraints::Solution const&, swift::Type, swift::Type, llvm::ArrayRef<unsigned int>, swift::constraints::ConstraintLocator*)"}
 // RUN: not --crash %target-swift-frontend -typecheck %s
+// REQUIRES: asserts
 class a < b, c {
   typealias d = b typealias e =
       c class f<b, c> : a<b, c> class g<h, i> : f<(h, i), c> {


### PR DESCRIPTION
6a33401772c7458.swift doesn't seem to crash in non-asserts mode, so mark is as requiring asserts so it does not fail when building for non-asserts.