### PR TITLE
[6.2, stdlib] fix small-string UTF8Span support

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -752,11 +752,14 @@ public func expectNil<T>(_ value: T?,
 }
 
 @discardableResult
-public func expectNotNil<T>(_ value: T?,
+@lifetime(copy value)
+public func expectNotNil<T: ~Copyable & ~Escapable>(
+  _ value: consuming T?,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) -> T? {
+  file: String = #file, line: UInt = #line
+) -> T? {
   if value == nil {
     expectationFailure("expected optional to be non-nil", trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -17,6 +17,7 @@ import SwiftShims
 // functionality and guidance for efficiently working with Strings.
 //
 @frozen
+@_addressableForDependencies
 public // SPI(corelibs-foundation)
 struct _StringGuts: @unchecked Sendable {
   @usableFromInline

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -89,7 +89,6 @@ extension String {
   ///     print(String(s1.utf8.prefix(15))!)
   ///     // Prints "They call me 'B"
   @frozen
-  @_addressableForDependencies
   public struct UTF8View: Sendable {
     @usableFromInline
     internal var _guts: _StringGuts

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -630,7 +630,6 @@ extension Substring: LosslessStringConvertible {
 
 extension Substring {
   @frozen
-  @_addressableForDependencies
   public struct UTF8View: Sendable {
     @usableFromInline
     internal var _slice: Slice<String.UTF8View>

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -417,7 +417,7 @@ public func testTrivialInoutBorrow(p: inout UnsafePointer<Int>) -> Span<Int> {
 
 private let immortalInt = 0
 
-private let immortalString = ""
+private let immortalStrings: [String] = []
 
 @lifetime(immortal)
 func testImmortalInt() -> Span<Int> {
@@ -427,10 +427,10 @@ func testImmortalInt() -> Span<Int> {
 }
 
 @lifetime(immortal)
-func testImmortalString() -> Span<String> {
-  let nilBasedBuffer = UnsafeBufferPointer<String>(start: nil, count: 0)
+func testImmortalStrings() -> Span<[String]> {
+  let nilBasedBuffer = UnsafeBufferPointer<[String]>(start: nil, count: 0)
   let span = Span(base: nilBasedBuffer.baseAddress, count: nilBasedBuffer.count)
-  return _overrideLifetime(span, borrowing: immortalString)
+  return _overrideLifetime(span, borrowing: immortalStrings)
 }
 
 let ptr = UnsafePointer<Int>(bitPattern: 1)!

--- a/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-base.swift.expected
@@ -363,8 +363,6 @@ Func ContiguousArray.withUnsafeMutableBufferPointer(_:) is now without rethrows
 
 // Adoption of @_addressableForDependencies
 Struct CollectionOfOne is now with @_addressableForDependencies
-Struct String.UTF8View is now with @_addressableForDependencies
-Struct Substring.UTF8View is now with @_addressableForDependencies
 
 Protocol CodingKey has added inherited protocol SendableMetatype
 Protocol Error has added inherited protocol SendableMetatype

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -825,8 +825,7 @@ Func _SliceBuffer.withUnsafeMutableBufferPointer(_:) has mangled name changing f
 Struct String.Index has added a conformance to an existing protocol CustomDebugStringConvertible
 
 Struct CollectionOfOne is now with @_addressableForDependencies
-Struct String.UTF8View is now with @_addressableForDependencies
-Struct Substring.UTF8View is now with @_addressableForDependencies
+Struct _StringGuts is now with @_addressableForDependencies
 
 Enum _SwiftifyInfo is a new API without '@available'
 Enum _SwiftifyExpr is a new API without '@available'

--- a/test/stdlib/OptionalGeneralizations.swift
+++ b/test/stdlib/OptionalGeneralizations.swift
@@ -92,3 +92,23 @@ suite.test("Initializer references") {
     expectTrue(r != nil)
   }
 }
+
+suite.test("expectNotNil()") {
+  func opt1<T: ~Copyable>(_ t: consuming T) -> T? { Optional.some(t) }
+  _ = expectNotNil(opt1(TrivialStruct()))
+  _ = expectNotNil(opt1(NoncopyableStruct()))
+  _ = expectNotNil(opt1(RegularClass()))
+#if $NonescapableTypes
+  @lifetime(copy t)
+  func opt2<T: ~Copyable & ~Escapable>(_ t: consuming T) -> T? { t }
+
+  let ne = NonescapableStruct()
+  _ = expectNotNil(opt2(ne))
+
+  let ncne = NoncopyableNonescapableStruct()
+  _ = expectNotNil(opt2(ncne))
+
+  let nent = NonescapableNontrivialStruct()
+  _ = expectNotNil(opt2(nent))
+#endif
+}

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -86,7 +86,7 @@ suite.test("Span from Large Native String's Substring")
   }
 }
 
-suite.test("Span from UTF8Span")
+suite.test("Span from String.utf8Span")
 .require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
 
@@ -111,4 +111,19 @@ suite.test("UTF8Span from Span")
 
   let span2 = utf8.span
   expectTrue(span1.isIdentical(to: span2))
+}
+
+suite.test("Span from Substring.utf8Span")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = String(22000).dropFirst().dropLast()
+  let utf8span = s.utf8Span
+  let span1 = utf8span.span
+  let utf8view = s.utf8
+  let span2 = utf8view.span
+  expectEqual(span1.count, span2.count)
+  for (i,j) in zip(span1.indices, span2.indices) {
+    expectEqual(span1[i], span2[j])
+  }
 }

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -85,3 +85,30 @@ suite.test("Span from Large Native String's Substring")
     expectEqual(span[i], u[i])
   }
 }
+
+suite.test("Span from UTF8Span")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = String(200)
+  let utf8span = s.utf8Span
+  let span1 = utf8span.span
+  let utf8view = s.utf8
+  let span2 = utf8view.span
+  expectEqual(span1.count, span2.count)
+  for (i,j) in zip(span1.indices, span2.indices) {
+    expectEqual(span1[i], span2[j])
+  }
+}
+
+suite.test("UTF8Span from Span")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let s = String(200).utf8
+  let span1 = s.span
+  guard let utf8 = expectNotNil(try? UTF8Span(validating: span1)) else { return }
+
+  let span2 = utf8.span
+  expectTrue(span1.isIdentical(to: span2))
+}


### PR DESCRIPTION
Explanation: fixes and `String.utf8Span` properties for the small string representation.

Scope: enables new feature (previously the properties only worked for the large string representation.)
Original PRs: https://github.com/swiftlang/swift/pull/82013, https://github.com/swiftlang/swift/pull/82064 and https://github.com/swiftlang/swift/pull/82077
Risk: Low, this has low adoption
Testing: CI
Reviewed by: @lorentey, @atrick, @stephentyrone 