### PR TITLE
SILGen: adjust check for optional-to-optional conversion

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -509,7 +509,8 @@ ManagedValue Transform::transform(ManagedValue v,
   bool inputIsOptional = (bool) inputObjectType;
 
   CanType outputObjectType = outputSubstType.getOptionalObjectType();
-  bool outputIsOptional = (bool) outputObjectType;
+  bool outputIsOptional =
+      static_cast<bool>(loweredResultTy.getASTType().getOptionalObjectType());
 
   // If the value is less optional than the desired formal type, wrap in
   // an optional.

--- a/test/SILGen/Inputs/module.modulemap
+++ b/test/SILGen/Inputs/module.modulemap
@@ -1,3 +1,7 @@
 module PointerAuth {
-   header "ptrauth_field_fptr_import.h"
- }
+  header "ptrauth_field_fptr_import.h"
+}
+
+module Variadic {
+  header "variadic.h"
+}

--- a/test/SILGen/Inputs/variadic.h
+++ b/test/SILGen/Inputs/variadic.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdarg.h>
+
+#define u_vformatMessage swift_u_vformatMessage
+void u_vformatMessage(int i, va_list ap);

--- a/test/SILGen/variadic.swift
+++ b/test/SILGen/variadic.swift
@@ -1,0 +1,18 @@
+// RUN: %swift_frontend_plain -emit-silgen %s -I %S/Inputs -o - -parse-as-library -verify | %FileCheck %s
+
+import Variadic
+
+public func f() {
+  withVaList([0.0]) {
+    u_vformatMessage(0, $0)
+  }
+}
+
+            // closure #1 in f()
+// CHECK: bb0(%0 : $*(), %1 : $CVaListPointer):
+            // function_ref u_vformatMessage.getter
+// CHECK: [[PROJECTION:%.*]] = function_ref @$sSC16u_vformatMessageyys5Int32V_s14CVaListPointerVSgtcvg : $@convention(thin) () -> @owned @callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()
+// CHECK: [[FUNCTION:%.*]] = apply [[PROJECTION]]() : $@convention(thin) () -> @owned @callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()
+// CHECK: [[VALIST:%.*]] = enum $Optional<CVaListPointer>, #Optional.some!enumelt, %1
+// CHECK: [[BORROW:%.*]] = begin_borrow [[FUNCTION]]
+// CHECK: {{.*}} = apply [[BORROW]]({{.*}}, [[VALIST]]) : $@callee_guaranteed (Int32, Optional<CVaListPointer>) -> ()


### PR DESCRIPTION
The new macro aliasing uncovered a latent issue where we would attempt to perform an optional-to-optional conversion on a type that is non-optional though may be aliased to an optional. `CVaList` is sometimes an optional pointer and would be interpreted as an optional type which would fail the assertion in the optional-to-optional conversion.