### PR TITLE
[6.2][cxx-interop] Avoid swiftifying private and protected methods

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -9141,6 +9141,12 @@ void ClangImporter::Implementation::swiftify(FuncDecl *MappedDecl) {
   if (!ClangDecl)
     return;
 
+  // FIXME: for private macro generated functions we do not serialize the
+  // SILFunction's body anywhere triggering assertions.
+  if (ClangDecl->getAccess() == clang::AS_protected ||
+      ClangDecl->getAccess() == clang::AS_private)
+    return;
+
   if (ClangDecl->getNumParams() != MappedDecl->getParameters()->size())
     return;
 

--- a/test/Interop/Cxx/class/access/swiftify-private-fileid.swift
+++ b/test/Interop/Cxx/class/access/swiftify-private-fileid.swift
@@ -1,0 +1,38 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-ir -I %swift_src_root/lib/ClangImporter/SwiftBridging -plugin-path %swift-plugin-dir %t/blessed.swift -module-name main -I %t/Inputs -o %t/out -Xcc -std=c++20  -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers -verify
+
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// FIXME swift-ci linux tests do not support std::span
+// UNSUPPORTED: OS=linux-gnu, OS=linux-android, OS=linux-androideabi
+
+//--- Inputs/swiftify-non-public.h
+#pragma once
+
+#include "swift/bridging"
+#include <span>
+
+using IntSpan = std::span<const int>;
+
+class SWIFT_PRIVATE_FILEID("main/blessed.swift") MyClass {
+private:
+    void takesSpan(IntSpan s [[clang::noescape]]) {}
+};
+
+//--- Inputs/module.modulemap
+module SwiftifyNonPublic {
+    requires cplusplus
+    header "swiftify-non-public.h"
+}
+
+//--- blessed.swift
+import CxxStdlib
+import SwiftifyNonPublic
+
+extension MyClass {
+  mutating func passesSpan(_ s: Span<CInt>) {
+    takesSpan(s) // expected-error {{cannot convert value of type}}
+  }
+}


### PR DESCRIPTION
Explanation: We do not serialize the private macro generated swift method's bodies which crashes the compiler. This PR skips generating swiftified overloads to these private/protected method to work around the crash.
Issue: rdar://152181531
Risk: Low, the change is straightforward.
Testing: Regression test added.
Original PR: #82016
Reviewer: @hnrklssn
