### PR TITLE
[6.2][cxx-interop] Only swiftify template instantiations behind typealiases

### DIFF
--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -165,12 +165,20 @@ inline SpanOfInt MixedFuncWithMutableSafeWrapper7(int * __counted_by(len) p, int
   return SpanOfInt(p, len);
 }
 
+template <typename X>
+struct S {};
+
 struct SpanWithoutTypeAlias {
   std::span<const int> bar() [[clang::lifetimebound]];
   void foo(std::span<const int> s [[clang::noescape]]);
+  void otherTemplatedType(ConstSpanOfInt copy [[clang::noescape]], S<int>);
+  void otherTemplatedType2(ConstSpanOfInt copy [[clang::noescape]], S<int> *);
 };
 
 inline void func(ConstSpanOfInt copy [[clang::noescape]]) {}
 inline void mutableKeyword(SpanOfInt copy [[clang::noescape]]) {}
+
+inline void spanWithoutTypeAlias(std::span<const int> s [[clang::noescape]]) {}
+inline void mutableSpanWithoutTypeAlias(std::span<int> s [[clang::noescape]]) {}
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H


### PR DESCRIPTION
Explanation: C++ template instantiations that are not behind type aliases don't have corresponding Swift names that are both syntactically and semantically valid types. This PR prevents generating swiftified overloads for those types.
Issue: rdar://151422108
Risk: Low, we swiftify functions less often.
Testing: Regression test added.
Original PR: #81973
Reviewer: @hnrklssn