### PR TITLE
[6.2][cxx-interop] Support _LIBCPP_PREFERRED_OVERLOAD

### DIFF
--- a/test/Interop/Cxx/modules/Inputs/ambiguous_a.h
+++ b/test/Interop/Cxx/modules/Inputs/ambiguous_a.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void f(int a);

--- a/test/Interop/Cxx/modules/Inputs/ambiguous_b.h
+++ b/test/Interop/Cxx/modules/Inputs/ambiguous_b.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void f(int a) __attribute__((enable_if(a > 0, ""))) __attribute__((enable_if(true, "")));

--- a/test/Interop/Cxx/modules/Inputs/module.modulemap
+++ b/test/Interop/Cxx/modules/Inputs/module.modulemap
@@ -17,3 +17,13 @@ module TopLevelModule {
   }
   export *
 }
+
+module AmbiguousA {
+  header "ambiguous_a.h"
+  requires cplusplus
+}
+
+module AmbiguousB {
+  header "ambiguous_a.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/modules/preferred-overload.swift
+++ b/test/Interop/Cxx/modules/preferred-overload.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=default
+
+import AmbiguousA
+import AmbiguousB
+
+func g(_ x: CInt) {
+    f(x)
+}

--- a/test/Interop/Cxx/objc-correctness/memchr.swift
+++ b/test/Interop/Cxx/objc-correctness/memchr.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -cxx-interoperability-mode=default -typecheck -verify -I %S/Inputs %s
+
+// REQUIRES: objc_interop
+// REQUIRES: VENDOR=apple
+
+import Darwin
+
+func test_memchr() {
+    var src = "hello"
+    var _ = src.withUTF8 { srcBuf in
+        Darwin.memchr(srcBuf.baseAddress!, 137, src.count)
+    }
+}


### PR DESCRIPTION
Explanation: Some functions are implemented both in libc and libc++. Clang uses the enable_if attribute to resolve otherwise ambiguous functions calls. This PR makes the name lookup aware of this attribute.
Issue: rdar://152192945
Risk: Low, only C/C++ APIs with enable_if attributes are affected.
Testing: Regression test added.
Original PR: #82019
Reviewer: @hnrklssn
