### PR TITLE
[RemoteInspection] Add a hook to process addresses before converting

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -150,6 +150,13 @@ public:
     return RemoteAbsolutePointer("", readValue);
   }
 
+  /// Performs the inverse operation of \ref resolvePointer.
+  /// A use-case for this is to turn file addresses into in-process addresses.
+  virtual std::optional<RemoteAddress>
+  resolveRemoteAddress(RemoteAddress address) const {
+    return std::nullopt;
+  }
+
   virtual std::optional<RemoteAbsolutePointer>
   resolvePointerAsSymbol(RemoteAddress address) {
     return std::nullopt;

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2907,8 +2907,10 @@ private:
     case ContextDescriptorKind::Anonymous: {
       // Use the remote address to identify the anonymous context.
       char addressBuf[18];
+      RemoteAddress address(descriptor.getAddressData());
+      address = Reader->resolveRemoteAddress(address).value_or(address);
       snprintf(addressBuf, sizeof(addressBuf), "$%" PRIx64,
-               (uint64_t)descriptor.getAddressData());
+               (uint64_t)address.getAddressData());
       auto anonNode = dem.createNode(Node::Kind::AnonymousContext);
       CharVector addressStr;
       addressStr.append(addressBuf, dem);


### PR DESCRIPTION
them to hex strings when creating anonymous context descriptors. This aims to solve a problem when LLDB reads reflection metadata directly from local binary files instead of downloading them from in-process memory.

LLDB's MemoryReader implements this to convert the file address into an in-process address, so mangled names created from instance metadata can be matched with the field info data read from the local files.

rdar://152743797
(cherry picked from commit 540df142d718294bdde44ca72a17d40ecbd0a4fb)


Explanation: A hook needed by LLDB to perform address space conversions.
Issue: rdar://152743797
Risk: Low.
Testing: Tested indirectly via LLDB.
Original PR: https://github.com/swiftlang/swift/pull/82073
Reviewer: @mikeash 