### PR TITLE
[SIL] RemarkStreamer: Use mangled function names

### DIFF
--- a/include/swift/SIL/SILRemarkStreamer.h
+++ b/include/swift/SIL/SILRemarkStreamer.h
@@ -107,7 +107,7 @@ llvm::remarks::Remark SILRemarkStreamer::toLLVMRemark(
   llvmRemark.RemarkType = toRemarkType<RemarkT>();
   llvmRemark.PassName = optRemark.getPassName();
   llvmRemark.RemarkName = optRemark.getIdentifier();
-  llvmRemark.FunctionName = optRemark.getDemangledFunctionName();
+  llvmRemark.FunctionName = optRemark.getFunction()->getName();
   llvmRemark.Loc =
       toRemarkLocation(optRemark.getLocation(), getASTContext().SourceMgr);
 

--- a/test/Driver/opt-record.swift
+++ b/test/Driver/opt-record.swift
@@ -27,7 +27,7 @@ public func bar() {
   // YAML:        File:            {{.*}}opt-record.swift
   // YAML:        Line:            [[@LINE-6]]
   // YAML:        Column:          3
-  // YAML-NEXT: Function:        'bar()'
+  // YAML-NEXT: Function:        '$s12optrecordmod3baryyF'
   // YAML-NEXT: Args:
   // YAML-NEXT:   - Callee:          '"optrecordmod.foo()"'
   // YAML-NEXT:     DebugLoc:

--- a/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
+++ b/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
@@ -30,7 +30,7 @@ public var global = Klass() // expected-remark {{heap allocated ref of type 'Kla
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 42 ]], Column: 12 }
-// CHECK-NEXT: Function:        'getGlobal()'
+// CHECK-NEXT: Function:        '$s4null9getGlobalAA5KlassCyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'begin exclusive access to value of type '''
 // CHECK-NEXT:   - ValueType:       Klass
@@ -45,7 +45,7 @@ public var global = Klass() // expected-remark {{heap allocated ref of type 'Kla
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 27 ]], Column: 12 }
-// CHECK-NEXT: Function:        'getGlobal()'
+// CHECK-NEXT: Function:        '$s4null9getGlobalAA5KlassCyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'end exclusive access to value of type '''
 // CHECK-NEXT:   - ValueType:       Klass
@@ -60,7 +60,7 @@ public var global = Klass() // expected-remark {{heap allocated ref of type 'Kla
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift',
 // CHECK-NEXT:                    Line: [[# @LINE + 12]], Column: 5 }
-// CHECK-NEXT: Function:        'getGlobal()'
+// CHECK-NEXT: Function:        '$s4null9getGlobalAA5KlassCyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'retain of type '''
 // CHECK-NEXT:   - ValueType:       Klass
@@ -85,7 +85,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 51 ]], Column: 11 }
-// CHECK-NEXT: Function:        'useGlobal()'
+// CHECK-NEXT: Function:        '$s4null9useGlobalyyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'heap allocated ref of type '''
 // CHECK-NEXT:   - ValueType:
@@ -96,7 +96,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 40 ]], Column: 5 }
-// CHECK-NEXT: Function:        'useGlobal()'
+// CHECK-NEXT: Function:        '$s4null9useGlobalyyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'retain of type '''
 // CHECK-NEXT:   - ValueType:       Klass
@@ -110,7 +110,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 26 ]], Column: 12 }
-// CHECK-NEXT: Function:        'useGlobal()'
+// CHECK-NEXT: Function:        '$s4null9useGlobalyyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'release of type '''
 // CHECK-NEXT:   - ValueType:
@@ -121,7 +121,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 15 ]], Column: 12 }
-// CHECK-NEXT: Function:        'useGlobal()'
+// CHECK-NEXT: Function:        '$s4null9useGlobalyyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'release of type '''
 // CHECK-NEXT:   - ValueType:       Klass

--- a/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
+++ b/test/SILOptimizer/assemblyvision_remark/basic_yaml.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swiftc_driver -O -Rpass-missed=sil-assembly-vision-remark-gen -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil %s -o /dev/null -Xfrontend -verify
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver -wmo -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil -save-optimization-record=yaml  -save-optimization-record-path %t/note.yaml %s -o /dev/null && %FileCheck --input-file=%t/note.yaml %s
+// RUN: %target-swiftc_driver -wmo -O -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xfrontend -enable-copy-propagation -emit-sil -save-optimization-record=yaml -save-optimization-record-path %t/note.yaml -module-name optrecordmod %s -o /dev/null && %FileCheck --input-file=%t/note.yaml %s
 
 // REQUIRES: optimized_stdlib,swift_stdlib_no_asserts
 // REQUIRES: swift_in_compiler
@@ -30,7 +30,7 @@ public var global = Klass() // expected-remark {{heap allocated ref of type 'Kla
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 42 ]], Column: 12 }
-// CHECK-NEXT: Function:        '$s4null9getGlobalAA5KlassCyF'
+// CHECK-NEXT: Function:        '$s12optrecordmod9getGlobalAA5KlassCyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'begin exclusive access to value of type '''
 // CHECK-NEXT:   - ValueType:       Klass
@@ -45,7 +45,7 @@ public var global = Klass() // expected-remark {{heap allocated ref of type 'Kla
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 27 ]], Column: 12 }
-// CHECK-NEXT: Function:        '$s4null9getGlobalAA5KlassCyF'
+// CHECK-NEXT: Function:        '$s12optrecordmod9getGlobalAA5KlassCyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'end exclusive access to value of type '''
 // CHECK-NEXT:   - ValueType:       Klass
@@ -60,7 +60,7 @@ public var global = Klass() // expected-remark {{heap allocated ref of type 'Kla
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift',
 // CHECK-NEXT:                    Line: [[# @LINE + 12]], Column: 5 }
-// CHECK-NEXT: Function:        '$s4null9getGlobalAA5KlassCyF'
+// CHECK-NEXT: Function:        '$s12optrecordmod9getGlobalAA5KlassCyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'retain of type '''
 // CHECK-NEXT:   - ValueType:       Klass
@@ -85,7 +85,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 51 ]], Column: 11 }
-// CHECK-NEXT: Function:        '$s4null9useGlobalyyF'
+// CHECK-NEXT: Function:        '$s12optrecordmod9useGlobalyyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'heap allocated ref of type '''
 // CHECK-NEXT:   - ValueType:
@@ -96,7 +96,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 40 ]], Column: 5 }
-// CHECK-NEXT: Function:        '$s4null9useGlobalyyF'
+// CHECK-NEXT: Function:        '$s12optrecordmod9useGlobalyyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'retain of type '''
 // CHECK-NEXT:   - ValueType:       Klass
@@ -110,7 +110,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 26 ]], Column: 12 }
-// CHECK-NEXT: Function:        '$s4null9useGlobalyyF'
+// CHECK-NEXT: Function:        '$s12optrecordmod9useGlobalyyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'release of type '''
 // CHECK-NEXT:   - ValueType:
@@ -121,7 +121,7 @@ public func getGlobal() -> Klass {
 // CHECK-NEXT: Name:            sil.memory
 // CHECK-NEXT: DebugLoc:        { File: '{{.*}}basic_yaml.swift', 
 // CHECK-NEXT:                    Line: [[# @LINE + 15 ]], Column: 12 }
-// CHECK-NEXT: Function:        '$s4null9useGlobalyyF'
+// CHECK-NEXT: Function:        '$s12optrecordmod9useGlobalyyF'
 // CHECK-NEXT: Args:
 // CHECK-NEXT:   - String:          'release of type '''
 // CHECK-NEXT:   - ValueType:       Klass

--- a/test/SILOptimizer/devirt_speculate.swift
+++ b/test/SILOptimizer/devirt_speculate.swift
@@ -101,7 +101,7 @@ class Sub7 : Base {
 // YAML:   File:            {{.*}}/devirt_speculate.swift
 // YAML:   Line:            118
 // YAML:   Column:          5
-// YAML-NEXT: Function:        'testMaxNumSpeculativeTargets(_:)'
+// YAML-NEXT: Function:        '$s16devirt_speculate28testMaxNumSpeculativeTargetsyyAA4BaseCF'
 // YAML-NEXT: Args:
 // YAML-NEXT:   - String:          'Partially devirtualized call with run-time checks for '
 // YAML-NEXT:   - NumSubTypesChecked: '6'

--- a/test/SILOptimizer/devirtualize.sil
+++ b/test/SILOptimizer/devirtualize.sil
@@ -137,7 +137,7 @@ bb0(%0 : $@thick C.Type):
 // YAML:        File:            {{.*}}/devirtualize.sil
 // YAML:        Line:            127
 // YAML:        Column:          8
-// YAML-NEXT: Function:        'caller(_:)'
+// YAML-NEXT: Function:        _TF4metaP33_7026FC13D35FB9700BACF693F51A99016callerFMCS_P33_7026FC13D35FB9700BACF693F51A99011CT_
 // YAML-NEXT: Args:
 // YAML-NEXT:   - String:          'Devirtualized call to class method '
 // YAML-NEXT:   - Method:          '"static meta.B.foo(_:)"'

--- a/test/SILOptimizer/devirtualize_ownership.sil
+++ b/test/SILOptimizer/devirtualize_ownership.sil
@@ -138,7 +138,7 @@ bb0(%0 : $@thick C.Type):
 // YAML:        File:            {{.*}}/devirtualize_ownership.sil
 // YAML:        Line:            128
 // YAML:        Column:          8
-// YAML-NEXT: Function:        'caller(_:)'
+// YAML-NEXT: Function:        _TF4metaP33_7026FC13D35FB9700BACF693F51A99016callerFMCS_P33_7026FC13D35FB9700BACF693F51A99011CT_
 // YAML-NEXT: Args:
 // YAML-NEXT:   - String:          'Devirtualized call to class method '
 // YAML-NEXT:   - Method:          '"static meta.B.foo(_:)"'


### PR DESCRIPTION
Remarks emitted by LLVM use the mangled function name. Be consistent with LLVM when serializing SIL remarks, so external tools can properly filter for all remarks attributed to a certain function.