### PR TITLE
[6.2][Diagnostics] Correctly diagnose situations when immutable value is passed to `inout` parameter

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5136,6 +5136,9 @@ ERROR(assignment_bang_has_immutable_subcomponent,none,
 NOTE(candidate_is_not_assignable,none,
      "candidate is not assignable: %kind0",
      (const ValueDecl *))
+NOTE(candidate_expects_inout_argument,none,
+     "candidate expects in-out value for parameter #%0 but argument is immutable",
+     (unsigned))
 
 NOTE(change_to_mutating,none,
      "mark %select{method|%1}0 'mutating' to make 'self' mutable",

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -730,7 +730,9 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   }
 
   if (locator->isLastElement<LocatorPathElt::ArgumentAttribute>()) {
-    return getConstraintLocator(anchor, path.drop_back());
+    auto argLoc = getConstraintLocator(anchor, path.drop_back());
+    return getCalleeLocator(argLoc, lookThroughApply, getType, simplifyType,
+                            getOverloadFor);
   }
 
   // If we have a locator that starts with a key path component element, we

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -349,3 +349,31 @@ do {
     }
   }
 }
+
+do {
+  struct S {
+    let x: Int
+    var y: Int
+  }
+
+  func overloaded(_: String) {}
+  // expected-note@-1 3 {{candidate expects value of type 'String' for parameter #1 (got 'Int')}}
+  func overloaded(_: inout Int) {}
+  // expected-note@-1 3 {{candidate expects in-out value for parameter #1 but argument is immutable}}
+
+  func testImmutable(s: S) {
+    overloaded(s.x) // expected-error {{no exact matches in call to local function 'overloaded'}}
+  }
+  
+  func testMutable(s: inout S) {
+    overloaded(s.x) // expected-error {{no exact matches in call to local function 'overloaded'}}
+  }
+
+  func testImmutableBase(s: S) {
+    overloaded(s.y) // expected-error {{no exact matches in call to local function 'overloaded'}}
+  }
+
+  func testMissingAddressOf(s: inout S) {
+    overloaded(s.y) // expected-error {{passing value of type 'Int' to an inout parameter requires explicit '&'}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/82053

---

- Explanation:

  Currently the note is going to point to the "callee" but that is
  incorrect when the failure is related to an argument of a call.

  Detect this situation in `RValueTreatedAsLValueFailure::diagnoseAsNote`
  and produce a correct note.

- Resolves: rdar://150689994

- Main Branch PR: https://github.com/swiftlang/swift/pull/82053

- Risk: Very Low. This is a diagnostic change.

- Reviewed By: @bnbarham 

- Testing: Added new test-cases to the test suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
