### PR TITLE
[cmake] Remove remaining `XCODE` checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -874,12 +874,7 @@ include(CMakePushCheckState)
 
 # Print out path and version of any installed commands
 message(STATUS "CMake (${CMAKE_COMMAND}) Version: ${CMAKE_VERSION}")
-if(XCODE)
-  set(version_flag -version)
-else()
-  set(version_flag --version)
-endif()
-execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} ${version_flag}
+execute_process(COMMAND ${CMAKE_MAKE_PROGRAM} --version
   OUTPUT_VARIABLE _CMAKE_MAKE_PROGRAM_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 message(STATUS "CMake Make Program (${CMAKE_MAKE_PROGRAM}) Version: ${_CMAKE_MAKE_PROGRAM_VERSION}")
@@ -1146,14 +1141,6 @@ endif()
 #
 # Configure SDKs.
 #
-
-if(XCODE)
-  # FIXME: It used to be the case that Xcode would force
-  # -m${platform}-version-min flags that would conflict with those computed
-  # by build-script. version-min flags are deprecated in favor of -target since
-  # clang-11, so we might be able to undo this.
-  set(SWIFT_SDKS "OSX")
-endif()
 
 # FIXME: the parameters we specify in SWIFT_SDKS are lacking architecture specifics,
 # so we need to hard-code it. For example, the SDK for Android is just 'ANDROID',
@@ -1596,22 +1583,6 @@ add_subdirectory(cmake/modules)
 swift_install_in_component(FILES "LICENSE.txt"
                            DESTINATION "share/swift"
                            COMPONENT license)
-
-# Add a documentation target so that documentation shows up in the
-# Xcode project.
-if(XCODE)
-  add_custom_target(Documentation
-      SOURCES
-        README.md
-        docs)
-
-  file(GLOB SWIFT_TOPLEVEL_HEADERS
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/swift${dir}/*.h
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/swift${dir}/*.td
-      ${CMAKE_CURRENT_SOURCE_DIR}/include/swift${dir}/*.def)
-  add_custom_target(Miscellaneous
-      SOURCES ${SWIFT_TOPLEVEL_HEADERS})
-endif()
 
 # New standard library build
 option(SWIFT_ENABLE_NEW_RUNTIME_BUILD "Build Swift runtimes with new build system" OFF)

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -279,12 +279,6 @@ function(add_swift_compiler_modules_library name)
   endforeach()
 
   # Create a static library containing all module object files.
-  if (XCODE)
-    # Xcode does not compile libraries that contain only object files.
-    # Therefore, it fails to create the static library. As a workaround,
-    # we add an empty source file force_lib.c to the target.
-    set(all_obj_files force_lib.c ${all_obj_files})
-  endif()
   add_library(${name} STATIC ${all_obj_files})
   add_dependencies(${name} ${all_module_targets})
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)

--- a/lib/RemoteAST/CMakeLists.txt
+++ b/lib/RemoteAST/CMakeLists.txt
@@ -1,20 +1,6 @@
-if(XCODE)
-  file(GLOB_RECURSE REMOTE_LIB_HEADERS
-    ${SWIFT_SOURCE_DIR}/include/swift/Remote/*.h
-    ${SWIFT_SOURCE_DIR}/include/swift/Remote/*.def)
-
-  set_source_files_properties(${REMOTE_LIB_HEADERS}
-    PROPERTIES
-    HEADER_FILE_ONLY true)
-  source_group("libRemote Headers" FILES ${REMOTE_LIB_HEADERS})
-else()
-  set(REMOTE_LIB_HEADERS)
-endif()
-
 add_swift_host_library(swiftRemoteAST STATIC
   RemoteAST.cpp
-  InProcessMemoryReader.cpp
-  ${REMOTE_LIB_HEADERS})
+  InProcessMemoryReader.cpp)
 target_link_libraries(swiftRemoteAST PUBLIC
   swiftDemangling)
 target_link_libraries(swiftRemoteAST PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,11 +12,7 @@ function(swift_configure_lit_site_cfg source_path destination_path installed_nam
   string(REPLACE ${CMAKE_CFG_INTDIR} ${SWIFT_BUILD_MODE} LLVM_TOOLS_DIR ${LLVM_TOOLS_BINARY_DIR})
   string(REPLACE ${CMAKE_CFG_INTDIR} ${SWIFT_BUILD_MODE} LLVM_LIBS_DIR  ${LLVM_LIBRARY_DIR})
 
-  if (XCODE)
-    string(REPLACE ${CMAKE_CFG_INTDIR} Debug LIT_SWIFTLIB_DIR ${SWIFTLIB_DIR})
-  else ()
-    set(LIT_SWIFTLIB_DIR ${SWIFTLIB_DIR})
-  endif ()
+  set(LIT_SWIFTLIB_DIR ${SWIFTLIB_DIR})
 
   configure_file("${source_path}" "${destination_path}" @ONLY)
 

--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -79,16 +79,6 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   else()
     message(FATAL_ERROR "Can't understand SOURCEKIT_DEPLOYMENT_OS '${SOURCEKIT_DEPLOYMENT_OS}';")
   endif()
-
-  # Add deployment target to C/C++ compiler and linker flags.
-  # FIXME: CMAKE_OSX_DEPLOYMENT_TARGET falls over when used for iOS versions.
-  if (XCODE)
-    if (SOURCEKIT_DEPLOYMENT_OS MATCHES "^macosx")
-      set(CMAKE_XCODE_ATTRIBUTE_MACOSX_DEPLOYMENT_TARGET ${SOURCEKIT_DEPLOYMENT_TARGET})
-    else()
-      set(CMAKE_XCODE_ATTRIBUTE_IPHONEOS_DEPLOYMENT_TARGET ${SOURCEKIT_DEPLOYMENT_TARGET})
-    endif()
-  endif()
 endif()
 
 include_directories(BEFORE


### PR DESCRIPTION
I missed these when ripping out support for CMake Xcode project generation in #79320