### PR TITLE
[6.2] [SymbolGraphGen] distinguish between headers of the same name in different modules

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -28,6 +28,21 @@ using namespace symbolgraphgen;
 
 namespace {
 
+/// Get the fully-qualified module name of the given `ModuleDecl` as a `std::string`.
+///
+/// For example, if `M` is a submodule of `ParentModule` named `SubModule`,
+/// this function would return `"ParentModule.SubModule"`.
+std::string getFullModuleName(const ModuleDecl *M) {
+  if (!M) return {};
+
+  std::string S;
+  llvm::raw_string_ostream OS(S);
+
+  M->getReverseFullModuleName().printForward(OS);
+
+  return S;
+}
+
 /// Compare the two \c ModuleDecl instances to see whether they are the same.
 ///
 /// This does a by-name comparison to consider a module's underlying Clang module to be equivalent
@@ -36,7 +51,7 @@ namespace {
 /// If the `isClangEqual` argument is set to `false`, the modules must also be from the same
 /// compiler, i.e. a Swift module and its underlying Clang module would be considered not equal.
 bool areModulesEqual(const ModuleDecl *lhs, const ModuleDecl *rhs, bool isClangEqual = true) {
-  if (lhs->getNameStr() != rhs->getNameStr())
+  if (getFullModuleName(lhs) != getFullModuleName(rhs))
     return false;
 
   if (!isClangEqual && (lhs->isNonSwiftModule() != rhs->isNonSwiftModule()))

--- a/test/SymbolGraph/ClangImporter/HeaderNameCollision.swift
+++ b/test/SymbolGraph/ClangImporter/HeaderNameCollision.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name HeaderCollision -F %t -output-dir %t -pretty-print -v
+// RUN: %FileCheck %s --input-file %t/HeaderCollision.symbols.json --check-prefix MODULE
+// RUN: %FileCheck %s --input-file %t/HeaderCollision@Dependency.symbols.json --check-prefix EXTENSION
+
+// REQUIRES: objc_interop
+
+// Ensure that extensions to a dependency's types, declared in a header with the same name as the
+// dependency's type's header, correctly get sorted into an extension header rather than the module
+// itself.
+
+// MODULE: "symbols": []
+// EXTENSION: "precise": "c:objc(cs)DependencyClass(im)addNumber:to:"
+
+//--- Dependency.framework/Modules/module.modulemap
+framework module Dependency {
+    umbrella header "Dependency.h"
+    export *
+    module * { export * }
+}
+
+//--- Dependency.framework/Headers/Dependency.h
+#import <Dependency/DependencyClass.h>
+
+//--- Dependency.framework/Headers/DependencyClass.h
+@import Foundation;
+
+@class DependencyClass;
+
+@interface DependencyClass : NSObject
+
+@end
+
+//--- HeaderCollision.framework/Modules/module.modulemap
+framework module HeaderCollision {
+    umbrella header "HeaderCollision.h"
+    export *
+    module * { export * }
+}
+
+//--- HeaderCollision.framework/Headers/HeaderCollision.h
+#import <HeaderCollision/DependencyClass.h>
+
+//--- HeaderCollision.framework/Headers/DependencyClass.h
+#import <Dependency/DependencyClass.h>
+
+@interface DependencyClass (HeaderCollisionClassAdditions)
+
+- (NSInteger)addNumber:(NSInteger)x to:(NSInteger)y;
+
+@end


### PR DESCRIPTION
- **Explanation**: Makes SymbolGraphGen use fully-qualified module names when comparing modules for determining symbol sources.
- **Scope**: Fixes an uncommon bug when extending an Objective-C type using a header with the same name as the source module's header.
- **Issues**: rdar://152676102
- **Original PRs**: #82112
- **Risk**: Low. The change does not affect normal compilation, and the change will only affect which symbol graph a symbol is sorted into, and shouldn't introduce any crashes.
- **Testing**: Automated tests verify the change.
- **Reviewers**: @franklinsch 
