### PR TITLE
tests: add a new test for the ClangImporter

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/module.modulemap
@@ -279,3 +279,7 @@ module "Weird C Module" {
 module Aliases {
   header "Aliases.h"
 }
+
+module RetroactiveVersioning {
+  header "versioning.h"
+}

--- a/test/ClangImporter/Inputs/custom-modules/versioning.h
+++ b/test/ClangImporter/Inputs/custom-modules/versioning.h
@@ -1,0 +1,9 @@
+#pragma once
+extern const int kVersion;
+extern const int kVersion1;
+extern const int kVersion2;
+#if OLD_DEPLOYMENT_TARGET
+#define kVersion kVersion1
+#else
+#define kVersion kVersion2
+#endif

--- a/test/ClangImporter/versioning.swift
+++ b/test/ClangImporter/versioning.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift %s -I %S/Inputs/custom-modules
+// XFAIL: *
+
+// expected-no-diagnostics
+
+import RetroactiveVersioning
+let _ = kVersion


### PR DESCRIPTION
Add a test case for shadowing definitions that are often used for retraoctive aliasing and forward compatibility.