### PR TITLE
build: Ensure static headers are always symlinked

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -155,6 +155,10 @@ add_custom_command_target(unused_var
 
 add_dependencies(copy_shim_headers symlink_clang_headers_static)
 
+# Add dependency to ensure that the static headers are installed. This is needed because no target
+# depends on the static headers, so they would not be installed otherwise.
+add_dependencies(symlink_clang_headers symlink_clang_headers_static)
+
 if(NOT SWIFT_BUILT_STANDALONE)
   if(TARGET clang-resource-headers) # LLVM > 8
     set(clang_resource_headers clang-resource-headers)


### PR DESCRIPTION
When using the Swift static build on Windows, projects like Foundation use the clang headers from the toolchain build `lib` directory. No target in the toolchain build depends on the static clang headers, so they do not get installed. As a workaround, this makes the static clang headers symlink target a dependency of the regular dynamic version of the headers, ensuring they are installed as part of the toolchain build.