### PR TITLE
modulemap: Add missing dependency on vcruntime

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -40,6 +40,7 @@ module _malloc [system] [no_undeclared_includes] {
 
 module _stdlib [system] [no_undeclared_includes] {
   use corecrt
+  use vcruntime
   header "stdlib.h"
   export *
 }


### PR DESCRIPTION
`stdlib.h` includes `limits.h`, which is defined in the `vcruntime` module.