### PR TITLE
[6.2] AST: More robust TypeBase::getSuperclassForDecl()

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -517,14 +517,20 @@ Type TypeBase::getSuperclassForDecl(const ClassDecl *baseClass,
     t = t->getSuperclass(useArchetypes);
   }
 
-#ifndef NDEBUG
-  auto *currentClass = getConcreteTypeForSuperclassTraversing(this)
-      ->getClassOrBoundGenericClass();
-  assert(baseClass->isSuperclassOf(currentClass) &&
-         "no inheritance relationship between given classes");
-#endif
+  if (CONDITIONAL_ASSERT_enabled()) {
+    auto *currentClass = getConcreteTypeForSuperclassTraversing(this)
+        ->getClassOrBoundGenericClass();
+    ASSERT(baseClass->isSuperclassOf(currentClass) &&
+           "no inheritance relationship between given classes");
+  }
 
-  return ErrorType::get(this);
+  // We can end up here if the AST is invalid, because then
+  // getSuperclassDecl() might resolve to a decl, and yet
+  // getSuperclass() is just an ErrorType. Make sure we still
+  // return a nominal type as the result though, and not an
+  // ErrorType, because that's what callers expect.
+  return baseClass->getDeclaredInterfaceType()
+      .subst(SubstitutionMap())->getCanonicalType();
 }
 
 SubstitutionMap TypeBase::getContextSubstitutionMap() {

--- a/test/Generics/unify_superclass_types_invalid.swift
+++ b/test/Generics/unify_superclass_types_invalid.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+class Base<T> {}
+class Derived : Base<Foo> {}
+// expected-error@-1 {{cannot find type 'Foo' in scope}}
+
+// CHECK-LABEL: unify_superclass_types_invalid.(file).f@
+// CHECK: Generic signature: <T where T : Derived>
+func f<T>(_: T) where T: Base<Int>, T: Derived {}


### PR DESCRIPTION
6.2 cherry-pick of part of https://github.com/swiftlang/swift/pull/82115.

* **Description:** Fix a possible crash when a superclass requirement involves an invalid class declaration. A utility method would return ErrorType, which wasn't handled correctly by all callers. Change the utility method to always return a nominal type instead.

* **Risk:** Low.

* **Tested:** New test case added.

* **Reviewed by:** @xedin 