### PR TITLE
docs: Avoid using Latin abbreviations in the ABI documentation

### DIFF
--- a/docs/ABI/CallingConvention.rst
+++ b/docs/ABI/CallingConvention.rst
@@ -29,7 +29,7 @@ compatibility should be opt-in and site-specific.  If Swift would
 benefit from internally using a better convention than C/Objective-C uses,
 and switching to that convention doesn't damage the dynamic abilities
 of our target platforms (debugging, dtrace, stack traces, unwinding,
-etc.), there should be nothing preventing us from doing so.  (If we
+and so on), there should be nothing preventing us from doing so.  (If we
 did want to guarantee compatibility on this level, this paper would be
 a lot shorter!)
 
@@ -40,10 +40,10 @@ components, each operating on a different abstraction level:
   vs. pass-by-value),
 
 * the ownership and validity conventions about argument and result
-  values ("+0" vs. "+1", etc.), and
+  values ("+0" vs. "+1", and so on), and
 
 * the "physical" representation conventions of how values are actually
-  communicated between functions (in registers, on the stack, etc.).
+  communicated between functions (in registers, on the stack, and so on).
 
 We'll tackle each of these in turn, then conclude with a detailed
 discussion of function signature lowering.
@@ -246,7 +246,7 @@ value from *somewhere*:
   global variable `x`, call an unknown function `bar()`, and then use
   `r` in some way.  If `bar()` can't possibly overwrite `x`, `foo()`
   doesn't have to do anything to keep `r` alive across the call;
-  otherwise it does (e.g. by retaining it in a refcounted
+  otherwise it does (for example, by retaining it in a refcounted
   environment).  This is a situation where humans are often much
   smarter than compilers.  Of course, it's also a situation where
   humans are sometimes insufficiently conservative.
@@ -297,7 +297,7 @@ considering here:
 
   This is optimal if the caller can acquire the value without
   responsibility and the callee doesn't require responsibility of it.
-  In very simple code --- e.g., loading values from an array and
+  In very simple code --- for example, loading values from an array and
   passing them to a comparator function which just reads a few fields
   from each and returns --- this can be extremely efficient.
 
@@ -696,7 +696,7 @@ anything else with the result is if it needs to spill the value before
 emitting the call.
 
 Therefore, in principle, it would be really nice if it were possible
-to tell these functions to return in a very specific way, e.g. to
+to tell these functions to return in a very specific way, for example to
 return two values in the second and third argument registers, or to
 return a value at a specific location relative to the stack pointer
 (although this might be excessively constraining; it would be
@@ -800,7 +800,7 @@ of things:
     isn't statically known.  Therefore, the signature of a function
     intended to be passed as this argument must pass them indirectly,
     even if they are actually known statically to be non-address-only
-    types like (e.g.) `Int` and `Float`.
+    types like (for example) `Int` and `Float`.
 
 * It expands tuples in the parameter and result types.  This is done
   at this level both because it is affected by abstraction patterns
@@ -878,9 +878,9 @@ range), (2) the special type **opaque**, or (3) the special type
 combined.
 
 For most of the types in Swift, this process is obvious: they either
-correspond to an obvious legal type (e.g. thick metatypes are
+correspond to an obvious legal type (for example, thick metatypes are
 pointer-sized integers), or to an obvious sequence of scalars
-(e.g. class existentials are a sequence of pointer-sized integers).
+(for example, class existentials are a sequence of pointer-sized integers).
 Only a few cases remain:
 
 * Integer types that are not legal types should be mapped as opaque.

--- a/docs/ABI/CallingConventionSummary.rst
+++ b/docs/ABI/CallingConventionSummary.rst
@@ -75,7 +75,7 @@ Register usage
 Stack frame
 ^^^^^^^^^^^
 
-On function entry, ``rsp+8`` is **16-byte aligned**, i.e. the start of the memory
+On function entry, ``rsp+8`` is **16-byte aligned**, that is, the start of the memory
 arguments is 16-byte aligned; the initial stack pointer is shown below as "entry
 ``rsp``",  but a typical non-leaf function will start by doing::
 

--- a/docs/ABI/GenericSignature.md
+++ b/docs/ABI/GenericSignature.md
@@ -66,7 +66,7 @@ A generic signature is *canonical* when each of its constraints is [canonical](#
    is always a type parameter (call it `T`).
    Constraints are ordered as follows:
    1. A superclass constraint `T: C`, where `C` is a class.
-   2. A layout constraint (e.g., `T: some-layout`), where the right-hand
+   2. A layout constraint (for example, `T: some-layout`), where the right-hand
       side is `AnyObject` or one of the non-user-visible layout constraints
       like `_Trivial`.
    3. Conformance constraints `T: P`, where `P` is a protocol. The
@@ -111,9 +111,9 @@ Given two protocols `P1` and `P2`, protocol `P1` precedes `P2` in the canonical 
 
 ### Canonical constraints
 
-A given constraint can be described in multiple ways. In our running example, the conformance constraint for the element type can be expressed as either `C1.Element: Equatable` or `C2.Element: Equatable`, because `C1.Element` and `C2.Element` name the same type. There might be an infinite number of ways to name the same type (e.g., `C1.SubSequence.SubSequence.Iterator.Element` is also equivalent to `C1.Element`). All of the spellings that refer to the same time comprise the *equivalence class* of that type.
+A given constraint can be described in multiple ways. In our running example, the conformance constraint for the element type can be expressed as either `C1.Element: Equatable` or `C2.Element: Equatable`, because `C1.Element` and `C2.Element` name the same type. There might be an infinite number of ways to name the same type (for example, `C1.SubSequence.SubSequence.Iterator.Element` is also equivalent to `C1.Element`). All of the spellings that refer to the same time comprise the *equivalence class* of that type.
 
-Each equivalence class has a corresponding *anchor*, which is a type parameter that is the least type according to the [type parameter ordering](#type-parameter-ordering). Anchors are used to describe requirements canonically. A concrete type (i.e., a type that is not a type parameter) is canonical when each type parameter within it has either been replaced with its equivalent (canonical) concrete type (when such a constraint exists in the generic signature) or is the anchor of its equivalence class.
+Each equivalence class has a corresponding *anchor*, which is a type parameter that is the least type according to the [type parameter ordering](#type-parameter-ordering). Anchors are used to describe requirements canonically. A concrete type (that is, a type that is not a type parameter) is canonical when each type parameter within it has either been replaced with its equivalent (canonical) concrete type (when such a constraint exists in the generic signature) or is the anchor of its equivalence class.
 
 A layout or conformance constraint is canonical when its left-hand side is the anchor of its equivalence class. A superclass constraint is canonical when its left-hand side is the anchor of its equivalence class and its right-hand side is a canonical concrete (class) type. Same-type constraint canonicalization is discussed in detail in the following section, but some basic rules apply: the left-hand side is always a type parameter, and the right-hand side is either a type parameter that follows the left-hand side (according to the [type parameter ordering](#type-parameter-ordering)) or is a canonical concrete type.
 
@@ -126,7 +126,7 @@ The canonical form of superclass, layout, and conformance constraints are direct
  C1.Element: Equatable, C1.Element == C2.Element, C1.Element == C3.Element>
 ```
 
-All of `C1.Element`, `C2.Element`, and `C3.Element` are in the same equivalence class, which can be formed by different sets of same-type constraints, e.g.,
+All of `C1.Element`, `C2.Element`, and `C3.Element` are in the same equivalence class, which can be formed by different sets of same-type constraints, for example,
 
 ```swift
 C1.Element == C2.Element, C1.Element == C3.Element
@@ -144,9 +144,9 @@ or
 C1.Element == C3.Element, C2.Element == C3.Element
 ```
 
-All of these sets of constraints have the same effect (i.e., form the same equivalence class), but the second one happens to be the canonical form.
+All of these sets of constraints have the same effect (that is, form the same equivalence class), but the second one happens to be the canonical form.
 
-The canonical form is determined by first dividing all of the types in the same equivalence class into distinct components. Two types `T1` and `T2` are in the same component if the same type constraint `T1 == T2` can be proven true based on other known constraints in the generic signature (i.e., if `T1 == T2` would be redundant). For example, `C1.Element` and `C1.SubSequence.Element` are in the same component, because `C1: Collection` and the `Collection` protocol contains the constraint `Element == SubSequence.Element`. However, `C1.Element` and `C2.Element` are in different components.
+The canonical form is determined by first dividing all of the types in the same equivalence class into distinct components. Two types `T1` and `T2` are in the same component if the same type constraint `T1 == T2` can be proven true based on other known constraints in the generic signature (that is, if `T1 == T2` would be redundant). For example, `C1.Element` and `C1.SubSequence.Element` are in the same component, because `C1: Collection` and the `Collection` protocol contains the constraint `Element == SubSequence.Element`. However, `C1.Element` and `C2.Element` are in different components.
 
 Each component has a *local anchor*, which is a type parameter that is the least type within that component, according to the [type parameter ordering](#type-parameter-ordering). The local anchors are then sorted (again, using [type parameter ordering](#type-parameter-ordering)); call the anchors `A1`, `A2`, ..., `An` where `Ai < Aj` for `i < j`. The canonical set of constraints depends on whether the equivalence class has been constrained to a concrete type:
 

--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -438,7 +438,7 @@ declarations marked ``private`` declarations will use this mangling; if the
 entity's context is enough to uniquely identify the entity, the simple
 ``identifier`` form is preferred.
 
-Twenty operators of the form 'LA', 'LB', etc. are reserved to described
+Twenty operators of the form 'LA', 'LB', and so on are reserved to described
 entities related to the entity whose name is provided. For example, 'LE' and
 'Le' in the "SC" module are used to represent the structs synthesized by the
 Clang importer for various "error code" enums.
@@ -537,7 +537,7 @@ both circumstances. For example:
     func f5() {}
   }
 
-For intermediate nested types, i.e., those between the top level and the entity,
+For intermediate nested types, that is, those between the top level and the entity,
 any inverses that remain in at the signature of the entity are mangled into
 that entity's generic signature:
 
@@ -1116,7 +1116,7 @@ from any character in a ``<GENERIC-PARAM-COUNT>``.
   retroactive-conformance ::= any-protocol-conformance 'g' INDEX
 
 When a protocol conformance used to satisfy one of a bound generic type's
-generic requirements is retroactive (i.e., it is specified in a module other
+generic requirements is retroactive (that is, it is specified in a module other
 than the module of the conforming type or the conformed-to protocol), it is
 mangled with its offset into the set of conformance requirements, the
 root protocol conformance, and the suffix 'g'.
@@ -1159,7 +1159,7 @@ if the previous character is not an uppercase letter::
   _abc1_def_G2hi       // contains three words 'abc1', 'def' and G2hi
 
 The words of all identifiers, which are encoded in the current mangling are
-enumerated and assigned to a letter: a = first word, b = second word, etc.
+enumerated and assigned to a letter: a = first word, b = second word, and so on.
 
 An identifier containing word substitutions is a sequence of run-length encoded
 sub-strings and references to previously mangled words.

--- a/docs/ABI/OldMangling.rst
+++ b/docs/ABI/OldMangling.rst
@@ -81,7 +81,7 @@ Globals
 
   entity ::= nominal-type                // named type declaration
   entity ::= static? entity-kind context entity-name
-  entity-kind ::= 'F'                    // function (ctor, accessor, etc.)
+  entity-kind ::= 'F'                    // function (ctor, accessor, and so on)
   entity-kind ::= 'v'                    // variable (let/var)
   entity-kind ::= 'i'                    // subscript ('i'ndex) itself (not the individual accessors)
   entity-kind ::= 'I'                    // initializer
@@ -325,7 +325,7 @@ types.  However, in some cases it is more useful to encode the exact
 implementation details of a function type.
 
 Any ``<impl-function-attribute>`` productions must appear in the order
-in which they are specified above: e.g. a pseudogeneric C function is
+in which they are specified above: for example, a pseudogeneric C function is
 mangled with ``Ccg``.  ``g`` and ``G`` are exclusive and mark the presence
 of a generic signature immediately following.
 

--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -12,7 +12,7 @@ including every instantiation of generic types. These metadata records can
 be used by (TODO: reflection and) debugger tools to discover information about
 types. For non-generic nominal types, these metadata records are generated
 statically by the compiler. For instances of generic types, and for intrinsic
-types such as tuples, functions, protocol compositions, etc., metadata records
+types such as tuples, functions, protocol compositions, and so on, metadata records
 are lazily created by the runtime as required. Every type has a unique metadata
 record; two **metadata pointer** values are equal iff the types are equivalent.
 
@@ -143,7 +143,7 @@ contain the following fields:
 Currently we have specialized ABI endpoints to retrieve metadata for functions
 with 0/1/2/3 parameters - `swift_getFunctionTypeMetadata{0|1|2|3}` and the general
 one `swift_getFunctionTypeMetadata` which handles all other function types and
-functions with parameter flags e.g. `(inout Int) -> Void`. Based on the usage
+functions with parameter flags, for example `(inout Int) -> Void`. Based on the usage
 information collected from Swift Standard Library and Overlays as well as Source
 Compatibility Suite it was decided not to have specialized ABI endpoints for
 functions with parameter flags due their minimal use.
@@ -454,7 +454,7 @@ Protocol Conformance Records
 
 A *protocol conformance record* states that a given type conforms to a
 particular protocol. Protocol conformance records are emitted into their own
-section, which is scanned by the Swift runtime when needed (e.g., in response to
+section, which is scanned by the Swift runtime when needed (for example, in response to
 a `swift_conformsToProtocol()` query). Each protocol conformance record
 contains:
 
@@ -517,8 +517,8 @@ A type metadata may be in one of several different dynamic states:
 
 - An **abstract** metadata stores just enough information to allow the
   identity of the type to be recovered: namely, the metadata's kind
-  (e.g. **struct**) and any kind-specific identity information it
-  entails (e.g. the `nominal type descriptor`_ and any generic arguments).
+  (for example, **struct**) and any kind-specific identity information it
+  entails (for example, the `nominal type descriptor`_ and any generic arguments).
 
 - A **layout-complete** metadata additionally stores the components of
   the type's "external layout", necessary to compute the layout of any
@@ -640,7 +640,7 @@ logic, and in practice most metadata will be dynamically complete.
 Note that this rule can be applied without considering the request.
 
 Code outside of the runtime should never attempt to ascertain a
-metadata's current state by inspecting it, e.g. to see if it has a value
+metadata's current state by inspecting it, for example, to see if it has a value
 witness table.  Metadata initialization is not required to use
 synchronization when initializing the metadata record; the necessary
 synchronization is done at a higher level in the structures which record


### PR DESCRIPTION
These updates to the ABI documentation remove the usage of Latin abbreviations, per the [Apple Style Guide](https://help.apple.com/applestyleguide/). The following mapping was used:

| Latin | Translation |
| ------- | ---------------- |
| e.g.  | for example |
| etc. | and so on     |
| i.e.    | that is    |

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
