### PR TITLE
Add explicit cast to nsec in android platforms

### DIFF
--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -327,7 +327,7 @@ clock_and_value_to_time(int clock, long long sec, long long nsec) {
 #else
     struct timespec ts = { 
       .tv_sec = static_cast<long>(sec),
-      .tv_nsec = nsec
+      .tv_nsec = static_cast<long>(nsec)
     };
 #endif
     return dispatch_walltime(&ts, 0);


### PR DESCRIPTION
I am seeing a build error for Android for invalid narrowing after #79139, https://github.com/swiftlang/swift/pull/82154 did add a special case for non-windows, non-apple platform. but did not account for nsec implicit casting from `long long` to `long`. still seeing build errors on android.

> D:/r/_work/swift-build/swift-build/SourceCache/swift/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp:325:18: error: non-constant-expression cannot be narrowed from type 'long long' to 'long' in initializer list [-Wc++11-narrowing]
  325 |       .tv_nsec = nsec
      |                  ^~~~

