### PR TITLE
SIL: let `Type.getNominalFields` return nil for a struct with unreferenceable storage

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -159,6 +159,9 @@ public struct Type : TypeProperties, CustomStringConvertible, NoReflectionChildr
     guard let nominal = nominal, !nominal.isResilient(in: function) else {
       return nil
     }
+    if let structDecl = nominal as? StructDecl, structDecl.hasUnreferenceableStorage {
+      return nil
+    }
     return NominalFieldsArray(type: self, function: function)
   }
 

--- a/test/SILOptimizer/Inputs/bitfield.h
+++ b/test/SILOptimizer/Inputs/bitfield.h
@@ -3,3 +3,10 @@ struct S {
     int a;
     int b : 8;
 };
+
+struct S2 {
+  int a;
+  int :4;
+  int b;
+};
+

--- a/test/SILOptimizer/global_init_opt.swift
+++ b/test/SILOptimizer/global_init_opt.swift
@@ -9,6 +9,7 @@ var gg: Int = {
 
 // Test that the compiler doesn't crash with a global C bitfield.
 var bitfield = S(a: 0, b: 0)
+var bitfield2 = S2(a: 0, b: 0)
 
 // CHECK-LABEL: sil @$s4test3cseSiyF
 // CHECK:   builtin "once"


### PR DESCRIPTION
Like C bitfields.
Fixes a crash in the InitializeStaticGlobals pass in case a global having a C struct type with bitfield is initialized statically.
