### PR TITLE
[NFC] [cxx-interop] Re-enabling a test on Windows platform.

### DIFF
--- a/test/Interop/Cxx/foreign-reference/inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/inheritance.swift
@@ -1,8 +1,7 @@
 // REQUIRES: executable_test
-// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -I %S/Inputs)
+// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -I %S%{fs-sep}Inputs)
 
-// TODO: Fix this lit test failure on windows rdar://145218056
-// XFAIL: OS=windows-msvc
+
 
 import Inheritance
 import StdlibUnittest


### PR DESCRIPTION
[PR-80694](https://github.com/swiftlang/swift/pull/80694) proposed a solution to fix the issue with paths for lit tests, preventing crashes on Windows CI. In this patch, I'm implementing a similar approach to re-enable this test, which I introduced in [PR-77522](https://github.com/swiftlang/swift/pull/77522): `test/Interop/Cxx/foreign-reference/inheritance.swift`

rdar://145218056