### PR TITLE
[cxx-interop] Fix crash in ASTMangler triggered by UsingShadowDecls

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -49,6 +49,7 @@
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
 #include "clang/AST/DeclObjC.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/Mangle.h"
@@ -3080,7 +3081,7 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
 
   auto *nominal = dyn_cast<NominalTypeDecl>(decl);
 
-  if (nominal && isa<BuiltinTupleDecl>(nominal))
+  if (isa_and_nonnull<BuiltinTupleDecl>(nominal))
     return appendOperator("BT");
 
   // Check for certain standard types.
@@ -3131,6 +3132,12 @@ void ASTMangler::appendAnyGenericType(const GenericTypeDecl *decl,
 
       return false;
     }
+
+    // Mangle `Foo` from `namespace Bar { class Foo; } using Bar::Foo;` the same
+    // way as if we spelled `Bar.Foo` explicitly.
+    if (const auto *usingShadowDecl =
+            dyn_cast<clang::UsingShadowDecl>(namedDecl))
+      namedDecl = usingShadowDecl->getTargetDecl();
 
     // Mangle ObjC classes using their runtime names.
     auto interface = dyn_cast<clang::ObjCInterfaceDecl>(namedDecl);

--- a/test/Interop/Cxx/namespace/Inputs/module.modulemap
+++ b/test/Interop/Cxx/namespace/Inputs/module.modulemap
@@ -69,3 +69,8 @@ module MembersTransitive {
   header "members-transitive.h"
   requires cplusplus
 }
+
+module UsingFromNamespace {
+  header "using-from-namespace.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/namespace/Inputs/using-from-namespace.h
+++ b/test/Interop/Cxx/namespace/Inputs/using-from-namespace.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Test {
+  class Foo {};
+  namespace Test2 {
+  class Bar {};
+  } // namespace Test2
+
+  using Test2::Bar;
+} // namespace Test
+
+using Test::Bar;
+using Test::Foo;

--- a/test/Interop/Cxx/namespace/using-from-namespace.swift
+++ b/test/Interop/Cxx/namespace/using-from-namespace.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-emit-irgen -I %S/Inputs/ -cxx-interoperability-mode=default -g %s
+
+import UsingFromNamespace
+
+func f(_ foo: Foo) {}
+func g(_ bar: Bar) {}


### PR DESCRIPTION
We did not handle this declaration kind. This PR makes sure we mangle it the same way we do for the target declaration.

Fixes #82108.
