### PR TITLE
[6.2]  Update spelling for representing lifetime dependencies to @_lifetime

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1144,10 +1144,11 @@ BridgedLifetimeEntry BridgedLifetimeEntry_createParsed(
     BridgedASTContext cContext, BridgedSourceRange cRange,
     BridgedArrayRef cSources, BridgedLifetimeDescriptor cTarget);
 
-SWIFT_NAME("BridgedLifetimeAttr.createParsed(_:atLoc:range:entry:)")
+SWIFT_NAME(
+    "BridgedLifetimeAttr.createParsed(_:atLoc:range:entry:isUnderscored:)")
 BridgedLifetimeAttr BridgedLifetimeAttr_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
-    BridgedSourceRange cRange, BridgedLifetimeEntry cEntry);
+    BridgedSourceRange cRange, BridgedLifetimeEntry cEntry, bool isUnderscored);
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedMacroSyntax {
   BridgedMacroSyntaxFreestanding,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -240,6 +240,10 @@ protected:
 
       NumFeatures : 31
     );
+
+    SWIFT_INLINE_BITFIELD(LifetimeAttr, DeclAttribute, 1,
+      isUnderscored : 1
+    );
   } Bits;
   // clang-format on
 
@@ -3219,16 +3223,20 @@ class LifetimeAttr final : public DeclAttribute {
   LifetimeEntry *entry;
 
   LifetimeAttr(SourceLoc atLoc, SourceRange baseRange, bool implicit,
-               LifetimeEntry *entry)
+               LifetimeEntry *entry, bool isUnderscored)
       : DeclAttribute(DeclAttrKind::Lifetime, atLoc, baseRange, implicit),
-        entry(entry) {}
+        entry(entry) {
+    Bits.LifetimeAttr.isUnderscored = isUnderscored;
+  }
 
 public:
   static LifetimeAttr *create(ASTContext &context, SourceLoc atLoc,
                               SourceRange baseRange, bool implicit,
-                              LifetimeEntry *entry);
+                              LifetimeEntry *entry, bool isUnderscored);
 
   LifetimeEntry *getLifetimeEntry() const { return entry; }
+
+  bool isUnderscored() const { return bool(Bits.LifetimeAttr.isUnderscored); }
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::Lifetime;
@@ -3236,8 +3244,11 @@ public:
 
   /// Create a copy of this attribute.
   LifetimeAttr *clone(ASTContext &ctx) const {
-    return new (ctx) LifetimeAttr(AtLoc, Range, isImplicit(), entry);
+    return new (ctx)
+        LifetimeAttr(AtLoc, Range, isImplicit(), entry, isUnderscored());
   }
+
+  std::string getString() const;
 
   bool isEquivalent(const LifetimeAttr *other, Decl *attachedTo) const;
 };

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -841,6 +841,7 @@ DECL_ATTR(lifetime, Lifetime,
   OnAccessor | OnConstructor | OnFunc | OnSubscript,
   LongAttribute | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove | AllowMultipleAttributes | EquivalentInABIAttr,
   161)
+DECL_ATTR_ALIAS(_lifetime, Lifetime)
 
 SIMPLE_DECL_ATTR(_addressableSelf, AddressableSelf,
   OnAccessor | OnConstructor | OnFunc | OnSubscript,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8195,7 +8195,7 @@ ERROR(pack_iteration_where_clause_not_supported, none,
 // MARK: Lifetime Dependence Syntax
 //------------------------------------------------------------------------------
 
-ERROR(use_lifetime_underscored, PointsToFirstBadToken,
+WARNING(use_lifetime_underscored, PointsToFirstBadToken,
       "Unsupported use of @lifetime, use @_lifetime to specify lifetime dependencies", ())
 
 ERROR(lifetime_dependence_invalid_param_name, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8195,6 +8195,9 @@ ERROR(pack_iteration_where_clause_not_supported, none,
 // MARK: Lifetime Dependence Syntax
 //------------------------------------------------------------------------------
 
+ERROR(use_lifetime_underscored, PointsToFirstBadToken,
+      "Unsupported use of @lifetime, use @_lifetime to specify lifetime dependencies", ())
+
 ERROR(lifetime_dependence_invalid_param_name, none,
       "invalid parameter name specified %0", (Identifier))
 ERROR(lifetime_dependence_invalid_param_index, none,
@@ -8229,7 +8232,7 @@ ERROR(lifetime_dependence_immortal_alone, none,
       "cannot specify any other dependence source along with immortal", ())
 ERROR(lifetime_dependence_invalid_inherit_escapable_type, none,
       "cannot copy the lifetime of an Escapable type, use "
-      "'@lifetime(%1%0)' instead",
+      "'@_lifetime(%1%0)' instead",
       (StringRef, StringRef))
 ERROR(lifetime_dependence_cannot_use_parsed_borrow_consuming, none,
       "invalid use of %0 dependence with %1 ownership",
@@ -8260,11 +8263,11 @@ ERROR(lifetime_dependence_feature_required_inout, none,
       (StringRef, Identifier))
 
 ERROR(lifetime_dependence_cannot_infer_return, none,
-      "%0 with a ~Escapable result requires '@lifetime(...)'", (StringRef))
+      "%0 with a ~Escapable result requires '@_lifetime(...)'", (StringRef))
 ERROR(lifetime_dependence_cannot_infer_mutating, none,
-      "%0 with a ~Escapable 'self' requires '@lifetime(self: ...)'", (StringRef))
+      "%0 with a ~Escapable 'self' requires '@_lifetime(self: ...)'", (StringRef))
 ERROR(lifetime_dependence_cannot_infer_inout, none,
-      "%0 with a ~Escapable 'inout' parameter requires '@lifetime(%1: ...)'",
+      "%0 with a ~Escapable 'inout' parameter requires '@_lifetime(%1: ...)'",
       (StringRef, Identifier))
 
 //------------------------------------------------------------------------------
@@ -8275,15 +8278,15 @@ ERROR(lifetime_dependence_cannot_infer_return_no_param, none,
       "%0 with a ~Escapable result needs a parameter to depend on",
       (StringRef))
 NOTE(lifetime_dependence_cannot_infer_return_immortal, none,
-     "'@lifetime(immortal)' can be used to indicate that values produced by "
+     "'@_lifetime(immortal)' can be used to indicate that values produced by "
      "this initializer have no lifetime dependencies", ())
 ERROR(lifetime_dependence_cannot_infer_bitwisecopyable, none,
       "cannot infer lifetime dependence on %0 because '%1' is BitwiseCopyable, "
-      "specify '@lifetime(borrow self)'",
+      "specify '@_lifetime(borrow self)'",
       (StringRef, StringRef))
 ERROR(lifetime_dependence_cannot_infer_kind, none,
       "cannot infer the lifetime dependence scope on %0 with a ~Escapable "
-      "parameter, specify '@lifetime(borrow %1)' or '@lifetime(copy %1)'",
+      "parameter, specify '@_lifetime(borrow %1)' or '@_lifetime(copy %1)'",
       (StringRef, StringRef))
 ERROR(lifetime_dependence_cannot_infer_scope_ownership, none,
       "cannot borrow the lifetime of '%0', which has consuming ownership on %1",

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -1166,6 +1166,9 @@ public:
   /// \returns true if this module is the "swift" standard library module.
   bool isStdlibModule() const;
 
+  /// \returns true if this module is the "Cxx" module.
+  bool isCxxModule() const;
+
   /// \returns true if this module is the "_Concurrency" standard library module.
   bool isConcurrencyModule() const;
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -355,6 +355,9 @@ struct PrintOptions {
   /// as public
   bool SuppressIsolatedDeinit = false;
 
+  /// Suppress @_lifetime attribute and emit @lifetime instead.
+  bool SuppressLifetimes = false;
+
   /// Whether to print the \c{/*not inherited*/} comment on factory initializers.
   bool PrintFactoryInitializerComment = true;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -526,6 +526,9 @@ EXPERIMENTAL_FEATURE(CopyBlockOptimization, true)
 /// in a file scope.
 EXPERIMENTAL_FEATURE(DefaultIsolationPerFile, false)
 
+/// Enable @_lifetime attribute
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1158,7 +1158,8 @@ public:
 
   bool isParameterSpecifier() {
     if (Tok.is(tok::kw_inout)) return true;
-    if (Context.LangOpts.hasFeature(Feature::LifetimeDependence) &&
+    if ((Context.LangOpts.hasFeature(Feature::LifetimeDependence) ||
+         Context.LangOpts.hasFeature(Feature::Lifetimes)) &&
         isSILLifetimeDependenceToken())
       return true;
     if (!canHaveParameterSpecifierContextualKeyword()) return false;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1127,8 +1127,8 @@ public:
   );
 
   /// Parse the @lifetime attribute.
-  ParserResult<LifetimeAttr> parseLifetimeAttribute(SourceLoc AtLoc,
-                                                    SourceLoc Loc);
+  ParserResult<LifetimeAttr>
+  parseLifetimeAttribute(StringRef attrName, SourceLoc atLoc, SourceLoc loc);
 
   /// Common utility to parse swift @lifetime decl attribute and SIL @lifetime
   /// type modifier.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3258,6 +3258,13 @@ suppressingFeatureIsolatedDeinit(PrintOptions &options,
   action();
 }
 
+static void
+suppressingFeatureLifetimes(PrintOptions &options,
+                                     llvm::function_ref<void()> action) {
+  llvm::SaveAndRestore<bool> scope(options.SuppressLifetimes, true);
+  action();
+}
+
 namespace {
 struct ExcludeAttrRAII {
   std::vector<AnyAttrKind> &ExcludeAttrList;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1683,7 +1683,11 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DeclAttrKind::Lifetime: {
     auto *attr = cast<LifetimeAttr>(this);
-    Printer << attr->getString();
+    if (!attr->isUnderscored() || Options.SuppressLifetimes) {
+      Printer << "@lifetime" << attr->getLifetimeEntry()->getString();
+    } else {
+      Printer << "@_lifetime" << attr->getLifetimeEntry()->getString();
+    }
     break;
   }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1683,7 +1683,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DeclAttrKind::Lifetime: {
     auto *attr = cast<LifetimeAttr>(this);
-    Printer << attr->getLifetimeEntry()->getString();
+    Printer << attr->getString();
     break;
   }
 
@@ -1951,7 +1951,7 @@ StringRef DeclAttribute::getAttrName() const {
       return "_allowFeatureSuppression";
     }
   case DeclAttrKind::Lifetime:
-    return "lifetime";
+    return cast<LifetimeAttr>(this)->isUnderscored() ? "_lifetime" : "lifetime";
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -3144,8 +3144,15 @@ isEquivalent(const AllowFeatureSuppressionAttr *other, Decl *attachedTo) const {
 
 LifetimeAttr *LifetimeAttr::create(ASTContext &context, SourceLoc atLoc,
                                    SourceRange baseRange, bool implicit,
-                                   LifetimeEntry *entry) {
-  return new (context) LifetimeAttr(atLoc, baseRange, implicit, entry);
+                                   LifetimeEntry *entry, bool isUnderscored) {
+  return new (context)
+      LifetimeAttr(atLoc, baseRange, implicit, entry, isUnderscored);
+}
+
+std::string LifetimeAttr::getString() const {
+  return (isUnderscored() ? std::string("@_lifetime")
+                          : std::string("@lifetime")) +
+         getLifetimeEntry()->getString();
 }
 
 bool LifetimeAttr::isEquivalent(const LifetimeAttr *other,

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -527,10 +527,11 @@ BridgedLifetimeEntry BridgedLifetimeEntry_createParsed(
 
 BridgedLifetimeAttr BridgedLifetimeAttr_createParsed(
     BridgedASTContext cContext, BridgedSourceLoc cAtLoc,
-    BridgedSourceRange cRange, BridgedLifetimeEntry cEntry) {
+    BridgedSourceRange cRange, BridgedLifetimeEntry cEntry,
+    bool isUnderscored) {
   return LifetimeAttr::create(cContext.unbridged(), cAtLoc.unbridged(),
                               cRange.unbridged(), /*implicit=*/false,
-                              cEntry.unbridged());
+                              cEntry.unbridged(), isUnderscored);
 }
 
 BridgedMacroRole BridgedMacroRole_fromString(BridgedStringRef str) {

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -257,10 +257,36 @@ static bool usesFeatureSendingArgsAndResults(Decl *decl) {
   return false;
 }
 
+static bool findUnderscoredLifetimeAttr(Decl *decl) {
+  auto hasUnderscoredLifetimeAttr = [](Decl *decl) {
+    if (!decl->getAttrs().hasAttribute<LifetimeAttr>()) {
+      return false;
+    }
+    // Since we ban mixing @lifetime and @_lifetime on the same decl, checking
+    // any one LifetimeAttr on the decl is sufficient.
+    // FIXME: Implement the ban.
+    return decl->getAttrs().getAttribute<LifetimeAttr>()->isUnderscored();
+  };
+
+  switch (decl->getKind()) {
+  case DeclKind::Var: {
+    auto *var = cast<VarDecl>(decl);
+    return llvm::any_of(var->getAllAccessors(), hasUnderscoredLifetimeAttr);
+  }
+  default:
+    return hasUnderscoredLifetimeAttr(decl);
+  }
+}
+
 static bool usesFeatureLifetimeDependence(Decl *decl) {
   if (decl->getAttrs().hasAttribute<LifetimeAttr>()) {
+    if (findUnderscoredLifetimeAttr(decl)) {
+      // Experimental feature Lifetimes will guard the decl.
+      return false;
+    }
     return true;
   }
+
   if (auto *afd = dyn_cast<AbstractFunctionDecl>(decl)) {
     return afd->getInterfaceType()
       ->getAs<AnyFunctionType>()
@@ -270,6 +296,10 @@ static bool usesFeatureLifetimeDependence(Decl *decl) {
     return !varDecl->getTypeInContext()->isEscapable();
   }
   return false;
+}
+
+static bool usesFeatureLifetimes(Decl *decl) {
+  return findUnderscoredLifetimeAttr(decl);
 }
 
 static bool usesFeatureInoutLifetimeDependence(Decl *decl) {

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -300,7 +300,7 @@ public:
     assert(lifetimeDependencies.empty());
 
     // Handle Builtins first because, even though Builtins require
-    // LifetimeDependence, we don't force Feature::LifetimeDependence
+    // LifetimeDependence, we don't force the experimental feature
     // to be enabled when importing the Builtin module.
     if (afd->isImplicit() && afd->getModuleContext()->isBuiltinModule()) {
       inferBuiltin();
@@ -308,6 +308,7 @@ public:
     }
 
     if (!ctx.LangOpts.hasFeature(Feature::LifetimeDependence)
+        && !ctx.LangOpts.hasFeature(Feature::Lifetimes)
         && !ctx.SourceMgr.isImportMacroGeneratedLoc(returnLoc)) {
 
       // Infer inout dependencies without requiring a feature flag. On

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -38,7 +38,7 @@ LifetimeEntry::create(const ASTContext &ctx, SourceLoc startLoc,
 }
 
 std::string LifetimeEntry::getString() const {
-  std::string result = "@lifetime(";
+  std::string result = "(";
   if (targetDescriptor.has_value()) {
     result += targetDescriptor->getString();
     result += ": ";

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2017,6 +2017,10 @@ bool ModuleDecl::isStdlibModule() const {
   return !getParent() && getName() == getASTContext().StdlibModuleName;
 }
 
+bool ModuleDecl::isCxxModule() const {
+  return !getParent() && getName() == getASTContext().Id_Cxx;
+}
+
 bool ModuleDecl::isConcurrencyModule() const {
   return !getParent() && getName() == getASTContext().Id_Concurrency;
 }

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -1165,19 +1165,17 @@ extension ASTGenVisitor {
   ///   @lifetime(self)
   ///   ```
   func generateLifetimeAttr(attribute node: AttributeSyntax) -> BridgedLifetimeAttr? {
-    guard self.ctx.langOptsHasFeature(.LifetimeDependence) else {
-      // TODO: Diagnose
-      fatalError("@lifetime attribute requires 'LifetimeDependence' feature")
-    }
     guard let entry = self.generateLifetimeEntry(attribute: node) else {
       // TODO: Diagnose?
       return nil
     }
+
     return .createParsed(
       self.ctx,
       atLoc: self.generateSourceLoc(node.atSign),
       range: self.generateAttrSourceRange(node),
-      entry: entry
+      entry: entry,
+      isUnderscored: node.attributeName.as(IdentifierTypeSyntax.self)?.name.text == "_lifetime"
     )
   }
 

--- a/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/SwiftifyImportMacro.swift
@@ -1383,7 +1383,7 @@ func getReturnLifetimeAttribute(
     .attribute(
       AttributeSyntax(
         atSign: .atSignToken(),
-        attributeName: IdentifierTypeSyntax(name: "lifetime"),
+        attributeName: IdentifierTypeSyntax(name: "_lifetime"),
         leftParen: .leftParenToken(),
         arguments: .argumentList(LabeledExprListSyntax(args)),
         rightParen: .rightParenToken()))
@@ -1441,7 +1441,7 @@ func containsLifetimeAttr(_ attrs: AttributeListSyntax, for paramName: TokenSynt
     guard let attr = elem.as(AttributeSyntax.self) else {
       continue
     }
-    if attr.attributeName != "lifetime" {
+    if attr.attributeName != "_lifetime" {
       continue
     }
     guard let args = attr.arguments?.as(LabeledExprListSyntax.self) else {
@@ -1475,7 +1475,7 @@ func paramLifetimeAttributes(
       .attribute(
         AttributeSyntax(
           atSign: .atSignToken(),
-          attributeName: IdentifierTypeSyntax(name: "lifetime"),
+          attributeName: IdentifierTypeSyntax(name: "_lifetime"),
           leftParen: .leftParenToken(),
           arguments: .argumentList(LabeledExprListSyntax([LabeledExprSyntax(expression: expr)])),
           rightParen: .rightParenToken())))

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5349,7 +5349,8 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
     }
 
     if (P.isSILLifetimeDependenceToken()) {
-      if (!P.Context.LangOpts.hasFeature(Feature::LifetimeDependence)) {
+      if (!P.Context.LangOpts.hasFeature(Feature::LifetimeDependence) &&
+          !P.Context.LangOpts.hasFeature(Feature::Lifetimes)) {
         P.diagnose(Tok, diag::requires_experimental_feature,
                    "lifetime dependence specifier", false,
                    Feature::LifetimeDependence.getName());

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2564,28 +2564,22 @@ parseLifetimeDescriptor(Parser &P,
   }
 }
 
-ParserResult<LifetimeAttr> Parser::parseLifetimeAttribute(SourceLoc atLoc,
+ParserResult<LifetimeAttr> Parser::parseLifetimeAttribute(StringRef attrName,
+                                                          SourceLoc atLoc,
                                                           SourceLoc loc) {
   ParserStatus status;
-  if (!Context.LangOpts.hasFeature(Feature::LifetimeDependence) &&
-      !Context.SourceMgr.isImportMacroGeneratedLoc(atLoc)) {
-    diagnose(loc, diag::requires_experimental_feature, "@lifetime", false,
-             Feature::LifetimeDependence.getName());
-    status.setIsParseError();
-    return status;
-  }
 
   auto lifetimeEntry = parseLifetimeEntry(loc);
   if (lifetimeEntry.isNull()) {
     status.setIsParseError();
     return status;
   }
+
   return ParserResult<LifetimeAttr>(LifetimeAttr::create(
       Context, atLoc, SourceRange(loc, lifetimeEntry.get()->getEndLoc()),
-      /* implicit */ false, lifetimeEntry.get()));
+      /* implicit */ false, lifetimeEntry.get(),
+      attrName.compare("_lifetime") == 0));
 }
-
-
 
 /// Parses a (possibly optional) argument for an attribute containing a single, arbitrary identifier.
 ///
@@ -3970,7 +3964,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
   case DeclAttrKind::Lifetime: {
-    auto Attr = parseLifetimeAttribute(AtLoc, Loc);
+    auto Attr = parseLifetimeAttribute(AttrName, AtLoc, Loc);
     Status |= Attr;
     if (Attr.isNonNull())
       Attributes.add(Attr.get());

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -8183,19 +8183,25 @@ void AttributeChecker::visitWeakLinkedAttr(WeakLinkedAttr *attr) {
 }
 
 void AttributeChecker::visitLifetimeAttr(LifetimeAttr *attr) {
-  // Allow @lifetime only in the stdlib, cxx and backward compatibility modules
-  if (!attr->isUnderscored() &&
-      !(Ctx.MainModule->isStdlibModule() || Ctx.MainModule->isCxxModule() ||
-        Ctx.MainModule->getABIName() == Ctx.StdlibModuleName)) {
-    Ctx.Diags.diagnose(attr->getLocation(), diag::use_lifetime_underscored);
-  }
-  if (!Ctx.LangOpts.hasFeature(Feature::LifetimeDependence) &&
-      !Ctx.SourceMgr.isImportMacroGeneratedLoc(attr->getLocation())) {
-    diagnose(attr->getLocation(), diag::requires_experimental_feature,
-             std::string("@") + (attr->isUnderscored()
-                                     ? std::string("_lifetime")
-                                     : std::string("lifetime")),
-             false, Feature::LifetimeDependence.getName());
+  if (!attr->isUnderscored()) {
+    // Allow @lifetime only in the stdlib, cxx and backward compatibility
+    // modules under -enable-experimental-feature LifetimeDependence
+    if (!Ctx.MainModule->isStdlibModule() && !Ctx.MainModule->isCxxModule() &&
+        Ctx.MainModule->getABIName() != Ctx.StdlibModuleName) {
+      Ctx.Diags.diagnose(attr->getLocation(), diag::use_lifetime_underscored);
+    }
+    if (!Ctx.LangOpts.hasFeature(Feature::LifetimeDependence)) {
+      diagnose(attr->getLocation(), diag::requires_experimental_feature,
+               "@lifetime", false, Feature::LifetimeDependence.getName());
+    }
+  } else {
+    // Allow @_lifetime under -enable-experimental-feature Lifetimes
+    if (!Ctx.LangOpts.hasFeature(Feature::Lifetimes) &&
+        !Ctx.SourceMgr.isImportMacroGeneratedLoc(attr->getLocation())) {
+      diagnose(attr->getLocation(), diag::requires_experimental_feature,
+               "@_lifetime",
+               false, Feature::Lifetimes.getName());
+    }
   }
 }
 

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend-dump-parse \
 // RUN:   -enable-experimental-feature Extern \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature RawLayout \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-concurrency \
@@ -12,7 +12,7 @@
 
 // RUN: %target-swift-frontend-dump-parse \
 // RUN:   -enable-experimental-feature Extern \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature RawLayout \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-concurrency \
@@ -25,7 +25,7 @@
 // RUN:   -module-abi-name ASTGen \
 // RUN:   -enable-experimental-feature ParserASTGen \
 // RUN:   -enable-experimental-feature Extern \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature RawLayout \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
 // RUN:   -enable-experimental-concurrency \
@@ -36,7 +36,7 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: swift_feature_ParserASTGen
 // REQUIRES: swift_feature_Extern
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_RawLayout
 // REQUIRES: swift_feature_SymbolLinkageMarkers
 
@@ -211,13 +211,13 @@ struct OpTest {
 
 struct E {}
 struct NE : ~Escapable {}
-@lifetime(copy ne) func derive(_ ne: NE) -> NE { ne }
-@lifetime(borrow ne1, copy ne2) func derive(_ ne1: NE, _ ne2: NE) -> NE {
+@_lifetime(copy ne) func derive(_ ne: NE) -> NE { ne }
+@_lifetime(borrow ne1, copy ne2) func derive(_ ne1: NE, _ ne2: NE) -> NE {
   if (Int.random(in: 1..<100) < 50) { return ne1 }
   return ne2
 }
-@lifetime(borrow borrow) func testNameConflict(_ borrow: E) -> NE { NE() }
-@lifetime(result: copy source) func testTarget(_ result: inout NE, _ source: consuming NE) { result = source }
+@_lifetime(borrow borrow) func testNameConflict(_ borrow: E) -> NE { NE() }
+@_lifetime(result: copy source) func testTarget(_ result: inout NE, _ source: consuming NE) { result = source }
 
 actor MyActor {
   nonisolated let constFlag: Bool = false

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -1,8 +1,8 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: -enable-experimental-feature SuppressedAssociatedTypes
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_SuppressedAssociatedTypes
 
 // expected-note@+1 {{'T' has '~Copyable' constraint preventing implicit 'Copyable' conformance}}
@@ -249,7 +249,7 @@ struct BuggerView<T: ~Copyable>: ~Escapable, Copyable {}
 
 struct MutableBuggerView<T: ~Copyable>: ~Copyable, ~Escapable {}
 
-@lifetime(mutRef: copy mutRef)
+@_lifetime(mutRef: copy mutRef)
 func checkNominals(_ mutRef: inout MutableBuggerView<NC>,
                    _ ref: BuggerView<NC>,
                    _ intMutRef: borrowing MutableBuggerView<Int>,

--- a/test/IRGen/addressable.swift
+++ b/test/IRGen/addressable.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -module-name A -emit-ir -primary-file %s \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: -enable-experimental-feature AddressableTypes \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_feature_AddressableTypes
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 public struct NE: ~Escapable {}
 
@@ -12,11 +12,11 @@ public struct NE: ~Escapable {}
 public struct Holder {}
 
 @_silgen_name("holder_NE")
-@lifetime(borrow holder)
+@_lifetime(borrow holder)
 func getNE(_ holder: Holder) -> NE
 
 @_silgen_name("holder_mut_NE")
-@lifetime(&holder)
+@_lifetime(&holder)
 func getMutNE(_ holder: inout Holder) -> NE
 
 // The parameter cannot be 'nocapture'.

--- a/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/counted-by-lifetimebound.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // RUN: %target-swift-ide-test -print-module -module-to-print=CountedByLifetimeboundClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByLifetimebound.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByLifetimebound.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __lifetimebound parameters and return values.
 
@@ -13,49 +13,49 @@ import CountedByLifetimeboundClang
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func constant(_ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>?
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(borrow p)
+// CHECK-NEXT: @_lifetime(borrow p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func noncountedLifetime(_ len: Int32, _ p: UnsafeMutablePointer<Int32>!) -> MutableSpan<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ len: Int32, _ p: inout MutableSpan<Int32>?) -> MutableSpan<Int32>?
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ len: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
 

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -Xcc -Wno-nullability-completeness | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by __noescape parameters.
 
@@ -13,90 +13,90 @@ import CountedByNoEscapeClang
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(_anonymous_param1: copy _anonymous_param1)
+// CHECK-NEXT: @_lifetime(_anonymous_param1: copy _anonymous_param1)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func anonymous(_ _anonymous_param1: inout MutableSpan<Int32>?)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(func: copy func)
+// CHECK-NEXT: @_lifetime(func: copy func)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func clash(func: inout MutableSpan<Int32>?, clash where: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(_clash2_param1: copy _clash2_param1)
+// CHECK-NEXT: @_lifetime(_clash2_param1: copy _clash2_param1)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func clash2(func _clash2_param1: inout MutableSpan<Int32>?, clash2 _clash2_param2: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: inout MutableSpan<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(_func_param1: copy _func_param1)
+// CHECK-NEXT: @_lifetime(_func_param1: copy _func_param1)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func `func`(_ _func_param1: inout MutableSpan<Int32>?)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(borrow extension)
-// CHECK-NEXT: @lifetime(func: copy func)
+// CHECK-NEXT: @_lifetime(borrow extension)
+// CHECK-NEXT: @_lifetime(func: copy func)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func funcRenamed(func: inout MutableSpan<Int32>?, extension: Int32, init: Int32, open: Int32, var: Int32, is: Int32, as: Int32, in: Int32, guard: Int32, where: Int32) -> UnsafeMutableRawPointer!
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(borrow _funcRenamedAnon_param2)
-// CHECK-NEXT: @lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
+// CHECK-NEXT: @_lifetime(borrow _funcRenamedAnon_param2)
+// CHECK-NEXT: @_lifetime(_funcRenamedAnon_param1: copy _funcRenamedAnon_param1)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func funcRenamedAnon(func _funcRenamedAnon_param1: inout MutableSpan<Int32>?, extension _funcRenamedAnon_param2: Int32, init _funcRenamedAnon_param3: Int32, open _funcRenamedAnon_param4: Int32, var _funcRenamedAnon_param5: Int32, is _funcRenamedAnon_param6: Int32, as _funcRenamedAnon_param7: Int32, in _funcRenamedAnon_param8: Int32, guard _funcRenamedAnon_param9: Int32, where _funcRenamedAnon_param10: Int32) -> UnsafeMutableRawPointer!
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(_in_param1: copy _in_param1)
+// CHECK-NEXT: @_lifetime(_in_param1: copy _in_param1)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func `in`(func _in_param1: inout MutableSpan<Int32>?, in _in_param2: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(func: copy func)
+// CHECK-NEXT: @_lifetime(func: copy func)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func keyword(_ func: inout MutableSpan<Int32>?, _ extension: Int32, _ init: Int32, _ open: Int32, _ var: Int32, _ is: Int32, _ as: Int32, _ in: Int32, _ guard: Int32, _ where: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func keywordType(_ p: inout MutableSpan<actor?>, _ p2: actor) -> actor
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(_lenName_param2: copy _lenName_param2)
+// CHECK-NEXT: @_lifetime(_lenName_param2: copy _lenName_param2)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func lenName(_ _lenName_param0: Int32, _ _lenName_param1: Int32, _ _lenName_param2: inout MutableSpan<Int32>?)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ p: inout MutableSpan<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ p: inout MutableSpan<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ p: inout MutableSpan<Int32>?)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(func: copy func)
+// CHECK-NEXT: @_lifetime(func: copy func)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func open(func: inout MutableSpan<Int32>?, open where: Int32)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(_pointerName_param1: copy _pointerName_param1)
+// CHECK-NEXT: @_lifetime(_pointerName_param1: copy _pointerName_param1)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func pointerName(_ _pointerName_param1: inout MutableSpan<Int32>?)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func returnLifetimeBound(_ len1: Int32, _ p: inout MutableSpan<Int32>) -> MutableSpan<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -104,50 +104,50 @@ import CountedByNoEscapeClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p1: copy p1)
-// CHECK-NEXT: @lifetime(p2: copy p2)
+// CHECK-NEXT: @_lifetime(p1: copy p1)
+// CHECK-NEXT: @_lifetime(p2: copy p2)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p1: inout MutableSpan<Int32>, _ p2: inout MutableSpan<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ p: inout MutableSpan<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_ p: inout MutableSpan<Int32>)
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callComplexExpr(_ p: inout MutableSpan<CInt>) {
   complexExpr(CInt(p.count), 1, &p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callNonnull(_ p: inout MutableSpan<CInt>) {
   nonnull(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callNullUnspecified(_ p: inout MutableSpan<CInt>) {
   nullUnspecified(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callNullable(_ p: inout MutableSpan<CInt>?) {
   nullable(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callReturnLifetimeBound(_ p: inout MutableSpan<CInt>) {
   let _: MutableSpan<CInt> = returnLifetimeBound(2, &p)
@@ -161,85 +161,85 @@ public func callReturnPointer() {
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
-@lifetime(p2: copy p2)
+@_lifetime(p: copy p)
+@_lifetime(p2: copy p2)
 @inlinable
 public func callShared(_ p: inout MutableSpan<CInt>, _ p2: inout MutableSpan<CInt>) {
   shared(&p, &p2)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callSimple(_ p: inout MutableSpan<CInt>) {
   simple(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callSwiftAttr(_ p: inout MutableSpan<CInt>) {
   swiftAttr(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callAnonymous(_ p: inout MutableSpan<CInt>?) {
   anonymous(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callKeyword(_ p: inout MutableSpan<CInt>?) {
   keyword(&p, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callFunc(_ p: inout MutableSpan<CInt>?) {
   `func`(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callFuncRenameKeyword(_ p: inout MutableSpan<CInt>?) {
   let _ = funcRenamed(func: &p, extension: 1, init: 2, open: 3, var: 4, is: 5, as: 6, in: 7, guard: 8, where: 9)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callFuncRenameClash(_ p: inout MutableSpan<CInt>?) {
   clash(func: &p, clash: 1)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callFuncRenameClashKeyword(_ p: inout MutableSpan<CInt>?) {
   `open`(func: &p, open: 1)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callFuncRenameClashKeywordAnon(_ p: inout MutableSpan<CInt>?) {
   `in`(func: &p, in: 1)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callPointerName(_ p: inout MutableSpan<CInt>?) {
   pointerName(&p)
 }
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 @inlinable
 public func callLenName(_ p: inout MutableSpan<CInt>?) {
   lenName(CInt(p?.count ?? 0), 2, &p)

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // RUN: %target-swift-ide-test -print-module -module-to-print=SizedByLifetimeboundClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByLifetimebound.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -strict-memory-safety -warnings-as-errors -Xcc -Werror -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByLifetimebound.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -strict-memory-safety -warnings-as-errors -Xcc -Werror -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __lifetimebound parameters and return values.
 
@@ -13,53 +13,53 @@ import SizedByLifetimeboundClang
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy _bytesized_param1)
+// CHECK-NEXT: @_lifetime(copy _bytesized_param1)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func bytesized(_ _bytesized_param1: RawSpan) -> MutableRawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy _charsized_param0)
-// CHECK-NEXT: @lifetime(_charsized_param0: copy _charsized_param0)
+// CHECK-NEXT: @_lifetime(copy _charsized_param0)
+// CHECK-NEXT: @_lifetime(_charsized_param0: copy _charsized_param0)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_ _charsized_param0: inout MutableRawSpan) -> MutableRawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func complexExpr(_ len: Int32, _ offset: Int32, _ p: RawSpan) -> RawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_ len: Int32, _ p: RawSpan) -> RawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(borrow p)
+// CHECK-NEXT: @_lifetime(borrow p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nonsizedLifetime(_ len: Int32, _ p: UnsafeRawPointer!) -> RawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nullUnspecified(_ len: Int32, _ p: RawSpan) -> RawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_ len: Int32, _ p: RawSpan?) -> RawSpan?
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func opaque(_ len: Int32, _ p: RawSpan) -> RawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func shared(_ p: RawSpan) -> RawSpan
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func simple(_ len: Int32, _ p: RawSpan) -> RawSpan
 
 
@@ -113,7 +113,7 @@ public func callBytesized(_ p: RawSpan) {
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 public func callCharsized(_ p: inout MutableRawSpan) {
   let _: MutableRawSpan = charsized(&p)
 }

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature Lifetimes -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature LifetimeDependence -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature Lifetimes -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __noescape parameters.
 import SizedByNoEscapeClang
@@ -17,7 +17,7 @@ import SizedByNoEscapeClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(_charsized_param0: copy _charsized_param0)
+// CHECK-NEXT: @_lifetime(_charsized_param0: copy _charsized_param0)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func charsized(_  _charsized_param0: inout MutableRawSpan)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -112,7 +112,7 @@ public func callBytesized(_ p: RawSpan) {
 
 @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 @inlinable
-@lifetime(p: copy p)
+@_lifetime(p: copy p)
 public func callCharsized(_ p: inout MutableRawSpan) {
   charsized(&p)
 }

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -3,10 +3,10 @@
 // RUN: %FileCheck %s < %t/interface.swift
 
 // Make sure we trigger typechecking and SIL diagnostics
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -cxx-interoperability-mode=default -strict-memory-safety -warnings-as-errors -Xcc -std=c++20 %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -cxx-interoperability-mode=default -strict-memory-safety -warnings-as-errors -Xcc -std=c++20 %s
 
 // REQUIRES: swift_feature_SafeInteropWrappers
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu
@@ -17,7 +17,7 @@ import StdSpan
 import CxxStdlib
 
 // CHECK:     struct DependsOnSelf {
-// CHECK:       @lifetime(borrow self)
+// CHECK:       @_lifetime(borrow self)
 // CHECK-NEXT:  @_alwaysEmitIntoClient @_disfavoredOverload public borrowing func get() -> Span<CInt>
 // CHECK-NEXT:  borrowing func get() -> ConstSpanOfInt
 
@@ -36,7 +36,7 @@ import CxxStdlib
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT:   @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT:   @lifetime(borrow self)
+// CHECK-NEXT:   @_lifetime(borrow self)
 // CHECK-NEXT:   @_alwaysEmitIntoClient @_disfavoredOverload public mutating func bar() -> Span<CInt>
 // CHECK-NEXT:   mutating func bar() -> std.{{.*}}span<__cxxConst<CInt>, _C{{.*}}_{{.*}}>
 // CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
@@ -47,45 +47,45 @@ import CxxStdlib
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(s: copy s)
+// CHECK-NEXT: @_lifetime(s: copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func FuncWithMutableSafeWrapper(_ s: inout MutableSpan<CInt>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy s)
-// CHECK-NEXT: @lifetime(s: copy s)
+// CHECK-NEXT: @_lifetime(copy s)
+// CHECK-NEXT: @_lifetime(s: copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func FuncWithMutableSafeWrapper2(_ s: inout MutableSpan<CInt>) -> MutableSpan<CInt>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(&v)
+// CHECK-NEXT: @_lifetime(&v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func FuncWithMutableSafeWrapper3(_ v: inout VecOfInt) -> MutableSpan<CInt>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func MixedFuncWithMutableSafeWrapper1(_ p: inout MutableSpan<Int32>) -> MutableSpan<CInt>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(&v)
+// CHECK-NEXT: @_lifetime(&v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func MixedFuncWithMutableSafeWrapper2(_ v: inout VecOfInt, _ len: Int32) -> MutableSpan<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(s: copy s)
+// CHECK-NEXT: @_lifetime(s: copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func MixedFuncWithMutableSafeWrapper3(_ s: inout MutableSpan<CInt>, _ p: UnsafeMutableBufferPointer<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(s: copy s)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(s: copy s)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func MixedFuncWithMutableSafeWrapper4(_ s: inout MutableSpan<CInt>, _ p: inout MutableSpan<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(p: copy p)
+// CHECK-NEXT: @_lifetime(p: copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func MixedFuncWithMutableSafeWrapper5(_ s: SpanOfInt, _ p: inout MutableSpan<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -104,22 +104,22 @@ import CxxStdlib
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy s)
+// CHECK-NEXT: @_lifetime(copy s)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func funcWithSafeWrapper2(_ s: Span<CInt>) -> Span<CInt>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(borrow v)
+// CHECK-NEXT: @_lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func funcWithSafeWrapper3(_ v: borrowing VecOfInt) -> Span<CInt>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy p)
+// CHECK-NEXT: @_lifetime(copy p)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mixedFuncWithSafeWrapper1(_ p: Span<Int32>) -> Span<CInt>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(borrow v)
+// CHECK-NEXT: @_lifetime(borrow v)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mixedFuncWithSafeWrapper2(_ v: borrowing VecOfInt, _ len: Int32) -> Span<Int32>
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -142,7 +142,7 @@ import CxxStdlib
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.1, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
-// CHECK-NEXT: @lifetime(copy: copy copy)
+// CHECK-NEXT: @_lifetime(copy: copy copy)
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func mutableKeyword(_ copy: inout MutableSpan<CInt>)
 
 func callMethodWithSafeWrapper(_ x: inout X, s: Span<CInt>) {
@@ -154,17 +154,17 @@ func callFooBar(_ x: inout SpanWithoutTypeAlias, _ s: ConstSpanOfInt) {
     unsafe x.foo(s)
 }
 
-@lifetime(span: copy span)
+@_lifetime(span: copy span)
 func callFuncWithMutableSafeWrapper(_ span: inout MutableSpan<CInt>, ) {
     FuncWithMutableSafeWrapper(&span)
 }
 
-@lifetime(span: copy span)
+@_lifetime(span: copy span)
 func callFuncWithMutableSafeWrapper2(_ span: inout MutableSpan<CInt>, ) {
     let _: MutableSpan<CInt> = FuncWithMutableSafeWrapper2(&span)
 }
 
-@lifetime(span: copy span)
+@_lifetime(span: copy span)
 func callMixedFuncWithMutableSafeWrapper1(_ span: inout MutableSpan<CInt>, ) {
     let _: MutableSpan<CInt> = MixedFuncWithMutableSafeWrapper1(&span)
 }
@@ -174,18 +174,18 @@ func MixedFuncWithMutableSafeWrapper2(_ v: VecOfInt) {
     let _ = MixedFuncWithMutableSafeWrapper2(&v2, 37)
 }
 
-@lifetime(span: copy span)
+@_lifetime(span: copy span)
 func callMixedFuncWithMutableSafeWrapper3(_ span: inout MutableSpan<CInt>, _ p: UnsafeMutableBufferPointer<CInt>) {
     unsafe MixedFuncWithMutableSafeWrapper3(&span, p)
 }
 
-@lifetime(span1: copy span2)
-@lifetime(span2: copy span2)
+@_lifetime(span1: copy span2)
+@_lifetime(span2: copy span2)
 func callMixedFuncWithMutableSafeWrapper4(_ span1: inout MutableSpan<CInt>, _ span2: inout MutableSpan<CInt>) {
     MixedFuncWithMutableSafeWrapper4(&span1, &span2)
 }
 
-@lifetime(span: copy span)
+@_lifetime(span: copy span)
 func callMixedFuncWithMutableSafeWrapper5(_ span: inout MutableSpan<CInt>, _ s: SpanOfInt) {
     unsafe MixedFuncWithMutableSafeWrapper5(s, &span)
 }
@@ -238,7 +238,7 @@ func callMixedFuncWithSafeWrapper7(_ p: UnsafeBufferPointer<CInt>) {
     let _: ConstSpanOfInt = unsafe mixedFuncWithSafeWrapper7(p)
 }
 
-@lifetime(span: copy span)
+@_lifetime(span: copy span)
 func callMutableKeyword(_ span: inout MutableSpan<CInt>) {
     mutableKeyword(&span)
 }

--- a/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Anonymous.swift
@@ -38,7 +38,7 @@ public func myFunc4(_: UnsafeMutablePointer<CInt>, _ len: CInt) {
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(_myFunc4_param0: copy _myFunc4_param0) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(_myFunc4_param0: copy _myFunc4_param0) @_disfavoredOverload
 // CHECK-NEXT: public func myFunc4(_ _myFunc4_param0: inout MutableSpan<CInt>) {
 // CHECK-NEXT:     let _myFunc4_param1 = CInt(exactly: _myFunc4_param0.count)!
 // CHECK-NEXT:     return unsafe _myFunc4_param0.withUnsafeMutableBufferPointer { __myFunc4_param0Ptr in

--- a/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/ConstantCount.swift
@@ -100,7 +100,7 @@ func noescapeMutOpt(_ ptr: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func noescape(_ ptr: Span<CInt>) -> UnsafePointer<CInt> {
 // CHECK-NEXT:     let _ptrCount = ptr.count
 // CHECK-NEXT:     if _ptrCount != 37 {
@@ -128,7 +128,7 @@ func noescapeMutOpt(_ ptr: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func noescapeOpt(_ ptr: Span<CInt>?) -> UnsafePointer<CInt>? {
 // CHECK-NEXT:     let _ptrCount = ptr?.count ?? 0
 // CHECK-NEXT:     if _ptrCount != 37 {
@@ -145,7 +145,7 @@ func noescapeMutOpt(_ ptr: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func noescapeMut(_ ptr: inout MutableSpan<CInt>) {
 // CHECK-NEXT:     let _ptrCount = ptr.count
 // CHECK-NEXT:     if _ptrCount != 37 {
@@ -156,7 +156,7 @@ func noescapeMutOpt(_ ptr: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func noescapeMut(_ ptr: inout MutableSpan<CInt>) -> UnsafeMutablePointer<CInt> {
 // CHECK-NEXT:     let _ptrCount = ptr.count
 // CHECK-NEXT:     if _ptrCount != 37 {
@@ -167,7 +167,7 @@ func noescapeMutOpt(_ ptr: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func noescapeMutOpt(_ ptr: inout MutableSpan<CInt>?) {
 // CHECK-NEXT:     let _ptrCount = ptr?.count ?? 0
 // CHECK-NEXT:     if _ptrCount != 37 {
@@ -184,7 +184,7 @@ func noescapeMutOpt(_ ptr: UnsafeMutablePointer<CInt>?) -> UnsafeMutablePointer<
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func noescapeMutOpt(_ ptr: inout MutableSpan<CInt>?) -> UnsafeMutablePointer<CInt>? {
 // CHECK-NEXT:     let _ptrCount = ptr?.count ?? 0
 // CHECK-NEXT:     if _ptrCount != 37 {

--- a/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/MutableSpan.swift
@@ -7,7 +7,7 @@
 func myFunc(_ ptr: UnsafeMutablePointer<CInt>, _ len: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: inout MutableSpan<CInt>) {
 // CHECK-NEXT:     let len = CInt(exactly: ptr.count)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBufferPointer { _ptrPtr in

--- a/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Nullable.swift
@@ -24,7 +24,7 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 // CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, len)
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ ptr: inout MutableSpan<CInt>?) {
 // CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
 // CHECK-NEXT:     return { () in
@@ -38,7 +38,7 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @lifetime(ptr2: copy ptr2) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
 // CHECK-NEXT: func myFunc3(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) {
 // CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
 // CHECK-NEXT:     let len2 = CInt(exactly: ptr2?.count ?? 0)!
@@ -69,7 +69,7 @@ func myFunc4(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt) -> UnsafeMutablePo
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc4(_ ptr: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
 // CHECK-NEXT:     let len = CInt(exactly: ptr?.count ?? 0)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime({ () in

--- a/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/PointerReturn.swift
@@ -1,7 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature LifetimeDependence -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature Lifetimes -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
 @_SwiftifyImport(.countedBy(pointer: .return, count: "len"))
 func myFunc(_ len: CInt) -> UnsafeMutablePointer<CInt> {
@@ -28,7 +28,7 @@ func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _
 // CHECK-NEXT: func nonEscaping(_ len: CInt) -> UnsafeBufferPointer<CInt> {
 // CHECK-NEXT:     return unsafe UnsafeBufferPointer<CInt> (start: unsafe nonEscaping(len), count: Int(len))
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy p) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentCopy(_ p: Span<CInt>, _ len2: CInt) -> Span<CInt> {
 // CHECK-NEXT:     let len1 = CInt(exactly: p.count)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe p.withUnsafeBufferPointer { _pPtr in
@@ -36,7 +36,7 @@ func lifetimeDependentBorrow(_ p: borrowing UnsafePointer<CInt>, _ len1: CInt, _
 // CHECK-NEXT:             }, count: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeBufferPointer<CInt>, _ len2: CInt) -> Span<CInt> {
 // CHECK-NEXT:     let len1 = CInt(exactly: unsafe p.count)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span<CInt> (_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, len1, len2), count: Int(len2)), copying: ())

--- a/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
+++ b/test/Macros/SwiftifyImport/CountedBy/Whitespace.swift
@@ -9,7 +9,7 @@ func myFunc(_ ptr: UnsafeMutablePointer<CInt>?, _ len: CInt, _ ptr2: UnsafeMutab
 
 // CHECK:------------------------------
 // CHECK-NEXT:/// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT:@_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @lifetime(ptr2: copy ptr2) @_disfavoredOverload
+// CHECK-NEXT:@_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
 // CHECK-NEXT:func myFunc(_ ptr: inout MutableSpan<CInt>?, _ ptr2: inout MutableSpan<CInt>?) -> MutableSpan<CInt>? {
 // CHECK-NEXT:    let len = CInt(exactly: ptr?.count ?? 0)!
 // CHECK-NEXT:    let len2 = CInt(exactly: ptr2?.count ?? 0)!

--- a/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/LifetimeboundSpan.swift
@@ -61,32 +61,32 @@ func myFunc9(_ span: MutableSpanOfInt) -> MutableSpanOfInt {
 func myFunc10(_ self: MutableSpanOfInt) -> MutableSpanOfInt {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ span: Span<CInt>) -> Span<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc(SpanOfInt(span))), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow vec) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ vec: borrowing VecOfInt) -> Span<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc2(vec)), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy span1, copy span2) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span1, copy span2) @_disfavoredOverload
 // CHECK-NEXT: func myFunc3(_ span1: Span<CInt>, _ span2: Span<CInt>) -> Span<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc3(SpanOfInt(span1), SpanOfInt(span2))), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow vec, copy span) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow vec, copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc4(_ vec: borrowing VecOfInt, _ span: Span<CInt>) -> Span<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc4(vec, SpanOfInt(span))), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow self) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow self) @_disfavoredOverload
 // CHECK-NEXT: func myFunc5() -> Span<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(Span(_unsafeCxxSpan: unsafe myFunc5()), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc6(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: CInt) -> Span<CInt> {
 // CHECK-NEXT:     let _ptrCount = ptr.byteCount
 // CHECK-NEXT:     if _ptrCount != count * size {
@@ -97,7 +97,7 @@ func myFunc10(_ self: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:             }), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc7(_ span: Span<CInt>, _ ptr: RawSpan, _ count: CInt, _ size: CInt) -> Span<CInt> {
 // CHECK-NEXT:     let _ptrCount = ptr.byteCount
 // CHECK-NEXT:     if _ptrCount != count * size {
@@ -108,7 +108,7 @@ func myFunc10(_ self: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:             }), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc8(_ ptr: RawSpan, _ span: Span<CInt>, _ count: CInt, _ size: CInt) -> Span<CInt> {
 // CHECK-NEXT:     let _ptrCount = ptr.byteCount
 // CHECK-NEXT:     if _ptrCount != count * size {
@@ -119,14 +119,14 @@ func myFunc10(_ self: MutableSpanOfInt) -> MutableSpanOfInt {
 // CHECK-NEXT:             }), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy span) @lifetime(span: copy span) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy span) @_lifetime(span: copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc9(_ span: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
 // CHECK-NEXT:       return unsafe myFunc9(MutableSpanOfInt(_spanPtr))
 // CHECK-NEXT:             }), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy `self`) @lifetime(`self`: copy `self`) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy `self`) @_lifetime(`self`: copy `self`) @_disfavoredOverload
 // CHECK-NEXT: func myFunc10(_ `self`: inout MutableSpan<CInt>) -> MutableSpan<CInt> {
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableSpan(_unsafeCxxSpan: unsafe `self`.withUnsafeMutableBufferPointer { _selfPtr in
 // CHECK-NEXT:         return unsafe myFunc10(MutableSpanOfInt(_selfPtr))

--- a/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
+++ b/test/Macros/SwiftifyImport/CxxSpan/NoEscapeSpan.swift
@@ -1,7 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-frontend %s -cxx-interoperability-mode=default -I %S/Inputs -Xcc -std=c++20 -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature LifetimeDependence -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -cxx-interoperability-mode=default -I %S/Inputs -Xcc -std=c++20 -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature Lifetimes -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
 // FIXME swift-ci linux tests do not support std::span
 // UNSUPPORTED: OS=linux-gnu
@@ -30,21 +30,21 @@ func myFunc4(_ span: MutableSpanOfInt, _ secondSpan: MutableSpanOfInt) {
 // CHECK-NEXT:     return unsafe myFunc(SpanOfInt(span), secondSpan)
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(span: copy span) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(span: copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ span: inout MutableSpan<CInt>, _ secondSpan: MutableSpanOfInt) {
 // CHECK-NEXT:     return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
 // CHECK-NEXT:         return unsafe myFunc2(MutableSpanOfInt(_spanPtr), secondSpan)
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(span: copy span) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(span: copy span) @_disfavoredOverload
 // CHECK-NEXT: func myFunc3(_ span: inout MutableSpan<CInt>, _ secondSpan: Span<CInt>) {
 // CHECK-NEXT:     return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in
 // CHECK-NEXT:         return unsafe myFunc3(MutableSpanOfInt(_spanPtr), SpanOfInt(secondSpan))
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(span: copy span) @lifetime(secondSpan: copy secondSpan) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(span: copy span) @_lifetime(secondSpan: copy secondSpan) @_disfavoredOverload
 // CHECK-NEXT: func myFunc4(_ span: inout MutableSpan<CInt>, _ secondSpan: inout MutableSpan<CInt>) {
 // CHECK-NEXT:     return unsafe secondSpan.withUnsafeMutableBufferPointer { _secondSpanPtr in
 // CHECK-NEXT:         return unsafe span.withUnsafeMutableBufferPointer { _spanPtr in

--- a/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/MutableRawSpan.swift
@@ -7,7 +7,7 @@
 func myFunc(_ ptr: UnsafeMutableRawPointer, _ size: CInt) {
 }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc(_ ptr: inout MutableRawSpan) {
 // CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in

--- a/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/Nullable.swift
@@ -24,7 +24,7 @@ func myFunc4(_ ptr: UnsafeMutableRawPointer?, _ len: CInt) -> UnsafeMutableRawPo
 // CHECK-NEXT:     return unsafe myFunc(ptr?.baseAddress, size)
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc2(_ ptr: inout MutableRawSpan?) {
 // CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
 // CHECK-NEXT:     return { () in
@@ -38,7 +38,7 @@ func myFunc4(_ ptr: UnsafeMutableRawPointer?, _ len: CInt) -> UnsafeMutableRawPo
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @lifetime(ptr2: copy ptr2) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_lifetime(ptr2: copy ptr2) @_disfavoredOverload
 // CHECK-NEXT: func myFunc3(_ ptr: inout MutableRawSpan?, _ ptr2: inout MutableRawSpan?) {
 // CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
 // CHECK-NEXT:     let len2 = CInt(exactly: ptr2?.byteCount ?? 0)!
@@ -69,7 +69,7 @@ func myFunc4(_ ptr: UnsafeMutableRawPointer?, _ len: CInt) -> UnsafeMutableRawPo
 // CHECK-NEXT:     }()
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func myFunc4(_ ptr: inout MutableRawSpan?) -> MutableRawSpan? {
 // CHECK-NEXT:     let len = CInt(exactly: ptr?.byteCount ?? 0)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime({ () in

--- a/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/PointerReturn.swift
@@ -1,7 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature LifetimeDependence -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -plugin-path %swift-plugin-dir -enable-experimental-feature Lifetimes -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
 @_SwiftifyImport(.sizedBy(pointer: .return, size: "len"))
 func myFunc(_ len: CInt) -> UnsafeMutableRawPointer {
@@ -37,7 +37,7 @@ func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawPointer, _ len1: 
 // CHECK-NEXT:     return unsafe UnsafeRawBufferPointer(start: unsafe nonEscaping(len), count: Int(len))
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy p) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentCopy(_ p: RawSpan, _ len2: CInt) -> RawSpan {
 // CHECK-NEXT:     let len1 = CInt(exactly: p.byteCount)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe p.withUnsafeBytes { _pPtr in
@@ -45,13 +45,13 @@ func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawPointer, _ len1: 
 // CHECK-NEXT:             }, byteCount: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentBorrow(_ p: borrowing UnsafeRawBufferPointer, _ len2: CInt) -> RawSpan {
 // CHECK-NEXT:     let len1 = CInt(exactly: unsafe p.count)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe lifetimeDependentBorrow(p.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy p) @lifetime(p: copy p) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy p) @_lifetime(p: copy p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentCopyMut(_ p: inout MutableRawSpan, _ len2: CInt) -> MutableRawSpan {
 // CHECK-NEXT:     let len1 = CInt(exactly: p.byteCount)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe p.withUnsafeMutableBytes { _pPtr in
@@ -59,7 +59,7 @@ func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawPointer, _ len1: 
 // CHECK-NEXT:             }, byteCount: Int(len2)), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(borrow p) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(borrow p) @_disfavoredOverload
 // CHECK-NEXT: func lifetimeDependentBorrowMut(_ p: borrowing UnsafeMutableRawBufferPointer, _ len2: CInt) -> MutableRawSpan {
 // CHECK-NEXT:     let len1 = CInt(exactly: unsafe p.count)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe lifetimeDependentBorrowMut(p.baseAddress!, len1, len2), byteCount: Int(len2)), copying: ())

--- a/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
+++ b/test/Macros/SwiftifyImport/SizedBy/TypedPointer.swift
@@ -1,7 +1,7 @@
 // REQUIRES: swift_swift_parser
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature LifetimeDependence -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature Lifetimes -plugin-path %swift-plugin-dir -strict-memory-safety -warnings-as-errors -dump-macro-expansions 2>&1 | %FileCheck --match-full-lines %s
 
 @_SwiftifyImport(.sizedBy(pointer: .param(1), size: "size"))
 func constParam(_ ptr: UnsafePointer<CChar>, _ size: CInt) {}
@@ -83,7 +83,7 @@ func mutReturnDependence(_ size: CInt, _ ptr: UnsafeMutablePointer<UInt8>) -> Un
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func mutParamNoreturn(_ ptr: inout MutableRawSpan) {
 // CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe ptr.withUnsafeMutableBytes { _ptrPtr in
@@ -91,7 +91,7 @@ func mutReturnDependence(_ size: CInt, _ ptr: UnsafeMutablePointer<UInt8>) -> Un
 // CHECK-NEXT:     }
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func constReturnDependence(_ ptr: RawSpan) -> RawSpan {
 // CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(RawSpan(_unsafeStart: unsafe ptr.withUnsafeBytes { _ptrPtr in
@@ -99,7 +99,7 @@ func mutReturnDependence(_ size: CInt, _ ptr: UnsafeMutablePointer<UInt8>) -> Un
 // CHECK-NEXT:             }, byteCount: Int(size)), copying: ())
 // CHECK-NEXT: }
 
-// CHECK:      @_alwaysEmitIntoClient @lifetime(copy ptr) @lifetime(ptr: copy ptr) @_disfavoredOverload
+// CHECK:      @_alwaysEmitIntoClient @_lifetime(copy ptr) @_lifetime(ptr: copy ptr) @_disfavoredOverload
 // CHECK-NEXT: func mutReturnDependence(_ ptr: inout MutableRawSpan) -> MutableRawSpan {
 // CHECK-NEXT:     let size = CInt(exactly: ptr.byteCount)!
 // CHECK-NEXT:     return unsafe _swiftifyOverrideLifetime(MutableRawSpan(_unsafeStart: unsafe ptr.withUnsafeMutableBytes { _ptrPtr in

--- a/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_underscored_dependence.swift
@@ -1,0 +1,79 @@
+public struct AnotherView : ~Escapable {
+  @usableFromInline let _ptr: UnsafeRawBufferPointer
+  @usableFromInline let _count: Int
+  @_lifetime(borrow ptr)
+  internal init(_ ptr: UnsafeRawBufferPointer, _ count: Int) {
+    self._ptr = ptr
+    self._count = count
+  }
+}
+
+public struct BufferView : ~Escapable {
+  @usableFromInline let _ptr: UnsafeRawBufferPointer
+  @usableFromInline let _count: Int
+  @usableFromInline 
+  @_lifetime(borrow ptr)
+  internal init(_ ptr: UnsafeRawBufferPointer, _ count: Int) {
+    self._ptr = ptr
+    self._count = count
+  }
+
+  @inlinable
+  @_lifetime(borrow a)
+  internal init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) {
+    let bv = BufferView(ptr, a.count)
+    self = _overrideLifetime(bv, borrowing: a)
+  }
+  @inlinable
+  @_lifetime(copy a)
+  internal init(_ ptr: UnsafeRawBufferPointer, _ a: consuming AnotherView) {
+    let bv = BufferView(ptr, a._count)
+    self = _overrideLifetime(bv, copying: a)
+  }
+}
+
+@inlinable
+@_lifetime(copy x)
+public func derive(_ x: consuming BufferView) -> BufferView {
+  let pointer = x._ptr
+  let bv = BufferView(pointer, x._count)
+  return _overrideLifetime(bv, copying: x)
+}
+
+@inlinable
+public func use(_ x: consuming BufferView) {}
+
+@inlinable
+@_lifetime(copy view)
+public func consumeAndCreate(_ view: consuming BufferView) -> BufferView {
+  let pointer = view._ptr
+  let bv = BufferView(pointer, view._count)
+  return _overrideLifetime(bv, copying: view)
+}
+
+// FIXME: Filed rdar://150398673 ([nonescapable] allocbox-to-stack fails causing lifetime diagnostics to fail)
+// Remove _overrideLifetime when this is fixed.
+@inlinable
+@_lifetime(copy this, copy that)
+public func deriveThisOrThat(_ this: consuming BufferView, _ that: consuming BufferView) -> BufferView {
+  if (Int.random(in: 1..<100) == 0) {
+    let thisView = BufferView(this._ptr, this._count)
+    return _overrideLifetime(thisView, copying: this)
+  }
+  let thatView = BufferView(that._ptr, that._count)
+  return _overrideLifetime(thatView, copying: that)
+}
+
+public struct Container {
+  var buffer: UnsafeRawBufferPointer
+  var object: AnyObject
+}
+
+extension Container {
+  public var storage: BufferView {
+    get {
+      let view = BufferView(buffer, 1)
+      return _overrideLifetime(view, borrowing: self)
+    }
+  }
+}

--- a/test/ModuleInterface/lifetime_underscored_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_underscored_dependence_test.swift
@@ -1,0 +1,112 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
+// RUN:     -enable-experimental-feature Lifetimes \
+// RUN:     -enable-experimental-feature Lifetimes \
+// RUN:     -o %t/lifetime_underscored_dependence.swiftmodule \
+// RUN:     -emit-module-interface-path %t/lifetime_underscored_dependence.swiftinterface \
+// RUN:     %S/Inputs/lifetime_underscored_dependence.swift
+
+// Check the interfaces
+
+// RUN: %FileCheck %s < %t/lifetime_underscored_dependence.swiftinterface
+
+// See if we can compile a module through just the interface and typecheck using it.
+
+// RUN: %target-swift-frontend -compile-module-from-interface \
+// RUN:    -enable-experimental-feature Lifetimes \
+// RUN:    %t/lifetime_underscored_dependence.swiftinterface -o %t/lifetime_underscored_dependence.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -I %t %s \
+// RUN:    -enable-experimental-feature Lifetimes
+
+// REQUIRES: swift_feature_Lifetimes
+
+import lifetime_underscored_dependence
+// CHECK:  #if compiler(>=5.3) && $Lifetimes
+// CHECK:  @_lifetime(borrow a)
+// CHECK:  @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: borrowing Swift.Array<Swift.Int>) {
+// CHECK:    let bv = BufferView(ptr, a.count)
+// CHECK:    self = _overrideLifetime(bv, borrowing: a)
+// CHECK:  }
+// CHECK:  #else
+// CHECK:  @lifetime(borrow a)
+// CHECK:  @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: borrowing Swift.Array<Swift.Int>) {
+// CHECK:    let bv = BufferView(ptr, a.count)
+// CHECK:    self = _overrideLifetime(bv, borrowing: a)
+// CHECK:  }
+// CHECK:  #endif
+
+// CHECK:  #if compiler(>=5.3) && $Lifetimes
+// CHECK:  @_lifetime(copy a)
+// CHECK:  @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: consuming lifetime_underscored_dependence.AnotherView) {
+// CHECK:    let bv = BufferView(ptr, a._count)
+// CHECK:    self = _overrideLifetime(bv, copying: a)
+// CHECK:  }
+// CHECK:  #else
+// CHECK:  @lifetime(copy a)
+// CHECK:  @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: consuming lifetime_underscored_dependence.AnotherView) {
+// CHECK:    let bv = BufferView(ptr, a._count)
+// CHECK:    self = _overrideLifetime(bv, copying: a)
+// CHECK:  }
+// CHECK:  #endif
+
+// CHECK:#if compiler(>=5.3) && $Lifetimes
+// CHECK:@_lifetime(copy x)
+// CHECK:@inlinable public func derive(_ x: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:  let pointer = x._ptr
+// CHECK:  let bv = BufferView(pointer, x._count)
+// CHECK:  return _overrideLifetime(bv, copying: x)
+// CHECK:}
+// CHECK:#else
+// CHECK:@lifetime(copy x)
+// CHECK:@inlinable public func derive(_ x: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:  let pointer = x._ptr
+// CHECK:  let bv = BufferView(pointer, x._count)
+// CHECK:  return _overrideLifetime(bv, copying: x)
+// CHECK:}
+// CHECK:#endif
+
+// CHECK:#if compiler(>=5.3) && $Lifetimes
+// CHECK:@_lifetime(copy view)
+// CHECK:@inlinable public func consumeAndCreate(_ view: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:  let pointer = view._ptr
+// CHECK:  let bv = BufferView(pointer, view._count)
+// CHECK:  return _overrideLifetime(bv, copying: view)
+// CHECK:}
+// CHECK:#else
+// CHECK:@lifetime(copy view)
+// CHECK:@inlinable public func consumeAndCreate(_ view: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:  let pointer = view._ptr
+// CHECK:  let bv = BufferView(pointer, view._count)
+// CHECK:  return _overrideLifetime(bv, copying: view)
+// CHECK:}
+// CHECK:#endif
+
+// CHECK:#if compiler(>=5.3) && $Lifetimes
+// CHECK:@_lifetime(copy this, copy that)
+// CHECK:@inlinable public func deriveThisOrThat(_ this: consuming lifetime_underscored_dependence.BufferView, _ that: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:  if (Int.random(in: 1..<100) == 0) {
+// CHECK:    let thisView = BufferView(this._ptr, this._count)
+// CHECK:    return _overrideLifetime(thisView, copying: this)
+// CHECK:  }
+// CHECK:  let thatView = BufferView(that._ptr, that._count)
+// CHECK:  return _overrideLifetime(thatView, copying: that)
+// CHECK:}
+// CHECK:#else
+// CHECK:@lifetime(copy this, copy that)
+// CHECK:@inlinable public func deriveThisOrThat(_ this: consuming lifetime_underscored_dependence.BufferView, _ that: consuming lifetime_underscored_dependence.BufferView) -> lifetime_underscored_dependence.BufferView {
+// CHECK:  if (Int.random(in: 1..<100) == 0) {
+// CHECK:    let thisView = BufferView(this._ptr, this._count)
+// CHECK:    return _overrideLifetime(thisView, copying: this)
+// CHECK:  }
+// CHECK:  let thatView = BufferView(that._ptr, that._count)
+// CHECK:  return _overrideLifetime(thatView, copying: that)
+// CHECK:}
+// CHECK:#endif
+
+// Check that an implicitly dependent variable accessor is guarded by LifetimeDependence.
+//
+// CHECK: extension lifetime_underscored_dependence.Container {
+// CHECK-NEXT: #if compiler(>=5.3) && $NonescapableTypes && $LifetimeDependence
+// CHECK-NEXT:   public var storage: lifetime_underscored_dependence.BufferView {

--- a/test/Parse/lifetime_attr.swift
+++ b/test/Parse/lifetime_attr.swift
@@ -1,17 +1,17 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LifetimeDependence 
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature Lifetimes 
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct E {}
 
 struct NE : ~Escapable {}
 
-@lifetime(copy ne)
+@_lifetime(copy ne)
 func derive(_ ne: NE) -> NE {
   ne
 }
 
-@lifetime(borrow ne1, copy ne2)
+@_lifetime(borrow ne1, copy ne2)
 func derive(_ ne1: NE, _ ne2: NE) -> NE {
   if (Int.random(in: 1..<100) < 50) {
     return ne1
@@ -19,17 +19,17 @@ func derive(_ ne1: NE, _ ne2: NE) -> NE {
   return ne2
 }
 
-@lifetime // expected-error{{expected '(' after lifetime dependence specifier}}
-func testMissingLParenError(_ ne: NE) -> NE { // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+@_lifetime // expected-error{{expected '(' after lifetime dependence specifier}}
+func testMissingLParenError(_ ne: NE) -> NE { // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
   ne
 }
 
-@lifetime() // expected-error{{expected identifier, index or self in lifetime dependence specifier}}
-func testMissingDependence(_ ne: NE) -> NE { // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+@_lifetime() // expected-error{{expected identifier, index or self in lifetime dependence specifier}}
+func testMissingDependence(_ ne: NE) -> NE { // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
   ne
 }
 
-@lifetime(borrow borrow)
+@_lifetime(borrow borrow)
 func testNameConflict(_ borrow: E) -> NE {
   NE()
 }

--- a/test/SIL/Parser/basic2_noncopyable_generics.sil
+++ b/test/SIL/Parser/basic2_noncopyable_generics.sil
@@ -1,15 +1,15 @@
 // RUN: %target-sil-opt                                      \
 // RUN:     %s                                               \
-// RUN:     -enable-experimental-feature LifetimeDependence   \
+// RUN:     -enable-experimental-feature Lifetimes   \
 // RUN: |                                                    \
 // RUN: %target-sil-opt                                      \
-// RUN:     -enable-experimental-feature LifetimeDependence   \
+// RUN:     -enable-experimental-feature Lifetimes   \
 // RUN: |                                                    \
 // RUN: %FileCheck %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
-// For -enable-experimental-feature LifetimeDependence
+// For -enable-experimental-feature Lifetimes
 
 // TODO: Once NoncopyableGenerics/NonescapableTypes is no longer behind a feature flag, merge this into basic2.
 
@@ -29,7 +29,7 @@ struct NCG<T> : ~Copyable {
 // CHECK-NEXT:    var t: T
 struct NEG<T : ~Escapable> : ~Escapable {
   var t: T
-  @lifetime(copy t)
+  @_lifetime(copy t)
   init(_ t: consuming T) {
     self.t = t
   }

--- a/test/SIL/Parser/lifetime_dependence.sil
+++ b/test/SIL/Parser/lifetime_dependence.sil
@@ -1,8 +1,8 @@
 // RUN: %target-sil-opt %s \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN: | %FileCheck %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage canonical
 
@@ -11,14 +11,14 @@ import Swift
 
 struct BufferView : ~Escapable {
   @_hasStorage let ptr: UnsafeRawBufferPointer { get }
-  @lifetime(borrow ptr) @inlinable init(_ ptr: UnsafeRawBufferPointer) 
-  @lifetime(borrow a) init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) 
+  @_lifetime(borrow ptr) @inlinable init(_ ptr: UnsafeRawBufferPointer) 
+  @_lifetime(borrow a) init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) 
 }
 
-@lifetime(borrow x) 
+@_lifetime(borrow x) 
 func derive(_ x: borrowing BufferView) -> BufferView
 
-@lifetime(copy x)
+@_lifetime(copy x)
 func consumeAndCreate(_ x: consuming BufferView) -> BufferView
 
 sil hidden [unsafe_nonescapable_result] @bufferviewinit1 : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> @owned BufferView {

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -1,37 +1,37 @@
 // RUN: %target-swift-frontend %s \
 // RUN: -emit-sil  -target %target-swift-5.1-abi-triple \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: | %FileCheck %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct BufferView : ~Escapable {
   let ptr: UnsafeRawBufferPointer
   let c: Int
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
   }
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   init(independent ptr: UnsafeRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
   }
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2ChcfC : $@convention(method) (@guaranteed BufferView, @thin BufferView.Type) -> @lifetime(copy 0) @owned BufferView {
-  @lifetime(copy otherBV)
+  @_lifetime(copy otherBV)
   init(_ otherBV: borrowing BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
   }
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyA2CcfC : $@convention(method) (@owned BufferView, @thin BufferView.Type) -> @lifetime(copy 0) @owned BufferView {
-  @lifetime(copy otherBV)
+  @_lifetime(copy otherBV)
   init(_ otherBV: consuming BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
   }
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence10BufferViewVyACSW_SaySiGhtcfC : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> @lifetime(borrow 0) @owned BufferView {
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) {
     self.ptr = ptr
     self.c = a.count
@@ -41,7 +41,7 @@ struct BufferView : ~Escapable {
 struct MutableBufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeMutableRawBufferPointer
   let c: Int
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   init(_ ptr: UnsafeMutableRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
@@ -59,20 +59,20 @@ func testBasic() {
 }
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence6deriveyAA10BufferViewVADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(copy 0)  @owned BufferView {
-@lifetime(copy x)
+@_lifetime(copy x)
 func derive(_ x: borrowing BufferView) -> BufferView {
   let newBV = BufferView(x.ptr, x.c)
   return _overrideLifetime(newBV, copying: x)
 }
 
-@lifetime(copy x)
+@_lifetime(copy x)
 func derive(_ unused: Int, _ x: borrowing BufferView) -> BufferView {
   let newBV = BufferView(independent: x.ptr, x.c)
   return _overrideLifetime(newBV, copying: x)
 }
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence16consumeAndCreateyAA10BufferViewVADnF : $@convention(thin) (@owned BufferView) -> @lifetime(copy 0)  @owned BufferView {
-@lifetime(copy x)
+@_lifetime(copy x)
 func consumeAndCreate(_ x: consuming BufferView) -> BufferView {
   let bv = BufferView(independent: x.ptr, x.c)
   return _overrideLifetime(bv, copying: x)
@@ -84,29 +84,29 @@ struct Wrapper : ~Escapable {
   var _view: BufferView
   var view: BufferView {
 // CHECK: sil hidden @$s28implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvr : $@yield_once @convention(method) (@guaranteed Wrapper) -> @lifetime(copy 0) @yields @guaranteed BufferView {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield _view
     }
 // CHECK: sil hidden @$s28implicit_lifetime_dependence7WrapperV4viewAA10BufferViewVvM : $@yield_once @convention(method) (@inout Wrapper) -> @lifetime(borrow 0) @yields @inout BufferView {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _modify {
       yield &_view
     }
   }
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperVyAcA10BufferViewVcfC : $@convention(method) (@owned BufferView, @thin Wrapper.Type) -> @lifetime(copy 0) @owned Wrapper {
-  @lifetime(copy view)
+  @_lifetime(copy view)
   init(_ view: consuming BufferView) {
     self._view = view
   }
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView1AA10BufferViewVyKF : $@convention(method) (@guaranteed Wrapper) -> @lifetime(copy 0)  (@owned BufferView, @error any Error) {
-  @lifetime(copy self)
+  @_lifetime(copy self)
   borrowing func getView1() throws -> BufferView {
     return _view
   }
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7WrapperV8getView2AA10BufferViewVyYaKF : $@convention(method) @async (@owned Wrapper) -> @lifetime(copy 0)  (@owned BufferView, @error any Error) {
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming func getView2() async throws -> BufferView {
     return _view
   }
@@ -148,7 +148,7 @@ struct GenericBufferView<Element> : ~Escapable {
   let count: Int
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewV11baseAddress5countACyxGSV_SitcfC : $@convention(method) <Element> (UnsafeRawPointer, Int, @thin GenericBufferView<Element>.Type) -> @lifetime(borrow 0) @owned GenericBufferView<Element> {
-  @lifetime(borrow baseAddress)
+  @_lifetime(borrow baseAddress)
   init<Storage>(baseAddress: Pointer,
                 count: Int,
                 dependsOn: borrowing Storage) {
@@ -156,7 +156,7 @@ struct GenericBufferView<Element> : ~Escapable {
                                       count: count)
   }
   // unsafe private API
-  @lifetime(borrow baseAddress)
+  @_lifetime(borrow baseAddress)
   init(baseAddress: Pointer, count: Int) {
     precondition(count >= 0, "Count must not be negative")
     self.baseAddress = baseAddress
@@ -174,7 +174,7 @@ struct GenericBufferView<Element> : ~Escapable {
   }
 // CHECK: sil hidden @$s28implicit_lifetime_dependence17GenericBufferViewVyACyxGAA9FakeRangeVySVGcig : $@convention(method) <Element> (FakeRange<UnsafeRawPointer>, @guaranteed GenericBufferView<Element>) -> @lifetime(copy 1) @owned GenericBufferView<Element> {
   subscript(bounds: FakeRange<Pointer>) -> Self {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       let pointer = UnsafeRawPointer(bounds.lowerBound)
       let result = GenericBufferView(
@@ -188,7 +188,7 @@ struct GenericBufferView<Element> : ~Escapable {
 }
 
 // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence23tupleLifetimeDependenceyAA10BufferViewV_ADtADF : $@convention(thin) (@guaranteed BufferView) -> @lifetime(copy 0)  (@owned BufferView, @owned BufferView) {
-@lifetime(copy x)
+@_lifetime(copy x)
 func tupleLifetimeDependence(_ x: borrowing BufferView) -> (BufferView, BufferView) {
   let newX1 = BufferView(x.ptr, x.c)
   let newX2 = BufferView(x.ptr, x.c)
@@ -204,26 +204,26 @@ public struct OuterNE: ~Escapable {
 
   // Explicit setter with an infered dependence on 'newValue'.
   public var inner2: InnerNE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get { inner1 }
-    @lifetime(self: copy newValue)
+    @_lifetime(self: copy newValue)
     set { inner1 = newValue }
   }
 
   public struct InnerNE: ~Escapable {
-    @lifetime(copy owner)
+    @_lifetime(copy owner)
     init<Owner: ~Escapable & ~Copyable>(
       owner: borrowing Owner
     ) {}
   }
 
-  @lifetime(copy owner)
+  @_lifetime(copy owner)
   init<Owner: ~Copyable & ~Escapable>(owner: borrowing Owner) {
     self.inner1 = InnerNE(owner: owner)
   }
 
   // CHECK-LABEL: sil hidden @$s28implicit_lifetime_dependence7OuterNEV8setInner5valueyAC0gE0V_tF : $@convention(method) (@guaranteed OuterNE.InnerNE, @lifetime(copy 0) @inout OuterNE) -> () {
-  @lifetime(self: copy value)
+  @_lifetime(self: copy value)
   mutating func setInner(value: InnerNE) {
     self.inner1 = value
   }

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -1,32 +1,32 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_SuppressedAssociatedTypes
 
 protocol P {
   associatedtype E: ~Escapable
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func getE() -> E
 }
 
 extension P {
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func getDefault() -> E {
     return getE()
   }
 }
 
 public struct View: ~Escapable {
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init() { }
 }
 
 public struct PView: P {
-  @lifetime(immortal)
+  @_lifetime(immortal)
   borrowing func getE() -> View { return View() }
 }
 

--- a/test/SIL/lifetime_dependence_param_position_test.swift
+++ b/test/SIL/lifetime_dependence_param_position_test.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend %s -emit-silgen \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 
 public struct Span<Element> : ~Escapable {
   private var baseAddress: UnsafeRawPointer
   public let count: Int
-  @lifetime(copy owner)
+  @_lifetime(copy owner)
   public init<Owner: ~Copyable & ~Escapable>(
       baseAddress: UnsafeRawPointer,
       count: Int,
@@ -30,7 +30,7 @@ extension ContiguousArray {
 }
 
 // CHECK-LABEL: sil hidden @$s39lifetime_dependence_param_position_test11mayReassign4span2toyAA4SpanVySiGz_s15ContiguousArrayVySiGtF : $@convention(thin) (_lifetime(_borrow 1) @inout Span<Int>, @guaranteed ContiguousArray<Int>) -> () {
-@lifetime(span: borrow to)
+@_lifetime(span: borrow to)
 func mayReassign(span: inout Span<Int>, to: ContiguousArray<Int>) {
   span = to.span
 }

--- a/test/SIL/lifetime_dependence_span_lifetime_attr.swift
+++ b/test/SIL/lifetime_dependence_span_lifetime_attr.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // TODO: Use real Range
 public struct FakeRange<Bound> {
@@ -59,7 +59,7 @@ public struct Span<Element> : ~Escapable {
   public let count: Int
   private var baseAddress: UnsafeRawPointer { start._rawValue }
 // CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanV11baseAddress5count9dependsOnACyxGSV_Siqd__htcRi_d__Ri0_d__lufC : $@convention(method) <Element><Owner where Owner : ~Copyable, Owner : ~Escapable> (UnsafeRawPointer, Int, @in_guaranteed Owner, @thin Span<Element>.Type) -> @lifetime(copy 2) @owned Span<Element> {
-  @lifetime(copy owner)
+  @_lifetime(copy owner)
   public init<Owner: ~Copyable & ~Escapable>(
       baseAddress: UnsafeRawPointer,
       count: Int,
@@ -70,7 +70,7 @@ public struct Span<Element> : ~Escapable {
       )
   }
 // CHECK-LABEL: sil hidden @$s025lifetime_dependence_span_A5_attr4SpanV5start5count9dependsOnACyxGAA0E5IndexVyxG_Siqd__htcRi_d__Ri0_d__lufC : $@convention(method) <Element><Owner where Owner : ~Copyable, Owner : ~Escapable> (SpanIndex<Element>, Int, @in_guaranteed Owner, @thin Span<Element>.Type) -> @lifetime(copy 2) @owned Span<Element> {
-  @lifetime(copy owner)
+  @_lifetime(copy owner)
   init<Owner: ~Copyable & ~Escapable>(
     start index: SpanIndex<Element>,
     count: Int,
@@ -126,7 +126,7 @@ extension Span {
  
 // CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanVyACyxGAA9FakeRangeVyAA0E5IndexVyxGGcig : $@convention(method) <Element> (FakeRange<SpanIndex<Element>>, @guaranteed Span<Element>) -> @lifetime(copy 1) @owned Span<Element> {
   public subscript(bounds: FakeRange<SpanIndex<Element>>) -> Self {
-  @lifetime(copy self)
+  @_lifetime(copy self)
     get {
       let span = Span(
         start: bounds.lowerBound,
@@ -137,7 +137,7 @@ extension Span {
   }
 
 // CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanV6prefix4upToACyxGAA0E5IndexVyxG_tF : $@convention(method) <Element> (SpanIndex<Element>, @guaranteed Span<Element>) -> @lifetime(copy 1) @owned Span<Element> {
-  @lifetime(copy self)
+  @_lifetime(copy self)
   borrowing public func prefix(upTo index: SpanIndex<Element>) -> Self {
     index == startIndex
     ? Self(start: start, count: 0, dependsOn: copy self)
@@ -145,14 +145,14 @@ extension Span {
   }
 
 // CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanV6prefix7throughACyxGAA0E5IndexVyxG_tF : $@convention(method) <Element> (SpanIndex<Element>, @guaranteed Span<Element>) -> @lifetime(copy 1) @owned Span<Element> {
-  @lifetime(copy self)
+  @_lifetime(copy self)
   borrowing public func prefix(through index: Index) -> Self {
     let nc = distance(from: startIndex, to: index) &+ 1
     return Self(start: start, count: nc, dependsOn: copy self)
   }
 
 // CHECK-LABEL: sil @$s025lifetime_dependence_span_A5_attr4SpanV6prefixyACyxGSiF : $@convention(method) <Element> (Int, @owned Span<Element>) -> @lifetime(copy 1) @owned Span<Element> {
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming public func prefix(_ maxLength: Int) -> Self {
     precondition(maxLength >= 0, "Can't have a prefix of negative length.")
     let nc = maxLength < count ? maxLength : count
@@ -162,7 +162,7 @@ extension Span {
 
 extension ContiguousArray {
   public var view: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing _read {
       yield Span(
         baseAddress: _baseAddressIfContiguous!, count: count, dependsOn: self

--- a/test/SILGen/addressable_for_dependencies.swift
+++ b/test/SILGen/addressable_for_dependencies.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature AddressableTypes -enable-experimental-feature LifetimeDependence %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes %s | %FileCheck %s
 
 // REQUIRES: swift_feature_AddressableTypes
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 @_addressableForDependencies
 struct Foo { var x: String }
@@ -11,26 +11,26 @@ struct Bar { var foo: Foo }
 struct Dep: ~Escapable {
     var x: Int = 0
 
-    @lifetime(immortal)
+    @_lifetime(immortal)
     init() { }
 }
 
 // CHECK-LABEL: sil {{.*}}@$s{{.*}}12dependencyOn3foo{{.*}} :
 // CHECK-SAME:    (@in_guaranteed Foo) -> 
-@lifetime(borrow foo)
+@_lifetime(borrow foo)
 func dependencyOn(foo: Foo) -> Dep {
     // CHECK-NOT: load_borrow
 }
 // CHECK-LABEL: sil {{.*}}@$s{{.*}}12dependencyOn3bar{{.*}} :
 // CHECK-SAME:    (@in_guaranteed Bar) -> 
-@lifetime(borrow bar)
+@_lifetime(borrow bar)
 func dependencyOn(bar: Bar) -> Dep {
     // CHECK-NOT: load_borrow
 }
 
 // CHECK-LABEL: sil {{.*}}@$s{{.*}}12dependencyOn3foo6butNot{{.*}} :
 // CHECK-SAME:    (@in_guaranteed Foo, @guaranteed Foo) -> 
-@lifetime(borrow foo)
+@_lifetime(borrow foo)
 func dependencyOn(foo: Foo, butNot _: Foo) -> Dep {
     // CHECK: bb0(%0 : $*Foo,
     // CHECK:   apply {{.*}}(%0)
@@ -39,7 +39,7 @@ func dependencyOn(foo: Foo, butNot _: Foo) -> Dep {
 
 // CHECK-LABEL: sil {{.*}}@$s{{.*}}12dependencyOn3bar6butNot{{.*}} :
 // CHECK-SAME:    (@in_guaranteed Bar, @guaranteed Bar) -> 
-@lifetime(borrow bar)
+@_lifetime(borrow bar)
 func dependencyOn(bar: Bar, butNot _: Bar) -> Dep {
     // CHECK: bb0(%0 : $*Bar,
     // CHECK:   apply {{.*}}(%0)
@@ -49,14 +49,14 @@ func dependencyOn(bar: Bar, butNot _: Bar) -> Dep {
 extension Foo {
     // CHECK-LABEL: sil {{.*}}@$s{{.*}}3FooV16dependencyOnSelf{{.*}} :
     // CHECK-SAME:    (@in_guaranteed Foo) -> 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func dependencyOnSelf() -> Dep {
         // CHECK-NOT: load_borrow
     }
 
     // CHECK-LABEL: sil {{.*}}@$s{{.*}}3FooV16dependencyOnSelf6butNot{{.*}} :
     // CHECK-SAME:    (@guaranteed Foo, @in_guaranteed Foo) -> 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func dependencyOnSelf(butNot _: Foo) -> Dep {
         // CHECK: bb0({{.*}}, %1 : $*Foo)
         // CHECK:   apply {{.*}}(%1)
@@ -65,7 +65,7 @@ extension Foo {
 
     // CHECK-LABEL: sil {{.*}}@$s{{.*}}3FooV19dependencyNotOnSelf{{.*}} :
     // CHECK-SAME:    (@in_guaranteed Foo, @guaranteed Foo) -> 
-    @lifetime(borrow foo)
+    @_lifetime(borrow foo)
     func dependencyNotOnSelf(butOn foo: Foo) -> Dep {
         // CHECK: bb0(%0 : $*Foo,
         // CHECK:   apply {{.*}}(%0)
@@ -76,13 +76,13 @@ extension Foo {
 extension Bar {
     // CHECK-LABEL: sil {{.*}}@$s{{.*}}3BarV16dependencyOnSelf{{.*}} :
     // CHECK-SAME:    (@in_guaranteed Bar) -> 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func dependencyOnSelf() -> Dep {
     }
 
     // CHECK-LABEL: sil {{.*}}@$s{{.*}}3BarV16dependencyOnSelf6butNot{{.*}} :
     // CHECK-SAME:    (@guaranteed Bar, @in_guaranteed Bar) -> 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func dependencyOnSelf(butNot _: Bar) -> Dep {
         // CHECK: bb0({{.*}}, %1 : $*Bar)
         // CHECK:   apply {{.*}}(%1)
@@ -91,7 +91,7 @@ extension Bar {
 
     // CHECK-LABEL: sil {{.*}}@$s{{.*}}3BarV19dependencyNotOnSelf{{.*}} :
     // CHECK-SAME:    (@in_guaranteed Bar, @guaranteed Bar) -> 
-    @lifetime(borrow bar)
+    @_lifetime(borrow bar)
     func dependencyNotOnSelf(butOn bar: Bar) -> Dep {
         // CHECK: bb0(%0 : $*Bar,
         // CHECK:   apply {{.*}}(%0)
@@ -104,5 +104,5 @@ extension Bar {
 
 // CHECK-LABEL: sil {{.*}}@$s28addressable_for_dependencies14defaulArgument1iAA3DepVSi_tF :
 // CHECK-SAME: $@convention(thin) (Int) -> @lifetime(borrow 0) @owned Dep {
-@lifetime(borrow i)
+@_lifetime(borrow i)
 func defaulArgument(i: Int = 0) -> Dep {}

--- a/test/SILGen/addressable_representation.swift
+++ b/test/SILGen/addressable_representation.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature LifetimeDependence -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature AddressableParameters -module-name main %s -define-availability 'Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999' | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature Lifetimes -enable-experimental-feature BuiltinModule -enable-experimental-feature AddressableTypes -enable-experimental-feature AddressableParameters -module-name main %s -define-availability 'Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999' | %FileCheck %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BuiltinModule
 // REQUIRES: swift_feature_AddressableTypes
 // REQUIRES: swift_feature_AddressableParameters
@@ -215,13 +215,13 @@ struct CO1 {
     init(_ s: String) { self.s = s }
 
     var storage: Span<String> {
-        @lifetime(borrow self)
+        @_lifetime(borrow self)
         borrowing get {
             fatalError()
         }
     }
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func getStorage() -> Span<String> {
         fatalError()
     }
@@ -235,13 +235,13 @@ struct CO2<T> {
     init(_ s: T) { self.s = s }
 
     var storage: Span<T> {
-        @lifetime(borrow self)
+        @_lifetime(borrow self)
         borrowing get {
             fatalError()
         }
     }
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func getStorage() -> Span<T> {
         fatalError()
     }

--- a/test/SILGen/bitwise_copyable_stdlib.swift
+++ b/test/SILGen/bitwise_copyable_stdlib.swift
@@ -7,11 +7,11 @@
 // RUN:     -module-name Swift                               \
 // RUN:     -disable-availability-checking                   \
 // RUN:     -enable-experimental-feature BuiltinModule       \
-// RUN:     -enable-experimental-feature LifetimeDependence  \
+// RUN:     -enable-experimental-feature Lifetimes  \
 // RUN:     -enable-builtin-module
 
 // REQUIRES: swift_feature_BuiltinModule
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // Force verification of TypeLowering's isTrivial.
 

--- a/test/SILGen/dependency_through_closure.swift
+++ b/test/SILGen/dependency_through_closure.swift
@@ -1,16 +1,16 @@
-// RUN: %target-swift-emit-silgen -verify -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes %s
+// RUN: %target-swift-emit-silgen -verify -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_AddressableTypes
 
 @_addressableForDependencies
 struct Owner {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func reference() -> Reference { fatalError() }
 }
 
 struct Reference: ~Escapable {
-    @lifetime(immortal)
+    @_lifetime(immortal)
     init() { fatalError() }
 
     func use() {}

--- a/test/SILGen/lifetime_dependence_lowering.swift
+++ b/test/SILGen/lifetime_dependence_lowering.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableParameters -enable-experimental-feature AddressableTypes %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableParameters -enable-experimental-feature AddressableTypes %s | %FileCheck %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_AddressableTypes
 
@@ -9,81 +9,81 @@ struct Foo: ~Escapable { }
 struct Butt {
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test1{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 1) @owned Foo
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func test1(other: Butt) -> Foo {
     }
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test2{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 0) @owned Foo
-    @lifetime(borrow other)
+    @_lifetime(borrow other)
     func test2(other: Butt) -> Foo {
     }
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test3{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 4) @owned Foo
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func test3(other: Butt, tuple: (Butt, Butt), another: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test4{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 0) @owned Foo
-    @lifetime(borrow other)
+    @_lifetime(borrow other)
     func test4(other: Butt, tuple: (Butt, Butt), another: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test5{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 1, borrow 2) @owned Foo
-    @lifetime(borrow tuple)
+    @_lifetime(borrow tuple)
     func test5(other: Butt, tuple: (Butt, Butt), another: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test6{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 3) @owned Foo
-    @lifetime(borrow another)
+    @_lifetime(borrow another)
     func test6(other: Butt, tuple: (Butt, Butt), another: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test7{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 2) @owned Foo
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func test7(other: Butt, nothing: (), another: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test8{{.*}} : $
     // CHECK-SAME: -> @lifetime(immortal) @owned Foo
-    @lifetime(borrow nothing)
+    @_lifetime(borrow nothing)
     func test8(other: Butt, nothing: (), another: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}5test9{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 0) @owned Foo
-    @lifetime(borrow other)
+    @_lifetime(borrow other)
     func test9(other: Butt, nothing: (), another: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test10{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 1) @owned Foo
-    @lifetime(borrow another)
+    @_lifetime(borrow another)
     func test10(other: Butt, nothing: (), another: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test11{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow address 1) @owned Foo
     @_addressableSelf
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func test11(other: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test12{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 0) @owned Foo
     @_addressableSelf
-    @lifetime(borrow other)
+    @_lifetime(borrow other)
     func test12(other: Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test13{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow 1) @owned Foo
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func test13(other: @_addressable Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test14{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow address 0) @owned Foo
-    @lifetime(borrow other)
+    @_lifetime(borrow other)
     func test14(other: @_addressable Butt) -> Foo {}
 
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test15{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow address 0) @owned Foo
-    @lifetime(borrow tuple)
+    @_lifetime(borrow tuple)
     func test15(tuple: @_addressable (Butt, Butt)) -> Foo {}
 }
 
@@ -91,21 +91,21 @@ struct Butt {
 struct AddressableForDeps {
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test16{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow address_for_deps 3) @owned Foo
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     func test16(tuple: (AddressableForDeps, AddressableForDeps),
                 other: AddressableForDeps) -> Foo {}
 
     // The dependency makes the tuple pass as a single indirect argument.
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test17{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow address_for_deps 0) @owned Foo
-    @lifetime(borrow tuple)
+    @_lifetime(borrow tuple)
     func test17(tuple: (AddressableForDeps, AddressableForDeps),
                 other: AddressableForDeps) -> Foo {}
 
     // The tuple destructures as usual, but `other` is passed indirectly.
     // CHECK-LABEL: sil{{.*}} @$s{{.*}}6test18{{.*}} : $
     // CHECK-SAME: -> @lifetime(borrow address_for_deps 2) @owned Foo
-    @lifetime(borrow other)
+    @_lifetime(borrow other)
     func test18(tuple: (AddressableForDeps, AddressableForDeps),
                 other: AddressableForDeps) -> Foo {}
 }

--- a/test/SILOptimizer/Inputs/SpanExtras.swift
+++ b/test/SILOptimizer/Inputs/SpanExtras.swift
@@ -15,7 +15,7 @@ public struct MutableSpan<Element: ~Copyable>: ~Copyable & ~Escapable {
   }
 
   @usableFromInline @inline(__always)
-  @lifetime(borrow start)
+  @_lifetime(borrow start)
   init(
     _unchecked start: UnsafeMutableRawPointer?,
     count: Int
@@ -33,7 +33,7 @@ extension MutableSpan where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
   @usableFromInline @inline(__always)
-  @lifetime(borrow elements)
+  @_lifetime(borrow elements)
   internal init(
     _unchecked elements: UnsafeMutableBufferPointer<Element>
   ) {
@@ -42,7 +42,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeElements buffer: UnsafeMutableBufferPointer<Element>
   ) {
@@ -56,7 +56,7 @@ extension MutableSpan where Element: ~Copyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow start)
+  @_lifetime(borrow start)
   public init(
     _unsafeStart start: UnsafeMutablePointer<Element>,
     count: Int
@@ -72,7 +72,7 @@ extension MutableSpan where Element: ~Copyable {
 extension MutableSpan {
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow elements)
+  @_lifetime(borrow elements)
   public init(
     _unsafeElements elements: borrowing Slice<UnsafeMutableBufferPointer<Element>>
   ) {
@@ -86,7 +86,7 @@ extension MutableSpan {
 extension MutableSpan where Element: BitwiseCopyable {
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: UnsafeMutableRawBufferPointer
   ) {
@@ -107,7 +107,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow pointer)
+  @_lifetime(borrow pointer)
   public init(
     _unsafeStart pointer: UnsafeMutableRawPointer,
     byteCount: Int
@@ -119,7 +119,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow buffer)
+  @_lifetime(borrow buffer)
   public init(
     _unsafeBytes buffer: borrowing Slice<UnsafeMutableRawBufferPointer>
   ) {
@@ -133,7 +133,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 extension Span where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow mutableSpan)
+  @_lifetime(borrow mutableSpan)
   public init(_unsafeMutableSpan mutableSpan: borrowing MutableSpan<Element>) {
     let pointer = mutableSpan._pointer?.assumingMemoryBound(to: Element.self)
     let buffer = UnsafeBufferPointer(start: pointer, count: mutableSpan.count)
@@ -147,7 +147,7 @@ extension MutableSpan where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
   public var storage: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       Span(_unsafeMutableSpan: self)
     }
@@ -165,7 +165,7 @@ extension MutableSpan where Element: ~Copyable {
 extension RawSpan {
 
   @_alwaysEmitIntoClient
-  @lifetime(borrow mutableSpan)
+  @_lifetime(borrow mutableSpan)
   public init<Element: BitwiseCopyable>(
     _unsafeMutableSpan mutableSpan: borrowing MutableSpan<Element>
   ) {
@@ -238,7 +238,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   @unsafe //FIXME: remove when the lifetime inference is fixed
   @_alwaysEmitIntoClient
   public var _unsafeRawSpan: RawSpan {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get { RawSpan(_unsafeMutableSpan: self) }
   }
 }
@@ -254,12 +254,12 @@ extension MutableSpan where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   public subscript(_ position: Index) -> Element {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _read {
       precondition(indices.contains(position), "index out of bounds")
       yield self[unchecked: position]
     }
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify {
       precondition(indices.contains(position), "index out of bounds")
       yield &self[unchecked: position]
@@ -279,7 +279,7 @@ extension MutableSpan where Element: ~Copyable {
     unsafeAddress {
       UnsafePointer(_unsafeAddressOfElement(unchecked: position))
     }
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     unsafeMutableAddress {
       _unsafeAddressOfElement(unchecked: position)
     }
@@ -299,14 +299,14 @@ extension MutableSpan where Element: ~Copyable {
 @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, visionOS 9999, *)
 extension MutableSpan where Element: ~Copyable {
 
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func swapAt(_ i: Index, _ j: Index) {
     precondition(indices.contains(Index(i)))
     precondition(indices.contains(Index(j)))
     swapAt(unchecked: i, unchecked: j)
   }
 
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func swapAt(unchecked i: Index, unchecked j: Index) {
     let pi = _unsafeAddressOfElement(unchecked: i)
     let pj = _unsafeAddressOfElement(unchecked: j)
@@ -331,7 +331,7 @@ extension MutableSpan where Element: BitwiseCopyable {
       precondition(indices.contains(position))
       return self[unchecked: position]
     }
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     set {
       precondition(indices.contains(position))
       self[unchecked: position] = newValue
@@ -352,7 +352,7 @@ extension MutableSpan where Element: BitwiseCopyable {
       let offset = position&*MemoryLayout<Element>.stride
       return _start().loadUnaligned(fromByteOffset: offset, as: Element.self)
     }
-    @lifetime(self: copy self)
+    @_lifetime(self: copy self)
     set {
       let offset = position&*MemoryLayout<Element>.stride
       _start().storeBytes(of: newValue, toByteOffset: offset, as: Element.self)
@@ -373,7 +373,7 @@ extension MutableSpan where Element: ~Copyable {
 
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func withUnsafeMutableBufferPointer<E: Error, Result: ~Copyable>(
     _ body: (UnsafeMutableBufferPointer<Element>) throws(E) -> Result
   ) throws(E) -> Result {
@@ -402,7 +402,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 
   //FIXME: mark closure parameter as non-escaping
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func withUnsafeMutableBytes<E: Error, Result: ~Copyable>(
     _ body: (_ buffer: UnsafeMutableRawBufferPointer) throws(E) -> Result
   ) throws(E) -> Result {
@@ -419,7 +419,7 @@ extension MutableSpan where Element: BitwiseCopyable {
 extension MutableSpan {
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(repeating repeatedValue: Element) {
     _start().withMemoryRebound(to: Element.self, capacity: count) {
       $0.update(repeating: repeatedValue, count: count)
@@ -427,7 +427,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update<S: Sequence>(
     from source: S
   ) -> (unwritten: S.Iterator, index: Index) where S.Element == Element {
@@ -437,7 +437,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(
     from elements: inout some IteratorProtocol<Element>
   ) -> Index {
@@ -451,7 +451,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: some Collection<Element>
   ) -> Index {
@@ -472,7 +472,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(fromContentsOf source: Span<Element>) -> Index {
     guard !source.isEmpty else { return 0 }
     precondition(
@@ -488,7 +488,7 @@ extension MutableSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: borrowing MutableSpan<Element>
   ) -> Index {
@@ -501,7 +501,7 @@ extension MutableSpan {
 extension MutableSpan where Element: BitwiseCopyable {
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(
     repeating repeatedValue: Element
   ) where Element: BitwiseCopyable {
@@ -514,7 +514,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update<S: Sequence>(
     from source: S
   ) -> (unwritten: S.Iterator, index: Index)
@@ -525,7 +525,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(
     from elements: inout some IteratorProtocol<Element>
   ) -> Index {
@@ -539,7 +539,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: some Collection<Element>
   ) -> Index where Element: BitwiseCopyable {
@@ -560,7 +560,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: Span<Element>
   ) -> Index where Element: BitwiseCopyable {
@@ -578,7 +578,7 @@ extension MutableSpan where Element: BitwiseCopyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func update(
     fromContentsOf source: borrowing MutableSpan<Element>
   ) -> Index where Element: BitwiseCopyable {
@@ -619,7 +619,7 @@ public struct OutputSpan<Element: ~Copyable>: ~Copyable, ~Escapable {
   }
 
   @usableFromInline @inline(__always)
-  @lifetime(borrow start)
+  @_lifetime(borrow start)
   init(
     _unchecked start: UnsafeMutableRawPointer?,
     capacity: Int,
@@ -642,7 +642,7 @@ extension OutputSpan where Element: ~Copyable {
 @available(macOS 9999, *)
 @available(macOS 9999, *)
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(_ value: consuming Element) {
     precondition(_initialized < capacity, "Output buffer overflow")
     let p = _start.advanced(by: _initialized&*MemoryLayout<Element>.stride)
@@ -672,7 +672,7 @@ extension OutputSpan where Element: ~Copyable {
 extension OutputSpan {
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(repeating repeatedValue: Element, count: Int) {
     let available = capacity &- _initialized
     precondition(
@@ -688,7 +688,7 @@ extension OutputSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append<S>(
     from elements: S
   ) -> S.Iterator where S: Sequence, S.Element == Element {
@@ -698,7 +698,7 @@ extension OutputSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(
     from elements: inout some IteratorProtocol<Element>
   ) {
@@ -711,7 +711,7 @@ extension OutputSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(
     fromContentsOf source: some Collection<Element>
   ) {
@@ -742,7 +742,7 @@ extension OutputSpan {
   }
 
   //FIXME: remove once rdar://136838539 & rdar://136849171 are fixed
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(
     fromContentsOf source: UnsafeBufferPointer<Element>
   ) {
@@ -760,7 +760,7 @@ extension OutputSpan {
 
   //FIXME: rdar://136838539 & rdar://136849171
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(
     fromContentsOf source: Span<Element>
   ) {
@@ -779,7 +779,7 @@ extension OutputSpan {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func append(fromContentsOf source: borrowing MutableSpan<Element>) {
     source.withUnsafeBufferPointer { append(fromContentsOf: $0) }
   }
@@ -789,7 +789,7 @@ extension OutputSpan {
 extension OutputSpan where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func moveAppend(
     fromContentsOf source: consuming Self
   ) {
@@ -808,7 +808,7 @@ extension OutputSpan where Element: ~Copyable {
   }
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func moveAppend(
     fromContentsOf source: UnsafeMutableBufferPointer<Element>
   ) {
@@ -834,7 +834,7 @@ extension OutputSpan where Element: ~Copyable {
 extension OutputSpan {
 
   @_alwaysEmitIntoClient
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func moveAppend(
     fromContentsOf source: Slice<UnsafeMutableBufferPointer<Element>>
   ) {
@@ -852,7 +852,7 @@ extension OutputSpan where Element: ~Copyable {
 
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing get {
       let pointer = _pointer?.assumingMemoryBound(to: Element.self)
       let buffer = UnsafeBufferPointer(start: pointer, count: _initialized)
@@ -865,7 +865,7 @@ extension OutputSpan where Element: ~Copyable {
      type checking error for non-existent _read accessor)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(borrow self)
+    @_lifetime(&self)
     mutating get { // the accessor must provide a mutable projection
       let pointer = _pointer?.assumingMemoryBound(to: Element.self)
       let buffer = UnsafeMutableBufferPointer(start: pointer, count: _initialized)
@@ -906,7 +906,7 @@ extension Span {
 
 //  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, visionOS 9999, *)
 //  public static var empty: Span {
-//    @lifetime(immortal)
+//    @_lifetime(immortal)
 //    get {
 //      let nilBasedBuffer = UnsafeBufferPointer<Element>(start: nil, count: 0)
 //      let span = Span(_unsafeElements: nilBasedBuffer)
@@ -915,7 +915,7 @@ extension Span {
 //  }
 //
 //  @available(macOS 9999, iOS 9999, tvOS 9999, watchOS 9999, visionOS 9999, *)
-//  @lifetime(immortal)
+//  @_lifetime(immortal)
 //  public init() {
 //    let nilBasedBuffer = UnsafeBufferPointer<Element>(start: nil, count: 0)
 //    let span = Span(_unsafeElements: nilBasedBuffer)

--- a/test/SILOptimizer/addressable_dependencies.swift
+++ b/test/SILOptimizer/addressable_dependencies.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BuiltinModule -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BuiltinModule -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes %s | %FileCheck %s
 
 // REQUIRES: swift_feature_BuiltinModule
 // REQUIRES: swift_feature_AddressableTypes
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 import Builtin
 
@@ -11,7 +11,7 @@ struct NodeRef: ~Escapable {
 
     // CHECK-LABEL: sil {{.*}}@${{.*}}7NodeRefV4node{{.*}}fC :
     // CHECK-SAME:    (@in_guaranteed Node,
-    @lifetime(borrow node)
+    @_lifetime(borrow node)
     init(node: borrowing Node) {
         // CHECK: bb0(%0 : @noImplicitCopy $*Node,
         // CHECK:   [[RAW_PTR:%.*]] = address_to_pointer {{.*}}%0
@@ -21,7 +21,7 @@ struct NodeRef: ~Escapable {
 
     // CHECK-LABEL: sil {{.*}}@${{.*}}7NodeRefV9allocated{{.*}}fC :
     // CHECK-SAME:    (@guaranteed AllocatedNode,
-    @lifetime(borrow allocated)
+    @_lifetime(borrow allocated)
     init(allocated: borrowing AllocatedNode) {
         self.parent = allocated.node
     }
@@ -34,7 +34,7 @@ struct Node {
     var ref: NodeRef {
       // CHECK-LABEL: sil {{.*}}@${{.*}}4NodeV3ref{{.*}}Vvg :
       // CHECK-SAME:    (@in_guaranteed Node) ->
-      @lifetime(borrow self)
+      @_lifetime(borrow self)
       borrowing get {
         // CHECK: bb0(%0 : @noImplicitCopy $*Node):
         // CHECK: [[REF:%.*]] = apply {{.*}}(%0,
@@ -51,7 +51,7 @@ struct AllocatedNode: ~Copyable {
     var ref: NodeRef {
       // CHECK-LABEL: sil {{.*}}@${{.*}}13AllocatedNodeV3ref{{.*}}Vvg :
       // CHECK-SAME:    (@guaranteed AllocatedNode) ->
-      @lifetime(borrow self)
+      @_lifetime(borrow self)
       borrowing get {
         return NodeRef(allocated: self)
       }
@@ -66,7 +66,7 @@ struct Schmector {
     var storage: Spam {
         // CHECK-LABEL: sil {{.*}}@${{.*}}9SchmectorV7storage{{.*}}Vvg :
         // CHECK-SAME:    (@in_guaranteed Schmector) ->
-        @lifetime(borrow self)
+        @_lifetime(borrow self)
         borrowing get {
             let pointer = UnsafePointer<Int>(Builtin.addressOfBorrow(self))
             let spam = Spam(base: pointer, count: 10)
@@ -76,6 +76,6 @@ struct Schmector {
 }
 
 struct Spam: ~Escapable {
-    @lifetime(borrow base)
+    @_lifetime(borrow base)
     init(base: UnsafePointer<Int>, count: Int) {}
 }

--- a/test/SILOptimizer/addressable_move_only_checking.swift
+++ b/test/SILOptimizer/addressable_move_only_checking.swift
@@ -1,9 +1,9 @@
-// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BuiltinModule -enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes -enable-experimental-feature AddressableParameters -verify %s
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BuiltinModule -enable-experimental-feature Lifetimes -enable-experimental-feature AddressableTypes -enable-experimental-feature AddressableParameters -verify %s
 
 // REQUIRES: swift_feature_BuiltinModule
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_AddressableTypes
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 @_addressableForDependencies
 struct Node {
@@ -15,14 +15,14 @@ struct Node {
 struct NodeRef: ~Escapable {
     private var parent: UnsafePointer<Node>
 
-    @lifetime(borrow node)
+    @_lifetime(borrow node)
     init(node: borrowing Node) { fatalError() }
 }
 
 // Ensure there aren't spurious errors about consumption when an addressable
 // parameter is passed as a normal loadable parameter to another function
 // or method.
-@lifetime(borrow node)
+@_lifetime(borrow node)
 func test(node: borrowing Node) -> NodeRef {
     node.grungle()
     return NodeRef(node: node)

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1,10 +1,10 @@
-// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature LifetimeDependence -opt-mode=none  -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB --check-prefix=CHECK-DEB
-// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature LifetimeDependence -opt-mode=speed -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT --check-prefix=CHECK-OPT
+// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature Lifetimes -opt-mode=none  -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB --check-prefix=CHECK-DEB
+// RUN: %target-sil-opt -sil-print-types -enable-experimental-feature Lifetimes -opt-mode=speed -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT --check-prefix=CHECK-OPT
 //
 // TODO: migrate the remaining tests from destroy_hoisting.sil.
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage canonical
 
@@ -1237,7 +1237,7 @@ struct NEAggregate: ~Escapable {
   var ne: NEGutless
   let regular: Regular
 
-  @lifetime(copy ne) init(ne: NEMarker)
+  @_lifetime(copy ne) init(ne: NEMarker)
 }
 
 // CHECK-LABEL: sil [ossa] @no_destructure_nonescapable : {{.*}} {

--- a/test/SILOptimizer/lifetime_dependence/Inputs/lifetime_depend_diagnose.swiftinterface
+++ b/test/SILOptimizer/lifetime_dependence/Inputs/lifetime_depend_diagnose.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name lifetime_depend_diagnose -enable-experimental-feature LifetimeDependence -swift-version 5 -enable-library-evolution
+// swift-module-flags: -module-name lifetime_depend_diagnose -enable-experimental-feature Lifetimes -swift-version 5 -enable-library-evolution
 import Swift
 import _Concurrency
 import _StringProcessing
@@ -10,7 +10,7 @@ public struct NE : ~Swift.Escapable {
   @usableFromInline
   internal let _pointer: Swift.UnsafeRawPointer?
 
-  @lifetime(borrow pointer)
+  @_lifetime(borrow pointer)
   public init(pointer: Swift.UnsafeRawPointer?) {
     self._pointer = pointer
   }
@@ -19,7 +19,7 @@ public struct NE : ~Swift.Escapable {
 extension NE {
   // This is illegal at the source level because NE.init is implicitly @lifetime(borrow),
   // so we can't return it as dependent on @lifetime(copy self).
-  @lifetime(copy self)
+  @_lifetime(copy self)
   @unsafe @_alwaysEmitIntoClient public func forward() -> NE {
     return NE(pointer: _pointer)
   }

--- a/test/SILOptimizer/lifetime_dependence/addressable_lifetime_with_resilience.swift
+++ b/test/SILOptimizer/lifetime_dependence/addressable_lifetime_with_resilience.swift
@@ -1,19 +1,19 @@
-// RUN: %target-swift-frontend -enable-experimental-feature AddressableTypes -enable-experimental-feature LifetimeDependence -enable-library-evolution -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature AddressableTypes -enable-experimental-feature Lifetimes -enable-library-evolution -emit-sil -verify %s
 
 // REQUIRES: swift_feature_AddressableTypes
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 internal struct Wrapper {
     let inner: Resilient
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing func getSpan() -> RawSpan { self.inner.getSpan() }
 }
 
 public struct Resilient {
     var field: AnyObject
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing func getSpan() -> RawSpan { fatalError() }
 }
 
@@ -23,13 +23,13 @@ public struct Resilient {
 internal struct AFDWrapper {
     let inner: AFDResilient
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing func getSpan() -> RawSpan { self.inner.getSpan() }
 }
 
 @_addressableForDependencies
 public struct AFDResilient {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     borrowing func getSpan() -> RawSpan { fatalError() }
 }
 */

--- a/test/SILOptimizer/lifetime_dependence/coroutine.swift
+++ b/test/SILOptimizer/lifetime_dependence/coroutine.swift
@@ -1,19 +1,19 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct View : ~Escapable {
   let ptr: UnsafeRawBufferPointer
   let c: Int
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
   }
-  @lifetime(copy otherBV)
+  @_lifetime(copy otherBV)
   init(_ otherBV: borrowing View) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
@@ -24,7 +24,7 @@ struct View : ~Escapable {
   }
   // This overload requires a separate label because overloading
   // on borrowing/consuming attributes is not allowed
-  @lifetime(copy k)
+  @_lifetime(copy k)
   init(consumingView k: consuming View) {
     self.ptr = k.ptr
     self.c = k.c
@@ -36,16 +36,16 @@ struct Wrapper : ~Escapable {
 
   // Nested coroutine access.
   var view: View {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield _view
     }
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _modify {
       yield &_view
     }
   }
-  @lifetime(copy view)
+  @_lifetime(copy view)
   init(_ view: consuming View) {
     self._view = view
   }

--- a/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
+++ b/test/SILOptimizer/lifetime_dependence/dependence_insertion.sil
@@ -2,13 +2,13 @@
 // RUN:   -lifetime-dependence-insertion \
 // RUN:   -enable-address-dependencies \
 // RUN:   -sil-verify-all \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature AddressableParameters \
 // RUN:   -enable-experimental-feature AddressableTypes \
 // RUN:   %s | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_AddressableTypes
 
@@ -19,14 +19,14 @@ import Swift
 struct NE: ~Escapable {
   var p: UnsafeRawPointer
 
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init()
 }
 
 struct NCE: ~Escapable, ~Copyable {
   var p: UnsafeRawPointer
 
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init()
 }
 

--- a/test/SILOptimizer/lifetime_dependence/initializer.swift
+++ b/test/SILOptimizer/lifetime_dependence/initializer.swift
@@ -3,10 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct Span<T>: ~Escapable {
   private var base: UnsafePointer<T>
@@ -18,7 +18,7 @@ struct Span<T>: ~Escapable {
     self.count = count
   }
 
-  @lifetime(borrow generic)
+  @_lifetime(borrow generic)
   init<S>(base: UnsafePointer<T>, count: Int, generic: borrowing S) {
     self.base = base
     self.count = count
@@ -28,7 +28,7 @@ struct Span<T>: ~Escapable {
 struct Wrapper<T: BitwiseCopyable>: ~Escapable {
   private let span: Span<T>
 
-  @lifetime(copy span)
+  @_lifetime(copy span)
   init(span: borrowing Span<T>) {
     self.span = copy span
   }
@@ -42,7 +42,7 @@ struct SuperWrapper<T: BitwiseCopyable>: ~Escapable {
 
   // Make sure that LocalVariableUtils can successfully analyze 'self'. That's required to determine that the assignment
   // of `wrapper` is returned without escaping
-  @lifetime(copy span)
+  @_lifetime(copy span)
   init(span: borrowing Span<T>) {
     self.wrapper = Wrapper(span: span)
   }

--- a/test/SILOptimizer/lifetime_dependence/inout.swift
+++ b/test/SILOptimizer/lifetime_dependence/inout.swift
@@ -3,10 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct Span<T>: ~Escapable {
   private var base: UnsafePointer<T>
@@ -18,7 +18,7 @@ struct Span<T>: ~Escapable {
     self.count = count
   }
 
-  @lifetime(borrow generic)
+  @_lifetime(borrow generic)
   init<S>(base: UnsafePointer<T>, count: Int, generic: borrowing S) {
     self.base = base
     self.count = count
@@ -28,7 +28,7 @@ struct Span<T>: ~Escapable {
 struct Wrapper<T: BitwiseCopyable>: ~Escapable {
   private let span: Span<T>
 
-  @lifetime(copy span)
+  @_lifetime(copy span)
   init(span: borrowing Span<T>) {
     self.span = copy span
   }
@@ -42,7 +42,7 @@ struct SuperWrapper<T: BitwiseCopyable>: ~Escapable {
 
   // Make sure that LocalVariableUtils can successfully analyze 'self'. That's required to determine that the assignment
   // of `wrapper` is returned without escaping
-  @lifetime(copy span)
+  @_lifetime(copy span)
   init(span: borrowing Span<T>) {
     self.wrapper = Wrapper(span: span)
   }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_borrow.swift
@@ -3,13 +3,13 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 @_unsafeNonescapableResult
-@lifetime(copy source)
+@_lifetime(copy source)
 internal func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(
@@ -31,7 +31,7 @@ struct BV : ~Escapable {
 
   public var isEmpty: Bool { i == 0 }
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
@@ -48,14 +48,14 @@ struct MBV : ~Escapable, ~Copyable {
   let p: UnsafeRawPointer
   let i: Int
   
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
 
   // Requires a borrow.
-  @lifetime(copy self)
+  @_lifetime(copy self)
   borrowing func getBV() -> BV {
     let bv = BV(p, i)
     return _overrideLifetime(bv, copying: self)
@@ -66,32 +66,32 @@ struct MBV : ~Escapable, ~Copyable {
 struct NEBV : ~Escapable {
   var bv: BV
 
-  @lifetime(copy bv)
+  @_lifetime(copy bv)
   init(_ bv: consuming BV) {
     self.bv = bv
   }
 }
 
 // Propagate a borrow.
-@lifetime(copy container)
+@_lifetime(copy container)
 func bv_get_borrow(container: borrowing MBV) -> BV {
   container.getBV()
 }
 
 // Copy a borrow.
-@lifetime(copy container)
+@_lifetime(copy container)
 func bv_get_copy(container: borrowing MBV) -> BV {
   return container.getBV()
 }
 
 // Recognize nested accesses as part of the same dependence scope.
-@lifetime(copy container)
+@_lifetime(copy container)
 func bv_get_mutate(container: inout MBV) -> BV {
   container.getBV()
 }
 
 // Create and decompose a nonescapable aggregate.
-@lifetime(borrow cn)
+@_lifetime(borrow cn)
 func ne_wrap_and_extract_member(cn: borrowing CN) -> BV {
   let bv = BV(cn)
   let ne = NEBV(bv)

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_closure.swift
@@ -3,10 +3,10 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct NCInt: ~Copyable {
   var value: Int
@@ -17,7 +17,7 @@ struct NCInt: ~Copyable {
 struct NEInt : ~Escapable {
   let value: Int
 
-  @lifetime(borrow borrowed)
+  @_lifetime(borrow borrowed)
   init(borrowed: borrowing NCInt) {
     self.value = borrowed.value
   }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_diagnostics.swift
@@ -1,23 +1,23 @@
 // RUN: %target-swift-frontend %s -Xllvm -sil-print-types -emit-sil \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let c: Int
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeRawPointer, _ c: Int) {
     self.p = p
     self.c = c
   }
 }
 
-@lifetime(copy bv)
+@_lifetime(copy bv)
 func bv_copy(_ bv: borrowing BV) -> BV {
   copy bv
 }
@@ -37,13 +37,13 @@ public struct NEInt: ~Escapable {
   // CHECK: end_access [[A]] : $*NEInt
   // CHECK: end_access [[A]] : $*NEInt
   var iprop: NEInt {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read { yield self }
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify { yield &self }
   }
 
-  @lifetime(borrow owner)
+  @_lifetime(borrow owner)
   init(owner: borrowing NCInt) {
     self.i = owner.i
   }
@@ -56,7 +56,7 @@ public enum NEOptional<Wrapped: ~Escapable>: ~Escapable {
 
 extension NEOptional where Wrapped: ~Escapable {
   // Test that enum initialization passes diagnostics.
-  @lifetime(copy some)
+  @_lifetime(copy some)
   public init(_ some: consuming Wrapped) { self = .some(some) }
 }
 
@@ -69,7 +69,7 @@ func takeClosure(_: () -> ()) {}
 // CHECK:        apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> @lifetime(copy 0) @owned BV
 // CHECK-NEXT:   return %3 : $BV
 // CHECK-LABEL: } // end sil function '$s4test14bv_borrow_copyyAA2BVVADF'
-@lifetime(borrow bv)
+@_lifetime(borrow bv)
 func bv_borrow_copy(_ bv: borrowing BV) -> BV {
   bv_copy(bv) 
 }
@@ -83,7 +83,7 @@ func bv_borrow_copy(_ bv: borrowing BV) -> BV {
 // CHECK:         %{{.*}} = mark_dependence [nonescaping] [[R]] : $BV on %0 : $BV
 // CHECK-NEXT:    return %{{.*}} : $BV
 // CHECK-LABEL: } // end sil function '$s4test010bv_borrow_C00B0AA2BVVAE_tF'
-@lifetime(borrow bv)
+@_lifetime(borrow bv)
 func bv_borrow_borrow(bv: borrowing BV) -> BV {
   bv_borrow_copy(bv)
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_generic.swift
@@ -2,12 +2,12 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:   -parse-stdlib -module-name Swift
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_SuppressedAssociatedTypes
 
 @_marker public protocol Escapable {}
@@ -19,12 +19,12 @@ precedencegroup AssignmentPrecedence { assignment: true }
 
 protocol P {
   associatedtype E: ~Escapable
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func getE() -> E
 }
 
 extension P {
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func getDefault() -> E {
     return getE()
   }
@@ -52,29 +52,29 @@ struct NCInt: ~Copyable {
 struct NEInt: ~Escapable {
   let value: Builtin.Int64
 
-  @lifetime(copy o)
+  @_lifetime(copy o)
   init<O: ~Copyable & ~Escapable>(v: Builtin.Int64, o: borrowing O) {
     self.value = v
   }
 
   // Test a generic storage owner.
-  @lifetime(borrow borrowed)
+  @_lifetime(borrow borrowed)
   init(borrowed: borrowing NCInt) {
     self.init(v: borrowed.value, o: borrowed)
   }
 }
 
-@lifetime(copy ne)
+@_lifetime(copy ne)
 public func consume_indirect<NE: ~Escapable>(ne: consuming NE) -> NE {
   return ne
 }
 
-@lifetime(copy ne)
+@_lifetime(copy ne)
 public func copy_indirect<NE: ~Escapable>(ne: borrowing NE) -> NE {
   return copy ne
 }
 
-@lifetime(copy ne)
+@_lifetime(copy ne)
 public func copy_inout<NE: ~Escapable>(ne: inout NE) -> NE {
   return copy ne
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit.swift
@@ -3,15 +3,15 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.
 @_unsafeNonescapableResult
-@lifetime(copy source)
+@_lifetime(copy source)
 func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
   dependent: consuming T, dependsOn source: borrowing U)
   -> T {
@@ -22,19 +22,19 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
  
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(independent p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
 
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming func derive() -> BV {
     // Technically, this "new" view does not depend on the 'view' argument.
     // This unsafely creates a new view with no dependence.
@@ -48,41 +48,41 @@ struct NEBV : ~Escapable {
   var bv: BV
 
   // Test lifetime inheritance through initialization.
-  @lifetime(copy bv)
+  @_lifetime(copy bv)
   init(_ bv: consuming BV) {
     self.bv = bv
   }
 
   var view: BV {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield bv
     }
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _modify {
       yield &bv
     }
   }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   func borrowedView() -> BV {
     bv
   }
 }
 
 // Test lifetime inheritance through chained consumes.
-@lifetime(copy bv)
+@_lifetime(copy bv)
 func bv_derive(bv: consuming BV) -> BV {
   bv.derive()
 }
 
 // Test lifetime inheritance through stored properties.
-@lifetime(copy nebv)
+@_lifetime(copy nebv)
 func ne_extract_member(nebv: consuming NEBV) -> BV {
   return nebv.bv
 }
 
-@lifetime(copy nebv)
+@_lifetime(copy nebv)
 func ne_yield_member(nebv: consuming NEBV) -> BV {
   return nebv.view
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_inherit_fail.swift
@@ -3,15 +3,15 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.
 @_unsafeNonescapableResult
-@lifetime(copy source)
+@_lifetime(copy source)
 func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
   dependent: consuming T, dependsOn source: borrowing U)
   -> T {
@@ -22,19 +22,19 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(independent p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   consuming func derive() -> BV {
     // Technically, this "new" view does not depend on the 'view' argument.
     // This unsafely creates a new view with no dependence.
@@ -46,7 +46,7 @@ struct BV : ~Escapable {
 struct NE : ~Escapable {
   var bv: BV
 
-  @lifetime(copy bv)
+  @_lifetime(copy bv)
   init(_ bv: consuming BV) {
     self.bv = bv
   }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_insertion.swift
@@ -2,17 +2,17 @@
 // RUN:   -Xllvm -sil-print-types -Xllvm -sil-print-after=lifetime-dependence-insertion \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
@@ -24,7 +24,7 @@ struct NC : ~Copyable {
   let i: Int
 
   // Requires a borrow.
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func getBV() -> BV {
     BV(p, i)
   }
@@ -59,7 +59,7 @@ func bv_borrow_var(p: UnsafeRawPointer, i: Int) {
 // CHECK: [[MD:%.*]] = mark_dependence [unresolved] [[BV]] : $BV on %0 : $UnsafePointer<Int>
 // CHECK: return [[MD]] : $BV
 // CHECK-LABEL: } // end sil function '$s4test18bv_pointer_convert1pAA2BVVSPySiG_tF'
-@lifetime(borrow p)
+@_lifetime(borrow p)
 func bv_pointer_convert(p: UnsafePointer<Int>) -> BV {
   BV(p, 0)
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_mutate.swift
@@ -3,16 +3,16 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct MutableSpan : ~Escapable, ~Copyable {
   let base: UnsafeMutableRawPointer
   let count: Int
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeMutableRawPointer, _ c: Int) {
     self.base = p
     self.count = c
@@ -34,7 +34,7 @@ struct MutableSpan : ~Escapable, ~Copyable {
     var base: UnsafeMutableRawPointer
     var count: Int
 
-    @lifetime(borrow base)
+    @_lifetime(borrow base)
     init(base: UnsafeMutableRawPointer, count: Int) {
       self.base = base
       self.count = count
@@ -50,7 +50,7 @@ struct MutableSpan : ~Escapable, ~Copyable {
   }
 
   var iterator: Iter {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       let newIter = Iter(base: base, count: count)
       return _overrideLifetime(newIter, copying: self)
@@ -73,7 +73,7 @@ struct NC : ~Copyable {
   let c: Int
 
   // Requires a mutable borrow.
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating func getMutableSpan() -> MutableSpan {
     MutableSpan(p, c)
   }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_optional.swift
@@ -2,15 +2,15 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // Simply test that it is possible for a module to define a pseudo-Optional type without triggering any compiler errors.
 
 public protocol ExpressibleByNilLiteral: ~Copyable & ~Escapable {
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init(nilLiteral: ()) 
 }
 
@@ -30,7 +30,7 @@ extension Nillable: BitwiseCopyable where Wrapped: BitwiseCopyable { }
 
 extension Nillable: ExpressibleByNilLiteral where Wrapped: ~Copyable & ~Escapable {
   @_transparent
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init(nilLiteral: ()) {
     self = .none
   }
@@ -38,7 +38,7 @@ extension Nillable: ExpressibleByNilLiteral where Wrapped: ~Copyable & ~Escapabl
 
 extension Nillable where Wrapped: ~Copyable & ~Escapable {
   @_transparent
-  @lifetime(copy some)
+  @_lifetime(copy some)
   public init(_ some: consuming Wrapped) { self = .some(some) }
 }
 

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param.swift
@@ -3,15 +3,15 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // TODO: Remove @_unsafeNonescapableResult. Instead, the unsafe dependence should be expressed by a builtin that is
 // hidden within the function body.
 @_unsafeNonescapableResult
-@lifetime(copy source)
+@_lifetime(copy source)
 func unsafeLifetime<T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable>(
   dependent: consuming T, dependsOn source: borrowing U)
   -> T {
@@ -22,13 +22,13 @@ struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
   }
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(independent p: UnsafeRawPointer, _ i: Int) {
     self.p = p
     self.i = i
@@ -38,7 +38,7 @@ struct BV : ~Escapable {
   public var isEmpty: Bool { i == 0 }
 
   // Test consuming `self`
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming func derive() -> BV {
     // Technically, this "new" view does not depend on the 'view' argument.
     // This unsafely creates a new view with no dependence.
@@ -51,7 +51,7 @@ struct BV : ~Escapable {
 struct NE {
   var bv: BV
 
-  @lifetime(copy bv)
+  @_lifetime(copy bv)
   init(_ bv: BV) {
     self.bv = bv
   }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_param_fail.swift
@@ -3,16 +3,16 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let c: Int
 
-  @lifetime(borrow p)
+  @_lifetime(borrow p)
   init(_ p: UnsafeRawPointer, _ c: Int) {
     self.p = p
     self.c = c
@@ -33,45 +33,45 @@ struct NC : ~Copyable {
 struct NE {
   var bv: BV
 
-  @lifetime(copy bv)
+  @_lifetime(copy bv)
   init(_ bv: consuming BV) {
     self.bv = bv
   }
 }
 
-@lifetime(other: copy bv)
+@_lifetime(other: copy bv)
 func bv_assign_inout_copy(bv: BV, other: inout BV) {
   other = bv // OK
 }
 
-@lifetime(other: borrow bv)
+@_lifetime(other: borrow bv)
 func bv_assign_inout_borrow(bv: BV, other: inout BV) {
   other = bv
 }
 
-@lifetime(bv: copy bv)
-@lifetime(other: copy bv)
+@_lifetime(bv: copy bv)
+@_lifetime(other: copy bv)
 func bvmut_assign_inout(bv: inout BV, other: inout BV) {
   other = bv
 }
 
-@lifetime(other: copy bv)
+@_lifetime(other: copy bv)
 func bvcons_assign_inout(bv: consuming BV, other: inout BV) {
   other = bv
 }
 
-@lifetime(other: copy bv)
+@_lifetime(other: copy bv)
 func bv_assign_field(bv: BV, other: inout NE) {
   other.bv = bv
 }
 
-@lifetime(bv: copy bv)
-@lifetime(other: copy bv)
+@_lifetime(bv: copy bv)
+@_lifetime(other: copy bv)
 func bvmut_assign_field(bv: inout BV, other: inout NE) {
   other.bv = bv
 }
 
-@lifetime(other: copy bv)
+@_lifetime(other: copy bv)
 func bvcons_assign_field(bv: consuming BV, other: inout NE) {
   other.bv = bv
 }

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_scope_fixup.swift
@@ -1,16 +1,16 @@
-// RUN: %target-swift-frontend %s -Xllvm -sil-print-types -emit-sil \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: %target-swift-frontend %s -Xllvm -sil-print-types -Xllvm -sil-disable-pass=onone-simplification -emit-sil \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 /// Unsafely discard any lifetime dependency on the `dependent` argument. Return
 /// a value identical to `dependent` that inherits all lifetime dependencies from
 /// the `source` argument.
 @_unsafeNonescapableResult
 @_transparent
-@lifetime(copy source)
+@_lifetime(copy source)
 internal func _overrideLifetime<
   T: ~Copyable & ~Escapable, U: ~Copyable & ~Escapable
 >(
@@ -31,12 +31,12 @@ struct NCContainer : ~Copyable {
 struct View : ~Escapable {
   let ptr: UnsafeRawBufferPointer
   let c: Int
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
   }
-  @lifetime(copy otherBV)
+  @_lifetime(copy otherBV)
   init(_ otherBV: borrowing View) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
@@ -47,7 +47,7 @@ struct View : ~Escapable {
   }
   // This overload requires a separate label because overloading
   // on borrowing/consuming attributes is not allowed
-  @lifetime(copy k)
+  @_lifetime(copy k)
   init(consumingView k: consuming View) {
     self.ptr = k.ptr
     self.c = k.c
@@ -65,11 +65,11 @@ struct NCMutableContainer : ~Copyable {
 
 struct MutableView : ~Copyable, ~Escapable {
   let ptr: UnsafeMutableRawBufferPointer
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   init(_ ptr: UnsafeMutableRawBufferPointer) {
     self.ptr = ptr
   }
-  @lifetime(copy otherBV)
+  @_lifetime(copy otherBV)
   init(_ otherBV: borrowing MutableView) {
     self.ptr = otherBV.ptr
   }
@@ -79,7 +79,7 @@ struct MutableView : ~Copyable, ~Escapable {
 }
 
 extension MutableView {
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating public func update() -> Self {
     return unsafe MutableView(ptr)
   }
@@ -93,17 +93,17 @@ func consume(_ o : consuming View) {}
 func use(_ o : borrowing MutableView) {}
 func consume(_ o : consuming MutableView) {}
 
-@lifetime(copy x)
+@_lifetime(copy x)
 func getConsumingView(_ x: consuming View) -> View {
   return View(consumingView: x)
 }
 
-@lifetime(borrow x)
+@_lifetime(borrow x)
 func getBorrowingView(_ x: borrowing View) -> View {
   return View(x.ptr, x.c)
 }
 
-@lifetime(borrow x)
+@_lifetime(borrow x)
 func getBorrowingView(_ x: borrowing NCContainer) -> View {
   return View(x.ptr, x.c)
 }
@@ -220,16 +220,16 @@ func test8(_ a: inout Array<Int>) {
 struct Wrapper : ~Escapable {
   var _view: View
   var view: View {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield _view
     }
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _modify {
       yield &_view
     }
   }
-  @lifetime(copy view)
+  @_lifetime(copy view)
   init(_ view: consuming View) {
     self._view = view
   }
@@ -245,7 +245,7 @@ func test9() {
   }
 }
 
-@lifetime(copy x)
+@_lifetime(copy x)
 func getViewTuple(_ x: borrowing View) -> (View, View) {
   let x1 = View(x.ptr, x.c)
   let x2 = View(x.ptr, x.c)

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -1,13 +1,13 @@
 // RUN: %target-sil-opt \
 // RUN:   -lifetime-dependence-scope-fixup \
 // RUN:   -sil-verify-all \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature AddressableParameters \
 // RUN:   -enable-experimental-feature AddressableTypes \
 // RUN:   %s | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_AddressableTypes
 
@@ -21,7 +21,7 @@ import Swift
 struct NE : ~Escapable {
   var p: UnsafeRawPointer
 
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init()
 }
 

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -4,12 +4,12 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -enable-builtin-module \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature AddressableParameters \
 // RUN:   -enable-experimental-feature AddressableTypes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_AddressableTypes
 
@@ -22,13 +22,13 @@ public struct Span<T>: ~Escapable {
   private var base: UnsafePointer<T>?
   private var count: Int
 
-  @lifetime(borrow base)
+  @_lifetime(borrow base)
   init(base: UnsafePointer<T>?, count: Int) {
     self.base = base
     self.count = count
   }
 
-  @lifetime(borrow generic)
+  @_lifetime(borrow generic)
   init<S>(base: UnsafePointer<T>?, count: Int, generic: borrowing S) {
     self.base = base
     self.count = count
@@ -42,7 +42,7 @@ public struct Span<T>: ~Escapable {
 }
 
 extension Span {
-  @lifetime(copy self)
+  @_lifetime(copy self)
   consuming func dropFirst() -> Span<T> {
     let nextPointer = self.base.flatMap { $0 + 1 }
     let local = Span(base: nextPointer, count: self.count - 1)
@@ -51,7 +51,7 @@ extension Span {
 }
 
 extension Span {
-  @lifetime(copy self)
+  @_lifetime(copy self)
   mutating func droppingPrefix(length: Int) -> /* */ Span<T> {
     let oldBase = base
     let result = Span(base: oldBase, count: length)
@@ -67,7 +67,7 @@ struct MutableSpan<T>: ~Escapable, ~Copyable {
   let base: UnsafeMutablePointer<T>
   let count: Int
 
-  @lifetime(&base)
+  @_lifetime(&base)
   init(base: UnsafeMutablePointer<T>, count: Int) {
     self.base = base
     self.count = count
@@ -75,7 +75,7 @@ struct MutableSpan<T>: ~Escapable, ~Copyable {
 }
 
 extension Array {
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func span() -> Span<Element> {
     /* not the real implementation */
     let p = self.withUnsafeBufferPointer { $0.baseAddress! }
@@ -85,7 +85,7 @@ extension Array {
 }
 
 extension Array {
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating func mutableSpan() -> MutableSpan<Element> {
     /* not the real implementation */
     let p = self.withUnsafeMutableBufferPointer { $0.baseAddress! }
@@ -97,7 +97,7 @@ extension Array {
 struct InnerTrivial {
   var p: UnsafePointer<Int>
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func span() -> Span<Int> {
     Span(base: p, count: 1)
   }
@@ -109,7 +109,7 @@ struct TrivialHolder {
 
   var addressableInt: AddressableInt { unsafeAddress { pa } }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func span() -> Span<Int> {
     Span(base: p, count: 1)
   }
@@ -122,7 +122,7 @@ struct Holder {
 
   var addressableInt: AddressableInt { unsafeAddress { pa } }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func span() -> Span<Int> {
     Span(base: p, count: 1)
   }
@@ -132,7 +132,7 @@ struct Holder {
 struct AddressableInt {
   let value: Int
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func span() -> Span<Int> {
     // TODO: we actually want the address of self.value
     let p = UnsafePointer<Int>(Builtin.unprotectedAddressOfBorrow(self))
@@ -145,7 +145,7 @@ struct AddressableInt {
 struct AddressableObject {
   let object: AnyObject
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   borrowing func span() -> Span<AnyObject> {
     // TODO: we actually want the address of self.object
     let p = UnsafePointer<AnyObject>(Builtin.unprotectedAddressOfBorrow(self))
@@ -192,24 +192,24 @@ struct Outer {
 
 func parse(_ span: Span<Int>) {}
 
-@lifetime(copy arg)
+@_lifetime(copy arg)
 func copySpan<T>(_ arg: Span<T>) -> /* */ Span<T> { arg }
 
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func reborrowSpan<T>(_ arg: Span<T>) -> Span<T> { arg }
 
-@lifetime(&arg)
+@_lifetime(&arg)
 func reborrowGenericInout<T: ~Escapable>(_ arg: inout T) -> T { arg }
 
-@lifetime(copy arg)
+@_lifetime(copy arg)
 func inheritSpan<T>(_ arg: Span<T>) -> Span<T> { arg }
 
-@lifetime(copy arg)
+@_lifetime(copy arg)
 func inheritGeneric<T: ~Escapable>(_ arg: consuming T) -> T { arg }
 
 public struct NE: ~Escapable {}
 
-@lifetime(&ne)
+@_lifetime(&ne)
 func borrowNE<T: ~Escapable>(ne: inout T) -> T {
   ne
 }
@@ -221,7 +221,7 @@ func borrowNE<T: ~Escapable>(ne: inout T) -> T {
 struct View: ~Escapable {
   let owner: AnyObject
 
-  @lifetime(borrow owner)
+  @_lifetime(borrow owner)
   init(owner: borrowing AnyObject) {
     self.owner = copy owner // OK
   }
@@ -231,12 +231,12 @@ struct MutableView: ~Escapable, ~Copyable {
   let owner: AnyObject
 
   // A copy of a borrow is indistinguishable with the borrow scope.
-  @lifetime(borrow owner)
+  @_lifetime(borrow owner)
   init(owner: borrowing AnyObject) {
     self.owner = copy owner // OK
   }
 
-  @lifetime(&mutableOwner)
+  @_lifetime(&mutableOwner)
   init(mutableOwner: inout AnyObject) {
     // Initialization of a ~Escapable value is unenforced. So we can initialize
     // the `owner` property without locally borrowing `mutableOwner`.
@@ -251,7 +251,7 @@ struct Container<T> {
 }
 
 // Dependence on an empty initialized value should be scoped to variable decl.
-@lifetime(copy x)
+@_lifetime(copy x)
 func f(x: NotEscapable) -> NotEscapable {
   let local = NotEscapable() // expected-error {{lifetime-dependent variable 'local' escapes its scope}}
   // expected-note @-1{{it depends on the lifetime of this parent value}}
@@ -313,13 +313,13 @@ func testInheritedCopyVar(_ arg: [Int] ) {
   parse(result) // ✅ Safe: within lifetime of 'a'
 }
 
-@lifetime(copy span)
+@_lifetime(copy span)
 public func testBorrowInheritedArg<T>(_ span: Span<T>) -> Span<T> {
   reborrowSpan(span) // expected-error {{lifetime-dependent value escapes its scope}}
   // expected-note @-2{{it depends on the lifetime of argument 'span'}}
 } // expected-note {{this use causes the lifetime-dependent value to escape}}
 
-@lifetime(copy t)
+@_lifetime(copy t)
 public func testBorrowInheritedInoutArg<T: ~Escapable>(_ t: inout T) -> T {
   // expected-error @-1{{lifetime-dependent variable 't' escapes its scope}}
   // expected-note @-2{{it depends on the lifetime of argument 't'}}
@@ -327,12 +327,12 @@ public func testBorrowInheritedInoutArg<T: ~Escapable>(_ t: inout T) -> T {
   // expected-note @-1{{this use causes the lifetime-dependent value to escape}}
 }
 
-@lifetime(copy span)
+@_lifetime(copy span)
 public func testCopyInheritedArg<T>(_ span: Span<T>) -> Span<T> {
   inheritSpan(span)
 }
 
-@lifetime(copy t)
+@_lifetime(copy t)
 public func testCopyInheritedGenericArg<T: ~Escapable>(_ t: consuming T) -> T {
   inheritGeneric(t)
 }
@@ -370,7 +370,7 @@ func testScopedOfInheritedWithLet(_ arg: [Int] ) {
 //  _ = consume ne2
 //  _ = dep
 //
-@lifetime(copy ne)
+@_lifetime(copy ne)
 public func testScopedOfInheritedInout<T: ~Escapable>(ne: inout T) -> T {
   // expected-error @-1{{lifetime-dependent variable 'ne' escapes its scope}}
   // expected-note  @-2{{it depends on the lifetime of argument 'ne'}}
@@ -382,7 +382,7 @@ public func testScopedOfInheritedInout<T: ~Escapable>(ne: inout T) -> T {
 // Scoped dependence on trivial values
 // =============================================================================
 
-@lifetime(borrow a)
+@_lifetime(borrow a)
 func testTrivialScope<T>(a: Array<T>) -> Span<T> {
   let p = a.withUnsafeBufferPointer { $0.baseAddress! }
   return Span(base: p, count: 1)
@@ -406,7 +406,7 @@ public func testTrivialLocalDeadEnd(p: UnsafePointer<Int>) {
 
 // Test dependence on a borrow of a trivial inout. The access scope can be ignored since we don't care about the
 // in-memory value.
-@lifetime(borrow p)
+@_lifetime(borrow p)
 public func testTrivialInoutBorrow(p: inout UnsafePointer<Int>) -> Span<Int> {
   return Span(base: p, count: 1)
 }
@@ -419,14 +419,14 @@ private let immortalInt = 0
 
 private let immortalStrings: [String] = []
 
-@lifetime(immortal)
+@_lifetime(immortal)
 func testImmortalInt() -> Span<Int> {
   let nilBasedBuffer = UnsafeBufferPointer<Int>(start: nil, count: 0)
   let span = Span(base: nilBasedBuffer.baseAddress, count: nilBasedBuffer.count)
   return _overrideLifetime(span, borrowing: immortalInt)
 }
 
-@lifetime(immortal)
+@_lifetime(immortal)
 func testImmortalStrings() -> Span<[String]> {
   let nilBasedBuffer = UnsafeBufferPointer<[String]>(start: nil, count: 0)
   let span = Span(base: nilBasedBuffer.baseAddress, count: nilBasedBuffer.count)
@@ -437,7 +437,7 @@ let ptr = UnsafePointer<Int>(bitPattern: 1)!
 let globalTrivial = InnerTrivial(p: ptr)
 
 // An immortal span can depend on a caller's local borrow scope even though the callee sees no such dependency.
-@lifetime(borrow local)
+@_lifetime(borrow local)
 func testGlobal(local: InnerTrivial) -> Span<Int> {
   globalTrivial.span()
 }
@@ -446,12 +446,12 @@ func testGlobal(local: InnerTrivial) -> Span<Int> {
 // Scoped dependence on mutable values
 // =============================================================================
 
-@lifetime(&a)
+@_lifetime(&a)
 func testInoutBorrow(a: inout [Int]) -> Span<Int> {
   a.span() // OK
 }
 
-@lifetime(&a)
+@_lifetime(&a)
 func testInoutMutableBorrow(a: inout [Int]) -> MutableSpan<Int> {
   a.mutableSpan()
 }
@@ -461,26 +461,26 @@ func testInoutMutableBorrow(a: inout [Int]) -> MutableSpan<Int> {
 // =============================================================================
 
 extension Container {
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   func span() -> Span<T> {
     // borrowing the 'pointer' member is allowed.
     Span(base: self.pointer, count: self.count) // OK
   }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   func view() -> View {
     // borrowing the 'view' member is allowed.
     View(owner: self.owner) // OK
   }
 
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating func mutableView() -> MutableView {
     // Reading 'self.owner' creates a local borrow scope. The caller's exclusive access on 'self' is sufficient for the
     // result.
     MutableView(owner: self.owner) // OK
   }
 
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating func mutableViewModifiesOwner() -> MutableView {
     // Passing '&self.owner' inout creates a nested exclusive access that must extend to all uses of the new
     // MutableView. This is allowed because the nested access is logically extended to the end of the function (without
@@ -488,7 +488,7 @@ extension Container {
     MutableView(mutableOwner: &self.owner)
   }
 
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating func mutableSpan() -> MutableSpan<T> {
     // Reading 'self.pointer' creates a local borrow scope. The local borrow
     // scope is ignored because 'pointer' is a trivial value. Instead, the new
@@ -497,22 +497,22 @@ extension Container {
   }
 }
 
-@lifetime(borrow outer)
+@_lifetime(borrow outer)
 func testBorrowStoredTrivial(outer: Outer) -> Span<Int> {
   outer._innerTrivial.span()
 }
 
-@lifetime(borrow outer)
+@_lifetime(borrow outer)
 func testBorrowStoredObject(outer: Outer) -> Span<Int> {
   outer._innerObject.span()
 }
 
-@lifetime(borrow outer)
+@_lifetime(borrow outer)
 func testBorrowTrivialAddressProjection(outer: Outer) -> Span<Int> {
   outer.innerTrivialAddress.span()
 }
 
-@lifetime(borrow outer)
+@_lifetime(borrow outer)
 func testBorrowObjectAddressProjection(outer: Outer) -> Span<Int> {
   outer.innerObjectAddress.span()
 }
@@ -535,14 +535,14 @@ func testLocalExtendObjectTemp(outer: Outer) {
   parse(span)
 }
 
-@lifetime(borrow outer)
+@_lifetime(borrow outer)
 func testReturnTrivialTemp(outer: Outer) -> Span<Int> {
   outer.innerTrivialTemp.span()
   // expected-error @-1{{lifetime-dependent value escapes its scope}}
   // expected-note  @-2{{it depends on the lifetime of this parent value}}
 } // expected-note {{this use causes the lifetime-dependent value to escape}}
 
-@lifetime(borrow outer)
+@_lifetime(borrow outer)
 func testReturnObjectTemp(outer: Outer) -> Span<Int> {
   outer.innerObjectTemp.span()
   // expected-error @-1{{lifetime-dependent value escapes its scope}}
@@ -554,25 +554,25 @@ func testReturnObjectTemp(outer: Outer) -> Span<Int> {
 // =============================================================================
 
 // @_addressableForDependencies supports returning a Span.
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func testAddressableInt(arg: AddressableInt) -> Span<Int> {
   arg.span()
 }
 
 // @_addressableForDependencies supports returning a Span.
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func testAddressableObject(arg: AddressableObject) -> Span<AnyObject> {
   arg.span()
 }
 
 // Helper: create a dependence on the argument's address.
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func dependsOnTrivialAddressHelper(arg: @_addressable TrivialHolder) -> Span<Int> {
   arg.span()
 }
 
 // Helper: create a dependence on the argument's address.
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func dependsOnAddressHelper(arg: @_addressable Holder) -> Span<Int> {
   arg.span()
 }
@@ -580,7 +580,7 @@ func dependsOnAddressHelper(arg: @_addressable Holder) -> Span<Int> {
 /* TODO: requires -enable-address-dependencies
 
 // Non-addressable error returning a Span.
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func testTrivialNonAddressable(arg: TrivialHolder) -> Span<Int> {
   dependsOnTrivialAddressHelper(arg: arg)
   // todo-error @-1{{lifetime-dependent value escapes its scope}
@@ -588,7 +588,7 @@ func testTrivialNonAddressable(arg: TrivialHolder) -> Span<Int> {
 } // todo-note  {{this use causes the lifetime-dependent value to escape}}
 
 // Non-addressable error returning a Span.
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func testNonAddressable(arg: Holder) -> Span<Int> {
   dependsOnAddressHelper(arg: arg)
   // todo-error @-1{{lifetime-dependent value escapes its scope}
@@ -597,13 +597,13 @@ func testNonAddressable(arg: Holder) -> Span<Int> {
 */
 
 /* TODO: rdar://145872854 (SILGen: @addressable inout arguments are copied)
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func test(arg: inout AddressableInt) -> Span<Int> {
   arg.span()
 }
 
 // unsafeAddress generates an addressable value with a local scope.
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func testBorrowedAddressableInt(arg: Holder) -> Int {
   let span = arg.addressableInt.span()
   return span[0]
@@ -611,7 +611,7 @@ func testBorrowedAddressableInt(arg: Holder) -> Int {
 
 // unsafeAddress generates an addressable value.
 // Error returning a dependence on its local scope.
-@lifetime(borrow arg)
+@_lifetime(borrow arg)
 func testBorrowedAddressableIntReturn(arg: Holder) -> Span<Int> {
   arg.addressableInt.span()
   // todo-error @-1{{lifetime-dependent value escapes its scope}

--- a/test/SILOptimizer/lifetime_dependence/stdlib_span.swift
+++ b/test/SILOptimizer/lifetime_dependence/stdlib_span.swift
@@ -4,10 +4,10 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-access-control \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // Test dependencies on the standard library Span APIs.
 
@@ -18,7 +18,7 @@
 extension UnsafeRawBufferPointer {
   @available(SwiftStdlib 6.2, *)
   public var storage: RawSpan {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get {
       let span = RawSpan(_unsafeBytes: self)
       return _overrideLifetime(span, borrowing: self)
@@ -37,14 +37,14 @@ func testUBPStorage(ubp: UnsafeRawBufferPointer) {
 }
 
 @available(SwiftStdlib 6.2, *)
-@lifetime(borrow ubp)
+@_lifetime(borrow ubp)
 func testUBPStorageReturn(ubp: UnsafeRawBufferPointer) -> RawSpan {
   // 'storage' can be returned since the function's return value also has a dependence on 'ubp'.
   return ubp.storage
 }
 
 @available(SwiftStdlib 6.2, *)
-@lifetime(borrow ubp)
+@_lifetime(borrow ubp)
 func testUBPStorageCopy(ubp: UnsafeRawBufferPointer) -> RawSpan {
   let localBuffer = ubp
   return localBuffer.storage // expected-error {{lifetime-dependent value escapes its scope}}

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -3,11 +3,11 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name Swift \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -o /dev/null
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // Verify diagnostics from the LifetimeDependenceDiagnostics pass.
 
@@ -25,7 +25,7 @@ struct NE : ~Escapable {}
 struct NEObject : ~Escapable {
   var c: C
 
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init()
 }
 

--- a/test/SILOptimizer/lifetime_dependence/verify_library_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_library_diagnostics.swift
@@ -7,11 +7,11 @@
 // RUN:   -enable-builtin-module \
 // RUN:   -module-name test \
 // RUN:   -define-availability "Span 0.1:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, visionOS 9999" \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature AddressableParameters
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_AddressableParameters
 
 // Test diagnostic output for interesting corner cases. Similar to semantics.swift, but this tests corner cases in the
@@ -23,7 +23,7 @@ public struct NE : ~Escapable {
 }
 
 public struct NEImmortal: ~Escapable {
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init() {}
 }
 
@@ -47,10 +47,10 @@ public struct NoncopyableImplicitAccessors : ~Copyable & ~Escapable {
   public var ne: NE
 
   public var neComputedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get { ne }
 
-    @lifetime(&self)
+    @_lifetime(&self)
     set {
       ne = newValue
     }

--- a/test/SILOptimizer/moveonly_addresschecker.swift
+++ b/test/SILOptimizer/moveonly_addresschecker.swift
@@ -1,20 +1,20 @@
 // RUN: %target-swift-emit-sil -sil-verify-all -verify \
 // RUN: -enable-experimental-feature NoImplicitCopy \
 // RUN: -enable-experimental-feature MoveOnlyClasses \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: -enable-experimental-feature BuiltinModule \
 // RUN: -Xllvm -sil-print-final-ossa-module %s | %FileCheck %s
 
 // RUN: %target-swift-emit-sil -O -sil-verify-all -verify \
 // RUN: -enable-experimental-feature NoImplicitCopy \
 // RUN: -enable-experimental-feature MoveOnlyClasses \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: -enable-experimental-feature BuiltinModule \
 // RUN: %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
 // REQUIRES: swift_feature_NoImplicitCopy
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_BuiltinModule
 
 // This file contains tests that used to crash due to verifier errors. It must
@@ -69,13 +69,13 @@ struct TestCoroAccessorOfCoroAccessor<T : ~Escapable> : ~Copyable & ~Escapable {
   var t: T
 
   var inner: TestCoroAccessorOfCoroAccessor<T> {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       fatalError()
     }
   }
   var outer: TestCoroAccessorOfCoroAccessor<T> {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield inner
     }

--- a/test/SILOptimizer/mutable_span_bounds_check_tests.swift
+++ b/test/SILOptimizer/mutable_span_bounds_check_tests.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module-path %t/SpanExtras.swiftmodule %S/Inputs/SpanExtras.swift -enable-builtin-module  -enable-experimental-feature LifetimeDependence -O
-// RUN: %target-swift-frontend -I %t -O -emit-sil %s -enable-experimental-feature LifetimeDependence -disable-availability-checking | %FileCheck %s --check-prefix=CHECK-SIL 
-// RUN: %target-swift-frontend -I %t -O -emit-ir %s -enable-experimental-feature LifetimeDependence -disable-availability-checking | %FileCheck %s --check-prefix=CHECK-IR
+// RUN: %target-swift-frontend -emit-module-path %t/SpanExtras.swiftmodule %S/Inputs/SpanExtras.swift -enable-builtin-module  -enable-experimental-feature Lifetimes -O
+// RUN: %target-swift-frontend -I %t -O -emit-sil %s -enable-experimental-feature Lifetimes -disable-availability-checking | %FileCheck %s --check-prefix=CHECK-SIL 
+// RUN: %target-swift-frontend -I %t -O -emit-ir %s -enable-experimental-feature Lifetimes -disable-availability-checking | %FileCheck %s --check-prefix=CHECK-IR
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
 
@@ -44,7 +44,7 @@ public func span_zero_init(_ output: inout MutableSpan<Int>) {
 // CHECK-IR: define {{.*}} void @"$s31mutable_span_bounds_check_tests0B14_copy_elemwiseyy10SpanExtras07MutableH0VySiGz_s0H0VySiGtF"
 // CHECK-IR: vector.body
 // CHECK-IR: store <{{.*}}>
-@lifetime(output: copy output, copy input)
+@_lifetime(output: copy output, copy input)
 public func span_copy_elemwise(_ output: inout MutableSpan<Int>, _ input: Span<Int>) {
   precondition(output.count >= input.count)
   for i in input.indices {
@@ -66,7 +66,7 @@ public func span_copy_elemwise(_ output: inout MutableSpan<Int>, _ input: Span<I
 // CHECK-IR: define {{.*}} void @"$s31mutable_span_bounds_check_tests0B16_append_elemwiseyy10SpanExtras06OutputH0VySiGz_s0H0VySiGtF"
 // CHECK-IR: vector.body
 // CHECK-IR: store <{{.*}}>
-@lifetime(output: copy output, copy input)
+@_lifetime(output: copy output, copy input)
 public func span_append_elemwise(_ output: inout OutputSpan<Int>, _ input: Span<Int>) {
   for i in input.indices {
     output.append(input[i])
@@ -85,7 +85,7 @@ public func span_append_elemwise(_ output: inout OutputSpan<Int>, _ input: Span<
 // CHECK-IR: define {{.*}} void @"$s31mutable_span_bounds_check_tests0B12_sum_wo_trapyy10SpanExtras07MutableI0VySiGz_s0I0VySiGAItF"
 // CHECK-IR: vector.body
 // CHECK-IR: store <{{.*}}>
-@lifetime(output: copy output, copy input1, copy input2)
+@_lifetime(output: copy output, copy input1, copy input2)
 public func span_sum_wo_trap(_ output: inout MutableSpan<Int>, _ input1: Span<Int>, _ input2: Span<Int>) {
   precondition(input1.count == input2.count)
   precondition(output.count == input1.count)
@@ -100,7 +100,7 @@ public func span_sum_wo_trap(_ output: inout MutableSpan<Int>, _ input1: Span<In
 // CHECK-SIL-NOT: cond_fail {{.*}}, "precondition failure"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s31mutable_span_bounds_check_tests0B14_sum_with_trapyy10SpanExtras07MutableI0VySiGz_s0I0VySiGAItF'
-@lifetime(output: copy input1, copy input2)
+@_lifetime(output: copy input1, copy input2)
 public func span_sum_with_trap(_ output: inout MutableSpan<Int>, _ input1: Span<Int>, _ input2: Span<Int>) {
   precondition(input1.count == input2.count)
   precondition(output.count == input1.count)

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -1,5 +1,5 @@
 // RUN: %target-sil-opt -sil-print-types -update-borrowed-from -test-runner \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: %s -o /dev/null 2>&1 | %FileCheck %s
 //
 // TODO: when complete lifetime verification become the default for SIL verification,
@@ -7,7 +7,7 @@
 // -disable-ownership-verification
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage canonical
 
@@ -39,7 +39,7 @@ sil @getC : $@convention(thin) () -> @owned C
 struct NE: ~Escapable {
   var object: C
 
-  @lifetime(borrow object)
+  @_lifetime(borrow object)
   init(object: borrowing C) { self.object = copy object }
 }
 

--- a/test/SILOptimizer/span_bounds_check_tests.swift
+++ b/test/SILOptimizer/span_bounds_check_tests.swift
@@ -1,15 +1,15 @@
 // RUN: %target-swift-frontend %s -emit-sil -O \
 // RUN:   -disable-availability-checking \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   | %FileCheck %s --check-prefix=CHECK-SIL
 
 // RUN: %target-swift-frontend %s -emit-ir -O \
 // RUN:   -disable-availability-checking \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   | %FileCheck %s  --check-prefix=CHECK-IR
 
 // REQUIRES: swift_in_compiler
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_stdlib_no_asserts, optimized_stdlib
 
 // Bounds check should be eliminated
@@ -328,7 +328,7 @@ public func mutate_span(_ v: inout Span<Int>) { }
 // CHECK-SIL-NOT: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests06inout_A33_sum_iterate_to_unknown_with_trapySis4SpanVySiGz_SitF'
-@lifetime(v: copy v)
+@_lifetime(v: copy v)
 public func inout_span_sum_iterate_to_unknown_with_trap(_ v: inout Span<Int>, _ n: Int) -> Int {
   var sum = 0
   for i in 0...n {
@@ -343,7 +343,7 @@ public func inout_span_sum_iterate_to_unknown_with_trap(_ v: inout Span<Int>, _ 
 // CHECK-SIL: cond_fail {{.*}}, "Index out of bounds"
 // CHECK-SIL: cond_br
 // CHECK-SIL-LABEL: } // end sil function '$s23span_bounds_check_tests06inout_A41_sum_iterate_to_unknown_with_trap_dontoptySis4SpanVySiGz_SitF'
-@lifetime(v: copy v)
+@_lifetime(v: copy v)
 public func inout_span_sum_iterate_to_unknown_with_trap_dontopt(_ v: inout Span<Int>, _ n: Int) -> Int {
   var sum = 0
   for i in 0...n {

--- a/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
+++ b/test/Sema/Inputs/lifetime_depend_infer.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name lifetime_depend_infer -enable-experimental-feature LifetimeDependence -swift-version 5 -enable-library-evolution
+// swift-module-flags: -module-name lifetime_depend_infer -enable-experimental-feature Lifetimes -swift-version 5 -enable-library-evolution
 import Swift
 import _Concurrency
 import _StringProcessing
@@ -11,7 +11,7 @@ import _SwiftConcurrencyShims
 public struct NE : ~Swift.Escapable {
 }
 public struct NEImmortal : ~Swift.Escapable {
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init()
 
 }
@@ -19,42 +19,42 @@ public struct NEImmortal : ~Swift.Escapable {
 public struct NonEscapableSelf : ~Swift.Escapable {
   public func methodNoParam() -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(self)
+  @_lifetime(self)
   public func methodNoParamLifetime() -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func methodNoParamCopy() -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func methodNoParamBorrow() -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(self)
+  @_lifetime(self)
   public mutating func mutatingMethodNoParamLifetime() -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public mutating func mutatingMethodNoParamCopy() -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func mutatingMethodNoParamBorrow() -> lifetime_depend_infer.NonEscapableSelf
   
   public func methodOneParam(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(self)
+  @_lifetime(self)
   public func methodOneParamLifetime(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public func methodOneParamCopy(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func methodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(self)
+  @_lifetime(self)
   public mutating func mutatingMethodOneParamLifetime(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public mutating func mutatingMethodOneParamCopy(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf
   
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func mutatingMethodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NonEscapableSelf 
 }
 
@@ -68,28 +68,28 @@ public struct NoncopyableInoutMethods : ~Swift.Copyable & ~Swift.Escapable {
 }
 
 public struct EscapableTrivialSelf {
-  @lifetime(self)
+  @_lifetime(self)
   public func methodNoParamLifetime() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func methodNoParamBorrow() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(self)
+  @_lifetime(self)
   public mutating func mutatingMethodNoParamLifetime() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func mutatingMethodNoParamBorrow() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(self)
+  @_lifetime(self)
   public func methodOneParamLifetime(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func methodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(self)
+  @_lifetime(self)
   public mutating func mutatingMethodOneParamLifetime(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func mutatingMethodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
 }
@@ -97,34 +97,34 @@ public struct EscapableNonTrivialSelf {
   public init(c: lifetime_depend_infer.C)
   public func methodNoParam() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(self)
+  @_lifetime(self)
   public func methodNoParamLifetime() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func methodNoParamBorrow() -> lifetime_depend_infer.NEImmortal
   
   public func mutatingMethodNoParam() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(self)
+  @_lifetime(self)
   public mutating func mutatingMethodNoParamLifetime() -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func mutatingMethodNoParamBorrow() -> lifetime_depend_infer.NEImmortal
   
   public func methodOneParam(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(self)
+  @_lifetime(self)
   public func methodOneParamLifetime(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   public func methodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
   public mutating func mutatingMethodOneParam(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(self)
+  @_lifetime(self)
   public mutating func mutatingMethodOneParamLifetime(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func mutatingMethodOneParamBorrow(_: Swift.Int) -> lifetime_depend_infer.NEImmortal
   
 }
@@ -152,40 +152,40 @@ public struct NonescapableInoutInitializers : ~Swift.Escapable {
   public init(c: inout lifetime_depend_infer.C)
   
 }
-@lifetime(immortal)
+@_lifetime(immortal)
 public func noParamImmortal() -> lifetime_depend_infer.NEImmortal
 
-@lifetime(c)
+@_lifetime(c)
 public func oneParamLifetime(c: lifetime_depend_infer.C) -> lifetime_depend_infer.NEImmortal
 
 public func oneParamBorrow(c: borrowing lifetime_depend_infer.C) -> lifetime_depend_infer.NEImmortal
 
-@lifetime(c)
+@_lifetime(c)
 public func oneParamBorrowLifetime(c: borrowing lifetime_depend_infer.C) -> lifetime_depend_infer.NEImmortal
 
 public func oneParamInout(c: inout lifetime_depend_infer.C) -> lifetime_depend_infer.NEImmortal
 
-@lifetime(c)
+@_lifetime(c)
 public func oneParamInoutLifetime(c: inout lifetime_depend_infer.C) -> lifetime_depend_infer.NEImmortal
 
-@lifetime(c)
+@_lifetime(c)
 public func twoParamsLifetime(c: lifetime_depend_infer.C, _: Swift.Int) -> lifetime_depend_infer.NEImmortal
 
 public func twoParamsBorrow(c: borrowing lifetime_depend_infer.C, _: Swift.Int) -> lifetime_depend_infer.NEImmortal
 
 public func neParam(ne: lifetime_depend_infer.NE) -> lifetime_depend_infer.NE
 
-@lifetime(ne)
+@_lifetime(ne)
 public func neParamLifetime(ne: lifetime_depend_infer.NE) -> lifetime_depend_infer.NE
 
 public func neParamBorrow(ne: borrowing lifetime_depend_infer.NE) -> lifetime_depend_infer.NE
 
-@lifetime(ne)
+@_lifetime(ne)
 public func neParamBorrowLifetime(ne: borrowing lifetime_depend_infer.NE) -> lifetime_depend_infer.NE
 
 public func neParamConsume(ne: consuming lifetime_depend_infer.NE) -> lifetime_depend_infer.NE
 
-@lifetime(ne)
+@_lifetime(ne)
 public func neParamConsumeLifetime(ne: consuming lifetime_depend_infer.NE) -> lifetime_depend_infer.NE
 
 public func neTwoParam(ne: lifetime_depend_infer.NE, _: Swift.Int) -> lifetime_depend_infer.NE
@@ -207,7 +207,7 @@ public struct NonescapableSelfAccessors : ~Swift.Escapable {
   
   public var neYielded: lifetime_depend_infer.NE {
     _read
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify
   }
   
@@ -221,49 +221,49 @@ public struct NoncopyableSelfAccessors : ~Copyable & ~Escapable {
   
   public var neYielded: lifetime_depend_infer.NE {
     _read
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify
   }
   
   public var neComputedLifetime: lifetime_depend_infer.NE {
-    @lifetime(self)
+    @_lifetime(self)
     get
-    @lifetime(self)
+    @_lifetime(self)
     set
   }
   
   public var neYieldedLifetime: lifetime_depend_infer.NE {
-    @lifetime(self)
+    @_lifetime(self)
     _read
-    @lifetime(self)
+    @_lifetime(self)
     _modify
   }
   
   public var neComputedCopy: lifetime_depend_infer.NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get
-    @lifetime(copy self)
+    @_lifetime(copy self)
     set
   }
   
   public var neYieldedCopy: lifetime_depend_infer.NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _modify
   }
   
   public var neComputedBorrow: lifetime_depend_infer.NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get
-    @lifetime(&self)
+    @_lifetime(&self)
     set
   }
   
   public var neYieldedBorrow: lifetime_depend_infer.NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _read
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify
   }
 }
@@ -271,19 +271,19 @@ public struct NoncopyableSelfAccessors : ~Copyable & ~Escapable {
 public struct NonEscapableMutableSelf : ~Swift.Escapable {
   public mutating func mutatingMethodNoParam()
   
-  @lifetime(self: self)
+  @_lifetime(self: self)
   public mutating func mutatingMethodNoParamLifetime()
   
-  @lifetime(self: copy self)
+  @_lifetime(self: copy self)
   public mutating func mutatingMethodNoParamCopy()
   
-  @lifetime(self: self)
+  @_lifetime(self: self)
   public mutating func mutatingMethodOneParamLifetime(_: lifetime_depend_infer.NE)
   
-  @lifetime(copy self)
+  @_lifetime(copy self)
   public mutating func mutatingMethodOneParamCopy(_: lifetime_depend_infer.NE)
   
-  @lifetime(&self)
+  @_lifetime(&self)
   public mutating func mutatingMethodOneParamBorrow(_: lifetime_depend_infer.NE)
 }
 #endif

--- a/test/Sema/escapable_substitution_lifetime_dependency.swift
+++ b/test/Sema/escapable_substitution_lifetime_dependency.swift
@@ -1,8 +1,8 @@
-// RUN: %target-swift-frontend -enable-experimental-feature LifetimeDependence -emit-sil -verify %s
+// RUN: %target-swift-frontend -enable-experimental-feature Lifetimes -emit-sil -verify %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
-@lifetime(copy x)
+@_lifetime(copy x)
 func id<T: ~Escapable>(_ x: T) -> T {
     return x
 }
@@ -25,7 +25,7 @@ func doubleidGeneric<U>(_: U.Type) -> (U) -> U {
     return double(id)
 }
 
-@lifetime(x: copy y)
+@_lifetime(x: copy y)
 func overwrite<T: ~Escapable>(_ x: inout T, _ y: T) {
     x = y
 }

--- a/test/Sema/implicit_lifetime_dependence.swift
+++ b/test/Sema/implicit_lifetime_dependence.swift
@@ -1,11 +1,11 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature LifetimeDependence
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Lifetimes
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct BufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeRawBufferPointer?
   let c: Int
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   init(_ ptr: UnsafeRawBufferPointer?, _ c: Int) {
     self.ptr = ptr
     self.c = c
@@ -26,7 +26,7 @@ struct ImplicitInit3 : ~Escapable, ~Copyable {
 }
 
 func foo1() -> BufferView { // expected-error{{a function with a ~Escapable result needs a parameter to depend on}}
-  // expected-note@-1{{'@lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
+  // expected-note@-1{{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
   return BufferView(nil, 0)
 }
 

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -1,46 +1,46 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature LifetimeDependence
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature Lifetimes
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct NE : ~Escapable {
-  @lifetime(copy self) // expected-error{{invalid lifetime dependence specifier on non-existent self}}
+  @_lifetime(copy self) // expected-error{{invalid lifetime dependence specifier on non-existent self}}
   init() {}
 }
 
-@lifetime(copy nonexisting) // expected-error{{invalid parameter name specified 'nonexisting'}}
+@_lifetime(copy nonexisting) // expected-error{{invalid parameter name specified 'nonexisting'}}
 func invalidAttrOnNonExistingParam(_ ne: NE) -> NE {
   ne
 }
 
-@lifetime(copy self) // expected-error{{invalid lifetime dependence specifier on non-existent self}}
+@_lifetime(copy self) // expected-error{{invalid lifetime dependence specifier on non-existent self}}
 func invalidAttrOnNonExistingSelf(_ ne: NE) -> NE {
   ne
 }
 
-@lifetime(2) // expected-error{{invalid parameter index specified '2'}}
+@_lifetime(2) // expected-error{{invalid parameter index specified '2'}}
 func invalidAttrOnNonExistingParamIndex(_ ne: NE) -> NE {
   ne
 }
 
-@lifetime(copy ne, borrow ne) // expected-error{{duplicate lifetime dependence specifier}}
+@_lifetime(copy ne, borrow ne) // expected-error{{duplicate lifetime dependence specifier}}
 func invalidDuplicateLifetimeDependence1(_ ne: borrowing NE) -> NE {
   ne
 }
 
 class Klass {}
 
-@lifetime(borrow x) // expected-error{{invalid use of borrow dependence with consuming ownership}}
+@_lifetime(borrow x) // expected-error{{invalid use of borrow dependence with consuming ownership}}
 func invalidDependence(_ x: consuming Klass) -> NE {
   NE()
 }
 
-@lifetime(result: copy source) 
-@lifetime(result: borrow source) // TODO: display error here
+@_lifetime(result: copy source) 
+@_lifetime(result: borrow source) // TODO: display error here
 func invalidTarget(_ result: inout NE, _ source: consuming NE) { // expected-error{{invalid duplicate target lifetime dependencies on function}}
   result = source
 }
 
-@lifetime(immortal)
+@_lifetime(immortal)
 func immortalConflict(_ immortal: Int) -> NE { // expected-error{{conflict between the parameter name and 'immortal' contextual keyword}}
   NE()
 }
@@ -61,25 +61,25 @@ do {
 }
 
 // rdar://146401190 ([nonescapable] implement non-inout parameter dependencies)
-@lifetime(span: borrow holder)
+@_lifetime(span: borrow holder)
 func testParameterDep(holder: AnyObject, span: Span<Int>) {}  // expected-error{{lifetime-dependent parameter must be 'inout'}}
 
-@lifetime(&ne)
+@_lifetime(&ne)
 func inoutLifetimeDependence(_ ne: inout NE) -> NE {
   ne
 }
 
-@lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&k)' instead}}
+@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&k)' instead}}
 func dependOnEscapable(_ k: inout Klass) -> NE {
   NE()
 }
 
-@lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow k)' instead}}
+@_lifetime(copy k) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow k)' instead}}
 func dependOnEscapable(_ k: borrowing Klass) -> NE { 
   NE()
 }
 
-@lifetime(copy k) // expected-error{{invalid lifetime dependence on an Escapable value with consuming ownership}}
+@_lifetime(copy k) // expected-error{{invalid lifetime dependence on an Escapable value with consuming ownership}}
 func dependOnEscapable(_ k: consuming Klass) -> NE { 
   NE()
 }

--- a/test/Sema/lifetime_attr_nofeature.swift
+++ b/test/Sema/lifetime_attr_nofeature.swift
@@ -4,7 +4,7 @@
 struct NE : ~Escapable { // expected-error{{an implicit initializer cannot return a ~Escapable result}}
 }
 
-@lifetime(copy ne) // expected-error{{'@lifetime' attribute is only valid when experimental feature LifetimeDependence is enabled}} expected-error{{expected declaration}}
+@_lifetime(copy ne) // expected-error{{'@_lifetime' attribute is only valid when experimental feature Lifetimes is enabled}}
 func derive(_ ne: NE) -> NE { // expected-error{{a function cannot return a ~Escapable result}}
   ne
 }

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // Coverage testing for LifetimeDependence inferrence logic. The tests are grouped according to the design of
 // LifetimeDependenceChecker.
@@ -11,7 +11,7 @@ class C {}
 struct NE: ~Escapable {}
 
 struct NEImmortal: ~Escapable {
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init() {}
 }
 
@@ -20,96 +20,96 @@ struct NEImmortal: ~Escapable {
 // =============================================================================
 
 struct NonEscapableSelf: ~Escapable {
-  func methodNoParam() -> NonEscapableSelf { self } // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+  func methodNoParam() -> NonEscapableSelf { self } // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
 
-  @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+  @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
   func methodNoParamLifetime() -> NonEscapableSelf { self }
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   func methodNoParamCopy() -> NonEscapableSelf { self }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodNoParamBorrow() -> NonEscapableSelf { self }
 
-  mutating func mutatingMethodNoParam() -> NonEscapableSelf { self } // expected-error{{a mutating method with a ~Escapable result requires '@lifetime(...)'}}
- // expected-error@-1{{a mutating method with a ~Escapable 'self' requires '@lifetime(self: ...)'}}
+  mutating func mutatingMethodNoParam() -> NonEscapableSelf { self } // expected-error{{a mutating method with a ~Escapable result requires '@_lifetime(...)'}}
+ // expected-error@-1{{a mutating method with a ~Escapable 'self' requires '@_lifetime(self: ...)'}}
 
-  @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+  @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
   mutating func mutatingMethodNoParamLifetime() -> NonEscapableSelf { self }
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   mutating func mutatingMethodNoParamCopy() -> NonEscapableSelf { self }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   mutating func mutatingMethodNoParamBorrow() -> NonEscapableSelf { self }
 
-  func methodOneParam(_: Int) -> NonEscapableSelf { self } // expected-error{{a method with a ~Escapable result requires '@lifetime(...)'}}
+  func methodOneParam(_: Int) -> NonEscapableSelf { self } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)'}}
 
-  @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+  @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
   func methodOneParamLifetime(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   func methodOneParamCopy(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodOneParamBorrow(_: Int) -> NonEscapableSelf { self }
 
-  mutating func mutatingMethodOneParam(_: Int) -> NonEscapableSelf { self } // expected-error{{a mutating method with a ~Escapable result requires '@lifetime(...)'}}
-  // expected-error@-1{{a mutating method with a ~Escapable 'self' requires '@lifetime(self: ...)'}}
+  mutating func mutatingMethodOneParam(_: Int) -> NonEscapableSelf { self } // expected-error{{a mutating method with a ~Escapable result requires '@_lifetime(...)'}}
+  // expected-error@-1{{a mutating method with a ~Escapable 'self' requires '@_lifetime(self: ...)'}}
 
-  @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+  @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   mutating func mutatingMethodOneParamCopy(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   mutating func mutatingMethodOneParamBorrow(_: Int) -> NonEscapableSelf { self }
 }
 
 struct EscapableTrivialSelf {
   func methodNoParam() -> NEImmortal { NEImmortal() } // expected-error{{cannot infer lifetime dependence on a method because 'self' is BitwiseCopyable}}
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   func methodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
   func methodNoParamCopy() -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
   func mutatingMethodNoParam() -> NEImmortal { NEImmortal() } // expected-error{{cannot infer lifetime dependence on a method because 'self' is BitwiseCopyable}}
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   mutating func mutatingMethodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
   mutating func mutatingMethodNoParamCopy() -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   mutating func mutatingMethodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
-  func methodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a method with a ~Escapable result requires '@lifetime(...)'}}
+  func methodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)'}}
 
-  @lifetime(self)
+  @_lifetime(self)
   func methodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
   func methodOneParamCopy(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   func methodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 
-  mutating func mutatingMethodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a mutating method with a ~Escapable result requires '@lifetime(...)'}}
+  mutating func mutatingMethodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a mutating method with a ~Escapable result requires '@_lifetime(...)'}}
 
-  @lifetime(self)
+  @_lifetime(self)
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
   mutating func mutatingMethodOneParamCopy(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   mutating func mutatingMethodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 }
 
@@ -120,13 +120,13 @@ struct EscapableNonTrivialSelf {
 
   func methodNoParam() -> NEImmortal { NEImmortal() }
 
-  @lifetime(self)
+  @_lifetime(self)
   func methodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
   func methodNoParamCopy() -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   func methodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
   mutating func mutatingMethodNoParam() -> NEImmortal { NEImmortal() }
@@ -135,35 +135,35 @@ struct EscapableNonTrivialSelf {
 
   mutating func mutatingMethodInoutNonEscapableParam(_: inout NE) {}
 
-  @lifetime(self)
+  @_lifetime(self)
   mutating func mutatingMethodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
   mutating func mutatingMethodNoParamCopy() -> NEImmortal { NEImmortal() }
 
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating func mutatingMethodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
-  func methodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a method with a ~Escapable result requires '@lifetime(...)'}}
+  func methodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)'}}
 
-  @lifetime(self)
+  @_lifetime(self)
   func methodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(borrow self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(borrow self)' instead}}
   func methodOneParamCopy(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   func methodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 
-  mutating func mutatingMethodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a mutating method with a ~Escapable result requires '@lifetime(...)'}}
+  mutating func mutatingMethodOneParam(_: Int) -> NEImmortal { NEImmortal() } // expected-error{{a mutating method with a ~Escapable result requires '@_lifetime(...)'}}
 
-  @lifetime(self)
+  @_lifetime(self)
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@lifetime(&self)' instead}}
+  @_lifetime(copy self) // expected-error{{cannot copy the lifetime of an Escapable type, use '@_lifetime(&self)' instead}}
   mutating func mutatingMethodOneParamCopy(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating func mutatingMethodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 }
 
@@ -182,13 +182,13 @@ struct NonescapableInitializers: ~Escapable {
   var c: C
 
   init() { c = C() } // expected-error{{an initializer with a ~Escapable result needs a parameter to depend on}}
-  // expected-note@-1{{'@lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
+  // expected-note@-1{{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
  
   init(c: C) { self.c = c } // expected-error{{cannot borrow the lifetime of 'c', which has consuming ownership on an initializer}}
 
-  init(c: C, _: Int) { self.c = c } // expected-error{{an initializer with a ~Escapable result requires '@lifetime(...)'}}
+  init(c: C, _: Int) { self.c = c } // expected-error{{an initializer with a ~Escapable result requires '@_lifetime(...)'}}
 
-  init(ne: NE) { c = C() } // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+  init(ne: NE) { c = C() } // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 }
 
 struct NonescapableConsumingInitializers: ~Escapable {
@@ -196,9 +196,9 @@ struct NonescapableConsumingInitializers: ~Escapable {
 
   init(c: consuming C) { self.c = c } // expected-error{{cannot borrow the lifetime of 'c', which has consuming ownership on an initializer}}
 
-  init(c: consuming C, _: Int) { self.c = c } // expected-error{{an initializer with a ~Escapable result requires '@lifetime(...)'}}
+  init(c: consuming C, _: Int) { self.c = c } // expected-error{{an initializer with a ~Escapable result requires '@_lifetime(...)'}}
 
-  init(ne: consuming NE) { c = C() } // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+  init(ne: consuming NE) { c = C() } // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 }
 
 struct NonescapableBorrowingInitializers: ~Escapable {
@@ -206,9 +206,9 @@ struct NonescapableBorrowingInitializers: ~Escapable {
 
   init(c: borrowing C) { self.c = c } // OK
 
-  init(c: borrowing C, _: Int) { self.c = c } // expected-error{{an initializer with a ~Escapable result requires '@lifetime(...)'}}
+  init(c: borrowing C, _: Int) { self.c = c } // expected-error{{an initializer with a ~Escapable result requires '@_lifetime(...)'}}
 
-  init(ne: borrowing NE) { c = C() } // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+  init(ne: borrowing NE) { c = C() } // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 }
 
 struct NonescapableInoutInitializers: ~Escapable {
@@ -216,69 +216,69 @@ struct NonescapableInoutInitializers: ~Escapable {
 
   init(c: inout C) { self.c = c } // OK
 
-  init(c: inout C, _: Int) { self.c = c } // expected-error{{an initializer with a ~Escapable result requires '@lifetime(...)'}}
+  init(c: inout C, _: Int) { self.c = c } // expected-error{{an initializer with a ~Escapable result requires '@_lifetime(...)'}}
 
-  init(ne: inout NE) { c = C() } // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+  init(ne: inout NE) { c = C() } // expected-error{{cannot infer the lifetime dependence scope on an initializer with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 }
 
 func noParam() -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result needs a parameter to depend on}}
-// expected-note@-1{{'@lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
+// expected-note@-1{{'@_lifetime(immortal)' can be used to indicate that values produced by this initializer have no lifetime dependencies}}
 
-@lifetime(immortal)
+@_lifetime(immortal)
 func noParamImmortal() -> NEImmortal { NEImmortal() } // OK
 
 func oneParam(c: C) -> NEImmortal { NEImmortal() }
 
-@lifetime(c)
+@_lifetime(c)
 func oneParamLifetime(c: C) -> NEImmortal { NEImmortal() }
 
 func oneParamConsume(c: consuming C) -> NEImmortal { NEImmortal() } // expected-error{{cannot borrow the lifetime of 'c', which has consuming ownership on a function}}
 
-@lifetime(c) // expected-error{{invalid lifetime dependence on an Escapable value with consuming ownership}}
+@_lifetime(c) // expected-error{{invalid lifetime dependence on an Escapable value with consuming ownership}}
 func oneParamConsumeLifetime(c: consuming C) -> NEImmortal { NEImmortal() }
 
 func oneParamBorrow(c: borrowing C) -> NEImmortal { NEImmortal() } // OK
 
-@lifetime(c)
+@_lifetime(c)
 func oneParamBorrowLifetime(c: borrowing C) -> NEImmortal { NEImmortal() } // OK
 
 func oneParamInout(c: inout C) -> NEImmortal { NEImmortal() } // OK
 
-@lifetime(c)
+@_lifetime(c)
 func oneParamInoutLifetime(c: inout C) -> NEImmortal { NEImmortal() } // OK
 
-func twoParams(c: C, _: Int) -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result requires '@lifetime(...)'}}
+func twoParams(c: C, _: Int) -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result requires '@_lifetime(...)'}}
 
-@lifetime(c)
+@_lifetime(c)
 func twoParamsLifetime(c: C, _: Int) -> NEImmortal { NEImmortal() }
 
-func twoParamsConsume(c: consuming C, _: Int) -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result requires '@lifetime(...)'}}
+func twoParamsConsume(c: consuming C, _: Int) -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result requires '@_lifetime(...)'}}
 
-func twoParamsBorrow(c: borrowing C, _: Int) -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result requires '@lifetime(...)'}}
+func twoParamsBorrow(c: borrowing C, _: Int) -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result requires '@_lifetime(...)'}}
 
-func twoParamsInout(c: inout C, _: Int) -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result requires '@lifetime(...)'}}
+func twoParamsInout(c: inout C, _: Int) -> NEImmortal { NEImmortal() } // expected-error{{a function with a ~Escapable result requires '@_lifetime(...)'}}
 
-func neParam(ne: NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+func neParam(ne: NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 
-@lifetime(ne) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+@_lifetime(ne) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 func neParamLifetime(ne: NE) -> NE { ne }
 
-func neParamBorrow(ne: borrowing NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+func neParamBorrow(ne: borrowing NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 
-@lifetime(ne) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+@_lifetime(ne) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 func neParamBorrowLifetime(ne: borrowing NE) -> NE { ne }
 
-func neParamConsume(ne: consuming NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+func neParamConsume(ne: consuming NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 
-@lifetime(ne) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+@_lifetime(ne) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 func neParamConsumeLifetime(ne: consuming NE) -> NE { ne }
 
-func neParamInout(ne: inout NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+func neParamInout(ne: inout NE) -> NE { ne } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 
-@lifetime(ne) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow ne)' or '@lifetime(copy ne)'}}
+@_lifetime(ne) // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
 func neParamInoutLifetime(ne: inout NE) -> NE { ne }
 
-func neTwoParam(ne: NE, _:Int) -> NE { ne } // expected-error{{a function with a ~Escapable result requires '@lifetime(...)'}}
+func neTwoParam(ne: NE, _:Int) -> NE { ne } // expected-error{{a function with a ~Escapable result requires '@_lifetime(...)'}}
 
 func voidInoutOneParam(_: inout NE) {} // OK
 
@@ -321,99 +321,99 @@ struct Accessors {
 struct NonescapableSelfAccessors: ~Escapable {
   var ne: NE
 
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init() {
     ne = NE()
   }
 
   var neComputed: NE {
-    get { // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    get { // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
       ne
     }
 
-    set { // expected-error{{a mutating method with a ~Escapable 'self' requires '@lifetime(self: ...)'}}
+    set { // expected-error{{a mutating method with a ~Escapable 'self' requires '@_lifetime(self: ...)'}}
       ne = newValue
     }
   }
 
   var neYielded: NE {
-    _read { // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    _read { // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
       yield ne
     }
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _modify {
       yield &ne
     }
   }
 
   var neComputedLifetime: NE {
-    @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
     get {
       ne
     }
 
-    @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
     set {
       ne = newValue
     }
   }
 
   var neYieldedLifetime: NE {
-    @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
     _read {
       yield ne
     }
 
-    @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
     _modify {
       yield &ne
     }
   }
 
   var neComputedCopy: NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       ne
     }
 
-    @lifetime(copy self)
+    @_lifetime(copy self)
     set {
       ne = newValue
     }
   }
 
   var neYieldedCopy: NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield ne
     }
 
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _modify {
       yield &ne
     }
   }
 
   var neComputedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get {
       ne
     }
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     set {
       ne = newValue
     }
   }
 
   var neYieldedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _read {
       yield ne
     }
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _modify {
       yield &ne
     }
@@ -424,93 +424,93 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
   var ne: NE
 
   var neComputed: NE {
-    get { // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    get { // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
       ne
     }
 
-    set { // expected-error{{a mutating method with a ~Escapable 'self' requires '@lifetime(self: ...)'}}
+    set { // expected-error{{a mutating method with a ~Escapable 'self' requires '@_lifetime(self: ...)'}}
       ne = newValue
     }
   }
 
   var neYielded: NE {
-    _read { // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    _read { // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
       yield ne
     }
 
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify {
       yield &ne
     }
   }
 
   var neComputedLifetime: NE {
-    @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
     get {
       ne
     }
 
-    @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
     set {
       ne = newValue
     }
   }
 
   var neYieldedLifetime: NE {
-    @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
     _read {
       yield ne
     }
 
-    @lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+    @_lifetime(self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
     _modify {
       yield &ne
     }
   }
 
   var neComputedCopy: NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       ne
     }
 
-    @lifetime(copy self)
+    @_lifetime(copy self)
     set {
       ne = newValue
     }
   }
 
   var neYieldedCopy: NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield ne
     }
 
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _modify {
       yield &ne
     }
   }
 
   var neComputedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get {
       ne
     }
 
-    @lifetime(&self)
+    @_lifetime(&self)
     set {
       ne = newValue
     }
   }
 
   var neYieldedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _read {
       yield ne
     }
 
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify {
       yield &ne
     }
@@ -524,26 +524,26 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
 struct NonEscapableMutableSelf: ~Escapable {
   // This is unambiguous: inout 'self' needs a dependency, and it can't be a borrow dependency because the original
   // value is consumed.
-  /* @lifetime(self: copy self) */
+  /* @_lifetime(self: copy self) */
   mutating func mutatingMethodNoParam() {} // OK
 
-  @lifetime(self: self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+  @_lifetime(self: self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
   mutating func mutatingMethodNoParamLifetime() {}
 
-  @lifetime(self: copy self) // OK
+  @_lifetime(self: copy self) // OK
   mutating func mutatingMethodNoParamCopy() {}
 
-  @lifetime(self: borrow self) // expected-error{{invalid use of borrow dependence on the same inout parameter}}
+  @_lifetime(self: borrow self) // expected-error{{invalid use of borrow dependence on the same inout parameter}}
   mutating func mutatingMethodNoParamBorrow() {}
 
-  mutating func mutatingMethodOneParam(_: NE) {} // expected-error{{a mutating method with a ~Escapable 'self' requires '@lifetime(self: ...)'}}
+  mutating func mutatingMethodOneParam(_: NE) {} // expected-error{{a mutating method with a ~Escapable 'self' requires '@_lifetime(self: ...)'}}
 
-  @lifetime(self: self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@lifetime(borrow self)' or '@lifetime(copy self)'}}
+  @_lifetime(self: self) // expected-error{{cannot infer the lifetime dependence scope on a mutating method with a ~Escapable parameter, specify '@_lifetime(borrow self)' or '@_lifetime(copy self)'}}
   mutating func mutatingMethodOneParamLifetime(_: NE) {}
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   mutating func mutatingMethodOneParamCopy(_: NE) {}
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   mutating func mutatingMethodOneParamBorrow(_: NE) {}
 }

--- a/test/Sema/lifetime_depend_infer_lazy.swift
+++ b/test/Sema/lifetime_depend_infer_lazy.swift
@@ -1,8 +1,8 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-lifetime-dependence-inference
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // Coverage testing for LifetimeDependence inferrence logic. The tests are grouped according to the design of
 // LifetimeDependenceChecker.
@@ -12,7 +12,7 @@ class C {}
 struct NE: ~Escapable {}
 
 struct NEImmortal: ~Escapable {
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init() {}
 }
 
@@ -23,68 +23,68 @@ struct NEImmortal: ~Escapable {
 struct NonEscapableSelf: ~Escapable {
   func methodNoParam() -> NonEscapableSelf { self } // OK
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   func methodNoParamLifetime() -> NonEscapableSelf { self }
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   func methodNoParamCopy() -> NonEscapableSelf { self }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodNoParamBorrow() -> NonEscapableSelf { self }
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   mutating func mutatingMethodNoParamLifetime() -> NonEscapableSelf { self }
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   mutating func mutatingMethodNoParamCopy() -> NonEscapableSelf { self }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   mutating func mutatingMethodNoParamBorrow() -> NonEscapableSelf { self }
 
   func methodOneParam(_: Int) -> NonEscapableSelf { self } // OK
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   func methodOneParamLifetime(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   func methodOneParamCopy(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodOneParamBorrow(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   mutating func mutatingMethodOneParamCopy(_: Int) -> NonEscapableSelf { self }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   mutating func mutatingMethodOneParamBorrow(_: Int) -> NonEscapableSelf { self }
 }
 
 struct EscapableTrivialSelf {
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   func methodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   mutating func mutatingMethodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   mutating func mutatingMethodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   func methodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   mutating func mutatingMethodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 }
 
@@ -95,34 +95,34 @@ struct EscapableNonTrivialSelf {
 
   func methodNoParam() -> NEImmortal { NEImmortal() } // OK
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   func methodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
   func mutatingMethodNoParam() -> NEImmortal { NEImmortal() } // OK
 
-  @lifetime(self)
+  @_lifetime(self)
   mutating func mutatingMethodNoParamLifetime() -> NEImmortal { NEImmortal() }
 
-  @lifetime(&self)
+  @_lifetime(&self)
   mutating func mutatingMethodNoParamBorrow() -> NEImmortal { NEImmortal() }
 
   func methodOneParam(_: Int) -> NEImmortal { NEImmortal() } // OK
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   func methodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(borrow self) // OK
+  @_lifetime(borrow self) // OK
   func methodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 
   mutating func mutatingMethodOneParam(_: Int) -> NEImmortal { NEImmortal() } // OK
 
-  @lifetime(self) // OK
+  @_lifetime(self) // OK
   mutating func mutatingMethodOneParamLifetime(_: Int) -> NEImmortal { NEImmortal() }
 
-  @lifetime(&self) // OK
+  @_lifetime(&self) // OK
   mutating func mutatingMethodOneParamBorrow(_: Int) -> NEImmortal { NEImmortal() }
 }
 
@@ -159,40 +159,40 @@ struct NonescapableInoutInitializers: ~Escapable {
   init(c: inout C) { self.c = copy c } // OK
 }
 
-@lifetime(immortal)
+@_lifetime(immortal)
 func noParamImmortal() -> NEImmortal { NEImmortal() } // OK
 
-@lifetime(c)
+@_lifetime(c)
 func oneParamLifetime(c: C) -> NEImmortal { NEImmortal() }
 
 func oneParamBorrow(c: borrowing C) -> NEImmortal { NEImmortal() } // OK
 
-@lifetime(c)
+@_lifetime(c)
 func oneParamBorrowLifetime(c: borrowing C) -> NEImmortal { NEImmortal() } // OK
 
 func oneParamInout(c: inout C) -> NEImmortal { NEImmortal() } // OK
 
-@lifetime(c)
+@_lifetime(c)
 func oneParamInoutLifetime(c: inout C) -> NEImmortal { NEImmortal() } // OK
 
-@lifetime(c)
+@_lifetime(c)
 func twoParamsLifetime(c: C, _: Int) -> NEImmortal { NEImmortal() }
 
 func twoParamsBorrow(c: borrowing C, _: Int) -> NEImmortal { NEImmortal() } // OK
 
 func neParam(ne: NE) -> NE { ne } // OK
 
-@lifetime(ne) // OK
+@_lifetime(ne) // OK
 func neParamLifetime(ne: NE) -> NE { ne }
 
 func neParamBorrow(ne: borrowing NE) -> NE { copy ne } // OK
 
-@lifetime(ne) // OK
+@_lifetime(ne) // OK
 func neParamBorrowLifetime(ne: borrowing NE) -> NE { copy ne }
 
 func neParamConsume(ne: consuming NE) -> NE { ne } // OK
 
-@lifetime(ne) // OK
+@_lifetime(ne) // OK
 func neParamConsumeLifetime(ne: consuming NE) -> NE { ne }
 
 func neTwoParam(ne: NE, _:Int) -> NE { ne } // OK
@@ -234,7 +234,7 @@ struct Accessors {
 struct NonescapableSelfAccessors: ~Escapable {
   var ne: NE
 
-  @lifetime(immortal)
+  @_lifetime(immortal)
   init() {
     ne = NE()
   }
@@ -254,79 +254,79 @@ struct NonescapableSelfAccessors: ~Escapable {
       yield ne
     }
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _modify {
       yield &ne
     }
   }
 
   var neComputedLifetime: NE {
-    @lifetime(self) // OK
+    @_lifetime(self) // OK
     get {
       ne
     }
 
-    @lifetime(self) // OK
+    @_lifetime(self) // OK
     set {
       ne = newValue
     }
   }
 
   var neYieldedLifetime: NE {
-    @lifetime(self) // OK
+    @_lifetime(self) // OK
     _read {
       yield ne
     }
 
-    @lifetime(self) // OK
+    @_lifetime(self) // OK
     _modify {
       yield &ne
     }
   }
 
   var neComputedCopy: NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       ne
     }
 
-    @lifetime(copy self)
+    @_lifetime(copy self)
     set {
       ne = newValue
     }
   }
 
   var neYieldedCopy: NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield ne
     }
 
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _modify {
       yield &ne
     }
   }
 
   var neComputedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get {
       ne
     }
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     set {
       ne = newValue
     }
   }
 
   var neYieldedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _read {
       yield ne
     }
 
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _modify {
       yield &ne
     }
@@ -351,79 +351,79 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
       yield ne
     }
 
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify {
       yield &ne
     }
   }
 
   var neComputedLifetime: NE {
-    @lifetime(self) // OK
+    @_lifetime(self) // OK
     get {
       ne
     }
 
-    @lifetime(self) // OK
+    @_lifetime(self) // OK
     set {
       ne = newValue
     }
   }
 
   var neYieldedLifetime: NE {
-    @lifetime(self) // OK
+    @_lifetime(self) // OK
     _read {
       yield ne
     }
 
-    @lifetime(self) // OK
+    @_lifetime(self) // OK
     _modify {
       yield &ne
     }
   }
 
   var neComputedCopy: NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     get {
       ne
     }
 
-    @lifetime(copy self)
+    @_lifetime(copy self)
     set {
       ne = newValue
     }
   }
 
   var neYieldedCopy: NE {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield ne
     }
 
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _modify {
       yield &ne
     }
   }
 
   var neComputedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     get {
       ne
     }
 
-    @lifetime(&self)
+    @_lifetime(&self)
     set {
       ne = newValue
     }
   }
 
   var neYieldedBorrow: NE {
-    @lifetime(borrow self)
+    @_lifetime(borrow self)
     _read {
       yield ne
     }
 
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify {
       yield &ne
     }
@@ -437,18 +437,18 @@ struct NoncopyableSelfAccessors: ~Copyable & ~Escapable {
 struct NonEscapableMutableSelf: ~Escapable {
   mutating func mutatingMethodNoParam() {} // OK
 
-  @lifetime(self: self) // OK
+  @_lifetime(self: self) // OK
   mutating func mutatingMethodNoParamLifetime() {}
 
-  @lifetime(self: copy self) // OK
+  @_lifetime(self: copy self) // OK
   mutating func mutatingMethodNoParamCopy() {}
 
-  @lifetime(self: self) // OK
+  @_lifetime(self: self) // OK
   mutating func mutatingMethodOneParamLifetime(_: NE) {}
 
-  @lifetime(copy self) // OK
+  @_lifetime(copy self) // OK
   mutating func mutatingMethodOneParamCopy(_: NE) {}
 
-  @lifetime(borrow self)
+  @_lifetime(borrow self)
   mutating func mutatingMethodOneParamBorrow(_: NE) {}
 }

--- a/test/Sema/lifetime_depend_noattr.swift
+++ b/test/Sema/lifetime_depend_noattr.swift
@@ -1,8 +1,8 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -disable-availability-checking \
-// RUN:   -enable-experimental-feature LifetimeDependence
+// RUN:   -enable-experimental-feature Lifetimes
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 // These tests complement lifetime_depend_nofeature.swift. If you add a test here, add one there.
  
@@ -13,18 +13,18 @@
 struct EmptyNonEscapable: ~Escapable {} // OK - no dependence
 
 // Don't allow non-Escapable return values.
-func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@lifetime(borrow span)' or '@lifetime(copy span)'}}
+func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow span)' or '@_lifetime(copy span)'}}
 
 func neInout(span: inout RawSpan) {} // OK - inferred
 
 struct S {
-  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '@lifetime(...)}}
+  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)}}
 
   func neInout(span: inout RawSpan) {} // OK - inferred
 }
 
 class C {
-  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '@lifetime(...)'}}
+  func neReturn(span: RawSpan) -> RawSpan { span } // expected-error{{a method with a ~Escapable result requires '@_lifetime(...)'}}
 
   func neInout(span: inout RawSpan) {} // OK - inferred
 }

--- a/test/Sema/lifetime_dependence_functype.swift
+++ b/test/Sema/lifetime_dependence_functype.swift
@@ -1,6 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature LifetimeDependence
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Lifetimes
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 struct NC: ~Copyable {
   var ne: NE {
@@ -13,23 +13,23 @@ struct NE: ~Escapable {
   init() {}
 }
 
-@lifetime(copy ne)
+@_lifetime(copy ne)
 func transfer(_ ne: NE) -> NE {
   ne
 }
 
-@lifetime(copy ne)
-func applyAnnotatedTransfer(ne: NE, @lifetime(0) transfer: (NE) -> NE) -> NE { // expected-error{{'@lifetime' attribute cannot be applied to this declaration}}
+@_lifetime(copy ne)
+func applyAnnotatedTransfer(ne: NE, @_lifetime(0) transfer: (NE) -> NE) -> NE { // expected-error{{'@_lifetime' attribute cannot be applied to this declaration}}
   transfer(ne)
 }
 
-@lifetime(copy ne)
+@_lifetime(copy ne)
 func applyTransfer(ne: NE, transfer: (NE) ->  NE) -> NE {
   transfer(ne)
 }
 
 func testTransfer(nc: consuming NC) {
-  let transferred = applyTransfer(ne: nc.ne, transfer: transfer) // expected-error{{does not conform to expected type 'Escapable'}} e/xpected-error{{cannot convert value of type '(NE) -> @lifetime(copy 0) NE' to expected argument type '(NE) -> NE'}}
+  let transferred = applyTransfer(ne: nc.ne, transfer: transfer) // expected-error{{does not conform to expected type 'Escapable'}} e/xpected-error{{cannot convert value of type '(NE) -> @_lifetime(copy 0) NE' to expected argument type '(NE) -> NE'}}
 
   _ = consume nc
   _ = transfer(transferred)
@@ -39,13 +39,13 @@ func borrow(_ nc: borrowing NC) -> NE {
   nc.ne
 }
 
-@lifetime(borrow nc)
+@_lifetime(borrow nc)
 func applyBorrow(nc: borrowing NC, borrow: (borrowing NC) -> NE) -> NE {
   borrow(nc)
 }
 
 func testBorrow(nc: consuming NC) {
-  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{does not conform to expected type 'Escapable'}} ex/pected-error{{cannot convert value of type '(borrowing NC) -> @lifetime(borrow 0) NE' to expected argument type '(borrowing NC) -> NE}}
+  let borrowed = applyBorrow(nc: nc, borrow: borrow) // expected-error{{does not conform to expected type 'Escapable'}} ex/pected-error{{cannot convert value of type '(borrowing NC) -> @_lifetime(borrow 0) NE' to expected argument type '(borrowing NC) -> NE}}
   _ = consume nc
   _ = transfer(borrowed)
 }

--- a/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_explicit_lifetime_dependence.swift
@@ -1,6 +1,6 @@
 public struct AnotherView : ~Escapable {
   let ptr: UnsafeRawBufferPointer
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   public init(_ ptr: UnsafeRawBufferPointer) {
     self.ptr = ptr
   }
@@ -9,19 +9,19 @@ public struct AnotherView : ~Escapable {
 public struct BufferView : ~Escapable {
   public let ptr: UnsafeRawBufferPointer
   @inlinable
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   public init(_ ptr: UnsafeRawBufferPointer) {
     self.ptr = ptr
   }
-  @lifetime(borrow a)
+  @_lifetime(borrow a)
   public init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) {
     self.ptr = ptr
   }
-  @lifetime(copy a)
+  @_lifetime(copy a)
   public init(_ ptr: UnsafeRawBufferPointer, _ a: consuming AnotherView) {
     self.ptr = ptr
   }
-  @lifetime(copy a, borrow b)
+  @_lifetime(copy a, borrow b)
   public init(_ ptr: UnsafeRawBufferPointer, _ a: consuming AnotherView, _ b: borrowing Array<Int>) {
     self.ptr = ptr
   }
@@ -29,31 +29,31 @@ public struct BufferView : ~Escapable {
 
 public struct MutableBufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeMutableRawBufferPointer
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   public init(_ ptr: UnsafeMutableRawBufferPointer) {
     self.ptr = ptr
   }
 }
 
 @inlinable
-@lifetime(borrow x)
+@_lifetime(borrow x)
 public func derive(_ x: borrowing BufferView) -> BufferView {
   return BufferView(x.ptr)
 }
 
 public func use(_ x: borrowing BufferView) {}
 
-@lifetime(borrow view)
+@_lifetime(borrow view)
 public func borrowAndCreate(_ view: borrowing BufferView) -> BufferView {
   return BufferView(view.ptr)
 }
 
-@lifetime(copy view)
+@_lifetime(copy view)
 public func consumeAndCreate(_ view: consuming BufferView) -> BufferView {
   return BufferView(view.ptr)
 }
 
-@lifetime(borrow this, copy that)
+@_lifetime(borrow this, copy that)
 public func deriveThisOrThat(_ this: borrowing BufferView, _ that: borrowing BufferView) -> BufferView {
   if (Int.random(in: 1..<100) == 0) {
     return BufferView(this.ptr)
@@ -63,16 +63,16 @@ public func deriveThisOrThat(_ this: borrowing BufferView, _ that: borrowing Buf
 
 public struct Wrapper : ~Escapable {
   var _view: BufferView
-  @lifetime(copy view)
+  @_lifetime(copy view)
   public init(_ view: consuming BufferView) {
     self._view = view
   }
   public var view: BufferView {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield _view
     }
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify {
       yield &_view
     }
@@ -86,7 +86,7 @@ public enum FakeOptional<Wrapped: ~Escapable>: ~Escapable {
 extension FakeOptional: Escapable where Wrapped: Escapable {}
 
 extension FakeOptional where Wrapped: ~Escapable {
-  @lifetime(immortal)
+  @_lifetime(immortal)
   public init(_ nilLiteral: ()) {
     self = .none
   }

--- a/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
+++ b/test/Serialization/Inputs/def_implicit_lifetime_dependence.swift
@@ -1,13 +1,13 @@
 public struct BufferView : ~Escapable {
   public let ptr: UnsafeRawBufferPointer
   public let c: Int
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   public init(_ ptr: UnsafeRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
   }
   @inlinable
-  @lifetime(copy otherBV)
+  @_lifetime(copy otherBV)
   public init(_ otherBV: borrowing BufferView) {
     self.ptr = otherBV.ptr
     self.c = otherBV.c
@@ -17,7 +17,7 @@ public struct BufferView : ~Escapable {
 public struct MutableBufferView : ~Escapable, ~Copyable {
   let ptr: UnsafeMutableRawBufferPointer
   let c: Int
-  @lifetime(borrow ptr)
+  @_lifetime(borrow ptr)
   public init(_ ptr: UnsafeMutableRawBufferPointer, _ c: Int) {
     self.ptr = ptr
     self.c = c
@@ -25,17 +25,17 @@ public struct MutableBufferView : ~Escapable, ~Copyable {
 }
 
 @inlinable
-@lifetime(copy x)
+@_lifetime(copy x)
 public func derive(_ x: borrowing BufferView) -> BufferView {
   return BufferView(x.ptr, x.c)
 }
 
-@lifetime(copy view)
+@_lifetime(copy view)
 public func borrowAndCreate(_ view: borrowing BufferView) -> BufferView {
   return BufferView(view.ptr, view.c )
 }
 
-@lifetime(copy view)
+@_lifetime(copy view)
 public func consumeAndCreate(_ view: consuming BufferView) -> BufferView {
   return BufferView(view.ptr, view.c)
 }
@@ -58,16 +58,16 @@ public struct Container : ~Copyable {
 public struct Wrapper : ~Escapable {
   var _view: BufferView
   public var view: BufferView {
-    @lifetime(copy self)
+    @_lifetime(copy self)
     _read {
       yield _view
     }
-    @lifetime(&self)
+    @_lifetime(&self)
     _modify {
       yield &_view
     }
   }
-  @lifetime(copy view)
+  @_lifetime(copy view)
   public init(_ view: consuming BufferView) {
     self._view = view
   }

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_explicit_lifetime_dependence.swift \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: -disable-lifetime-dependence-diagnostics
 
 // RUN: llvm-bcanalyzer %t/def_explicit_lifetime_dependence.swiftmodule 
 
 // RUN: %target-swift-frontend -module-name lifetime-dependence -emit-sil -I %t %s \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: | %FileCheck %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 import def_explicit_lifetime_dependence
 func testBasic() {

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_implicit_lifetime_dependence.swift \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: -disable-lifetime-dependence-diagnostics
 
 // RUN: llvm-bcanalyzer %t/def_implicit_lifetime_dependence.swiftmodule 
 
 // RUN: %target-swift-frontend -module-name lifetime-dependence -emit-sil -I %t %s \
-// RUN: -enable-experimental-feature LifetimeDependence \
+// RUN: -enable-experimental-feature Lifetimes \
 // RUN: | %FileCheck %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 import def_implicit_lifetime_dependence
 

--- a/test/attr/attr_abi.swift
+++ b/test/attr/attr_abi.swift
@@ -1,9 +1,9 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -enable-experimental-feature AddressableParameters -enable-experimental-feature NoImplicitCopy -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature StrictMemorySafety -enable-experimental-feature LifetimeDependence -enable-experimental-feature CImplementation -import-bridging-header %S/Inputs/attr_abi.h -parse-as-library -debugger-support
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Extern -enable-experimental-feature AddressableParameters -enable-experimental-feature NoImplicitCopy -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature StrictMemorySafety -enable-experimental-feature Lifetimes -enable-experimental-feature CImplementation -import-bridging-header %S/Inputs/attr_abi.h -parse-as-library -debugger-support
 
 // REQUIRES: swift_feature_AddressableParameters
 // REQUIRES: swift_feature_CImplementation
 // REQUIRES: swift_feature_Extern
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_NoImplicitCopy
 // REQUIRES: swift_feature_StrictMemorySafety
 // REQUIRES: swift_feature_SymbolLinkageMarkers
@@ -2051,22 +2051,22 @@ protocol BorrowedAttr {
   var v3: Int { get set }
 }
 
-// @lifetime -- must match in @abi
+// @_lifetime -- must match in @abi
 // TODO: Probably possible to make these unconstrained as long as we ensure
 // that `@_addressableForDependencies` doesn't cause a calling convention
 // change.
 struct Lifetime: ~Escapable {
-  @abi(@lifetime(borrow i1) init(i1: UnsafeRawPointer))
-  @lifetime(borrow i1) init(i1: UnsafeRawPointer) {}
+  @abi(@_lifetime(borrow i1) init(i1: UnsafeRawPointer))
+  @_lifetime(borrow i1) init(i1: UnsafeRawPointer) {}
 
-  @abi(@lifetime(borrow i2) init(i2: UnsafeRawPointer)) // expected-error {{extra 'lifetime' attribute in '@abi'}} {{8-28=}}
+  @abi(@_lifetime(borrow i2) init(i2: UnsafeRawPointer)) // expected-error {{extra '_lifetime' attribute in '@abi'}} {{8-29=}}
   init(i2: UnsafeRawPointer) {}
 
-  @abi(init(i3: UnsafeRawPointer)) // expected-error {{missing 'lifetime' attribute in '@abi'}} {{8-8=@lifetime(borrow i3) }}
-  @lifetime(borrow i3) init(i3: UnsafeRawPointer) {} // expected-note {{should match attribute here}}
+  @abi(init(i3: UnsafeRawPointer)) // expected-error {{missing '_lifetime' attribute in '@abi'}} {{8-8=@_lifetime(borrow i3) }}
+  @_lifetime(borrow i3) init(i3: UnsafeRawPointer) {} // expected-note {{should match attribute here}}
 
-  @abi(@lifetime(borrow i4) init(i4: UnsafeRawPointer, i4a: UnsafeRawPointer)) // expected-error {{'lifetime' attribute in '@abi' should match '@lifetime(borrow i4a)'}} {{8-28=@lifetime(borrow i4a)}}
-  @lifetime(borrow i4a) init(i4: UnsafeRawPointer, i4a: UnsafeRawPointer) {} // expected-note {{should match attribute here}}
+  @abi(@_lifetime(borrow i4) init(i4: UnsafeRawPointer, i4a: UnsafeRawPointer)) // expected-error {{'_lifetime' attribute in '@abi' should match '@_lifetime(borrow i4a)'}} {{8-29=@_lifetime(borrow i4a)}}
+  @_lifetime(borrow i4a) init(i4: UnsafeRawPointer, i4a: UnsafeRawPointer) {} // expected-note {{should match attribute here}}
 }
 
 // @_unsafeNonescapableResult -- must match in @abi

--- a/validation-test/Sema/rdar149385088.swift
+++ b/validation-test/Sema/rdar149385088.swift
@@ -1,12 +1,12 @@
 // RUN: %target-typecheck-verify-swift \
-// RUN:   -enable-experimental-feature LifetimeDependence \
+// RUN:   -enable-experimental-feature Lifetimes \
 // RUN:   -enable-experimental-feature CoroutineAccessors
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 // REQUIRES: swift_feature_CoroutineAccessors
 
 struct NE<T : ~Copyable & ~Escapable> : ~Copyable & ~Escapable {
-  @lifetime(&t)
+  @_lifetime(&t)
   init(
     t: inout T
   )
@@ -16,7 +16,7 @@ struct NE<T : ~Copyable & ~Escapable> : ~Copyable & ~Escapable {
 
 struct S : ~Copyable & ~Escapable {
   var mutableBytes: NE<S> {
-    @lifetime(&self)
+    @_lifetime(&self)
     mutating get {
       return NE(t: &self)
     }


### PR DESCRIPTION
Explanation: LifetimeDependence is a supported experimental feature for which we have to maintain source compatibility. During language evolution if we decide to update its semantics or syntax under `@lifetime` attribute, it can introduce significant confusion and maintenance problems to both early adopters and compiler developers.

To mitigate this, this PR introduces an underscore, effectively making the annotation `@_lifetime`, to provide a clear distinction and avoid potential conflicts during future development. Standard library will continue to use `@lifetime` in the near term.

`@_lifetime` is implemented as a suppressible language feature and `@lifetime` is printed in the suppressed path since the oldest compilers we have to support with a new sdk have support for `@lifetime`. This will ensure when the standard library migrates to `@_lifetime` we will continue to support older compilers.

Issue: rdar://151901744

Scope: Affects early adopters of lifetime dependencies

Risk: Medium. Along with the source changes being large, this change can cause a warning with @lifetime uses outside the stdlib. 


Main PR: https://github.com/swiftlang/swift/pull/82067

Reviewers: @atrick @tshortli 

Testing: swift CI testing. 