### PR TITLE
[6.2] [CS] Avoid solver-allocated inputs with `typesSatisfyConstraint`

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -720,6 +720,12 @@ public:
     return getRecursiveProperties().hasTypeVariable();
   }
 
+  // Convenience for checking whether the given type either has a type
+  // variable or placeholder.
+  bool hasTypeVariableOrPlaceholder() const {
+    return hasTypeVariable() || hasPlaceholder();
+  }
+
   /// Determine where this type is a type variable or a dependent
   /// member root in a type variable.
   bool isTypeVariableOrMember();

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -185,9 +185,12 @@ CoerceToCheckedCast *CoerceToCheckedCast::attempt(ConstraintSystem &cs,
                                                   Type fromType, Type toType,
                                                   bool useConditionalCast,
                                                   ConstraintLocator *locator) {
-  // If any of the types has a type variable, don't add the fix.
-  if (fromType->hasTypeVariable() || toType->hasTypeVariable())
+  // If any of the types have type variables or placeholders, don't add the fix.
+  // `typeCheckCheckedCast` doesn't support checking such types.
+  if (fromType->hasTypeVariableOrPlaceholder() ||
+      toType->hasTypeVariableOrPlaceholder()) {
     return nullptr;
+  }
 
   auto anchor = locator->getAnchor();
   if (auto *assignExpr = getAsExpr<AssignExpr>(anchor))

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1413,11 +1413,10 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     auto type1 = types.Type1;
     auto type2 = types.Type2;
 
-    // If either of the types still contains type variables, we can't
-    // compare them.
-    // FIXME: This is really unfortunate. More type variable sharing
-    // (when it's sound) would help us do much better here.
-    if (type1->hasTypeVariable() || type2->hasTypeVariable()) {
+    // If either of the types have holes or unresolved type variables, we can't
+    // compare them. `isSubtypeOf` cannot be used with solver-allocated types.
+    if (type1->hasTypeVariableOrPlaceholder() ||
+        type2->hasTypeVariableOrPlaceholder()) {
       identical = false;
       continue;
     }
@@ -1469,15 +1468,12 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // The systems are not considered equivalent.
     identical = false;
 
-    // Archetypes are worse than concrete types (i.e. non-placeholder and
-    // non-archetype)
+    // Archetypes are worse than concrete types
     // FIXME: Total hack.
-    if (type1->is<ArchetypeType>() && !type2->is<ArchetypeType>() &&
-        !type2->is<PlaceholderType>()) {
+    if (type1->is<ArchetypeType>() && !type2->is<ArchetypeType>()) {
       ++score2;
       continue;
-    } else if (type2->is<ArchetypeType>() && !type1->is<ArchetypeType>() &&
-               !type1->is<PlaceholderType>()) {
+    } else if (type2->is<ArchetypeType>() && !type1->is<ArchetypeType>()) {
       ++score1;
       continue;
     }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -1413,10 +1413,9 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     auto type1 = types.Type1;
     auto type2 = types.Type2;
 
-    // If either of the types have holes or unresolved type variables, we can't
-    // compare them. `isSubtypeOf` cannot be used with solver-allocated types.
-    if (type1->hasTypeVariableOrPlaceholder() ||
-        type2->hasTypeVariableOrPlaceholder()) {
+    // `isSubtypeOf` cannot be used with solver-allocated types.
+    if (type1->getRecursiveProperties().isSolverAllocated() ||
+        type2->getRecursiveProperties().isSolverAllocated()) {
       identical = false;
       continue;
     }
@@ -1468,12 +1467,15 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     // The systems are not considered equivalent.
     identical = false;
 
-    // Archetypes are worse than concrete types
+    // Archetypes are worse than concrete types (i.e. non-placeholder and
+    // non-archetype)
     // FIXME: Total hack.
-    if (type1->is<ArchetypeType>() && !type2->is<ArchetypeType>()) {
+    if (type1->is<ArchetypeType>() && !type2->is<ArchetypeType>() &&
+        !type2->is<PlaceholderType>()) {
       ++score2;
       continue;
-    } else if (type2->is<ArchetypeType>() && !type1->is<ArchetypeType>()) {
+    } else if (type2->is<ArchetypeType>() && !type1->is<ArchetypeType>() &&
+               !type1->is<PlaceholderType>()) {
       ++score1;
       continue;
     }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4903,8 +4903,12 @@ static bool
 repairViaBridgingCast(ConstraintSystem &cs, Type fromType, Type toType,
                       SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
                       ConstraintLocatorBuilder locator) {
-  if (fromType->hasTypeVariable() || toType->hasTypeVariable())
+  // Don't check if any of the types have type variables or placeholders,
+  // `typeCheckCheckedCast` doesn't support checking solver-allocated types.
+  if (fromType->hasTypeVariableOrPlaceholder() ||
+      toType->hasTypeVariableOrPlaceholder()) {
     return false;
+  }
 
   auto objectType1 = fromType->getOptionalObjectType();
   auto objectType2 = toType->getOptionalObjectType();
@@ -9366,10 +9370,12 @@ static ConstraintFix *maybeWarnAboutExtraneousCast(
   if (locator.endsWith<LocatorPathElt::GenericArgument>())
     return nullptr;
 
-  // Both types have to be fixed.
-  if (fromType->hasTypeVariable() || toType->hasTypeVariable() ||
-      fromType->hasPlaceholder() || toType->hasPlaceholder())
+  // Both types have to be resolved, `typeCheckCheckedCast` doesn't support
+  // checking solver-allocated types.
+  if (fromType->hasTypeVariableOrPlaceholder() ||
+      toType->hasTypeVariableOrPlaceholder()) {
     return nullptr;
+  }
 
   SmallVector<LocatorPathElt, 4> path;
   auto anchor = locator.getLocatorParts(path);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1060,9 +1060,10 @@ bool TypeChecker::typesSatisfyConstraint(Type type1, Type type2,
   // avoid lifetime issues for e.g cases where we lazily populate the
   // `ContextSubMap` on `NominalOrBoundGenericNominalType` in the nested arena,
   // since it will be destroyed on leaving.
-  ASSERT(!type1->getRecursiveProperties().isSolverAllocated() &&
-         !type2->getRecursiveProperties().isSolverAllocated() &&
-         "Cannot escape solver-allocated types into a nested ConstraintSystem");
+  CONDITIONAL_ASSERT(
+      !type1->getRecursiveProperties().isSolverAllocated() &&
+      !type2->getRecursiveProperties().isSolverAllocated() &&
+      "Cannot escape solver-allocated types into a nested ConstraintSystem");
 
   ConstraintSystem cs(dc, ConstraintSystemOptions());
   if (openArchetypes) {

--- a/validation-test/compiler_crashers_2_fixed/3d5f395354b12a8.swift
+++ b/validation-test/compiler_crashers_2_fixed/3d5f395354b12a8.swift
@@ -1,0 +1,6 @@
+// {"signature":"bool llvm::function_ref<bool (swift::ProtocolConformanceRef)>::callback_fn<(anonymous namespace)::MismatchedIsolatedConformances>(long, swift::ProtocolConformanceRef)"}
+// RUN: not %target-swift-frontend -typecheck %s
+func a {
+  {               print("\(\ " ")\n"
+  }
+  "\()\n"

--- a/validation-test/compiler_crashers_2_fixed/77b431f821682d0.swift
+++ b/validation-test/compiler_crashers_2_fixed/77b431f821682d0.swift
@@ -1,0 +1,3 @@
+// {"signature":"swift::ProtocolConformanceRef::forEachMissingConformance(llvm::function_ref<bool (swift::BuiltinProtocolConformance*)>) const"}
+// RUN: not %target-swift-frontend -typecheck %s
+.a == .!   == b /  c

--- a/validation-test/compiler_crashers_2_fixed/7cee1719e3503ef6.swift
+++ b/validation-test/compiler_crashers_2_fixed/7cee1719e3503ef6.swift
@@ -1,0 +1,3 @@
+// {"signature":"swift::GenericParamKey::findIndexIn(llvm::ArrayRef<swift::GenericTypeParamType*>) const"}
+// RUN: not %target-swift-frontend -typecheck %s
+a[[[[ a a?[[a a?

--- a/validation-test/compiler_crashers_2_fixed/dfd09450bb7a1.swift
+++ b/validation-test/compiler_crashers_2_fixed/dfd09450bb7a1.swift
@@ -1,0 +1,5 @@
+// {"signature":"swift::ProtocolConformanceRef::forAbstract(swift::Type, swift::ProtocolDecl*)"}
+// RUN: not %target-swift-frontend -typecheck %s
+@resultBuilder struct a {
+  static buildBlock<b, c, d, e>(b, c, d, e) func f<h>(_ : Bool @a Bool->h) {                         f(true {
+    cond in var g : Int g 2 30\ g

--- a/validation-test/compiler_crashers_2_fixed/ee519bcc17697e87.swift
+++ b/validation-test/compiler_crashers_2_fixed/ee519bcc17697e87.swift
@@ -1,0 +1,4 @@
+// {"signature":"(anonymous namespace)::ApplyClassifier::classifyApply(swift::ApplyExpr*, llvm::DenseSet<swift::Expr const*, llvm::DenseMapInfo<swift::Expr const*, void>>*)"}
+// RUN: not %target-swift-frontend -typecheck %s
+let a = switch  \0 {
+case 0.0


### PR DESCRIPTION
*6.2 cherry-pick of #82147, minus the more risky parts of that change*

- Explanation: Fixes an issue where we would allow solver-allocated types to leak into a nested ConstraintSystem arena, which lead to lifetime issues in cases where e.g the `ContextSubMap` for a `NominalOrBoundGenericNominalType` is lazily computed. This resulted in use-after-frees.
- Scope: Affects diagnostic logic and CSRanking
- Issue: rdar://152763265
- Risk: Low/Medium, it does touch CSRanking logic, but it should only affect solutions that are already invalid. I've also tweaked the check to be even narrower for 6.2, it just checks for `isSolverAllocated` instead of `hasTypeVariableOrPlaceholder`.
- Testing: Added tests to test suite
- Reviewer: Slava Pestov