### PR TITLE
[6.2] Sema: Never record argument label mismatches for unlabeled trailing closures

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -377,6 +377,13 @@ static bool matchCallArgumentsImpl(
     assert(argIdx != numArgs && "Must have a valid index to claim");
     assert(!claimedArgs[argIdx] && "Argument already claimed");
 
+    // Prevent recording of an argument label mismatche for an unlabeled
+    // trailing closure. An unlabeled trailing closure is necessarily the first
+    // one and vice versa, per language syntax.
+    if (unlabeledTrailingClosureArgIndex == argIdx) {
+      expectedName = Identifier();
+    }
+
     if (!actualArgNames.empty()) {
       // We're recording argument names; record this one.
       actualArgNames[argIdx] = expectedName;

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2697,8 +2697,10 @@ bool swift::diagnoseArgumentLabelError(ASTContext &ctx,
     }
   }
 
+  assert((numMissing + numExtra + numWrong > 0) &&
+         "Should not call this function with nothing to diagnose");
+
   // Emit the diagnostic.
-  assert(numMissing > 0 || numExtra > 0 || numWrong > 0);
   llvm::SmallString<16> haveBuffer; // note: diagOpt has references to this
   llvm::SmallString<16> expectedBuffer; // note: diagOpt has references to this
 


### PR DESCRIPTION
- **Explanation**: 
  Fixes a crash on invalid. The previous logic was causing a label mismatch constraint fix to be recorded for an unlabeled trailing closure argument matching a variadic paramater after a late recovery argument claim in `matchCallArgumentsImpl`, because the recovery claiming skips arguments matching defaulted parameters, but not variadic ones. We may want to reconsider that last part, but currently it regresses the quality of some diagnostics, and this is a targeted fix.

  The previous behavior is fine because the diagnosis routine associate with the constraint fix (`diagnoseArgumentLabelError`) skips unlabeled trailing closures when tallying labeling issues — *unless* there are no other issues and the tally is zero, which we assert it is not. 

  *Does not miscompile with assertions disabled.*
- **Scope**: Unlabeled trailing closure argument matching diagnostics QoI.
- **Issues**: rdar://152313388.
- **Original PRs**: #82020.
- **Risk**: Low. Worst-case potential regression should be in diagnostic quality.
- **Testing**: Passed source compatibility suite.
- **Reviewers**: @xedin
