### PR TITLE
[TypeChecker] Remove `@_inheritActorContext` effect from synchronous …

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7889,10 +7889,10 @@ void AttributeChecker::visitInheritActorContextAttr(
         .warnUntilFutureSwiftVersion();
   }
 
-  // Eiether `async` or `@isolated(any)`.
+  // Either `async` or `@isolated(any)`.
   if (!(funcTy->isAsync() || funcTy->getIsolation().isErased())) {
-    diagnose(
-        attr->getLocation(),
+    diagnoseAndRemoveAttr(
+        attr,
         diag::inherit_actor_context_only_on_async_or_isolation_erased_params,
         attr)
         .warnUntilFutureSwiftVersion();

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1752,3 +1752,29 @@ actor UserDefinedActorSelfDotMethod {
     return functionRef // expected-error {{cannot convert return expression of type '(isolated Self) -> () -> ()' to return type '(UserDefinedActorSelfDotMethod) -> @isolated(any) () -> Void'}}
   }
 }
+
+func requireSendableInheritContext(@_inheritActorContext _: @Sendable () -> ()) {}
+// expected-warning@-1 {{@_inheritActorContext only applies to '@isolated(any)' parameters or parameters with asynchronous function types; this will be an error in a future Swift language mode}}
+
+actor InvalidInheritedActorIsolation {
+  func actorFunction() {} // expected-note {{calls to instance method 'actorFunction()' from outside of its actor context are implicitly asynchronous}}
+
+  func test() {
+    requireSendableInheritContext {
+      self.actorFunction()
+      // expected-error@-1 {{call to actor-isolated instance method 'actorFunction()' in a synchronous nonisolated context}}
+    }
+  }
+}
+
+@MainActor
+class InvalidInheritedGlobalActorIsolation {
+  func mainActorFunction() {} // expected-note {{calls to instance method 'mainActorFunction()' from outside of its actor context are implicitly asynchronous}}
+
+  func test() {
+    requireSendableInheritContext {
+      self.mainActorFunction()
+      // expected-error@-1 {{call to main actor-isolated instance method 'mainActorFunction()' in a synchronous nonisolated context}}
+    }
+  }
+}

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -370,3 +370,26 @@ func testSendableMetatypeDowngrades() {
     // expected-complete-tns-warning@-1 {{type 'T' does not conform to the 'SendableMetatype' protocol}}
   }
 }
+
+do {
+  func test(@_inheritActorContext _: @Sendable () -> Void) async {
+    // expected-warning@-1 {{@_inheritActorContext only applies to '@isolated(any)' parameters or parameters with asynchronous function types; this will be an error in a future Swift language mode}}
+  }
+
+  @MainActor
+  @preconcurrency
+  class Test {
+    struct V {}
+
+    var value: V? // expected-note {{property declared here}}
+
+    func run() async {
+      await test {
+        if let value {
+          // expected-warning@-1 {{main actor-isolated property 'value' can not be referenced from a Sendable closure; this is an error in the Swift 6 language mode}}
+          print(value)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
…types

The compiler would previously accept use of `@_inheritActorContext` on a parameter with a synchronous function type which wasn't marked as `@isolated(any)`. That is incorrect because in such cases the attribute has no effect and furthermore would prevent Sendable and isolation checking.

Uses like that are currently diagnosed by the type-checker but we need to go one step further and remove the effect in such case to prevent invalid uses.

Resolves: rdar://143581268

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
