### PR TITLE
AssociatedTypeInference: Make a cycle breaking hack more principled

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1147,12 +1147,6 @@ ERROR(ambiguous_module_type,none,
 ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
       (DeclNameRef, unsigned))
-ERROR(unsupported_recursion_in_associated_type_reference,none,
-      "unsupported recursion for reference to %kind0 of type %1",
-      (const ValueDecl *, Type))
-ERROR(broken_associated_type_witness,none,
-      "reference to invalid %kind0 of type %1",
-      (const ValueDecl *, Type))
 
 ERROR(unspaced_binary_operator_fixit,none,
       "missing whitespace between %0 and %1 operators",

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -587,17 +587,6 @@ NormalProtocolConformance::getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
      return { witnessType, nullptr };
   }
 
-  // If this conformance is in a state where it is inferring type witnesses but
-  // we didn't find anything, fail.
-  //
-  // FIXME: This is unsound, because we may not have diagnosed anything but
-  // still end up with an ErrorType in the AST.
-  if (getDeclContext()->getASTContext().evaluator.hasActiveRequest(
-         ResolveTypeWitnessesRequest{
-             const_cast<NormalProtocolConformance *>(this)})) {
-    return { Type(), nullptr };
-  }
-
   return evaluateOrDefault(
       assocType->getASTContext().evaluator,
       TypeWitnessRequest{const_cast<NormalProtocolConformance *>(this),

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -267,6 +267,8 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
   // If the protocol is invertible, fall back to a global lookup instead of
   // evaluating a conformance path, to avoid an infinite substitution issue.
+  //
+  // FIXME: Figure out a more principled way of breaking this cycle.
   if (proto->getInvertibleProtocolKind())
     return swift::lookupConformance(type.subst(*this), proto);
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2653,12 +2653,11 @@ AssociatedTypeInference::computeDerivedTypeWitness(
     return std::make_pair(Type(), nullptr);
 
   // Can we derive conformances for this protocol and adoptee?
-  NominalTypeDecl *derivingTypeDecl = dc->getSelfNominalTypeDecl();
-  if (!DerivedConformance::derivesProtocolConformance(dc, derivingTypeDecl,
-                                                      proto))
+  if (!DerivedConformance::derivesProtocolConformance(conformance))
     return std::make_pair(Type(), nullptr);
 
   // Try to derive the type witness.
+  NominalTypeDecl *derivingTypeDecl = dc->getSelfNominalTypeDecl();
   auto result = deriveTypeWitness(conformance, derivingTypeDecl, assocType);
   if (!result.first)
     return std::make_pair(Type(), nullptr);

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -597,7 +597,7 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
             checkTypeWitness(memberTypeInContext, assocType, conformance)) {
       nonViable.push_back({typeDecl, checkResult});
     } else {
-      viable.push_back({typeDecl, memberType, nullptr});
+      viable.push_back({typeDecl, memberType});
     }
   }
 

--- a/lib/Sema/DerivedConformance/DerivedConformance.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformance.cpp
@@ -104,7 +104,7 @@ bool DerivedConformance::derivesProtocolConformance(
   if (*derivableKind == KnownDerivableProtocolKind::DistributedActor)
     return canDeriveDistributedActor(Nominal, DC);
   if (*derivableKind == KnownDerivableProtocolKind::DistributedActorSystem)
-    return canDeriveDistributedActorSystem(Nominal, DC);
+    return canDeriveDistributedActorSystem(Conformance);
 
   if (*derivableKind == KnownDerivableProtocolKind::AdditiveArithmetic)
     return canDeriveAdditiveArithmetic(Nominal, DC);

--- a/lib/Sema/DerivedConformance/DerivedConformance.h
+++ b/lib/Sema/DerivedConformance/DerivedConformance.h
@@ -333,8 +333,8 @@ public:
                                         DeclContext *dc);
 
   /// Whether we can derive the given DistributedActorSystem requirements.
-  static bool canDeriveDistributedActorSystem(NominalTypeDecl *nominal,
-                                              DeclContext *dc);
+  static bool canDeriveDistributedActorSystem(
+      NormalProtocolConformance *conformance);
 
   /// Derive a 'DistributedActor' requirement for an distributed actor.
   ///

--- a/lib/Sema/DerivedConformance/DerivedConformance.h
+++ b/lib/Sema/DerivedConformance/DerivedConformance.h
@@ -95,16 +95,11 @@ public:
   /// declarations for requirements of the protocol that are not satisfied by
   /// the type's explicit members.
   ///
-  /// \param nominal The nominal type for which we are determining whether to
-  /// derive a witness.
-  ///
-  /// \param protocol The protocol whose requirements are being derived.
+  /// \param conformance The conformance.
   ///
   /// \return True if the type can implicitly derive a conformance for the
   /// given protocol.
-  static bool derivesProtocolConformance(DeclContext *DC,
-                                         NominalTypeDecl *nominal,
-                                         ProtocolDecl *protocol);
+  static bool derivesProtocolConformance(NormalProtocolConformance *conformance);
 
   /// Diagnose problems, if any, preventing automatic derivation of protocol
   /// requirements

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -497,7 +497,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       // Add the type to the result set, so that we can diagnose the
       // reference instead of just saying the member does not exist.
       if (types.insert(memberType->getCanonicalType()).second)
-        result.addResult({typeDecl, memberType, nullptr});
+        result.addResult({typeDecl, memberType});
 
       continue;
     }
@@ -528,7 +528,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
 
     // If we haven't seen this type result yet, add it to the result set.
     if (types.insert(memberType->getCanonicalType()).second)
-      result.addResult({typeDecl, memberType, nullptr});
+      result.addResult({typeDecl, memberType});
   }
 
   if (!result) {
@@ -566,7 +566,7 @@ LookupTypeResult TypeChecker::lookupMemberType(DeclContext *dc,
       auto memberType =
           substMemberTypeWithBase(typeDecl, type);
       if (types.insert(memberType->getCanonicalType()).second)
-        result.addResult({typeDecl, memberType, assocType});
+        result.addResult({typeDecl, memberType});
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4816,16 +4816,35 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
   if (!requirement->isProtocolRequirement())
     return;
 
+  auto &evaluator = getASTContext().evaluator;
+
   // Resolve the type witnesses for all associated types referenced by
   // the requirement. If any are erroneous, don't bother resolving the
   // witness.
-  auto referenced = evaluateOrDefault(getASTContext().evaluator,
+  auto referenced = evaluateOrDefault(evaluator,
                                       ReferencedAssociatedTypesRequest{requirement},
                                       TinyPtrVector<AssociatedTypeDecl *>());
   for (auto assocType : referenced) {
+    // There's a weird cycle break here. If we're in the middle of resolving
+    // type witnesses, we return from here without recording a value witness.
+    // This is handled by not caching the result, and the conformance checker
+    // will then attempt to resolve the value witness later.
+    if (evaluator.hasActiveRequest(TypeWitnessRequest{Conformance, assocType})) {
+      return;
+    }
+
+    if (!Conformance->hasTypeWitness(assocType)) {
+      if (evaluator.hasActiveRequest(ResolveTypeWitnessesRequest{Conformance})) {
+        return;
+      }
+    }
+
     auto typeWitness = Conformance->getTypeWitness(assocType);
     if (!typeWitness)
       return;
+
+    // However, if the type witness was already resolved and it has an error
+    // type, mark the conformance invalid and give up.
     if (typeWitness->hasError()) {
       Conformance->setInvalid();
       return;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -84,9 +84,6 @@ enum class DeclTypeCheckingSemantics {
 struct LookupTypeResultEntry {
   TypeDecl *Member;
   Type MemberType;
-  /// The associated type that the Member/MemberType were inferred for, but only
-  /// if inference happened when creating this entry.
-  AssociatedTypeDecl *InferredAssociatedType;
 };
 
 /// The result of name lookup for types.

--- a/test/AssociatedTypeInference/type_witness_request_cycle.swift
+++ b/test/AssociatedTypeInference/type_witness_request_cycle.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift
+
+// This used to crash -- rdar://120388028
+
+struct Node {}
+
+let x = Outer(implementation: Inner<Node>())
+
+protocol Proto {
+    associatedtype Node
+    func doThings(things: Outer<Node, Self>)
+}
+
+struct Outer<Node, Impl: Proto> where Impl.Node == Node {
+    var implementation: Impl
+}
+
+struct Inner<Node>: Proto { // expected-error {{circular reference}}
+// expected-note@-1 {{through reference here}}
+    func doThings(things: Outer<Node, Inner<Node>>) {}
+    // expected-note@-1 2{{through reference here}}
+    // expected-note@-2 {{while resolving type 'Outer<Node, Inner<Node>>'}}
+}

--- a/test/decl/protocol/typealias_inference.swift
+++ b/test/decl/protocol/typealias_inference.swift
@@ -12,10 +12,13 @@ protocol BaseProtocol {
   init(closure: Closure)
 }
 
-struct Base<Value>: BaseProtocol {
+struct Base<Value>: BaseProtocol { // expected-error {{circular reference}}
+// expected-note@-1 {{through reference here}}
   private let closure: Closure
 
-  init(closure: Closure) { //expected-error {{reference to invalid type alias 'Closure' of type 'Base<Value>'}}
+  init(closure: Closure) {
+  // expected-note@-1 {{while resolving type 'Closure'}}
+  // expected-note@-2 2{{through reference here}}
     self.closure = closure
   }
 }

--- a/test/multifile/protocol-conformance-broken.swift
+++ b/test/multifile/protocol-conformance-broken.swift
@@ -9,6 +9,6 @@ protocol P {
 struct X { }
 
 func g() {
-  let _: X.AT? = nil // expected-error{{reference to invalid associated type 'AT' of type 'X'}}
+  let _: X.AT? = nil
 }
 

--- a/validation-test/compiler_crashers_2_fixed/0127-issue-48118.swift
+++ b/validation-test/compiler_crashers_2_fixed/0127-issue-48118.swift
@@ -28,12 +28,15 @@ extension P {
     }
 }
 
-public struct S: P {
+public struct S: P { // expected-error {{circular reference}}
+// expected-note@-1 {{through reference here}}
     public typealias PA = String
     public typealias PB = Int
 
     public func f1(_ x: Context, _ y: PA) {
     }
-    public func f2(_ x: Context, _ y: PB) { // expected-error {{reference to invalid type alias 'Context' of type 'S'}}
+    public func f2(_ x: Context, _ y: PB) {
+    // expected-note@-1 2{{through reference here}}
+    // expected-note@-2 {{while resolving type 'Context'}}
     }
 }


### PR DESCRIPTION
We would return an ErrorType without diagnosing anything from NormalProtocolConformance::getTypeWitnessAndDecl() to signal a transient condition to associated type inference. But other callers that receive an ErrorType don't expect that this can happen, and they in turn won't diagnose anything. So we'd end up in SILGen with a broken AST.

Instead, push the cycle break up into getWitnessTypeForMatching(), and remove the hack from getTypeWitnessAndDecl(). If someone else calls getTypeWitnessAndDecl() and that causes a request cycle, we will now diagnose the request cycle via the usual mechanism.

Fixes rdar://120388028.