### PR TITLE
test: remove the expectation that dispatch is static

### DIFF
--- a/test/Backtracing/CrashStatic.swift
+++ b/test/Backtracing/CrashStatic.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library %import-static-libdispatch -Onone -static-stdlib -g -o %t/CrashStatic
+// RUN: %target-build-swift %s -parse-as-library -Onone -static-stdlib -g -o %t/CrashStatic
 // RUN: %target-codesign %t/CrashStatic
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer %target-run %t/CrashStatic 2>&1 || true) | %FileCheck %s
 

--- a/test/Backtracing/StaticBacktracer.swift
+++ b/test/Backtracing/StaticBacktracer.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -parse-as-library %import-static-libdispatch -Onone -g -o %t/StaticBacktracer
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/StaticBacktracer
 // RUN: %target-codesign %t/StaticBacktracer
 // RUN: /usr/bin/ldd %backtracer-static | %FileCheck %s --check-prefix LIBS
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no,swift-backtrace=%backtracer-static %target-run %t/StaticBacktracer 2>&1 || true) | %FileCheck %s

--- a/test/Driver/static-stdlib-autolink-linux.swift
+++ b/test/Driver/static-stdlib-autolink-linux.swift
@@ -1,13 +1,12 @@
 // Statically link a program with concurrency module
 // REQUIRES: static_stdlib
 // REQUIRES: concurrency
-// REQUIRES: libdispatch_static
 
 // RUN: %empty-directory(%t)
 // RUN: echo 'public func asyncFunc() async { print("Hello") }' > %t/asyncModule.swift
 
 // RUN: %target-swiftc_driver -emit-library -emit-module -module-name asyncModule -module-link-name asyncModule %t/asyncModule.swift -static -static-stdlib -o %t/libasyncModule.a
-// RUN: %target-swiftc_driver -parse-as-library -static -static-stdlib -module-name main %s %import-static-libdispatch -I%t -L%t -o %t/main
+// RUN: %target-swiftc_driver -parse-as-library -static -static-stdlib -module-name main %s -I%t -L%t -o %t/main
 
 // RUN: %t/main | %FileCheck %s
 // CHECK: Hello

--- a/test/Driver/static-stdlib-linux-lld.swift
+++ b/test/Driver/static-stdlib-linux-lld.swift
@@ -3,7 +3,7 @@
 // REQUIRES: static_stdlib
 print("hello world!")
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver -static-stdlib -use-ld=lld %import-static-libdispatch -o %t/static-stdlib-lld %s
+// RUN: %target-swiftc_driver -static-stdlib -use-ld=lld -o %t/static-stdlib-lld %s
 // RUN: %t/static-stdlib-lld | %FileCheck %s
 // RUN: ldd %t/static-stdlib-lld | %FileCheck %s --check-prefix=LDD
 // CHECK: hello world!

--- a/test/Driver/static-stdlib-linux.swift
+++ b/test/Driver/static-stdlib-linux.swift
@@ -3,7 +3,7 @@
 // REQUIRES: static_stdlib
 print("hello world!")
 // RUN: %empty-directory(%t)
-// RUN: %target-swiftc_driver %import-static-libdispatch -static-stdlib -o %t/static-stdlib %s
+// RUN: %target-swiftc_driver -static-stdlib -o %t/static-stdlib %s
 // RUN: %t/static-stdlib | %FileCheck %s
 // RUN: ldd %t/static-stdlib | %FileCheck %s --check-prefix=LDD
 // CHECK: hello world!

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1875,14 +1875,6 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
         config.import_libdispatch = ('-I %s -I %s -L %s -vfsoverlay %s'
             % (libdispatch_source_dir, libdispatch_swift_module_dir, libdispatch_artifact_dir, libdispatch_vfs_yaml))
 
-    libdispatch_static_artifact_dir = os.path.join(config.libdispatch_static_build_path, 'lib')
-    libdispatch_static_artifacts = [
-        make_path(libdispatch_static_artifact_dir, 'libdispatch.a'),
-        make_path(libdispatch_static_artifact_dir, 'libBlocksRuntime.a')]
-    if (all(os.path.exists(p) for p in libdispatch_static_artifacts)):
-        config.available_features.add('libdispatch_static')
-        config.import_libdispatch_static = '-L %s' % libdispatch_static_artifact_dir
-
     config.target_build_swift = (
         '%s -target %s -toolchain-stdlib-rpath %s %s %s %s %s'
         % (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt,
@@ -3073,11 +3065,6 @@ run_filecheck = '%s %s --allow-unused-prefixes --sanitize BUILD_DIR=%s --sanitiz
 config.substitutions.append(('%FileCheck', run_filecheck))
 config.substitutions.append(('%raw-FileCheck', shell_quote(config.filecheck)))
 config.substitutions.append(('%import-libdispatch', getattr(config, 'import_libdispatch', '')))
-# WARNING: the order of components in a substitution name has to be different from the previous one, as lit does
-# a pure string substitution without understanding that these components are grouped together. That is, the following
-# subsitution name can't be `%import-libdispatch-static`, otherwise the first two components will be substituted with
-# the value of `%import-libdispatch` substitution with `-static` string appended to it.
-config.substitutions.append(('%import-static-libdispatch', getattr(config, 'import_libdispatch_static', '')))
 
 # Disable COW soundness checks in the swift runtime by default.
 # (But it's required to set this environment variable to something)


### PR DESCRIPTION
libdispatch will be built dynamically always as that is a C library and it does not make sense to have more than one copy in an address space, particularly if you have a Swift plugin hosted within a C program that has dispatch linked in.