### PR TITLE
[build] Switch over to new `--cross-compile-build-swift-tools` flag when cross-compiling Foundation macros

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2331,7 +2331,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     continue
                 fi
 
-                if [[ "${BUILD_SWIFT_TOOLS}" == "0" ]]; then
+                if [[ "${CROSS_COMPILE_BUILD_SWIFT_TOOLS}" == "0" ]]; then
                     echo "Skipping building Foundation Macros for ${host}, because the host tools are not being built"
                     continue
                 fi
@@ -2920,7 +2920,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     continue
                 fi
 
-                if [[ "${BUILD_SWIFT_TOOLS}" == "0" && "${product}" == "foundation_macros" ]]; then
+                if [[ "${CROSS_COMPILE_BUILD_SWIFT_TOOLS}" == "0" && "${product}" == "foundation_macros" ]]; then
                     echo "Skipping installing Foundation Macros for ${host}, because the host tools are not being built"
                     continue
                 fi


### PR DESCRIPTION
Follow-on to #38441, missed this there.