### PR TITLE
{AST,Basic}Bridging: Use  `<swift/bridging>` and try directly bridging one of our enums

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -19,6 +19,7 @@
 // Pure bridging mode does not permit including any C++/llvm/swift headers.
 // See also the comments for `BRIDGING_MODE` in the top-level CMakeLists.txt file.
 //
+#include "swift/AST/DiagnosticKind.h"
 #include "swift/Basic/BasicBridging.h"
 
 #ifdef USED_IN_CPP_SOURCE
@@ -565,15 +566,6 @@ public:
   BridgedDiagnosticFixIt(BridgedSourceLoc start, uint32_t length, BridgedStringRef text);
 };
 
-/// Diagnostic severity when reporting diagnostics.
-enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagnosticSeverity : size_t {
-  BridgedFatalError,
-  BridgedError,
-  BridgedWarning,
-  BridgedRemark,
-  BridgedNote,
-};
-
 class BridgedDiagnostic {
 public:
   struct Impl;
@@ -612,7 +604,7 @@ bool BridgedDiagnosticEngine_hadAnyError(BridgedDiagnosticEngine);
 SWIFT_NAME("BridgedDiagnostic.init(at:message:severity:engine:)")
 BridgedDiagnostic BridgedDiagnostic_create(BridgedSourceLoc cLoc,
                                            BridgedStringRef cText,
-                                           BridgedDiagnosticSeverity severity,
+                                           swift::DiagnosticKind severity,
                                            BridgedDiagnosticEngine cDiags);
 
 /// Highlight a source range as part of the diagnostic.

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -118,17 +118,15 @@ public:
   BridgedIdentifier(const void *_Nullable raw) : Raw(raw) {}
 
   BRIDGED_INLINE BridgedIdentifier(swift::Identifier ident);
-
   BRIDGED_INLINE swift::Identifier unbridged() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  const void *_Nullable getRaw() const { return Raw; }
+
+  BRIDGED_INLINE
+  SWIFT_COMPUTED_PROPERTY
+  bool getIsOperator() const;
 };
-
-SWIFT_NAME("getter:BridgedIdentifier.raw(self:)")
-inline const void *_Nullable BridgedIdentifier_raw(BridgedIdentifier ident) {
-  return ident.Raw;
-}
-
-SWIFT_NAME("getter:BridgedIdentifier.isOperator(self:)")
-BRIDGED_INLINE bool BridgedIdentifier_isOperator(const BridgedIdentifier);
 
 struct BridgedLocatedIdentifier {
   SWIFT_NAME("name")
@@ -236,6 +234,11 @@ BridgedDeclNameLoc_createParsed(
 // MARK: ASTContext
 //===----------------------------------------------------------------------===//
 
+enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedEndianness : size_t {
+  EndianLittle,
+  EndianBig,
+};
+
 class BridgedASTContext {
   swift::ASTContext * _Nonnull Ctx;
 
@@ -245,16 +248,30 @@ public:
 
   SWIFT_UNAVAILABLE("Use '.raw' instead")
   BRIDGED_INLINE swift::ASTContext &unbridged() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  void *_Nonnull getRaw() const { return Ctx; }
+
+  SWIFT_COMPUTED_PROPERTY
+  unsigned getMajorLanguageVersion() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  unsigned getLangOptsTargetPointerBitWidth() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  bool getLangOptsAttachCommentsToDecls() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  BridgedEndianness getLangOptsTargetEndianness() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  BridgedAvailabilityMacroMap getAvailabilityMacroMap() const;
 };
 
 #define IDENTIFIER_WITH_NAME(Name, _) \
 SWIFT_NAME("getter:BridgedASTContext.id_" #Name "(self:)") \
 BRIDGED_INLINE BridgedIdentifier BridgedASTContext_id_##Name(BridgedASTContext bridged);
 #include "swift/AST/KnownIdentifiers.def"
-
-SWIFT_NAME("getter:BridgedASTContext.raw(self:)")
-BRIDGED_INLINE
-void * _Nonnull BridgedASTContext_raw(BridgedASTContext bridged);
 
 SWIFT_NAME("BridgedASTContext.init(raw:)")
 BRIDGED_INLINE
@@ -282,9 +299,6 @@ BridgedASTContext_getDollarIdentifier(BridgedASTContext cContext, size_t idx);
 SWIFT_NAME("BridgedASTContext.langOptsHasFeature(self:_:)")
 bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
                                           BridgedFeature feature);
-
-SWIFT_NAME("getter:BridgedASTContext.majorLanguageVersion(self:)")
-unsigned BridgedASTContext_majorLanguageVersion(BridgedASTContext cContext);
 
 SWIFT_NAME("BridgedASTContext.langOptsCustomConditionSet(self:_:)")
 bool BridgedASTContext_langOptsCustomConditionSet(BridgedASTContext cContext,
@@ -318,24 +332,9 @@ SWIFT_NAME("BridgedASTContext.langOptsIsActiveTargetPtrAuth(self:_:)")
 bool BridgedASTContext_langOptsIsActiveTargetPtrAuth(BridgedASTContext cContext,
                                                      BridgedStringRef cName);
 
-SWIFT_NAME("getter:BridgedASTContext.langOptsTargetPointerBitWidth(self:)")
-unsigned BridgedASTContext_langOptsTargetPointerBitWidth(BridgedASTContext cContext);
-
 SWIFT_NAME("BridgedASTContext.langOptsGetTargetAtomicBitWidths(self:_:)")
 SwiftInt BridgedASTContext_langOptsGetTargetAtomicBitWidths(BridgedASTContext cContext,
                                                       SwiftInt* _Nullable * _Nonnull cComponents);
-
-enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedEndianness : size_t {
-  EndianLittle,
-  EndianBig,
-};
-
-SWIFT_NAME("getter:BridgedASTContext.langOptsAttachCommentsToDecls(self:)")
-bool BridgedASTContext_langOptsAttachCommentsToDecls(
-    BridgedASTContext cContext);
-
-SWIFT_NAME("getter:BridgedASTContext.langOptsTargetEndianness(self:)")
-BridgedEndianness BridgedASTContext_langOptsTargetEndianness(BridgedASTContext cContext);
 
 SWIFT_NAME("BridgedASTContext.langOptsGetLanguageVersion(self:_:)")
 SwiftInt BridgedASTContext_langOptsGetLanguageVersion(BridgedASTContext cContext,
@@ -344,10 +343,6 @@ SwiftInt BridgedASTContext_langOptsGetLanguageVersion(BridgedASTContext cContext
 SWIFT_NAME("BridgedASTContext.langOptsGetCompilerVersion(self:_:)")
 SwiftInt BridgedASTContext_langOptsGetCompilerVersion(BridgedASTContext cContext,
                                                       SwiftInt* _Nullable * _Nonnull cComponents);
-
-SWIFT_NAME("getter:BridgedASTContext.availabilityMacroMap(self:)")
-BridgedAvailabilityMacroMap
-BridgedASTContext_getAvailabilityMacroMap(BridgedASTContext cContext);
 
 /* Deallocate an array of Swift int values that was allocated in C++. */
 void deallocateIntBuffer(SwiftInt * _Nullable cComponents);
@@ -442,7 +437,7 @@ public:
     return BridgedASTNode(e.unbridged(), BridgedASTNodeKindExpr);
   }
 
-  SWIFT_UNAVAILABLE("use .kind")
+  SWIFT_COMPUTED_PROPERTY
   BridgedASTNodeKind getKind() const {
     return static_cast<BridgedASTNodeKind>(opaque & 0x7);
   }
@@ -453,11 +448,6 @@ public:
 
   BRIDGED_INLINE swift::ASTNode unbridged() const;
 };
-
-SWIFT_NAME("getter:BridgedASTNode.kind(self:)")
-inline BridgedASTNodeKind BridgedASTNode_getKind(BridgedASTNode node) {
-  return node.getKind();
-}
 
 // Declare `.asDecl` on each BridgedXXXDecl type, which upcasts a wrapper for
 // a Decl subclass to a BridgedDecl.
@@ -1930,8 +1920,11 @@ class BridgedCaptureListEntry {
 
 public:
   BRIDGED_INLINE BridgedCaptureListEntry(swift::CaptureListEntry CLE);
-
   BRIDGED_INLINE swift::CaptureListEntry unbridged() const;
+
+  BRIDGED_INLINE
+  SWIFT_COMPUTED_PROPERTY
+  BridgedVarDecl getVarDecl() const;
 };
 
 SWIFT_NAME("BridgedCaptureListEntry.createParsed(_:declContext:ownership:"
@@ -1942,10 +1935,6 @@ BridgedCaptureListEntry BridegedCaptureListEntry_createParsed(
     BridgedSourceRange cOwnershipRange, BridgedIdentifier cName,
     BridgedSourceLoc cNameLoc, BridgedSourceLoc cEqualLoc,
     BridgedExpr cInitializer);
-
-SWIFT_NAME("getter:BridgedCaptureListEntry.varDecl(self:)")
-BRIDGED_INLINE BridgedVarDecl
-BridegedCaptureListEntry_getVar(BridgedCaptureListEntry entry);
 
 SWIFT_NAME("BridgedCaptureListExpr.createParsed(_:captureList:closure:)")
 BridgedCaptureListExpr BridgedCaptureListExpr_createParsed(BridgedASTContext cContext,

--- a/include/swift/AST/ASTBridgingImpl.h
+++ b/include/swift/AST/ASTBridgingImpl.h
@@ -43,8 +43,8 @@ swift::Identifier BridgedIdentifier::unbridged() const {
   return swift::Identifier::getFromOpaquePointer(Raw);
 }
 
-bool BridgedIdentifier_isOperator(const BridgedIdentifier ident) {
-  return ident.unbridged().isOperator();
+bool BridgedIdentifier::getIsOperator() const {
+  return unbridged().isOperator();
 }
 
 //===----------------------------------------------------------------------===//
@@ -100,10 +100,6 @@ swift::DeclNameLoc BridgedDeclNameLoc::unbridged() const {
 BridgedASTContext::BridgedASTContext(swift::ASTContext &ctx) : Ctx(&ctx) {}
 
 swift::ASTContext &BridgedASTContext::unbridged() const { return *Ctx; }
-
-void * _Nonnull BridgedASTContext_raw(BridgedASTContext bridged) {
-  return &bridged.unbridged();
-}
 
 BridgedASTContext BridgedASTContext_fromRaw(void * _Nonnull ptr) {
   return *static_cast<swift::ASTContext *>(ptr);
@@ -938,8 +934,8 @@ swift::CaptureListEntry BridgedCaptureListEntry::unbridged() const {
   return swift::CaptureListEntry(PBD);
 }
 
-BridgedVarDecl BridegedCaptureListEntry_getVar(BridgedCaptureListEntry entry) {
-  return entry.unbridged().getVar();
+BridgedVarDecl BridgedCaptureListEntry::getVarDecl() const {
+  return unbridged().getVar();
 }
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -19,6 +19,7 @@
 #ifndef SWIFT_BASIC_DIAGNOSTICCONSUMER_H
 #define SWIFT_BASIC_DIAGNOSTICCONSUMER_H
 
+#include "swift/AST/DiagnosticKind.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/SourceLoc.h"
 #include "llvm/Support/SourceMgr.h"
@@ -29,15 +30,6 @@ namespace swift {
   class DiagnosticEngine;
   class SourceManager;
   enum class DiagID : uint32_t;
-
-/// Describes the kind of diagnostic.
-///
-enum class DiagnosticKind : uint8_t {
-  Error,
-  Warning,
-  Remark,
-  Note
-};
 
 /// Information about a diagnostic passed to DiagnosticConsumers.
 struct DiagnosticInfo {

--- a/include/swift/AST/DiagnosticKind.h
+++ b/include/swift/AST/DiagnosticKind.h
@@ -1,0 +1,33 @@
+//===-- AST/DiagnosticKind.h ------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_DIAGNOSTIC_KIND_H
+#define SWIFT_AST_DIAGNOSTIC_KIND_H
+
+/// This header is included in a bridging header. Be *very* careful with what
+/// you include here! See include caveats in `ASTBridging.h`.
+#include "swift/Basic/SwiftBridging.h"
+#include <stdint.h>
+
+namespace swift {
+
+/// Describes the kind of diagnostic.
+enum class ENUM_EXTENSIBILITY_ATTR(open) DiagnosticKind : uint8_t {
+  Error SWIFT_NAME("error"),
+  Warning SWIFT_NAME("warning"),
+  Remark SWIFT_NAME("remark"),
+  Note SWIFT_NAME("note")
+};
+
+} // namespace swift
+
+#endif // SWIFT_AST_DIAGNOSTIC_KIND_H

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -104,13 +104,10 @@ typedef uintptr_t SwiftUInt;
                                                                                \
     SWIFT_UNAVAILABLE("Use '.raw' instead")                                    \
     Qualifier Node *Nullability unbridged() const { return Ptr; }              \
-  };                                                                           \
                                                                                \
-  SWIFT_NAME("getter:Bridged" #Name ".raw(self:)")                             \
-  inline Qualifier void *Nullability Bridged##Name##_getRaw(                   \
-      Bridged##Name bridged) {                                                 \
-    return bridged.unbridged();                                                \
-  }                                                                            \
+    SWIFT_COMPUTED_PROPERTY                                                    \
+    Qualifier void *Nullability getRaw() const { return unbridged(); };        \
+  };                                                                           \
                                                                                \
   SWIFT_NAME("Bridged" #Name ".init(raw:)")                                    \
   inline Bridged##Name Bridged##Name##_fromRaw(                                \
@@ -162,20 +159,19 @@ public:
     return {static_cast<const T *>(Data), Length};
   }
 #endif
+
+  SWIFT_COMPUTED_PROPERTY
+  const void *_Nullable getData() const { return Data; }
+
+  SWIFT_COMPUTED_PROPERTY
+  SwiftInt getCount() const { return static_cast<SwiftInt>(Length); }
+
+  SWIFT_COMPUTED_PROPERTY
+  bool getIsEmpty() const { return Length == 0; }
 };
 
-SWIFT_NAME("getter:BridgedArrayRef.data(self:)")
-BRIDGED_INLINE
-const void *_Nullable BridgedArrayRef_data(BridgedArrayRef arr);
-
-SWIFT_NAME("getter:BridgedArrayRef.count(self:)")
-BRIDGED_INLINE SwiftInt BridgedArrayRef_count(BridgedArrayRef arr);
-
-SWIFT_NAME("getter:BridgedArrayRef.isEmpty(self:)")
-BRIDGED_INLINE bool BridgedArrayRef_isEmpty(BridgedArrayRef arr);
-
 //===----------------------------------------------------------------------===//
-// MARK: Data
+// MARK: BridgedData
 //===----------------------------------------------------------------------===//
 
 class BridgedData {
@@ -191,17 +187,15 @@ public:
   SWIFT_NAME("init(baseAddress:count:)")
   BridgedData(const char *_Nullable baseAddress, size_t length)
       : BaseAddress(baseAddress), Length(length) {}
+
+  SWIFT_COMPUTED_PROPERTY
+  const char *_Nullable getBaseAddress() const { return BaseAddress; }
+
+  SWIFT_COMPUTED_PROPERTY
+  SwiftInt getCount() const { return static_cast<SwiftInt>(Length); }
+
+  void free() const;
 };
-
-SWIFT_NAME("getter:BridgedData.baseAddress(self:)")
-BRIDGED_INLINE
-const char *_Nullable BridgedData_baseAddress(BridgedData data);
-
-SWIFT_NAME("getter:BridgedData.count(self:)")
-BRIDGED_INLINE SwiftInt BridgedData_count(BridgedData data);
-
-SWIFT_NAME("BridgedData.free(self:)")
-void BridgedData_free(BridgedData data);
 
 //===----------------------------------------------------------------------===//
 // MARK: Feature
@@ -232,18 +226,17 @@ public:
   BridgedStringRef(const char *_Nullable data, size_t length)
       : Data(data), Length(length) {}
 
+  SWIFT_COMPUTED_PROPERTY
+  const uint8_t *_Nullable getData() const { return (const uint8_t *)Data; }
+
+  SWIFT_COMPUTED_PROPERTY
+  SwiftInt getCount() const { return Length; }
+
+  SWIFT_COMPUTED_PROPERTY
+  bool getIsEmpty() const { return Length == 0; }
+
   void write(BridgedOStream os) const;
 };
-
-SWIFT_NAME("getter:BridgedStringRef.data(self:)")
-BRIDGED_INLINE 
-const uint8_t *_Nullable BridgedStringRef_data(BridgedStringRef str);
-
-SWIFT_NAME("getter:BridgedStringRef.count(self:)")
-BRIDGED_INLINE SwiftInt BridgedStringRef_count(BridgedStringRef str);
-
-SWIFT_NAME("getter:BridgedStringRef.isEmpty(self:)")
-BRIDGED_INLINE bool BridgedStringRef_empty(BridgedStringRef str);
 
 class BridgedOwnedString {
   char *_Nonnull Data;
@@ -251,21 +244,21 @@ class BridgedOwnedString {
 
 public:
   BridgedOwnedString(llvm::StringRef stringToCopy);
-
   BRIDGED_INLINE llvm::StringRef unbridgedRef() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  const uint8_t *_Nonnull getData() const {
+    return (const uint8_t *)(Data ? Data : "");
+  }
+
+  SWIFT_COMPUTED_PROPERTY
+  SwiftInt getCount() const { return Length; }
+
+  SWIFT_COMPUTED_PROPERTY
+  bool getIsEmpty() const { return Length == 0; }
 
   void destroy() const;
 } SWIFT_SELF_CONTAINED;
-
-SWIFT_NAME("getter:BridgedOwnedString.data(self:)")
-BRIDGED_INLINE 
-const uint8_t *_Nullable BridgedOwnedString_data(BridgedOwnedString str);
-
-SWIFT_NAME("getter:BridgedOwnedString.count(self:)")
-BRIDGED_INLINE SwiftInt BridgedOwnedString_count(BridgedOwnedString str);
-
-SWIFT_NAME("getter:BridgedOwnedString.isEmpty(self:)")
-BRIDGED_INLINE bool BridgedOwnedString_empty(BridgedOwnedString str);
 
 //===----------------------------------------------------------------------===//
 // MARK: BridgedOptionalInt
@@ -296,8 +289,15 @@ public:
   SWIFT_UNAVAILABLE("Use init(raw:) instead")
   BridgedOStream(llvm::raw_ostream * _Nonnull os) : os(os) {}
 
+  SWIFT_NAME("init(raw:)")
+  BridgedOStream(void *_Nonnull os)
+      : os(static_cast<llvm::raw_ostream *>(os)) {}
+
   SWIFT_UNAVAILABLE("Use '.raw' instead")
   llvm::raw_ostream * _Nonnull unbridged() const { return os; }
+
+  SWIFT_COMPUTED_PROPERTY
+  void *_Nonnull getRaw(BridgedOStream bridged) const { return unbridged(); }
 
   void write(BridgedStringRef string) const;
 
@@ -305,16 +305,6 @@ public:
 
   void flush() const;
 };
-
-SWIFT_NAME("getter:BridgedOStream.raw(self:)")
-inline void * _Nonnull BridgedOStream_getRaw(BridgedOStream bridged) {
-  return bridged.unbridged();
-}
-
-SWIFT_NAME("BridgedOStream.init(raw:)")
-inline BridgedOStream BridgedOStream_fromRaw(void * _Nonnull os) {
-  return static_cast<llvm::raw_ostream *>(os);
-}
 
 BridgedOStream Bridged_dbgs();
 
@@ -338,13 +328,13 @@ public:
   SWIFT_IMPORT_UNSAFE
   const void *_Nullable getOpaquePointerValue() const { return Raw; }
 
+  SWIFT_COMPUTED_PROPERTY
+  bool getIsValid() const { return Raw != nullptr; }
+
   SWIFT_NAME("advanced(by:)")
   BRIDGED_INLINE
   BridgedSourceLoc advancedBy(size_t n) const;
 };
-
-SWIFT_NAME("getter:BridgedSourceLoc.isValid(self:)")
-BRIDGED_INLINE bool BridgedSourceLoc_isValid(BridgedSourceLoc loc);
 
 //===----------------------------------------------------------------------===//
 // MARK: SourceRange
@@ -388,19 +378,13 @@ public:
   BRIDGED_INLINE BridgedCharSourceRange(swift::CharSourceRange range);
 
   BRIDGED_INLINE swift::CharSourceRange unbridged() const;
+
+  SWIFT_COMPUTED_PROPERTY
+  BridgedSourceLoc getStart() const { return Start; }
+
+  SWIFT_COMPUTED_PROPERTY
+  SwiftInt getByteLength() const { return static_cast<SwiftInt>(ByteLength); }
 };
-
-SWIFT_NAME("getter:BridgedCharSourceRange.start(self:)")
-inline BridgedSourceLoc
-BridgedCharSourceRange_start(BridgedCharSourceRange range) {
-  return range.Start;
-}
-
-SWIFT_NAME("getter:BridgedCharSourceRange.byteLength(self:)")
-inline SwiftInt
-BridgedCharSourceRange_byteLength(BridgedCharSourceRange range) {
-  return static_cast<SwiftInt>(range.ByteLength);
-}
 
 //===----------------------------------------------------------------------===//
 // MARK: std::vector<BridgedCharSourceRange>

--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -38,7 +38,7 @@
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 #include "swift/Basic/BridgedSwiftObject.h"
-#include "swift/Basic/Compiler.h"
+#include "swift/Basic/SwiftBridging.h"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -53,13 +53,6 @@
 #include "llvm/ADT/APInt.h"
 #include <string>
 #include <vector>
-#endif
-
-// FIXME: We ought to be importing '<swift/bridging>' instead.
-#if __has_attribute(swift_name)
-#define SWIFT_NAME(NAME) __attribute__((swift_name(NAME)))
-#else
-#define SWIFT_NAME(NAME)
 #endif
 
 #if __has_attribute(availability)

--- a/include/swift/Basic/BasicBridgingImpl.h
+++ b/include/swift/Basic/BasicBridgingImpl.h
@@ -20,34 +20,6 @@
 SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 
 //===----------------------------------------------------------------------===//
-// MARK: BridgedArrayRef
-//===----------------------------------------------------------------------===//
-
-const void *_Nullable BridgedArrayRef_data(BridgedArrayRef arr) {
-  return arr.Data;
-}
-
-SwiftInt BridgedArrayRef_count(BridgedArrayRef arr) {
-  return static_cast<SwiftInt>(arr.Length);
-}
-
-bool BridgedArrayRef_isEmpty(BridgedArrayRef arr) {
-  return arr.Length == 0;
-}
-
-//===----------------------------------------------------------------------===//
-// MARK: BridgedData
-//===----------------------------------------------------------------------===//
-
-const char *_Nullable BridgedData_baseAddress(BridgedData data) {
-  return data.BaseAddress;
-}
-
-SwiftInt BridgedData_count(BridgedData data) {
-  return static_cast<SwiftInt>(data.Length);
-}
-
-//===----------------------------------------------------------------------===//
 // MARK: BridgedStringRef
 //===----------------------------------------------------------------------===//
 
@@ -58,36 +30,11 @@ llvm::StringRef BridgedStringRef::unbridged() const {
   return llvm::StringRef(Data, Length);
 }
 
-const uint8_t *_Nullable BridgedStringRef_data(BridgedStringRef str) {
-  return (const uint8_t *)str.unbridged().data();
-}
-
-SwiftInt BridgedStringRef_count(BridgedStringRef str) {
-  return (SwiftInt)str.unbridged().size();
-}
-
-bool BridgedStringRef_empty(BridgedStringRef str) {
-  return str.unbridged().empty();
-}
-
 //===----------------------------------------------------------------------===//
 // MARK: BridgedOwnedString
 //===----------------------------------------------------------------------===//
 
 llvm::StringRef BridgedOwnedString::unbridgedRef() const { return llvm::StringRef(Data, Length); }
-
-const uint8_t *_Nullable BridgedOwnedString_data(BridgedOwnedString str) {
-  auto *data = str.unbridgedRef().data();
-  return (const uint8_t *)(data ? data : "");
-}
-
-SwiftInt BridgedOwnedString_count(BridgedOwnedString str) {
-  return (SwiftInt)str.unbridgedRef().size();
-}
-
-bool BridgedOwnedString_empty(BridgedOwnedString str) {
-  return str.unbridgedRef().empty();
-}
 
 //===----------------------------------------------------------------------===//
 // MARK: BridgedSourceLoc
@@ -99,10 +46,6 @@ BridgedSourceLoc::BridgedSourceLoc(swift::SourceLoc loc)
 swift::SourceLoc BridgedSourceLoc::unbridged() const {
   return swift::SourceLoc(
       llvm::SMLoc::getFromPointer(static_cast<const char *>(Raw)));
-}
-
-bool BridgedSourceLoc_isValid(BridgedSourceLoc loc) {
-  return loc.getOpaquePointerValue() != nullptr;
 }
 
 BridgedSourceLoc BridgedSourceLoc::advancedBy(size_t n) const {

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -90,13 +90,6 @@
 #define SWIFT_IMPORT_UNSAFE
 #endif
 
-/// Same as `SWIFT_SELF_CONTAINED` in <swift/bridging>.
-#if __has_attribute(swift_attr)
-#define SWIFT_SELF_CONTAINED __attribute__((swift_attr("import_owned")))
-#else
-#define SWIFT_SELF_CONTAINED
-#endif
-
 #ifdef __GNUC__
 #define SWIFT_ATTRIBUTE_NORETURN __attribute__((noreturn))
 #elif defined(_MSC_VER)

--- a/include/swift/Basic/SwiftBridging.h
+++ b/include/swift/Basic/SwiftBridging.h
@@ -1,0 +1,61 @@
+//===--- Basic/SwiftBridging.h ----------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This is a wrapper around `<swift/bridging>` that redefines `SWIFT_NAME` to
+/// accept a string literal, and some other macros in case the header is
+/// unavailable (e.g. during bootstrapping). String literals enable us to
+/// properly format the long Swift declaration names that many of our bridging
+/// functions have.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_SWIFT_BRIDGING_H
+#define SWIFT_BASIC_SWIFT_BRIDGING_H
+
+#include "swift/Basic/Compiler.h"
+#if __has_include(<swift/bridging>)
+#include <swift/bridging>
+#else
+
+#if __has_attribute(swift_attr)
+
+/// Specifies that a C++ `class` or `struct` owns and controls the lifetime of
+/// all of the objects it references. Such type should not reference any
+/// objects whose lifetime is controlled externally. This annotation allows
+/// Swift to import methods that return a `class` or `struct` type that is
+/// annotated with this macro.
+#define SWIFT_SELF_CONTAINED __attribute__((swift_attr("import_owned")))
+
+#else // #if __has_attribute(swift_attr)
+
+#define SWIFT_SELF_CONTAINED
+#define SWIFT_COMPUTED_PROPERTY
+
+#endif // #if __has_attribute(swift_attr)
+
+#endif // #if __has_include(<swift/bridging>)
+
+// Redefine SWIFT_NAME.
+#ifdef SWIFT_NAME
+#undef SWIFT_NAME
+#endif
+
+#if __has_attribute(swift_name)
+/// Specifies a name that will be used in Swift for this declaration instead of
+/// its original name.
+#define SWIFT_NAME(_name) __attribute__((swift_name(_name)))
+#else
+#define SWIFT_NAME(_name)
+#endif
+
+#endif // SWIFT_BASIC_SWIFT_BRIDGING_H
+

--- a/include/swift/Basic/SwiftBridging.h
+++ b/include/swift/Basic/SwiftBridging.h
@@ -35,6 +35,19 @@
 /// annotated with this macro.
 #define SWIFT_SELF_CONTAINED __attribute__((swift_attr("import_owned")))
 
+/// Specifies that a specific C++ method should be imported as a computed
+/// property. If this macro is specified on a getter, a getter will be
+/// synthesized. If this macro is specified on a setter, both a getter and
+/// setter will be synthesized.
+///
+/// For example:
+///  ```
+///    int getX() SWIFT_COMPUTED_PROPERTY;
+///  ```
+/// Will be imported as `var x: CInt {...}`.
+#define SWIFT_COMPUTED_PROPERTY                                                \
+  __attribute__((swift_attr("import_computed_property")))
+
 #else // #if __has_attribute(swift_attr)
 
 #define SWIFT_SELF_CONTAINED

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -28,7 +28,7 @@ void swift_ASTGen_addQueuedSourceFile(
 void swift_ASTGen_addQueuedDiagnostic(
     void *_Nonnull queued, void *_Nonnull state,
     BridgedStringRef text,
-    BridgedDiagnosticSeverity severity,
+    swift::DiagnosticKind severity,
     BridgedSourceLoc sourceLoc,
     BridgedStringRef categoryName,
     BridgedStringRef documentationPath,
@@ -38,7 +38,7 @@ void swift_ASTGen_addQueuedDiagnostic(
 void swift_ASTGen_renderSingleDiagnostic(
     void *_Nonnull state,
     BridgedStringRef text,
-    BridgedDiagnosticSeverity severity,
+    swift::DiagnosticKind severity,
     BridgedStringRef categoryName,
     BridgedStringRef documentationPath,
     ssize_t colorize,

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -13,11 +13,12 @@
 #ifndef SWIFT_SIL_LOCATION_H
 #define SWIFT_SIL_LOCATION_H
 
-#include "llvm/ADT/PointerUnion.h"
 #include "swift/AST/ASTNode.h"
-#include "swift/Basic/SourceLoc.h"
-#include "swift/SIL/SILAllocated.h"
 #include "swift/AST/TypeAlignments.h"
+#include "swift/Basic/SourceLoc.h"
+#include "swift/Basic/SwiftBridging.h"
+#include "swift/SIL/SILAllocated.h"
+#include "llvm/ADT/PointerUnion.h"
 
 #include <cstddef>
 #include <type_traits>

--- a/lib/AST/Bridging/ASTContextBridging.cpp
+++ b/lib/AST/Bridging/ASTContextBridging.cpp
@@ -36,8 +36,8 @@ bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
   return cContext.unbridged().LangOpts.hasFeature((Feature)feature);
 }
 
-unsigned BridgedASTContext_majorLanguageVersion(BridgedASTContext cContext) {
-  return cContext.unbridged().LangOpts.EffectiveLanguageVersion[0];
+unsigned BridgedASTContext::getMajorLanguageVersion() const {
+  return unbridged().LangOpts.EffectiveLanguageVersion[0];
 }
 
 bool BridgedASTContext_langOptsCustomConditionSet(BridgedASTContext cContext,
@@ -90,23 +90,20 @@ bool BridgedASTContext_langOptsIsActiveTargetPtrAuth(BridgedASTContext cContext,
       PlatformConditionKind::PtrAuth, cName.unbridged());
 }
 
-unsigned
-BridgedASTContext_langOptsTargetPointerBitWidth(BridgedASTContext cContext) {
-  return cContext.unbridged().LangOpts.Target.isArch64Bit()   ? 64
-         : cContext.unbridged().LangOpts.Target.isArch32Bit() ? 32
-         : cContext.unbridged().LangOpts.Target.isArch16Bit() ? 16
-                                                              : 0;
+unsigned BridgedASTContext::getLangOptsTargetPointerBitWidth() const {
+  return unbridged().LangOpts.Target.isArch64Bit()   ? 64
+         : unbridged().LangOpts.Target.isArch32Bit() ? 32
+         : unbridged().LangOpts.Target.isArch16Bit() ? 16
+                                                     : 0;
 }
 
-bool BridgedASTContext_langOptsAttachCommentsToDecls(
-    BridgedASTContext cContext) {
-  return cContext.unbridged().LangOpts.AttachCommentsToDecls;
+bool BridgedASTContext::getLangOptsAttachCommentsToDecls() const {
+  return unbridged().LangOpts.AttachCommentsToDecls;
 }
 
-BridgedEndianness
-BridgedASTContext_langOptsTargetEndianness(BridgedASTContext cContext) {
-  return cContext.unbridged().LangOpts.Target.isLittleEndian() ? EndianLittle
-                                                               : EndianBig;
+BridgedEndianness BridgedASTContext::getLangOptsTargetEndianness() const {
+  return unbridged().LangOpts.Target.isLittleEndian() ? EndianLittle
+                                                      : EndianBig;
 }
 
 /// Convert an array of numbers into a form we can use in Swift.
@@ -179,7 +176,6 @@ bool BridgedASTContext_canImport(BridgedASTContext cContext,
       versionKind == CanImportUnderlyingVersion);
 }
 
-BridgedAvailabilityMacroMap
-BridgedASTContext_getAvailabilityMacroMap(BridgedASTContext cContext) {
-  return &cContext.unbridged().getAvailabilityMacroMap();
+BridgedAvailabilityMacroMap BridgedASTContext::getAvailabilityMacroMap() const {
+  return &unbridged().getAvailabilityMacroMap();
 }

--- a/lib/AST/Bridging/DiagnosticsBridging.cpp
+++ b/lib/AST/Bridging/DiagnosticsBridging.cpp
@@ -118,7 +118,7 @@ struct BridgedDiagnostic::Impl {
 
 BridgedDiagnostic BridgedDiagnostic_create(BridgedSourceLoc cLoc,
                                            BridgedStringRef cText,
-                                           BridgedDiagnosticSeverity severity,
+                                           DiagnosticKind severity,
                                            BridgedDiagnosticEngine cDiags) {
   StringRef origText = cText.unbridged();
   BridgedDiagnostic::Impl::Allocator alloc;
@@ -128,19 +128,16 @@ BridgedDiagnostic BridgedDiagnostic_create(BridgedSourceLoc cLoc,
 
   Diag<StringRef> diagID;
   switch (severity) {
-  case BridgedDiagnosticSeverity::BridgedError:
+  case DiagnosticKind::Error:
     diagID = diag::bridged_error;
     break;
-  case BridgedDiagnosticSeverity::BridgedFatalError:
-    diagID = diag::bridged_fatal_error;
-    break;
-  case BridgedDiagnosticSeverity::BridgedNote:
+  case DiagnosticKind::Note:
     diagID = diag::bridged_note;
     break;
-  case BridgedDiagnosticSeverity::BridgedRemark:
+  case DiagnosticKind::Remark:
     diagID = diag::bridged_remark;
     break;
-  case BridgedDiagnosticSeverity::BridgedWarning:
+  case DiagnosticKind::Warning:
     diagID = diag::bridged_warning;
     break;
   }

--- a/lib/AST/DiagnosticBridge.cpp
+++ b/lib/AST/DiagnosticBridge.cpp
@@ -26,21 +26,6 @@
 using namespace swift;
 
 #if SWIFT_BUILD_SWIFT_SYNTAX
-static BridgedDiagnosticSeverity bridgeDiagnosticSeverity(DiagnosticKind kind) {
-  switch (kind) {
-  case DiagnosticKind::Error:
-    return BridgedDiagnosticSeverity::BridgedError;
-
-  case DiagnosticKind::Warning:
-    return BridgedDiagnosticSeverity::BridgedWarning;
-
-  case DiagnosticKind::Remark:
-    return BridgedDiagnosticSeverity::BridgedRemark;
-
-  case DiagnosticKind::Note:
-    return BridgedDiagnosticSeverity::BridgedNote;
-  }
-}
 
 /// Enqueue a diagnostic with ASTGen's diagnostic rendering.
 static void addQueueDiagnostic(void *queuedDiagnostics,
@@ -52,8 +37,6 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
     DiagnosticEngine::formatDiagnosticText(out, info.FormatString,
                                            info.FormatArgs);
   }
-
-  BridgedDiagnosticSeverity severity = bridgeDiagnosticSeverity(info.Kind);
 
   // Map the highlight ranges.
   SmallVector<BridgedCharSourceRange, 2> highlightRanges;
@@ -72,7 +55,7 @@ static void addQueueDiagnostic(void *queuedDiagnostics,
   swift_ASTGen_addQueuedDiagnostic(
       queuedDiagnostics, perFrontendState,
       text.str(),
-      severity, info.Loc,
+      info.Kind, info.Loc,
       info.Category,
       documentationPath,
       highlightRanges.data(), highlightRanges.size(),
@@ -102,11 +85,9 @@ void DiagnosticBridge::emitDiagnosticWithoutLocation(
                                            info.FormatArgs);
   }
 
-  BridgedDiagnosticSeverity severity = bridgeDiagnosticSeverity(info.Kind);
-
   BridgedStringRef bridgedRenderedString{nullptr, 0};
   swift_ASTGen_renderSingleDiagnostic(
-      perFrontendState, text.str(), severity, info.Category,
+      perFrontendState, text.str(), info.Kind, info.Category,
       llvm::StringRef(info.CategoryDocumentationURL), forceColors ? 1 : 0,
       &bridgedRenderedString);
 

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -120,7 +120,7 @@ public func emitDiagnostic(
 }
 
 extension DiagnosticSeverity {
-  public var bridged: BridgedDiagnosticSeverity {
+  public var bridged: swift.DiagnosticKind {
     switch self {
     case .error: return .error
     case .note: return .note
@@ -177,10 +177,9 @@ fileprivate struct SimpleDiagnostic: DiagnosticMessage {
   }
 }
 
-extension BridgedDiagnosticSeverity {
+extension swift.DiagnosticKind {
   var asSeverity: DiagnosticSeverity {
     switch self {
-    case .fatalError: return .error
     case .error: return .error
     case .warning: return .warning
     case .remark: return .remark
@@ -250,7 +249,7 @@ public func addQueuedDiagnostic(
   queuedDiagnosticsPtr: UnsafeMutableRawPointer,
   perFrontendDiagnosticStatePtr: UnsafeMutableRawPointer,
   text: BridgedStringRef,
-  severity: BridgedDiagnosticSeverity,
+  severity: swift.DiagnosticKind,
   cLoc: BridgedSourceLoc,
   categoryName: BridgedStringRef,
   documentationPath: BridgedStringRef,
@@ -430,7 +429,7 @@ public func addQueuedDiagnostic(
 public func renderSingleDiagnostic(
   perFrontendDiagnosticStatePtr: UnsafeMutableRawPointer,
   text: BridgedStringRef,
-  severity: BridgedDiagnosticSeverity,
+  severity: swift.DiagnosticKind,
   categoryName: BridgedStringRef,
   documentationPath: BridgedStringRef,
   colorize: Int,

--- a/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/PluginHost.swift
@@ -262,7 +262,7 @@ class PluginDiagnosticsEngine {
     fixItChanges: [PluginMessage.Diagnostic.FixIt.Change] = []
   ) {
     // Map severity
-    let bridgedSeverity: BridgedDiagnosticSeverity
+    let bridgedSeverity: swift.DiagnosticKind
     switch severity {
     case .error: bridgedSeverity = .error
     case .note: bridgedSeverity = .note

--- a/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
+++ b/lib/ASTGen/Sources/MacroEvaluation/SourceManager.swift
@@ -130,7 +130,7 @@ extension SourceManager {
     fixItChanges: [FixIt.Change] = []
   ) {
     // Map severity
-    let bridgedSeverity = severity.bridged
+    let bridgedSeverity: swift.DiagnosticKind = severity.bridged
 
     // Emit the diagnostic
     var mutableMessage = message

--- a/lib/Basic/BasicBridging.cpp
+++ b/lib/Basic/BasicBridging.cpp
@@ -75,13 +75,13 @@ void BridgedOwnedString::destroy() const {
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Data
+// MARK: BridgedData
 //===----------------------------------------------------------------------===//
 
-void BridgedData_free(BridgedData data) {
-  if (data.BaseAddress == nullptr)
+void BridgedData::free() const {
+  if (BaseAddress == nullptr)
     return;
-  free(const_cast<char *>(data.BaseAddress));
+  ::free(const_cast<char *>(BaseAddress));
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
* Use `<swift/bridging>`.
* Directly bridge `swift::DiagnosticKind` instead of having an intermediate `BridgedDiagnosticSeverity` enum.