### PR TITLE
🍒 [6.2] line-directive: Stop expanding response files

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -1015,13 +1015,13 @@ function(_compile_swift_files
   # need to work around this by avoiding long command line arguments. This can
   # be achieved by writing the list of file paths to a file, then reading that
   # list in the Python script.
-  string(REPLACE ";" "'\n'" source_files_quoted "${source_files}")
-  string(SHA1 file_name "'${source_files_quoted}'")
+  string(REPLACE ";" "\n" source_files_quoted "${source_files}")
+  string(SHA1 file_name "${source_files_quoted}")
   set(file_path_target "filelist-${file_name}")
   set(file_path "${CMAKE_CURRENT_BINARY_DIR}/${file_name}.txt")
 
   if (NOT TARGET ${file_path_target})
-    file(WRITE "${file_path}.tmp" "'${source_files_quoted}'")
+    file(WRITE "${file_path}.tmp" "${source_files_quoted}")
     add_custom_command_target(unused_var
       COMMAND ${CMAKE_COMMAND} -E copy_if_different "${file_path}.tmp" "${file_path}"
       CUSTOM_TARGET_NAME ${file_path_target}

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -680,7 +680,7 @@ def run():
         # delegates to the Win32 CreateProcess API. Unix systems handle
         # non-normalized paths, so don't have this problem.
         # Arguments passed to the process are normalized by the process.
-        command_args = expand_response_files(sys.argv[dashes + 1:])
+        command_args = sys.argv[dashes + 1:]
         command_args[0] = os.path.normpath(command_args[0])
 
         try:

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -208,9 +208,7 @@ def map_line_from_source_file(source_filename, source_line_num,
 
 def read_response_file(file_path):
     with open(file_path, 'r') as files:
-        # "Make an iterator out of shlex.shlex.get_token, then consume items
-        # until it returns None." (Then eagerly convert the result to a list so
-        # that we can close the file.)
+        # Read a response file and return a list of files (one per line).
         return [line.strip() for line in files if line.strip()]
 
 

--- a/utils/line-directive
+++ b/utils/line-directive
@@ -211,8 +211,7 @@ def read_response_file(file_path):
         # "Make an iterator out of shlex.shlex.get_token, then consume items
         # until it returns None." (Then eagerly convert the result to a list so
         # that we can close the file.)
-        return list(iter(shlex.shlex(files, file_path, posix=True).get_token,
-                         None))
+        return [line.strip() for line in files if line.strip()]
 
 
 def expand_response_files(files):
@@ -686,13 +685,18 @@ def run():
         command_args = expand_response_files(sys.argv[dashes + 1:])
         command_args[0] = os.path.normpath(command_args[0])
 
-        command = subprocess.Popen(
-            command_args,
-            stderr=subprocess.STDOUT,
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-            encoding='UTF-8'
-        )
+        try:
+            command = subprocess.Popen(
+                command_args,
+                stderr=subprocess.STDOUT,
+                stdout=subprocess.PIPE,
+                universal_newlines=True,
+                encoding='UTF-8'
+            )
+        except Exception as e:
+            sys.stderr.write(f"Error executing command: {e}\n")
+            sys.stderr.write(f"Command: {' '.join(shlex.quote(arg) for arg in command_args)}\n")
+            sys.exit(1)
 
         sources = '(?P<file>' + '|'.join(re.escape(s) for s in sources) + ')'
 
@@ -731,7 +735,12 @@ def run():
                         m.group('tail'))
             sys.stdout.write(output)
 
-        sys.exit(command.wait())
+        exit_code = command.wait()
+        if exit_code != 0:
+            sys.stderr.write(f"Command failed with exit code {exit_code}\n")
+            sys.stderr.write(f"Command: {' '.join(shlex.quote(arg) for arg in command_args)}\n")
+
+        sys.exit(exit_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- **Explanation**:
  `line-directive` was expanding response files for the swiftc invocation, which was causing issues on CI when the file list got too long. This changes the script to stop expanding response files and pass them as-is to the swiftc invocation instead. The format for the response files was also incorrect, with each individual file being quoted, so this fixes the CMake script generating those.
  Finally, this changes `line-directive` to dump the command line on failure.
- **Scope**:
  This fixes the response file format and removes the expansion of the response file in `line-directive`. The scope is limited and should prevent issues on the release branch like the ones we saw on main.
- **Issues**:
  N/A
- **Original PRs**:
  #81996
  #82023
  #82028
- **Risk**:
  Very low risk, CI should catch any potential issue.
- **Testing**:
  Local build on main + CI
- **Reviewers**:
  @compnerd
  @etcwilde 