### PR TITLE
IRGen: internalise well known types with static linking

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3963,16 +3963,21 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
   // inside the standard library with the definition being in the runtime
   // preventing the normal detection from identifying that this is module
   // local.
-  if (getSwiftModule()->isStdlibModule())
+  //
+  // If we are statically linking the standard library, we need to internalise
+  // the symbols.
+  if (getSwiftModule()->isStdlibModule() ||
+      (Context.getStdlibModule() &&
+       Context.getStdlibModule()->isStaticLibrary()))
     if (entity.isTypeKind() &&
         (IsWellKnownBuiltinOrStructralType(entity.getType()) ||
          entity.getType() == kAnyFunctionType))
       if (auto *GV = dyn_cast<llvm::GlobalValue>(var))
-          if (GV->hasDLLImportStorageClass())
-            ApplyIRLinkage({llvm::GlobalValue::ExternalLinkage,
-                            llvm::GlobalValue::DefaultVisibility,
-                            llvm::GlobalValue::DefaultStorageClass})
-                .to(GV);
+        if (GV->hasDLLImportStorageClass())
+          ApplyIRLinkage({llvm::GlobalValue::ExternalLinkage,
+                          llvm::GlobalValue::DefaultVisibility,
+                          llvm::GlobalValue::DefaultStorageClass})
+              .to(GV);
 
   // Install the concrete definition if we have one.
   if (definition && definition.hasInit()) {


### PR DESCRIPTION
When statically linking the standard library ensure that we emit the well known metadata and accessors with internal linkage. This fixes a number of warnings about incorrect DLL storage when building Foundation on Windows for static linking.