### PR TITLE
LowerHopToActor: insert a borrow scope for an `Optional<Actor>.none` value

### DIFF
--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -273,7 +273,7 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
   if (auto wrappedActor = actorType->getOptionalObjectType()) {
     assert(makeOptional);
 
-    if (B.hasOwnership() && actor->getOwnershipKind() == OwnershipKind::Owned) {
+    if (B.hasOwnership() && actor->getOwnershipKind() != OwnershipKind::Guaranteed) {
       actor = B.createBeginBorrow(loc, actor);
       needEndBorrow = true;
     }

--- a/test/SILOptimizer/lower_hop_to_actor.sil
+++ b/test/SILOptimizer/lower_hop_to_actor.sil
@@ -307,3 +307,17 @@ bb0(%0 : @guaranteed $Optional<any Actor>):
   return %r
 }
 
+// CHECK-LABEL: sil [ossa] @optional_none :
+// CHECK:         %0 = enum
+// CHECK-NEXT:    %1 = begin_borrow %0
+// CHECK-NEXT:    switch_enum %1
+// CHECK:         mark_dependence
+// CHECK-NEXT:    end_borrow %1
+// CHECKL:      } // end sil function '@optional_none'
+sil [ossa] @optional_none : $@convention(thin) @async () -> () {
+bb0:
+  %0 = enum $Optional<any Actor>, #Optional.none!enumelt
+  hop_to_executor %0
+  %r = tuple ()
+  return %r
+}


### PR DESCRIPTION
An optional-none value has "none" ownership, but still a borrow scope is needed.

Fixes a SIL verifier crash.
rdar://153066034
