### PR TITLE
[6.2][Concurrency] Correct memory effect attributes of task_create

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2376,7 +2376,7 @@ FUNCTION(TaskCreate,
               RefCountedPtrTy),
          ATTRS(NoUnwind),
          EFFECT(RuntimeEffect::Concurrency),
-         MEMEFFECTS(ArgMemOnly))
+         MEMEFFECTS(ReadOnly))
 
 // void swift_task_switch(AsyncContext *resumeContext,
 //                        TaskContinuationFunction *resumeFunction,

--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -79,8 +79,6 @@ extension Task where Failure == ${FAILURE_TYPE} {
   public static func immediate(
     name: String? = nil,
     priority: TaskPriority? = nil,
-    % # NOTE: This closure cannot be 'sending' because we'll trigger ' pattern that the region based isolation checker does not understand how to check'
-    % #       In this case: `func syncOnMyGlobalActor() { Task.immediate { @MyGlobalActor in } }`
     @_implicitSelfCapture @_inheritActorContext(always) operation: sending @isolated(any) @escaping () async throws -> Success
   ) -> Task<Success, ${FAILURE_TYPE}> {
 

--- a/test/Concurrency/Runtime/startImmediately.swift
+++ b/test/Concurrency/Runtime/startImmediately.swift
@@ -392,28 +392,6 @@ print("callActorFromStartSynchronousTask() - actor in custom executor with its o
 let actorQueue = DispatchQueue(label: "recipient-actor-queue")
 callActorFromStartSynchronousTask(recipient: .recipientOnQueue(RecipientOnQueue(queue: actorQueue)))
 
-
-//            50: callActorFromStartSynchronousTask()
-//            51: before immediate [thread:0x00007000054f5000] @ :366
-//            52: inside immediate [thread:0x00007000054f5000] @ :372
-//            53: inside immediate, call rec.sync() [thread:0x00007000054f5000] @ :380
-//            54: Recipient/sync(syncTaskThreadID:) Current actor thread id = 0x000070000567e000 @ :336
-//            55: inside immediate, call rec.sync() done [thread:0x000070000567e000] @ :385
-//            56: Inner thread id = 0x00007000054f5000
-//            57: Current thread id = 0x000070000567e000
-//            60: after immediate [thread:0x00007000054f5000] @ :418
-//            61: - async work on queue
-//            62: - async work on queue
-//            63: - async work on queue
-//            64: - async work on queue
-//            65: - async work on queue
-//            67: - async work on queue
-//            68: - async work on queue
-//            69: - async work on queue
-//            71: Inner thread id = 0x00007000054f5000
-//            72: Current thread id = 0x000070000567e000
-//            73: inside immediate, done [thread:0x000070000567e000] @ :414
-
 // CHECK-LABEL: callActorFromStartSynchronousTask() - actor in custom executor with its own queue
 // No interleaving allowed between "before" and "inside":
 // CHECK: before immediate [thread:[[CALLING_THREAD4:.*]]]
@@ -452,3 +430,33 @@ actor RecipientOnQueue: RecipientProtocol {
     try? await Task.sleep(for: .milliseconds(100))
   }
 }
+
+print("\n\n==== ------------------------------------------------------------------")
+print("call_startSynchronously_insideActor()")
+
+actor A {
+  func f() {
+    Task.startSynchronously(name: "hello") { print("Task.startSynchronously (\(Task.name!))") }
+    Task.startSynchronously() { print("Task.startSynchronously") }
+  }
+
+  func f2() {
+    Task.immediate(name: "hello") { print("Task.immediate (\(Task.name!))") }
+    Task.immediate() { print("Task.immediate") }
+
+    Task.immediate(name: "hello") { @MainActor in print("Task.immediate { @MainActor } (\(Task.name!))") }
+    Task.immediate() { @MainActor in print("Task.immediate { @MainActor }") }
+  }
+}
+
+func call_startSynchronously_insideActor() async {
+  await A().f()
+  await A().f2()
+}
+
+await call_startSynchronously_insideActor()
+
+// CHECK-LABEL: call_startSynchronously_insideActor()
+// Those two definitely in this order, however the startSynchronously is not determinate
+// CHECK: Task.immediate
+// CHECK: Task.immediate { @MainActor }


### PR DESCRIPTION
**Description**: Without this, llvm would sometimes wrongly assume there's no indirect
accesses and the optimizations can lead to a runtime crash, by optimizing away initializing options properly.

**Scope/Impact**: Users of some apis which have multiple task options can experience crashes; This only manifested on some startSynchronously legacy API users so far but this is purely accidental -- it seems other APIs were just "lucky" (for years), since the functions were AEIC.
**Risk:** Low, corrects memory semantics annotation to prevent too aggressive optimizations.
**Testing**: Added test which triggered the miscompile.
**Reviewed by**: @mikeash @fhahn @rjmccall 

**Original PR:** https://github.com/swiftlang/swift/pull/82179
**Radar:** rdar://152548190