### PR TITLE
[Concurrency] Remove deprecation attribute for now.

### DIFF
--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -31,7 +31,6 @@ import Swift
 ///
 /// Customizing the global concurrent executor is currently not supported.
 @available(SwiftStdlib 6.0, *)
-@available(*, deprecated, renamed: "Task.defaultExecutor")
 @_unavailableInEmbedded
 public var globalConcurrentExecutor: any TaskExecutor {
   get {


### PR DESCRIPTION
This deprecation attribute is possibly a little premature.

rdar://150531873
