### PR TITLE
[6.2] GenericSpecializer: remove some kind of instructions if their operands become trivial after specialization

### DIFF
--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -284,6 +284,16 @@ protected:
     super::visitCopyValueInst(Copy);
   }
 
+  void visitExplicitCopyValueInst(ExplicitCopyValueInst *Copy) {
+    // If the substituted type is trivial, ignore the copy.
+    SILType copyTy = getOpType(Copy->getType());
+    if (copyTy.isTrivial(*Copy->getFunction())) {
+      recordFoldedValue(SILValue(Copy), getOpValue(Copy->getOperand()));
+      return;
+    }
+    super::visitExplicitCopyValueInst(Copy);
+  }
+
   void visitDestroyValueInst(DestroyValueInst *Destroy) {
     // If the substituted type is trivial, ignore the destroy.
     SILType destroyTy = getOpType(Destroy->getOperand()->getType());
@@ -291,6 +301,24 @@ protected:
       return;
     }
     super::visitDestroyValueInst(Destroy);
+  }
+
+  void visitEndLifetimeInst(EndLifetimeInst *endLifetime) {
+    // If the substituted type is trivial, ignore the end_lifetime.
+    SILType ty = getOpType(endLifetime->getOperand()->getType());
+    if (ty.isTrivial(*endLifetime->getFunction())) {
+      return;
+    }
+    super::visitEndLifetimeInst(endLifetime);
+  }
+
+  void visitExtendLifetimeInst(ExtendLifetimeInst *extendLifetime) {
+    // If the substituted type is trivial, ignore the extend_lifetime.
+    SILType ty = getOpType(extendLifetime->getOperand()->getType());
+    if (ty.isTrivial(*extendLifetime->getFunction())) {
+      return;
+    }
+    super::visitExtendLifetimeInst(extendLifetime);
   }
 
   void visitDifferentiableFunctionExtractInst(

--- a/test/SILOptimizer/specialize_opaque.sil
+++ b/test/SILOptimizer/specialize_opaque.sil
@@ -12,6 +12,8 @@ import Builtin
 // CHECK:   %{{.*}} = apply [[F]](%0, %1) : $@convention(thin) (Builtin.Int64, Builtin.Int64) -> ()
 // CHECK-NOT: copy_value
 // CHECK-NOT: destroy_value
+// CHECK-NOT: extend_lifetime
+// CHECK-NOT: end_lifetime
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function '$s3fooBi64__Tg5'
 sil hidden [ossa] @foo : $@convention(thin) <T> (@in T, @in T) -> () {
@@ -19,9 +21,11 @@ bb0(%0 : @owned $T, %1 : @owned $T):
   %f = function_ref @foo : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> ()
   %cp0 = copy_value %0 : $T
   %cp1 = copy_value %1 : $T
+  %cp3 = explicit_copy_value %1 : $T
   %call = apply %f<T>(%cp0, %cp1) : $@convention(thin) <τ_0_0> (@in τ_0_0, @in τ_0_0) -> ()
   destroy_value %1 : $T
-  destroy_value %0 : $T
+  end_lifetime %0 : $T
+  extend_lifetime %cp3 : $T
   %10 = tuple ()
   return %10 : $()
 }


### PR DESCRIPTION
* **Explanation**: Unfortunately the fix https://github.com/swiftlang/swift/pull/81606 triggered another bug in the generic specializer which results in a SIL verifier crash. This fix removes certain instructions, which must not be created for trivial types, when specializing a generic function.
* **Risk**: Low. It's a small change which only affects code which would have crashed the compiler anyway. It only affects `InlineArray.init`.
* **Testing**: Tested by lit tests.
* **Issue**: https://github.com/swiftlang/swift/issues/82093, rdar://152807200
* **Reviewer**:  @nate-chandler
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/82148
