### PR TITLE
[windows] make WindowsSDKs configurable through env variables

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -68,6 +68,10 @@ if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 set SkipPackagingArg=-SkipPackaging
 if not "%SKIP_PACKAGING%"=="1" set "SkipPackagingArg= "
 
+:: Build the -WindowsSDKs argument, if any, otherwise build all the SDKs.
+set "WindowsSDKsArg= "
+if not "%WINDOWS_SDKS%"=="" set "WindowsSDKsArg=-WindowsSDKs %WINDOWS_SDKS%"
+
 call :CloneRepositories || (exit /b 1)
 
 :: We only have write access to BuildRoot, so use that as the image root.
@@ -76,6 +80,7 @@ powershell.exe -ExecutionPolicy RemoteSigned -File %~dp0build.ps1 ^
   -BinaryCache %BuildRoot% ^
   -ImageRoot %BuildRoot% ^
   %SkipPackagingArg% ^
+  %WindowsSDKsArg% ^
   %TestArg% ^
   -Stage %PackageRoot% ^
   -Summary || (exit /b 1)


### PR DESCRIPTION
We are working on setting up a new LLDB bot to test LLDB support for Swift on Windows. This bot will only run the lldb test suite.

This patch adds a new environment variable which allows to specify which Windows SDKs we want to build programatically.