### PR TITLE
stdlib: Fix missing `unsafe` operators in more places

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -26,7 +26,7 @@ extension std.string {
       // Use the 2 parameter constructor.
       // The MSVC standard library has a enable_if template guard
       // on the 3 parameter constructor, and thus it's not imported into Swift.
-      std.string(buffer, string.utf8.count)
+      unsafe std.string(buffer, string.utf8.count)
 #else
       unsafe std.string(buffer, string.utf8.count, .init())
 #endif
@@ -40,7 +40,7 @@ extension std.string {
       // Use the 2 parameter constructor.
       // The MSVC standard library has a enable_if template guard
       // on the 3 parameter constructor, and thus it's not imported into Swift.
-      self.init(str, UTF8._nullCodeUnitOffset(in: str))
+      unsafe self.init(str, UTF8._nullCodeUnitOffset(in: str))
 #else
       unsafe self.init(str, UTF8._nullCodeUnitOffset(in: str), .init())
 #endif

--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -260,7 +260,7 @@ fileprivate class _Lock {
     #elseif os(WASI)
     // WASI environment has only a single thread
     #else
-    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
+    unsafe self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
     guard unsafe pthread_mutex_init(self.underlying, nil) == 0 else {
       fatalError("pthread_mutex_init failed")
     }

--- a/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/LinuxImpl.swift
@@ -23,19 +23,19 @@ extension Atomic where Value == UInt32 {
   // This returns 'false' on success and 'true' on error. Check 'errno' for the
   // specific error value.
   internal borrowing func _futexLock() -> UInt32 {
-    _swift_stdlib_futex_lock(.init(_rawAddress))
+    unsafe _swift_stdlib_futex_lock(.init(_rawAddress))
   }
 
   // This returns 'false' on success and 'true' on error. Check 'errno' for the
   // specific error value.
   internal borrowing func _futexTryLock() -> UInt32 {
-    _swift_stdlib_futex_trylock(.init(_rawAddress))
+    unsafe _swift_stdlib_futex_trylock(.init(_rawAddress))
   }
 
   // This returns 'false' on success and 'true' on error. Check 'errno' for the
   // specific error value.
   internal borrowing func _futexUnlock() -> UInt32 {
-    _swift_stdlib_futex_unlock(.init(_rawAddress))
+    unsafe _swift_stdlib_futex_unlock(.init(_rawAddress))
   }
 }
 

--- a/stdlib/public/Synchronization/Mutex/WasmImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WasmImpl.swift
@@ -26,7 +26,7 @@ internal func _swift_stdlib_wake(on: UnsafePointer<UInt32>, count: UInt32) -> UI
 extension Atomic where Value == _MutexHandle.State {
   internal borrowing func _wait(expected: _MutexHandle.State) {
     #if _runtime(_multithreaded)
-    _ = _swift_stdlib_wait(
+    _ = unsafe _swift_stdlib_wait(
       on: .init(_rawAddress),
       expected: expected.rawValue,
 
@@ -39,7 +39,7 @@ extension Atomic where Value == _MutexHandle.State {
   internal borrowing func _wake() {
     #if _runtime(_multithreaded)
     // Only wake up 1 thread
-    _ = _swift_stdlib_wake(on: .init(_rawAddress), count: 1)
+    _ = unsafe _swift_stdlib_wake(on: .init(_rawAddress), count: 1)
     #endif
   }
 }

--- a/stdlib/public/Synchronization/Mutex/WindowsImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/WindowsImpl.swift
@@ -14,6 +14,7 @@ import WinSDK.core.synch
 
 @available(SwiftStdlib 6.0, *)
 @frozen
+@safe
 @_staticExclusiveOnly
 public struct _MutexHandle: ~Copyable {
   @usableFromInline
@@ -23,14 +24,14 @@ public struct _MutexHandle: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   public init() {
-    value = _Cell(SRWLOCK())
+    unsafe value = _Cell(SRWLOCK())
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _lock() {
-    AcquireSRWLockExclusive(value._address)
+    unsafe AcquireSRWLockExclusive(value._address)
   }
 
   @available(SwiftStdlib 6.0, *)
@@ -38,13 +39,13 @@ public struct _MutexHandle: ~Copyable {
   @_transparent
   internal borrowing func _tryLock() -> Bool {
     // Windows BOOLEAN gets imported as 'UInt8'...
-    TryAcquireSRWLockExclusive(value._address) != 0
+    unsafe TryAcquireSRWLockExclusive(value._address) != 0
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _unlock() {
-    ReleaseSRWLockExclusive(value._address)
+    unsafe ReleaseSRWLockExclusive(value._address)
   }
 }

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -314,7 +314,7 @@ public struct CVaListPointer {
        __vr_top: UnsafeMutablePointer<Int>?,
        __gr_off: Int32,
        __vr_off: Int32) {
-    _value = (__stack, __gr_top, __vr_top, __gr_off, __vr_off)
+    unsafe _value = (__stack, __gr_top, __vr_top, __gr_off, __vr_off)
   }
 }
 
@@ -322,11 +322,11 @@ public struct CVaListPointer {
 extension CVaListPointer: CustomDebugStringConvertible {
   @safe
   public var debugDescription: String {
-    return "(\(_value.__stack.debugDescription), " +
-           "\(_value.__gr_top.debugDescription), " +
-           "\(_value.__vr_top.debugDescription), " +
-           "\(_value.__gr_off), " +
-           "\(_value.__vr_off))"
+    return "(\(unsafe _value.__stack.debugDescription), " +
+           "\(unsafe _value.__gr_top.debugDescription), " +
+           "\(unsafe _value.__vr_top.debugDescription), " +
+           "\(unsafe _value.__gr_off), " +
+           "\(unsafe _value.__vr_off))"
   }
 }
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3120,7 +3120,7 @@ internal func _resolveRelativeIndirectableAddress(_ base: UnsafeRawPointer,
 internal func _resolveCompactFunctionPointer(_ base: UnsafeRawPointer, _ offset: Int32)
     -> UnsafeRawPointer {
 #if SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER
-  return UnsafeRawPointer(bitPattern: Int(offset))._unsafelyUnwrappedUnchecked
+  return unsafe UnsafeRawPointer(bitPattern: Int(offset))._unsafelyUnwrappedUnchecked
 #else
   return unsafe _resolveRelativeAddress(base, offset)
 #endif

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -1005,7 +1005,7 @@ extension _StringObject {
       _internalInvariantFailure()
     }
     #if !$Embedded
-    return _unsafeUncheckedDowncast(storage, to: __StringStorage.self)
+    return unsafe _unsafeUncheckedDowncast(storage, to: __StringStorage.self)
     #else
     return Builtin.castFromNativeObject(storage)
     #endif
@@ -1044,7 +1044,7 @@ extension _StringObject {
       _internalInvariantFailure()
     }
     #if !$Embedded
-    return _unsafeUncheckedDowncast(storage, to: __SharedStringStorage.self)
+    return unsafe _unsafeUncheckedDowncast(storage, to: __SharedStringStorage.self)
     #else
     return Builtin.castFromNativeObject(storage)
     #endif

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -47,7 +47,7 @@ public struct UInt128: Sendable {
 #if _endian(little)
     self = unsafe unsafeBitCast((_low, _high), to: Self.self)
 #else
-    self = unsafeBitCast((_high, _low), to: Self.self)
+    self = unsafe unsafeBitCast((_high, _low), to: Self.self)
 #endif
   }
   

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -1,3 +1,4 @@
+
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -621,10 +622,10 @@ final internal class __VaListBuilder {
 #if (arch(arm) && !os(iOS)) || arch(arm64_32) || arch(wasm32)
     if let arg = arg as? _CVarArgAligned {
       let alignmentInWords = arg._cVarArgAlignment / MemoryLayout<Int>.size
-      let misalignmentInWords = count % alignmentInWords
+      let misalignmentInWords = unsafe count % alignmentInWords
       if misalignmentInWords != 0 {
         let paddingInWords = alignmentInWords - misalignmentInWords
-        appendWords([Int](repeating: -1, count: paddingInWords))
+        unsafe appendWords([Int](repeating: -1, count: paddingInWords))
       }
     }
 #endif


### PR DESCRIPTION
Add `unsafe` where it is still missing. I missed these in previous passes due to conditional compilation.