### PR TITLE
Cherry-pick [ClangImporter] Look through bounds attributes for template matching #82076

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2254,6 +2254,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
   }
 
   clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
+  returnType = desugarIfBoundsAttributed(returnType);
   // In C interop mode, the return type of library builtin functions
   // like 'memcpy' from headers like 'string.h' drops
   // any nullability specifiers from their return type, and preserves it on the
@@ -2364,6 +2365,7 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
   ImportDiagnosticAdder addDiag(*this, clangDecl,
                                 clangDecl->getSourceRange().getBegin());
   clang::QualType returnType = desugarIfElaborated(clangDecl->getReturnType());
+  returnType = desugarIfBoundsAttributed(returnType);
 
   ImportedType importedType = importer::findOptionSetEnum(returnType, *this);
 
@@ -2430,6 +2432,7 @@ ClangImporter::Implementation::importParameterType(
     ArrayRef<GenericTypeParamDecl *> genericParams,
     llvm::function_ref<void(Diagnostic &&)> addImportDiagnosticFn) {
   auto paramTy = desugarIfElaborated(param->getType());
+  paramTy = desugarIfBoundsAttributed(paramTy);
 
   ImportTypeKind importKind = paramIsCompletionHandler
                                   ? ImportTypeKind::CompletionHandlerParameter

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2094,6 +2094,22 @@ inline clang::QualType desugarIfElaborated(clang::QualType type) {
   return type;
 }
 
+inline clang::QualType desugarIfBoundsAttributed(clang::QualType type) {
+  if (auto BAT = dyn_cast<clang::BoundsAttributedType>(type))
+    return BAT->desugar();
+  if (auto VT = dyn_cast<clang::ValueTerminatedType>(type))
+    return VT->desugar();
+  if (auto AT = dyn_cast<clang::AttributedType>(type))
+    switch (AT->getAttrKind()) {
+      case clang::attr::PtrUnsafeIndexable:
+      case clang::attr::PtrSingle:
+        return AT->desugar();
+      default:
+        break;
+    }
+  return type;
+}
+
 /// Option set enums are sometimes imported as typedefs which assign a name to
 /// the type, but are unavailable in Swift.
 ///

--- a/test/Interop/Cxx/swiftify-import/bounds-attrs-in-template.swift
+++ b/test/Interop/Cxx/swiftify-import/bounds-attrs-in-template.swift
@@ -1,0 +1,68 @@
+// REQUIRES: swift_feature_SafeInteropWrappers
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers %t/template.swift -dump-macro-expansions -emit-ir -o %t/out -verify
+// RUN: %target-swift-ide-test -plugin-path %swift-plugin-dir -I %t/Inputs -cxx-interoperability-mode=default -enable-experimental-feature SafeInteropWrappers -print-module -module-to-print=Template -source-filename=x | %FileCheck %s
+
+// CHECK: func cb_template<T>(_ p: UnsafePointer<T>, _ size: Int{{.*}}) -> UnsafePointer<T>
+// CHECK: func eb_template<T>(_ p: UnsafePointer<T>, _ end: UnsafePointer<T>) -> UnsafePointer<T>
+// CHECK: func s_template<T>(_ p: UnsafePointer<T>) -> UnsafePointer<T>
+// CHECK: func ui_template<T>(_ p: UnsafePointer<T>) -> UnsafePointer<T>
+
+//--- Inputs/module.modulemap
+module Template {
+    header "template.h"
+    requires cplusplus
+}
+
+//--- Inputs/template.h
+#include <ptrcheck.h>
+#include <lifetimebound.h>
+
+template <class T>
+inline const T* __counted_by(size) cb_template(const T* __counted_by(size) p __noescape, int size) { return p; }
+
+template <class T>
+inline const T* __ended_by(end) eb_template(const T* __ended_by(end) p __noescape, const T* end) { return p; }
+
+template <class T>
+inline const T* __single s_template(const T* __single p) { return p; }
+
+template <class T>
+inline const T* __unsafe_indexable ui_template(const T* __unsafe_indexable p) { return p; }
+
+// FIXME: parse null_terminated in templated contexts
+// template <class T>
+// inline const T* __null_terminated nt_template(const T* __null_terminated p) {}
+
+//--- template.swift
+import Template
+
+// make sure the original functions are still available when parsing bounds attributes
+func testOriginalCB(p: UnsafePointer<CInt>, len: CInt) {
+  let _ = cb_template(p, len)
+}
+func testOriginalEB(p: UnsafePointer<CInt>, end: UnsafePointer<CInt>) {
+  let _ = eb_template(p, end)
+}
+func testOriginalS(s: UnsafePointer<CInt>) {
+  let _ = s_template(s)
+}
+func testOriginalUI(s: UnsafePointer<CInt>) {
+  let _ = ui_template(s)
+}
+
+ // FIXME: generate safe overloads for templated functions (rdar://151481042)
+func testSafeOverloadCB(s: Span<CInt>) {
+  // expected-error@+3{{generic parameter 'T' could not be inferred}}
+  // expected-error@+2{{cannot convert value of type 'Span<CInt>'}}
+  // expected-error@+1{{missing argument for parameter #2 in call}}
+  cb_template(s)
+}
+func testSafeOverloadEB(s: Span<CInt>) {
+  // expected-error@+3{{generic parameter 'T' could not be inferred}}
+  // expected-error@+2{{cannot convert value of type 'Span<CInt>'}}
+  // expected-error@+1{{missing argument for parameter #2 in call}}
+  eb_template(s)
+}


### PR DESCRIPTION
- **Explanation**:
When instantiating templated functions with pointers to the templated type, the ClangImporter does not strip type sugar. This strips type sugar for bounds attributes, to make sure that they import the same regardless of whether they are parsed or not.
- **Scope**:
This affects code compiled with SafeInteropWrappers, as that enables parsing bounds safety attributes. Only templated functions are affected. These functions do not get safe interop wrappers, as that currently does not support templated functions, but without this change even the original function cannot be called, which is a regression compared to when bounds attributes are ignored.
- **Issues**:
rdar://151041990
- **Original PRs**:
https://github.com/swiftlang/swift/pull/82076
- **Risk**:
Low - although the template instantiation logic should very likely strip all sugar types, this change minimises risk by only stripping the bounds attribute sugar.
- **Testing**:
Added regression tests
- **Reviewers**:
@Xazax-hun 