### PR TITLE
Parser: Accept `@cdecl` with an optional identifier for a custom C name

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -970,11 +970,12 @@ BridgedBackDeployedAttr BridgedBackDeployedAttr_createParsed(
     BridgedSourceRange cRange, BridgedPlatformKind cPlatform,
     BridgedVersionTuple cVersion);
 
-SWIFT_NAME("BridgedCDeclAttr.createParsed(_:atLoc:range:name:)")
+SWIFT_NAME("BridgedCDeclAttr.createParsed(_:atLoc:range:name:underscored:)")
 BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
                                                BridgedSourceLoc cAtLoc,
                                                BridgedSourceRange cRange,
-                                               BridgedStringRef cName);
+                                               BridgedStringRef cName,
+                                               bool underscored);
 
 SWIFT_NAME(
     "BridgedCustomAttr.createParsed(_:atLoc:type:initContext:argumentList:)")

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1532,6 +1532,9 @@ ERROR(attr_expected_comma,none,
 ERROR(attr_expected_string_literal,none,
 "expected string literal in '%0' attribute", (StringRef))
 
+ERROR(attr_expected_cname,none,
+      "expected C identifier in '%0' attribute", (StringRef))
+
 ERROR(attr_expected_option_such_as,none,
       "expected '%0' option such as '%1'", (StringRef, StringRef))
 

--- a/lib/AST/Bridging/DeclAttributeBridging.cpp
+++ b/lib/AST/Bridging/DeclAttributeBridging.cpp
@@ -247,10 +247,11 @@ BridgedBackDeployedAttr BridgedBackDeployedAttr_createParsed(
 BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
                                                BridgedSourceLoc cAtLoc,
                                                BridgedSourceRange cRange,
-                                               BridgedStringRef cName) {
+                                               BridgedStringRef cName,
+                                               bool underscored) {
   return new (cContext.unbridged())
       CDeclAttr(cName.unbridged(), cAtLoc.unbridged(), cRange.unbridged(),
-                /*Implicit=*/false, /*Underscored*/true);
+                /*Implicit=*/false, /*Underscored*/underscored);
 }
 
 BridgedCustomAttr BridgedCustomAttr_createParsed(

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4543,7 +4543,10 @@ StringRef ValueDecl::getCDeclName() const {
 
   // Handle explicit cdecl attributes.
   if (auto cdeclAttr = getAttrs().getAttribute<CDeclAttr>()) {
-    return cdeclAttr->Name;
+    if (!cdeclAttr->Name.empty())
+      return cdeclAttr->Name;
+    else
+      return getBaseIdentifier().str();
   }
 
   return "";

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -535,20 +535,37 @@ extension ASTGenVisitor {
   /// E.g.:
   ///   ```
   ///   @_cdecl("c_function_name")
+  ///   @cdecl(c_function_name)
+  ///   @cdecl
   ///   ```
   func generateCDeclAttr(attribute node: AttributeSyntax) -> BridgedCDeclAttr? {
-    self.generateWithLabeledExprListArguments(attribute: node) { args in
-      guard let name = self.generateConsumingSimpleStringLiteralAttrOption(args: &args) else {
+    let attrName = node.attributeName.as(IdentifierTypeSyntax.self)?.name.text
+    let underscored = attrName?.hasPrefix("_") ?? false
+
+    var name: BridgedStringRef? = nil
+    if node.arguments != nil || underscored {
+      name = self.generateWithLabeledExprListArguments(attribute: node) {
+          args in
+        if underscored {
+          self.generateConsumingSimpleStringLiteralAttrOption(args: &args)
+        } else {
+           self.generateConsumingPlainIdentifierAttrOption(args: &args) {
+             return $0.rawText.bridged
+           }
+        }
+      }
+      guard name != nil else {
         return nil
       }
-
-      return .createParsed(
-        self.ctx,
-        atLoc: self.generateSourceLoc(node.atSign),
-        range: self.generateAttrSourceRange(node),
-        name: name
-      )
     }
+
+    return .createParsed(
+      self.ctx,
+      atLoc: self.generateSourceLoc(node.atSign),
+      range: self.generateAttrSourceRange(node),
+      name: name ?? "",
+      underscored: underscored
+    )
   }
 
   struct GeneratedDerivativeOriginalDecl {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3014,7 +3014,45 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DeclAttrKind::CDecl:
+  case DeclAttrKind::CDecl: {
+    if (!AttrName.starts_with("_") &&
+
+        // Backwards support for @cdecl("stringId"). Remove before enabling in
+        // production so we accept only the identifier format.
+        lookahead<bool>(1, [&](CancellableBacktrackingScope &) {
+           return Tok.isNot(tok::string_literal);
+        })) {
+
+      std::optional<StringRef> CName;
+      if (consumeIfAttributeLParen()) {
+        // Custom C name.
+        if (Tok.isNot(tok::identifier)) {
+          diagnose(Loc, diag::attr_expected_cname, AttrName);
+          return makeParserSuccess();
+        }
+
+        CName = Tok.getText();
+        consumeToken(tok::identifier);
+        AttrRange = SourceRange(Loc, Tok.getRange().getStart());
+
+        if (!consumeIf(tok::r_paren)) {
+          diagnose(Loc, diag::attr_expected_rparen, AttrName,
+                   DeclAttribute::isDeclModifier(DK));
+          return makeParserSuccess();
+        }
+      } else {
+        AttrRange = SourceRange(Loc);
+      }
+
+      Attributes.add(new (Context) CDeclAttr(CName.value_or(StringRef()), AtLoc,
+                                             AttrRange, /*Implicit=*/false,
+                                             /*isUnderscored*/false));
+      break;
+    }
+
+    // Leave legacy @_cdecls to the logic expecting a string.
+    LLVM_FALLTHROUGH;
+  }
   case DeclAttrKind::Expose:
   case DeclAttrKind::SILGenName: {
     if (!consumeIfAttributeLParen()) {

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1307,7 +1307,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
           if (!clangMangling.empty())
             return clangMangling;
         }
-        return CDeclA->Name.str();
+        return getDecl()->getCDeclName().str();
       }
 
     if (SKind == ASTMangler::SymbolKind::DistributedThunk) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2387,8 +2387,8 @@ void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
     diagnose(attr->getLocation(), diag::cdecl_not_at_top_level,
              attr);
 
-  // The name must not be empty.
-  if (attr->Name.empty())
+  // @_cdecl name must not be empty.
+  if (attr->Name.empty() && attr->Underscored)
     diagnose(attr->getLocation(), diag::cdecl_empty_name,
              attr);
 

--- a/test/ASTGen/attrs.swift
+++ b/test/ASTGen/attrs.swift
@@ -5,6 +5,7 @@
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature RawLayout \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
+// RUN:   -enable-experimental-feature CDecl \
 // RUN:   -enable-experimental-concurrency \
 // RUN:   -enable-experimental-move-only \
 // RUN:   -enable-experimental-feature ParserASTGen \
@@ -15,6 +16,7 @@
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature RawLayout \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
+// RUN:   -enable-experimental-feature CDecl \
 // RUN:   -enable-experimental-concurrency \
 // RUN:   -enable-experimental-move-only \
 // RUN:   | %sanitize-address > %t/cpp-parser.ast
@@ -28,6 +30,7 @@
 // RUN:   -enable-experimental-feature LifetimeDependence \
 // RUN:   -enable-experimental-feature RawLayout \
 // RUN:   -enable-experimental-feature SymbolLinkageMarkers \
+// RUN:   -enable-experimental-feature CDecl \
 // RUN:   -enable-experimental-concurrency \
 // RUN:   -enable-experimental-move-only
 
@@ -39,6 +42,7 @@
 // REQUIRES: swift_feature_LifetimeDependence
 // REQUIRES: swift_feature_RawLayout
 // REQUIRES: swift_feature_SymbolLinkageMarkers
+// REQUIRES: swift_feature_CDecl
 
 // rdar://116686158
 // UNSUPPORTED: asan
@@ -95,7 +99,9 @@ func fn(_: Int) {}
 
 @_disallowFeatureSuppression(NoncopyableGenerics) public struct LoudlyNC<T: ~Copyable> {}
 
-@_cdecl("c_function_name") func foo(x: Int) {}
+@_cdecl("c_function_name") func cdeclUnderscore(x: Int) {}
+@cdecl(c_function_name_official) func cdecl(x: Int) {}
+@cdecl func cdeclDefault() {}
 
 struct StaticProperties {
   dynamic var property: Int { return 1 }

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -33,6 +33,10 @@ func a0_simple(x: Int, bar y: Int) -> Int { return x }
 // CHECK-LABEL: // My documentation
 // CHECK-LABEL: SWIFT_EXTERN ptrdiff_t simple(ptrdiff_t x, ptrdiff_t y) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
+@cdecl
+func a1_defaultName(x: Int) -> Int { return x }
+// CHECK-LABEL: SWIFT_EXTERN ptrdiff_t a1_defaultName(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
+
 @cdecl("primitiveTypes")
 public func b_primitiveTypes(i: Int, ci: CInt, l: CLong, c: CChar, f: Float, d: Double, b: Bool) {}
 // CHECK-LABEL: SWIFT_EXTERN void primitiveTypes(ptrdiff_t i, int ci, long l, char c, float f, double d, bool b) SWIFT_NOEXCEPT;

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -28,8 +28,8 @@
 // CHECK: #endif
 
 /// My documentation
-@cdecl("simple")
-func a_simple(x: Int, bar y: Int) -> Int { return x }
+@cdecl(simple)
+func a0_simple(x: Int, bar y: Int) -> Int { return x }
 // CHECK-LABEL: // My documentation
 // CHECK-LABEL: SWIFT_EXTERN ptrdiff_t simple(ptrdiff_t x, ptrdiff_t y) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 

--- a/test/SILGen/cdecl-official.swift
+++ b/test/SILGen/cdecl-official.swift
@@ -1,0 +1,55 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-silgen %s -module-name cdecl \
+// RUN:   -enable-experimental-feature CDecl > %t/out.sil
+// RUN: %FileCheck %s -input-file %t/out.sil
+
+// REQUIRES: swift_feature_CDecl
+
+// CHECK-LABEL: sil hidden [thunk] [ossa] @pear : $@convention(c)
+// CHECK:         function_ref @$s5cdecl5apple{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden [ossa] @$s5cdecl5apple{{[_0-9a-zA-Z]*}}F
+@cdecl(pear)
+func apple(_ f: @convention(c) (Int) -> Int) { }
+
+// CHECK-LABEL: sil hidden [ossa] @$s5cdecl16forceCEntryPoint{{[_0-9a-zA-Z]*}}F
+// CHECK:         function_ref @grapefruit : $@convention(c) (Int) -> Int
+// CHECK:         function_ref apple(_:)
+// CHECK:         function_ref @$s5cdecl5appleyyS2iXCF : $@convention(thin) (@convention(c) (Int) -> Int) -> ()
+// FIXME should it be function_ref @apple?
+func forceCEntryPoint() {
+  apple(orange)
+}
+
+// CHECK-LABEL: sil hidden [thunk] [ossa] @grapefruit : $@convention(c)
+// CHECK:         function_ref @$s5cdecl6orange{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil hidden [ossa] @$s5cdecl6orange{{[_0-9a-zA-Z]*}}F
+@cdecl(grapefruit)
+func orange(_ x: Int) -> Int {
+  return x
+}
+
+// CHECK-LABEL: sil [serialized] [thunk] [ossa] @cauliflower : $@convention(c)
+// CHECK:         function_ref @$s5cdecl8broccoli{{[_0-9a-zA-Z]*}}F
+// CHECK-LABEL: sil [ossa] @$s5cdecl8broccoli{{[_0-9a-zA-Z]*}}F
+// FIXME should it be `sil hidden`?
+@cdecl(cauliflower)
+public func broccoli(_ x: Int) -> Int {
+  return x
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @collard_greens : $@convention(c)
+// CHECK:         function_ref @$s5cdecl4kale[[PRIVATE:.*]]
+// CHECK:       sil private [ossa] @$s5cdecl4kale[[PRIVATE:.*]]
+@cdecl(collard_greens)
+private func kale(_ x: Int) -> Int {
+  return x
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @defaultName : $@convention(c)
+// CHECK:         function_ref @$s5cdecl11defaultName[[PRIVATE:.*]]
+// CHECK:       sil private [ossa] @$s5cdecl11defaultName[[PRIVATE:.*]]
+@cdecl
+private func defaultName(_ x: Int) -> Int {
+  return x
+}

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -24,8 +24,7 @@
 // expected-error @-1 {{expected ')' in 'cdecl' attribute}}
 // expected-error @-2 {{expected declaration}}
 
-@cdecl("") // expected-error{{@cdecl symbol name cannot be empty}}
-func emptyName(x: Int) -> Int { return x }
+@cdecl func defaultName() {}
 
 @cdecl("noBody")
 func noBody(x: Int) -> Int // expected-error{{expected '{' in body of function}}

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -6,7 +6,23 @@
 
 // REQUIRES: swift_feature_CDecl
 
-@cdecl("cdecl_foo") func foo(x: Int) -> Int { return x }
+@cdecl(cdecl_foo) func foo(x: Int) -> Int { return x }
+
+@cdecl(not an identifier) func invalidName() {}
+// expected-error @-1 {{expected ')' in 'cdecl' attribute}}
+// expected-error @-2 {{expected declaration}}
+
+@cdecl() func emptyParen() {}
+// expected-error @-1 {{expected C identifier in 'cdecl' attribute}}
+// expected-error @-2 {{expected declaration}}
+
+@cdecl(42) func aNumber() {}
+// expected-error @-1 {{expected C identifier in 'cdecl' attribute}}
+// expected-error @-2 {{expected declaration}}
+
+@cdecl(a:selector:) func selectordName() {}
+// expected-error @-1 {{expected ')' in 'cdecl' attribute}}
+// expected-error @-2 {{expected declaration}}
 
 @cdecl("") // expected-error{{@cdecl symbol name cannot be empty}}
 func emptyName(x: Int) -> Int { return x }


### PR DESCRIPTION
Update the C++ and ASTGen parsers to accept `@cdecl` with an optional identifier argument for a custom C name. If no arguments are passed, the C name defaults to the name of the function with the attribute.

We still parse `@_cdecl` expecting a string argument.

The C++ parser still accepts strings as arguments for ease of landing this change. This can be lifted once other PRs are merged. We’ll also need a small change for @cdecl enums to behave properly without a custom C name.