### PR TITLE
[6.2] Change send-never-sendable of isolated partial applies to use SIL level info instead of AST info.

### DIFF
--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1866,30 +1866,23 @@ bool SentNeverSendableDiagnosticInferrer::initForSendingPartialApply(
 bool SentNeverSendableDiagnosticInferrer::initForIsolatedPartialApply(
     Operand *op, AbstractClosureExpr *ace,
     std::optional<ActorIsolation> actualCallerIsolation) {
-  SmallVector<std::tuple<CapturedValue, unsigned, ApplyIsolationCrossing>, 8>
-      foundCapturedIsolationCrossing;
-  ace->getIsolationCrossing(foundCapturedIsolationCrossing);
-  if (foundCapturedIsolationCrossing.empty())
+  auto diagnosticPair = findClosureUse(op);
+  if (!diagnosticPair)
     return false;
 
-  // We use getASTAppliedArgIndex instead of getAppliedArgIndex to ensure that
-  // we ignore for our indexing purposes any implicit initial parameters like
-  // isolated(any).
-  unsigned opIndex = ApplySite(op->getUser()).getASTAppliedArgIndex(*op);
-  for (auto &p : foundCapturedIsolationCrossing) {
-    if (std::get<1>(p) == opIndex) {
-      auto loc = RegularLocation(std::get<0>(p).getLoc());
-      auto crossing = std::get<2>(p);
-      auto declIsolation = crossing.getCallerIsolation();
-      auto closureIsolation = crossing.getCalleeIsolation();
-      if (!bool(declIsolation) && actualCallerIsolation) {
-        declIsolation = *actualCallerIsolation;
-      }
-      diagnosticEmitter.emitNamedFunctionArgumentClosure(
-          loc, std::get<0>(p).getDecl()->getBaseIdentifier(),
-          ApplyIsolationCrossing(declIsolation, closureIsolation));
-      return true;
-    }
+  auto *diagnosticOp = diagnosticPair->first;
+
+  ApplyIsolationCrossing crossing(
+      *op->getFunction()->getActorIsolation(),
+      *diagnosticOp->getFunction()->getActorIsolation());
+
+  // We do not need to worry about failing to infer a name here since we are
+  // going to be returning some form of a SILFunctionArgument which is always
+  // easy to find a name for.
+  if (auto rootValueAndName = inferNameAndRootHelper(op->get())) {
+    diagnosticEmitter.emitNamedFunctionArgumentClosure(
+        diagnosticOp->getUser()->getLoc(), rootValueAndName->first, crossing);
+    return true;
   }
 
   return false;

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -205,10 +205,8 @@ struct Clock {
   let ns = customActorIsolatedGlobal
 
   let _ = { @MainActor in
-    // TODO: The type checker seems to think that the isolation here is
-    // nonisolated instead of custom actor isolated.
     print(ns) // expected-tns-warning {{sending 'ns' risks causing data races}}
-    // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later global actor 'CustomActor'-isolated uses}}
     // expected-complete-warning @-2 {{capture of 'ns' with non-Sendable type 'NonSendableKlass' in a '@Sendable' closure}}
   }
 

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -81,10 +81,9 @@ func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
 
 actor ActorWithAsyncIsolatedInit {
   init(_ newK: NonSendableKlass) async {
-    // TODO: This should say actor isolated.
     let _ = { @MainActor in
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
-      // expected-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later actor-isolated uses}}
     }
   }
 }
@@ -150,7 +149,7 @@ class ClassWithAsyncIsolatedInit {
   init(_ newK: NonSendableKlass) async {
     let _ = { @MainActor in
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
-      // expected-note @-1 {{global actor 'CustomActor'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{global actor 'CustomActor'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later global actor 'CustomActor'-isolated uses}}
     }
   }
 }

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -59,10 +59,8 @@ distributed actor MyDistributedActor {
 
   distributed func transferActorIsolatedArgIntoClosure(_ x: NonSendableKlass) async {
     _ = { @MainActor in
-      // TODO: In 2nd part of message should say actor-isolated instead of later
-      // nonisolated uses in the case of a closure.
       print(x) // expected-error {{sending 'x' risks causing data races}}
-      // expected-note @-1 {{'self'-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{'self'-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later actor-isolated uses}}
     }
   }
 


### PR DESCRIPTION
Explanation: This PR changes how we emit errors when sending values that can never be sent to use SIL level routines instead of AST level routines. Because we were using AST level routines, we attempted to emit an error for the self sourceloc which in a method does not exist. So we were emitting the error at <unknown>. Now that we are using the SIL level routines, we emit the actual error at the use source loc and use the name of the captured variable.

Scope: Just changes how we emit an error. The actual code that identifies errors is unchanged.

Resolves: rdar://151955519

Main PR: https://github.com/swiftlang/swift/pull/82149

Risk: Low. This does not impact where we emit errors... it just changes the way the errors look.

Testing: Added compiler tests

Reviewer: @xedin 
