### PR TITLE
[AST] Delete copy constructor for `LoadedExecutablePlugin::PluginProcess`

### DIFF
--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -152,6 +152,9 @@ class LoadedExecutablePlugin : public CompilerPlugin {
         : process(process), input(input), output(output) {}
     ~PluginProcess();
 
+    PluginProcess(const PluginProcess &) = delete;
+    PluginProcess &operator=(const PluginProcess &) = delete;
+
     ssize_t write(const void *buf, size_t nbyte) const;
     ssize_t read(void *buf, size_t nbyte) const;
   };


### PR DESCRIPTION
Avoid a potential footgun here since copying would lead to waiting for the child process multiple times.