### PR TITLE
[Concurrency] Fix null pointer dereference for task-to-thread model.

### DIFF
--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -91,14 +91,14 @@ internal func _jobGetExecutorPrivateData(
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_getMainExecutor")
-internal func _getMainExecutor() -> any SerialExecutor {
+internal func _getMainExecutorAsSerialExecutor() -> (any SerialExecutor)? {
   return MainActor.executor
 }
 #else
 // For task-to-thread model, this is implemented in C++
 @available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_getMainExecutor")
-internal func _getMainExecutor() -> any SerialExecutor
+internal func _getMainExecutorAsSerialExecutor() -> (any SerialExecutor)?
 #endif // SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 #endif // !$Embedded
 

--- a/stdlib/public/Concurrency/ExecutorImpl.swift
+++ b/stdlib/public/Concurrency/ExecutorImpl.swift
@@ -47,7 +47,11 @@ internal func donateToGlobalExecutor(
 @available(SwiftStdlib 6.2, *)
 @_silgen_name("swift_task_getMainExecutorImpl")
 internal func getMainExecutor() -> UnownedSerialExecutor {
-  return unsafe _getMainExecutor().asUnownedSerialExecutor()
+  let executor = _getMainExecutorAsSerialExecutor()
+  if let executor {
+    return unsafe executor.asUnownedSerialExecutor()
+  }
+  return unsafe unsafeBitCast(executor, to: UnownedSerialExecutor.self)
 }
 
 @available(SwiftStdlib 6.2, *)


### PR DESCRIPTION
In task-to-thread concurrency mode, `_getMainExecutorAsSerialExecutor` returns `SerialExecutorRef::generic()`, which is, give or take, NULL. Unfortunately we'd declared it as returning `any SerialExecutor`, rather than `(any SerialExecutor)?`, and then the `getMainExecutor()` function was calling `asUnownedSerialExecutor()` on it, which then crashes.

rdar://153152063
