### PR TITLE
ClangImporter: work around the inability to adjust the Darwin overlay

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -377,6 +377,12 @@ namespace {
 ValueDecl *importDeclAlias(ClangImporter::Implementation &clang,
                            swift::DeclContext *DC, const clang::ValueDecl *D,
                            Identifier alias) {
+  if (DC->getASTContext().LangOpts.Target.isOSDarwin() &&
+      DC->getParentModule()->getName().str() == StringRef("_stdio") &&
+      llvm::any_of(llvm::ArrayRef<StringRef>{"stdin", "stdout", "stderr"},
+                   [alias = alias.str()](StringRef Id) { return alias == Id; }))
+    return nullptr;
+
   // Variadic functions cannot be imported into Swift.
   // FIXME(compnerd) emit a diagnostic for the missing diagnostic.
   if (const auto *FD = dyn_cast<clang::FunctionDecl>(D))

--- a/test/ClangImporter/ignore-darwin-aliasing.swift
+++ b/test/ClangImporter/ignore-darwin-aliasing.swift
@@ -1,0 +1,4 @@
+// RUN: %target-typecheck-verify-swift %s
+// REQUIRES: VENDOR=apple
+
+import var Darwin.stderr


### PR DESCRIPTION
Explicitly carve out `_stdio.stdin`, `_stdio.stdout`, `_stdio.stderr` as unaliased as the macros are explicitly imported through the `_stdio` overlay.