### PR TITLE
[Concurrency] NonisolatedNonsendingByDefault/NFC: Move 'same module' …

### DIFF
--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -73,6 +73,11 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
       return;
     }
 
+    // Only diagnose declarations from the current module.
+    if (decl->getModuleContext() != ctx.MainModule) {
+      return;
+    }
+
     // If the attribute cannot appear on this kind of declaration, we can't
     // diagnose it.
     if (!DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::Concurrent,
@@ -153,10 +158,6 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
 
   const auto featureName = feature.getName();
   if (decl) {
-    // Only diagnose declarations from the current module.
-    if (decl->getModuleContext() != ctx.MainModule)
-      return;
-
     // Diagnose the function, but slap the attribute on the storage declaration
     // instead if the function is an accessor.
     auto *functionDecl = dyn_cast<AbstractFunctionDecl>(decl);


### PR DESCRIPTION
…check higher

This is a follow-up to https://github.com/swiftlang/swift/pull/82173 which moves the check higher to make it an early exist.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
