### PR TITLE
🍒 modulemap: Add missing dependency on vcruntime

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -40,6 +40,7 @@ module _malloc [system] [no_undeclared_includes] {
 
 module _stdlib [system] [no_undeclared_includes] {
   use corecrt
+  use vcruntime
   header "stdlib.h"
   export *
 }


### PR DESCRIPTION
- **Explanation**:
  `stdlib.h` includes `limits.h`, which is defined in the `vcruntime` module.
- **Scope**:
  This fixes the module map usage with static linking on Windows.
- **Issues**:
  N/A
- **Original PRs**:
  #82126
- **Risk**:
  Very low. CI should catch any issue.
- **Testing**:
  Local build + CI.
- **Reviewers**:
  @compnerd 