### PR TITLE
Quick support for calling extern c functions with Builtin vector types.

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -813,6 +813,15 @@ ClangTypeConverter::visitBuiltinFloatType(BuiltinFloatType *type) {
   llvm_unreachable("cannot translate floating-point format to C");
 }
 
+clang::QualType
+ClangTypeConverter::visitBuiltinVectorType(BuiltinVectorType *type) {
+  auto &clangCtx = ClangASTContext;
+  auto eltTy = visit(type->getElementType());
+  return clangCtx.getVectorType(
+    eltTy, type->getNumElements(), clang::VectorKind::Generic
+  );
+}
+
 clang::QualType ClangTypeConverter::visitArchetypeType(ArchetypeType *type) {
   // We see these in the case where we invoke an @objc function
   // through a protocol.

--- a/lib/AST/ClangTypeConverter.h
+++ b/lib/AST/ClangTypeConverter.h
@@ -157,6 +157,7 @@ private:
   clang::QualType visitBuiltinRawPointerType(BuiltinRawPointerType *type);
   clang::QualType visitBuiltinIntegerType(BuiltinIntegerType *type);
   clang::QualType visitBuiltinFloatType(BuiltinFloatType *type);
+  clang::QualType visitBuiltinVectorType(BuiltinVectorType *type);
   clang::QualType visitArchetypeType(ArchetypeType *type);
   clang::QualType visitDependentMemberType(DependentMemberType *type);
   template <bool templateArgument = false>

--- a/test/Prototypes/builtin-vector-via-extern-c.swift
+++ b/test/Prototypes/builtin-vector-via-extern-c.swift
@@ -1,4 +1,4 @@
-//===--- SIMDFloatComparisons.swift.gyb -----------------------*- swift -*-===//
+//===----------------------------------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -9,9 +9,9 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: %empty-directory(%t)
-// RUN: %gyb %s -o %t/SIMDFloatComparisons.swift
-// RUN: %target-swift-frontend -primary-file %t/SIMDFloatComparisons.swift -emit-ir -enable-experimental-feature BuiltinModule -enable-experimental-feature Extern | %FileCheck %t/SIMDFloatComparisons.swift --check-prefix=CHECK
+// REQUIRES: swift_feature_Extern
+// REQUIRES: swift_feature_BuiltinModule
+// RUN: %target-swift-frontend -primary-file %s -enable-experimental-feature BuiltinModule -enable-experimental-feature Extern -emit-ir | %FileCheck %s --check-prefix=CHECK
 
 import Builtin
 
@@ -23,7 +23,7 @@ public func saturatingAdd(_ a: SIMD16<UInt8>, _ b: SIMD16<UInt8>) -> SIMD16<UInt
   // Hack around init from Builtin type being stdlib-internal using unsafeBitCast.
   unsafeBitCast(_uaddSat(a._storage._value, b._storage._value), to: SIMD16<UInt8>.self)
 }
-// CHECK: s20SIMDFloatComparisons13saturatingAddys6SIMD16Vys5UInt8VGAG_AGtF{{.*}} {
+// CHECK: saturatingAdd{{.*}} {
 // CHECK: entry:
 // CHECK: call <16 x i8> @llvm.uadd.sat.v16i8
 

--- a/test/Prototypes/builtin-vector-via-extern-c.swift
+++ b/test/Prototypes/builtin-vector-via-extern-c.swift
@@ -1,0 +1,29 @@
+//===--- SIMDFloatComparisons.swift.gyb -----------------------*- swift -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/SIMDFloatComparisons.swift
+// RUN: %target-swift-frontend -primary-file %t/SIMDFloatComparisons.swift -emit-ir -enable-experimental-feature BuiltinModule -enable-experimental-feature Extern | %FileCheck %t/SIMDFloatComparisons.swift --check-prefix=CHECK
+
+import Builtin
+
+@_extern(c, "llvm.uadd.sat.v16i8") @usableFromInline
+func _uaddSat(_ a: Builtin.Vec16xInt8, _ b: Builtin.Vec16xInt8) -> Builtin.Vec16xInt8
+
+@_transparent
+public func saturatingAdd(_ a: SIMD16<UInt8>, _ b: SIMD16<UInt8>) -> SIMD16<UInt8> {
+  // Hack around init from Builtin type being stdlib-internal using unsafeBitCast.
+  unsafeBitCast(_uaddSat(a._storage._value, b._storage._value), to: SIMD16<UInt8>.self)
+}
+// CHECK: s20SIMDFloatComparisons13saturatingAddys6SIMD16Vys5UInt8VGAG_AGtF{{.*}} {
+// CHECK: entry:
+// CHECK: call <16 x i8> @llvm.uadd.sat.v16i8
+


### PR DESCRIPTION
This gives us a means to use llvm's intrinsics that implement more niche SIMD instructions from the standard library, where we cannot use the C intrinsics headers from clang (because they're in the cpp module).