### PR TITLE
[Concurrency] NonisolatedNonsendingByDefault: Except `@Test` test-cases and `$` prefixed declarations from migration

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -362,7 +362,7 @@ public:
   }
 
   bool hasDollarPrefix() const {
-    return getIdentifier().hasDollarPrefix();
+    return !isSpecial() && getIdentifier().hasDollarPrefix();
   }
 
   /// A representation of the name to be displayed to users. May be ambiguous

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Basic/Assertions.h"
@@ -55,6 +56,27 @@ public:
   /// behavior.
   void diagnose() const;
 };
+
+/// Determine whether the decl represents a test function that is
+/// annotated with `@Test` macro from the swift-testing framework.
+/// Such functions should be exempt from the migration because their
+/// execution is controlled by the framework and the change in
+/// behavior doesn't affect them.
+static bool isSwiftTestingTestFunction(ValueDecl *decl) {
+  if (!isa<FuncDecl>(decl))
+    return false;
+
+  return llvm::any_of(decl->getAttrs(), [&decl](DeclAttribute *attr) {
+    auto customAttr = dyn_cast<CustomAttr>(attr);
+    if (!customAttr)
+      return false;
+
+    auto *macro = decl->getResolvedMacro(customAttr);
+    return macro && macro->getBaseIdentifier().is("Test") &&
+           macro->getParentModule()->getName().is("Testing");
+  });
+}
+
 } // end anonymous namespace
 
 void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
@@ -75,6 +97,11 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
 
     // Only diagnose declarations from the current module.
     if (decl->getModuleContext() != ctx.MainModule) {
+      return;
+    }
+
+    // `@Test` test-case have special semantics.
+    if (isSwiftTestingTestFunction(decl)) {
       return;
     }
 

--- a/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
+++ b/lib/Sema/NonisolatedNonsendingByDefaultMigration.cpp
@@ -105,6 +105,12 @@ void NonisolatedNonsendingByDefaultMigrationTarget::diagnose() const {
       return;
     }
 
+    // A special declaration that was either synthesized by the compiler
+    // or a macro expansion.
+    if (decl->getBaseName().hasDollarPrefix()) {
+      return;
+    }
+
     // If the attribute cannot appear on this kind of declaration, we can't
     // diagnose it.
     if (!DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::Concurrent,


### PR DESCRIPTION
- `@Test` asynchronous functions

  The execution of these functions is controlled by the testing
  framework and it's okay if their behavior changes when the feature
  flag is enabled.

- `$` prefix functions declarations

  These are special declarations that are synthesized by the compiler
  or a macro and warnings about them are non-actionable.

Resolves: rdar://152687527

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
