### PR TITLE
build-script: fix `--skip-build-llvm` not having full effect

### DIFF
--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -623,7 +623,7 @@ class BuildScriptInvocation(object):
         # Swift still needs a few LLVM targets like tblgen to be built for it to be
         # configured. Instead, handle this in the product for now.
         builder.add_product(products.LLVM,
-                            is_enabled=self.args.build_llvm or self.args.build_swift)
+                            is_enabled=self.args.build_llvm or self.args.build_swift or self.args.build_lldb)
 
         builder.add_product(products.StaticSwiftLinuxConfig,
                             is_enabled=self.args.install_static_linux_config)

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -623,7 +623,7 @@ class BuildScriptInvocation(object):
         # Swift still needs a few LLVM targets like tblgen to be built for it to be
         # configured. Instead, handle this in the product for now.
         builder.add_product(products.LLVM,
-                            is_enabled=True)
+                            is_enabled=self.args.build_llvm or self.args.build_swift)
 
         builder.add_product(products.StaticSwiftLinuxConfig,
                             is_enabled=self.args.install_static_linux_config)


### PR DESCRIPTION
While LLVM cannot be completely disabled when Swift is built, we should still allow skipping LLVM configuration and build steps when Swift is not built. This can happen, for example, when `build-script` user wants an ad-hoc incremental build with `--skip-build-swift` for products that don't depend on LLVM and Swift, or if LLVM and Swift were already configured and built in previous `build-script` invocations.
