### PR TITLE
[Sema] Scale back CodingKeys hack in `TypeChecker::lookupUnqualifiedType`

### DIFF
--- a/test/Sema/rdar153096639.swift
+++ b/test/Sema/rdar153096639.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+// Make sure we don't run into a request cycle for the below use of 'CodingKeys'
+// in an `init(from:)` signature.
+
+protocol P {
+  associatedtype X
+}
+
+struct S: Codable {
+  var foo: String?
+
+  enum CodingKeys: CodingKey {
+    case foo
+  }
+
+  init<T: P>(from: T) where T.X == CodingKeys {}
+}


### PR DESCRIPTION
I previously added this hack to match the logic in `TypeChecker::lookupUnqualified` (#79850), but it turns out that can introduce request cycles for cases where `CodingKeys` is used in a generic requirement for one of `Codable`'s potential value witnesses. Scale back the hack such that it's only done when we get an initial empty lookup result, ensuring we maintain source compatibility. Both these lookup hacks should go away once we properly handle CodingKeys  synthesis.

rdar://153096639