### PR TITLE
[6.2] [Sema] Scale back CodingKeys hack in `TypeChecker::lookupUnqualifiedType`

### DIFF
--- a/test/Sema/rdar153096639.swift
+++ b/test/Sema/rdar153096639.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+
+// Make sure we don't run into a request cycle for the below use of 'CodingKeys'
+// in an `init(from:)` signature.
+
+protocol P {
+  associatedtype X
+}
+
+struct S: Codable {
+  var foo: String?
+
+  enum CodingKeys: CodingKey {
+    case foo
+  }
+
+  init<T: P>(from: T) where T.X == CodingKeys {}
+}


### PR DESCRIPTION
*6.2 cherry-pick of #82237*

- Explanation: Fixes a source compatibility regression that could occur when `CodingKeys` is used in a generic requirement for one of `Codable`'s potential value witnesses
- Scope: Scales back a lookup hack added previously for 6.2 to maintain compatibility with 6.1
- Issue: rdar://153096639
- Risk: Low, implements a more limited form of a recent 6.2 change
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich