### PR TITLE
[6.2][IRGen] Emit null check before swift_conformsToProtocol for nullable metatypes

### DIFF
--- a/lib/IRGen/GenCast.h
+++ b/lib/IRGen/GenCast.h
@@ -99,8 +99,8 @@ namespace irgen {
   /// not, the cast is done as a class instance cast.
   void emitScalarExistentialDowncast(
       IRGenFunction &IGF, llvm::Value *orig, SILType srcType, SILType destType,
-      CheckedCastMode mode, std::optional<MetatypeRepresentation> metatypeKind,
-      Explosion &ex);
+      CheckedCastMode mode, bool sourceWrappedInOptional,
+      std::optional<MetatypeRepresentation> metatypeKind, Explosion &ex);
 
   /// Emit a checked cast from a metatype to AnyObject.
   llvm::Value *emitMetatypeToAnyObjectDowncast(IRGenFunction &IGF,

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -12,6 +12,7 @@ struct NotClass {}
 class A {}
 class B: A {}
 final class F: A {}
+protocol Q {}
 
 sil_vtable A {}
 sil_vtable B {}
@@ -434,4 +435,25 @@ bb2:
 
 bb3(%11 : $Optional<C & PAnyObject>):
   return %11 : $Optional<C & PAnyObject>
+}
+
+// CHECK-LABEL: define{{.*}} @checked_cast_optional_metatype
+// CHECK: [[COND:%.*]] = icmp ne ptr {{%.*}}, null
+// CHECK-NEXT: br i1 [[COND]], label %is-non-nil, label %is-nil
+// CHECK: nil-checked-cont:
+// CHECK:   %4 = phi { ptr, ptr } [ {{%.*}}, %is-non-nil ], [ zeroinitializer, %is-nil ]
+sil @checked_cast_optional_metatype : $@convention(thin) (Optional<@thick any Any.Type>) -> Optional<@thick any Q.Type> {
+bb0(%0 : $Optional<@thick any Any.Type>):
+  checked_cast_br Optional<any Any.Type> in %0 to any Q.Type, bb1, bb2
+
+bb1(%3 : $@thick any Q.Type):
+  %4 = enum $Optional<@thick any Q.Type>, #Optional.some!enumelt, %3
+  br bb3(%4)
+
+bb2:
+  %6 = enum $Optional<@thick any Q.Type>, #Optional.none!enumelt
+  br bb3(%6)
+
+bb3(%8 : $Optional<@thick any Q.Type>):
+  return %8
 }


### PR DESCRIPTION
- **Explanation**: swift_conformsToProtocol does not properly handle nullptr values, which can currently be passed if the source type is an optional metatype. This change adds emission of a null check before calling the runtime function in these cases.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: IRGen for checked casts
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://149882902
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/82240
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. This change only affects the specific case that currently causes issues. Other instances should not be affected.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Added a regression test
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @aschwaighofer @mikeash 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->