### PR TITLE
Further relax concrete simd ir tests

### DIFF
--- a/test/stdlib/SIMDFloatComparisons.swift.gyb
+++ b/test/stdlib/SIMDFloatComparisons.swift.gyb
@@ -42,8 +42,7 @@ func compare_eq${n}x${bits}(
 // CHECK${arch}: compare_eq${n}x${bits}{{.*}} {
 // CHECK${arch}: entry:
 // CHECK${arch}: [[TMP:%[0-9]+]] = fcmp oeq <${n} x ${llvm}> %0, %1
-// CHECK${arch}-NEXT: [[RES:%[0-9]+]] = sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
-// CHECK${arch}-NEXT: ret <${n} x i${bits}> [[RES]]
+// CHECK${arch}-NEXT: sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
 
 %   if bits == 16:
 #if arch(arm64)
@@ -60,8 +59,7 @@ func compare_ne${n}x${bits}(
 // CHECK${arch}: compare_ne${n}x${bits}{{.*}} {
 // CHECK${arch}: entry:
 // CHECK${arch}: [[TMP:%[0-9]+]] = fcmp une <${n} x ${llvm}> %0, %1
-// CHECK${arch}-NEXT: [[RES:%[0-9]+]] = sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
-// CHECK${arch}-NEXT: ret <${n} x i${bits}> [[RES]]
+// CHECK${arch}-NEXT: sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
 
 %   if bits == 16:
 #if arch(arm64)
@@ -78,8 +76,7 @@ func compare_lt${n}x${bits}(
 // CHECK${arch}: compare_lt${n}x${bits}{{.*}} {
 // CHECK${arch}: entry:
 // CHECK${arch}: [[TMP:%[0-9]+]] = fcmp olt <${n} x ${llvm}> %0, %1
-// CHECK${arch}-NEXT: [[RES:%[0-9]+]] = sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
-// CHECK${arch}-NEXT: ret <${n} x i${bits}> [[RES]]
+// CHECK${arch}-NEXT: sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
 
 %   if bits == 16:
 #if arch(arm64)
@@ -96,8 +93,7 @@ func compare_le${n}x${bits}(
 // CHECK${arch}: compare_le${n}x${bits}{{.*}} {
 // CHECK${arch}: entry:
 // CHECK${arch}: [[TMP:%[0-9]+]] = fcmp ole <${n} x ${llvm}> %0, %1
-// CHECK${arch}-NEXT: [[RES:%[0-9]+]] = sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
-// CHECK${arch}-NEXT: ret <${n} x i${bits}> [[RES]]
+// CHECK${arch}-NEXT: sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
 
 %   if bits == 16:
 #if arch(arm64)
@@ -114,8 +110,7 @@ func compare_ge${n}x${bits}(
 // CHECK${arch}: compare_ge${n}x${bits}{{.*}} {
 // CHECK${arch}: entry:
 // CHECK${arch}: [[TMP:%[0-9]+]] = fcmp oge <${n} x ${llvm}> %0, %1
-// CHECK${arch}-NEXT: [[RES:%[0-9]+]] = sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
-// CHECK${arch}-NEXT: ret <${n} x i${bits}> [[RES]]
+// CHECK${arch}-NEXT: sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
 
 %   if bits == 16:
 #if arch(arm64)
@@ -132,8 +127,7 @@ func compare_gt${n}x${bits}(
 // CHECK${arch}: compare_gt${n}x${bits}{{.*}} {
 // CHECK${arch}: entry:
 // CHECK${arch}: [[TMP:%[0-9]+]] = fcmp ogt <${n} x ${llvm}> %0, %1
-// CHECK${arch}-NEXT: [[RES:%[0-9]+]] = sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
-// CHECK${arch}-NEXT: ret <${n} x i${bits}> [[RES]]
+// CHECK${arch}-NEXT: sext <${n} x i1> [[TMP]] to <${n} x i${bits}>
 
 %  end
 % end

--- a/test/stdlib/SIMDFloatInitializers.swift.gyb
+++ b/test/stdlib/SIMDFloatInitializers.swift.gyb
@@ -37,16 +37,10 @@ func repeating${n}x${bits}(_ scalar: ${scalar}) -> SIMD${n}<${scalar}> {
 %   if bits == 16:
 #endif
 %   end
-
 // CHECK${arch}: repeating${n}x${bits}{{.*}} {
 // CHECK${arch}: entry:
 // CHECK${arch}: [[TMP:%[0-9]+]] = insertelement <${n} x ${llvm}> {{.*}} ${llvm} %0, i32 0
 // CHECK${arch}-NEXT: [[REP:%[0-9]+]] = shufflevector <${n} x ${llvm}> [[TMP]], <${n} x ${llvm}> {{.*}}, <${n} x i32> zeroinitializer
-%   if totalBits == 64:
-// CHECK-arm64-NEXT: ret <${n} x ${llvm}> [[REP]]
-%   else:
-// CHECK${arch}-NEXT: ret <${n} x ${llvm}> [[REP]]
-%   end
 
 %  end
 % end

--- a/test/stdlib/SIMDMaskInitializers.swift.gyb
+++ b/test/stdlib/SIMDMaskInitializers.swift.gyb
@@ -27,11 +27,6 @@ func repeating${n}_mask${bits}(_ scalar: Bool) -> SIMDMask<SIMD${n}<Int${bits}>>
 // CHECK: entry:
 // CHECK: [[TMP:%[0-9]+]] = insertelement <${n} x i${bits}> {{.*}}, i${bits} %{{.*}}, i32 0
 // CHECK-NEXT: [[REP:%[0-9]+]] = shufflevector <${n} x i${bits}> [[TMP]], <${n} x i${bits}> {{.*}}, <${n} x i32> zeroinitializer
-%   if totalBits == 64:
-// CHECK-arm64-NEXT: ret <${n} x i${bits}> [[REP]]
-%   else:
-// CHECK-NEXT: ret <${n} x i${bits}> [[REP]]
-%   end
 
 %  end
 % end

--- a/test/stdlib/SIMDSignedInitializers.swift.gyb
+++ b/test/stdlib/SIMDSignedInitializers.swift.gyb
@@ -20,7 +20,6 @@ import Swift
 %  n = totalBits // bits
 %  if n != 1:
 %   neonSuffix = str(n) + {8:'b',16:'h',32:'s',64:'d'}[bits]
-
 func repeating${n}_int${bits}(_ scalar: Int${bits}) -> SIMD${n}<Int${bits}> {
   SIMD${n}(repeating: scalar)
 }
@@ -28,11 +27,7 @@ func repeating${n}_int${bits}(_ scalar: Int${bits}) -> SIMD${n}<Int${bits}> {
 // CHECK: entry:
 // CHECK: [[TMP:%[0-9]+]] = insertelement <${n} x i${bits}> {{.*}}, i${bits} %0, i32 0
 // CHECK-NEXT: [[REP:%[0-9]+]] = shufflevector <${n} x i${bits}> [[TMP]], <${n} x i${bits}> {{.*}}, <${n} x i32> zeroinitializer
-%   if totalBits == 64:
-// CHECK-arm64-NEXT: ret <${n} x i${bits}> [[REP]]
-%   else:
-// CHECK-NEXT: ret <${n} x i${bits}> [[REP]]
-%   end
+
 %  end
 % end
 %end

--- a/test/stdlib/SIMDUnsignedInitializers.swift.gyb
+++ b/test/stdlib/SIMDUnsignedInitializers.swift.gyb
@@ -20,7 +20,6 @@ import Swift
 %  n = totalBits // bits
 %  if n != 1:
 %   neonSuffix = str(n) + {8:'b',16:'h',32:'s',64:'d'}[bits]
-
 func repeating${n}_uint${bits}(_ scalar: UInt${bits}) -> SIMD${n}<UInt${bits}> {
   SIMD${n}(repeating: scalar)
 }
@@ -28,11 +27,7 @@ func repeating${n}_uint${bits}(_ scalar: UInt${bits}) -> SIMD${n}<UInt${bits}> {
 // CHECK: entry:
 // CHECK: [[TMP:%[0-9]+]] = insertelement <${n} x i${bits}> {{.*}}, i${bits} %{{.*}}, i32 0
 // CHECK-NEXT: [[REP:%[0-9]+]] = shufflevector <${n} x i${bits}> [[TMP]], <${n} x i${bits}> {{.*}}, <${n} x i32> zeroinitializer
-%   if totalBits == 64:
-// CHECK-arm64-NEXT: ret <${n} x i${bits}> [[REP]]
-%   else:
-// CHECK-NEXT: ret <${n} x i${bits}> [[REP]]
-%   end
+
 %  end
 % end
 %end


### PR DESCRIPTION
It turns out that on some targets we generate a call to initialize a SIMD vector from a Builtin.Vec, even though everything is transparent, so the checks for the return using a specific value were too fragile.

rdar://153260158