### PR TITLE
[6.2][Runtime] Remove redundant swift_auth_code_function, use existing swift_auth_code.

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -554,17 +554,6 @@ swift_auth_code(T value, unsigned extra) {
 #endif
 }
 
-template <typename T>
-SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE static inline T
-swift_auth_code_function(T value, unsigned extra) {
-#if SWIFT_PTRAUTH
-  return (T)ptrauth_auth_function((void *)value,
-                                  ptrauth_key_function_pointer, extra);
-#else
-  return value;
-#endif
-}
-
 /// Does this platform support backtrace-on-crash?
 #ifdef __APPLE__
 #  include <TargetConditionals.h>

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2576,7 +2576,7 @@ static void swift_task_deinitOnExecutorImpl(void *object,
                                             SerialExecutorRef newExecutor,
                                             size_t rawFlags) {
   // Sign the function pointer
-  work = swift_auth_code_function(
+  work = swift_auth_code(
       work, SpecialPointerAuthDiscriminators::DeinitWorkFunction);
   // If the current executor is compatible with running the new executor,
   // we can just immediately continue running with the resume function

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1763,7 +1763,7 @@ swift_task_addCancellationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(CancellationNotificationStatusRecord));
-  auto unsigned_handler = swift_auth_code_function(handler,
+  auto unsigned_handler = swift_auth_code(handler,
       SpecialPointerAuthDiscriminators::CancellationNotificationFunction);
   auto *record = ::new (allocation)
       CancellationNotificationStatusRecord(unsigned_handler, context);
@@ -1817,7 +1817,7 @@ swift_task_addPriorityEscalationHandlerImpl(
     void *context) {
   void *allocation =
       swift_task_alloc(sizeof(EscalationNotificationStatusRecord));
-  auto unsigned_handler = swift_auth_code_function(handler,
+  auto unsigned_handler = swift_auth_code(handler,
       SpecialPointerAuthDiscriminators::EscalationNotificationFunction);
   auto *record = ::new (allocation)
       EscalationNotificationStatusRecord(unsigned_handler, context);


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift/pull/82245 to `release/6.2`.

rdar://153169049