### PR TITLE
[xcodegen] `realpath` Swift target sources

### DIFF
--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/SwiftTargets.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/SwiftTargets.swift
@@ -124,10 +124,14 @@ struct SwiftTargets {
         // A relative path is for a file in the build directory, it's external.
         let abs = buildDir.path.appending(r)
         guard abs.exists else { continue }
-        sources.externalSources.append(abs)
+        sources.externalSources.append(abs.realPath)
 
       case .absolute(let a):
-        guard a.exists, let rel = a.removingPrefix(buildDir.repoPath) else {
+        guard a.exists else { continue }
+        // Symlinks shouldn't really be a concern here, but we need to realpath
+        // in order to canonicalize the casing.
+        let a = a.realPath
+        guard let rel = a.removingPrefix(buildDir.repoPath) else {
           sources.externalSources.append(a)
           continue
         }

--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/Path/AbsolutePath.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/Path/AbsolutePath.swift
@@ -52,7 +52,7 @@ public extension AbsolutePath {
     (try? FileManager.default.destinationOfSymbolicLink(atPath: rawPath)) != nil
   }
 
-  var resolvingSymlinks: Self {
+  var realPath: Self {
     guard let resolved = realpath(rawPath, nil) else { return self }
     defer {
       free(resolved)

--- a/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
+++ b/utils/swift-xcodegen/Sources/swift-xcodegen/SwiftXcodegen.swift
@@ -84,7 +84,7 @@ struct SwiftXcodegen: AsyncParsableCommand, Sendable {
 
     // Check to see if we have a separate runnable build dir.
     let runnableBuildDirPath = 
-      self.runnableBuildDir?.absoluteInWorkingDir.resolvingSymlinks
+      self.runnableBuildDir?.absoluteInWorkingDir.realPath
     let runnableBuildDir = try runnableBuildDirPath.map {
       try NinjaBuildDir(at: $0, projectRootDir: ninja.projectRootDir)
         .buildDir(for: .swift)
@@ -332,7 +332,7 @@ struct SwiftXcodegen: AsyncParsableCommand, Sendable {
   }
 
   func generate() async throws {
-    let buildDirPath = buildDir.absoluteInWorkingDir.resolvingSymlinks
+    let buildDirPath = buildDir.absoluteInWorkingDir.realPath
     log.info("Generating project for '\(buildDirPath)'...")
 
     let projectRootDir = self.projectRootDir?.absoluteInWorkingDir


### PR DESCRIPTION
Make sure we call `realpath` for the Swift target sources read from the build settings to ensure we canonicalize their casing.