### PR TITLE
Experimentally change SliceBuffer to use explicit unsigned compare

### DIFF
--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -304,8 +304,9 @@ internal struct _SliceBuffer<Element>
   /// `startIndex ≤ index < endIndex`
   @inlinable
   internal func _checkValidSubscript(_ index: Int) {
-    _precondition(
-      index >= startIndex && index < endIndex, "Index out of bounds")
+    let translatedIndex = UInt(bitPattern: index &- startIndex)
+    let translatedEnd = UInt(bitPattern: endIndex &- startIndex)
+    _precondition(translatedIndex < translatedEnd, "Index out of bounds")
   }
 
   @inlinable


### PR DESCRIPTION
It looks like LLVM doesn't decide to perform this transform on its own in all cases, even at -O, so let's try doing it manually for experimentation purposes and see what happens.