### PR TITLE
Revert "Tests: enable Swift PM tests in Windows toolchain build"

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -60,7 +60,7 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestArg=-Test lld,lldb,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp,swiftpm,
+set TestArg=-Test lld,lldb,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp,
 for %%I in (%SKIP_TESTS%) do (call set TestArg=%%TestArg:%%I,=%%)
 if "%TestArg:~-1%"=="," (set TestArg=%TestArg:~0,-1%) else (set TestArg= )
 


### PR DESCRIPTION
The Windows Platform build (some tests) is causing some issues with PR testing in some projects (e.g.: swift-package-manager, swift-driver).  #80405 was recently introduced to execute the SwiftPM tests.

Revert the change that introduced the execution of SwiftPM tests in the `build.ps1` so we can unblock projects.

Reverts swiftlang/swift#80405