### PR TITLE
utils: pass along Foundation and XCTest to TSC

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2780,7 +2780,11 @@ function Build-ToolsSupportCore([Hashtable] $Platform) {
     -SwiftSDK (Get-SwiftSDK Windows) `
     -Defines @{
       BUILD_SHARED_LIBS = "YES";
+      CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
       CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
+
+      Foundation_DIR = $(Get-ProjectCMakeModules $Platform DynamicFoundation);
+      XCTest_DIR = (Get-ProjectCMakeModules $Platform XCTest);
     }
 }
 


### PR DESCRIPTION
This is required to build the TSCSupport module for SPM's consumption.