### PR TITLE
LifetimeDependence type check: infer trivial _read accessor

### DIFF
--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -318,6 +318,36 @@ struct Accessors {
   }
 }
 
+struct TrivialAccessors {
+  let p: UnsafeRawPointer
+
+  // The implicit _read/_modify accessors must be inferred. They cannot be written explicitly because a getter is
+  // already defined.
+  var neComputed: NEImmortal {
+    @_lifetime(borrow self)
+    get { // OK
+      NEImmortal()
+    }
+
+    @_lifetime(&self)
+    set { // OK (no dependency)
+    }
+  }
+
+  var neYielded: NEImmortal {
+    @_lifetime(borrow self)
+    _read { // OK
+      yield NEImmortal()
+    }
+
+    @_lifetime(&self)
+    _modify { // OK
+      var ne = NEImmortal()
+      yield &ne
+    }
+  }
+}
+
 struct NonescapableSelfAccessors: ~Escapable {
   var ne: NE
 


### PR DESCRIPTION
This fixes a small oversight in the type checker's LifetimeDependence
inference. Allow inference on _read accessors even when 'self' is a trivial
type. This is needed because the compiler synthesizes a _read accessor even when
the user defines a getter (this is probably a mistake, but it's easire to just
fix inference at this point). There is no workaround because it defining both a
getter and '_read' is illegal!

    extension UnsafeMutableRawBufferPointer {
      var mutableBytes: MutableRawSpan {
        @_lifetime(borrow self)
        get {
          unsafe MutableRawSpan(_unsafeBytes: self)
        }
      }
    }

Fixes rdar://153346478 (Can't compile the
UnsafeMutableRawBufferPointer.mutableBytes property)
