### PR TITLE
[Concurrency][Embedded] Make sure Embedded Swift links Impl functions.

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -867,6 +867,11 @@ public:
   /// Returns true if linking succeeded, false otherwise.
   bool linkFunction(SILFunction *F, LinkingMode LinkMode);
 
+  /// Attempt to deserialize witness table for protocol conformance \p PC.
+  ///
+  /// Returns true if linking succeeded, false otherwise.
+  bool linkWitnessTable(ProtocolConformance *PC, LinkingMode LinkMode);
+
   /// Check if a given function exists in any of the modules.
   /// i.e. it can be linked by linkFunction.
   bool hasFunction(StringRef Name);

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -433,6 +433,10 @@ bool SILModule::linkFunction(SILFunction *F, SILModule::LinkingMode Mode) {
   return SILLinkerVisitor(*this, Mode).processFunction(F);
 }
 
+bool SILModule::linkWitnessTable(ProtocolConformance *PC, SILModule::LinkingMode Mode) {
+  return SILLinkerVisitor(*this, Mode).processConformance(ProtocolConformanceRef(PC));
+}
+
 bool SILModule::hasFunction(StringRef Name) {
   if (lookUpFunction(Name))
     return true;

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -48,7 +48,7 @@ public:
     // (swift_retain, etc.). Link them in so they can be referenced in IRGen.
     if (M.getOptions().EmbeddedSwift && LinkEmbeddedRuntime) {
       linkEmbeddedRuntimeFromStdlib();
-      linkEmbeddedConcurrencyHookImpls();
+      linkEmbeddedConcurrency();
     }
 
     // In embedded Swift, we need to explicitly link any @_used globals and
@@ -81,7 +81,7 @@ public:
       linkEmbeddedRuntimeFunctionByName("swift_retainCount", { RefCounting });
   }
 
-  void linkEmbeddedConcurrencyHookImpls() {
+  void linkEmbeddedConcurrency() {
     using namespace RuntimeConstants;
 
     // Note: we ignore errors here, because, depending on the exact situation
@@ -99,6 +99,11 @@ public:
   linkUsedFunctionByName(#NAME "Impl", SILLinkage::HiddenExternal)
 
     #include "swift/Runtime/ConcurrencyHooks.def"
+
+    linkUsedFunctionByName("swift_task_asyncMainDrainQueueImpl",
+                           SILLinkage::HiddenExternal);
+    linkUsedFunctionByName("swift_createDefaultExecutors",
+                           SILLinkage::HiddenExternal);
   }
 
   void linkEmbeddedRuntimeFunctionByName(StringRef name,

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -105,7 +105,7 @@ public:
                            SILLinkage::HiddenExternal);
     linkUsedFunctionByName("swift_createDefaultExecutors",
                            SILLinkage::HiddenExternal);
-    linkEmbeddedRuntimeWitnessTable();
+    linkEmbeddedRuntimeWitnessTables();
   }
 
   void linkEmbeddedRuntimeFunctionByName(StringRef name,
@@ -124,20 +124,16 @@ public:
     linkUsedFunctionByName(name, SILLinkage::PublicExternal);
   }
 
-  void linkEmbeddedRuntimeWitnessTable() {
+  void linkEmbeddedRuntimeWitnessTables() {
     SILModule &M = *getModule();
 
     auto *mainActor = M.getASTContext().getMainActorDecl();
     if (mainActor) {
       for (auto *PC : mainActor->getAllConformances()) {
         auto *ProtoDecl = PC->getProtocol();
-        auto name = ProtoDecl->getName();
-        if (name.str() == "Actor") {
-          auto &e = llvm::errs();
-          e << "Found MainActor: Actor conformance\n";
+        if (ProtoDecl->getName().str() == "Actor") {
+          M.linkWitnessTable(PC, SILModule::LinkingMode::LinkAll);
           if (auto *WT = M.lookUpWitnessTable(PC)) {
-            WT = M.getSILLoader()->lookupWitnessTable(WT);
-            e << "Looked up MainActor: Actor witness table\n";
             WT->setLinkage(SILLinkage::Public);
           }
         }

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -36,11 +36,9 @@ public protocol Executor: AnyObject, Sendable {
   func enqueue(_ job: consuming ExecutorJob)
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 
-  #if !$Embedded
   /// `true` if this is the main executor.
   @available(StdlibDeploymentTarget 6.2, *)
   var isMainExecutor: Bool { get }
-  #endif
 }
 
 @available(StdlibDeploymentTarget 6.2, *)
@@ -145,12 +143,10 @@ extension Executor where Self: Equatable {
 
 extension Executor {
 
-  #if !$Embedded
   // This defaults to `false` so that existing third-party Executor
   // implementations will work as expected.
   @available(StdlibDeploymentTarget 6.2, *)
   public var isMainExecutor: Bool { false }
-  #endif
 
 }
 
@@ -368,7 +364,7 @@ public protocol SerialExecutor: Executor {
 @available(StdlibDeploymentTarget 6.0, *)
 extension SerialExecutor {
 
-  #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+  #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   @available(StdlibDeploymentTarget 6.2, *)
   public var isMainExecutor: Bool { return MainActor.executor._isSameExecutor(self) }
   #endif
@@ -579,11 +575,9 @@ public protocol MainExecutor: RunLoopExecutor, SerialExecutor {
 /// executors.
 @available(StdlibDeploymentTarget 6.2, *)
 public protocol ExecutorFactory {
-  #if !$Embedded
   /// Constructs and returns the main executor, which is started implicitly
   /// by the `async main` entry point and owns the "main" thread.
   static var mainExecutor: any MainExecutor { get }
-  #endif
 
   /// Constructs and returns the default or global executor, which is the
   /// default place in which we run tasks.
@@ -596,7 +590,7 @@ typealias DefaultExecutorFactory = PlatformExecutorFactory
 @available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_createExecutors")
 public func _createExecutors<F: ExecutorFactory>(factory: F.Type) {
-  #if !$Embedded && !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+  #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   MainActor._executor = factory.mainExecutor
   #endif
   Task._defaultExecutor = factory.defaultExecutor


### PR DESCRIPTION
Teach the Embedded Swift compiler to include the Impl functions for the functions that provide Concurrency hooks.
