### PR TITLE
Tests: enable Swift PM tests in Windows toolchain build

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -62,7 +62,7 @@ set TMPDIR=%BuildRoot%\tmp
 set NINJA_STATUS=[%%f/%%t][%%p][%%es] 
 
 :: Build the -Test argument, if any, by subtracting skipped tests
-set TestsList=lld,lldb,lldb-swift,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp
+set TestsList=lld,lldb,lldb-swift,swift,dispatch,foundation,xctest,swift-format,sourcekit-lsp,swiftpm
 set "TestArg="
 set "Skip=,%SKIP_TESTS%,"
 for %%I in (%TestsList%) do (

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -4109,7 +4109,7 @@ function Test-PackageManager() {
   }
 
   Build-SPMProject `
-    -Action Test `
+    -Action TestParallel `
     -Src $SrcDir `
     -Bin "$BinaryCache\$($HostPlatform.Triple)\PackageManagerTests" `
     -Platform $HostPlatform `


### PR DESCRIPTION
Reverts swiftlang/swift#82265, which re-applies swiftlang/swift#80405

Enable the SwiftPM tests in the Windows toolchain build to get extra confidence the change did not introduce any regression on the Windows platform.

In addition to the re-application of swiftlang/swift#80405, execute SwiftPM tesst in parallel

Fixes: https://github.com/swiftlang/swift-package-manager/issues/8895
Depends on: https://github.com/swiftlang/swift-package-manager/pull/8899