### PR TITLE
[stdlib] add missing computed properties

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -583,6 +583,18 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
+%if Mutable:
+
+  @unsafe
+  @available(SwiftStdlib 6.2, *)
+  public var mutableSpan: MutableSpan<Element> {
+    @lifetime(borrow self)
+    @_alwaysEmitIntoClient
+    get {
+      unsafe MutableSpan(_unsafeElements: self)
+    }
+  }
+%end
 }
 
 extension Unsafe${Mutable}BufferPointer {

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1162,6 +1162,16 @@ extension Unsafe${Mutable}RawBufferPointer {
     }
   }
 
+  @unsafe
+  @available(SwiftStdlib 6.2, *)
+  public var mutableBytes: MutableRawSpan {
+    @lifetime(borrow self)
+    @_alwaysEmitIntoClient
+    get {
+      unsafe MutableRawSpan(_unsafeBytes: self)
+    }
+  }
+
 %  end
   @_alwaysEmitIntoClient
   public func withContiguousStorageIfAvailable<R>(

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -934,6 +934,8 @@ Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
 Added: _$ss11InlineArrayVsRi__rlE11mutableSpans07MutableD0Vyq_Gvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
+Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
+Added: _$sSw12mutableBytess14MutableRawSpanVvr
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -935,6 +935,8 @@ Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
 Added: _$ss11InlineArrayVsRi__rlE11mutableSpans07MutableD0Vyq_Gvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
+Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
+Added: _$sSw12mutableBytess14MutableRawSpanVvr
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -514,3 +514,26 @@ suite.test("extracting suffixes")
     expectEqual(span.extracting(droppingFirst: 1).byteCount, b.count)
   }
 }
+
+suite.test("MutableRawSpan from UnsafeMutableRawBufferPointer")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  let b = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: capacity*MemoryLayout<Int64>.stride,
+    alignment: MemoryLayout<Int64>.alignment
+  )
+  defer {
+    b.deallocate()
+  }
+  _ = b.initializeMemory(as: Int64.self, fromContentsOf: 0..<Int64(capacity))
+
+  var span = b.mutableBytes
+  span.storeBytes(of: 3, toByteOffset: 10, as: UInt16.self)
+
+  _ = consume span
+
+  let v = b.load(fromByteOffset: 8, as: Int64.self)
+  expectNotEqual(v, 1)
+}

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -720,3 +720,25 @@ suite.test("extracting suffixes")
     expectEqual(span.extracting(droppingFirst: 1).count, b.count)
   }
 }
+
+suite.test("MutableSpan from UnsafeMutableBufferPointer")
+.require(.stdlib_6_2).code {
+  guard #available(SwiftStdlib 6.2, *) else { return }
+
+  let capacity = 4
+  let b = UnsafeMutableBufferPointer<Int>.allocate(capacity: capacity)
+  defer {
+    b.deallocate()
+  }
+  _ = b.initialize(fromContentsOf: 0..<capacity)
+
+  var span = b.mutableSpan
+  expectEqual(span.count, capacity)
+
+  span.swapAt(0, 3)
+  span.swapAt(1, 2)
+
+  _ = consume span
+
+  expectTrue(b.elementsEqual((0..<capacity).reversed()))
+}


### PR DESCRIPTION
[SE-0467](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0467-MutableSpan.md) adds an unsafe `mutableSpan` property to `UnsafeMutableBufferPointer`, and a similar `mutableBytes` property to `UnsafeMutableRawBufferPointer`. They were missing in the original implementation; here they are.

Addresses rdar://153219174
(requires https://github.com/swiftlang/swift/pull/82268)
