### PR TITLE
[build-script] build LLVMTestingSupport only if target is generated

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -175,7 +175,6 @@ KNOWN_SETTINGS=(
     skip-clean-xctest                             "0"               "skip cleaning the xctest build"
 
     ## Test Options
-    llvm-include-tests                            "1"               "Set to true to generate testing targets for LLVM. Set to true by default."
     long-test                                     "0"               "set to run the long test suite"
     only-executable-test                          ""                "only run the executable variant of the swift lit tests"
     stress-test                                   "0"               "set to run the stress test suite"

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1421,8 +1421,14 @@ def create_argument_parser():
                 'Can be called multiple times '
                 'to add multiple such options.')
 
-    option('--no-llvm-include-tests', toggle_false('llvm_include_tests'),
-           help='do not generate testing targets for LLVM')
+    with mutually_exclusive_group():
+        set_defaults(llvm_include_tests=True)
+
+        option('--no-llvm-include-tests', toggle_false('llvm_include_tests'),
+               help='do not generate testing targets for LLVM')
+
+        option('--llvm-include-tests', toggle_true('llvm_include_tests'),
+               help='generate testing targets for LLVM')
 
     option('--llvm-cmake-options', append,
            type=argparse.ShellSplitType(),

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -557,7 +557,8 @@ EXPECTED_OPTIONS = [
     SetOption('--no-swift-stdlib-strict-availability',
               dest='swift_stdlib_strict_availability', value=False),
 
-    SetFalseOption('--no-llvm-include-tests', dest='llvm_include_tests'),
+    DisableOption('--no-llvm-include-tests', dest='llvm_include_tests'),
+    EnableOption('--llvm-include-tests', dest='llvm_include_tests'),
 
     SetTrueOption('--install-back-deploy-concurrency',
                   dest='install_backdeployconcurrency'),

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -271,10 +271,7 @@ class LLVM(cmake_product.CMakeProduct):
                     'llvm-size'
                 ])
         else:
-            # We build LLVMTestingSupport unconditionally
-            # to support scenarios where tests are run
-            # outside of `build-script` (e.g. with `run-test`)
-            build_targets = ['all', 'LLVMTestingSupport']
+            build_targets = ['all']
 
             if self.args.llvm_ninja_targets_for_cross_compile_hosts and \
                self.is_cross_compile_target(host_target):
@@ -421,6 +418,12 @@ class LLVM(cmake_product.CMakeProduct):
         if not self.args.llvm_include_tests:
             llvm_cmake_options.define('LLVM_INCLUDE_TESTS', 'NO')
             llvm_cmake_options.define('CLANG_INCLUDE_TESTS', 'NO')
+
+        if ("-DLLVM_INCLUDE_TESTS=NO" not in llvm_cmake_options
+            and "-DLLVM_INCLUDE_TESTS:BOOL=FALSE" not in llvm_cmake_options):
+            # This supports scenarios where tests are run
+            # outside of `build-script` (e.g. with `run-test`)
+            build_targets.append('LLVMTestingSupport')
 
         build_root = os.path.dirname(self.build_dir)
         host_machine_target = targets.StdlibDeploymentTarget.host_target().name


### PR DESCRIPTION
Otherwise the build will fail if we pass `--no-llvm-include-tests` or we
set directly `LLVM_INCLUDE_TESTS` directly to `FALSE`/`OFF`

Also take the chance to wire `--llvm-include-tests` properly in build-script

Addresses rdar://153562845