### PR TITLE
[Test] Fix Interpreter/layout_string_witnesses_dynamic.swift

### DIFF
--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -16,9 +16,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// test disabled until rdar://151476435 is fixed
-// REQUIRES: rdar151476435
-
 import Swift
 import layout_string_witnesses_types
 import layout_string_witnesses_types_resilient
@@ -33,7 +30,7 @@ class TestClass {
 
 func testGeneric() {
     let ptr = allocateInternalGenericPtr(of: TestClass.self)
-    
+
     do {
         let x = TestClass()
         testGenericInit(ptr, to: x)
@@ -1246,7 +1243,7 @@ func testNonCopyableGenericStructSimpleClass() {
     let ptr = UnsafeMutableBufferPointer<NonCopyableGenericStruct<SimpleClass>>.allocate(capacity: 1)
 
     let x = NonCopyableGenericStruct(x: 23, y: SimpleClass(x: 23))
-    ptr[0] = x
+    ptr.initializeElement(at: 0, to: x)
 
     // CHECK-NEXT: Before deinit
     print("Before deinit")
@@ -1264,7 +1261,7 @@ func testNonCopyableGenericEnumSimpleClass() {
     let ptr = UnsafeMutableBufferPointer<NonCopyableGenericEnum<SimpleClass>>.allocate(capacity: 1)
 
     let x = NonCopyableGenericEnum.x(23, SimpleClass(x: 23))
-    ptr[0] = x
+    ptr.initializeElement(at: 0, to: x)
 
     // CHECK-NEXT: Before deinit
     print("Before deinit")


### PR DESCRIPTION
rdar://151476435

Two tests incorrectly assigned values to an uninitialized pointer instead of initializing it. This caused crashes on some distros.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
