### PR TITLE
[IRGen] Fix FixedArray of fixedSize 1 element addressing.

### DIFF
--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -53,8 +53,15 @@ protected:
       return;
     }
     if (fixedSize == 1) {
-      // only one element to operate on
-      return body(addrs);
+      auto zero = llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0);
+      // only one element to operate on; index to it in each array
+      SmallVector<Address, 2> eltAddrs;
+      eltAddrs.reserve(addrs.size());
+      for (auto index : indices(addrs)) {
+        eltAddrs.push_back(Element.indexArray(IGF, addrs[index], zero,
+                                              getElementSILType(IGF.IGM, T)));
+      }
+      return body(eltAddrs);
     }
     
     auto arraySize = getArraySize(IGF, T);

--- a/validation-test/IRGen/rdar151726387.sil
+++ b/validation-test/IRGen/rdar151726387.sil
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -parse-sil -emit-ir %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct O {
+  var arr: Builtin.FixedArray<1, I>
+  struct I {
+    var eyes: SIMD64<Int8>
+    var neighs: String
+  }
+}
+
+sil @copy : $@convention(thin) (@in_guaranteed O) -> (@out O) {
+entry(%out : $*O, %in : $*O):
+  copy_addr %in to [init] %out : $*O
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
When a `FixedArray`'s fixed size is 1, it looks like `[1 x %Ty]`. Given an array's address, performing an operation on each element's address entail's indexing into the array to each element's index to produce an element's address for each index.  That is true even when the array consists of a single element. In that case, produce an address for that single element by indexing to index 0 into each passed-in array.

rdar://151726387
