### PR TITLE
6.2: [IRGen] Fix FixedArray of fixedSize 1 element addressing

### DIFF
--- a/lib/IRGen/GenArray.cpp
+++ b/lib/IRGen/GenArray.cpp
@@ -53,8 +53,15 @@ protected:
       return;
     }
     if (fixedSize == 1) {
-      // only one element to operate on
-      return body(addrs);
+      auto zero = llvm::ConstantInt::get(IGF.IGM.IntPtrTy, 0);
+      // only one element to operate on; index to it in each array
+      SmallVector<Address, 2> eltAddrs;
+      eltAddrs.reserve(addrs.size());
+      for (auto index : indices(addrs)) {
+        eltAddrs.push_back(Element.indexArray(IGF, addrs[index], zero,
+                                              getElementSILType(IGF.IGM, T)));
+      }
+      return body(eltAddrs);
     }
     
     auto arraySize = getArraySize(IGF, T);

--- a/validation-test/IRGen/rdar151726387.sil
+++ b/validation-test/IRGen/rdar151726387.sil
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -parse-sil -emit-ir %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct O {
+  var arr: Builtin.FixedArray<1, I>
+  struct I {
+    var eyes: SIMD64<Int8>
+    var neighs: String
+  }
+}
+
+sil @copy : $@convention(thin) (@in_guaranteed O) -> (@out O) {
+entry(%out : $*O, %in : $*O):
+  copy_addr %in to [init] %out : $*O
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
**Explanation**: Fix assertion failures when emitting code for `FixedArray`s of size 1.

When emitting code for operations performed on addresses of type `FixedArray` (the type backing `InlineArray`), code which operates on the address of each element of the `FixedArray` is emitted.  Typically, this involves emitting a loop over the array elements, projecting an address for the element at the loop index, and performing an operation on that address.  As an optimization, however, when the `FixedArray` is of fixed length 1, no loop is emitted.  Instead, a single operation for that one element is emitted.

Previously, this optimization wasn't indexing into the length-1 array.  Instead it was just forwarding along the address of the array itself.  This resulted in problems downstream of that failure-to-index because the various subsequent address projection operations had their meanings skewed by the missing address-of-element-at-index-0 projection.

Here, this is fixed by forming the address of the element at index 0 and passing it off to the code that emits the operations on elements.
**Scope**: Affects `InlineArray`s of fixed size 1.
**Issue**: rdar://151726387
**Original PR**: https://github.com/swiftlang/swift/pull/82280
**Risk**: Low, this only affects the code-path for emitting operations on `InlineArray` of size 1.
**Testing**: Added test.
**Reviewer**: Joe Groff ( @jckarter )