### PR TITLE
[ABIChecker] Use -Isystem and -Fsystem for swift-api-digester

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -328,7 +328,7 @@ def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption, ArgumentIsPath]>,
 
 def Fsystem : Separate<["-"], "Fsystem">,
   Flags<[FrontendOption, ArgumentIsPath, SwiftSymbolGraphExtractOption,
-         SwiftSynthesizeInterfaceOption]>,
+         SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
   HelpText<"Add directory to system framework search path">;
 
 def I : JoinedOrSeparate<["-"], "I">,
@@ -340,7 +340,7 @@ def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption, ArgumentIsPath]>,
 
 def Isystem : Separate<["-"], "Isystem">,
   Flags<[FrontendOption, ArgumentIsPath, SwiftSymbolGraphExtractOption,
-         SwiftSynthesizeInterfaceOption]>,
+         SwiftAPIDigesterOption, SwiftSynthesizeInterfaceOption]>,
   HelpText<"Add directory to the system import search path">;
 
 def import_underlying_module : Flag<["-"], "import-underlying-module">,

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -38,6 +38,7 @@
 #include "swift/Option/Options.h"
 #include "swift/Parse/ParseVersion.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/VirtualOutputBackends.h"
 #include "llvm/Support/raw_ostream.h"
 #include <functional>
@@ -2261,11 +2262,12 @@ private:
   std::string BaselineSDK;
   std::string Triple;
   std::string SwiftVersion;
-  std::vector<std::string> CCSystemFrameworkPaths;
+  std::vector<std::string> SystemFrameworkPaths;
   std::vector<std::string> BaselineFrameworkPaths;
   std::vector<std::string> FrameworkPaths;
-  std::vector<std::string> BaselineModuleInputPaths;
-  std::vector<std::string> ModuleInputPaths;
+  std::vector<std::string> SystemModuleImportPaths;
+  std::vector<std::string> BaselineModuleImportPaths;
+  std::vector<std::string> ModuleImportPaths;
   std::string ModuleList;
   std::vector<std::string> ModuleNames;
   std::vector<std::string> PreferInterfaceForModules;
@@ -2362,11 +2364,13 @@ public:
     BaselineSDK = ParsedArgs.getLastArgValue(OPT_bsdk).str();
     Triple = ParsedArgs.getLastArgValue(OPT_target).str();
     SwiftVersion = ParsedArgs.getLastArgValue(OPT_swift_version).str();
-    CCSystemFrameworkPaths = ParsedArgs.getAllArgValues(OPT_iframework);
+    SystemFrameworkPaths = ParsedArgs.getAllArgValues(OPT_Fsystem);
+    llvm::append_range(SystemFrameworkPaths, ParsedArgs.getAllArgValues(OPT_iframework));
     BaselineFrameworkPaths = ParsedArgs.getAllArgValues(OPT_BF);
     FrameworkPaths = ParsedArgs.getAllArgValues(OPT_F);
-    BaselineModuleInputPaths = ParsedArgs.getAllArgValues(OPT_BI);
-    ModuleInputPaths = ParsedArgs.getAllArgValues(OPT_I);
+    SystemModuleImportPaths = ParsedArgs.getAllArgValues(OPT_Isystem);
+    BaselineModuleImportPaths = ParsedArgs.getAllArgValues(OPT_BI);
+    ModuleImportPaths = ParsedArgs.getAllArgValues(OPT_I);
     ModuleList = ParsedArgs.getLastArgValue(OPT_module_list_file).str();
     ModuleNames = ParsedArgs.getAllArgValues(OPT_module);
     PreferInterfaceForModules =
@@ -2421,7 +2425,7 @@ public:
   }
 
   bool hasBaselineInput() {
-    return !BaselineModuleInputPaths.empty() ||
+    return !BaselineModuleImportPaths.empty() ||
            !BaselineFrameworkPaths.empty() || !BaselineSDK.empty();
   }
 
@@ -2476,29 +2480,30 @@ public:
       InitInvoke.setRuntimeResourcePath(ResourceDir);
     }
     std::vector<SearchPathOptions::SearchPath> FramePaths;
-    for (const auto &path : CCSystemFrameworkPaths) {
+    for (const auto &path : SystemFrameworkPaths) {
       FramePaths.push_back({path, /*isSystem=*/true});
+    }
+    std::vector<SearchPathOptions::SearchPath> ImportPaths;
+    for (const auto &path : SystemModuleImportPaths) {
+      ImportPaths.push_back({path, /*isSystem=*/true});
     }
     if (IsBaseline) {
       for (const auto &path : BaselineFrameworkPaths) {
         FramePaths.push_back({path, /*isSystem=*/false});
       }
-      std::vector<SearchPathOptions::SearchPath> ImportPaths;
-      for (const auto &path : BaselineModuleInputPaths) {
+      for (const auto &path : BaselineModuleImportPaths) {
         ImportPaths.push_back({path, /*isSystem=*/false});
       }
-      InitInvoke.setImportSearchPaths(ImportPaths);
     } else {
       for (const auto &path : FrameworkPaths) {
         FramePaths.push_back({path, /*isSystem=*/false});
       }
-      std::vector<SearchPathOptions::SearchPath> ImportPaths;
-      for (const auto &path : ModuleInputPaths) {
+      for (const auto &path : ModuleImportPaths) {
         ImportPaths.push_back({path, /*isSystem=*/false});
       }
-      InitInvoke.setImportSearchPaths(ImportPaths);
     }
     InitInvoke.setFrameworkSearchPaths(FramePaths);
+    InitInvoke.setImportSearchPaths(ImportPaths);
     if (!ModuleList.empty()) {
       if (readFileLineByLine(ModuleList, Modules))
         exit(1);

--- a/utils/api_checker/swift-api-checker.py
+++ b/utils/api_checker/swift-api-checker.py
@@ -146,7 +146,7 @@ class DumpConfig:
                '/tmp/ModuleCache', '-swift-version',
                swift_ver, '-abort-on-module-fail']
         for path in self.frameworks:
-            cmd.extend(['-iframework', path])
+            cmd.extend(['-Fsystem', path])
         for path in self.inputs:
             cmd.extend(['-I', path])
         if self.abi:


### PR DESCRIPTION
Use the Swift -Fsystem flag for swift-api-digester instead of the clang -iframework flag. Add support for -Isystem for parity.

rdar://152747420