### PR TITLE
SILGen: Handle struct fields and addressors as addressable storage.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3539,27 +3539,198 @@ Expr *ArgumentSource::findStorageReferenceExprForBorrow() && {
 ManagedValue
 SILGenFunction::tryEmitAddressableParameterAsAddress(ArgumentSource &&arg,
                                                      ValueOwnership ownership) {
+  if (!arg.isExpr()) {
+    return ManagedValue();
+  }
+
   // If the function takes an addressable parameter, and its argument is
   // a reference to an addressable declaration with compatible ownership,
   // forward the address along in-place.
-  if (arg.isExpr()) {
-    auto origExpr = std::move(arg).asKnownExpr();
-    auto expr = origExpr;
-    
-    if (auto le = dyn_cast<LoadExpr>(expr)) {
-      expr = le->getSubExpr();
-    }
-    if (auto dre = dyn_cast<DeclRefExpr>(expr)) {
-      if (auto param = dyn_cast<VarDecl>(dre->getDecl())) {
-        if (auto addr = getLocalVariableAddressableBuffer(param, expr,
-                                                          ownership)) {
-          return ManagedValue::forBorrowedAddressRValue(addr);
-        }
+  auto origExpr = std::move(arg).asKnownExpr();
+  auto expr = origExpr;
+  
+  // If the expression does not have a stable address to return, then restore
+  // the ArgumentSource and return a null value to the caller.
+  auto notAddressable = [&] {
+    arg = ArgumentSource(origExpr);
+    return ManagedValue();
+  };
+  
+  if (auto le = dyn_cast<LoadExpr>(expr)) {
+    expr = le->getSubExpr();
+  }
+  if (auto dre = dyn_cast<DeclRefExpr>(expr)) {
+    if (auto param = dyn_cast<VarDecl>(dre->getDecl())) {
+      if (auto addr = getLocalVariableAddressableBuffer(param, expr,
+                                                        ownership)) {
+        return ManagedValue::forBorrowedAddressRValue(addr);
       }
     }
-    arg = ArgumentSource(origExpr);
   }
-  return ManagedValue();
+  
+  // Property or subscript member accesses may also be addressable.
+  
+  AccessKind accessKind;
+  switch (ownership) {
+  case ValueOwnership::Shared:
+  case ValueOwnership::Default:
+    accessKind = AccessKind::Read;
+    break;
+  case ValueOwnership::Owned:
+  case ValueOwnership::InOut:
+    accessKind = AccessKind::ReadWrite;
+    break;
+  }
+
+  LookupExpr *lookupExpr;
+  AbstractStorageDecl *memberStorage;
+  SubstitutionMap subs;
+  AccessSemantics accessSemantics;
+  PreparedArguments indices;
+
+  if (auto mre = dyn_cast<MemberRefExpr>(expr)) {
+    lookupExpr = mre;
+    memberStorage = dyn_cast<VarDecl>(mre->getMember().getDecl());
+    subs = mre->getMember().getSubstitutions();
+    accessSemantics = mre->getAccessSemantics();
+  } else if (auto se = dyn_cast<SubscriptExpr>(expr)) {
+    lookupExpr = se;
+    auto subscriptDecl = cast<SubscriptDecl>(se->getMember().getDecl());
+    memberStorage = subscriptDecl;
+    subs = se->getMember().getSubstitutions();
+    accessSemantics = se->getAccessSemantics();
+    
+    indices = PreparedArguments(
+      subscriptDecl->getInterfaceType()->castTo<AnyFunctionType>()
+                   ->getParams(),
+      se->getArgs());
+  } else {
+    return notAddressable();
+  }
+  
+  if (!memberStorage) {
+    return notAddressable();
+  }
+  
+  auto strategy = memberStorage->getAccessStrategy(accessSemantics, accessKind,
+    SGM.M.getSwiftModule(), F.getResilienceExpansion(),
+    std::make_pair<>(expr->getSourceRange(), FunctionDC),
+    /*old abi (doesn't matter here)*/ false);
+
+  switch (strategy.getKind()) {
+  case AccessStrategy::Storage: {
+    auto vd = cast<VarDecl>(memberStorage);
+    // TODO: Is it possible and/or useful for class storage to be
+    // addressable?
+    if (!vd->getDeclContext()->getInnermostTypeContext()
+         ->getDeclaredTypeInContext()->getStructOrBoundGenericStruct()) {
+      return notAddressable();
+    }
+  
+    // If the storage holds the fully-abstracted representation of the
+    // type, then we can use its address.
+    auto absBaseTy = getLoweredType(AbstractionPattern::getOpaque(),
+                 lookupExpr->getBase()->getType()->getWithoutSpecifierType());
+    auto memberTy = absBaseTy.getFieldType(vd, &F);
+    auto absMemberTy = getLoweredType(AbstractionPattern::getOpaque(),
+                            lookupExpr->getType()->getWithoutSpecifierType());
+    
+    if (memberTy.getAddressType() != absMemberTy.getAddressType()) {
+      // The storage is not fully abstracted, so it can't serve as a
+      // stable address.
+      return notAddressable();
+    }
+    
+    // Otherwise, we can project the field address from the stable address
+    // of the base, if it has one. Try to get the stable address for the
+    // base.
+    auto baseAddr = tryEmitAddressableParameterAsAddress(
+      ArgumentSource(lookupExpr->getBase()), ownership);
+      
+    if (!baseAddr) {
+      return notAddressable();
+    }
+    
+    // Project the field's address.
+    auto fieldAddr = B.createStructElementAddr(lookupExpr,
+                                               baseAddr.getValue(), vd);
+    return ManagedValue::forBorrowedAddressRValue(fieldAddr);
+  }
+  
+  case AccessStrategy::DirectToAccessor:
+  case AccessStrategy::DispatchToAccessor: {
+    // Non-addressor accessors don't produce stable addresses.
+    if (strategy.getAccessor() != AccessorKind::Address
+        && strategy.getAccessor() != AccessorKind::MutableAddress) {
+      return notAddressable();
+    }
+    // TODO: Non-yielding borrow/mutate accessors can also be considered
+    // addressable when we have those.
+    
+    auto addressor = memberStorage->getAccessor(strategy.getAccessor());
+    auto addressorRef = SILDeclRef(addressor, SILDeclRef::Kind::Func);
+    auto absMemberTy = getLoweredType(AbstractionPattern::getOpaque(),
+                               lookupExpr->getType()->getWithoutSpecifierType())
+      .getAddressType();
+
+    // Evaluate the base in the current formal access scope.
+    ManagedValue base;
+    // If the addressor wants the base addressable, try to honor that
+    // request.
+    auto addressorSelf = addressor->getImplicitSelfDecl();
+    if (addressorSelf->isAddressable()
+        || getTypeLowering(lookupExpr->getBase()->getType()
+                                     ->getWithoutSpecifierType())
+            .getRecursiveProperties().isAddressableForDependencies()) {
+      ValueOwnership baseOwnership = addressorSelf->isInOut()
+        ? ValueOwnership::InOut
+        : ValueOwnership::Shared;
+      
+      base = tryEmitAddressableParameterAsAddress(
+        ArgumentSource(lookupExpr->getBase()), baseOwnership);
+    }
+    
+    // Otherwise, project the base as an lvalue.
+    if (!base) {
+      SGFAccessKind silAccess;
+      switch (accessKind) {
+      case AccessKind::Read:
+        silAccess = SGFAccessKind::BorrowedAddressRead;
+        break;
+      case AccessKind::ReadWrite:
+      case AccessKind::Write:
+        silAccess = SGFAccessKind::ReadWrite;
+        break;
+      }
+      
+      LValue lv = emitLValue(lookupExpr, silAccess);
+      
+      drillToLastComponent(lookupExpr->getBase(), std::move(lv), base);
+    }
+    
+    // Materialize the base outside of the scope of the addressor call,
+    // since the returned address may depend on the materialized
+    // representation, even if it isn't transitively addressable.
+    auto baseTy = lookupExpr->getBase()->getType()->getCanonicalType();
+    ArgumentSource baseArg = prepareAccessorBaseArgForFormalAccess(
+      lookupExpr->getBase(), base, baseTy, addressorRef);
+    
+    // Invoke the addressor to directly produce the address.
+    return emitAddressorAccessor(lookupExpr,
+       addressorRef, subs,
+       std::move(baseArg),
+       /*super*/ false, /*direct accessor use*/ true,
+       std::move(indices),
+       absMemberTy, /*on self*/ false);
+  }
+  
+  case AccessStrategy::MaterializeToTemporary:
+  case AccessStrategy::DispatchToDistributedThunk:
+    // These strategies never produce a value with a stable address.
+    return notAddressable();
+  }
+  
+  llvm_unreachable("uncovered switch!");
 }
 
 namespace {
@@ -7284,6 +7455,34 @@ ArgumentSource AccessorBaseArgPreparer::prepare() {
   return prepareAccessorObjectBaseArg();
 }
 
+ArgumentSource SILGenFunction::prepareAccessorBaseArgForFormalAccess(
+                                                      SILLocation loc,
+                                                      ManagedValue base,
+                                                      CanType baseFormalType,
+                                                      SILDeclRef accessor) {
+  if (!base) {
+    return ArgumentSource();
+  }
+    
+  base = base.formalAccessBorrow(*this, loc);
+  // If the base needs to be materialized, do so in
+  // the outer formal evaluation scope, since an addressor or
+  // other dependent value may want to point into the materialization.
+  auto &baseInfo = getConstantInfo(getTypeExpansionContext(), accessor);
+
+  if (!baseInfo.FormalPattern.isForeign()) {
+    auto baseFnTy = baseInfo.SILFnType;
+
+    if (baseFnTy->getSelfParameter().isFormalIndirect()
+        && base.getType().isObject()
+        && silConv.useLoweredAddresses()) {
+      base = base.formallyMaterialize(*this, loc);
+    }
+  }
+
+  return prepareAccessorBaseArg(loc, base, baseFormalType, accessor);
+}
+
 ArgumentSource SILGenFunction::prepareAccessorBaseArg(SILLocation loc,
                                                       ManagedValue base,
                                                       CanType baseFormalType,
@@ -7603,10 +7802,7 @@ ManagedValue SILGenFunction::emitAddressorAccessor(
 
   emission.addCallSite(loc, std::move(subscriptIndices));
 
-  // Unsafe{Mutable}Pointer<T> or
-  // (Unsafe{Mutable}Pointer<T>, Builtin.UnknownPointer) or
-  // (Unsafe{Mutable}Pointer<T>, Builtin.NativePointer) or
-  // (Unsafe{Mutable}Pointer<T>, Builtin.NativePointer?) or
+  // Result must be Unsafe{Mutable}Pointer<T>
   SmallVector<ManagedValue, 2> results;
   emission.apply().getAll(results);
 

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -477,29 +477,6 @@ static ManagedValue emitBuiltinUnprotectedAddressOf(SILGenFunction &SGF,
                                       /*stackProtected=*/ false);
 }
 
-// Like `tryEmitAddressableParameterAsAddress`, but also handles struct element projections.
-static SILValue emitAddressOf(Expr *e, SILGenFunction &SGF, SILLocation loc) {
-
-  if (auto *memberRef = dyn_cast<MemberRefExpr>(e)) {
-    VarDecl *fieldDecl = dyn_cast<VarDecl>(memberRef->getDecl().getDecl());
-    if (!fieldDecl)
-      return SILValue();
-    SILValue addr = emitAddressOf(memberRef->getBase(), SGF, loc);
-    if (!addr)
-      return SILValue();
-    if (addr->getType().getStructOrBoundGenericStruct() != fieldDecl->getDeclContext())
-      return SILValue();
-    return SGF.B.createStructElementAddr(loc, addr, fieldDecl);
-  }
-
-  if (auto addressableAddr = SGF.tryEmitAddressableParameterAsAddress(
-                                                      ArgumentSource(e),
-                                                      ValueOwnership::Shared)) {
-    return addressableAddr.getValue();
-  }
-  return SILValue();
-}
-
 /// Specialized emitter for Builtin.addressOfBorrow.
 static ManagedValue emitBuiltinAddressOfBorrowBuiltins(SILGenFunction &SGF,
                                                SILLocation loc,
@@ -514,11 +491,15 @@ static ManagedValue emitBuiltinAddressOfBorrowBuiltins(SILGenFunction &SGF,
 
   auto argument = (*argsOrError)[0];
 
+  SILValue addr;
   // Try to borrow the argument at +0 indirect.
   // If the argument is a reference to a borrowed addressable parameter, then
   // use that parameter's stable address.
-  SILValue addr = emitAddressOf(argument, SGF, loc);
-  if (!addr) {
+  if (auto addressableAddr = SGF.tryEmitAddressableParameterAsAddress(
+                                                      ArgumentSource(argument),
+                                                      ValueOwnership::Shared)) {
+    addr = addressableAddr.getValue();
+  } else {
     // We otherwise only support the builtin applied to values that
     // are naturally emitted borrowed in memory. (But it would probably be good
     // to phase this out since it's not really well-defined how long

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2754,8 +2754,6 @@ RValue RValueEmitter::visitMemberRefExpr(MemberRefExpr *e,
          "RValueEmitter shouldn't be called on lvalues");
   assert(isa<VarDecl>(e->getMember().getDecl()));
 
-  // Everything else should use the l-value logic.
-
   // Any writebacks for this access are tightly scoped.
   FormalEvaluationScope scope(SGF);
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -44,6 +44,7 @@ class ConsumableManagedValue;
 class LogicalPathComponent;
 class LValue;
 class ManagedValue;
+class PathComponent;
 class PreparedArguments;
 class RValue;
 class CalleeTypeInfo;
@@ -1978,6 +1979,10 @@ public:
   ArgumentSource prepareAccessorBaseArg(SILLocation loc, ManagedValue base,
                                         CanType baseFormalType,
                                         SILDeclRef accessor);
+  ArgumentSource prepareAccessorBaseArgForFormalAccess(SILLocation loc,
+                                                       ManagedValue base,
+                                                       CanType baseFormalType,
+                                                       SILDeclRef accessor);
 
   RValue emitGetAccessor(
       SILLocation loc, SILDeclRef getter, SubstitutionMap substitutions,
@@ -2201,7 +2206,12 @@ public:
 
   RValue emitLoadOfLValue(SILLocation loc, LValue &&src, SGFContext C,
                           bool isBaseLValueGuaranteed = false);
-
+  PathComponent &&
+  drillToLastComponent(SILLocation loc,
+                       LValue &&lv,
+                       ManagedValue &addr,
+                       TSanKind tsanKind = TSanKind::None);
+                     
   /// Emit a reference to a method from within another method of the type.
   std::tuple<ManagedValue, SILType>
   emitSiblingMethodRef(SILLocation loc,

--- a/test/SILGen/addressable_members.swift
+++ b/test/SILGen/addressable_members.swift
@@ -1,0 +1,148 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature AddressableParameters %s | %FileCheck %s
+
+// REQUIRES: swift_feature_AddressableParameters
+
+protocol Gen {
+    associatedtype Ass
+    associatedtype Ind
+}
+
+struct Foo: Gen {
+    typealias Ass = Bar
+    typealias Ind = Int
+
+    var bar: Bar
+
+    var barAddressor: Bar {
+        unsafeAddress { fatalError() }
+    }
+
+    var barSelfAddressor: Bar {
+        @_addressableSelf
+        unsafeAddress { fatalError() }
+    }
+
+    subscript(i: Int) -> Bar {
+        unsafeAddress { fatalError() }
+    }
+}
+struct Bar {
+    var bas: Bas
+}
+struct Bas {
+    var end: Int
+}
+
+extension Gen {
+    var genAddressor: Ass {
+        unsafeAddress { fatalError() }
+    }
+
+    var genSelfAddressor: Ass {
+        @_addressableSelf
+        unsafeAddress { fatalError() }
+    }
+
+    subscript(gen i: Ind) -> Ass {
+        unsafeAddress { fatalError() }
+    }
+    subscript(genSelf i: Ind) -> Ass {
+        @_addressableSelf
+        unsafeAddress { fatalError() }
+    }
+}
+
+
+func bas(_ bas: borrowing @_addressable Bas) { }
+
+func bar(_ bar: borrowing @_addressable Bar) { }
+
+// CHECK-LABEL: sil {{.*}} @${{.*}}19testAddressableBase
+func testAddressableBase(_ foo: borrowing @_addressable Foo, i: Int) {
+// CHECK: bb0(%0 : @noImplicitCopy $*Foo
+    // CHECK: [[WRAP_BASE:%.*]] = copyable_to_moveonlywrapper_addr %0
+    // CHECK: [[BASE:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[WRAP_BASE]]
+
+    // CHECK: [[BAR:%.*]] = struct_element_addr [[BASE]], #Foo.bar
+    // CHECK: [[UNWRAP_BAR:%.*]] = moveonlywrapper_to_copyable_addr [[BAR]]
+    // CHECK: apply {{.*}}([[UNWRAP_BAR]])
+    bar(foo.bar)
+
+    // CHECK: [[BAR:%.*]] = struct_element_addr [[BASE]], #Foo.bar
+    // CHECK: [[BAS:%.*]] = struct_element_addr [[BAR]], #Bar.bas
+    // CHECK: [[UNWRAP_BAS:%.*]] = moveonlywrapper_to_copyable_addr [[BAS]]
+    // CHECK: apply {{.*}}([[UNWRAP_BAS]])
+    bas(foo.bar.bas)
+
+    // non-addressable base:
+    // CHECK: [[ADDRESSOR:%.*]] = function_ref @{{.*}}12barAddressor{{.*}}lu :
+    // CHECK: [[ADDRESS:%.*]] = apply [[ADDRESSOR]](
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: [[ADDRESS_DEP:%.*]] = mark_dependence {{.*}} [[ADDRESS_ADDR]]
+    // CHECK: apply {{.*}}([[ADDRESS_DEP]])
+    bar(foo.barAddressor)
+
+    // addressable base:
+    // CHECK: [[ADDRESSOR:%.*]] = function_ref @{{.*}}16barSelfAddressor{{.*}}lu :
+    // CHECK: [[UNWRAP_FOO:%.*]] = moveonlywrapper_to_copyable_addr [[BASE]]
+    // CHECK: [[ADDRESS:%.*]] = apply [[ADDRESSOR]]([[UNWRAP_FOO]])
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: [[ADDRESS_DEP:%.*]] = mark_dependence {{.*}} [[ADDRESS_ADDR]]
+    // CHECK: apply {{.*}}([[ADDRESS_DEP]])
+    bar(foo.barSelfAddressor)
+
+    // non-addressable base:
+    // CHECK: [[ADDRESSOR:%.*]] = function_ref @$s19addressable_members3FooVyAA3BarVSicilu :
+    // CHECK: [[ADDRESS:%.*]] = apply [[ADDRESSOR]](
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: [[ADDRESS_DEP:%.*]] = mark_dependence {{.*}} [[ADDRESS_ADDR]]
+    // CHECK: apply {{.*}}([[ADDRESS_DEP]])
+    bar(foo[i])
+    // CHECK: [[ADDRESSOR:%.*]] = function_ref @$s19addressable_members3FooVyAA3BarVSicilu :
+    // CHECK: [[ADDRESS:%.*]] = apply [[ADDRESSOR]](
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: [[ADDRESS_DEP:%.*]] = mark_dependence {{.*}} [[ADDRESS_ADDR]]
+    // CHECK: [[BAS_ADDRESS:%.*]] = struct_element_addr [[ADDRESS_DEP]], #Bar.bas
+    // CHECK: apply {{.*}}([[BAS_ADDRESS]])
+    bas(foo[i].bas)
+
+    // Temporary materialization outlives addressor call, even if it's not
+    // expected to be addressable.
+    // CHECK: [[TEMP:%.*]] = alloc_stack $Foo
+    // CHECK: [[ADDRESS:%.*]] = apply {{.*}}<Foo>([[TEMP]])
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: mark_dependence [unresolved] [[ADDRESS_ADDR]] on [[TEMP]]
+    // CHECK: dealloc_stack [[TEMP]]
+    bar(foo.genAddressor)
+    bar(foo[gen: i])
+
+    bar(foo.genSelfAddressor)
+    bar(foo[genSelf: i])
+}
+
+func temporaryFoo() -> Foo { fatalError() }
+
+func testTemporaryBase(_ foo: borrowing @_addressable Foo, i: Int) {
+    bar(temporaryFoo().bar)
+    bas(temporaryFoo().bar.bas)
+
+    bar(temporaryFoo().barAddressor)
+
+    bar(temporaryFoo().barSelfAddressor)
+
+    bar(temporaryFoo()[i])
+    bas(temporaryFoo()[i].bas)
+
+    bar(temporaryFoo().genAddressor)
+    bar(temporaryFoo()[gen: i])
+}
+
+func testInoutBase(_ foo: inout Foo) {
+    bar(foo.bar)
+    bas(foo.bar.bas)
+}

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -609,5 +609,5 @@ func testBorrowedAddressableInt(arg: Holder) -> Int {
 func testBorrowedAddressableIntReturn(arg: Holder) -> Span<Int> {
   arg.addressableInt.span()
   // expected-error @-1{{lifetime-dependent value escapes its scope}}
-  // expected-note  @-3{{it depends on the lifetime of argument 'arg'}}
+  // expected-note  @-2{{it depends on the lifetime of this parent value}}
 } // expected-note  {{this use causes the lifetime-dependent value to escape}}


### PR DESCRIPTION
When accessing stored properties out of an addressable variable or parameter binding, the stored property's address inside the addressable storage of the aggregate is itself addressable. Also, if a computed property is implemented using an addressor, treat that as a sign that the returned address should be used as addressable storage as well. rdar://152280207
