### PR TITLE
[Concurrency] SE-0449: `nonisolated` on a type should prevent isolati…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5130,6 +5130,13 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
   if (dc->getSelfProtocolDecl())
     return std::nullopt;
 
+  // Prevent isolation inference from requirements if the conforming type
+  // has an explicit `nonisolated` attribute.
+  if (auto *NTD = dc->getSelfNominalTypeDecl()) {
+    if (NTD->getAttrs().hasAttribute<NonisolatedAttr>())
+      return std::nullopt;
+  }
+
   // Walk through each of the conformances in this context, collecting any
   // requirements that have actor isolation.
   auto conformances = idc->getLocalConformances( // note this

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -142,6 +142,34 @@ nonisolated class K: GloballyIsolated {
   }
 }
 
+@MainActor
+protocol GloballyIsolatedWithRequirements {
+  var x: NonSendable { get set } // expected-note {{property declared here}}
+  func test() // expected-note {{calls to instance method 'test()' from outside of its actor context are implicitly asynchronous}}
+}
+
+nonisolated class K2: GloballyIsolatedWithRequirements {
+  var x: NonSendable
+
+  func test() {}
+
+  func testNonWitness() {}
+
+  init(x: NonSendable) {
+    self.x = x // okay
+    test() // okay
+    testNonWitness() // okay
+  }
+
+  func test<T: GloballyIsolatedWithRequirements>(t: T, s: K2) {
+    _ = s.x // okay
+    _ = t.x // expected-error {{main actor-isolated property 'x' can not be referenced from a nonisolated context}}
+
+    s.test() // okay
+    t.test() // expected-error {{call to main actor-isolated instance method 'test()' in a synchronous nonisolated context}}
+  }
+}
+
 // MARK: - Storage of non-Sendable
 
 class KlassA {


### PR DESCRIPTION
…on inference from protocol requirements

If a `nonisolated` type conforms to a global-isolated protocol the witnesses to the protocol requirements should infer the isolation from the protocol but instead be `nonisolated`.

Resolves: rdar://145519840

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
