### PR TITLE
[Concurrency] fix documentation typos in TaskGroup.swift

### DIFF
--- a/stdlib/public/Concurrency/PriorityQueue.swift
+++ b/stdlib/public/Concurrency/PriorityQueue.swift
@@ -124,7 +124,7 @@ struct PriorityQueue<T> {
   private mutating func upHeap(ndx: Int) {
     var theNdx = ndx
     while theNdx > 0 {
-      let parentNdx = (theNdx - 1) / 2
+      let parentNdx = theNdx / 2
 
       if !compare(storage[theNdx], storage[parentNdx]) {
         break
@@ -151,13 +151,13 @@ struct PriorityQueue<T> {
   private mutating func downHeap(ndx:  Int) {
     var theNdx = ndx
     while true {
-      let leftNdx = 2 * theNdx + 1
+      let leftNdx = 2 * theNdx
 
       if leftNdx >= storage.count {
         break
       }
 
-      let rightNdx = 2 * theNdx + 2
+      let rightNdx = 2 * theNdx + 1
       var largestNdx = theNdx
 
       if compare(storage[leftNdx], storage[largestNdx]) {

--- a/stdlib/public/Concurrency/PriorityQueue.swift
+++ b/stdlib/public/Concurrency/PriorityQueue.swift
@@ -124,7 +124,7 @@ struct PriorityQueue<T> {
   private mutating func upHeap(ndx: Int) {
     var theNdx = ndx
     while theNdx > 0 {
-      let parentNdx = theNdx / 2
+      let parentNdx = (theNdx - 1) / 2
 
       if !compare(storage[theNdx], storage[parentNdx]) {
         break
@@ -151,13 +151,13 @@ struct PriorityQueue<T> {
   private mutating func downHeap(ndx:  Int) {
     var theNdx = ndx
     while true {
-      let leftNdx = 2 * theNdx
+      let leftNdx = 2 * theNdx + 1
 
       if leftNdx >= storage.count {
         break
       }
 
-      let rightNdx = 2 * theNdx + 1
+      let rightNdx = 2 * theNdx + 2
       var largestNdx = theNdx
 
       if compare(storage[leftNdx], storage[largestNdx]) {

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -364,7 +364,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///     return collected
   ///
   /// Awaiting on an empty group
-  /// immediate returns `nil` without suspending.
+  /// immediately returns `nil` without suspending.
   ///
   /// You can also use a `for`-`await`-`in` loop to collect results of a task group:
   ///
@@ -423,7 +423,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   ///
   /// At the start of the body of a `withTaskGroup(of:returning:body:)` call,
   /// the task group is always empty.
-  /// It`s guaranteed to be empty when returning from that body
+  /// It's guaranteed to be empty when returning from that body
   /// because a task group waits for all child tasks to complete before returning.
   ///
   /// - Returns: `true` if the group has no pending tasks; otherwise `false`.


### PR DESCRIPTION
### Summary

This PR fixes small documentation issues in `TaskGroup.swift`:

* Corrected a grammatical error:

  * `"Awaiting on an empty group immediate returns nil"` → `"immediately returns nil"`
  * This also maintains consistency with similar phrasing found on `lines 367` and `654`.
* Fixed a markdown syntax typo:

  * "It`s guaranteed" → "It's guaranteed"
  * Using an apostrophe instead of a backtick is more appropriate in this context.

### Motivation

Improves clarity and readability of developer-facing documentation comments. This is a non-functional change that does not affect compilation or behavior.

### Affected File

* `stdlib` / `public` / `Concurrency` / `TaskGroup.swift`

### Notes

These corrections are minor but contribute to maintaining the quality and polish of the standard library documentation.
