### PR TITLE
[AST] Replace type variables and placeholders in original ErrorTypes

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -446,13 +446,8 @@ Type TypeSubstituter::transformDependentMemberType(DependentMemberType *dependen
 
   auto result = conformance.getTypeWitness(assocType, IFS.getOptions());
   if (result->is<ErrorType>()) {
-    // Substitute the base type for the original ErrorType for type printing.
-    // Avoid doing this if the substitutions introduce type variables or
-    // placeholders since ErrorTypes can't be solver-allocated currently (and
-    // type variables aren't helpful when printing anyway).
     auto substBase = origBase.subst(IFS);
-    if (!substBase->hasTypeVariableOrPlaceholder())
-      return DependentMemberType::get(ErrorType::get(substBase), assocType);
+    return DependentMemberType::get(ErrorType::get(substBase), assocType);
   }
   return result;
 }

--- a/validation-test/compiler_crashers_2_fixed/cccd6394993ea4a2.swift
+++ b/validation-test/compiler_crashers_2_fixed/cccd6394993ea4a2.swift
@@ -1,3 +1,3 @@
 // {"signature":"swift::ErrorType::get(swift::Type)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 @convention(c) _->Int


### PR DESCRIPTION
Turns out we can also get solver-allocated original ErrorTypes through type resolution. Given the original type is only used for printing/debugging, let's just fold away any type variables and placeholders into UnresolvedType (which print as placeholders). This matches what `Solution::simplifyType` does.