### PR TITLE
[xcodegen] Make sure to `realPath` Clang file paths

### DIFF
--- a/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/ClangBuildArgsProvider.swift
+++ b/utils/swift-xcodegen/Sources/SwiftXcodeGen/BuildArgs/ClangBuildArgsProvider.swift
@@ -37,7 +37,8 @@ struct ClangBuildArgsProvider {
                           (output: AbsolutePath?, args: [Command.Argument])] = [:]
     for command in parsed {
       guard command.command.executable.knownCommand == .clang,
-            let relFilePath = command.file.removingPrefix(repoPath)
+            command.file.exists,
+            let relFilePath = command.file.realPath.removingPrefix(repoPath)
       else {
         continue
       }


### PR DESCRIPTION
Ensure we get the `realPath` for file paths in the `compile_commands.json` to canonicalize casing.