### PR TITLE
[Sema] Add null check in `createMemberwiseInitParameter`

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -230,10 +230,12 @@ static ParamDecl *createMemberwiseInitParameter(DeclContext *DC,
     // memberwise initializer will be in terms of the backing storage
     // type.
     if (var->isPropertyMemberwiseInitializedWithWrappedType()) {
-      varInterfaceType = var->getPropertyWrapperInitValueInterfaceType();
+      if (auto initTy = var->getPropertyWrapperInitValueInterfaceType()) {
+        varInterfaceType = initTy;
 
-      auto initInfo = var->getPropertyWrapperInitializerInfo();
-      isAutoClosure = initInfo.getWrappedValuePlaceholder()->isAutoClosure();
+        auto initInfo = var->getPropertyWrapperInitializerInfo();
+        isAutoClosure = initInfo.getWrappedValuePlaceholder()->isAutoClosure();
+      }
     } else {
       varInterfaceType = backingPropertyType;
     }

--- a/validation-test/compiler_crashers_2_fixed/5716fcca10bf3ff7.swift
+++ b/validation-test/compiler_crashers_2_fixed/5716fcca10bf3ff7.swift
@@ -1,5 +1,5 @@
 // {"signature":"createImplicitConstructor(swift::NominalTypeDecl*, ImplicitConstructorKind, swift::ASTContext&)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck -swift-version 5 %s
 struct a @propertyWrapper struct b < c {
   wrappedValue : c
 } @propertyWrapper struct d {


### PR DESCRIPTION
The property wrapper initializer info may be null if e.g we had a request cycle, just use the property's interface type in that case.

rdar://82899428