### PR TITLE
[6.2] SILGen: Handle struct fields and addressors as addressable storage.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2756,8 +2756,6 @@ RValue RValueEmitter::visitMemberRefExpr(MemberRefExpr *e,
          "RValueEmitter shouldn't be called on lvalues");
   assert(isa<VarDecl>(e->getMember().getDecl()));
 
-  // Everything else should use the l-value logic.
-
   // Any writebacks for this access are tightly scoped.
   FormalEvaluationScope scope(SGF);
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -44,6 +44,7 @@ class ConsumableManagedValue;
 class LogicalPathComponent;
 class LValue;
 class ManagedValue;
+class PathComponent;
 class PreparedArguments;
 class RValue;
 class CalleeTypeInfo;
@@ -1978,6 +1979,10 @@ public:
   ArgumentSource prepareAccessorBaseArg(SILLocation loc, ManagedValue base,
                                         CanType baseFormalType,
                                         SILDeclRef accessor);
+  ArgumentSource prepareAccessorBaseArgForFormalAccess(SILLocation loc,
+                                                       ManagedValue base,
+                                                       CanType baseFormalType,
+                                                       SILDeclRef accessor);
 
   RValue emitGetAccessor(
       SILLocation loc, SILDeclRef getter, SubstitutionMap substitutions,
@@ -2201,7 +2206,12 @@ public:
 
   RValue emitLoadOfLValue(SILLocation loc, LValue &&src, SGFContext C,
                           bool isBaseLValueGuaranteed = false);
-
+  PathComponent &&
+  drillToLastComponent(SILLocation loc,
+                       LValue &&lv,
+                       ManagedValue &addr,
+                       TSanKind tsanKind = TSanKind::None);
+                     
   /// Emit a reference to a method from within another method of the type.
   std::tuple<ManagedValue, SILType>
   emitSiblingMethodRef(SILLocation loc,

--- a/test/SILGen/addressable_members.swift
+++ b/test/SILGen/addressable_members.swift
@@ -1,0 +1,148 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature AddressableParameters %s | %FileCheck %s
+
+// REQUIRES: swift_feature_AddressableParameters
+
+protocol Gen {
+    associatedtype Ass
+    associatedtype Ind
+}
+
+struct Foo: Gen {
+    typealias Ass = Bar
+    typealias Ind = Int
+
+    var bar: Bar
+
+    var barAddressor: Bar {
+        unsafeAddress { fatalError() }
+    }
+
+    var barSelfAddressor: Bar {
+        @_addressableSelf
+        unsafeAddress { fatalError() }
+    }
+
+    subscript(i: Int) -> Bar {
+        unsafeAddress { fatalError() }
+    }
+}
+struct Bar {
+    var bas: Bas
+}
+struct Bas {
+    var end: Int
+}
+
+extension Gen {
+    var genAddressor: Ass {
+        unsafeAddress { fatalError() }
+    }
+
+    var genSelfAddressor: Ass {
+        @_addressableSelf
+        unsafeAddress { fatalError() }
+    }
+
+    subscript(gen i: Ind) -> Ass {
+        unsafeAddress { fatalError() }
+    }
+    subscript(genSelf i: Ind) -> Ass {
+        @_addressableSelf
+        unsafeAddress { fatalError() }
+    }
+}
+
+
+func bas(_ bas: borrowing @_addressable Bas) { }
+
+func bar(_ bar: borrowing @_addressable Bar) { }
+
+// CHECK-LABEL: sil {{.*}} @${{.*}}19testAddressableBase
+func testAddressableBase(_ foo: borrowing @_addressable Foo, i: Int) {
+// CHECK: bb0(%0 : @noImplicitCopy $*Foo
+    // CHECK: [[WRAP_BASE:%.*]] = copyable_to_moveonlywrapper_addr %0
+    // CHECK: [[BASE:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[WRAP_BASE]]
+
+    // CHECK: [[BAR:%.*]] = struct_element_addr [[BASE]], #Foo.bar
+    // CHECK: [[UNWRAP_BAR:%.*]] = moveonlywrapper_to_copyable_addr [[BAR]]
+    // CHECK: apply {{.*}}([[UNWRAP_BAR]])
+    bar(foo.bar)
+
+    // CHECK: [[BAR:%.*]] = struct_element_addr [[BASE]], #Foo.bar
+    // CHECK: [[BAS:%.*]] = struct_element_addr [[BAR]], #Bar.bas
+    // CHECK: [[UNWRAP_BAS:%.*]] = moveonlywrapper_to_copyable_addr [[BAS]]
+    // CHECK: apply {{.*}}([[UNWRAP_BAS]])
+    bas(foo.bar.bas)
+
+    // non-addressable base:
+    // CHECK: [[ADDRESSOR:%.*]] = function_ref @{{.*}}12barAddressor{{.*}}lu :
+    // CHECK: [[ADDRESS:%.*]] = apply [[ADDRESSOR]](
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: [[ADDRESS_DEP:%.*]] = mark_dependence {{.*}} [[ADDRESS_ADDR]]
+    // CHECK: apply {{.*}}([[ADDRESS_DEP]])
+    bar(foo.barAddressor)
+
+    // addressable base:
+    // CHECK: [[ADDRESSOR:%.*]] = function_ref @{{.*}}16barSelfAddressor{{.*}}lu :
+    // CHECK: [[UNWRAP_FOO:%.*]] = moveonlywrapper_to_copyable_addr [[BASE]]
+    // CHECK: [[ADDRESS:%.*]] = apply [[ADDRESSOR]]([[UNWRAP_FOO]])
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: [[ADDRESS_DEP:%.*]] = mark_dependence {{.*}} [[ADDRESS_ADDR]]
+    // CHECK: apply {{.*}}([[ADDRESS_DEP]])
+    bar(foo.barSelfAddressor)
+
+    // non-addressable base:
+    // CHECK: [[ADDRESSOR:%.*]] = function_ref @$s19addressable_members3FooVyAA3BarVSicilu :
+    // CHECK: [[ADDRESS:%.*]] = apply [[ADDRESSOR]](
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: [[ADDRESS_DEP:%.*]] = mark_dependence {{.*}} [[ADDRESS_ADDR]]
+    // CHECK: apply {{.*}}([[ADDRESS_DEP]])
+    bar(foo[i])
+    // CHECK: [[ADDRESSOR:%.*]] = function_ref @$s19addressable_members3FooVyAA3BarVSicilu :
+    // CHECK: [[ADDRESS:%.*]] = apply [[ADDRESSOR]](
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: [[ADDRESS_DEP:%.*]] = mark_dependence {{.*}} [[ADDRESS_ADDR]]
+    // CHECK: [[BAS_ADDRESS:%.*]] = struct_element_addr [[ADDRESS_DEP]], #Bar.bas
+    // CHECK: apply {{.*}}([[BAS_ADDRESS]])
+    bas(foo[i].bas)
+
+    // Temporary materialization outlives addressor call, even if it's not
+    // expected to be addressable.
+    // CHECK: [[TEMP:%.*]] = alloc_stack $Foo
+    // CHECK: [[ADDRESS:%.*]] = apply {{.*}}<Foo>([[TEMP]])
+    // CHECK: [[ADDRESS_RAW:%.*]] = struct_extract [[ADDRESS]], #UnsafePointer._rawValue
+    // CHECK: [[ADDRESS_ADDR:%.*]] = pointer_to_address [[ADDRESS_RAW]]
+    // CHECK: mark_dependence [unresolved] [[ADDRESS_ADDR]] on [[TEMP]]
+    // CHECK: dealloc_stack [[TEMP]]
+    bar(foo.genAddressor)
+    bar(foo[gen: i])
+
+    bar(foo.genSelfAddressor)
+    bar(foo[genSelf: i])
+}
+
+func temporaryFoo() -> Foo { fatalError() }
+
+func testTemporaryBase(_ foo: borrowing @_addressable Foo, i: Int) {
+    bar(temporaryFoo().bar)
+    bas(temporaryFoo().bar.bas)
+
+    bar(temporaryFoo().barAddressor)
+
+    bar(temporaryFoo().barSelfAddressor)
+
+    bar(temporaryFoo()[i])
+    bas(temporaryFoo()[i].bas)
+
+    bar(temporaryFoo().genAddressor)
+    bar(temporaryFoo()[gen: i])
+}
+
+func testInoutBase(_ foo: inout Foo) {
+    bar(foo.bar)
+    bas(foo.bar.bas)
+}

--- a/test/SILOptimizer/lifetime_dependence/semantics.swift
+++ b/test/SILOptimizer/lifetime_dependence/semantics.swift
@@ -617,5 +617,4 @@ func testBorrowedAddressableIntReturn(arg: Holder) -> Span<Int> {
   // todo-error @-1{{lifetime-dependent value escapes its scope}
   // todo-note  @-2{{it depends on the lifetime of this parent value}}
 } // todo-note  {{this use causes the lifetime-dependent value to escape}}
-
 */


### PR DESCRIPTION
Explanation: Applies the addressability logic to stored properties of addressable structs, as well as computed properties that are implemented using the `unsafeAddress`/`unsafeMutableAddress` addressor accessors. This is necessary for, among other things, C++ interop, where it is expected that projecting `shared_ptr` and other imported pointer/reference types does not copy a temporary, and where functions may produce ad-hoc references without formal dependencies.

Scope: Fills in missing functionality in the `@_addressable` feature.

Issue: rdar://152280207

Original PR: https://github.com/swiftlang/swift/pull/82288

Risk: Low. This should not affect most existing code, only affecting code that uses new C++ interop or `~Escapable` type features.

Testing: Swift CI, test cases from bug report

Reviewer: @atrick 