### PR TITLE
[cxx-interop] Disable test with an older runtime

### DIFF
--- a/test/Interop/Cxx/class/Inputs/simple-structs.h
+++ b/test/Interop/Cxx/class/Inputs/simple-structs.h
@@ -52,38 +52,4 @@ public:
   Outer() : privStruct(1, 2, 3, 4, 5, 6), publStruct(7, 8, 9, 10, 11, 12) {}
 };
 
-struct ImmortalFRT {
-private:
-  int priv = 1;
-
-public:
-  int publ = 2;
-} __attribute__((swift_attr("import_reference")))
-__attribute__((swift_attr("retain:immortal")))
-__attribute__((swift_attr("release:immortal")));
-
-struct FRTCustomStringConvertible {
-public:
-private:
-  int priv = 1;
-
-public:
-  int publ = 2;
-} __attribute__((swift_attr("import_reference")))
-__attribute__((swift_attr("retain:immortal")))
-__attribute__((swift_attr("release:immortal")));
-
-struct FRType {
-private:
-  int priv = 1;
-
-public:
-  int publ = 2;
-} __attribute__((swift_attr("import_reference")))
-__attribute__((swift_attr("retain:retain")))
-__attribute__((swift_attr("release:release")));
-
-void retain(FRType *v) {};
-void release(FRType *v) {};
-
 #endif

--- a/test/Interop/Cxx/class/print-simple-structs.swift
+++ b/test/Interop/Cxx/class/print-simple-structs.swift
@@ -1,8 +1,6 @@
-// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -I %S/Inputs) | %FileCheck %s
+// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -I %S/Inputs) | %FileCheck %s
 
 // REQUIRES: executable_test
-// Metadata for foreign reference types is not supported on Windows.
-// UNSUPPORTED: OS=windows-msvc
 
 import SimpleStructs
 
@@ -26,28 +24,6 @@ func printCxxStructNested() {
     print(s)
 }
 
-func printCxxImmortalFRT() {
-    let s = ImmortalFRT()
-    print(s)
-}
-
-extension FRTCustomStringConvertible : CustomStringConvertible {
-    public var description: String {
-        return "FRTCustomStringConvertible(publ: \(publ))"
-    }
-}
-
-func printCxxFRTCustomStringConvertible() {
-    let s = FRTCustomStringConvertible()
-    print(s)
-}
-
-func printCxxFRType() {
-    let s = FRType()
-    print(s)
-}
-
-
 printCxxStructPrivateFields() 
 // CHECK: HasPrivateFieldsOnly()
 
@@ -59,12 +35,3 @@ printCxxStructPrivatePublicProtectedFields()
 
 printCxxStructNested()
 // CHECK: Outer(publStruct: {{.*}}.HasPrivatePublicProtectedFields(publ1: 8, publ2: 12))
-
-printCxxImmortalFRT()
-// CHECK: ImmortalFRT()
-
-printCxxFRTCustomStringConvertible()
-// CHECK: FRTCustomStringConvertible(publ: 2)
-
-printCxxFRType()
-// CHECK: FRType()

--- a/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
+++ b/test/Interop/Cxx/foreign-reference/Inputs/module.modulemap
@@ -63,3 +63,8 @@ module FunctionsAndMethodsReturningFRT {
   header "cxx-functions-and-methods-returning-frt.h"
   requires cplusplus
 }
+
+module Printed {
+  header "printed.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/foreign-reference/Inputs/printed.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/printed.h
@@ -1,0 +1,34 @@
+struct ImmortalFRT {
+private:
+  int priv = 1;
+  
+public:
+  int publ = 2;
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")));
+
+struct FRTCustomStringConvertible {
+public:
+private:
+  int priv = 1;
+
+public:
+  int publ = 2;
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:immortal")))
+__attribute__((swift_attr("release:immortal")));
+
+struct FRType {
+private:
+  int priv = 1;
+
+public:
+  int publ = 2;
+} __attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retain")))
+__attribute__((swift_attr("release:release")));
+
+void retain(FRType *v) {};
+void release(FRType *v) {};
+

--- a/test/Interop/Cxx/foreign-reference/print-reference.swift
+++ b/test/Interop/Cxx/foreign-reference/print-reference.swift
@@ -1,0 +1,42 @@
+// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -I %S/Inputs) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Metadata for foreign reference types is not supported on Windows.
+// UNSUPPORTED: OS=windows-msvc
+
+// Temporarily disable when running with an older runtime (rdar://153205860)
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Printed
+
+func printCxxImmortalFRT() {
+    let s = ImmortalFRT()
+    print(s)
+}
+
+extension FRTCustomStringConvertible : CustomStringConvertible {
+    public var description: String {
+        return "FRTCustomStringConvertible(publ: \(publ))"
+    }
+}
+
+func printCxxFRTCustomStringConvertible() {
+    let s = FRTCustomStringConvertible()
+    print(s)
+}
+
+func printCxxFRType() {
+    let s = FRType()
+    print(s)
+}
+
+printCxxImmortalFRT()
+// CHECK: ImmortalFRT()
+
+printCxxFRTCustomStringConvertible()
+// CHECK: FRTCustomStringConvertible(publ: 2)
+
+printCxxFRType()
+// CHECK: FRType()


### PR DESCRIPTION
848fad00 introduced support for printing foreign reference types. It changes both the compiler and the runtime, and having the runtime change applied is required for the test to pass. Let's not try to run it with an old runtime.

This change also splits up a test for printing of value types from a test for printing of foreign reference types, since we don't have any runtime restrictions for value types.

rdar://153205860

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
