### PR TITLE
[6.2] [Sema] Add null check in `createMemberwiseInitParameter`

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -230,10 +230,12 @@ static ParamDecl *createMemberwiseInitParameter(DeclContext *DC,
     // memberwise initializer will be in terms of the backing storage
     // type.
     if (var->isPropertyMemberwiseInitializedWithWrappedType()) {
-      varInterfaceType = var->getPropertyWrapperInitValueInterfaceType();
+      if (auto initTy = var->getPropertyWrapperInitValueInterfaceType()) {
+        varInterfaceType = initTy;
 
-      auto initInfo = var->getPropertyWrapperInitializerInfo();
-      isAutoClosure = initInfo.getWrappedValuePlaceholder()->isAutoClosure();
+        auto initInfo = var->getPropertyWrapperInitializerInfo();
+        isAutoClosure = initInfo.getWrappedValuePlaceholder()->isAutoClosure();
+      }
     } else {
       varInterfaceType = backingPropertyType;
     }

--- a/validation-test/compiler_crashers_2_fixed/5716fcca10bf3ff7.swift
+++ b/validation-test/compiler_crashers_2_fixed/5716fcca10bf3ff7.swift
@@ -1,0 +1,6 @@
+// {"signature":"createImplicitConstructor(swift::NominalTypeDecl*, ImplicitConstructorKind, swift::ASTContext&)"}
+// RUN: not %target-swift-frontend -typecheck -swift-version 5 %s
+struct a @propertyWrapper struct b < c {
+  wrappedValue : c
+} @propertyWrapper struct d {
+  var wrappedValue @b var e : a @d var f


### PR DESCRIPTION
*6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82295*

- Explanation: Fixes a crash that could occur when attempting to create a memberwise initializer for a type that uses a property wrapper
- Scope: Affects the implicit memberwise initializer
- Issue: rdar://82899428
- Risk: Low, adds a null check
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich