### PR TITLE
[6.2][cxx-interop] Shared references are considered safe

### DIFF
--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -46,5 +46,5 @@ SWIFT_REQUEST(ClangImporter, ClangTypeEscapability,
               CxxEscapability(EscapabilityLookupDescriptor), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangDeclExplicitSafety,
-              ExplicitSafety(SafeUseOfCxxDeclDescriptor), Cached,
+              ExplicitSafety(CxxDeclExplicitSafetyDescriptor), Cached,
               NoLocationInfo)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1240,9 +1240,10 @@ ExplicitSafety Decl::getExplicitSafety() const {
   // If this declaration is from C, ask the Clang importer.
   if (auto clangDecl = getClangDecl()) {
     ASTContext &ctx = getASTContext();
-    return evaluateOrDefault(ctx.evaluator,
-                             ClangDeclExplicitSafety({clangDecl}),
-                             ExplicitSafety::Unspecified);
+    return evaluateOrDefault(
+        ctx.evaluator,
+        ClangDeclExplicitSafety({clangDecl, isa<ClassDecl>(this)}),
+        ExplicitSafety::Unspecified);
   }
   
   // Inference: Check the enclosing context, unless this is a type.

--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -63,6 +63,16 @@ View safeFunc(View v1 [[clang::noescape]], View v2 [[clang::lifetimebound]]);
 // Second non-escapable type is not annotated in any way.
 void unsafeFunc(View v1 [[clang::noescape]], View v2);
 
+class SharedObject {
+private:
+  int *p;
+} SWIFT_SHARED_REFERENCE(retainSharedObject, releaseSharedObject);
+
+inline void retainSharedObject(SharedObject *) {}
+inline void releaseSharedObject(SharedObject *) {}
+
+struct DerivedFromSharedObject : SharedObject {};
+
 //--- test.swift
 
 import Test
@@ -133,4 +143,14 @@ func useSafeLifetimeAnnotated(v: View) {
 func useUnsafeLifetimeAnnotated(v: View) {
     // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
     unsafeFunc(v, v) // expected-note{{reference to unsafe global function 'unsafeFunc'}}
+}
+
+@available(SwiftStdlib 5.8, *)
+func useSharedReference(frt: SharedObject) {
+  let _ = frt
+}
+
+@available(SwiftStdlib 5.8, *)
+func useSharedReference(frt: DerivedFromSharedObject) {
+  let _ = frt
 }


### PR DESCRIPTION
Explanation: Shared references imported from C++ were not considered safe. This is a widely used feature and this fix is blocking the users from adopting strictly memory safe Swift.
Issue: rdar://151039766
Risk: Low, the fix only changes what declarations are considered safe.
Testing: Regression test added.
Original PR: #82203
Reviewer: @egorzhdan @fahadnayyar
