### PR TITLE
Add a feature check for extern c support of builtin vectors

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -267,6 +267,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(ABIAttributeSE0479, 479, "@abi attribute on functi
 LANGUAGE_FEATURE(AlwaysInheritActorContext, 472, "@_inheritActorContext(always)")
 LANGUAGE_FEATURE(BuiltinSelect, 0, "Builtin.select")
 LANGUAGE_FEATURE(BuiltinInterleave, 0, "Builtin.interleave and Builtin.deinterleave")
+LANGUAGE_FEATURE(BuiltinVectorsExternC, 0, "Extern C support for Builtin vector types")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -679,6 +679,7 @@ static bool usesFeatureDefaultIsolationPerFile(Decl *D) {
 
 UNINTERESTING_FEATURE(BuiltinSelect)
 UNINTERESTING_FEATURE(BuiltinInterleave)
+UNINTERESTING_FEATURE(BuiltinVectorsExternC)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet


### PR DESCRIPTION
We want to be able to adopt (https://github.com/swiftlang/swift/pull/82225) in the stdlib without breaking people building at desk with older toolchains, so let's add a feature flag.
