### PR TITLE
[Observation] Restrict deinitialization fired events to be limited to one per registrar and send a \Self.self as the keypath to avoid property confusions

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -116,7 +116,7 @@ public struct ObservationRegistrar: Sendable {
       }
 
       var tracker: (@Sendable () -> Void)?
-      for (keyPath, ids) in lookups {
+      lookupIteration: for (keyPath, ids) in lookups {
         for id in ids {
           if let found = observations[id]?.willSetTracker {
             // convert the keyPath into its \Self.self version 
@@ -124,7 +124,7 @@ public struct ObservationRegistrar: Sendable {
             tracker = {
                found(selfKp)
             }
-            break
+            break lookupIteration
           }
         }
       }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -290,6 +290,7 @@ final class CowTest {
 @Observable
 final class DeinitTriggeredObserver {
   var property: Int = 3
+  var property2: Int = 4
   let deinitTrigger: () -> Void
 
   init(_ deinitTrigger: @escaping () -> Void) {
@@ -528,17 +529,18 @@ struct Validator {
 
     suite.test("weak container observation") {
       let changed = CapturedState(state: false)
-      let deinitialized = CapturedState(state: false)
+      let deinitialized = CapturedState(state: 0)
       var test = DeinitTriggeredObserver {
-        deinitialized.state = true
+        deinitialized.state += 1
       }
       withObservationTracking { [weak test] in
         _blackHole(test?.property)
+        _blackHole(test?.property2)
       } onChange: {
         changed.state = true
       }
       test = DeinitTriggeredObserver { }
-      expectEqual(deinitialized.state, true)
+      expectEqual(deinitialized.state, 1) // ensure only one invocation is done per deinitialization
       expectEqual(changed.state, true)
     }
 


### PR DESCRIPTION
This ensures that the deinitialization triggering of observation is limited to one willSet/onChange event and that keypath that is claimed for that change is then `\Self.self` 

This resolves rdar://153655165