### PR TITLE
Revert "[flow-isolation] Allow for initialization of fields of a Global Actor isolated class in its nonisolated inits"

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7919,17 +7919,6 @@ ActorReferenceResult ActorReferenceResult::forReference(
         (!actorInstance || actorInstance->isSelf())) {
       auto type = fromDC->mapTypeIntoContext(decl->getInterfaceType());
       if (!type->isSendableType()) {
-        // If we have an actor instance and our declIsolation is global actor
-        // isolated, but our context isolation is nonisolated... defer to flow
-        // isolation if this case passes the additional restrictions required by
-        // flow isolation (e.x.: the initializer's nominal type has to be
-        // isolated).
-        if (actorInstance &&
-            declIsolation.isGlobalActor() && contextIsolation.isNonisolated() &&
-            checkedByFlowIsolation(fromDC, *actorInstance, decl, declRefLoc, useKind)) {
-          return forSameConcurrencyDomain(declIsolation, options);
-        }
-
         // Treat the decl isolation as 'preconcurrency' to downgrade violations
         // to warnings, because violating Sendable here is accepted by the
         // Swift 5.9 compiler.

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -32,13 +32,6 @@ struct Money {
   }
 }
 
-actor OtherActorBackingActor { }
-
-@globalActor
-struct OtherActor {
-  static let shared = OtherActorBackingActor()
-}
-
 @available(SwiftStdlib 5.1, *)
 func takeBob(_ b: Bob) {}
 
@@ -839,78 +832,17 @@ func testActorWithInitAccessorInit() {
 
 @available(SwiftStdlib 5.1, *)
 actor TestNonisolatedUnsafe {
-  private nonisolated(unsafe) var child: MyOtherActor!
+  private nonisolated(unsafe) var child: OtherActor!
   init() {
-    child = MyOtherActor(parent: self)
+    child = OtherActor(parent: self)
   }
 }
 
 @available(SwiftStdlib 5.1, *)
-actor MyOtherActor {
+actor OtherActor {
   unowned nonisolated let parent: any Actor
 
   init(parent: any Actor) {
     self.parent = parent
-  }
-}
-
-func globalActorNonIsolatedInitializerTests() {
-  @MainActor
-  class C {
-    let ns: NonSendableType
-
-    nonisolated init() {
-      self.ns = NonSendableType()
-    }
-
-    nonisolated init(x: NonSendableType) {
-      self.ns = x
-    }
-
-    nonisolated func doSomething() {}
-
-    nonisolated init(x2 x: NonSendableType) {
-      self.ns = x
-      doSomething() // expected-note {{after calling instance method 'doSomething()', only nonisolated properties of 'self' can be accessed from this init}}
-      print(self.ns) // expected-warning {{cannot access property 'ns' here in nonisolated initializer}}
-    }
-  }
-
-  // Make sure this does not apply in cases where self is not actor isolated.
-  class D {
-    @MainActor let ns: NonSendableType // expected-note {{mutation of this property is only permitted within the actor}}
-
-    nonisolated init() {
-      self.ns = NonSendableType() // expected-warning {{main actor-isolated property 'ns' can not be mutated from a nonisolated context}}
-    }
-  }
-
-  actor A {
-    @MainActor let ns: NonSendableType
-
-    init() {
-      self.ns = NonSendableType()
-    }
-  }
-
-  @MainActor
-  class C2 {
-    @OtherActor let ns: NonSendableType
-
-    nonisolated init() {
-      self.ns = NonSendableType()
-    }
-
-    nonisolated init(_ x: NonSendableType) {
-      self.ns = x
-    }
-
-    nonisolated func doSomething() {}
-
-    nonisolated init(x2 x: NonSendableType) {
-      self.ns = x
-      doSomething() // expected-note {{after calling instance method 'doSomething()', only nonisolated properties of 'self' can be accessed from this init}}
-      print(self.ns) // expected-warning {{cannot access property 'ns' here in nonisolated initializer}}
-    }
   }
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -336,11 +336,13 @@ struct WrapperOnActor<Wrapped: Sendable> {
 public struct WrapperOnMainActor<Wrapped> {
   // Make sure inference of @MainActor on wrappedValue doesn't crash.
   
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
   public var wrappedValue: Wrapped
 
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
+    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a nonisolated context; this is an error in the Swift 6 language mode}}
     self.wrappedValue = wrappedValue
   }
 }

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -67,11 +67,13 @@ struct WrapperOnActor<Wrapped: Sendable> {
 public struct WrapperOnMainActor<Wrapped> {
   // Make sure inference of @MainActor on wrappedValue doesn't crash.
 
+  // expected-note@+1 {{mutation of this property is only permitted within the actor}}
   public var wrappedValue: Wrapped // expected-note {{property declared here}}
 
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
+    // expected-error@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a nonisolated context}}
     self.wrappedValue = wrappedValue
   }
 }

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -72,8 +72,10 @@ nonisolated struct NonisolatedStruct: GloballyIsolated {
   }
 
   struct Nested: GloballyIsolated {
+    // expected-note@+1 {{mutation of this property is only permitted within the actor}}
     var z: NonSendable
     nonisolated init(z: NonSendable) {
+      // expected-error@+1 {{main actor-isolated property 'z' can not be mutated from a nonisolated context}}
       self.z = z
     }
   }


### PR DESCRIPTION
This reverts commit 501bad55a83a3c00910793c825473b22b7b50037.

We found some other issues that we will need to fix in a later release so we can't cherry-pick this to 6.2. I am reverting this so that 6.2 and main have the same semantics here.
