### PR TITLE
[Runtime] Tail call swift_retain in ObjC retain implementation.

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -1159,8 +1159,7 @@ swift_getMangledTypeName(const Metadata *type);
 #define STANDARD_OBJC_METHOD_IMPLS_FOR_SWIFT_OBJECTS \
 - (id)retain { \
   auto SELF = reinterpret_cast<HeapObject *>(self); \
-  swift_retain(SELF); \
-  return self; \
+  return reinterpret_cast<id>(swift_retain(SELF)); \
 } \
 - (oneway void)release { \
   auto SELF = reinterpret_cast<HeapObject *>(self); \


### PR DESCRIPTION
The implementation of the ObjC -retain method saved a local variable and returned that after calling swift_retain, which forced it to create a stack frame. swift_retain returns the object being retained, so we can take advantage of that to have the compiler emit a tail call to it instead.