### PR TITLE
Remove FreeBSD from SWIFT_LIBSTDCXX_PLATFORMS as libc++ is the default standard library on FreeBSD

### DIFF
--- a/cmake/modules/SwiftCXXUtils.cmake
+++ b/cmake/modules/SwiftCXXUtils.cmake
@@ -1,6 +1,5 @@
 # Platforms that use libstdc++ as the system-wide default C++ standard library.
 set(SWIFT_LIBSTDCXX_PLATFORMS
     "LINUX"
-    "FREEBSD"
     "CYGWIN"
     "HAIKU")


### PR DESCRIPTION
Currently we have included "FreeBSD" in `SWIFT_LIBSTDCXX_PLATFORMS`. Which is incorrect as libc++ is the default standard library on FreeBSD since FreeBSD 10[^1]

[^1]: https://wiki.freebsd.org/NewC++Stack