### PR TITLE
[Sema] Tighten up function call check in `resolveKeyPathExpr`

### DIFF
--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -2531,11 +2531,11 @@ void PreCheckTarget::resolveKeyPathExpr(KeyPathExpr *KPE) {
         (void)outermostExpr;
         assert(OEE == outermostExpr);
         expr = OEE->getSubExpr();
-      } else if (auto AE = dyn_cast<ApplyExpr>(expr)) {
+      } else if (auto CE = dyn_cast<CallExpr>(expr)) {
         // foo(), foo(val value: Int) or unapplied foo
         components.push_back(KeyPathExpr::Component::forUnresolvedApply(
-            getASTContext(), AE->getArgs()));
-        expr = AE->getFn();
+            getASTContext(), CE->getArgs()));
+        expr = CE->getFn();
       } else {
         if (emitErrors) {
           // \(<expr>) may be an attempt to write a string interpolation outside

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -407,7 +407,6 @@ _ = /\()/
 // expected-error@-1 {{'/' is not a prefix unary operator}}
 // expected-error@-2 {{'/' is not a postfix unary operator}}
 // expected-error@-3 {{invalid component of Swift key path}}
-// expected-error@-4 {{type of expression is ambiguous without a type annotation}}
   
 do {
   let _: Regex = (/whatever\)/

--- a/test/expr/unary/keypath/keypath-unsupported-methods.swift
+++ b/test/expr/unary/keypath/keypath-unsupported-methods.swift
@@ -46,3 +46,16 @@ func f_56996() {
   _ = \Int.byteSwapped.signum() // expected-error {{key path cannot refer to instance method 'signum()'}}
   _ = \Int.byteSwapped.init() // expected-error {{key path cannot refer to initializer 'init()'}}
 }
+
+postfix operator ^
+postfix func ^ <T>(_ x: T) -> T { x }
+
+func unsupportedOperator() {
+  struct S {
+    var x: Int
+  }
+  _ = \.^ // expected-error {{invalid component of Swift key path}}
+  _ = \S^ // expected-error {{invalid component of Swift key path}}
+  _ = \S.x^ // expected-error {{invalid component of Swift key path}}
+  _ = \.x^ // expected-error {{invalid component of Swift key path}}
+}

--- a/validation-test/compiler_crashers_2_fixed/4c7611b7d95a1fb.swift
+++ b/validation-test/compiler_crashers_2_fixed/4c7611b7d95a1fb.swift
@@ -1,3 +1,3 @@
 // {"signature":"(anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 \.+=


### PR DESCRIPTION
Check for `CallExpr` instead of `ApplyExpr`, we don't support arbitrary postfix operators in key paths.

rdar://153671753