### PR TITLE
[6.2][Concurrency] SE-0449: Fix a few issues related to `nonisolated` type declarations

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5301,7 +5301,10 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
       llvm_unreachable("protocol cannot have erased isolation");
 
     case ActorIsolation::GlobalActor:
-      if (!foundIsolation) {
+      // If we encountered an explicit globally isolated conformance, allow it
+      // to override the nonisolated isolation kind.
+      if (!foundIsolation ||
+          conformance->getSourceKind() == ConformanceEntryKind::Explicit) {
         foundIsolation = {
           protoIsolation,
           IsolationSource(proto, IsolationSource::Conformance)

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5148,6 +5148,13 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
   if (dc->getSelfProtocolDecl())
     return std::nullopt;
 
+  // Prevent isolation inference from requirements if the conforming type
+  // has an explicit `nonisolated` attribute.
+  if (auto *NTD = dc->getSelfNominalTypeDecl()) {
+    if (NTD->getAttrs().hasAttribute<NonisolatedAttr>())
+      return std::nullopt;
+  }
+
   // Walk through each of the conformances in this context, collecting any
   // requirements that have actor isolation.
   auto conformances = idc->getLocalConformances( // note this

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5156,6 +5156,11 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
       std::tuple<ProtocolConformance *, ActorIsolation, ValueDecl *>;
   SmallVector<IsolatedRequirement, 2> isolatedRequirements;
   for (auto conformance : conformances) {
+    auto *implied =
+        conformance->getSourceKind() == ConformanceEntryKind::Implied
+            ? conformance->getImplyingConformance()
+            : nullptr;
+
     auto protocol = conformance->getProtocol();
     for (auto found : protocol->lookupDirect(value->getName())) {
       if (!isa<ProtocolDecl>(found->getDeclContext()))
@@ -5164,6 +5169,19 @@ getIsolationFromWitnessedRequirements(ValueDecl *value) {
       auto requirement = dyn_cast<ValueDecl>(found);
       if (!requirement || isa<TypeDecl>(requirement))
         continue;
+
+      // The conformance implied by an explicitly stated nonisolated protocol
+      // makes all of the requirements nonisolated.
+      if (implied &&
+          implied->getSourceKind() == ConformanceEntryKind::Explicit) {
+        auto protocol = implied->getProtocol();
+        if (protocol->getAttrs().hasAttribute<NonisolatedAttr>()) {
+          isolatedRequirements.push_back(IsolatedRequirement{
+              implied, ActorIsolation::forNonisolated(/*unsafe=*/false),
+              requirement});
+          continue;
+        }
+      }
 
       auto requirementIsolation = getActorIsolation(requirement);
       switch (requirementIsolation) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5276,13 +5276,26 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
     }
 
     auto *proto = conformance->getProtocol();
-    switch (auto protoIsolation = getActorIsolation(proto)) {
+    auto inferredIsolation = getInferredActorIsolation(proto);
+    auto protoIsolation = inferredIsolation.isolation;
+    switch (protoIsolation) {
     case ActorIsolation::ActorInstance:
     case ActorIsolation::Unspecified:
-    case ActorIsolation::Nonisolated:
     case ActorIsolation::CallerIsolationInheriting:
     case ActorIsolation::NonisolatedUnsafe:
       break;
+    case ActorIsolation::Nonisolated:
+      if (inferredIsolation.source.kind == IsolationSource::Kind::Explicit) {
+        if (!foundIsolation) {
+          // We found an explicitly 'nonisolated' protocol.
+          foundIsolation = {
+              protoIsolation,
+              IsolationSource(proto, IsolationSource::Conformance)};
+        }
+        continue;
+      } else {
+        break;
+      }
 
     case ActorIsolation::Erased:
       llvm_unreachable("protocol cannot have erased isolation");

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -102,6 +102,10 @@ nonisolated struct S1: GloballyIsolated {
 nonisolated protocol Refined: GloballyIsolated {}
 nonisolated protocol WhyNot {}
 
+nonisolated protocol NonisolatedWithMembers {
+  func test()
+}
+
 struct A: Refined {
   var x: NonSendable
   init(x: NonSendable) {
@@ -168,6 +172,16 @@ struct NonisolatedStruct {
   func callK2() {
     // expected-error@+1 {{call to main actor-isolated instance method 'k2()' in a synchronous nonisolated context}}
     return IsolatedCFlipped().k2()
+  }
+}
+
+@MainActor
+struct TestIsolated : NonisolatedWithMembers {
+  var x: NonSendable // expected-note {{property declared here}}
+
+  // requirement behaves as if it's explicitly `nonisolated` which gets inferred onto the witness
+  func test() {
+    _ = x // expected-error {{main actor-isolated property 'x' can not be referenced from a nonisolated context}}
   }
 }
 

--- a/test/Concurrency/nonisolated_rules.swift
+++ b/test/Concurrency/nonisolated_rules.swift
@@ -185,6 +185,27 @@ struct TestIsolated : NonisolatedWithMembers {
   }
 }
 
+@MainActor
+protocol Root {
+  func testRoot()
+}
+
+nonisolated protocol Child : Root {
+  func testChild()
+}
+
+struct TestDifferentLevels : Child {
+  func testRoot() {}
+  func testChild() {}
+  func testNonWitness() {}
+}
+
+nonisolated func testRequirementsOnMultipleNestingLevels(t: TestDifferentLevels) {
+  t.testRoot() // okay
+  t.testChild() // okay
+  t.testNonWitness() // okay
+}
+
 // MARK: - Extensions
 
 nonisolated extension GloballyIsolated {


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/79893, https://github.com/swiftlang/swift/pull/82289

---

- Explanation:

  - If the protocol from the conformance list explicitly strips off global actor with `nonisolated`, make sure to look for this explicit isolation source when computing the resulting isolation; to prevent accidental global actor inference on the conforming type.

  - If a `nonisolated` type conforms to a global-isolated protocol the witnesses to the protocol requirements should infer the isolation from the protocol but instead be `nonisolated`.

- Resolves: rdar://144798727, rdar://145519840

- Main Branch PRs: https://github.com/swiftlang/swift/pull/79893, https://github.com/swiftlang/swift/pull/82289

- Risk: Low. The change affects only declarations that conform to `nonisolated` protocols or declare as `nonisolated` type. 

- Reviewed By: @ktoso @hborla 

- Testing: Added new test-cases to the Concurrency test suite.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
