### PR TITLE
[RemoteInspection] Change RemoteAbsolutePointer (NFC) 

### DIFF
--- a/include/swift/Remote/MemoryReader.h
+++ b/include/swift/Remote/MemoryReader.h
@@ -147,7 +147,7 @@ public:
   virtual RemoteAbsolutePointer resolvePointer(RemoteAddress address,
                                                uint64_t readValue) {
     // Default implementation returns the read value as is.
-    return RemoteAbsolutePointer("", readValue);
+    return RemoteAbsolutePointer(RemoteAddress(readValue));
   }
 
   /// Performs the inverse operation of \ref resolvePointer.
@@ -166,7 +166,7 @@ public:
   virtual RemoteAbsolutePointer getSymbol(RemoteAddress address) {
     if (auto symbol = resolvePointerAsSymbol(address))
       return *symbol;
-    return RemoteAbsolutePointer("", address.getAddressData());
+    return RemoteAbsolutePointer(address);
   }
 
   /// Lookup a dynamic symbol name (ie dynamic loader binding) for the given

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -416,11 +416,9 @@ public:
   }
 
   RemoteAbsolutePointer stripSignedPointer(const RemoteAbsolutePointer &P) {
-    if (P.isResolved()) {
-      return RemoteAbsolutePointer("", 
-        P.getResolvedAddress().getAddressData() & PtrAuthMask);
-    }
-    return P;
+    return RemoteAbsolutePointer(
+        P.getSymbol(), P.getOffset(),
+        RemoteAddress(P.getResolvedAddress().getAddressData() & PtrAuthMask));
   }
 
   StoredPointer queryPtrAuthMask() {
@@ -519,28 +517,12 @@ public:
         // The second entry is a relative address to the mangled protocol
         // without symbolic references.
 
-        // lldb might return an unresolved remote absolute pointer from its
-        // resolvePointerAsSymbol implementation -- workaround this.
-        if (!resolved.isResolved()) {
-          auto remoteAddr = RemoteAddress(remoteAddress);
-          resolved =
-            RemoteAbsolutePointer("", remoteAddr.getAddressData());
-        }
-
         auto addr =
             resolved.getResolvedAddress().getAddressData() + sizeof(int32_t);
         int32_t offset;
         Reader->readInteger(RemoteAddress(addr), &offset);
         auto addrOfTypeRef = addr + offset;
         resolved = Reader->getSymbol(RemoteAddress(addrOfTypeRef));
-
-        // lldb might return an unresolved remote absolute pointer from its
-        // resolvePointerAsSymbol implementation -- workaround this.
-        if (!resolved.isResolved()) {
-          auto remoteAddr = RemoteAddress(addrOfTypeRef);
-          resolved =
-            RemoteAbsolutePointer("", remoteAddr.getAddressData());
-        }
 
         // Dig out the protocol from the protocol list.
         auto protocolList = readMangledName(resolved.getResolvedAddress(),
@@ -1379,12 +1361,10 @@ public:
   ParentContextDescriptorRef
   readContextDescriptor(const RemoteAbsolutePointer &address) {
     // Map an unresolved pointer to an unresolved context ref.
-    if (!address.isResolved()) {
+    if (!address.getSymbol().empty()) {
       // We can only handle references to a symbol without an offset currently.
-      if (address.getOffset() != 0) {
-        return ParentContextDescriptorRef();
-      }
-      return ParentContextDescriptorRef(address.getSymbol());
+      if (address.getOffset() == 0)
+        return ParentContextDescriptorRef(address.getSymbol());
     }
     
     return ParentContextDescriptorRef(
@@ -2016,7 +1996,7 @@ public:
 
   std::optional<StoredPointer> readResolvedPointerValue(StoredPointer address) {
     if (auto pointer = readPointer(address)) {
-      if (!pointer->isResolved())
+      if (!pointer->getResolvedAddress())
         return std::nullopt;
       return (StoredPointer)pointer->getResolvedAddress().getAddressData();
     }
@@ -2079,7 +2059,7 @@ protected:
       return std::nullopt;
     }
     
-    return RemoteAbsolutePointer("", resultAddress);
+    return RemoteAbsolutePointer(RemoteAddress(resultAddress));
   }
 
   /// Given a pointer to an Objective-C class, try to read its class name.
@@ -2335,13 +2315,11 @@ private:
     auto parentAddress = resolveRelativeIndirectableField(base, base->Parent);
     if (!parentAddress)
       return std::nullopt;
-    if (!parentAddress->isResolved()) {
+    if (!parentAddress->getSymbol().empty()) {
       // Currently we can only handle references directly to a symbol without
       // an offset.
-      if (parentAddress->getOffset() != 0) {
-        return std::nullopt;
-      }
-      return ParentContextDescriptorRef(parentAddress->getSymbol());
+      if (parentAddress->getOffset() == 0)
+        return ParentContextDescriptorRef(parentAddress->getSymbol());
     }
     auto addr = parentAddress->getResolvedAddress();
     if (!addr)

--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -63,35 +63,30 @@ public:
 
 /// A symbolic relocated absolute pointer value.
 class RemoteAbsolutePointer {
-  /// The symbol name that the pointer refers to. Empty if the value is absolute.
+  /// The symbol name that the pointer refers to. Empty if only an absolute
+  /// address is available.
   std::string Symbol;
-  /// The offset from the symbol, or the resolved remote address if \c Symbol is empty.
-  int64_t Offset;
+  /// The offset from the symbol.
+  int64_t Offset = 0;
+  /// The resolved remote address.
+  RemoteAddress Address = RemoteAddress{(uint64_t)0};
 
 public:
-  RemoteAbsolutePointer()
-    : Symbol(), Offset(0)
-  {}
-  
-  RemoteAbsolutePointer(std::nullptr_t)
-    : RemoteAbsolutePointer()
-  {}
-  
-  RemoteAbsolutePointer(llvm::StringRef Symbol, int64_t Offset)
-    : Symbol(Symbol), Offset(Offset)
-  {}
-  
-  bool isResolved() const { return Symbol.empty(); }
+  RemoteAbsolutePointer() = default;
+  RemoteAbsolutePointer(std::nullptr_t) : RemoteAbsolutePointer() {}
+
+  RemoteAbsolutePointer(llvm::StringRef Symbol, int64_t Offset,
+                        RemoteAddress Address)
+      : Symbol(Symbol), Offset(Offset), Address(Address) {}
+  RemoteAbsolutePointer(RemoteAddress Address) : Address(Address) {}
+
   llvm::StringRef getSymbol() const { return Symbol; }
   int64_t getOffset() const { return Offset; }
-  
-  RemoteAddress getResolvedAddress() const {
-    assert(isResolved());
-    return RemoteAddress(Offset);
-  }
-  
+
+  RemoteAddress getResolvedAddress() const { return Address; }
+
   explicit operator bool() const {
-    return Offset != 0 || !Symbol.empty();
+    return Address || !Symbol.empty();
   }
 };
 

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1019,7 +1019,7 @@ public:
       auto CDAddr = this->readCaptureDescriptorFromMetadata(*MetadataAddress);
       if (!CDAddr)
         return nullptr;
-      if (!CDAddr->isResolved())
+      if (!CDAddr->getResolvedAddress())
         return nullptr;
 
       // FIXME: Non-generic SIL boxes also use the HeapLocalVariable metadata

--- a/lib/StaticMirror/ObjectFileContext.cpp
+++ b/lib/StaticMirror/ObjectFileContext.cpp
@@ -322,9 +322,9 @@ Image::resolvePointer(uint64_t Addr, uint64_t pointerValue) const {
   // 32 bits.
   if (isMachOWithPtrAuth()) {
     return remote::RemoteAbsolutePointer(
-        "", HeaderAddress + (pointerValue & 0xffffffffull));
+        remote::RemoteAddress(HeaderAddress + (pointerValue & 0xffffffffull)));
   } else {
-    return remote::RemoteAbsolutePointer("", pointerValue);
+    return remote::RemoteAbsolutePointer(remote::RemoteAddress(pointerValue));
   }
 }
 
@@ -333,7 +333,8 @@ remote::RemoteAbsolutePointer Image::getDynamicSymbol(uint64_t Addr) const {
   if (found == DynamicRelocations.end())
     return nullptr;
   return remote::RemoteAbsolutePointer(found->second.Symbol,
-                                       found->second.Offset);
+                                       found->second.Offset,
+                                       remote::RemoteAddress((uint64_t)0));
 }
 
 std::pair<const Image *, uint64_t>
@@ -526,8 +527,8 @@ ObjectMemoryReader::resolvePointer(reflection::RemoteAddress Addr,
   // Mix in the image index again to produce a remote address pointing into the
   // same image.
   return remote::RemoteAbsolutePointer(
-      "", encodeImageIndexAndAddress(
-              image, resolved.getResolvedAddress().getAddressData()));
+      remote::RemoteAddress(encodeImageIndexAndAddress(
+          image, resolved.getResolvedAddress().getAddressData())));
 }
 
 remote::RemoteAbsolutePointer


### PR DESCRIPTION
This patch changes RemoteAbsolutePointer to store both the symbol and the resolved address. This allows us to retire some ugly workarounds to deal with non-symbolic addresses and it fixes code paths that would need these workarounds, but haven't implemented them yet (i.e., the pack shape handling in the symbolicReferenceResolver in MetadataReader.

Addresses parts of rdar://146273066.
rdar://153687085

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
