### PR TITLE
[PriorityQueue] Fix binary heap index calculations for 0-based arrays

### DIFF
--- a/stdlib/public/Concurrency/PriorityQueue.swift
+++ b/stdlib/public/Concurrency/PriorityQueue.swift
@@ -124,7 +124,7 @@ struct PriorityQueue<T> {
   private mutating func upHeap(ndx: Int) {
     var theNdx = ndx
     while theNdx > 0 {
-      let parentNdx = theNdx / 2
+      let parentNdx = (theNdx - 1) / 2
 
       if !compare(storage[theNdx], storage[parentNdx]) {
         break
@@ -151,13 +151,13 @@ struct PriorityQueue<T> {
   private mutating func downHeap(ndx:  Int) {
     var theNdx = ndx
     while true {
-      let leftNdx = 2 * theNdx
+      let leftNdx = 2 * theNdx + 1
 
       if leftNdx >= storage.count {
         break
       }
 
-      let rightNdx = 2 * theNdx + 1
+      let rightNdx = 2 * theNdx + 2
       var largestNdx = theNdx
 
       if compare(storage[leftNdx], storage[largestNdx]) {


### PR DESCRIPTION
## Corrects upHeap and downHeap index calculations:
- upHeap: `parentNdx = (theNdx - 1) / 2` instead of `theNdx / 2`
- downHeap: `leftNdx = 2 * theNdx + 1` instead of `2 * theNdx`
- downHeap: `rightNdx = 2 * theNdx + 2` instead of `2 * theNdx + 1`

## Summary
Fixes critical binary heap index calculation bug in PriorityQueue implementation.

## Problem  
The current implementation uses 1-based indexing formulas in 0-based arrays:
- `upHeap`: `parentNdx = theNdx / 2` 
- `downHeap`: `leftNdx = 2 * theNdx`, `rightNdx = 2 * theNdx + 1`

This causes:
- Index 0 considers itself as a child (leftNdx = 0)
- Wrong parent-child relationships (e.g., index 2 → parent 1 instead of 0)
- Heap property violations in specific scenarios

## Solution
Corrects to proper 0-based indexing:
- `upHeap`: `parentNdx = (theNdx - 1) / 2`
- `downHeap`: `leftNdx = 2 * theNdx + 1`, `rightNdx = 2 * theNdx + 2`

```swift
// Before
let parentNdx = theNdx / 2
let leftNdx = 2 * theNdx  
let rightNdx = 2 * theNdx + 1

// After
let parentNdx = (theNdx - 1) / 2
let leftNdx = 2 * theNdx + 1
let rightNdx = 2 * theNdx + 2
```