### PR TITLE
[Const Extract] Fix nil default argument being extracted as nil raw literal

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -414,7 +414,7 @@ extractCompileTimeValue(Expr *expr, const DeclContext *declContext) {
       assert(!decl->hasDefaultExpr());
       switch (decl->getDefaultArgumentKind()) {
       case DefaultArgumentKind::NilLiteral:
-        return std::make_shared<RawLiteralValue>("nil");
+        return std::make_shared<NilLiteralValue>();
       case DefaultArgumentKind::EmptyArray:
         return std::make_shared<ArrayValue>(
             std::vector<std::shared_ptr<CompileTimeValue>>());

--- a/test/ConstExtraction/ExtractCalls.swift
+++ b/test/ConstExtraction/ExtractCalls.swift
@@ -7,12 +7,15 @@
 protocol MyProto {}
 
 public struct Foo : MyProto {
-    let init1 = Bar()
-    let init2: Bat = .init()
-    let init3 = Bat(buz: "hello", fuz: adder(2, 3))
-    static var init4: Bar? = Bar()
+  let init1 = Bar()
+  let init2: Bat = .init()
+  let init3 = Bat(buz: "hello", fuz: adder(2, 3))
+  static var init4: Bar? = Bar()
 
-    let func1: Int = adder(2, 3)
+  let init5 = Hux()
+  let init6 = Hux(fuz: 42)
+
+  let func1: Int = adder(2, 3)
 }
 
 extension Foo {
@@ -26,15 +29,18 @@ func adder(_ x: Int, _ y: Int) -> Int {
 }
 
 public struct Bar {}
-public struct Bat {
-    let buz: String
+
+public class Bat {
+    let buz: String?
     let fuz: Int
 
-    init(buz: String = "", fuz: Int = 0) {
+    init(buz: String? = nil, fuz: Int = 0) {
         self.buz = buz
         self.fuz = fuz
     }
 }
+
+public class Hux: Bat {}
 
 // CHECK: [
 // CHECK-NEXT:  {
@@ -82,9 +88,8 @@ public struct Bat {
 // CHECK-NEXT:          "arguments": [
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "buz",
-// CHECK-NEXT:              "type": "Swift.String",
-// CHECK-NEXT:              "valueKind": "RawLiteral",
-// CHECK-NEXT:              "value": ""
+// CHECK-NEXT:              "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:              "valueKind": "NilLiteral"
 // CHECK-NEXT:            },
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "fuz",
@@ -109,7 +114,7 @@ public struct Bat {
 // CHECK-NEXT:          "arguments": [
 // CHECK-NEXT:            {
 // CHECK-NEXT:              "label": "buz",
-// CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "type": "Swift.Optional<Swift.String>",
 // CHECK-NEXT:              "valueKind": "RawLiteral",
 // CHECK-NEXT:              "value": "hello"
 // CHECK-NEXT:            },
@@ -139,13 +144,65 @@ public struct Bat {
 // CHECK-NEXT:        }
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "init5",
+// CHECK-NEXT:        "type": "ExtractCalls.Hux",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:        "line": 15,
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractCalls.Hux",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "buz",
+// CHECK-NEXT:              "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:              "valueKind": "NilLiteral"
+// CHECK-NEXT:            },
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "fuz",
+// CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "0"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "init6",
+// CHECK-NEXT:        "type": "ExtractCalls.Hux",
+// CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:        "line": 16,
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractCalls.Hux",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "buz",
+// CHECK-NEXT:              "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:              "valueKind": "NilLiteral"
+// CHECK-NEXT:            },
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "fuz",
+// CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "42"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "func1",
 // CHECK-NEXT:        "type": "Swift.Int",
 // CHECK-NEXT:        "mangledTypeName": "n/a - deprecated",        
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
-// CHECK-NEXT:        "line": 15,
+// CHECK-NEXT:        "line": 18,
 // CHECK-NEXT:         "valueKind": "FunctionCall",
 // CHECK-NEXT:         "value": {
 // CHECK-NEXT:           "name": "adder",
@@ -186,7 +243,7 @@ public struct Bat {
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
 // CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
-// CHECK-NEXT:        "line": 21,
+// CHECK-NEXT:        "line": 24,
 // CHECK-NEXT:        "valueKind": "InitCall",
 // CHECK-NEXT:        "value": {
 // CHECK-NEXT:          "type": "ExtractCalls.Foo.Boo",


### PR DESCRIPTION
This was missed in https://github.com/swiftlang/swift/pull/78511.

Resolves rdar://153563086