### PR TITLE
stdlib: handle `unsafe` annotations in additional places

### DIFF
--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -255,8 +255,8 @@ fileprivate class _Lock {
     unsafe self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
     unsafe self.underlying.initialize(to: os_unfair_lock())
     #elseif os(Windows)
-    self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
-    InitializeSRWLock(self.underlying)
+    unsafe self.underlying = UnsafeMutablePointer.allocate(capacity: 1)
+    unsafe InitializeSRWLock(self.underlying)
     #elseif os(WASI)
     // WASI environment has only a single thread
     #else
@@ -292,7 +292,7 @@ fileprivate class _Lock {
     #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
     unsafe os_unfair_lock_lock(self.underlying)
     #elseif os(Windows)
-    AcquireSRWLockExclusive(self.underlying)
+    unsafe AcquireSRWLockExclusive(self.underlying)
     #elseif os(WASI)
     // WASI environment has only a single thread
     #else
@@ -305,7 +305,7 @@ fileprivate class _Lock {
       #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS) || os(visionOS)
       unsafe os_unfair_lock_unlock(self.underlying)    
       #elseif os(Windows)
-      ReleaseSRWLockExclusive(self.underlying)
+      unsafe ReleaseSRWLockExclusive(self.underlying)
       #elseif os(WASI)
       // WASI environment has only a single thread
       #else

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -716,19 +716,19 @@ public func swift_unboxFromSwiftValueWithType<T>(
 
   if source === _nullPlaceholder {
     if let unpacked = Optional<Any>.none as? T {
-      result.initialize(to: unpacked)
+      unsafe result.initialize(to: unpacked)
       return true
     }
   }
     
   if let box = source as? __SwiftValue {
     if let value = box.value as? T {
-      result.initialize(to: value)
+      unsafe result.initialize(to: value)
       return true
     }
   } else if let box = source as? _NSSwiftValue {
     if let value = box.value as? T {
-      result.initialize(to: value)
+      unsafe result.initialize(to: value)
       return true
     }
   }
@@ -819,7 +819,7 @@ public func _bridgeAnythingToObjectiveC<T>(_ x: T) -> AnyObject {
 
   if !done {
     if type(of: source) as? AnyClass != nil {
-      result = unsafeBitCast(x, to: AnyObject.self)
+      result = unsafe unsafeBitCast(x, to: AnyObject.self)
     } else if let object = _bridgeToObjectiveCUsingProtocolIfPossible(source) {
       result = object
     } else {

--- a/stdlib/public/core/Int128.swift
+++ b/stdlib/public/core/Int128.swift
@@ -76,7 +76,7 @@ public struct Int128: Sendable {
   public var _value: Builtin.Int128 {
     @_transparent
     get {
-      unsafeBitCast(self, to: Builtin.Int128.self)
+      unsafe unsafeBitCast(self, to: Builtin.Int128.self)
     }
 
     @_transparent
@@ -88,7 +88,7 @@ public struct Int128: Sendable {
   @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(_ _value: Builtin.Int128) {
-    self = unsafeBitCast(_value, to: Self.self)
+    self = unsafe unsafeBitCast(_value, to: Self.self)
   }
 #endif
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -80,9 +80,10 @@ public class AnyKeyPath: _AppendKeyPath {
     unsafe _kvcKeyPathStringPtr = UnsafePointer<CChar>(bitPattern: -offset - 1)
 #elseif _pointerBitWidth(_32)
     if offset <= maximumOffsetOn32BitArchitecture {
-      _kvcKeyPathStringPtr = UnsafePointer<CChar>(bitPattern: (offset + 1))
+      unsafe _kvcKeyPathStringPtr =
+           UnsafePointer<CChar>(bitPattern: (offset + 1))
     } else {
-      _kvcKeyPathStringPtr = nil
+      unsafe _kvcKeyPathStringPtr = nil
     }
 #else
     // Don't assign anything.
@@ -104,7 +105,7 @@ public class AnyKeyPath: _AppendKeyPath {
     }
     return offset
 #elseif _pointerBitWidth(_32)
-    let offset = Int(bitPattern: _kvcKeyPathStringPtr) &- 1
+    let offset = unsafe Int(bitPattern: _kvcKeyPathStringPtr) &- 1
     // Pointers above 0x7fffffff will come in as negative numbers which are
     // less than maximumOffsetOn32BitArchitecture, be sure to reject them.
     if offset >= 0, offset <= maximumOffsetOn32BitArchitecture {
@@ -4152,7 +4153,7 @@ internal func _instantiateKeyPathBuffer(
   var walker = unsafe ValidatingInstantiateKeyPathBuffer(sizeVisitor: sizeWalker,
                                           instantiateVisitor: instantiateWalker)
 #else
-  var walker = InstantiateKeyPathBuffer(
+  var walker = unsafe InstantiateKeyPathBuffer(
     destData: destData,
     patternArgs: arguments,
     root: rootType)
@@ -4165,8 +4166,8 @@ internal func _instantiateKeyPathBuffer(
   let endOfReferencePrefixComponent =
     unsafe walker.instantiateVisitor.endOfReferencePrefixComponent
 #else
-  let isTrivial = walker.isTrivial
-  let endOfReferencePrefixComponent = walker.endOfReferencePrefixComponent
+  let isTrivial = unsafe walker.isTrivial
+  let endOfReferencePrefixComponent = unsafe walker.endOfReferencePrefixComponent
 #endif
 
   // Write out the header.

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -1245,7 +1245,7 @@ extension _StringObject {
       countAndFlags: countAndFlags)
 #elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     self.init(
-      variant: .immortal(start: bufPtr.baseAddress._unsafelyUnwrappedUnchecked),
+      variant: unsafe .immortal(start: bufPtr.baseAddress._unsafelyUnwrappedUnchecked),
       discriminator: Nibbles.largeImmortal(),
       countAndFlags: countAndFlags)
 #else

--- a/stdlib/public/core/UInt128.swift
+++ b/stdlib/public/core/UInt128.swift
@@ -76,7 +76,7 @@ public struct UInt128: Sendable {
   public var _value: Builtin.Int128 {
     @_transparent
     get {
-      unsafeBitCast(self, to: Builtin.Int128.self)
+      unsafe unsafeBitCast(self, to: Builtin.Int128.self)
     }
 
     @_transparent
@@ -88,7 +88,7 @@ public struct UInt128: Sendable {
   @available(SwiftStdlib 6.0, *)
   @_transparent
   public init(_ _value: Builtin.Int128) {
-    self = unsafeBitCast(_value, to: Self.self)
+    self = unsafe unsafeBitCast(_value, to: Self.self)
   }
 #endif
 

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -609,7 +609,7 @@ final internal class __VaListBuilder {
     // We may need to retain an object that provides a pointer value.
     if let obj = arg as? _CVarArgObject {
       arg = obj._cVarArgObject
-      retainer.append(arg)
+      unsafe retainer.append(arg)
     }
 #endif
 


### PR DESCRIPTION
This applies more annotations in the `INTERNAL_CHECKS_ENABLED` disabled paths, Windows, 32-bit, and non-ObjC paths. Interestingly enough, there are a couple of compiler intrinsics which are also uncovered.