### PR TITLE
Platform: expose NTAPI

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -329,6 +329,11 @@ module WinSDK [system] {
     link "Mpr.Lib"
   }
 
+  module NTAPI {
+    header "winternl.h"
+    export *
+  }
+
   module Security {
     header "../shared/sddl.h"
 


### PR DESCRIPTION
The NTAPIs are sometimes required to access some system information. At the very least, the types defined here are useful to expose.