### PR TITLE
[IRGen] Fix placeholder logic for emission of conditionally inverted …

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1393,12 +1393,13 @@ namespace {
 
       // Create placeholders for the counts of the conditional requirements
       // for each conditional conformance to a supressible protocol.
-      unsigned numProtocols = countBitsUsed(protocols.rawBits());
+      unsigned numProtocols = 0;
       using PlaceholderPosition =
           ConstantAggregateBuilderBase::PlaceholderPosition;
       SmallVector<PlaceholderPosition, 2> countPlaceholders;
-      for (unsigned i : range(0, numProtocols)) {
-        (void)i;
+      for (auto kind : protocols) {
+        (void)kind;
+        numProtocols++;
         countPlaceholders.push_back(
             B.addPlaceholderWithSize(IGM.Int16Ty));
       }

--- a/validation-test/IRGen/rdar153681688.swift
+++ b/validation-test/IRGen/rdar153681688.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend %s -target %target-swift-5.9-abi-triple -emit-ir
+
+public enum Enum<T : ~Escapable> : ~Escapable {
+  case none
+  case some(T)
+}
+
+extension Enum: Escapable where T: Escapable {}


### PR DESCRIPTION
…protocols

rdar://153681688

Instead fo counting the actual conformances, the logic took the size of the bit field, i.e. used the highest set bit, so when a type had a conditional conformance only on ~Escapable, but not on ~Copyable, it would still add 2 placeholders, but only fill one.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
