### PR TITLE
organizes new articles into the existing pages for descriptions and groups

### DIFF
--- a/userdocs/diagnostics/diagnostic-descriptions.md
+++ b/userdocs/diagnostics/diagnostic-descriptions.md
@@ -8,7 +8,7 @@ Detailed explanations for various compiler diagnostics.
 ## Overview
 
 Swift diagnostics are classified into errors and warnings. Warnings can only be silenced in an
-intentional manner, e.g., adding `_ =` for an unused function result.
+intentional manner, for example adding `_ =` for an unused function result.
 
 Some diagnostics have more detailed explanations available. These include a `[#Name]` inline and
 reference to this documentation at the end of the compiler output on the command line, or is
@@ -37,3 +37,4 @@ presented specially within your IDE of choice. See below for the full list of th
 - <doc:opaque-type-inference>
 - <doc:mutable-global-variable>
 - <doc:existential-member-access-limitations>
+- <doc:trailing-closure-matching>

--- a/userdocs/diagnostics/diagnostic-groups.md
+++ b/userdocs/diagnostics/diagnostic-groups.md
@@ -10,26 +10,29 @@ Diagnostic groups allow controlling the behavior of warnings in a more precise m
 Diagnostic groups collect some number of diagnostics together under a common group name. This allows
 for extra documentation to help explain relevant language concepts, as well as the ability to
 control the behavior of warnings in a more precise manner:
+
 - `-Werror <group>` - upgrades warnings in the specified group to errors
 - `-Wwarning <group>` - indicates that warnings in the specified group should remain warnings, even
   if they were previously upgraded to errors
 
 As a concrete example, to upgrade deprecated declaration warnings to errors:
+
 ```sh
 -Werror DeprecatedDeclaration
 ```
 
 Or upgrade all warnings except deprecated declaration to errors:
+
 ```sh
 -warnings-as-errors -Wwarning DeprecatedDeclaration
 ```
-
 
 ## Topics
 
 - <doc:compilation-caching>
 - <doc:deprecated-declaration>
 - <doc:implementation-only-deprecated>
+- <doc:missing-module-on-known-paths>
 - <doc:preconcurrency-import>
 - <doc:clang-declaration-import>
 - <doc:missing-module-on-known-paths>

--- a/userdocs/diagnostics/missing-module-on-known-paths.md
+++ b/userdocs/diagnostics/missing-module-on-known-paths.md
@@ -2,7 +2,6 @@
 
 Notes related to information about a missing module dependency.
 
-
 ## Overview
 
 This diagnostic group covers notes related to displaying information about a missing module dependency which the compiler is able to locate as present on a search path found in a loaded Swift binary module, but which is not specified to the current compilation.


### PR DESCRIPTION
Updates the curation (organization) for the newer articles in diagnostics.

3 articles were floating below the organized pages - this merges them into those groups.
- 1 new diagnostic description
- 2 new group descriptions

Reviewed manually with:

```sh
cd userdocs
xcrun docc preview diagnostics --allow-arbitrary-catalog-directories
```