### PR TITLE
[6.2][IRGen] Fix placeholder logic for emission of conditionally inverted protocols

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1394,12 +1394,13 @@ namespace {
 
       // Create placeholders for the counts of the conditional requirements
       // for each conditional conformance to a supressible protocol.
-      unsigned numProtocols = countBitsUsed(protocols.rawBits());
+      unsigned numProtocols = 0;
       using PlaceholderPosition =
           ConstantAggregateBuilderBase::PlaceholderPosition;
       SmallVector<PlaceholderPosition, 2> countPlaceholders;
-      for (unsigned i : range(0, numProtocols)) {
-        (void)i;
+      for (auto kind : protocols) {
+        (void)kind;
+        numProtocols++;
         countPlaceholders.push_back(
             B.addPlaceholderWithSize(IGM.Int16Ty));
       }

--- a/validation-test/IRGen/rdar153681688.swift
+++ b/validation-test/IRGen/rdar153681688.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend %s -target %target-swift-5.9-abi-triple -emit-ir
+
+public enum Enum<T : ~Escapable> : ~Escapable {
+  case none
+  case some(T)
+}
+
+extension Enum: Escapable where T: Escapable {}


### PR DESCRIPTION
- **Explanation**: Instead of counting the actual conformances, the logic took the size of the bit field, i.e. used the highest set bit, so when a type had a conditional conformance only on ~Escapable, but not on ~Copyable, it would still add 2 placeholders, but only fill one.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Metadata emission for types with conditional conformance on inverted protocols
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://153681688
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/82347
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Issue is affecting a very specific case and the fix is tested.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Added validation test that observes the issue before the fix and not after.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @meg-gupta 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
