### PR TITLE
[6.2][Test] Fix Interpreter/layout_string_witnesses_dynamic.swift

### DIFF
--- a/test/Interpreter/layout_string_witnesses_dynamic.swift
+++ b/test/Interpreter/layout_string_witnesses_dynamic.swift
@@ -16,9 +16,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// test disabled until rdar://151476435 is fixed
-// REQUIRES: rdar151476435
-
 import Swift
 import layout_string_witnesses_types
 import layout_string_witnesses_types_resilient
@@ -33,7 +30,7 @@ class TestClass {
 
 func testGeneric() {
     let ptr = allocateInternalGenericPtr(of: TestClass.self)
-    
+
     do {
         let x = TestClass()
         testGenericInit(ptr, to: x)
@@ -1246,7 +1243,7 @@ func testNonCopyableGenericStructSimpleClass() {
     let ptr = UnsafeMutableBufferPointer<NonCopyableGenericStruct<SimpleClass>>.allocate(capacity: 1)
 
     let x = NonCopyableGenericStruct(x: 23, y: SimpleClass(x: 23))
-    ptr[0] = x
+    ptr.initializeElement(at: 0, to: x)
 
     // CHECK-NEXT: Before deinit
     print("Before deinit")
@@ -1264,7 +1261,7 @@ func testNonCopyableGenericEnumSimpleClass() {
     let ptr = UnsafeMutableBufferPointer<NonCopyableGenericEnum<SimpleClass>>.allocate(capacity: 1)
 
     let x = NonCopyableGenericEnum.x(23, SimpleClass(x: 23))
-    ptr[0] = x
+    ptr.initializeElement(at: 0, to: x)
 
     // CHECK-NEXT: Before deinit
     print("Before deinit")


### PR DESCRIPTION
- **Explanation**: Two tests incorrectly assigned values to an uninitialized pointer instead of initializing it. This caused crashes on some distros.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: CVW tests
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://151476435
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/82279
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Only test code changed.
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Fixed the test and ran it on affected platform
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @mikeash 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->
