### PR TITLE
Add lifetime dependencies on function types representing ~Escapable enum elements with ~Escapable payloads

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8779,7 +8779,8 @@ public:
 /// EnumCaseDecl.
 class EnumElementDecl : public DeclContext, public ValueDecl {
   friend class EnumRawValuesRequest;
-  
+  friend class LifetimeDependenceInfoRequest;
+
   /// This is the type specified with the enum element, for
   /// example 'Int' in 'case Y(Int)'.  This is null if there is no type
   /// associated with this element, as in 'case Z' or in all elements of enum
@@ -8790,6 +8791,11 @@ class EnumElementDecl : public DeclContext, public ValueDecl {
   
   /// The raw value literal for the enum element, or null.
   LiteralExpr *RawValueExpr;
+
+protected:
+  struct {
+    unsigned NoLifetimeDependenceInfo : 1;
+  } LazySemanticInfo = {};
 
 public:
   EnumElementDecl(SourceLoc IdentifierLoc, DeclName Name,

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -324,8 +324,7 @@ public:
   /// Builds LifetimeDependenceInfo from a swift decl, either from the explicit
   /// lifetime dependence specifiers or by inference based on types and
   /// ownership modifiers.
-  static std::optional<ArrayRef<LifetimeDependenceInfo>>
-  get(AbstractFunctionDecl *decl);
+  static std::optional<ArrayRef<LifetimeDependenceInfo>> get(ValueDecl *decl);
 
   /// Builds LifetimeDependenceInfo from SIL
   static std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5114,8 +5114,7 @@ public:
 class LifetimeDependenceInfoRequest
     : public SimpleRequest<
           LifetimeDependenceInfoRequest,
-          std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>(
-              AbstractFunctionDecl *),
+          std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>(ValueDecl *),
           RequestFlags::SeparatelyCached | RequestFlags::SplitCached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -5124,7 +5123,7 @@ private:
   friend SimpleRequest;
 
   std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
-  evaluate(Evaluator &evaluator, AbstractFunctionDecl *AFD) const;
+  evaluate(Evaluator &evaluator, ValueDecl *AFD) const;
 
 public:
   // Separate caching.

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1274,6 +1274,7 @@ protected:
       break;
     case AccessorKind::Set: {
       const unsigned newValIdx = 0;
+      auto *afd = cast<AbstractFunctionDecl>(decl);
       auto *param = afd->getParameters()->get(newValIdx);
       Type paramTypeInContext =
         afd->mapTypeIntoContext(param->getInterfaceType());
@@ -1354,6 +1355,7 @@ protected:
         }
       }
     }
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     // Either a Get or Modify without any wrapped accessor. Handle these like a
     // read of the stored property.
     return inferLifetimeDependenceKind(

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -359,8 +359,15 @@ public:
 
   std::optional<llvm::ArrayRef<LifetimeDependenceInfo>> checkEnumElementDecl() {
     auto *eed = cast<EnumElementDecl>(decl);
-    auto enumType = eed->getParentEnum()->mapTypeIntoContext(
-        eed->getParentEnum()->getDeclaredInterfaceType());
+    auto *parentEnum = eed->getParentEnum();
+    auto enumType =
+        parentEnum->mapTypeIntoContext(parentEnum->getDeclaredInterfaceType());
+
+    // Add early bailout for imported enums.
+    if (parentEnum->hasClangNode()) {
+      return std::nullopt;
+    }
+
     // Escapable enum, bailout.
     if (!isDiagnosedNonEscapable(enumType)) {
       return std::nullopt;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2407,6 +2407,13 @@ static void maybeAddParameterIsolation(AnyFunctionType::ExtInfoBuilder &infoBuil
     infoBuilder = infoBuilder.withIsolation(FunctionTypeIsolation::forParameter());
 }
 
+std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
+getLifetimeDependencies(ASTContext &context, EnumElementDecl *enumElemDecl) {
+  return evaluateOrDefault(context.evaluator,
+                           LifetimeDependenceInfoRequest{enumElemDecl},
+                           std::nullopt);
+}
+
 Type
 InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
   auto &Context = D->getASTContext();
@@ -2696,13 +2703,25 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       resultTy = FunctionType::get(argTy, resultTy, info);
     }
 
+    auto lifetimeDependenceInfo = getLifetimeDependencies(Context, EED);
+
     // FIXME: Verify ExtInfo state is correct, not working by accident.
     if (auto genericSig = ED->getGenericSignature()) {
-      GenericFunctionType::ExtInfo info;
-      resultTy = GenericFunctionType::get(genericSig, {selfTy}, resultTy, info);
+      GenericFunctionType::ExtInfoBuilder infoBuilder;
+      if (lifetimeDependenceInfo.has_value()) {
+        infoBuilder =
+            infoBuilder.withLifetimeDependencies(*lifetimeDependenceInfo);
+      }
+      resultTy = GenericFunctionType::get(genericSig, {selfTy}, resultTy,
+                                          infoBuilder.build());
+
     } else {
-      FunctionType::ExtInfo info;
-      resultTy = FunctionType::get({selfTy}, resultTy, info);
+      FunctionType::ExtInfoBuilder infoBuilder;
+      if (lifetimeDependenceInfo.has_value()) {
+        infoBuilder =
+            infoBuilder.withLifetimeDependencies(*lifetimeDependenceInfo);
+      }
+      resultTy = FunctionType::get({selfTy}, resultTy, infoBuilder.build());
     }
 
     return resultTy;
@@ -3151,7 +3170,7 @@ ImplicitKnownProtocolConformanceRequest::evaluate(Evaluator &evaluator,
 
 std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
 LifetimeDependenceInfoRequest::evaluate(Evaluator &evaluator,
-                                        AbstractFunctionDecl *decl) const {
+                                        ValueDecl *decl) const {
   return LifetimeDependenceInfo::get(decl);
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5259,6 +5259,16 @@ public:
     elem->setAccess(std::max(cast<EnumDecl>(DC)->getFormalAccess(),
                              AccessLevel::Internal));
 
+    SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
+    while (auto info = MF.maybeReadLifetimeDependence()) {
+      assert(info.has_value());
+      lifetimeDependencies.push_back(*info);
+    }
+
+    ctx.evaluator.cacheOutput(LifetimeDependenceInfoRequest{elem},
+                              lifetimeDependencies.empty()? std::nullopt :
+                                  ctx.AllocateCopy(lifetimeDependencies));
+
     return elem;
   }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 954; // Checked cast inst options
+const uint16_t SWIFTMODULE_VERSION_MINOR = 955; // Lifetime dependencies on enum element
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5021,6 +5021,14 @@ public:
                                   nameComponentsAndDependencies);
     if (auto *PL = elem->getParameterList())
       writeParameterList(PL);
+
+    auto fnType = ty->getAs<AnyFunctionType>();
+    if (fnType) {
+      auto lifetimeDependencies = fnType->getLifetimeDependencies();
+      if (!lifetimeDependencies.empty()) {
+        S.writeLifetimeDependencies(lifetimeDependencies);
+      }
+    }
   }
 
   void visitSubscriptDecl(const SubscriptDecl *subscript) {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_enums.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_enums.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -sil-verify-all | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+public protocol OptionalType<Wrapped> {
+  associatedtype Wrapped
+
+  static func some(_ wrapped: Wrapped) -> Self
+  static func somePair(_ wrapped1: Wrapped, _ wrapped2: Wrapped) -> Self
+  static func esc(_ e: E) -> Self
+}
+
+public struct E {}
+
+public enum FakeOptional<Wrapped : ~Escapable & ~Copyable> : ~Escapable & ~Copyable {
+  case none
+  case some(Wrapped)
+  case somePair(Wrapped, Wrapped)
+  case esc(E)
+}
+
+extension FakeOptional: Copyable where Wrapped: Copyable & ~Escapable {}
+
+extension FakeOptional: Escapable where Wrapped: Escapable & ~Copyable {}
+
+extension FakeOptional : OptionalType {}
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO4someyACyxGxcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (@in Wrapped, @thin FakeOptional<Wrapped>.Type) -> @lifetime(copy 0) @out FakeOptional<Wrapped> {
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO8somePairyACyxGx_xtcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (@in Wrapped, @in Wrapped, @thin FakeOptional<Wrapped>.Type) -> @lifetime(copy 0, copy 1) @out FakeOptional<Wrapped> {
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO3escyACyxGAA1EVcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (E, @thin FakeOptional<Wrapped>.Type) -> @out FakeOptional<Wrapped> {
+

--- a/test/Serialization/Inputs/def_lifetime_dependence_enums.swift
+++ b/test/Serialization/Inputs/def_lifetime_dependence_enums.swift
@@ -1,0 +1,29 @@
+public protocol OptionalType<Wrapped> {
+  associatedtype Wrapped
+
+  static func some(_ wrapped: Wrapped) -> Self
+  static func somePair(_ wrapped1: Wrapped, _ wrapped2: Wrapped) -> Self
+  static func esc(_ e: E) -> Self
+}
+
+public struct E {}
+
+public enum FakeOptional<Wrapped : ~Escapable & ~Copyable> : ~Escapable & ~Copyable {
+  case none
+  case some(Wrapped)
+  case somePair(Wrapped, Wrapped)
+  case esc(E)
+}
+
+extension FakeOptional: Copyable where Wrapped: Copyable & ~Escapable {}
+
+extension FakeOptional: Escapable where Wrapped: Escapable & ~Copyable {}
+
+extension FakeOptional : OptionalType {}
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO4someyACyxGxcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (@in Wrapped, @thin FakeOptional<Wrapped>.Type) -> @lifetime(copy 0) @out FakeOptional<Wrapped> {
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO8somePairyACyxGx_xtcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (@in Wrapped, @in Wrapped, @thin FakeOptional<Wrapped>.Type) -> @lifetime(copy 0, copy 1) @out FakeOptional<Wrapped> {
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO3escyACyxGAA1EVcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (E, @thin FakeOptional<Wrapped>.Type) -> @out FakeOptional<Wrapped> {
+

--- a/test/Serialization/lifetime_dependence_enums.swift
+++ b/test/Serialization/lifetime_dependence_enums.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_lifetime_dependence_enums.swift 
+
+// RUN: llvm-bcanalyzer %t/def_lifetime_dependence_enums.swiftmodule 
+
+// RUN: %target-swift-frontend -c -module-name lifetime-dependence-enums -Xllvm -sil-print-after=EarlyPerfInliner -O -I %t %s \
+// RUN: -enable-experimental-feature Lifetimes -o /dev/null 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+import def_lifetime_dependence_enums 
+
+@inline(__always)
+public func testSome<T : OptionalType>(_ t: T, _ w: T.Wrapped) -> T {
+  return T.self.some(w)
+}
+
+@inline(__always)
+public func testSomePair<T : OptionalType>(_ t: T, _ w: T.Wrapped) -> T {
+  return T.self.somePair(w, w)
+}
+
+// CHECK-LABEL: sil [ossa] @$s4main5test1yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF : 
+// Match the second instance of EarlyPerfInliner
+// CHECK-LABEL: sil [ossa] @$s4main5test1yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF : 
+// CHECK: [[FUNC:%.*]] = function_ref @$s29def_lifetime_dependence_enums12FakeOptionalO4someyACyxGxcAEmlF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@in τ_0_0, @thin FakeOptional<τ_0_0>.Type) -> @lifetime(copy 0) @out FakeOptional<τ_0_0>
+// CHECK: apply [[FUNC]]<W>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@in τ_0_0, @thin FakeOptional<τ_0_0>.Type) -> @lifetime(copy 0) @out FakeOptional<τ_0_0>
+// CHECK-LABEL: } // end sil function '$s4main5test1yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF'
+public func test1<W>(_ f: FakeOptional<W>, _ w: FakeOptional<W>.Wrapped) -> some OptionalType {
+  return testSome(f, w)
+}
+
+// CHECK-LABEL: sil [ossa] @$s4main5test2yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF : 
+// Match the second instance of EarlyPerfInliner
+// CHECK-LABEL: sil [ossa] @$s4main5test2yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF : 
+// CHECK:   [[FUNC:%.*]] = function_ref @$s29def_lifetime_dependence_enums12FakeOptionalO8somePairyACyxGx_xtcAEmlF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@in τ_0_0, @in τ_0_0, @thin FakeOptional<τ_0_0>.Type) -> @lifetime(copy 0, copy 1) @out FakeOptional<τ_0_0> // user: %13
+// CHECK:   apply [[FUNC]]<W>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@in τ_0_0, @in τ_0_0, @thin FakeOptional<τ_0_0>.Type) -> @lifetime(copy 0, copy 1) @out FakeOptional<τ_0_0>
+// CHECK-LABEL: } // end sil function '$s4main5test2yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF'
+public func test2<W>(_ f: FakeOptional<W>, _ w: FakeOptional<W>.Wrapped) -> some OptionalType {
+  return testSomePair(f, w)
+}
+


### PR DESCRIPTION
Enum elements are represented as a function type. Enums can satisfy a protocol's static method constraint by defining a enum element with the same signature. 

We do not infer lifetime dependence on function types related to `EnumElementDecl`. This results to source compatibility bugs in some cases since `Optional` is now conditionally `~Escapable`. In the example below a protocol specifying a static `some` method ends up with a generated witness that does not have lifetime dependencies leading to illegible diagnostics. 

```
public protocol OptionalType<Wrapped> {
    associatedtype Wrapped
    static func some(_ wrapped: Wrapped) -> Self
}

extension Optional: OptionalType {}
```

This PR adds lifetime dependencies for function types representative of `EnumElementDecl`s.  

rdar://152104558 