### PR TITLE
FreeBSD: Link C++ runtimes when Cxx interop is enabled

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -573,7 +573,8 @@ void swift::dependencies::registerCxxInteropLibraries(
                       return mainModuleName == Name;
                     })) {
     // Only link with CxxStdlib on platforms where the overlay is available.
-    if (Target.isOSDarwin() || Target.isOSLinux() || Target.isOSWindows())
+    if (Target.isOSDarwin() || Target.isOSLinux() || Target.isOSWindows() ||
+        Target.isOSFreeBSD())
       RegistrationCallback(LinkLibrary{"swiftCxxStdlib", LibraryKind::Library,
                                        hasStaticCxxStdlib});
   }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1656,9 +1656,10 @@ const char *ToolChain::getClangLinkerDriver(
   // a C++ standard library if it's not needed, in particular because the
   // standard library that `clang++` selects by default may not be the one that
   // is desired.
-  const char *LinkerDriver =
-      Args.hasArg(options::OPT_enable_experimental_cxx_interop) ? "clang++"
-                                                                : "clang";
+  bool useCxxLinker = Args.hasArg(options::OPT_enable_experimental_cxx_interop);
+  if (Arg *arg = Args.getLastArg(options::OPT_cxx_interoperability_mode))
+      useCxxLinker |= StringRef(arg->getValue()) != "off";
+  const char *LinkerDriver = useCxxLinker ? "clang++" : "clang";
   if (const Arg *A = Args.getLastArg(options::OPT_tools_directory)) {
     StringRef toolchainPath(A->getValue());
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -391,7 +391,8 @@ void CompilerInvocation::computeCXXStdlibOptions() {
     // (see https://reviews.llvm.org/D101479).
     LangOpts.CXXStdlib = CXXStdlibKind::Msvcprt;
     LangOpts.PlatformDefaultCXXStdlib = CXXStdlibKind::Msvcprt;
-  } else if (LangOpts.Target.isOSLinux() || LangOpts.Target.isOSDarwin()) {
+  } else if (LangOpts.Target.isOSLinux() || LangOpts.Target.isOSDarwin() ||
+             LangOpts.Target.isOSFreeBSD()) {
     auto [clangDriver, clangDiagEngine] =
         ClangImporter::createClangDriver(LangOpts, ClangImporterOpts);
     auto clangDriverArgs = ClangImporter::createClangArgs(

--- a/test/Interop/Cxx/stdlib/avoid-import-cxx-math.swift
+++ b/test/Interop/Cxx/stdlib/avoid-import-cxx-math.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=swift-6
 // RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=upcoming-swift
 
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=freebsd
 
 import CxxStdlib
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence.swift
@@ -1,7 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=freebsd
 
 // REQUIRES: rdar102364960
 

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -11,7 +11,7 @@
 
 // REQUIRES: executable_test
 //
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=freebsd
 
 import StdlibUnittest
 #if !BRIDGING_HEADER


### PR DESCRIPTION
This patch gets all of the C++ interop tests passing on FreeBSD. There were two bugs.

First, the Swift tests use the old Swift driver, which only used the experimental C++ interop flag to determine whether or not to use clang++ or clang. Changing the legacy driver to align more closely with the behavior of the Swift driver:

```swift
      var cxxCompatEnabled = parsedOptions.hasArgument(.enableExperimentalCxxInterop)
      if let cxxInteropMode = parsedOptions.getLastArgument(.cxxInteroperabilityMode) {
        if cxxInteropMode.asSingle != "off" {
          cxxCompatEnabled = true
        }
      }
      // ...
      let clangTool: Tool = cxxCompatEnabled ? .clangxx : .clang
      // ...
```

 - https://github.com/swiftlang/swift-driver/blob/1670905e1a74a31379470bc4947e123ab21923a4/Sources/SwiftDriver/Jobs/GenericUnixToolchain%2BLinkerSupport.swift#L82-L87

Second, there were several tests that didn't pass the flag to the driver, but to the frontend, so that didn't fix all of the tests. The tests passing it to the frontend are relying on the autolink mechanism to automatically pull in a C++ runtime and an overlay. A separate patch adds FreeBSD to the list of OS's to automatically link the C++ runtime when C++ interop is enabled.

Third, this isn't fixing bugs, but just enabling a handful of tests that are passing but were marked unsupported.