### PR TITLE
[stdlib] Update `InlineArray` documentation

### DIFF
--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -142,7 +142,7 @@ extension InlineArray where Element: ~Copyable {
   /// - Parameter body: A closure that returns an owned `Element` to emplace at
   ///   the passed in index.
   ///
-  /// - Complexity: O(*n*), where *n* is the number of elements in the array.
+  /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init<E: Error>(_ body: (Index) throws(E) -> Element) throws(E) {
@@ -190,7 +190,7 @@ extension InlineArray where Element: ~Copyable {
   ///     preceding element, and returns an owned `Element` instance to emplace
   ///     into the array.
   ///
-  /// - Complexity: O(*n*), where *n* is the number of elements in the array.
+  /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init<E: Error>(
@@ -243,7 +243,7 @@ extension InlineArray where Element: Copyable {
   ///
   /// - Parameter value: The instance to initialize this array with.
   ///
-  /// - Complexity: O(*n*), where *n* is the number of elements in the array.
+  /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init(repeating value: Element) {
@@ -454,7 +454,7 @@ extension InlineArray where Element: ~Copyable {
 }
 
 //===----------------------------------------------------------------------===//
-// MARK: Span
+// MARK: - Span APIs
 //===----------------------------------------------------------------------===//
 
 @available(SwiftStdlib 6.2, *)

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -141,8 +141,6 @@ extension InlineArray where Element: ~Copyable {
   ///
   /// - Parameter body: A closure that returns an owned `Element` to emplace at
   ///   the passed in index.
-  ///
-  /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init<E: Error>(_ body: (Index) throws(E) -> Element) throws(E) {
@@ -189,8 +187,6 @@ extension InlineArray where Element: ~Copyable {
   ///   - next: A closure that takes an immutable borrow reference to the
   ///     preceding element, and returns an owned `Element` instance to emplace
   ///     into the array.
-  ///
-  /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init<E: Error>(
@@ -242,8 +238,6 @@ extension InlineArray where Element: Copyable {
   /// Initializes every element in this array to a copy of the given value.
   ///
   /// - Parameter value: The instance to initialize this array with.
-  ///
-  /// - Complexity: O(1)
   @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public init(repeating value: Element) {


### PR DESCRIPTION
Remove misleading big O notation from initializers.

Follow-up to commit 23e1741978ce394543efe30d639563e67b5d907e and [forums post](https://forums.swift.org/t/how-to-check-two-array-instances-for-identity-equality-in-constant-time/78792/65).