### PR TITLE
presets: allow incremental rebuilds of stdlib for WASI

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3268,6 +3268,8 @@ install-swift-testing
 install-swift-testing-macros
 install-xctest
 
+# For local use only. This allows quickly rebuilding and testing Wasm stdlib
+# end-to-end without rebuilding the whole toolchain.
 [preset: wasm_stdlib_incremental]
 
 assertions

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -3267,3 +3267,38 @@ install-swiftpm
 install-swift-testing
 install-swift-testing-macros
 install-xctest
+
+[preset: wasm_stdlib_incremental]
+
+assertions
+swift-enable-ast-verifier=0
+no-swift-stdlib-assertions
+build-embedded-stdlib-cross-compiling
+build-wasm-stdlib
+release-debuginfo
+test
+lit-args=-v --time-tests
+skip-test-swiftdocc
+skip-test-cmark
+skip-test-lldb
+skip-test-swift
+skip-test-llbuild
+skip-test-swiftpm
+skip-test-swift-driver
+skip-test-xctest
+skip-test-foundation
+skip-test-libdispatch
+skip-test-playgroundsupport
+skip-test-indexstore-db
+skip-test-sourcekit-lsp
+skip-test-swiftformat
+skip-build-llvm
+skip-build-swift
+skip-early-swift-driver
+skip-build-cmark
+install-destdir=%(install_destdir)s
+
+[preset: wasm_stdlib_incremental,macos]
+
+mixin-preset=wasm_stdlib_incremental
+build-subdir=buildbot_osx


### PR DESCRIPTION
This allows quickly rebuilding and testing wasm stdlib end-to-end without rebuilding the whole toolchain.