### PR TITLE
Track Wasm-related `build-script` files in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -298,6 +298,8 @@
 /utils/swift_build_support/products/sourcekitlsp.py           @bnbarham @hamishknight @rintaro
 /utils/swift_build_support/products/swiftformat.py            @allevato @bnbarham @hamishknight @rintaro
 /utils/swift_build_support/products/swiftsyntax.py            @bnbarham @hamishknight @rintaro
+/utils/swift_build_support/products/wasm*                     @bnbarham @MaxDesiatov @kateinoigakukun
+/utils/swift_build_support/products/wasi*                     @bnbarham @MaxDesiatov @kateinoigakukun
 /utils/update-checkout*                                       @etcwilde @justice-adams-apple @shahmishal
 /utils/update_checkout/                                       @etcwilde @justice-adams-apple @shahmishal
 /utils/update_checkout/update-checkout-config.json            @shahmishal


### PR DESCRIPTION
Wasm-related changed should be tracked in `CODEOWNERS`, and we have separate `build-script` Python modules to include in that list.