### PR TITLE
Allow inout parameters in expression macros

### DIFF
--- a/lib/Sema/PreCheckTarget.cpp
+++ b/lib/Sema/PreCheckTarget.cpp
@@ -1315,8 +1315,9 @@ public:
           lastInnerParenLoc = PE->getLParenLoc();
           parent = nextParent;
         }
-
-        if (isa<ApplyExpr>(parent) || isa<UnresolvedMemberExpr>(parent)) {
+        
+        if (isa<ApplyExpr>(parent) || isa<UnresolvedMemberExpr>(parent) ||
+            isa<MacroExpansionExpr>(parent)) {
           // If outermost paren is associated with a call or
           // a member reference, it might be valid to have `&`
           // before all of the parens.

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -240,6 +240,15 @@ public class TupleMacro: ExpressionMacro {
   }
 }
 
+public class VoidExpressionMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return "()"
+  }
+}
+
 enum CustomError: Error, CustomStringConvertible {
   case message(String)
 

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -151,7 +151,17 @@ struct S {
 @freestanding(expression) macro functionCallWithInoutParam(_ v: inout Int)
   = #externalMacro(module: "MacroDefinition", type: "VoidExpressionMacro")
 
+@freestanding(expression) macro functionCallWithTwoInoutParams(_ u: inout Int, _ v: inout Int)
+  = #externalMacro(module: "MacroDefinition", type: "VoidExpressionMacro")
+
+@freestanding(expression) macro functionCallWithInoutParamPlusOthers(
+  string: String, double: Double, _ v: inout Int)
+  = #externalMacro(module: "MacroDefinition", type: "VoidExpressionMacro")
+
 func testFunctionCallWithInoutParam() {
   var a = 0
+  var b = 0
   #functionCallWithInoutParam(&a)
+  #functionCallWithTwoInoutParams(&a, &b)
+  #functionCallWithInoutParamPlusOthers(string: "", double: 1.0, &a)
 }

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -145,3 +145,13 @@ struct S {
 #checkGeneric<String>()
 #checkGeneric2<String, Int>()
 #checkGenericHashableCodable<String, Int>()
+
+// Check that inout parameters are allowed in expression macros
+
+@freestanding(expression) macro functionCallWithInoutParam(_ v: inout Int)
+  = #externalMacro(module: "MacroDefinition", type: "VoidExpressionMacro")
+
+func testFunctionCallWithInoutParam() {
+  var a = 0
+  #functionCallWithInoutParam(&a)
+}


### PR DESCRIPTION
Sema seems to be flagging inout expressions (e.g. &foo) in expression macros as invalid, setting up a catch 22 where Sema emits an error when a parameter has the '&' sigil and type checking fails when it doesn't.

This resolves the issue by allowing inout expressions inside macro expansion expressions.

Resolves https://github.com/swiftlang/swift/issues/82369.