### PR TITLE
[6.2][CSSimplify] VariadicGenerics: Don't attempt to wrap optional into on…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7345,16 +7345,20 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // match `$T3` and propagate `Pack{Int}` to `$T2`.
   //
   // This is also important for situations like: `$T2 conv (Int, $T_exp)`
-  // becuase expansion could be defaulted to an empty pack which means
+  // because expansion could be defaulted to an empty pack which means
   // that under substitution that element would disappear and the type
   // would be just `(Int)`.
   //
-  // Notable exception here is `Any` which doesn't require wrapping and
-  // would be handled by existental promotion in cases where it's allowed.
+  // Notable exceptions here are: `Any` which doesn't require wrapping and
+  // would be handled by an existential promotion in cases where it's allowed,
+  // and `Optional<T>` which would be handled by optional injection.
   if (isTupleWithUnresolvedPackExpansion(origType1) ||
       isTupleWithUnresolvedPackExpansion(origType2)) {
-    if (desugar1->is<TupleType>() != desugar2->is<TupleType>() &&
-        (!desugar1->isAny() && !desugar2->isAny())) {
+    if (isa<TupleType>(desugar1) != isa<TupleType>(desugar2) &&
+        !desugar1->getOptionalObjectType() &&
+        !desugar2->getOptionalObjectType() &&
+        !desugar1->isAny() &&
+        !desugar2->isAny()) {
       return matchTypes(
           desugar1->is<TupleType>() ? type1
                                     : TupleType::get({type1}, getASTContext()),

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -76,3 +76,17 @@ func badCallToZip<each T, each U>(t: repeat each T, u: repeat each U) {
   // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'each T' and 'each U' have the same shape}}
   // expected-error@-2 {{pack expansion requires that 'each U' and 'each T' have the same shape}}
 }
+
+do {
+  func test<A, B, each C>(
+    _: A,
+    _: B,
+    _: repeat each C
+  ) throws -> (A, B, repeat each C) {
+    fatalError()
+  }
+
+  func test() {
+    guard let _ = try? test(1, 2, 3) else { return } // Ok
+  }
+}


### PR DESCRIPTION
…e-element tuple

Cherry-pick of https://github.com/swiftlang/swift/pull/82326

---

- Explanation:

  Fixes a bug that prevent matching types that contain pack expansions against optional types.

  If we have a tuple with unresolved pack expansion on one side and an optional type on the other, prevent `matchTypes` from wrapping optional into a one-element tuple because the matching should be handled as part of the optional injection.

- Resolves: rdar://152940244

- Main Branch PR: https://github.com/swiftlang/swift/pull/82326

- Risk: Low. This is a narrow fix that only affects swift code that is currently rejected by the compiler.

- Reviewed By: @hamishknight 

- Testing: Added new test-cases to the test suite.

(cherry picked from commit 6cfbafd96807563bf1da7a2acadf8dce7d349278)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
