### PR TITLE
Discover embedded tests when testing `wasmstdlib.py`

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -179,7 +179,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         # Test configuration
         self.cmake_options.define('SWIFT_INCLUDE_TESTS:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_ENABLE_SOURCEKIT_TESTS:BOOL', 'FALSE')
-        lit_test_paths = ['IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded/wasm']
+        lit_test_paths = ['IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded']
         lit_test_paths = [os.path.join(
             self.build_dir, 'test-wasi-wasm32', path) for path in lit_test_paths]
         self.cmake_options.define('SWIFT_LIT_TEST_PATHS:STRING',


### PR DESCRIPTION
Embedded tests are only included in the build now, a separate change is needed to mark relevant tests as supported.

Without this change:

```
[2025-06-21T00:53:52.507Z] --- Running tests for wasmstdlib ---
[...]
[2025-06-21T00:59:22.874Z] Total Discovered Tests: 1405
[2025-06-21T00:59:22.874Z]   Excluded         :   2 (0.14%)
[2025-06-21T00:59:22.874Z]   Unsupported      : 725 (51.60%)
[2025-06-21T00:59:22.874Z]   Passed           : 674 (47.97%)
[2025-06-21T00:59:22.874Z]   Expectedly Failed:   4 (0.28%)
[...]
[2025-06-20T17:42:41.045Z] Build Percentage 	 Build Duration (sec) 	 Build Phase
[2025-06-20T17:42:41.045Z] ================ 	 ==================== 	 ===========
[...]
[2025-06-21T02:02:24.048Z] 3.0%              	 324.31                	 Running tests for wasmstdlib
```

With this change:

```
[2025-06-20T16:33:58.389Z] --- Running tests for wasmstdlib ---
[...]
[2025-06-20T16:39:29.285Z] Total Discovered Tests: 1626
[2025-06-20T16:39:29.285Z]   Excluded         :   2 (0.12%)
[2025-06-20T16:39:29.285Z]   Unsupported      : 946 (58.18%)
[2025-06-20T16:39:29.285Z]   Passed           : 674 (41.45%)
[2025-06-20T16:39:29.285Z]   Expectedly Failed:   4 (0.25%)
[...]
[2025-06-20T17:42:41.045Z] Build Percentage 	 Build Duration (sec) 	 Build Phase
[2025-06-20T17:42:41.045Z] ================ 	 ==================== 	 ===========
[...]
[2025-06-20T17:42:41.045Z] 3.0%              	 322.87                	 Running tests for wasmstdlib
```