### PR TITLE
Add Feature: NonescapableAccessorOnTrivial

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -700,6 +700,14 @@ public:
   /// Returns true if this contextual type is (Escapable && !isNoEscape).
   bool mayEscape() { return !isNoEscape() && isEscapable(); }
 
+  /// Returns true if this contextual type satisfies a conformance to
+  /// BitwiseCopyable.
+  bool isBitwiseCopyable();
+
+  /// Returns true if this type satisfies a conformance to BitwiseCopyable in
+  /// the given generic signature.
+  bool isBitwiseCopyable(GenericSignature sig);
+
   /// Are values of this type essentially just class references,
   /// possibly with some sort of additional information?
   ///

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -530,6 +530,9 @@ EXPERIMENTAL_FEATURE(DefaultIsolationPerFile, false)
 /// Enable @_lifetime attribute
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
 
+/// Enable UnsafeMutablePointer.mutableSpan
+EXPERIMENTAL_FEATURE(NonescapableAccessorOnTrivial, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -963,3 +963,21 @@ bool TypeBase::isEscapable(GenericSignature sig) {
   }
   return contextTy->isEscapable();
 }
+
+bool TypeBase::isBitwiseCopyable() {
+  auto &ctx = getASTContext();
+  auto *bitwiseCopyableProtocol =
+    ctx.getProtocol(KnownProtocolKind::BitwiseCopyable);
+  if (!bitwiseCopyableProtocol) {
+    return false;
+  }
+  return (bool)checkConformance(this, bitwiseCopyableProtocol);
+}
+
+bool TypeBase::isBitwiseCopyable(GenericSignature sig) {
+  Type contextTy = this;
+  if (sig) {
+    contextTy = sig.getGenericEnvironment()->mapTypeIntoContext(contextTy);
+  }
+  return contextTy->isBitwiseCopyable();
+}

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -331,14 +331,25 @@ static bool usesFeatureLifetimeDependenceMutableAccessors(Decl *decl) {
     return false;
   }
   auto var = cast<VarDecl>(decl);
-  if (!var->isGetterMutating()) {
+  return var->isGetterMutating() && !var->getTypeInContext()->isEscapable();
+}
+
+static bool usesFeatureNonescapableAccessorOnTrivial(Decl *decl) {
+  if (!isa<VarDecl>(decl)) {
     return false;
   }
-  if (auto dc = var->getDeclContext()) {
-    if (auto nominal = dc->getSelfNominalTypeDecl()) {
-      auto sig = nominal->getGenericSignature();
-      return !var->getInterfaceType()->isEscapable(sig);
-    }
+  auto var = cast<VarDecl>(decl);
+  if (!var->hasParsedAccessors()) {
+    return false;
+  }
+  // Check for properties that are both non-Copyable and non-Escapable
+  // (MutableSpan).
+  if (var->getTypeInContext()->isNoncopyable()
+      && !var->getTypeInContext()->isEscapable()) {
+    auto selfTy = var->getDeclContext()->getSelfTypeInContext();
+    // Consider 'self' trivial if it is BitwiseCopyable and Escapable
+    // (UnsafeMutableBufferPointer).
+    return selfTy->isBitwiseCopyable() && selfTy->isEscapable();
   }
   return false;
 }

--- a/test/ModuleInterface/Inputs/lifetime_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_dependence.swift
@@ -77,3 +77,21 @@ extension Container {
     }
   }
 }
+
+// Test feature guard: NonescapableAccessorOnTrivial
+extension UnsafeMutableBufferPointer where Element: ~Copyable {
+  public var span: Span<Element> {
+    @lifetime(borrow self)
+    @_alwaysEmitIntoClient
+    get {
+      unsafe Span(_unsafeElements: self)
+    }
+  }
+  public var mutableSpan: MutableSpan<Element> {
+    @lifetime(borrow self)
+    @_alwaysEmitIntoClient
+    get {
+      unsafe MutableSpan(_unsafeElements: self)
+    }
+  }
+}

--- a/test/ModuleInterface/lifetime_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_dependence_test.swift
@@ -2,6 +2,7 @@
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature LifetimeDependence \
+// RUN:     -suppress-warnings \
 // RUN:     -o %t/lifetime_dependence.swiftmodule \
 // RUN:     -emit-module-interface-path %t/lifetime_dependence.swiftinterface \
 // RUN:     %S/Inputs/lifetime_dependence.swift
@@ -41,3 +42,13 @@ import lifetime_dependence
 // CHECK: extension lifetime_dependence.Container {
 // CHECK-NEXT: #if compiler(>=5.3) && $NonescapableTypes && $LifetimeDependence
 // CHECK-NEXT:   public var storage: lifetime_dependence.BufferView {
+
+// CHECK-LABEL: extension Swift.UnsafeMutableBufferPointer where Element : ~Copyable {
+// CHECK:   #if compiler(>=5.3) && $LifetimeDependence
+// CHECK:   public var span: Swift.Span<Element> {
+// CHECK:     @lifetime(borrow self)
+// CHECK:     @_alwaysEmitIntoClient get {
+// CHECK:   #if compiler(>=5.3) && $LifetimeDependence && $NonescapableAccessorOnTrivial
+// CHECK:   public var mutableSpan: Swift.MutableSpan<Element> {
+// CHECK:     @lifetime(borrow self)
+// CHECK:     @_alwaysEmitIntoClient get {


### PR DESCRIPTION
To guard the new UnsafeMutablePointer.mutableSpan APIs.

This allows older compilers to ignore the new APIs. Otherwise, the type checker
will crash on the synthesized _read accessor for a non-Escapable type:

    error: cannot infer lifetime dependence on the '_read' accessor because 'self'
    is BitwiseCopyable, specify '@lifetime(borrow self)'

I don't know why the _read is synthesized in these cases, but apparently it's
always been that way.

Fixes: rdar://153773093 ([nonescapable] add a compiler feature to guard
~Escapable accessors when self is trivial)
