### PR TITLE
[6.2] Sema: Expand isolated conformance inference to consider conformances to inherited protocols

### DIFF
--- a/test/Concurrency/Inputs/isolated_conformance_other.swift
+++ b/test/Concurrency/Inputs/isolated_conformance_other.swift
@@ -1,0 +1,5 @@
+public protocol P {
+  func f()
+}
+
+public protocol PDerived: P {}

--- a/test/Concurrency/isolated_conformance_inference.swift
+++ b/test/Concurrency/isolated_conformance_inference.swift
@@ -92,3 +92,7 @@ class InferMeDefaults {
   var someGlobalActorState: any P2.Type = DifferingConformances.self // expected-error{{global actor 'SomeGlobalActor'-isolated default value in a main actor-isolated context}}
   var bothState: any (P & P2).Type = DifferingConformances.self // expected-error{{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
 }
+
+protocol PDerived: P {}
+
+@MainActor struct ImpliedConformanceInference: PDerived { func f() {} }

--- a/test/Concurrency/isolated_conformance_inference_with_default_actor.swift
+++ b/test/Concurrency/isolated_conformance_inference_with_default_actor.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/isolated_conformance_other.swiftmodule %S/Inputs/isolated_conformance_other.swift -swift-version 6
+// RUN: %target-typecheck-verify-swift -I %t -swift-version 6 -enable-upcoming-feature InferIsolatedConformances -default-isolation MainActor -swift-version 6
+// REQUIRES: swift_feature_InferIsolatedConformances
+
+import isolated_conformance_other
+
+struct S1: P { func f() {} }
+struct S2: PDerived { func f() {} }


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82383

* **Description:** This change expands  isolated conformance inference to consider conformances to inherited protocols.

  Otherwise, if PDerived inherits from P and P's requirements are witnessed by `@MainActor`-isolated members, we fail to infer `@MainActor` isolation on the conformance to PDerived, forcing the user to write an explicit `@MainActor`.

* **Scope of the issue:** Usability problem with `-enable-upcoming-feature IsolatedConformanceInference`.

* **Issue:** Fixes https://github.com/swiftlang/swift/issues/82222.

* **Radar:** Fixes rdar://153219831.

* **Risk:** Medium, because it might introduce new request cycles, but only when this feature is enabled. This should be weighted against the usability improvement here.

* **Reviewed by:** TBD