### PR TITLE
[6.2][silgen] Make async_Main compatible with calling nonisolated(nonsending) functions.

### DIFF
--- a/test/SILGen/toplevel_globalactorvars.swift
+++ b/test/SILGen/toplevel_globalactorvars.swift
@@ -3,10 +3,14 @@
 // a
 // CHECK-LABEL: sil_global hidden @$s24toplevel_globalactorvars1aSivp : $Int
 
-// CHECK-LABEL: sil private [ossa] @async_Main
+// CHECK-LABEL: sil private [ossa] @async_Main : $@convention(thin) @async () -> () {
 // CHECK: bb0:
-// CHECK-NEXT: [[MAIN:%.*]] = builtin "buildMainActorExecutorRef"() : $Builtin.Executor
-// CHECK-NEXT: [[MAIN_OPTIONAL:%[0-9]+]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[MAIN]]
+// CHECK: [[META:%.*]] = metatype $@thick MainActor.Type
+// CHECK: [[FUNC:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK: [[ACTOR_RAW:%.*]] = apply [[FUNC]]([[META]])
+// CHECK: [[ACTOR_RAW_E:%.*]] = init_existential_ref [[ACTOR_RAW]]
+// CHECK: [[ACTOR_RAW_E_O:%.*]] = enum $Optional<any Actor>, #Optional.some!enumelt, [[ACTOR_RAW_E]]
+// CHECK: [[ACTOR:%.*]] = begin_borrow [[ACTOR_RAW_E_O]]
 
 actor MyActorImpl {}
 
@@ -67,7 +71,7 @@ await printFromMyActor(value: a)
 // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
 // CHECK: end_borrow [[ACTORREF]]
 // CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
-// CHECK: hop_to_executor [[MAIN_OPTIONAL]]
+// CHECK: hop_to_executor [[ACTOR]]
 
 if a < 10 {
 // CHECK: [[AACCESS:%[0-9]+]] = begin_access [read] [dynamic] [[AREF]] : $*Int
@@ -121,5 +125,12 @@ if a < 10 {
     // CHECK: hop_to_executor [[ACTORREF]] : $MyActorImpl
     // CHECK: end_borrow [[ACTORREF]]
     // CHECK: {{%[0-9]+}} = apply [[PRINTFROMMYACTOR_FUNC]]([[AGLOBAL]])
-    // CHECK: hop_to_executor [[MAIN_OPTIONAL]]
+    // CHECK: hop_to_executor [[ACTOR]]
 }
+
+nonisolated(nonsending) func nonisolatedNonSendingFunction() async {}
+
+// CHECK: [[FUNC:%.*]] = function_ref @$s24toplevel_globalactorvars29nonisolatedNonSendingFunctionyyYaF : $@convention(thin) @async (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()
+// CHECK: apply [[FUNC]]([[ACTOR]])
+// CHECK-NEXT: hop_to_executor [[ACTOR]]
+await nonisolatedNonSendingFunction()


### PR DESCRIPTION
Explanation: This PR changes how SILGen emits the executor for async_Main so that it emits an actual a reference to the main actor instead of just the main actor executor. The reason why we do this is that in contrast to previously where we just needed an executor for the purposes of hopping, we now also need to be able to pass off main actor-ness as a bonafide actor as an isolated parameter to nonisolated(nonsending) functions. To effectuate this, I just changed the executor setup code to emit the direct reference to the actor instead of the executor.

Scope: This just changes how we setup the executor to use in async_Main. It will not impact any other code.

Resolves: rdar://153082633

Main PR: https://github.com/swiftlang/swift/pull/82387

Risk: Low.  This just changes how we setup the executor to use in async_Main. It will not impact any other code. It uses a very standard, known code path that is used in the rest of SILGen for this purpose.

Testing: Added compiler tests

Reviewer: @xedin 
