### PR TITLE
Fix bug conversions of function returning function failed

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3884,6 +3884,17 @@ public:
     return containsPackExpansionType(getParams());
   }
 
+  /// Returns the number of curry levels of the function type.
+  unsigned getNumCurryLevels() const {
+    unsigned num = 1;
+    auto fn = this;
+    while (auto resultFn = fn->getResult()->getAs<AnyFunctionType>()) {
+      num++;
+      fn = resultFn;
+    }
+    return num;
+  }
+
   static bool containsPackExpansionType(ArrayRef<Param> params);
 
   static void printParams(ArrayRef<Param> Params, raw_ostream &OS,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5347,10 +5347,12 @@ bool ConstraintSystem::repairFailures(
     // this by forming an explicit call.
     auto convertTo = dstType->lookThroughAllOptionalTypes();
 
-    // If the RHS is a function type, the source must be a function-returning
-    // function.
-    if (convertTo->is<FunctionType>() && !resultType->is<FunctionType>())
-      return false;
+    // If the RHS is a function type,
+    // the source must have more curry levels.
+    if (auto convertToFnType = convertTo->getAs<FunctionType>()) {
+      if (fnType->getNumCurryLevels() <= convertToFnType->getNumCurryLevels())
+        return false;
+    }
 
     // Right-hand side can't be a type variable or dependent member, or `Any`
     // (if function conversion to `Any` didn't succeed there is something else

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1366,3 +1366,14 @@ do {
     try $0.missing // expected-error {{value of type 'Int' has no member 'missing'}}
   }
 }
+
+do {
+  let a: () -> () -> Void = {{}}
+  let _: (() -> () -> Void)? = a
+  let _: (() -> () -> Void)?? = a
+
+  class Super {}
+  class Sub: Super {}
+  let b: () -> () -> Sub = {{ return Sub() }}
+  let _: (() -> () -> Super)? = b
+}


### PR DESCRIPTION
# Description

resolves https://github.com/swiftlang/swift/issues/82397

```swift
let a: () -> () -> Void = {{}}
let _: (() -> () -> Void)? = a // 🔴 Cannot convert value of type '() -> Void' to specified type '() -> () -> Void'
```

regression of https://github.com/swiftlang/swift/pull/78377

```swift
- if (convertTo->is<FunctionType>())
+ if (convertTo->is<FunctionType>() && !resultType->is<FunctionType>())
    return false;
```

Since the new condition doesn’t handle the case where both `lhs` and `rhs` have the same curry levels, conversions of function-returning functions are incorrectly repaired by `repairByInsertingExplicitCall`. It should be resolved by [`ValueToOptionalConversion` ](https://github.com/kntkymt/swift/blob/0f98c1b7317a1ac52fd5fc6d961ed7d4f1c1bbed/lib/Sema/CSSimplify.cpp#L6418-L6419) by returning false in `repairByInsertingExplicitCall`.

# Solution

improve guard condition at `repairByInsertingExplicitCall`, specially: check curry levels of `lhs` and `rhs`. if `lhs` doesn't have more curry levels than `rhs`, it shouldn't be repaired by InsertingExplicitCall.

note that since the existing logic (`!resultType->is<FunctionType>()`) is designed to ensure that

- `lhs` has 2 (or more) curry levels and
- `rhs` has 1 (or more) curry level

, The new guard logic (`lhs.curryLevels <= rhs.curryLevels`) include this existing logic.
