### PR TITLE
Enable more tests for Embedded Wasm

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -611,6 +611,18 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB_CROSS_COMPILING)
       "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
       "test${VARIANT_SUFFIX}.lit.site.cfg")
   swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
+
+  set(VARIANT_SUFFIX "-embedded-wasi")
+  set(VARIANT_TRIPLE "wasm32-unknown-wasip1")
+  set(VARIANT_EXTERNAL_EMBEDDED_PLATFORM FALSE)
+  set(VARIANT_EXTERNAL_EMBEDDED_DEVICE)
+  set(SWIFT_TEST_RESULTS_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/swift-test-results/${VARIANT_TRIPLE}")
+  swift_configure_lit_site_cfg(
+      "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.in"
+      "${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.site.cfg"
+      "test${VARIANT_SUFFIX}.lit.site.cfg")
+  swift_generate_lit_swift_features_cfg("${CMAKE_CURRENT_BINARY_DIR}${VARIANT_SUFFIX}/lit.swift-features.cfg")
+  message(STATUS "SWIFT_LIT_ARGS is ${SWIFT_LIT_ARGS}")
 endif()
 
 # Add shortcuts for the default variant.

--- a/test/embedded/array-builtins-exec.swift
+++ b/test/embedded/array-builtins-exec.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -enable-builtin-module -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -wmo -enable-builtin-module) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
@@ -41,7 +39,7 @@ func exerciseArrayValueWitnesses<T>(_ value: T) {
 
   (buf + 0).initialize(to: value)
   (buf + 1).initialize(to: value)
-  
+
   Builtin.copyArray(T.self, (buf + 2)._rawValue, buf._rawValue, 2._builtinWordValue)
   Builtin.takeArrayBackToFront(T.self, (buf + 1)._rawValue, buf._rawValue, 4._builtinWordValue)
   Builtin.takeArrayFrontToBack(T.self, buf._rawValue, (buf + 1)._rawValue, 4._builtinWordValue)

--- a/test/embedded/basic-modules-generics-no-stdlib.swift
+++ b/test/embedded/basic-modules-generics-no-stdlib.swift
@@ -52,7 +52,7 @@ public func main() {
   protocolBoundFunc(GenericType<Bool>(Bool()))
 }
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)
 // CHECK: define {{.*}}void @"$e4Main4BoolVACycfC"()
 // CHECK: define {{.*}}void @"$e4Main4mainyyF"()
 // CHECK: define {{.*}}void @"$e8MyModule14nonGenericFuncyyF"()

--- a/test/embedded/basic-modules-no-stdlib.swift
+++ b/test/embedded/basic-modules-no-stdlib.swift
@@ -38,7 +38,7 @@ public func main() {
   moduleMain()
 }
 
-// CHECK: define {{.*}}@main{{.*}} {
+// CHECK: define {{.*}}@{{_*}}main{{.*}} {
 // CHECK: define {{.*}}void @"$e4Main4mainyyF"{{.*}} {
 // CHECK: define {{.*}}void @"$e8MyModule10moduleMainyyF"{{.*}} {
 // CHECK: define {{.*}}void @"$e8MyModule8ConcreteVACycfC"{{.*}} {

--- a/test/embedded/builtin-float.swift
+++ b/test/embedded/builtin-float.swift
@@ -2,7 +2,7 @@
 // RUN: mkdir -p %t/include
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -target armv7em-none-none-eabi -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
+// RUN: %target-swift-frontend -target %target-triple -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/builtin-float.swift
+++ b/test/embedded/builtin-float.swift
@@ -2,8 +2,9 @@
 // RUN: mkdir -p %t/include
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -target %target-triple -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
+// RUN: %target-swift-frontend -target armv7em-none-none-eabi -emit-ir %t/Main.swift -enable-experimental-feature Embedded -module-cache-path %t/ModuleCache -Xcc -I%t/include
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/classes-arrays.swift
+++ b/test/embedded/classes-arrays.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -wmo) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
@@ -56,7 +54,7 @@ struct Main {
       // CHECK: MySubSubClass.foo
     }
     print("")
-    
+
     print("5") // CHECK: 5
     objects = []
     // CHECK: MyClass.deinit

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,6 +1,7 @@
-// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target %target-triple -wmo | %FileCheck %s --check-prefix CHECK-SIL
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target %target-triple -wmo | %FileCheck %s --check-prefix CHECK-IR
+// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-SIL
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded
 

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-SIL
-// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target arm64e-apple-none -wmo | %FileCheck %s --check-prefix CHECK-IR
+// RUN: %target-swift-emit-sil %s -parse-stdlib -enable-experimental-feature Embedded -target %target-triple -wmo | %FileCheck %s --check-prefix CHECK-SIL
+// RUN: %target-swift-emit-ir %s -parse-stdlib -enable-experimental-feature Embedded -target %target-triple -wmo | %FileCheck %s --check-prefix CHECK-IR
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: swift_feature_Embedded

--- a/test/embedded/classes-multi-module.swift
+++ b/test/embedded/classes-multi-module.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModule.swift -o %t/MyModule.o -emit-module -emit-module-path %t/MyModule.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t %t/Main.swift -o %t/Main.o
-// RUN: %target-clang %t/Main.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/Main.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
@@ -28,7 +28,7 @@ class X<T: BinaryInteger> {
   var x: T
 
   init(x: T) { self.x = x }
-  
+
   func bar() {
     print(x)
   }

--- a/test/embedded/classes-optional.swift
+++ b/test/embedded/classes-optional.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s -parse-as-library -enable-experimental-feature Embedded -module-name main -emit-irgen | %FileCheck %s --check-prefix CHECK-IR
 // RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
@@ -77,7 +77,7 @@ struct Main {
 // CHECK-IR-NEXT:   ret void
 // CHECK-IR-NEXT: }
 
-// CHECK-IR:      define {{.*}}@main
+// CHECK-IR:      define {{.*}}@{{_*}}main
 // CHECK-IR-NEXT: entry:
 // CHECK-IR-NEXT:   alloca %T4main10MySubClassC
 // CHECK-IR-NEXT:   alloca %T4main12MyFinalClassC

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
@@ -84,7 +84,7 @@ struct Main {
     // CHECK: MySubClass.foo
     // CHECK: MySubSubClass.foo
     print("")
-    
+
     print("5") // CHECK: 5
     o.0 = nil
     // CHECK: MyClass.deinit

--- a/test/embedded/closures-heap.swift
+++ b/test/embedded/closures-heap.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -6,7 +6,7 @@
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx || OS=wasi
+// REQUIRES: OS=macosx
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,12 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-triple -lc++ -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=wasi
 // REQUIRES: swift_feature_Embedded
 
 import _Concurrency

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
-// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%target-triple -lc++ -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -L%swift_obj_root/lib/swift/embedded/%module-target-triple -lc++ -lswift_Concurrency -lswift_ConcurrencyDefaultExecutor -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: executable_test

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -enable-experimental-feature Extern -enable-experimental-feature Embedded -enforce-exclusivity=none %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/deinit-release.swift
+++ b/test/embedded/deinit-release.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/deinit-release2.swift
+++ b/test/embedded/deinit-release2.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -O -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -3,8 +3,11 @@
 
 // RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
 
-// Linux/ELF doesn't use the "_" prefix in symbol mangling.
-// RUN: if [ %target-os == "linux-gnu" ]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
+// Linux/ELF and Wasm don't use the "_" prefix in symbol mangling.
+// RUN: if [ %target-os == "linux-gnu" ] || [ %target-os == "wasi" ]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
+
+// Wasm has additional dependencies
+// RUN: if [ %target-os == "wasi" ]; then ex -sc '3i|__stack_pointer' -sc '1i|__memory_base' -sc '1i|__indirect_function_table' -cx %t/allowed-dependencies.txt; fi
 
 // RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
 
@@ -22,7 +25,7 @@
 
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang -x c -c %S/Inputs/linux-rng-support.c -o %t/linux-rng-support.o
-// RUN: %target-clang %t/a.o %t/print.o %t/linux-rng-support.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/print.o %t/linux-rng-support.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/dynamic-self.swift
+++ b/test/embedded/dynamic-self.swift
@@ -18,4 +18,4 @@ struct Main {
      }
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/extensions.swift
+++ b/test/embedded/extensions.swift
@@ -19,6 +19,6 @@ struct MyStruct {}
 
 extension MyStruct: MyProtocol {}
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)
 // CHECK-NOT: MyStruct
 // CHECK-NOT: MyProtocol

--- a/test/embedded/failable-crash.swift
+++ b/test/embedded/failable-crash.swift
@@ -16,4 +16,4 @@ public class MyClass<T> {
     }
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/float-abi-hard.swift
+++ b/test/embedded/float-abi-hard.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-emit-ir %t/Main.swift -import-bridging-header %t/BridgingHeader.h -parse-as-library -enable-experimental-feature Embedded -wmo \
 // RUN:  -target armv7em-none-none-eabi -Xcc -mthumb -Xcc -mcpu=cortex-m7 -Xcc -mfloat-abi=hard -Xcc -mfpu=fpv5-sp-d16 -Xcc -D__FPU_USED=1 -Xcc -falign-functions=16
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling
@@ -17,5 +16,5 @@ enum MyEnum: UInt8 {
     case a = 0
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(
 

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/hello.swift
+++ b/test/embedded/hello.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=none-wasm
 // REQUIRES: swift_feature_Embedded
 
 print("Hello, Embedded Swift!")

--- a/test/embedded/hello.swift
+++ b/test/embedded/hello.swift
@@ -2,7 +2,7 @@
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
-// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=none-wasm
+// REQUIRES: OS=macosx || OS=linux-gnu || OS=none-eabi || OS=none-elf || OS=wasi
 // REQUIRES: swift_feature_Embedded
 
 print("Hello, Embedded Swift!")

--- a/test/embedded/keypath-crash.swift
+++ b/test/embedded/keypath-crash.swift
@@ -20,7 +20,7 @@ public struct Binding<Value> {
 
 public struct State<Wrapped> {
   public var wrappedValue: Wrapped
-  
+
   public init(wrappedValue: Wrapped) {
     self.wrappedValue = wrappedValue
   }
@@ -51,4 +51,4 @@ public struct S<T> {
    }
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/linkage-mergeable-dead-strip.swift
+++ b/test/embedded/linkage-mergeable-dead-strip.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature SymbolLinkageMarkers -module-name main -mergeable-symbols -O %s -emit-ir | %FileCheck %s --check-prefix=CHECK-IR
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -enable-experimental-feature SymbolLinkageMarkers -module-name main -mergeable-symbols -O %s -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out -dead_strip
 // RUN: %llvm-nm --defined-only --format=just-symbols --demangle %t/a.out | sort | %FileCheck %s --check-prefix=CHECK-NM
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/linkage-mergeable.swift
+++ b/test/embedded/linkage-mergeable.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
-// RUN: %target-clang %t/a.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable2.swift
+++ b/test/embedded/linkage-mergeable2.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -O -c -emit-module -o %t/MyModule.o %t/MyModule.swift   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -O -c              -o %t/a.o        %t/Main.swift -I %t -enable-experimental-feature Embedded
-// RUN: %target-clang %t/a.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable3.swift
+++ b/test/embedded/linkage-mergeable3.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-clang %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/linkage-mergeable4.swift
+++ b/test/embedded/linkage-mergeable4.swift
@@ -3,7 +3,7 @@
 
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c -emit-module -o %t/MyModule.o             %t/MyModule.swift                   -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -mergeable-symbols -num-threads 2 -O -c              -o %t/MainA.o -o %t/MainB.o  %t/MainA.swift %t/MainB.swift -I %t -enable-experimental-feature Embedded -parse-as-library
-// RUN: %target-embedded-link %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
+// RUN: %target-embedded-link %target-clang-resource-dir-opt %t/MainA.o %t/MainB.o %t/MyModule.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -20,7 +20,7 @@ if 'embedded_stdlib' not in config.available_features:
   config.unsupported = True
 
 # (3) Restrict Embedded Swift tests only to the currently supported set of test target OS's, skip them otherwise.
-supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf", "OS=wasi"]
+supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf", "OS=wasip1"]
 if config.available_features.intersection(set(supported_test_os_list)) == set():
   config.unsupported = True
 

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -20,7 +20,7 @@ if 'embedded_stdlib' not in config.available_features:
   config.unsupported = True
 
 # (3) Restrict Embedded Swift tests only to the currently supported set of test target OS's, skip them otherwise.
-supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf"]
+supported_test_os_list = ["OS=macosx", "OS=linux-gnu", "OS=none-eabi", "OS=none-elf", "OS=wasi"]
 if config.available_features.intersection(set(supported_test_os_list)) == set():
   config.unsupported = True
 

--- a/test/embedded/modules-empty-object.swift
+++ b/test/embedded/modules-empty-object.swift
@@ -5,7 +5,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModuleB.swift -o %t/MyModuleB.o -emit-module -emit-module-path %t/MyModuleB.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t -parse-as-library %t/MyModuleC.swift -o %t/MyModuleC.o -emit-module -emit-module-path %t/MyModuleC.swiftmodule -emit-empty-object-file
 // RUN: %target-swift-frontend -enable-experimental-feature Embedded -c -I%t %t/Main.swift -o %t/Main.o
-// RUN: %target-clang %t/Main.o %t/MyModuleA.o %t/MyModuleB.o %t/MyModuleC.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/Main.o %t/MyModuleA.o %t/MyModuleB.o %t/MyModuleC.o -o %t/a.out
 // RUN: %target-run %t/a.out
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/modules-used2.swift
+++ b/test/embedded/modules-used2.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature Embedded -parse-as-library -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift
 // RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature Embedded -parse-as-library -I %t %t/Main.swift -emit-sil | %FileCheck %s --check-prefix CHECK-SIL
 // RUN: %target-swift-frontend -enable-experimental-feature SymbolLinkageMarkers -enable-experimental-feature Embedded -parse-as-library -I %t %t/Main.swift -c -o %t/a.o
-// RUN: %target-clang %t/a.o -o %t/a.out
+// RUN: %target-clang %target-clang-resource-dir-opt %t/a.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/no-allocations-print.swift
+++ b/test/embedded/no-allocations-print.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -no-allocations
 
-// RUN: %target-swift-emit-ir -target armv7-apple-none-macho -no-allocations %s -enable-experimental-feature Embedded
-// RUN: %target-swift-emit-ir -target arm64-apple-none-macho -no-allocations %s -enable-experimental-feature Embedded
+// RUN: %target-swift-emit-ir -target %target-triple -no-allocations %s -enable-experimental-feature Embedded
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/no-allocations-print.swift
+++ b/test/embedded/no-allocations-print.swift
@@ -1,7 +1,9 @@
 // RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -no-allocations
 
-// RUN: %target-swift-emit-ir -target %target-triple -no-allocations %s -enable-experimental-feature Embedded
+// RUN: %target-swift-emit-ir -target armv7-apple-none-macho -no-allocations %s -enable-experimental-feature Embedded
+// RUN: %target-swift-emit-ir -target arm64-apple-none-macho -no-allocations %s -enable-experimental-feature Embedded
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/once-dependent.swift
+++ b/test/embedded/once-dependent.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-clang %target-clang-resource-dir-opt %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
@@ -9,7 +9,7 @@
 
 public struct MyStructA {
   static var singleton = MyStructA()
-  
+
   init() {
     print("MyStructA.init")
     _ = MyStructB.singleton
@@ -19,7 +19,7 @@ public struct MyStructA {
 
 public struct MyStructB {
   static var singleton = MyStructB()
-  
+
   init() {
     print("MyStructB.init")
     _ = MyStructC.singleton
@@ -29,7 +29,7 @@ public struct MyStructB {
 
 public struct MyStructC {
   static var singleton = MyStructC()
-  
+
   init() {
     print("MyStructC.init")
     print("MyStructC.init done")

--- a/test/embedded/optionset2.swift
+++ b/test/embedded/optionset2.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -31,4 +30,4 @@ struct ShippingOptions: MyOptionSet {
 var s = ShippingOptions(rawValue: 42)
 print(s.isEmpty)
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)

--- a/test/embedded/optionset2.swift
+++ b/test/embedded/optionset2.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/osize-genericspecializer.swift
+++ b/test/embedded/osize-genericspecializer.swift
@@ -15,4 +15,4 @@ public func baz<T>(n: T) {
     let x: ContiguousArray<Int> = .init(repeating: 0, count: 1)
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/osize-releasedevirt.swift
+++ b/test/embedded/osize-releasedevirt.swift
@@ -11,4 +11,4 @@ public func foo() {
 func bar(_: UnsafePointer<UInt?>) {
 }
 
-// CHECK: define {{.*}}@main(
+// CHECK: define {{.*}}@{{_*}}main{{.*}}(

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -3,8 +3,7 @@
 // code, but in the embedded Swift's runtime that's somewhat reasonable thing
 // to do (but is to be avoided because of this).
 
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -18,4 +17,4 @@
 public func test() {}
 test()
 
-// CHECK: define {{.*}}i32 @main
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -3,8 +3,10 @@
 // code, but in the embedded Swift's runtime that's somewhat reasonable thing
 // to do (but is to be avoided because of this).
 
-// RUN: %target-swift-frontend -target %target-triple -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/static-object-non-darwin.swift
+++ b/test/embedded/static-object-non-darwin.swift
@@ -1,6 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -parse-as-library -module-name main -O -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
-// RUN: %target-swift-frontend -target %target-triple -parse-as-library -module-name main -Osize -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7em-none-none-eabi -parse-as-library -module-name main -O -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7em-none-none-eabi -parse-as-library -module-name main -Osize -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/static-object-non-darwin.swift
+++ b/test/embedded/static-object-non-darwin.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target armv7em-none-none-eabi -parse-as-library -module-name main -O -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
-// RUN: %target-swift-frontend -target armv7em-none-none-eabi -parse-as-library -module-name main -Osize -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -parse-as-library -module-name main -O -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -parse-as-library -module-name main -Osize -emit-ir %s -enable-experimental-feature Embedded -Xllvm -link-embedded-runtime=0 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/stdlib-array.swift
+++ b/test/embedded/stdlib-array.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -33,4 +32,4 @@ public func test() {
 
 test()
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)

--- a/test/embedded/stdlib-array.swift
+++ b/test/embedded/stdlib-array.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
@@ -46,7 +45,7 @@ public func checks(n: Int) {
   if n < 0 { assertionFailure("with message") }
 }
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)
 // CHECK: define {{.*}}i1 @"$e4main4boolSbyF"()
 // CHECK: define {{.*}}{{i32|i64}} @"$e4main3intSiyF"()
 // CHECK: define {{.*}}ptr @"$e4main3ptr1p1nS2V_SitF"(ptr %0, {{i32|i64}} %1)

--- a/test/embedded/stdlib-dictionary.swift
+++ b/test/embedded/stdlib-dictionary.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -20,4 +19,4 @@ public func test() {
 
 test()
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)

--- a/test/embedded/stdlib-dictionary.swift
+++ b/test/embedded/stdlib-dictionary.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-random.swift
+++ b/test/embedded/stdlib-random.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-random.swift
+++ b/test/embedded/stdlib-random.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -19,4 +18,4 @@ public func test() {
 
 test()
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)

--- a/test/embedded/stdlib-set.swift
+++ b/test/embedded/stdlib-set.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-set.swift
+++ b/test/embedded/stdlib-set.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -28,4 +27,4 @@ public func test() {
 
 test()
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)

--- a/test/embedded/stdlib-strings-interpolation3.swift
+++ b/test/embedded/stdlib-strings-interpolation3.swift
@@ -1,7 +1,8 @@
-// RUN: %target-swift-frontend -target %target-triple -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded
-// RUN: %target-swift-frontend -target %target-triple -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -O
-// RUN: %target-swift-frontend -target %target-triple -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -Osize
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -O
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -Osize
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM
 // REQUIRES: embedded_stdlib_cross_compiling

--- a/test/embedded/stdlib-strings-interpolation3.swift
+++ b/test/embedded/stdlib-strings-interpolation3.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -O
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -Osize
+// RUN: %target-swift-frontend -target %target-triple -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded
+// RUN: %target-swift-frontend -target %target-triple -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -O
+// RUN: %target-swift-frontend -target %target-triple -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded -Osize
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-types-riscv.swift
+++ b/test/embedded/stdlib-types-riscv.swift
@@ -6,6 +6,7 @@
 // REQUIRES: CODEGENERATOR=RISCV
 // REQUIRES: embedded_stdlib_cross_compiling
 // REQUIRES: swift_feature_Embedded
+// UNSUPPORTED: OS=wasi
 
 class MyClass {}
 

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
+// UNSUPPORTED: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-triple -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
@@ -47,4 +46,4 @@ public func test() {
 
 test()
 
-// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
+// CHECK: define {{.*}}i32 @{{_*}}main{{.*}}(i32 %0, ptr %1)

--- a/test/embedded/synchronization.swift
+++ b/test/embedded/synchronization.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -c -o %t/main.o
-// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
-// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -disable-availability-checking -wmo) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/traps-fatalerror-ir.swift
+++ b/test/embedded/traps-fatalerror-ir.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -O     -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
 // RUN: %target-swift-emit-ir -enable-experimental-feature Embedded -wmo %s -Osize -assert-config Debug | %FileCheck %s --check-prefix=CHECK-MESSAGE
 
+// XFAIL: OS=wasi
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib
 // REQUIRES: swift_stdlib_no_asserts

--- a/test/embedded/without-actually-escaping.swift
+++ b/test/embedded/without-actually-escaping.swift
@@ -2,7 +2,7 @@
 // RUN: %target-clang -x c -c %S/Inputs/unbuffered-putchar.c -o %t/unbuffered-putchar.o
 
 // RUN: %target-build-swift -enable-experimental-feature Embedded -wmo %s -Xlinker %t/unbuffered-putchar.o -o %t/a.out
-// RUN: not --crash %t/a.out 2>&1 | %FileCheck %s
+// RUN: %target-not-crash %target-run %t/a.out 2>&1 | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1276,6 +1276,7 @@ target_specific_module_triple = config.variant_triple
 target_future = target_specific_module_triple
 
 config.target_run = ''
+config.target_not_crash = 'not --crash'
 config.target_rtti_opt = '-fno-rtti'
 config.target_pic_opt = ''
 config.target_cxx_lib = '-lc++'
@@ -1284,6 +1285,7 @@ config.target_static_library_prefix = 'lib'
 config.target_static_library_suffix = '.a'
 config.target_env_prefix = ''
 config.target_sdk_libcxx_path = ''
+config.target_clang_resource_dir_opt = ''
 
 if run_vendor == 'apple':
     target_specific_module_triple = '{}-apple-{}'.format(
@@ -2061,6 +2063,8 @@ elif run_os == 'wasi':
     config.target_shared_library_suffix = ".a"
     config.target_sdk_name = "wasi"
     config.target_runtime = "native"
+    config.target_not_crash = "not"
+    config.target_clang_resource_dir_opt = f"-resource-dir {test_resource_dir}/../../../wasi-sysroot/wasm32-wasi"
 
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
 
@@ -2131,7 +2135,7 @@ elif run_os == 'wasi':
 
 elif config.external_embedded_platform:
     lit_config.note("Testing embedded platform " + config.variant_triple)
-    
+
     config.target_object_format = "elf"
     config.target_sdk_name = "embedded"
     config.target_runtime = "native"
@@ -3033,6 +3037,8 @@ config.substitutions.append(('%target-resilience-test', config.target_resilience
 config.substitutions.append(('%llvm-profdata', config.llvm_profdata))
 config.substitutions.append(('%llvm-cov', config.llvm_cov))
 config.substitutions.append(('%hmaptool', os.path.join(config.llvm_src_root, '..', 'clang', 'utils', 'hmaptool', 'hmaptool')))
+config.substitutions.append(('%target-not-crash', config.target_not_crash))
+config.substitutions.insert(0, ('%target-clang-resource-dir-opt', config.target_clang_resource_dir_opt))
 
 # Set up the host library environment.
 if hasattr(config, 'target_library_path_var'):
@@ -3154,7 +3160,7 @@ def linux_get_os_release():
     return os_id, os_release
 
 if platform.system() == 'Linux':
-    # Retrieve the Linux distro and version from `/etc/os-release`. 
+    # Retrieve the Linux distro and version from `/etc/os-release`.
     (distributor, release) = linux_get_os_release()
     if distributor == '' or release == '':
         # If `/etc/os-release` does not provide full results, fallback to `lsb_release`.

--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -82,6 +82,10 @@ class WASILibc(product.Product):
                 if not os.path.exists(dest_path):
                     shell.symlink("wasm32-wasi", dest_path)
 
+            dest_path = os.path.join(sysroot_install_path, "lib", "wasip1")
+            if not os.path.exists(dest_path):
+                shell.symlink("wasi", dest_path)
+
     @classmethod
     def get_dependencies(cls):
         return [llvm.LLVM]


### PR DESCRIPTION
These tests still require a manual `lit.py` invocation for Wasm, which will be added as a separate CMake target in a future PR.