### PR TITLE
[nonescapable] remove '@_lifetime' requirement on implicit accessors

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyMarkDependence.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyMarkDependence.swift
@@ -42,9 +42,13 @@ extension MarkDependenceAddrInst : OnoneSimplifiable, SILCombineSimplifiable {
 
 private extension MarkDependenceInstruction {
   var isRedundant: Bool {
-    if base.type.isObject && base.type.isTrivial(in: base.parentFunction) {
+    if base.type.isObject && base.type.isTrivial(in: base.parentFunction)
+         && !(base.definingInstruction is BeginApplyInst) {
       // Sometimes due to specialization/builtins, we can get a mark_dependence whose base is a trivial
       // typed object. Trivial values live forever. Therefore the mark_dependence does not have a meaning.
+      // begin_apply is a special case. A dependency on the token is limited to the coroutine scope (ideally, the token
+      // would have a non-trivial type like $Builtin.Token).
+      //
       // Note: the mark_dependence is still needed for lifetime diagnostics. So it's important that this
       //       simplification does not run before the lifetime diagnostic pass.
       return true

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
@@ -497,9 +497,17 @@ bool MoveOnlyObjectCheckerPImpl::eraseMarkWithCopiedOperand(
 
   auto replacement = cvi->getOperand();
   auto orig = replacement;
-  if (auto *copyToMoveOnly =
-          dyn_cast<CopyableToMoveOnlyWrapperValueInst>(orig)) {
-    orig = copyToMoveOnly->getOperand();
+  while (true) {
+    if (auto *copyToMoveOnly =
+        dyn_cast<CopyableToMoveOnlyWrapperValueInst>(orig)) {
+      orig = copyToMoveOnly->getOperand();
+      continue;
+    }
+    if (auto *markDep = dyn_cast<MarkDependenceInst>(orig)) {
+      orig = markDep->getValue();
+      continue;
+    }
+    break;
   }
 
   // TODO: Instead of pattern matching specific code generation patterns,

--- a/test/SILOptimizer/lifetime_dependence/accessors.swift
+++ b/test/SILOptimizer/lifetime_dependence/accessors.swift
@@ -1,0 +1,81 @@
+// RUN: %target-swift-emit-sil -enable-experimental-feature Lifetimes -primary-file %s | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+struct NE : ~Escapable {
+  let _p: UnsafeRawPointer
+
+  @_lifetime(borrow p)
+  init(_ p: UnsafeRawPointer) { self._p = p }
+}
+
+struct NCNE : ~Copyable, ~Escapable {
+  let _p: UnsafeRawPointer
+
+  @_lifetime(borrow p)
+  init(_ p: UnsafeRawPointer) {
+    self._p = p
+  }
+}
+
+struct NEStoredProp : ~Escapable {
+  var ne: NE
+  // NEStoredProp.ne.getter
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors12NEStoredPropV2neAA2NEVvg : $@convention(method) (@guaranteed NEStoredProp) -> @lifetime(copy 0) @owned NE {
+
+  // NEStoredProp.ne.setter
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors12NEStoredPropV2neAA2NEVvs : $@convention(method) (@owned NE, @lifetime(copy 0, copy 1) @inout NEStoredProp) -> () {
+
+  // NEStoredProp.ne.modify
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors12NEStoredPropV2neAA2NEVvM : $@yield_once @convention(method) (@lifetime(copy 0) @inout NEStoredProp) -> @lifetime(copy 0) @yields @inout NE {
+
+  // NEStoredProp.init(ne:)
+  // CHECK-LABEL: sil hidden @$s9accessors12NEStoredPropV2neAcA2NEV_tcfC : $@convention(method) (@owned NE, @thin NEStoredProp.Type) -> @lifetime(copy 0) @owned NEStoredProp {
+}
+
+struct NCNEStoredProp : ~Copyable & ~Escapable {
+  var ncne: NCNE
+  // NCNEStoredProp.ncne.read
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors14NCNEStoredPropV4ncneAA4NCNEVvr : $@yield_once @convention(method) (@guaranteed NCNEStoredProp) -> @lifetime(copy 0) @yields @guaranteed NCNE {
+
+  // NCNEStoredProp.ncne.setter
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors14NCNEStoredPropV4ncneAA4NCNEVvs : $@convention(method) (@owned NCNE, @lifetime(copy 0, copy 1) @inout NCNEStoredProp) -> () {
+
+  // NCNEStoredProp.ncne.modify
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors14NCNEStoredPropV4ncneAA4NCNEVvM : $@yield_once @convention(method) (@lifetime(copy 0) @inout NCNEStoredProp) -> @lifetime(copy 0) @yields @inout NCNE {
+
+  // NCNEStoredProp.init(ncne:)
+  // CHECK-LABEL: sil hidden @$s9accessors14NCNEStoredPropV4ncneAcA4NCNEV_tcfC : $@convention(method) (@owned NCNE, @thin NCNEStoredProp.Type) -> @lifetime(copy 0) @owned NCNEStoredProp {
+}
+
+struct NCNEHolder : ~Copyable, ~Escapable {
+  var p: UnsafeRawPointer
+
+  // this cannot be public in order to synthesize the _read accessor.
+  var ncneBorrow: NCNE {
+    // CHECK-LABEL: sil{{.*}} @$s9accessors10NCNEHolderV10ncneBorrowAA4NCNEVvr : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(borrow 0) @yields @guaranteed NCNE {
+    @_lifetime(borrow self)
+    borrowing get {
+      _overrideLifetime(NCNE(p), borrowing: self)
+    }
+    // CHECK-LABEL: sil{{.*}} @$s9accessors10NCNEHolderV10ncneBorrowAA4NCNEVvM : $@yield_once @convention(method) (@lifetime(copy 0) @inout NCNEHolder) -> @lifetime(borrow 0) @yields @inout NCNE {
+    @_lifetime(self: copy self)
+    set {
+      p = newValue._p
+    }
+  }
+
+  // this cannot be public in order to synthesize the _read accessor.
+  var ncneCopy: NCNE {
+    // CHECK-LABEL: sil{{.*}} @$s9accessors10NCNEHolderV8ncneCopyAA4NCNEVvr : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(copy 0) @yields @guaranteed NCNE {
+    @_lifetime(copy self)
+    borrowing get {
+      _overrideLifetime(NCNE(p), copying: self)
+    }
+    // CHECK-LABEL: sil{{.*}} @$s9accessors10NCNEHolderV8ncneCopyAA4NCNEVvM : $@yield_once @convention(method) (@lifetime(copy 0) @inout NCNEHolder) -> @lifetime(copy 0) @yields @inout NCNE {
+    @_lifetime(self: copy self)
+    set {
+      p = newValue._p
+    }
+  }
+}

--- a/test/SILOptimizer/lifetime_dependence/coroutine.swift
+++ b/test/SILOptimizer/lifetime_dependence/coroutine.swift
@@ -87,7 +87,8 @@ func use(_ o : borrowing View) {}
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [static] [[NC]]
 // CHECK:   [[NCVAL:%.*]] = load [[ACCESS]] 
 // CHECK:   ([[WRAPPER:%.*]], [[TOKEN1:%.*]]) = begin_apply %{{.*}}([[NCVAL]]) : $@yield_once @convention(method) (@guaranteed NCContainer) -> @lifetime(borrow 0) @yields @guaranteed Wrapper
-// CHECK:   [[MDI:%.*]] = mark_dependence [nonescaping] [[WRAPPER]] on [[ACCESS]]
+// CHECK:   [[SCOPE:%.*]] = mark_dependence [nonescaping] [[WRAPPER]] on [[TOKEN1]]
+// CHECK:   [[MDI:%.*]] = mark_dependence [nonescaping] [[SCOPE]] on [[ACCESS]]
 // CHECK:   retain_value [[MDI]]
 // CHECK:   debug_value [[MDI]], let, name "wrapper"
 //       let view = wrapper.view

--- a/test/SILOptimizer/moveonly_objectchecker.sil
+++ b/test/SILOptimizer/moveonly_objectchecker.sil
@@ -1,6 +1,7 @@
-// RUN: %target-sil-opt -sil-move-only-object-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-move-only-object-checker -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature Lifetimes -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage raw
 
@@ -8,14 +9,26 @@ import Swift
 
 class Klass: ~Copyable {}
 
+struct NCNE : ~Copyable, ~Escapable {}
+
+struct NCNEHolder : ~Copyable, ~Escapable {
+  var ncne: NCNE {
+    @_lifetime(borrow self)
+    get
+  }
+}
+
 sil @classUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed Klass) -> ()
+
+sil @read_ncne : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(borrow 0) @yields @guaranteed NCNE
+sil @use_ncne : $@convention(thin) (@guaranteed NCNE) -> ()
 
 // CHECK-LABEL: sil [ossa] @chainErrorTest : $@convention(thin) (@guaranteed Klass) -> () {
 // CHECK-NOT: copy_value
 // CHECK: explicit_copy_value
 // CHECK-NOT: copy_value
 // CHECK: explicit_copy_value
-// CHECK-NOT: copy_value
+// CHECK-NOT: copy_valuea
 // CHECK: } // end sil function 'chainErrorTest'
 sil [ossa] @chainErrorTest : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
@@ -50,4 +63,28 @@ bb0(%0 : @guaranteed $Klass):
   destroy_value %2 : $Klass
   %30 = tuple ()
   return %30 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testCopyOfMarkDep : $@convention(thin) (@guaranteed NCNEHolder) -> () {
+// CHECK-NOT: explicit_copy_value
+// CHECK-NOT: copy_value
+// CHECK-LABEL: } // end sil function 'testCopyOfMarkDep'
+sil [ossa] @testCopyOfMarkDep : $@convention(thin) (@guaranteed NCNEHolder) -> () {
+bb0(%0 : @guaranteed $NCNEHolder):
+  %1 = copy_value %0
+  %2 = mark_unresolved_non_copyable_value [no_consume_or_assign] %1
+  debug_value %2, let, name "h", argno 1
+  %4 = function_ref @read_ncne : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(borrow 0) @yields @guaranteed NCNE
+  (%5, %6) = begin_apply %4(%2) : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(borrow 0) @yields @guaranteed NCNE
+  %7 = mark_dependence [unresolved] %5 on %6
+  %8 = mark_dependence [unresolved] %7 on %2
+  %9 = copy_value %8
+  %10 = mark_unresolved_non_copyable_value [no_consume_or_assign] %9
+  %11 = function_ref @use_ncne : $@convention(thin) (@guaranteed NCNE) -> ()
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed NCNE) -> ()
+  destroy_value %10
+  %14 = end_apply %6 as $()
+  destroy_value %2
+  %16 = tuple ()
+  return %16
 }

--- a/test/SILOptimizer/simplify_mark_dependence.sil
+++ b/test/SILOptimizer/simplify_mark_dependence.sil
@@ -1,6 +1,6 @@
-// RUN: %target-sil-opt %s -onone-simplification -simplify-instruction=mark_dependence -enable-experimental-feature LifetimeDependence | %FileCheck %s
+// RUN: %target-sil-opt %s -onone-simplification -simplify-instruction=mark_dependence -enable-experimental-feature Lifetimes | %FileCheck %s
 
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 import Swift
 import Builtin
@@ -14,9 +14,19 @@ struct S {
 
 struct NE: ~Escapable {}
 
+struct NEHolder : ~Escapable {
+  var ne: NE {
+    @_lifetime(borrow self)
+    get
+  }
+}
+
 struct S2: ~Escapable {
   var a: NE
 }
+
+sil @read_ne : $@yield_once @convention(method) (@guaranteed NEHolder) -> @lifetime(borrow 0) @yields @guaranteed NE
+sil @use_ne : $@convention(thin) (@guaranteed NE) -> ()
 
 // CHECK-LABEL: sil [ossa] @mark_dependence_trivial_base :
 // CHECK:         %2 = copy_value %0
@@ -155,3 +165,26 @@ bb0(%0 : $*Builtin.Int64, %1 : $B):
   return %5
 }
 
+// CHECK-LABEL: sil hidden [ossa] @testChainedDependence : $@convention(thin) (@guaranteed NEHolder) -> () {
+// CHECK: bb0(%0 : @noImplicitCopy @guaranteed $NEHolder):
+// CHECK:   ([[YIELD:%[0-9]+]], [[TOKEN:%[0-9]+]]) = begin_apply %{{.*}}(%{{.*}}) : $@yield_once @convention(method) (@guaranteed NEHolder) -> @lifetime(borrow 0) @yields @guaranteed NE
+// CHECK:   [[MD1:%[0-9]+]] = mark_dependence [nonescaping] [[YIELD]] on [[TOKEN]]
+// CHECK:   mark_dependence [nonescaping] [[MD1]] on
+// CHECK-LABEL: } // end sil function 'testChainedDependence'
+sil hidden [ossa] @testChainedDependence : $@convention(thin) (@guaranteed NEHolder) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $NEHolder):
+  %2 = begin_borrow %0
+  %3 = function_ref @read_ne : $@yield_once @convention(method) (@guaranteed NEHolder) -> @lifetime(borrow 0) @yields @guaranteed NE
+  (%4, %5) = begin_apply %3(%2) : $@yield_once @convention(method) (@guaranteed NEHolder) -> @lifetime(borrow 0) @yields @guaranteed NE
+  %6 = mark_dependence [nonescaping] %4 on %5
+  %7 = mark_dependence [nonescaping] %6 on %2
+  %8 = copy_value %7
+  %9 = move_value [var_decl] %8
+  %11 = function_ref @use_ne : $@convention(thin) (@guaranteed NE) -> ()
+  %12 = apply %11(%9) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %9
+  %14 = end_apply %5 as $()
+  end_borrow %2
+  %16 = tuple ()
+  return %16
+}


### PR DESCRIPTION
And assorted tangential fixes for potential miscompiles and compiler crashes...

- **Fix MoveOnlyObjectCheckerPImpl::check() changed flag**
  Extract the special pattern matching logic that is otherwise unrelated to the
  check() function. This makes it obvious that the implementation was failing to
  set the 'changed' flag whenever needed.
  

- **Fix MoveOnlyObjectCheckerPImpl::check() for mark_dependence.**
  Handle the presence of mark_dependence instructions after a begin_apply.
  
  Fixes a compiler crash:
  "copy of noncopyable typed value. This is a compiler bug. ..."
  

- **Fix MarkDependenceInst.simplify()**
  Do not eliminate a mark_dependence on a begin_apply scope even though the token
  has a trivial type.
  
  Ideally, token would have a non-trivial Builtin type to avoid special cases.
  

- **Add lifetime dependence unit tests for syntesized accessors.**
  

- **[nonescapable] remove '@_lifetime' requirement on implicit accessors**
  This avoids diagnostic errors on synthesized accessors, which are impossible for developers to understand.
  
  Fixes rdar://153793344 (Lifetime-dependent value returned by generated accessor '_read')
  