### PR TITLE
[6.2] [nonescapable] remove '@_lifetime' requirement on implicit accessors

### DIFF
--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -464,6 +464,7 @@ protected:
     return false;
   }
 
+  // Infer ambiguous cases for backward compatibility.
   bool useLazyInference() const {
     return isInterfaceFile()
       || ctx.LangOpts.EnableExperimentalLifetimeDependenceInference;
@@ -935,7 +936,7 @@ protected:
     // Infer non-Escapable results.
     if (isDiagnosedNonEscapable(getResultOrYield())) {
       if (hasImplicitSelfParam()) {
-        // Methods and accessors that return or yield a non-Escapable value.
+        // Methods that return a non-Escapable value.
         inferNonEscapableResultOnSelf();
         return;
       }
@@ -973,32 +974,43 @@ protected:
     return true;
   }
 
-  // Infer method dependence: result depends on self. This includes _modify.
+  // Infer method dependence of result on self for
+  // methods, getters, and _modify accessors.
   void inferNonEscapableResultOnSelf() {
     auto *afd = cast<AbstractFunctionDecl>(decl);
     Type selfTypeInContext = dc->getSelfTypeInContext();
     if (selfTypeInContext->hasError()) {
       return;
     }
-    bool nonEscapableSelf = isDiagnosedNonEscapable(selfTypeInContext);
 
-    // Avoid diagnosing inference on mutating methods when 'self' is
-    // non-Escapable. The inout 'self' also needs an inferred dependence on
-    // itself. This will be diagnosed when checking for missing dependencies.
-    if (nonEscapableSelf && afd->getImplicitSelfDecl()->isInOut()) {
-      if (auto accessor = dyn_cast<AccessorDecl>(afd)) {
-        inferMutatingAccessor(accessor);
+    bool nonEscapableSelf = isDiagnosedNonEscapable(selfTypeInContext);
+    if (auto accessor = dyn_cast<AccessorDecl>(afd)) {
+      if (isImplicitOrSIL() || useLazyInference()) {
+        if (nonEscapableSelf && afd->getImplicitSelfDecl()->isInOut()) {
+          // Implicit accessors that return or yield a non-Escapable value may
+          // infer dependency on both self and result.
+          inferMutatingAccessor(accessor);
+        }
+        // Infer the result dependency on self based on the kind of accessor
+        // that is wrapped by this synthesized accessors.
+        if (auto dependenceKind =
+            getAccessorDependence(accessor, selfTypeInContext)) {
+          pushDeps(createDeps(resultIndex).add(selfIndex, *dependenceKind));
+        }
+        return;
       }
+      // Explicit accessors are inferred the same way as regular methods.
+    }
+    // Do infer the result of a mutating method when 'self' is
+    // non-Escapable. The missing dependence on inout 'self' will be diagnosed
+    // later anyway, so an explicit annotation will still be needed.
+    if (nonEscapableSelf && afd->getImplicitSelfDecl()->isInOut()) {
       return;
     }
-
     // Methods with parameters only apply to lazy inference.
     if (!useLazyInference() && afd->getParameters()->size() > 0) {
       return;
     }
-    // Allow inference for implicit getters, which simply return a stored,
-    // property, and for implicit _read/_modify, which cannot be defined
-    // explicitly alongside a regular getter.
     if (!useLazyInference() && !isImplicitOrSIL()) {
       // Require explicit @_lifetime(borrow self) for UnsafePointer-like self.
       if (!nonEscapableSelf && isBitwiseCopyable(selfTypeInContext, ctx)) {
@@ -1014,9 +1026,12 @@ protected:
         return;
       }
     }
+    // Infer based on ownership if possible for either explicit accessors or
+    // methods as long as they pass preceding ambiguity checks.
     auto kind = inferLifetimeDependenceKind(
         selfTypeInContext, afd->getImplicitSelfDecl()->getValueOwnership());
     if (!kind) {
+      // Special diagnostic for an attempt to depend on a consuming parameter.
       diagnose(returnLoc,
                diag::lifetime_dependence_cannot_infer_scope_ownership,
                "self", diagnosticQualifier());
@@ -1025,6 +1040,8 @@ protected:
     pushDeps(createDeps(resultIndex).add(selfIndex, *kind));
   }
 
+  // Infer the kind of dependence that makes sense for reading or writing a
+  // stored property (for getters or initializers).
   std::optional<LifetimeDependenceKind>
   inferLifetimeDependenceKind(Type sourceType, ValueOwnership ownership) {
     auto *afd = cast<AbstractFunctionDecl>(decl);
@@ -1039,8 +1056,9 @@ protected:
     auto loweredOwnership = ownership != ValueOwnership::Default
                                 ? ownership
                                 : getLoweredOwnership(afd);
-    if (loweredOwnership != ValueOwnership::Shared &&
-        loweredOwnership != ValueOwnership::InOut) {
+    // It is impossible to depend on a consumed Escapable value (unless it is
+    // BitwiseCopyable as checked above).
+    if (loweredOwnership == ValueOwnership::Owned) {
       return std::nullopt;
     }
     return LifetimeDependenceKind::Scope;
@@ -1194,7 +1212,10 @@ protected:
     // Handle implicit setters before diagnosing mutating methods. This
     // does not include global accessors, which have no implicit 'self'.
     if (auto accessor = dyn_cast<AccessorDecl>(afd)) {
-      inferMutatingAccessor(accessor);
+      // Explicit setters require explicit lifetime dependencies.
+      if (isImplicitOrSIL() || useLazyInference()) {
+        inferMutatingAccessor(accessor);
+      }
       return;
     }
     if (afd->getParameters()->size() > 0) {
@@ -1211,13 +1232,31 @@ protected:
                                        LifetimeDependenceKind::Inherit));
   }
 
+  // Infer dependence for an accessor whose non-escapable result depends on
+  // self. This includes _read and _modify.
+  void inferAccessor(AccessorDecl *accessor, Type selfTypeInContext) {
+    // Explicit accessors require explicit lifetime dependencies.
+    auto *afd = cast<AbstractFunctionDecl>(decl);
+    if (!isImplicitOrSIL() && !useLazyInference()) {
+      return;
+    }
+    bool nonEscapableSelf = isDiagnosedNonEscapable(selfTypeInContext);
+    if (nonEscapableSelf && afd->getImplicitSelfDecl()->isInOut()) {
+      // First, infer the dependency on the inout non-Escapable self. This may
+      // result in two inferred dependencies for accessors.
+      inferMutatingAccessor(accessor);
+    }
+    // Infer the result dependency on self based on the kind of accessor that
+    // is wrapped by this synthesized accessors.
+    if (auto dependenceKind =
+        getAccessorDependence(accessor, selfTypeInContext)) {
+      pushDeps(createDeps(resultIndex).add(selfIndex, *dependenceKind));
+    }
+  }
+
   // Infer a mutating accessor's non-Escapable 'self' dependencies.
   void inferMutatingAccessor(AccessorDecl *accessor) {
     auto *afd = cast<AbstractFunctionDecl>(decl);
-    if (!isImplicitOrSIL() && !useLazyInference()) {
-      // Explicit setters require explicit lifetime dependencies.
-      return;
-    }
     switch (accessor->getAccessorKind()) {
     case AccessorKind::Read:
     case AccessorKind::Read2:
@@ -1234,8 +1273,6 @@ protected:
       // _modify for them even though it won't be emitted.
       pushDeps(createDeps(selfIndex).add(selfIndex,
                                          LifetimeDependenceKind::Inherit));
-      pushDeps(createDeps(resultIndex).add(selfIndex,
-                                           LifetimeDependenceKind::Scope));
       break;
     case AccessorKind::Set: {
       const unsigned newValIdx = 0;
@@ -1255,7 +1292,7 @@ protected:
       // dependency, so the setter cannot depend on 'newValue'.
       if (!paramTypeInContext->isEscapable()) {
         targetDeps = std::move(targetDeps)
-          .add(newValIdx, LifetimeDependenceKind::Inherit);
+                         .add(newValIdx, LifetimeDependenceKind::Inherit);
       }
       pushDeps(std::move(targetDeps));
       break;
@@ -1275,6 +1312,55 @@ protected:
       // Unknown mutating accessor.
       break;
     }
+  }
+
+  // Implicit accessors must be consistent with the accessor that they
+  // wrap. Otherwise, the sythesized implementation will report a diagnostic
+  // error.
+  std::optional<LifetimeDependenceKind>
+  getAccessorDependence(AccessorDecl *accessor, Type selfTypeInContext) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
+    std::optional<AccessorKind> wrappedAccessorKind = std::nullopt;
+    switch (accessor->getAccessorKind()) {
+    case AccessorKind::Read:
+    case AccessorKind::Read2:
+    case AccessorKind::Modify:
+    case AccessorKind::Modify2:
+      // read/modify are syntesized as calls to the getter.
+      wrappedAccessorKind = AccessorKind::Get;
+      break;
+    case AccessorKind::Get:
+      // getters are synthesized as access to a stored property.
+      break;
+    default:
+      // Unknown synthesized accessor.
+      // Setters are handled in inferMutatingAccessor() because they don't
+      // return a value.
+      return std::nullopt;
+    }
+    if (wrappedAccessorKind) {
+      auto *var = cast<VarDecl>(accessor->getStorage());
+      for (auto *wrappedAccessor : var->getAllAccessors()) {
+        if (wrappedAccessor->isImplicit())
+          continue;
+        if (wrappedAccessor->getAccessorKind() == wrappedAccessorKind) {
+          if (auto deps = wrappedAccessor->getLifetimeDependencies()) {
+            for (auto &dep : *deps) {
+              if (dep.getTargetIndex() != resultIndex)
+                continue;
+              if (dep.checkInherit(selfIndex))
+                return LifetimeDependenceKind::Inherit;
+              if (dep.checkScope(selfIndex))
+                return LifetimeDependenceKind::Scope;
+            }
+          }
+        }
+      }
+    }
+    // Either a Get or Modify without any wrapped accessor. Handle these like a
+    // read of the stored property.
+    return inferLifetimeDependenceKind(
+      selfTypeInContext, afd->getImplicitSelfDecl()->getValueOwnership());
   }
 
   // Infer 'inout' parameter dependency when the only parameter is

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
@@ -497,9 +497,17 @@ bool MoveOnlyObjectCheckerPImpl::eraseMarkWithCopiedOperand(
 
   auto replacement = cvi->getOperand();
   auto orig = replacement;
-  if (auto *copyToMoveOnly =
-          dyn_cast<CopyableToMoveOnlyWrapperValueInst>(orig)) {
-    orig = copyToMoveOnly->getOperand();
+  while (true) {
+    if (auto *copyToMoveOnly =
+        dyn_cast<CopyableToMoveOnlyWrapperValueInst>(orig)) {
+      orig = copyToMoveOnly->getOperand();
+      continue;
+    }
+    if (auto *markDep = dyn_cast<MarkDependenceInst>(orig)) {
+      orig = markDep->getValue();
+      continue;
+    }
+    break;
   }
 
   // TODO: Instead of pattern matching specific code generation patterns,

--- a/test/SILOptimizer/lifetime_dependence/accessors.swift
+++ b/test/SILOptimizer/lifetime_dependence/accessors.swift
@@ -1,0 +1,81 @@
+// RUN: %target-swift-emit-sil -enable-experimental-feature Lifetimes -primary-file %s | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+struct NE : ~Escapable {
+  let _p: UnsafeRawPointer
+
+  @_lifetime(borrow p)
+  init(_ p: UnsafeRawPointer) { self._p = p }
+}
+
+struct NCNE : ~Copyable, ~Escapable {
+  let _p: UnsafeRawPointer
+
+  @_lifetime(borrow p)
+  init(_ p: UnsafeRawPointer) {
+    self._p = p
+  }
+}
+
+struct NEStoredProp : ~Escapable {
+  var ne: NE
+  // NEStoredProp.ne.getter
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors12NEStoredPropV2neAA2NEVvg : $@convention(method) (@guaranteed NEStoredProp) -> @lifetime(copy 0) @owned NE {
+
+  // NEStoredProp.ne.setter
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors12NEStoredPropV2neAA2NEVvs : $@convention(method) (@owned NE, @lifetime(copy 0, copy 1) @inout NEStoredProp) -> () {
+
+  // NEStoredProp.ne.modify
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors12NEStoredPropV2neAA2NEVvM : $@yield_once @convention(method) (@lifetime(copy 0) @inout NEStoredProp) -> @lifetime(copy 0) @yields @inout NE {
+
+  // NEStoredProp.init(ne:)
+  // CHECK-LABEL: sil hidden @$s9accessors12NEStoredPropV2neAcA2NEV_tcfC : $@convention(method) (@owned NE, @thin NEStoredProp.Type) -> @lifetime(copy 0) @owned NEStoredProp {
+}
+
+struct NCNEStoredProp : ~Copyable & ~Escapable {
+  var ncne: NCNE
+  // NCNEStoredProp.ncne.read
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors14NCNEStoredPropV4ncneAA4NCNEVvr : $@yield_once @convention(method) (@guaranteed NCNEStoredProp) -> @lifetime(copy 0) @yields @guaranteed NCNE {
+
+  // NCNEStoredProp.ncne.setter
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors14NCNEStoredPropV4ncneAA4NCNEVvs : $@convention(method) (@owned NCNE, @lifetime(copy 0, copy 1) @inout NCNEStoredProp) -> () {
+
+  // NCNEStoredProp.ncne.modify
+  // CHECK-LABEL: sil hidden [transparent] @$s9accessors14NCNEStoredPropV4ncneAA4NCNEVvM : $@yield_once @convention(method) (@lifetime(copy 0) @inout NCNEStoredProp) -> @lifetime(copy 0) @yields @inout NCNE {
+
+  // NCNEStoredProp.init(ncne:)
+  // CHECK-LABEL: sil hidden @$s9accessors14NCNEStoredPropV4ncneAcA4NCNEV_tcfC : $@convention(method) (@owned NCNE, @thin NCNEStoredProp.Type) -> @lifetime(copy 0) @owned NCNEStoredProp {
+}
+
+struct NCNEHolder : ~Copyable, ~Escapable {
+  var p: UnsafeRawPointer
+
+  // this cannot be public in order to synthesize the _read accessor.
+  var ncneBorrow: NCNE {
+    // CHECK-LABEL: sil{{.*}} @$s9accessors10NCNEHolderV10ncneBorrowAA4NCNEVvr : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(borrow 0) @yields @guaranteed NCNE {
+    @_lifetime(borrow self)
+    borrowing get {
+      _overrideLifetime(NCNE(p), borrowing: self)
+    }
+    // CHECK-LABEL: sil{{.*}} @$s9accessors10NCNEHolderV10ncneBorrowAA4NCNEVvM : $@yield_once @convention(method) (@lifetime(copy 0) @inout NCNEHolder) -> @lifetime(borrow 0) @yields @inout NCNE {
+    @_lifetime(self: copy self)
+    set {
+      p = newValue._p
+    }
+  }
+
+  // this cannot be public in order to synthesize the _read accessor.
+  var ncneCopy: NCNE {
+    // CHECK-LABEL: sil{{.*}} @$s9accessors10NCNEHolderV8ncneCopyAA4NCNEVvr : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(copy 0) @yields @guaranteed NCNE {
+    @_lifetime(copy self)
+    borrowing get {
+      _overrideLifetime(NCNE(p), copying: self)
+    }
+    // CHECK-LABEL: sil{{.*}} @$s9accessors10NCNEHolderV8ncneCopyAA4NCNEVvM : $@yield_once @convention(method) (@lifetime(copy 0) @inout NCNEHolder) -> @lifetime(copy 0) @yields @inout NCNE {
+    @_lifetime(self: copy self)
+    set {
+      p = newValue._p
+    }
+  }
+}

--- a/test/SILOptimizer/moveonly_objectchecker.sil
+++ b/test/SILOptimizer/moveonly_objectchecker.sil
@@ -1,6 +1,7 @@
-// RUN: %target-sil-opt -sil-move-only-object-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-move-only-object-checker -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature Lifetimes -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
 
 // REQUIRES: swift_feature_MoveOnlyClasses
+// REQUIRES: swift_feature_Lifetimes
 
 sil_stage raw
 
@@ -8,14 +9,26 @@ import Swift
 
 class Klass: ~Copyable {}
 
+struct NCNE : ~Copyable, ~Escapable {}
+
+struct NCNEHolder : ~Copyable, ~Escapable {
+  var ncne: NCNE {
+    @_lifetime(borrow self)
+    get
+  }
+}
+
 sil @classUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed Klass) -> ()
+
+sil @read_ncne : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(borrow 0) @yields @guaranteed NCNE
+sil @use_ncne : $@convention(thin) (@guaranteed NCNE) -> ()
 
 // CHECK-LABEL: sil [ossa] @chainErrorTest : $@convention(thin) (@guaranteed Klass) -> () {
 // CHECK-NOT: copy_value
 // CHECK: explicit_copy_value
 // CHECK-NOT: copy_value
 // CHECK: explicit_copy_value
-// CHECK-NOT: copy_value
+// CHECK-NOT: copy_valuea
 // CHECK: } // end sil function 'chainErrorTest'
 sil [ossa] @chainErrorTest : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
@@ -50,4 +63,28 @@ bb0(%0 : @guaranteed $Klass):
   destroy_value %2 : $Klass
   %30 = tuple ()
   return %30 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testCopyOfMarkDep : $@convention(thin) (@guaranteed NCNEHolder) -> () {
+// CHECK-NOT: explicit_copy_value
+// CHECK-NOT: copy_value
+// CHECK-LABEL: } // end sil function 'testCopyOfMarkDep'
+sil [ossa] @testCopyOfMarkDep : $@convention(thin) (@guaranteed NCNEHolder) -> () {
+bb0(%0 : @guaranteed $NCNEHolder):
+  %1 = copy_value %0
+  %2 = mark_unresolved_non_copyable_value [no_consume_or_assign] %1
+  debug_value %2, let, name "h", argno 1
+  %4 = function_ref @read_ncne : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(borrow 0) @yields @guaranteed NCNE
+  (%5, %6) = begin_apply %4(%2) : $@yield_once @convention(method) (@guaranteed NCNEHolder) -> @lifetime(borrow 0) @yields @guaranteed NCNE
+  %7 = mark_dependence [unresolved] %5 on %6
+  %8 = mark_dependence [unresolved] %7 on %2
+  %9 = copy_value %8
+  %10 = mark_unresolved_non_copyable_value [no_consume_or_assign] %9
+  %11 = function_ref @use_ncne : $@convention(thin) (@guaranteed NCNE) -> ()
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed NCNE) -> ()
+  destroy_value %10
+  %14 = end_apply %6 as $()
+  destroy_value %2
+  %16 = tuple ()
+  return %16
 }

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -1,6 +1,7 @@
-// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -enable-sil-verify-all %s -sil-combine -sil-combine-disable-alloc-stack-opts -enable-experimental-feature Lifetimes | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
 
 import Swift
 import Builtin
@@ -26,6 +27,18 @@ class Klass {}
 protocol FakeProtocol {
   func requirement()
 }
+
+struct NE: ~Escapable {}
+
+struct NEHolder : ~Escapable {
+  var ne: NE {
+    @_lifetime(borrow self)
+    get
+  }
+}
+
+sil @read_ne : $@yield_once @convention(method) (@guaranteed NEHolder) -> @lifetime(borrow 0) @yields @guaranteed NE
+sil @use_ne : $@convention(thin) (@guaranteed NE) -> ()
 
 /////////////////////////////////
 // Tests for SILCombinerApply. //
@@ -1018,4 +1031,28 @@ bb3:
   strong_release %0 : ${ var Int64 }
   %rv = tuple()
   return %rv : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @testChainedDependence : $@convention(thin) (@guaranteed NEHolder) -> () {
+// CHECK: bb0(%0 : @noImplicitCopy @guaranteed $NEHolder):
+// CHECK:   ([[YIELD:%[0-9]+]], [[TOKEN:%[0-9]+]]) = begin_apply %{{.*}}(%{{.*}}) : $@yield_once @convention(method) (@guaranteed NEHolder) -> @lifetime(borrow 0) @yields @guaranteed NE
+// CHECK:   [[MD1:%[0-9]+]] = mark_dependence [nonescaping] [[YIELD]] : $NE on [[TOKEN]]
+// CHECK:   mark_dependence [nonescaping] [[MD1]]
+// CHECK-LABEL: } // end sil function 'testChainedDependence'
+sil hidden [ossa] @testChainedDependence : $@convention(thin) (@guaranteed NEHolder) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $NEHolder):
+  %2 = begin_borrow %0
+  %3 = function_ref @read_ne : $@yield_once @convention(method) (@guaranteed NEHolder) -> @lifetime(borrow 0) @yields @guaranteed NE
+  (%4, %5) = begin_apply %3(%2) : $@yield_once @convention(method) (@guaranteed NEHolder) -> @lifetime(borrow 0) @yields @guaranteed NE
+  %6 = mark_dependence [nonescaping] %4 on %5
+  %7 = mark_dependence [nonescaping] %6 on %2
+  %8 = copy_value %7
+  %9 = move_value [var_decl] %8
+  %11 = function_ref @use_ne : $@convention(thin) (@guaranteed NE) -> ()
+  %12 = apply %11(%9) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %9
+  %14 = end_apply %5 as $()
+  end_borrow %2
+  %16 = tuple ()
+  return %16
 }


### PR DESCRIPTION
- **Fix SILCombine of MarkDependenceInst.**
  Do not eliminate a mark_dependence on a begin_apply scope even though the token
  has a trivial type.
  
  Ideally, token would have a non-trivial Builtin type to avoid special cases.
  
  (only relevant on 6.2)
  

- **Fix MoveOnlyObjectCheckerPImpl::check() changed flag**
  Extract the special pattern matching logic that is otherwise unrelated to the
  check() function. This makes it obvious that the implementation was failing to
  set the 'changed' flag whenever needed.
  
  (cherry picked from commit c41715ce8c2f5ddc9a07807d2ba9cd9ea2375a5e)
  

- **Fix MoveOnlyObjectCheckerPImpl::check() for mark_dependence.**
  Handle the presence of mark_dependence instructions after a begin_apply.
  
  Fixes a compiler crash:
  "copy of noncopyable typed value. This is a compiler bug. ..."
  
  (cherry picked from commit 7a29d9d8b6ecd0e8bbca814ee034881b9e533550)
  

- **[nonescapable] remove '@_lifetime' requirement on implicit accessors**
  This avoids diagnostic errors on synthesized accessors, which are impossible for developers to understand.
  
  Fixes rdar://153793344 (Lifetime-dependent value returned by generated accessor '_read')
  
  (cherry picked from commit 855b3e44463a9ba83a4e4241561d08117f962559)

--- CCC ---

Explanation: Fix lifetime inference for synthesized accessors. Otherwise the diagnostics not actionable because they don't point to real source locations. It is always safe to infer for synthesized code because the compiler knows what is being generated. Tangentially, fix a potential miscompile in instruction simplification and frequent compiler crash in the move checker that were blocking this fix.

Scope: Affects most users of the supported Lifetimes feature when combining ~Copyable with ~Escapable types.

Radar/SR Issue: rdar://153793344 (Lifetime-dependent value returned by generated accessor '_read')

main PR: https://github.com/swiftlang/swift/pull/82404

Risk: Low

- a simple optimization is disabled under a very specific condition that only applies to non-escapable types.

- the move checker now handles the presence of a mark_dependence instruction where previously it would always crash in that case. This is only expected to occur with non-escapable types.

- lifetime diagnostics now handle synthesized accessors which developers are unaware of. This only loosens diagnostics to accept more cases that the compiler itself generates, not user code.

Testing: Added source and SIL unit tests

Reviewer: Meghana Gupta
