### PR TITLE
Fix lifetime dependence diagnostics on Void types.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -199,9 +199,16 @@ private struct DiagnoseDependence {
     if function.hasUnsafeNonEscapableResult {
       return .continueWalk
     }
-    // If the dependence scope is global, then it has immortal lifetime.
-    if case .global = dependence.scope {
+    // Check for immortal lifetime.
+    switch dependence.scope {
+    case .global:
       return .continueWalk
+    case let .unknown(value):
+      if value.type.isVoid {
+        return .continueWalk
+      }
+    default:
+      break
     }
     // Check that the parameter dependence for this result is the same
     // as the current dependence scope.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
@@ -118,7 +118,7 @@ extension ForwardingUseDefWalker {
   }
   mutating func walkUpDefault(forwarded value: Value, _ path: PathContext)
     -> WalkResult {
-    if let inst = value.forwardingInstruction {
+    if let inst = value.forwardingInstruction, !inst.forwardedOperands.isEmpty {
       return walkUp(instruction: inst, path)
     }
     if let phi = Phi(value) {

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -106,6 +106,11 @@ public struct NEInt: ~Escapable {
   init(owner: borrowing NCInt) {
     self.i = owner.i
   }
+
+  @_lifetime(immortal)
+  init(immortal i: Int) {
+    self.i = i
+  }
 }
 
 struct TestDeinitCallsAddressor: ~Copyable, ~Escapable {
@@ -227,4 +232,14 @@ class ClassStorage {
     let ne = self.nc!.getNE()
     _ = ne
   }
+}
+
+// =============================================================================
+// Immortal
+// =============================================================================
+
+@_lifetime(immortal)
+func testVoid() -> NEInt {
+  let ne = NEInt(immortal: 3)
+  return _overrideLifetime(ne, borrowing: ())
 }


### PR DESCRIPTION
- **Fix lifetime diagnotics on an empty tuple.**
  Consider an empty tuple to be a value introducer rather than a forwarding
  instruction.
  
  Fixes rdar://153978086 ([nonescapable] compiler crash with dependency on an
  expression)
  

- **Fix lifetime dependence diagnostics on Void types.**
  Allow a dependence on Void to be considered immortal. This is the ultimate
  override in cases where no other code pattern is supported yet.
  