### PR TITLE
[6.2] Fix lifetime dependence diagnostics on Void types.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -199,9 +199,16 @@ private struct DiagnoseDependence {
     if function.hasUnsafeNonEscapableResult {
       return .continueWalk
     }
-    // If the dependence scope is global, then it has immortal lifetime.
-    if case .global = dependence.scope {
+    // Check for immortal lifetime.
+    switch dependence.scope {
+    case .global:
       return .continueWalk
+    case let .unknown(value):
+      if value.type.isVoid {
+        return .continueWalk
+      }
+    default:
+      break
     }
     // Check that the parameter dependence for this result is the same
     // as the current dependence scope.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
@@ -118,7 +118,7 @@ extension ForwardingUseDefWalker {
   }
   mutating func walkUpDefault(forwarded value: Value, _ path: PathContext)
     -> WalkResult {
-    if let inst = value.forwardingInstruction {
+    if let inst = value.forwardingInstruction, !inst.forwardedOperands.isEmpty {
       return walkUp(instruction: inst, path)
     }
     if let phi = Phi(value) {

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -106,6 +106,11 @@ public struct NEInt: ~Escapable {
   init(owner: borrowing NCInt) {
     self.i = owner.i
   }
+
+  @_lifetime(immortal)
+  init(immortal i: Int) {
+    self.i = i
+  }
 }
 
 struct TestDeinitCallsAddressor: ~Copyable, ~Escapable {
@@ -227,4 +232,14 @@ class ClassStorage {
     let ne = self.nc!.getNE()
     _ = ne
   }
+}
+
+// =============================================================================
+// Immortal
+// =============================================================================
+
+@_lifetime(immortal)
+func testVoid() -> NEInt {
+  let ne = NEInt(immortal: 3)
+  return _overrideLifetime(ne, borrowing: ())
 }


### PR DESCRIPTION
- **Fix lifetime diagnotics on an empty tuple.**
  Consider an empty tuple to be a value introducer rather than a forwarding
  instruction.
  
  Fixes rdar://153978086 ([nonescapable] compiler crash with dependency on an
  expression)
  
  (cherry picked from commit bcc4a78c4273ff7d68b7ba5a07d1c816b7d08089)
  

- **Fix lifetime dependence diagnostics on Void types.**
  Allow a dependence on Void to be considered immortal. This is the ultimate
  override in cases where no other code pattern is supported yet.
  
  (cherry picked from commit 36d2b5bee4ac0e4f32bbfad9156015347e7914c2)

--- CCC ---

Explanation: Fix lifetime dependence diagnostics on Void
types. Previously, the compiler would crash. This is important because
it is the only escape hatch for overriding lifetimes in patterns that
aren't yet safely handled.

Scope: Affects users of the supported Lifetimes feature when using
_overrideLifetime. This comes up quickly when building nonescapable
types on top of an unsafe layer.

Radar/SR Issue: rdar://153978086 ([nonescapable] compiler crash with dependency on an expression)

main PR: https://github.com/swiftlang/swift/pull/82408

Risk: Low

Testing: Added a unit test

Reviewer: Meghana Gupta
