### PR TITLE
[cxx-interop] Fix printing of namespaces declared in bridging headers

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2740,6 +2740,10 @@ static void addNamespaceMembers(Decl *decl,
     declOwner = declOwner->getTopLevelModule();
   auto Redecls = llvm::SmallVector<clang::NamespaceDecl *, 2>(namespaceDecl->redecls());
   std::stable_sort(Redecls.begin(), Redecls.end(), [&](clang::NamespaceDecl *LHS, clang::NamespaceDecl *RHS) {
+    // A namespace redeclaration will not have an owning Clang module if it is
+    // declared in a bridging header.
+    if (!LHS->getOwningModule() || !RHS->getOwningModule())
+      return (bool)LHS->getOwningModule() < (bool)RHS->getOwningModule();
     return LHS->getOwningModule()->Name < RHS->getOwningModule()->Name;
   });
   for (auto redecl : Redecls) {

--- a/test/Interop/Cxx/namespace/Inputs/bridging-header.h
+++ b/test/Interop/Cxx/namespace/Inputs/bridging-header.h
@@ -1,0 +1,15 @@
+namespace NS1 {
+namespace NS2 {
+
+struct InBridgingHeader1 {};
+
+} // namespace NS2
+} // namespace NS1
+
+namespace NS1 {
+namespace NS2 {
+
+struct InBridgingHeader2 {};
+
+} // namespace NS2
+} // namespace NS1

--- a/test/Interop/Cxx/namespace/bridging-header-module-interface.swift
+++ b/test/Interop/Cxx/namespace/bridging-header-module-interface.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -print-header -header-to-print %S/Inputs/bridging-header.h -import-objc-header %S/Inputs/bridging-header.h -source-filename=%s -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: struct InBridgingHeader1
+// CHECK: struct InBridgingHeader2


### PR DESCRIPTION
If a C++ namespace has redeclarations in a bridging header, printing AST for the namespace would crash the compiler. This is because such a redeclaration would not have an owning Clang module, and the AST printer did not account for that.

This change fixes the crash.

rdar://151715540

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
