### PR TITLE
Runtimes: adjust for incorrect Android behaviour

### DIFF
--- a/Runtimes/Overlay/Android/clang/CMakeLists.txt
+++ b/Runtimes/Overlay/Android/clang/CMakeLists.txt
@@ -32,7 +32,7 @@ install(FILES
   android.modulemap
   SwiftAndroidNDK.h
   SwiftBionic.h
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SwiftOverlay_PLATFORM_SUBDIR}/${SwiftOverlay_ARCH_SUBDIR})
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/swift/${SwiftOverlay_PLATFORM_SUBDIR}/${SwiftOverlay_ARCH_SUBDIR})
 
 install(FILES
   posix_filesystem.apinotes


### PR DESCRIPTION
The runtime mixes `swift` and `swift_static` SDK layouts when building Swift code on Android. The overlay is always referenced in `swift` and never from `swift_static`. Adjust the layout to match the driver.