### PR TITLE
🍒[cxx-interop] Fix printing of namespaces declared in bridging headers

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2737,6 +2737,10 @@ static void addNamespaceMembers(Decl *decl,
     declOwner = declOwner->getTopLevelModule();
   auto Redecls = llvm::SmallVector<clang::NamespaceDecl *, 2>(namespaceDecl->redecls());
   std::stable_sort(Redecls.begin(), Redecls.end(), [&](clang::NamespaceDecl *LHS, clang::NamespaceDecl *RHS) {
+    // A namespace redeclaration will not have an owning Clang module if it is
+    // declared in a bridging header.
+    if (!LHS->getOwningModule() || !RHS->getOwningModule())
+      return (bool)LHS->getOwningModule() < (bool)RHS->getOwningModule();
     return LHS->getOwningModule()->Name < RHS->getOwningModule()->Name;
   });
   for (auto redecl : Redecls) {

--- a/test/Interop/Cxx/namespace/Inputs/bridging-header.h
+++ b/test/Interop/Cxx/namespace/Inputs/bridging-header.h
@@ -1,0 +1,15 @@
+namespace NS1 {
+namespace NS2 {
+
+struct InBridgingHeader1 {};
+
+} // namespace NS2
+} // namespace NS1
+
+namespace NS1 {
+namespace NS2 {
+
+struct InBridgingHeader2 {};
+
+} // namespace NS2
+} // namespace NS1

--- a/test/Interop/Cxx/namespace/bridging-header-module-interface.swift
+++ b/test/Interop/Cxx/namespace/bridging-header-module-interface.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -print-header -header-to-print %S/Inputs/bridging-header.h -import-objc-header %S/Inputs/bridging-header.h -source-filename=%s -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: struct InBridgingHeader1
+// CHECK: struct InBridgingHeader2


### PR DESCRIPTION
  - **Explanation**: If a C++ namespace has redeclarations in a bridging header, printing AST for the namespace would crash the compiler. This is because such a redeclaration would not have an owning Clang module, and the AST printer did not account for that.
  - **Scope**: This change adds a null check in AST printer.
  - **Issues**: rdar://151715540
  - **Original PRs**: https://github.com/swiftlang/swift/pull/82413
  - **Risk**: Low, this only changes a code path that would previously crash.
  - **Testing**: Added a compiler test.
  - **Reviewers**: @QuietMisdreavus @Xazax-hun @j-hui 