### PR TITLE
[region-isolation] Fix crash due to missing visitVectorBaseAddrInst case

### DIFF
--- a/test/Concurrency/regionanalysis_trackable_value.sil
+++ b/test/Concurrency/regionanalysis_trackable_value.sil
@@ -682,3 +682,44 @@ bb3:
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on alloc_stack_inline_array_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: no][is_sendable: yes][region_value_kind: disconnected].
+// CHECK:     Rep Value: %2 = vector_base_addr %1
+// CHECK: end running test 1 of 1 on alloc_stack_inline_array_sendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @alloc_stack_inline_array_sendable : $@convention(thin) () -> () {
+bb0:
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %0 = alloc_stack $InlineArray<1, UInt8>
+  %1 = struct_element_addr %0: $*InlineArray<1, UInt8>, #InlineArray._storage
+  %2 = vector_base_addr %1 : $*Builtin.FixedArray<1, UInt8>
+  %3 = integer_literal $Builtin.Int8, 0
+  %4 = struct $UInt8 (%3)
+  store %4 to [trivial] %2
+  %6 = load [trivial] %0
+  dealloc_stack %0
+  debug_value [trace] %2
+
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on alloc_stack_inline_array_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+// CHECK: TrackableValue. State: TrackableValueState[id: 0][is_no_alias: yes][is_sendable: no][region_value_kind: disconnected].
+// CHECK:     Rep Value: %1 = alloc_stack $InlineArray
+// CHECK: end running test 1 of 1 on alloc_stack_inline_array_nonsendable: sil_regionanalysis_underlying_tracked_value with: @trace[0]
+sil [ossa] @alloc_stack_inline_array_nonsendable : $@convention(thin) (@owned NonSendableKlass) -> () {
+bb0(%arg : @owned $NonSendableKlass):
+  specify_test "sil_regionanalysis_underlying_tracked_value @trace[0]"
+  %0 = alloc_stack $InlineArray<1, NonSendableKlass>
+  %1 = struct_element_addr %0: $*InlineArray<1, NonSendableKlass>, #InlineArray._storage
+  %2 = vector_base_addr %1 : $*Builtin.FixedArray<1, NonSendableKlass>
+  store %arg to [init] %2
+  %6 = load [take] %0
+  destroy_value %6
+  dealloc_stack %0
+  debug_value [trace] %2
+
+  %7 = tuple ()
+  return %7 : $()
+}

--- a/test/Concurrency/transfernonsendable_rbi_result.swift
+++ b/test/Concurrency/transfernonsendable_rbi_result.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -parse-as-library %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
@@ -134,4 +134,9 @@ func callActorFuncsFromNonisolated(a : A, ns : NonSendable) async {
 func testGenericResults() async {
   let _: NonSendable = await mainActorGenericReturnNonSendable()
   // expected-error @-1 {{non-Sendable 'NonSendable'-typed result can not be returned from main actor-isolated global function 'mainActorGenericReturnNonSendable()' to nonisolated context}}
+}
+
+// https://github.com/swiftlang/swift/issues/81534
+func testInlineArray() {
+  let _: InlineArray<_, UInt8> = [0]
 }


### PR DESCRIPTION
Credit to https://github.com/stzn for initial work on the patch.

rdar://151401230