### PR TITLE
[Test] Disable IRGen/generic_tuples.swift on arm64e

### DIFF
--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -4,6 +4,7 @@
 // RUN: %target-swift-frontend -module-name generic_tuples -emit-ir -O %s
 
 // REQUIRES: PTRSIZE=64
+// UNSUPPORTED: CPU=arm64e
 
 // CHECK-DAG: [[OPAQUE:%swift.opaque]] = type opaque
 // CHECK-DAG: [[TUPLE_TYPE:%swift.tuple_type]] = type { %swift.type, i64, ptr, [0 x %swift.tuple_element_type] }


### PR DESCRIPTION
rdar://153961233

This test will fail on arm64e targets, because ptrauth is not handled.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
