### PR TITLE
[CSSimplify] Prevent `missing call` fix from recording fixes while ma…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5365,6 +5365,11 @@ bool ConstraintSystem::repairFailures(
       matchKind = ConstraintKind::Conversion;
     }
 
+    // FIXME: There is currently no easy way to avoid attempting
+    // fixes, matchTypes do not propagate `TMF_ApplyingFix` flag.
+    llvm::SaveAndRestore<ConstraintSystemOptions> options(
+        Options, Options - ConstraintSystemFlags::AllowFixes);
+
     auto result = matchTypes(resultType, dstType, matchKind,
                              TypeMatchFlags::TMF_ApplyingFix, locator);
 

--- a/test/Constraints/assignment.swift
+++ b/test/Constraints/assignment.swift
@@ -88,3 +88,16 @@ class С_56396 {
     self.callback = callback // expected-error {{cannot assign value of type '(Self) -> Void' to type '(С_56396) -> Void'}}
   }
 }
+
+// https://github.com/swiftlang/swift/issues/82397
+func testFunctionAssignsWithOptionals(fn: @escaping () -> () -> Void) {
+  let _: (() -> () -> Void)? = fn
+  let _: (() -> () -> Void)?? = fn
+
+  class Super {}
+  class Sub: Super {}
+
+  let b: () -> () -> Sub = { { return Sub() } }
+  let _: (() -> () -> Super)? = b
+  let _: (() -> () -> Super)?? = b
+}


### PR DESCRIPTION
…tching types

We need to be very careful while matching types to test whether a fix is applicable or not to avoid adding extraneous fixes and failing the path early. This is a temporary workaround, the real fix would be to let `matchTypes` to propagate `TMF_ApplyingFixes` down.

Resolves: rdar://154010220
Resolves: https://github.com/swiftlang/swift/issues/82397

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
