### PR TITLE
[6.2] Add lifetime dependencies on function types representing ~Escapable enum elements with ~Escapable payloads 

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8780,7 +8780,8 @@ public:
 /// EnumCaseDecl.
 class EnumElementDecl : public DeclContext, public ValueDecl {
   friend class EnumRawValuesRequest;
-  
+  friend class LifetimeDependenceInfoRequest;
+
   /// This is the type specified with the enum element, for
   /// example 'Int' in 'case Y(Int)'.  This is null if there is no type
   /// associated with this element, as in 'case Z' or in all elements of enum
@@ -8791,6 +8792,11 @@ class EnumElementDecl : public DeclContext, public ValueDecl {
   
   /// The raw value literal for the enum element, or null.
   LiteralExpr *RawValueExpr;
+
+protected:
+  struct {
+    unsigned NoLifetimeDependenceInfo : 1;
+  } LazySemanticInfo = {};
 
 public:
   EnumElementDecl(SourceLoc IdentifierLoc, DeclName Name,

--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -328,8 +328,7 @@ public:
   /// Builds LifetimeDependenceInfo from a swift decl, either from the explicit
   /// lifetime dependence specifiers or by inference based on types and
   /// ownership modifiers.
-  static std::optional<ArrayRef<LifetimeDependenceInfo>>
-  get(AbstractFunctionDecl *decl);
+  static std::optional<ArrayRef<LifetimeDependenceInfo>> get(ValueDecl *decl);
 
   /// Builds LifetimeDependenceInfo from SIL
   static std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5095,8 +5095,7 @@ public:
 class LifetimeDependenceInfoRequest
     : public SimpleRequest<
           LifetimeDependenceInfoRequest,
-          std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>(
-              AbstractFunctionDecl *),
+          std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>(ValueDecl *),
           RequestFlags::SeparatelyCached | RequestFlags::SplitCached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -5105,7 +5104,7 @@ private:
   friend SimpleRequest;
 
   std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
-  evaluate(Evaluator &evaluator, AbstractFunctionDecl *AFD) const;
+  evaluate(Evaluator &evaluator, ValueDecl *AFD) const;
 
 public:
   // Separate caching.

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -286,6 +286,12 @@ public:
     }
   }
 
+  LifetimeDependenceChecker(EnumElementDecl *eed)
+      : decl(eed), dc(eed->getDeclContext()), ctx(dc->getASTContext()) {
+    auto *paramList = eed->getParameterList();
+    resultIndex = paramList ? eed->getParameterList()->size() + 1 : 1;
+  }
+
   std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
   currentDependencies() const {
     if (lifetimeDependencies.empty()) {
@@ -349,6 +355,45 @@ public:
         diag::lifetime_dependence_cannot_infer_inout.ID);
     }
     return currentDependencies();
+  }
+
+  std::optional<llvm::ArrayRef<LifetimeDependenceInfo>> checkEnumElementDecl() {
+    auto *eed = cast<EnumElementDecl>(decl);
+    auto enumType = eed->getParentEnum()->mapTypeIntoContext(
+        eed->getParentEnum()->getDeclaredInterfaceType());
+    // Escapable enum, bailout.
+    if (!isDiagnosedNonEscapable(enumType)) {
+      return std::nullopt;
+    }
+    auto *params = eed->getParameterList();
+    // No payload, bailout.
+    if (!params) {
+      return std::nullopt;
+    }
+
+    auto resultIndex = params->size() + /*selfType*/ 1;
+    auto capacity = resultIndex + 1;
+    SmallBitVector inheritIndices(capacity);
+    SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
+
+    // Add all indices of ~Escapable parameters as lifetime dependence sources.
+    for (size_t i = 0; i < params->size(); i++) {
+      auto paramType = params->get(i)->getTypeInContext();
+      if (!isDiagnosedNonEscapable(paramType)) {
+        continue;
+      }
+      inheritIndices.set(i);
+    }
+    if (inheritIndices.none()) {
+      return std::nullopt;
+    }
+    auto lifetimeDependenceInfo = LifetimeDependenceInfo(
+        IndexSubset::get(eed->getASTContext(), inheritIndices), nullptr,
+        resultIndex,
+        /*isImmortal*/ false);
+    lifetimeDependencies.push_back(lifetimeDependenceInfo);
+
+    return eed->getASTContext().AllocateCopy(lifetimeDependencies);
   }
 
 protected:
@@ -1334,8 +1379,12 @@ protected:
 };
 
 std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>
-LifetimeDependenceInfo::get(AbstractFunctionDecl *afd) {
-  return LifetimeDependenceChecker(afd).checkFuncDecl();
+LifetimeDependenceInfo::get(ValueDecl *decl) {
+  if (auto *afd = dyn_cast<AbstractFunctionDecl>(decl)) {
+    return LifetimeDependenceChecker(afd).checkFuncDecl();
+  }
+  auto *eed = cast<EnumElementDecl>(decl);
+  return LifetimeDependenceChecker(eed).checkEnumElementDecl();
 }
 
 // This implements the logic for SIL type descriptors similar to source-level

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -359,8 +359,15 @@ public:
 
   std::optional<llvm::ArrayRef<LifetimeDependenceInfo>> checkEnumElementDecl() {
     auto *eed = cast<EnumElementDecl>(decl);
-    auto enumType = eed->getParentEnum()->mapTypeIntoContext(
-        eed->getParentEnum()->getDeclaredInterfaceType());
+    auto *parentEnum = eed->getParentEnum();
+    auto enumType =
+        parentEnum->mapTypeIntoContext(parentEnum->getDeclaredInterfaceType());
+
+    // Add early bailout for imported enums.
+    if (parentEnum->hasClangNode()) {
+      return std::nullopt;
+    }
+
     // Escapable enum, bailout.
     if (!isDiagnosedNonEscapable(enumType)) {
       return std::nullopt;

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -252,7 +252,7 @@ void LifetimeDependenceInfo::getConcatenatedData(
 }
 
 class LifetimeDependenceChecker {
-  AbstractFunctionDecl *afd;
+  ValueDecl *decl;
 
   DeclContext *dc;
   ASTContext &ctx;
@@ -273,9 +273,8 @@ class LifetimeDependenceChecker {
   bool performedDiagnostics = false;
 
 public:
-  LifetimeDependenceChecker(AbstractFunctionDecl *afd):
-    afd(afd), dc(afd->getDeclContext()), ctx(dc->getASTContext())
-  {
+  LifetimeDependenceChecker(AbstractFunctionDecl *afd)
+      : decl(afd), dc(afd->getDeclContext()), ctx(dc->getASTContext()) {
     auto resultTypeRepr = afd->getResultTypeRepr();
     returnLoc = resultTypeRepr ? resultTypeRepr->getLoc() : afd->getLoc();
 
@@ -292,13 +291,14 @@ public:
     if (lifetimeDependencies.empty()) {
       return std::nullopt;
     }
-    return afd->getASTContext().AllocateCopy(lifetimeDependencies);
+    return decl->getASTContext().AllocateCopy(lifetimeDependencies);
   }
 
   std::optional<llvm::ArrayRef<LifetimeDependenceInfo>> checkFuncDecl() {
-    assert(isa<FuncDecl>(afd) || isa<ConstructorDecl>(afd));
+    assert(isa<FuncDecl>(decl) || isa<ConstructorDecl>(decl));
     assert(lifetimeDependencies.empty());
 
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     // Handle Builtins first because, even though Builtins require
     // LifetimeDependence, we don't force the experimental feature
     // to be enabled when importing the Builtin module.
@@ -367,9 +367,7 @@ protected:
     return ctx.Diags.diagnose(decl, Diagnostic(id, std::move(args)...));
   }
 
-  bool isInit() const {
-    return isa<ConstructorDecl>(afd);
-  }
+  bool isInit() const { return isa<ConstructorDecl>(decl); }
 
   // For initializers, the implicit self parameter is ignored and instead shows
   // up as the result type.
@@ -381,11 +379,13 @@ protected:
   // the extra formal self parameter, a dependency targeting the formal result
   // index would incorrectly target the SIL metatype parameter.
   bool hasImplicitSelfParam() const {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     return !isInit() && afd->hasImplicitSelfDecl();
   }
 
   // In SIL, implicit initializers and accessors become explicit.
   bool isImplicitOrSIL() const {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (afd->isImplicit()) {
       return true;
     }
@@ -404,7 +404,7 @@ protected:
   bool isInterfaceFile() const {
     // TODO: remove this check once all compilers that are rev-locked to the
     // stdlib print the 'copy' dependence kind in the interface (Aug '25)
-    if (auto *sf = afd->getParentSourceFile()) {
+    if (auto *sf = decl->getDeclContext()->getParentSourceFile()) {
       if (sf->Kind == SourceFileKind::Interface) {
         return true;
       }
@@ -418,6 +418,7 @@ protected:
   }
 
   std::string diagnosticQualifier() const {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (afd->isImplicit()) {
       if (isInit()) {
         return "an implicit initializer";
@@ -462,6 +463,7 @@ protected:
   // initializers, the inout self parameter is actually considered the result
   // type so is not handled here.
   void diagnoseMissingSelfDependencies(DiagID diagID) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (!hasImplicitSelfParam()) {
       return;
     }
@@ -482,6 +484,7 @@ protected:
   }
   
   void diagnoseMissingInoutDependencies(DiagID diagID) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     unsigned paramIndex = 0;
     for (auto *param : *afd->getParameters()) {
       SWIFT_DEFER { paramIndex++; };
@@ -528,6 +531,7 @@ protected:
 
   bool isCompatibleWithOwnership(LifetimeDependenceKind kind, Type type,
                                  ValueOwnership ownership) const {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (kind == LifetimeDependenceKind::Inherit) {
       return true;
     }
@@ -568,6 +572,7 @@ protected:
   };
 
   TargetDeps createDeps(unsigned targetIndex) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     unsigned capacity = afd->hasImplicitSelfDecl()
       ? (afd->getParameters()->size() + 1)
       : afd->getParameters()->size();
@@ -598,6 +603,7 @@ protected:
   }
 
   Type getResultOrYield() const {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (auto *accessor = dyn_cast<AccessorDecl>(afd)) {
       if (accessor->isCoroutine()) {
         auto yieldTyInContext = accessor->mapTypeIntoContext(
@@ -617,11 +623,12 @@ protected:
 
   std::optional<LifetimeDependenceKind>
   getDependenceKindFromDescriptor(LifetimeDescriptor descriptor,
-                                  ParamDecl *decl) {
+                                  ParamDecl *paramDecl) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     auto loc = descriptor.getLoc();
-    auto type = decl->getTypeInContext();
+    auto type = paramDecl->getTypeInContext();
     auto parsedLifetimeKind = descriptor.getParsedLifetimeDependenceKind();
-    auto ownership = decl->getValueOwnership();
+    auto ownership = paramDecl->getValueOwnership();
     auto loweredOwnership = ownership != ValueOwnership::Default
                                 ? ownership
                                 : getLoweredOwnership(afd);
@@ -703,6 +710,7 @@ protected:
   // Finds the ParamDecl* and its index from a LifetimeDescriptor
   std::optional<std::pair<ParamDecl *, unsigned>>
   getParamDeclFromDescriptor(LifetimeDescriptor descriptor) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     switch (descriptor.getDescriptorKind()) {
     case LifetimeDescriptor::DescriptorKind::Named: {
       unsigned paramIndex = 0;
@@ -751,6 +759,7 @@ protected:
   }
 
   std::optional<ArrayRef<LifetimeDependenceInfo>> checkAttribute() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
     llvm::SmallSet<unsigned, 1> lifetimeDependentTargets;
     auto lifetimeAttrs = afd->getAttrs().getAttributes<LifetimeAttr>();
@@ -775,6 +784,7 @@ protected:
 
   std::optional<LifetimeDependenceInfo>
   checkAttributeEntry(LifetimeEntry *entry) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     auto capacity = afd->hasImplicitSelfDecl()
       ? (afd->getParameters()->size() + 1)
       : afd->getParameters()->size();
@@ -896,6 +906,7 @@ protected:
   /// If the current function is a mutating method and 'self' is non-Escapable,
   /// return 'self's ParamDecl.
   bool isMutatingNonEscapableSelf() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (!hasImplicitSelfParam())
       return false;
 
@@ -912,6 +923,7 @@ protected:
 
   // Infer method dependence: result depends on self. This includes _modify.
   void inferNonEscapableResultOnSelf() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     Type selfTypeInContext = dc->getSelfTypeInContext();
     if (selfTypeInContext->hasError()) {
       return;
@@ -963,6 +975,7 @@ protected:
 
   std::optional<LifetimeDependenceKind>
   inferLifetimeDependenceKind(Type sourceType, ValueOwnership ownership) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (!sourceType->isEscapable()) {
       return LifetimeDependenceKind::Inherit;
     }
@@ -985,6 +998,7 @@ protected:
   // to an implicit setter, because the implementation is simply an assignment
   // to stored property.
   void inferImplicitInit() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (afd->getParameters()->size() == 0) {
       // Empty ~Escapable types can be implicitly initialized without any
       // dependencies. In SIL, implicit initializers become explicit. Set
@@ -1024,6 +1038,7 @@ protected:
   // inference if any exist, infer scoped dependency, or infer no
   // dependency. Implicit setters for Escapable properties are not inferred.
   void inferNonEscapableResultOnParam() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     // This is only called when there is no 'self' argument that can be the
     // source of a dependence.
     assert(!hasImplicitSelfParam());
@@ -1073,6 +1088,7 @@ protected:
   // Lazy inference for .swiftinterface backward compatibility and
   // experimentation. Inference cases can be added but not removed.
   void lazillyInferNonEscapableResultOnParam() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     std::optional<unsigned> candidateParamIndex;
     std::optional<LifetimeDependenceKind> candidateLifetimeKind;
     unsigned paramIndex = 0;
@@ -1119,6 +1135,7 @@ protected:
   // Infer a mutating 'self' dependency when 'self' is non-Escapable and the
   // result is 'void'.
   void inferMutatingSelf() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (!isMutatingNonEscapableSelf()) {
       return;
     }
@@ -1144,6 +1161,7 @@ protected:
 
   // Infer a mutating accessor's non-Escapable 'self' dependencies.
   void inferMutatingAccessor(AccessorDecl *accessor) {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (!isImplicitOrSIL() && !useLazyInference()) {
       // Explicit setters require explicit lifetime dependencies.
       return;
@@ -1231,6 +1249,7 @@ protected:
   // Do not issue any diagnostics. This inference is triggered even when the
   // feature is disabled!
   void inferInoutParams() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (isMutatingNonEscapableSelf()) {
       return;
     }
@@ -1263,6 +1282,7 @@ protected:
   }
 
   void inferUnambiguousInoutParams() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     if (afd->getParameters()->size() != 1) {
       return;
     }
@@ -1280,6 +1300,7 @@ protected:
   }
 
   void inferBuiltin() {
+    auto *afd = cast<AbstractFunctionDecl>(decl);
     // Normal inout parameter inference works for most generic Builtins.
     inferUnambiguousInoutParams();
     if (!lifetimeDependencies.empty()) {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2738,24 +2738,36 @@ void ExpandBodyMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
 
 std::optional<std::optional<llvm::ArrayRef<LifetimeDependenceInfo>>>
 LifetimeDependenceInfoRequest::getCachedResult() const {
-  auto *func = std::get<0>(getStorage());
+  auto *decl = std::get<0>(getStorage());
+  bool noLifetimeDependenceInfo;
 
-  if (func->LazySemanticInfo.NoLifetimeDependenceInfo)
+  if (auto *func = dyn_cast<AbstractFunctionDecl>(decl)) {
+    noLifetimeDependenceInfo = func->LazySemanticInfo.NoLifetimeDependenceInfo;
+  } else {
+    auto *eed = cast<EnumElementDecl>(decl);
+    noLifetimeDependenceInfo = eed->LazySemanticInfo.NoLifetimeDependenceInfo;
+  }
+
+  if (noLifetimeDependenceInfo)
     return std::optional(std::optional<LifetimeDependenceInfo>());
 
-  return func->getASTContext().evaluator.getCachedNonEmptyOutput(*this);
+  return decl->getASTContext().evaluator.getCachedNonEmptyOutput(*this);
 }
 
 void LifetimeDependenceInfoRequest::cacheResult(
     std::optional<llvm::ArrayRef<LifetimeDependenceInfo>> result) const {
-  auto *func = std::get<0>(getStorage());
-  
+  auto *decl = std::get<0>(getStorage());
+
   if (!result) {
-    func->LazySemanticInfo.NoLifetimeDependenceInfo = 1;
-    return;
+    if (auto *func = dyn_cast<AbstractFunctionDecl>(decl)) {
+      func->LazySemanticInfo.NoLifetimeDependenceInfo = 1;
+      return;
+    }
+    auto *eed = cast<EnumElementDecl>(decl);
+    eed->LazySemanticInfo.NoLifetimeDependenceInfo = 1;
   }
 
-  func->getASTContext().evaluator.cacheNonEmptyOutput(*this, std::move(result));
+  decl->getASTContext().evaluator.cacheNonEmptyOutput(*this, std::move(result));
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5213,6 +5213,16 @@ public:
     elem->setAccess(std::max(cast<EnumDecl>(DC)->getFormalAccess(),
                              AccessLevel::Internal));
 
+    SmallVector<LifetimeDependenceInfo, 1> lifetimeDependencies;
+    while (auto info = MF.maybeReadLifetimeDependence()) {
+      assert(info.has_value());
+      lifetimeDependencies.push_back(*info);
+    }
+
+    ctx.evaluator.cacheOutput(LifetimeDependenceInfoRequest{elem},
+                              lifetimeDependencies.empty()? std::nullopt :
+                                  ctx.AllocateCopy(lifetimeDependencies));
+
     return elem;
   }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 942; // update LifetimeDependenceLayout
+const uint16_t SWIFTMODULE_VERSION_MINOR = 943; // Lifetime dependencies on enum element
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5014,6 +5014,14 @@ public:
                                   nameComponentsAndDependencies);
     if (auto *PL = elem->getParameterList())
       writeParameterList(PL);
+
+    auto fnType = ty->getAs<AnyFunctionType>();
+    if (fnType) {
+      auto lifetimeDependencies = fnType->getLifetimeDependencies();
+      if (!lifetimeDependencies.empty()) {
+        S.writeLifetimeDependencies(lifetimeDependencies);
+      }
+    }
   }
 
   void visitSubscriptDecl(const SubscriptDecl *subscript) {

--- a/test/SILOptimizer/lifetime_dependence/lifetime_dependence_enums.swift
+++ b/test/SILOptimizer/lifetime_dependence/lifetime_dependence_enums.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -sil-verify-all | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+public protocol OptionalType<Wrapped> {
+  associatedtype Wrapped
+
+  static func some(_ wrapped: Wrapped) -> Self
+  static func somePair(_ wrapped1: Wrapped, _ wrapped2: Wrapped) -> Self
+  static func esc(_ e: E) -> Self
+}
+
+public struct E {}
+
+public enum FakeOptional<Wrapped : ~Escapable & ~Copyable> : ~Escapable & ~Copyable {
+  case none
+  case some(Wrapped)
+  case somePair(Wrapped, Wrapped)
+  case esc(E)
+}
+
+extension FakeOptional: Copyable where Wrapped: Copyable & ~Escapable {}
+
+extension FakeOptional: Escapable where Wrapped: Escapable & ~Copyable {}
+
+extension FakeOptional : OptionalType {}
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO4someyACyxGxcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (@in Wrapped, @thin FakeOptional<Wrapped>.Type) -> @lifetime(copy 0) @out FakeOptional<Wrapped> {
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO8somePairyACyxGx_xtcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (@in Wrapped, @in Wrapped, @thin FakeOptional<Wrapped>.Type) -> @lifetime(copy 0, copy 1) @out FakeOptional<Wrapped> {
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO3escyACyxGAA1EVcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (E, @thin FakeOptional<Wrapped>.Type) -> @out FakeOptional<Wrapped> {
+

--- a/test/Serialization/Inputs/def_lifetime_dependence_enums.swift
+++ b/test/Serialization/Inputs/def_lifetime_dependence_enums.swift
@@ -1,0 +1,29 @@
+public protocol OptionalType<Wrapped> {
+  associatedtype Wrapped
+
+  static func some(_ wrapped: Wrapped) -> Self
+  static func somePair(_ wrapped1: Wrapped, _ wrapped2: Wrapped) -> Self
+  static func esc(_ e: E) -> Self
+}
+
+public struct E {}
+
+public enum FakeOptional<Wrapped : ~Escapable & ~Copyable> : ~Escapable & ~Copyable {
+  case none
+  case some(Wrapped)
+  case somePair(Wrapped, Wrapped)
+  case esc(E)
+}
+
+extension FakeOptional: Copyable where Wrapped: Copyable & ~Escapable {}
+
+extension FakeOptional: Escapable where Wrapped: Escapable & ~Copyable {}
+
+extension FakeOptional : OptionalType {}
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO4someyACyxGxcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (@in Wrapped, @thin FakeOptional<Wrapped>.Type) -> @lifetime(copy 0) @out FakeOptional<Wrapped> {
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO8somePairyACyxGx_xtcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (@in Wrapped, @in Wrapped, @thin FakeOptional<Wrapped>.Type) -> @lifetime(copy 0, copy 1) @out FakeOptional<Wrapped> {
+
+// CHECK-LABEL: sil shared [transparent] @$s25lifetime_dependence_enums12FakeOptionalO3escyACyxGAA1EVcAEmlF : $@convention(method) <Wrapped where Wrapped : ~Copyable, Wrapped : ~Escapable> (E, @thin FakeOptional<Wrapped>.Type) -> @out FakeOptional<Wrapped> {
+

--- a/test/Serialization/lifetime_dependence_enums.swift
+++ b/test/Serialization/lifetime_dependence_enums.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_lifetime_dependence_enums.swift 
+
+// RUN: llvm-bcanalyzer %t/def_lifetime_dependence_enums.swiftmodule 
+
+// RUN: %target-swift-frontend -c -module-name lifetime-dependence-enums -Xllvm -sil-print-after=EarlyPerfInliner -O -I %t %s \
+// RUN: -enable-experimental-feature Lifetimes -o /dev/null 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_feature_Lifetimes
+
+import def_lifetime_dependence_enums 
+
+@inline(__always)
+public func testSome<T : OptionalType>(_ t: T, _ w: T.Wrapped) -> T {
+  return T.self.some(w)
+}
+
+@inline(__always)
+public func testSomePair<T : OptionalType>(_ t: T, _ w: T.Wrapped) -> T {
+  return T.self.somePair(w, w)
+}
+
+// CHECK-LABEL: sil [ossa] @$s4main5test1yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF : 
+// Match the second instance of EarlyPerfInliner
+// CHECK-LABEL: sil [ossa] @$s4main5test1yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF : 
+// CHECK: [[FUNC:%.*]] = function_ref @$s29def_lifetime_dependence_enums12FakeOptionalO4someyACyxGxcAEmlF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@in τ_0_0, @thin FakeOptional<τ_0_0>.Type) -> @lifetime(copy 0) @out FakeOptional<τ_0_0>
+// CHECK: apply [[FUNC]]<W>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@in τ_0_0, @thin FakeOptional<τ_0_0>.Type) -> @lifetime(copy 0) @out FakeOptional<τ_0_0>
+// CHECK-LABEL: } // end sil function '$s4main5test1yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF'
+public func test1<W>(_ f: FakeOptional<W>, _ w: FakeOptional<W>.Wrapped) -> some OptionalType {
+  return testSome(f, w)
+}
+
+// CHECK-LABEL: sil [ossa] @$s4main5test2yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF : 
+// Match the second instance of EarlyPerfInliner
+// CHECK-LABEL: sil [ossa] @$s4main5test2yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF : 
+// CHECK:   [[FUNC:%.*]] = function_ref @$s29def_lifetime_dependence_enums12FakeOptionalO8somePairyACyxGx_xtcAEmlF : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@in τ_0_0, @in τ_0_0, @thin FakeOptional<τ_0_0>.Type) -> @lifetime(copy 0, copy 1) @out FakeOptional<τ_0_0> // user: %13
+// CHECK:   apply [[FUNC]]<W>({{.*}}) : $@convention(method) <τ_0_0 where τ_0_0 : ~Copyable, τ_0_0 : ~Escapable> (@in τ_0_0, @in τ_0_0, @thin FakeOptional<τ_0_0>.Type) -> @lifetime(copy 0, copy 1) @out FakeOptional<τ_0_0>
+// CHECK-LABEL: } // end sil function '$s4main5test2yQr29def_lifetime_dependence_enums12FakeOptionalOyxG_xtlF'
+public func test2<W>(_ f: FakeOptional<W>, _ w: FakeOptional<W>.Wrapped) -> some OptionalType {
+  return testSomePair(f, w)
+}
+


### PR DESCRIPTION
Explanation: Enum elements are represented as a function type. Enums can satisfy a protocol's static method constraint by defining a enum element with the same signature.

We do not infer lifetime dependence on function types related to EnumElementDecl. This results to source compatibility bugs in some cases since Optional is now conditionally ~Escapable. In the example below a protocol specifying a static some method ends up with a generated witness that does not have lifetime dependencies leading to illegible diagnostics.

```
public protocol OptionalType<Wrapped> {
    associatedtype Wrapped
    static func some(_ wrapped: Wrapped) -> Self
}

extension Optional: OptionalType {}
```
This PR adds lifetime dependencies for function types representative of EnumElementDecls.

Scope: Affects ~Escapable and conditionally ~Escapable types

Risk: Medium. New code is exercised in the type checker on all conditionally ~Escapable enums. 

Main PR: https://github.com/swiftlang/swift/pull/82354 

Reviewer: @atrick 

Testing: CI testing.

Issue: rdar://152104558
