### PR TITLE
[SE-0494][StdLib] Add `isTriviallyIdentical(to:)` Methods to Dictionary and Set

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SWIFT_BENCH_MODULES
     single-source/DictionaryCompactMapValues
     single-source/DictionaryCopy
     single-source/DictionaryGroup
+    single-source/DictionaryIdentical
     single-source/DictionaryKeysContains
     single-source/DictionaryLiteralTest
     single-source/DictionaryOfAnyHashableStrings
@@ -175,6 +176,7 @@ set(SWIFT_BENCH_MODULES
     # Disabled while layout prespecializations are experimental
     #single-source/SimpleArraySpecialization
     single-source/SequenceAlgos
+    single-source/SetIdentical
     single-source/SetTests
     single-source/SevenBoom
     single-source/Sim2DArray

--- a/benchmark/single-source/DictionaryIdentical.swift
+++ b/benchmark/single-source/DictionaryIdentical.swift
@@ -1,0 +1,46 @@
+//===--- DictionaryIdentical.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+public let benchmarks = [
+  BenchmarkInfo(name: "DictionaryEqualUnique", runFunction: run_DictionaryEqualUnique, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "DictionaryEqualShared", runFunction: run_DictionaryEqualShared, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "DictionaryIdentical", runFunction: run_DictionaryIdentical, tags: [.validation, .api, .Dictionary]),
+]
+
+@inline(never)
+public func run_DictionaryEqualUnique(_ n: Int) {
+  let d1 = Dictionary(uniqueKeysWithValues: zip(1...n, 1...n))
+  let d2 = Dictionary(uniqueKeysWithValues: zip(1...n, 1...n))
+  for _ in 0 ..< 100_000 {
+    check(d1 == d2)
+  }
+}
+
+@inline(never)
+public func run_DictionaryEqualShared(_ n: Int) {
+  let d1 = Dictionary(uniqueKeysWithValues: zip(1...n, 1...n))
+  let d2 = d1
+  for _ in 0 ..< 100_000 {
+    check(d1 == d2)
+  }
+}
+
+@inline(never)
+public func run_DictionaryIdentical(_ n: Int) {
+  let d1 = Dictionary(uniqueKeysWithValues: zip(1...n, 1...n))
+  let d2 = d1
+  for _ in 0 ..< 100_000 {
+    check(d1.isTriviallyIdentical(to: d2))
+  }
+}

--- a/benchmark/single-source/SetIdentical.swift
+++ b/benchmark/single-source/SetIdentical.swift
@@ -1,0 +1,46 @@
+//===--- SetIdentical.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+public let benchmarks = [
+  BenchmarkInfo(name: "SetEqualUnique", runFunction: run_SetEqualUnique, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetEqualShared", runFunction: run_SetEqualShared, tags: [.validation, .api, .Set]),
+  BenchmarkInfo(name: "SetIdentical", runFunction: run_SetIdentical, tags: [.validation, .api, .Set]),
+]
+
+@inline(never)
+public func run_SetEqualUnique(_ n: Int) {
+  let s1 = Set(1...n)
+  let s2 = Set(1...n)
+  for _ in 0 ..< 100_000 {
+    check(s1 == s2)
+  }
+}
+
+@inline(never)
+public func run_SetEqualShared(_ n: Int) {
+  let s1 = Set(1...n)
+  let s2 = s1
+  for _ in 0 ..< 100_000 {
+    check(s1 == s2)
+  }
+}
+
+@inline(never)
+public func run_SetIdentical(_ n: Int) {
+  let s1 = Set(1...n)
+  let s2 = s1
+  for _ in 0 ..< 100_000 {
+    check(s1.isTriviallyIdentical(to: s2))
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -75,6 +75,7 @@ import DictionaryBridgeToObjC
 import DictionaryCompactMapValues
 import DictionaryCopy
 import DictionaryGroup
+import DictionaryIdentical
 import DictionaryKeysContains
 import DictionaryLiteralTest
 import DictionaryOfAnyHashableStrings
@@ -179,6 +180,7 @@ import RomanNumbers
 import SIMDRandomMask
 import SIMDReduceInteger
 import SequenceAlgos
+import SetIdentical
 import SetTests
 import SevenBoom
 import Sim2DArray
@@ -277,6 +279,7 @@ register(DictionaryBridgeToObjC.benchmarks)
 register(DictionaryCompactMapValues.benchmarks)
 register(DictionaryCopy.benchmarks)
 register(DictionaryGroup.benchmarks)
+register(DictionaryIdentical.benchmarks)
 register(DictionaryKeysContains.benchmarks)
 register(DictionaryLiteralTest.benchmarks)
 register(DictionaryOfAnyHashableStrings.benchmarks)
@@ -382,6 +385,7 @@ register(RomanNumbers.benchmarks)
 register(SIMDRandomMask.benchmarks)
 register(SIMDReduceInteger.benchmarks)
 register(SequenceAlgos.benchmarks)
+register(SetIdentical.benchmarks)
 register(SetTests.benchmarks)
 register(SevenBoom.benchmarks)
 register(Sim2DArray.benchmarks)

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2154,3 +2154,64 @@ extension Dictionary.Index: @unchecked Sendable
   where Key: Sendable, Value: Sendable {}
 extension Dictionary.Iterator: @unchecked Sendable
   where Key: Sendable, Value: Sendable {}
+
+extension Dictionary {
+  /// Returns a boolean value indicating whether this dictionary is identical to
+  /// `other`.
+  ///
+  /// Two dictionary values are identical if there is no way to distinguish
+  /// between them.
+  ///
+  /// For any values `a`, `b`, and `c`:
+  ///
+  /// - `a.isTriviallyIdentical(to: a)` is always `true`. (Reflexivity)
+  /// - `a.isTriviallyIdentical(to: b)` implies `b.isTriviallyIdentical(to: a)`.
+  /// (Symmetry)
+  /// - If `a.isTriviallyIdentical(to: b)` and `b.isTriviallyIdentical(to: c)`
+  /// are both `true`, then `a.isTriviallyIdentical(to: c)` is also `true`.
+  /// (Transitivity)
+  /// - If `a` and `b` are `Equatable`, then `a.isTriviallyIdentical(b)` implies
+  /// `a == b`
+  ///   - `a == b` does not imply `a.isTriviallyIdentical(b)`
+  ///
+  /// Values produced by copying the same value, with no intervening mutations,
+  /// will compare identical:
+  ///
+  /// ```swift
+  /// let d = c
+  /// print(c.isTriviallyIdentical(to: d))
+  /// // Prints true
+  /// ```
+  /// 
+  /// Comparing dictionaries this way includes comparing (normally) hidden
+  /// implementation details such as the memory location of any underlying
+  /// dictionary storage object. Therefore, identical dictionaries are
+  /// guaranteed to compare equal with `==`, but not all equal dictionaries are
+  /// considered identical.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+#if _runtime(_ObjC)
+    if
+      self._variant.isNative,
+      other._variant.isNative,
+      unsafe (self._variant.asNative._storage === other._variant.asNative._storage)
+    {
+      return true
+    }
+    if
+      !self._variant.isNative,
+      !other._variant.isNative,
+      self._variant.asCocoa.object === other._variant.asCocoa.object
+    {
+      return true
+    }
+#else
+    if unsafe (self._variant.asNative._storage === other._variant.asNative._storage) {
+      return true
+    }
+#endif
+    return false
+  }
+}

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2171,8 +2171,7 @@ extension Dictionary {
   /// are both `true`, then `a.isTriviallyIdentical(to: c)` is also `true`.
   /// (Transitivity)
   /// - If `a` and `b` are `Equatable`, then `a.isTriviallyIdentical(b)` implies
-  /// `a == b`
-  ///   - `a == b` does not imply `a.isTriviallyIdentical(b)`
+  /// `a == b`. `a == b` does not imply `a.isTriviallyIdentical(b)`
   ///
   /// Values produced by copying the same value, with no intervening mutations,
   /// will compare identical:

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1658,3 +1658,62 @@ extension Set.Index: @unchecked Sendable
   where Element: Sendable { }
 extension Set.Iterator: @unchecked Sendable
   where Element: Sendable { }
+
+extension Set {
+  /// Returns a boolean value indicating whether this set is identical to
+  /// `other`.
+  ///
+  /// Two set values are identical if there is no way to distinguish between
+  /// them.
+  /// 
+  /// For any values `a`, `b`, and `c`:
+  ///
+  /// - `a.isTriviallyIdentical(to: a)` is always `true`. (Reflexivity)
+  /// - `a.isTriviallyIdentical(to: b)` implies `b.isTriviallyIdentical(to: a)`.
+  /// (Symmetry)
+  /// - If `a.isTriviallyIdentical(to: b)` and `b.isTriviallyIdentical(to: c)`
+  /// are both `true`, then `a.isTriviallyIdentical(to: c)` is also `true`.
+  /// (Transitivity)
+  /// - `a.isTriviallyIdentical(b)` implies `a == b`
+  ///   - `a == b` does not imply `a.isTriviallyIdentical(b)`
+  ///
+  /// Values produced by copying the same value, with no intervening mutations,
+  /// will compare identical:
+  ///
+  /// ```swift
+  /// let d = c
+  /// print(c.isTriviallyIdentical(to: d))
+  /// // Prints true
+  /// ```
+  ///
+  /// Comparing sets this way includes comparing (normally) hidden
+  /// implementation details such as the memory location of any underlying set
+  /// storage object. Therefore, identical sets are guaranteed to compare equal
+  /// with `==`, but not all equal sets are considered identical.
+  ///
+  /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  public func isTriviallyIdentical(to other: Self) -> Bool {
+#if _runtime(_ObjC)
+    if
+      self._variant.isNative,
+      other._variant.isNative,
+      unsafe (self._variant.asNative._storage === other._variant.asNative._storage)
+    {
+      return true
+    }
+    if
+      !self._variant.isNative,
+      !other._variant.isNative,
+      self._variant.asCocoa.object === other._variant.asCocoa.object
+    {
+      return true
+    }
+#else
+    if unsafe (self._variant.asNative._storage === other._variant.asNative._storage) {
+      return true
+    }
+#endif
+    return false
+  }
+}

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1674,8 +1674,7 @@ extension Set {
   /// - If `a.isTriviallyIdentical(to: b)` and `b.isTriviallyIdentical(to: c)`
   /// are both `true`, then `a.isTriviallyIdentical(to: c)` is also `true`.
   /// (Transitivity)
-  /// - `a.isTriviallyIdentical(b)` implies `a == b`
-  ///   - `a == b` does not imply `a.isTriviallyIdentical(b)`
+  /// - `a.isTriviallyIdentical(b)` implies `a == b`. `a == b` does not imply `a.isTriviallyIdentical(b)`
   ///
   /// Values produced by copying the same value, with no intervening mutations,
   /// will compare identical:

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -5789,6 +5789,21 @@ DictionaryTestSuite.test("BulkLoadingInitializer.Nonunique") {
   }
 }
 
+DictionaryTestSuite.test("Identical") {
+  let d1: Dictionary = ["a": 1, "b": 2, "c": 3]
+  expectTrue(d1.isTriviallyIdentical(to: d1))
+
+  let d2: Dictionary = d1
+  expectTrue(d1.isTriviallyIdentical(to: d2))
+
+  var d3: Dictionary = d2
+  d3.reserveCapacity(0)
+  expectFalse(d1.isTriviallyIdentical(to: d3))
+
+  let d4: Dictionary = ["a": 1, "b": 2, "c": 3]
+  expectFalse(d1.isTriviallyIdentical(to: d4))
+}
+
 DictionaryTestSuite.setUp {
 #if _runtime(_ObjC)
   // Exercise ARC's autoreleased return value optimization in Foundation.

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -4895,4 +4895,19 @@ if #available(SwiftStdlib 5.1, *) {
 }
 #endif
 
+SetTestSuite.test("Identical") {
+  let s1: Set = [0, 1, 2, 3]
+  expectTrue(s1.isTriviallyIdentical(to: s1))
+
+  let s2: Set = s1
+  expectTrue(s1.isTriviallyIdentical(to: s2))
+
+  var s3: Set = s2
+  s3.reserveCapacity(0)
+  expectFalse(s1.isTriviallyIdentical(to: s3))
+
+  let s4: Set = [0, 1, 2, 3]
+  expectFalse(s1.isTriviallyIdentical(to: s4))
+}
+
 runAllTests()


### PR DESCRIPTION
## Background

[SE-0494](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0494-add-is-identical-methods.md) has been accepted by LSG.

## Changes

Our `Dictionary` does not *directly* perform a fast path for equality checking in our `==` operator.[^1] We can actually steal an idea from `Dictionary.Keys`.[^2] If both variants are native, we compare the storage buffer directly. If both variants are Cocoa, we compare the objects directly.

```swift
extension Dictionary {
  @_alwaysEmitIntoClient
  public func isIdentical(to other: Self) -> Bool {
#if _runtime(_ObjC)
    if
      self._variant.isNative,
      other._variant.isNative,
      unsafe (self._variant.asNative._storage === other._variant.asNative._storage)
    {
      return true
    }
    if
      !self._variant.isNative,
      !other._variant.isNative,
      self._variant.asCocoa.object === other._variant.asCocoa.object
    {
      return true
    }
#else
    if unsafe (self._variant.asNative._storage === other._variant.asNative._storage) {
      return true
    }
#endif
    return false
  }
}
```

Our `Set` performs a similar check over variants for our `==` operator.[^3] We can check identity similar to `Dictionary`:

```swift
extension Set {
  @_alwaysEmitIntoClient
  public func isIdentical(to other: Self) -> Bool {
#if _runtime(_ObjC)
    if
      self._variant.isNative,
      other._variant.isNative,
      unsafe (self._variant.asNative._storage === other._variant.asNative._storage)
    {
      return true
    }
    if
      !self._variant.isNative,
      !other._variant.isNative,
      self._variant.asCocoa.object === other._variant.asCocoa.object
    {
      return true
    }
#else
    if unsafe (self._variant.asNative._storage === other._variant.asNative._storage) {
      return true
    }
#endif
    return false
  }
}
```

## Test Plan

New tests were added for `Dictionary` and `Set`.

## Benchmarks

New benchmarks were added for `Dictionary` and `Set`.

[^1]: https://github.com/swiftlang/swift/blob/swift-6.1.2-RELEASE/stdlib/public/core/Dictionary.swift#L1583-L1598
[^2]: https://github.com/swiftlang/swift/blob/swift-6.1.2-RELEASE/stdlib/public/core/Dictionary.swift#L1365-L1384
[^3]: https://github.com/swiftlang/swift/blob/swift-6.1.2-RELEASE/stdlib/public/core/Set.swift#L408-L424
