### PR TITLE
Extend the existing memoization of NSString's Hashable conformance to cover AnyObjects that are actually NSStrings as well

### DIFF
--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -879,18 +879,8 @@ tryCastToAnyHashable(
   
   switch (srcType->getKind()) {
   case MetadataKind::ForeignClass: // CF -> String
-  case MetadataKind::Existential: { // AnyObject can be an NSString
-#if SWIFT_OBJC_INTEROP
-    auto existentialType = cast<ExistentialTypeMetadata>(srcType);
-    // TODO: also handle non-class existentials that could contain an NSString
-    if (existentialType->getRepresentation() == ExistentialTypeRepresentation::Class) {
-      auto val = reinterpret_cast<const ClassExistentialContainer *>(srcValue)->Value;
-      auto cls = swift_getObjectType((HeapObject *)val);
-      hashableConformance = tryMemoizeNSStringHashableConformance(cls);
-    }
-#endif
-    // If no Obj-C interop, just fall through to the general case.
-    break;
+  case MetadataKind::Existential: {
+    return DynamicCastResult::Failure;
   }
   case MetadataKind::ObjCClassWrapper: { // Obj-C -> String
 #if SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -878,10 +878,10 @@ tryCastToAnyHashable(
   const HashableWitnessTable *hashableConformance = nullptr;
   
   switch (srcType->getKind()) {
-  case MetadataKind::ForeignClass: // CF -> String
   case MetadataKind::Existential: {
     return DynamicCastResult::Failure;
   }
+  case MetadataKind::ForeignClass: // CF -> String
   case MetadataKind::ObjCClassWrapper: { // Obj-C -> String
 #if SWIFT_OBJC_INTEROP
     hashableConformance = tryMemoizeNSStringHashableConformance(srcType);

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -850,7 +850,6 @@ struct ObjCBridgeMemo {
         destBridgeWitness, targetBridgedType);
     }
 };
-#endif
 
 static const HashableWitnessTable* tryMemoizeNSStringHashableConformance(const Metadata *cls) {
   auto nsString = getNSStringMetadata();
@@ -862,6 +861,7 @@ static const HashableWitnessTable* tryMemoizeNSStringHashableConformance(const M
   } while (cls != nullptr);
   return nullptr;
 }
+#endif
 
 static DynamicCastResult
 tryCastToAnyHashable(


### PR DESCRIPTION
Fixes rdar://154123172 (Consider memoizing the lookup for NSString's conformance to Hashable)