### PR TITLE
Allow '@unsafe' on import declarations to silence '@preconcurrency' warning

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -834,7 +834,7 @@ SIMPLE_DECL_ATTR(sensitive, Sensitive,
   159)
 
 SIMPLE_DECL_ATTR(unsafe, Unsafe,
-  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType | OnExtension | OnTypeAlias | OnEnumElement,
+  OnAbstractFunction | OnSubscript | OnVar | OnMacro | OnNominalType | OnExtension | OnTypeAlias | OnEnumElement | OnImport,
   UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove | ForbiddenInABIAttr,
   160)
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8481,7 +8481,7 @@ GROUPED_WARNING(override_safe_with_unsafe,StrictMemorySafety,none,
 
 GROUPED_WARNING(preconcurrency_import_unsafe,StrictMemorySafety,none,
       "'@preconcurrency' import is not memory-safe because it can silently "
-      "introduce data races", ())
+      "introduce data races; add '@unsafe' to indicate that this is unsafe", ())
 GROUPED_WARNING(unsafe_without_unsafe,StrictMemorySafety,none,
       "expression uses unsafe constructs but is not marked with 'unsafe'", ())
 GROUPED_WARNING(for_unsafe_without_unsafe,StrictMemorySafety,none,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2486,7 +2486,8 @@ public:
     // concurrency checking enabled.
     if (ID->preconcurrency() &&
         Ctx.LangOpts.StrictConcurrencyLevel == StrictConcurrency::Complete &&
-        Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety)) {
+        Ctx.LangOpts.hasFeature(Feature::StrictMemorySafety) &&
+        ID->getExplicitSafety() != ExplicitSafety::Unsafe) {
       diagnoseUnsafeUse(UnsafeUse::forPreconcurrencyImport(ID));
     }
   }

--- a/lib/Sema/TypeCheckUnsafe.cpp
+++ b/lib/Sema/TypeCheckUnsafe.cpp
@@ -195,7 +195,9 @@ void swift::diagnoseUnsafeUse(const UnsafeUse &use) {
 
   case UnsafeUse::PreconcurrencyImport: {
     auto importDecl = cast<ImportDecl>(use.getDecl());
-    importDecl->diagnose(diag::preconcurrency_import_unsafe);
+    importDecl->diagnose(diag::preconcurrency_import_unsafe)
+      .fixItInsert(importDecl->getAttributeInsertionLoc(false), "@unsafe ");
+
     return;
   }
   }

--- a/test/Unsafe/preconcurrency_silence.swift
+++ b/test/Unsafe/preconcurrency_silence.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/unsafe_swift_decls.swiftmodule %S/Inputs/unsafe_swift_decls.swift
+
+// RUN: %target-typecheck-verify-swift -strict-memory-safety -enable-experimental-feature StrictConcurrency -I %t
+
+// REQUIRES: concurrency
+// REQUIRES: swift_feature_StrictConcurrency
+
+@preconcurrency @unsafe import unsafe_swift_decls


### PR DESCRIPTION
'@preconcurrency' imports open up memory safety holes with respect to Sendable, which are diagnosed under strict memory safety + strict concurrency checking. Allow one to write '@unsafe' on those imports to silence the diagnostic about it.

Fixes rdar://154147698 