### PR TITLE
[6.2] AST: Tweak ConformanceLookupTable::compareConformances() some more

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -615,9 +615,10 @@ ConformanceLookupTable::Ordering ConformanceLookupTable::compareConformances(
       rhs->getDeclContext()->isAlwaysAvailableConformanceContext()) {
     // Diagnose conflicting marker protocol conformances that differ in
     // un-availability.
-    diagnoseSuperseded = (lhs->getProtocol()->isMarkerProtocol() &&
-                          isUnavailable(lhs->getDeclContext()) !=
-                          isUnavailable(rhs->getDeclContext()));
+    diagnoseSuperseded =
+      (lhs->getProtocol()->isMarkerProtocol() &&
+       isUnavailable(lhs->getDeclContext()) != isUnavailable(rhs->getDeclContext()) &&
+       (lhsKind != ConformanceEntryKind::Implied || rhsKind != ConformanceEntryKind::Implied));
 
     return (lhs->getDeclContext()->isAlwaysAvailableConformanceContext()
             ? Ordering::Before

--- a/test/Sema/conformance_availability_implied.swift
+++ b/test/Sema/conformance_availability_implied.swift
@@ -57,3 +57,12 @@ extension Conformer2: Derived1 {
 extension Conformer2: Derived2 {
   func f() {} // expected-note {{'f()' declared here}}
 }
+
+protocol P: MarkerBase {}
+
+struct Conformer3: P {}
+
+@available(*, unavailable)
+extension Conformer3: MarkerDerived1 {}
+
+takesMarkerBase(Conformer3.self)


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82446

* **Description:** If two conformances imply a conformance to the same marker protocol, don't diagnose redundancy if they differ by unavailability. Instead, allow the more available conformance to win.

* **Scope of the issue:** This allows declaring a type that conforms to a protocol that inherits from SendableMetatype, followed by an unavailable Sendable conformance on the same type.

* **Risk:** Low. Might break availability checking in some edge case, perhaps.

* **Radar:** rdar://152509409.

* **Reviewed by:** @AnthonyLatsis 