### PR TITLE
Sema: Fix the insertion location for conformances attributes

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1333,10 +1333,10 @@ public:
   getNormalConformance(Type conformingType,
                        ProtocolDecl *protocol,
                        SourceLoc loc,
+                       TypeRepr *inheritedTypeRepr,
                        DeclContext *dc,
                        ProtocolConformanceState state,
-                       ProtocolConformanceOptions options,
-                       SourceLoc preconcurrencyLoc = SourceLoc());
+                       ProtocolConformanceOptions options);
 
   /// Produce a self-conformance for the given protocol.
   SelfProtocolConformance *

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -604,6 +604,11 @@ void forEachPotentialAttachedMacro(
 
 /// Describes an inherited nominal entry.
 struct InheritedNominalEntry : Located<NominalTypeDecl *> {
+  /// The `TypeRepr` of the inheritance clause entry from which this nominal was
+  /// sourced, if any. For example, if this is a conformance to `Y` declared as
+  /// `struct S: X, Y & Z {}`, this is the `TypeRepr` for `Y & Z`.
+  TypeRepr *inheritedTypeRepr;
+
   ConformanceAttributes attributes;
 
   /// Whether this inherited entry was suppressed via "~".
@@ -612,10 +617,10 @@ struct InheritedNominalEntry : Located<NominalTypeDecl *> {
   InheritedNominalEntry() { }
 
   InheritedNominalEntry(NominalTypeDecl *item, SourceLoc loc,
-                        ConformanceAttributes attributes,
-                        bool isSuppressed)
-      : Located(item, loc), attributes(attributes),
-        isSuppressed(isSuppressed) {}
+                        TypeRepr *inheritedTypeRepr,
+                        ConformanceAttributes attributes, bool isSuppressed)
+      : Located(item, loc), inheritedTypeRepr(inheritedTypeRepr),
+        attributes(attributes), isSuppressed(isSuppressed) {}
 };
 
 /// Retrieve the set of nominal type declarations that are directly

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2913,10 +2913,10 @@ NormalProtocolConformance *
 ASTContext::getNormalConformance(Type conformingType,
                                  ProtocolDecl *protocol,
                                  SourceLoc loc,
+                                 TypeRepr *inheritedTypeRepr,
                                  DeclContext *dc,
                                  ProtocolConformanceState state,
-                                 ProtocolConformanceOptions options,
-                                 SourceLoc preconcurrencyLoc) {
+                                 ProtocolConformanceOptions options) {
   assert(dc->isTypeContext());
 
   llvm::FoldingSetNodeID id;
@@ -2930,8 +2930,7 @@ ASTContext::getNormalConformance(Type conformingType,
 
   // Build a new normal protocol conformance.
   auto result = new (*this) NormalProtocolConformance(
-      conformingType, protocol, loc, dc, state,
-      options, preconcurrencyLoc);
+      conformingType, protocol, loc, inheritedTypeRepr, dc, state, options);
   normalConformances.InsertNode(result, insertPos);
 
   return result;

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -149,13 +149,20 @@ void ConformanceLookupTable::destroy() {
 
 namespace {
   struct ConformanceConstructionInfo : public Located<ProtocolDecl *> {
+    /// The `TypeRepr` of the inheritance clause entry from which this nominal
+    /// was sourced, if any. For example, if this is a conformance to `Y`
+    /// declared as `struct S: X, Y & Z {}`, this is the `TypeRepr` for `Y & Z`.
+    TypeRepr *inheritedTypeRepr;
+
     ConformanceAttributes attributes;
 
     ConformanceConstructionInfo() { }
 
     ConformanceConstructionInfo(ProtocolDecl *item, SourceLoc loc,
+                                TypeRepr *inheritedTypeRepr,
                                 ConformanceAttributes attributes)
-        : Located(item, loc), attributes(attributes) {}
+        : Located(item, loc), inheritedTypeRepr(inheritedTypeRepr),
+          attributes(attributes) {}
   };
 }
 
@@ -210,8 +217,9 @@ void ConformanceLookupTable::forEachInStage(ConformanceStage stage,
       loader.first->loadAllConformances(next, loader.second, conformances);
       registerProtocolConformances(next, conformances);
       for (auto conf : conformances) {
-        protocols.push_back(
-            {conf->getProtocol(), SourceLoc(), ConformanceAttributes()});
+        protocols.push_back({conf->getProtocol(), SourceLoc(),
+                             /*inheritedTypeRepr=*/nullptr,
+                             ConformanceAttributes()});
       }
     } else if (next->getParentSourceFile() ||
                next->getParentModule()->isBuiltinModule()) {
@@ -220,7 +228,8 @@ void ConformanceLookupTable::forEachInStage(ConformanceStage stage,
       for (const auto &found :
                getDirectlyInheritedNominalTypeDecls(next, inverses, anyObject)) {
         if (auto proto = dyn_cast<ProtocolDecl>(found.Item))
-          protocols.push_back({proto, found.Loc, found.attributes});
+          protocols.push_back(
+              {proto, found.Loc, found.inheritedTypeRepr, found.attributes});
       }
     }
 
@@ -292,8 +301,6 @@ void ConformanceLookupTable::updateLookupTable(NominalTypeDecl *nominal,
     forEachInStage(
         stage, nominal,
         [&](NominalTypeDecl *nominal) {
-          auto source = ConformanceSource::forExplicit(nominal);
-
           // Get all of the protocols in the inheritance clause.
           InvertibleProtocolSet inverses;
           bool anyObject = false;
@@ -303,10 +310,12 @@ void ConformanceLookupTable::updateLookupTable(NominalTypeDecl *nominal,
             if (!proto)
               continue;
             auto kp = proto->getKnownProtocolKind();
-           assert(!found.isSuppressed ||
-                  kp.has_value() &&
-                      "suppressed conformance for non-known protocol!?");
+            assert(!found.isSuppressed ||
+                   kp.has_value() &&
+                       "suppressed conformance for non-known protocol!?");
             if (!found.isSuppressed) {
+              auto source = ConformanceSource::forExplicit(
+                  nominal, found.inheritedTypeRepr);
               addProtocol(
                   proto, found.Loc, source.withAttributes(found.attributes));
             }
@@ -318,11 +327,12 @@ void ConformanceLookupTable::updateLookupTable(NominalTypeDecl *nominal,
         [&](ExtensionDecl *ext, ArrayRef<ConformanceConstructionInfo> protos) {
           // The extension decl may not be validated, so we can't use
           // its inherited protocols directly.
-          auto source = ConformanceSource::forExplicit(ext);
-          for (auto locAndProto : protos)
-            addProtocol(
-                locAndProto.Item, locAndProto.Loc,
-                source.withAttributes(locAndProto.attributes));
+          for (auto locAndProto : protos) {
+            auto source = ConformanceSource::forExplicit(
+                ext, locAndProto.inheritedTypeRepr);
+            addProtocol(locAndProto.Item, locAndProto.Loc,
+                        source.withAttributes(locAndProto.attributes));
+          }
         });
     break;
 
@@ -972,12 +982,17 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
       implyingConf = origImplyingConf->getRootNormalConformance();
     }
 
+    TypeRepr *inheritedTypeRepr = nullptr;
+    if (entry->Source.getKind() == ConformanceEntryKind::Explicit) {
+      inheritedTypeRepr = entry->Source.getInheritedTypeRepr();
+    }
+
     // Create or find the normal conformance.
     auto normalConf = ctx.getNormalConformance(
-        conformingType, protocol, conformanceLoc, conformingDC,
-        ProtocolConformanceState::Incomplete,
-        entry->Source.getOptions(),
-        entry->Source.getPreconcurrencyLoc());
+        conformingType, protocol, conformanceLoc, inheritedTypeRepr,
+        conformingDC, ProtocolConformanceState::Incomplete,
+        entry->Source.getOptions());
+
     // Invalid code may cause the getConformance call below to loop, so break
     // the infinite recursion by setting this eagerly to shortcircuit with the
     // early return at the start of this function.
@@ -1045,10 +1060,11 @@ void ConformanceLookupTable::registerProtocolConformance(
 
   // Otherwise, add a new entry.
   auto inherited = dyn_cast<InheritedProtocolConformance>(conformance);
-  ConformanceSource source
-    = inherited   ? ConformanceSource::forInherited(cast<ClassDecl>(nominal)) :
-      synthesized ? ConformanceSource::forSynthesized(dc) :
-                    ConformanceSource::forExplicit(dc);
+  ConformanceSource source =
+      inherited ? ConformanceSource::forInherited(cast<ClassDecl>(nominal))
+      : synthesized
+          ? ConformanceSource::forSynthesized(dc)
+          : ConformanceSource::forExplicit(dc, /*inheritedEntry=*/nullptr);
 
   ASTContext &ctx = nominal->getASTContext();
   ConformanceEntry *entry = new (ctx) ConformanceEntry(SourceLoc(),

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -4090,7 +4090,8 @@ void swift::getDirectlyInheritedNominalTypeDecls(
 
   // Form the result.
   for (auto nominal : nominalTypes) {
-    result.push_back({nominal, loc, attributes, isSuppressed});
+    result.push_back({nominal, loc, inheritedTypes.getTypeRepr(i), attributes,
+                      isSuppressed});
   }
 }
 
@@ -4123,8 +4124,8 @@ swift::getDirectlyInheritedNominalTypeDecls(
     ConformanceAttributes attributes;
     if (attr->isUnchecked())
       attributes.uncheckedLoc = loc;
-    result.push_back(
-        {attr->getProtocol(), loc, attributes, /*isSuppressed=*/false});
+    result.push_back({attr->getProtocol(), loc, /*inheritedTypeRepr=*/nullptr,
+                      attributes, /*isSuppressed=*/false});
   }
 
   // Else we have access to this information on the where clause.
@@ -4135,7 +4136,8 @@ swift::getDirectlyInheritedNominalTypeDecls(
   // FIXME: Refactor SelfBoundsFromWhereClauseRequest to dig out
   // the source location.
   for (auto inheritedNominal : selfBounds.decls)
-    result.emplace_back(inheritedNominal, SourceLoc(), ConformanceAttributes(),
+    result.emplace_back(inheritedNominal, SourceLoc(),
+                        /*inheritedTypeRepr=*/nullptr, ConformanceAttributes(),
                         /*isSuppressed=*/false);
 
   return result;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -216,7 +216,6 @@ void NormalProtocolConformance::setSourceKindAndImplyingConformance(
   Bits.NormalProtocolConformance.SourceKind = unsigned(sourceKind);
   if (auto implying = implyingConformance) {
     ImplyingConformance = implying;
-    PreconcurrencyLoc = implying->getPreconcurrencyLoc();
     Bits.NormalProtocolConformance.Options =
         implyingConformance->getOptions().toRaw();
     if (getProtocol()->isMarkerProtocol()) {
@@ -515,6 +514,18 @@ TypeExpr *NormalProtocolConformance::getExplicitGlobalActorIsolation() const {
   return ctx.getGlobalCache().conformanceExplicitGlobalActorIsolation[this];
 }
 
+SourceLoc NormalProtocolConformance::getPreconcurrencyLoc() const {
+  if (!isPreconcurrency()) {
+    return SourceLoc();
+  }
+
+  if (!getInheritedTypeRepr()) {
+    return SourceLoc();
+  }
+
+  return getInheritedTypeRepr()->findAttrLoc(TypeAttrKind::Preconcurrency);
+}
+
 bool NormalProtocolConformance::hasExplicitGlobalActorIsolation() const {
   return Bits.NormalProtocolConformance.HasExplicitGlobalActor;
 }
@@ -803,6 +814,42 @@ void NormalProtocolConformance::resolveValueWitnesses() const {
   evaluateOrDefault(getProtocol()->getASTContext().evaluator,
                     ResolveValueWitnessesRequest{mutableThis},
                     evaluator::SideEffect());
+}
+
+void NormalProtocolConformance::applyConformanceAttribute(
+    InFlightDiagnostic &diag, std::string attrStr) const {
+  TypeRepr *inheritedTypeRepr = nullptr;
+  {
+    // Look through implied conformances.
+    auto *conformance = this;
+    while (conformance->getSourceKind() == ConformanceEntryKind::Implied) {
+      conformance = conformance->getImplyingConformance();
+    }
+    inheritedTypeRepr = conformance->getInheritedTypeRepr();
+  }
+
+  if (!inheritedTypeRepr) {
+    return;
+  }
+
+  // FIXME: We shouldn't be applying the attribute to all the protocols in a
+  // composition.
+  SourceLoc insertionLoc = [&] {
+    if (auto *attrTypeRepr = dyn_cast<AttributedTypeRepr>(inheritedTypeRepr)) {
+      // If this is a modifier, append, rather than prepend, it to the
+      // attribute list. Because e.g. `@unsafe nonisolated P` does parse,
+      // whereas `nonisolated @unsafe P` does not.
+      if (attrStr[0] != '@') {
+        return attrTypeRepr->getTypeRepr()->getStartLoc();
+      }
+    }
+
+    return inheritedTypeRepr->getStartLoc();
+  }();
+
+  attrStr += " ";
+
+  diag.fixItInsert(insertionLoc, attrStr);
 }
 
 SpecializedProtocolConformance::SpecializedProtocolConformance(

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8864,9 +8864,9 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
         if (lookupConformance(ty, protocol))
           continue;
         auto conformance = SwiftContext.getNormalConformance(
-            ty, protocol, nominal->getLoc(), nominal->getDeclContextForModule(),
-            ProtocolConformanceState::Complete,
-            ProtocolConformanceOptions());
+            ty, protocol, nominal->getLoc(), /*inheritedTypeRepr=*/nullptr,
+            nominal->getDeclContextForModule(),
+            ProtocolConformanceState::Complete, ProtocolConformanceOptions());
         conformance->setSourceKindAndImplyingConformance(
             ConformanceEntryKind::Synthesized, nullptr);
 
@@ -10747,9 +10747,8 @@ void ClangImporter::Implementation::loadAllConformances(
       options |= ProtocolConformanceFlags::Unchecked;
 
     auto conformance = SwiftContext.getNormalConformance(
-        dc->getDeclaredInterfaceType(),
-        protocol, SourceLoc(), dc,
-        ProtocolConformanceState::Incomplete,
+        dc->getDeclaredInterfaceType(), protocol, SourceLoc(),
+        /*inheritedTypeRepr=*/nullptr, dc, ProtocolConformanceState::Incomplete,
         options);
     conformance->setLazyLoader(this, /*context*/0);
     conformance->setState(ProtocolConformanceState::Complete);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3601,7 +3601,8 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
     for (auto protocol : missingProtocols) {
       // Create a fake conformance for this type to the given protocol.
       auto conformance = getASTContext().getNormalConformance(
-          nominal->getSelfInterfaceType(), protocol, SourceLoc(), nominal,
+          nominal->getSelfInterfaceType(), protocol, SourceLoc(),
+          /*inheritedTypeRepr=*/nullptr, nominal,
           ProtocolConformanceState::Incomplete, ProtocolConformanceOptions());
 
       // Resolve the conformance to generate fixits.

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -816,10 +816,9 @@ addDistributedActorCodableConformance(
   }
 
   auto conformance = C.getNormalConformance(
-      actor->getDeclaredInterfaceType(), proto,
-      actor->getLoc(), /*dc=*/actor,
-      ProtocolConformanceState::Incomplete,
-      ProtocolConformanceOptions());
+      actor->getDeclaredInterfaceType(), proto, actor->getLoc(),
+      /*inheritedTypeRepr=*/nullptr, /*dc=*/actor,
+      ProtocolConformanceState::Incomplete, ProtocolConformanceOptions());
   conformance->setSourceKindAndImplyingConformance(
       ConformanceEntryKind::Synthesized, nullptr);
   actor->registerProtocolConformance(conformance, /*synthesized=*/true);
@@ -1078,8 +1077,9 @@ GetDistributedActorAsActorConformanceRequest::evaluate(
     return nullptr;
 
   auto distributedActorAsActorConformance = ctx.getNormalConformance(
-      Type(ctx.TheSelfType), actorProto, SourceLoc(), ext,
-      ProtocolConformanceState::Incomplete, ProtocolConformanceOptions());
+      Type(ctx.TheSelfType), actorProto, SourceLoc(),
+      /*inheritedTypeRepr=*/nullptr, ext, ProtocolConformanceState::Incomplete,
+      ProtocolConformanceOptions());
   // NOTE: Normally we "register" a conformance, but here we don't
   // because we cannot (currently) register them in a protocol,
   // since they do not have conformance tables.

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -377,8 +377,8 @@ NormalProtocolConformance *
 DeriveImplicitBitwiseCopyableConformance::synthesizeConformance(
     DeclContext *dc) {
   auto conformance = context.getNormalConformance(
-      nominal->getDeclaredInterfaceType(), protocol, nominal->getLoc(), dc,
-      ProtocolConformanceState::Complete,
+      nominal->getDeclaredInterfaceType(), protocol, nominal->getLoc(),
+      /*inheritedTypeRepr=*/nullptr, dc, ProtocolConformanceState::Complete,
       ProtocolConformanceOptions());
   conformance->setSourceKindAndImplyingConformance(
       ConformanceEntryKind::Synthesized, nullptr);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7298,7 +7298,8 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
       options |= ProtocolConformanceFlags::Unchecked;
     auto conformance = ctx.getNormalConformance(
         nominal->getDeclaredInterfaceType(), proto, nominal->getLoc(),
-        conformanceDC, ProtocolConformanceState::Complete, options);
+        /*inheritedTypeRepr=*/nullptr, conformanceDC,
+        ProtocolConformanceState::Complete, options);
     conformance->setSourceKindAndImplyingConformance(
         ConformanceEntryKind::Synthesized, nullptr);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2707,8 +2707,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
         
         if (explicitConformance->getSourceKind() ==
               ConformanceEntryKind::Explicit) {
-          diag.fixItInsert(explicitConformance->getProtocolNameLoc(),
-                           "@unsafe ");
+          conformance->applyConformanceAttribute(diag, "@unsafe");
         }
       }
 
@@ -5027,14 +5026,12 @@ static void diagnoseConformanceIsolationErrors(
       if (auto nominal = globalActorIsolation->getAnyNominal())
         isMainActor = nominal->isMainActor();
 
-      ctx.Diags.diagnose(
+      auto diag = ctx.Diags.diagnose(
           conformance->getProtocolNameLoc(),
-          diag::note_isolate_conformance_to_global_actor,
-          globalActorIsolation,
-          isMainActor,
-          globalActorIsolation.getString())
-        .fixItInsert(conformance->getProtocolNameLoc(),
-                     "@" + globalActorIsolation.getString() + " ");
+          diag::note_isolate_conformance_to_global_actor, globalActorIsolation,
+          isMainActor, globalActorIsolation.getString());
+      conformance->applyConformanceAttribute(
+          diag, "@" + globalActorIsolation.getString());
     }
 
     // If marking witnesses as 'nonisolated' could work, suggest that.
@@ -5052,10 +5049,10 @@ static void diagnoseConformanceIsolationErrors(
     // If the conformance could be @preconcurrency, suggest it.
     if (!conformance->isIsolated() && !conformance->isPreconcurrency() &&
         !hasIsolatedConformances) {
-      ctx.Diags.diagnose(
-          conformance->getProtocolNameLoc(),
-          diag::note_make_conformance_preconcurrency)
-        .fixItInsert(conformance->getProtocolNameLoc(), "@preconcurrency ");
+      auto diag =
+          ctx.Diags.diagnose(conformance->getProtocolNameLoc(),
+                             diag::note_make_conformance_preconcurrency);
+      conformance->applyConformanceAttribute(diag, "@preconcurrency");
     }
 
     // Make a note of all of the isolation problems we encountered in this
@@ -6749,9 +6746,10 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
 
       auto nameLoc = normal->getProtocolNameLoc();
       if (nameLoc.isValid()) {
-        Context.Diags.diagnose(
-            nameLoc, diag::isolated_conformance_will_become_nonisolated, nominal, proto)
-          .fixItInsert(nameLoc, "nonisolated ");
+        auto diag = Context.Diags.diagnose(
+            nameLoc, diag::isolated_conformance_will_become_nonisolated,
+            nominal, proto);
+        normal->applyConformanceAttribute(diag, "nonisolated");
       }
     }
   }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1066,7 +1066,7 @@ ProtocolConformanceDeserializer::readNormalProtocolConformance(
   }
 
   auto conformance = ctx.getNormalConformance(
-      conformingType, proto, SourceLoc(), dc,
+      conformingType, proto, SourceLoc(), /*inheritedTypeRepr=*/nullptr, dc,
       ProtocolConformanceState::Incomplete,
       ProtocolConformanceOptions(rawOptions, globalActorTypeExpr));
 

--- a/test/Concurrency/isolated_conformance_migrate.swift
+++ b/test/Concurrency/isolated_conformance_migrate.swift
@@ -31,3 +31,31 @@ struct MA4: @MainActor P { }
 @MainActor
 struct MA5: nonisolated P { }
 
+// Make sure we correctly apply the conformance attribute for more complex
+// inheritance entries.
+do {
+  @MainActor protocol MainActorP { }
+  enum Nested {
+    protocol P { }
+    protocol Q { }
+  }
+  do {
+    @MainActor struct S: Nested.P { }
+    // expected-warning@-1 {{conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{26-26=nonisolated }}
+  }
+  do {
+    // Modifier inserted *after* '@unsafe'.
+    @MainActor struct S: @unsafe Nested.P { }
+    // expected-warning@-1 {{conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{34-34=nonisolated }}
+  }
+  do {
+    @MainActor struct S: Nested.P & Nested.Q { }
+    // expected-warning@-1 {{conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{26-26=nonisolated }}
+    // expected-warning@-2 {{conformance of 'S' to 'Q' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{26-26=nonisolated }}
+  }
+  do {
+    // FIXME: We shouldn't be applying nonisolated to both protocols.
+    @MainActor struct S: Nested.P & MainActorP { }
+    // expected-warning@-1 {{conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{26-26=nonisolated }}
+  }
+}


### PR DESCRIPTION
We were using `ProtocolNameLoc` for the insertion location, which is not necessarily the start location of the `TypeRepr` associated with the conformance:

```
warning: conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances' [isolated_conformance_will_become_nonisolated] [#IsolatedConformances]
@MainActor struct S: @unsafe Nested.P {}
                                    ^
                                    nonisolated
```

Fixes rdar://132570262.