### PR TITLE
[Diagnostics] Fix typo in 'overridden' warning message and identifier

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -195,8 +195,8 @@ WARNING(ignoring_option_obsolete,none,
         "ignoring '%0'; this option is obsolete", (StringRef))
 WARNING(ignoring_option_requires_option,none,
         "ignoring %0 (requires %1)", (StringRef, StringRef))
-WARNING(warn_ignore_option_overriden_by,none,
-        "ignoring %0 (overriden by %1)", (StringRef, StringRef))
+WARNING(warn_ignore_option_overridden_by,none,
+        "ignoring %0 (overridden by %1)", (StringRef, StringRef))
 
 WARNING(warn_implicit_concurrency_import_failed,none,
         "unable to perform implicit import of \"_Concurrency\" module: no such module found", ())

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1487,7 +1487,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Opts.AllowNonResilientAccess) {
     // Override the option to skip non-exportable decls.
     if (Opts.SkipNonExportableDecls) {
-      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
                      "-experimental-skip-non-exportable-decls",
                      "-allow-non-resilient-access");
       Opts.SkipNonExportableDecls = false;
@@ -1498,7 +1498,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
             FrontendOpts.RequestedAction)) {
       if (FrontendOpts.RequestedAction !=
           FrontendOptions::ActionType::TypecheckModuleFromInterface)
-        Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+        Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
                        "-allow-non-resilient-access",
                        "-compile-module-from-interface");
       Opts.AllowNonResilientAccess = false;
@@ -1960,7 +1960,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   if (Args.hasArg(
         OPT_experimental_skip_non_inlinable_function_bodies_without_types)) {
     if (LangOpts.AllowNonResilientAccess)
-      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
                      "-experimental-skip-non-inlinable-function-bodies-without-types",
                      "-allow-non-resilient-access");
     else
@@ -1971,7 +1971,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   // body skipping.
   if (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies)) {
     if (LangOpts.AllowNonResilientAccess)
-      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
                      "-experimental-skip-non-inlinable-function-bodies",
                      "-allow-non-resilient-access");
     else
@@ -1980,7 +1980,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_tbd_is_installapi)) {
     if (LangOpts.AllowNonResilientAccess)
-      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
                      "-tbd-is-installapi",
                      "-allow-non-resilient-access");
     else
@@ -1989,7 +1989,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_experimental_skip_all_function_bodies)) {
     if (LangOpts.AllowNonResilientAccess)
-      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
                      "-experimental-skip-all-function-bodies",
                      "-allow-non-resilient-access");
     else
@@ -2063,7 +2063,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
 
   if (LangOpts.AllowNonResilientAccess &&
       Opts.EnableLazyTypecheck) {
-    Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
+    Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overridden_by,
                    "-experimental-lazy-typecheck",
                    "-allow-non-resilient-access");
     Opts.EnableLazyTypecheck = false;

--- a/test/SILGen/package_allow_non_resilient_access.swift
+++ b/test/SILGen/package_allow_non_resilient_access.swift
@@ -44,7 +44,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-1
-// CHECK-DIAG-1: warning: ignoring -experimental-skip-non-exportable-decls (overriden by -allow-non-resilient-access)
+// CHECK-DIAG-1: warning: ignoring -experimental-skip-non-exportable-decls (overridden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -experimental-skip-non-inlinable-function-bodies-without-types with warning
@@ -57,7 +57,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-2
-// CHECK-DIAG-2: warning: ignoring -experimental-skip-non-inlinable-function-bodies-without-types (overriden by -allow-non-resilient-access)
+// CHECK-DIAG-2: warning: ignoring -experimental-skip-non-inlinable-function-bodies-without-types (overridden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -experimental-skip-non-inlinable-function-bodies with warning
@@ -70,7 +70,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-3
-// CHECK-DIAG-3: warning: ignoring -experimental-skip-non-inlinable-function-bodies (overriden by -allow-non-resilient-access)
+// CHECK-DIAG-3: warning: ignoring -experimental-skip-non-inlinable-function-bodies (overridden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -experimental-skip-all-function-bodies with warning
@@ -83,7 +83,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-4
-// CHECK-DIAG-4: warning: ignoring -experimental-skip-all-function-bodies (overriden by -allow-non-resilient-access)
+// CHECK-DIAG-4: warning: ignoring -experimental-skip-all-function-bodies (overridden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -experimental-lazy-typecheck with warning
@@ -96,7 +96,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-5
-// CHECK-DIAG-5: warning: ignoring -experimental-lazy-typecheck (overriden by -allow-non-resilient-access)
+// CHECK-DIAG-5: warning: ignoring -experimental-lazy-typecheck (overridden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Override -tbd-is-installapi with warning
@@ -109,7 +109,7 @@
 // RUN:   -experimental-allow-non-resilient-access \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-TBD
-// CHECK-DIAG-TBD: warning: ignoring -tbd-is-installapi (overriden by -allow-non-resilient-access)
+// CHECK-DIAG-TBD: warning: ignoring -tbd-is-installapi (overridden by -allow-non-resilient-access)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-ON
 
 /// Build Utils interface files.
@@ -130,7 +130,7 @@
 // RUN: -allow-non-resilient-access \
 // RUN: %t/Utils.package.swiftinterface -o %t/Utils.swiftmodule \
 // RUN: 2>&1 | %FileCheck %s --check-prefix=CHECK-DIAG-INTERFACE
-// CHECK-DIAG-INTERFACE: warning: ignoring -allow-non-resilient-access (overriden by -compile-module-from-interface)
+// CHECK-DIAG-INTERFACE: warning: ignoring -allow-non-resilient-access (overridden by -compile-module-from-interface)
 // RUN: llvm-bcanalyzer --dump %t/Utils.swiftmodule | %FileCheck %s --check-prefix=CHECK-OFF
 // CHECK-OFF-NOT: ALLOW_NON_RESILIENT_ACCESS
 


### PR DESCRIPTION
Fixes typo in user-visible warning message as well as the name of the diagnostic itself.