### PR TITLE
[cxx-interop] Fix test failure on older macOS

### DIFF
--- a/test/Interop/Cxx/foreign-reference/print-reference.swift
+++ b/test/Interop/Cxx/foreign-reference/print-reference.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -disable-availability-checking -I %S/Inputs) | %FileCheck %s
+// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -I %S/Inputs) | %FileCheck %s
 
 // REQUIRES: executable_test
 
@@ -12,10 +12,15 @@
 import Printed
 
 func printCxxImmortalFRT() {
-    let s = ImmortalFRT()
-    print(s)
+    if #available(SwiftStdlib 6.2, *) {
+        let s = ImmortalFRT()
+        print(s)
+    } else {
+        print("runtime too old")
+    }
 }
 
+@available(SwiftStdlib 5.9, *)
 extension FRTCustomStringConvertible : CustomStringConvertible {
     public var description: String {
         return "FRTCustomStringConvertible(publ: \(publ))"
@@ -23,20 +28,28 @@ extension FRTCustomStringConvertible : CustomStringConvertible {
 }
 
 func printCxxFRTCustomStringConvertible() {
-    let s = FRTCustomStringConvertible()
-    print(s)
+    if #available(SwiftStdlib 5.9, *) {
+        let s = FRTCustomStringConvertible()
+        print(s)
+    } else {
+        print("runtime too old")
+    }
 }
 
 func printCxxFRType() {
-    let s = FRType()
-    print(s)
+    if #available(SwiftStdlib 6.2, *) {
+        let s = FRType()
+        print(s)
+    } else {
+        print("runtime too old")
+    }
 }
 
 printCxxImmortalFRT()
-// CHECK: ImmortalFRT()
+// CHECK: {{ImmortalFRT()|runtime too old}}
 
 printCxxFRTCustomStringConvertible()
 // CHECK: FRTCustomStringConvertible(publ: 2)
 
 printCxxFRType()
-// CHECK: FRType()
+// CHECK: {{FRType()|runtime too old}}


### PR DESCRIPTION
The runtime logic for printing a foreign reference type is behind `if #available(SwiftStdlib 6.2, *)`, which means it won't run on older versions of macOS, even if you use a newer Swift runtime.

rdar://153735437

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
