### PR TITLE
Guard InlineArray addressors with feature flag

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -268,6 +268,7 @@ LANGUAGE_FEATURE(AlwaysInheritActorContext, 472, "@_inheritActorContext(always)"
 LANGUAGE_FEATURE(BuiltinSelect, 0, "Builtin.select")
 LANGUAGE_FEATURE(BuiltinInterleave, 0, "Builtin.interleave and Builtin.deinterleave")
 LANGUAGE_FEATURE(BuiltinVectorsExternC, 0, "Extern C support for Builtin vector types")
+LANGUAGE_FEATURE(AddressOfProperty, 0, "Builtin.unprotectedAddressOf properties")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -691,6 +691,7 @@ static bool usesFeatureDefaultIsolationPerFile(Decl *D) {
 UNINTERESTING_FEATURE(BuiltinSelect)
 UNINTERESTING_FEATURE(BuiltinInterleave)
 UNINTERESTING_FEATURE(BuiltinVectorsExternC)
+UNINTERESTING_FEATURE(AddressOfProperty)
 
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -69,7 +69,11 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal var _address: UnsafePointer<Element> {
+#if $AddressOfProperty
     unsafe UnsafePointer<Element>(Builtin.unprotectedAddressOfBorrow(_storage))
+#else
+    unsafe UnsafePointer<Element>(Builtin.unprotectedAddressOfBorrow(self))
+#endif
   }
 
   /// Returns a buffer pointer over the entire array.
@@ -86,7 +90,11 @@ extension InlineArray where Element: ~Copyable {
   @_transparent
   internal var _mutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
+#if $AddressOfProperty
       unsafe UnsafeMutablePointer<Element>(Builtin.unprotectedAddressOf(&_storage))
+#else
+      unsafe UnsafeMutablePointer<Element>(Builtin.unprotectedAddressOf(&self))
+#endif
     }
   }
 


### PR DESCRIPTION
To be able to parse a recent Swift.swiftinterface file with a 6.2 compiler. This is a follow-up fix for https://github.com/swiftlang/swift/pull/81441

rdar://154118968
