### PR TITLE
[Concurrency] Add functions to allow testing of external executors.

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -154,6 +154,10 @@ public:
     return Flags.getPriority();
   }
 
+  void setPriority(JobPriority priority) {
+    Flags.setPriority(priority);
+  }
+
   uint32_t getJobId() const {
     return Id;
   }

--- a/stdlib/public/Concurrency/ExecutorBridge.cpp
+++ b/stdlib/public/Concurrency/ExecutorBridge.cpp
@@ -55,6 +55,11 @@ uint8_t swift_job_getPriority(Job *job) {
 }
 
 extern "C" SWIFT_CC(swift)
+void swift_job_setPriority(Job *job, uint8_t priority) {
+  job->setPriority(JobPriority(priority));
+}
+
+extern "C" SWIFT_CC(swift)
 uint8_t swift_job_getKind(Job *job) {
   return (uint8_t)(job->Flags.getKind());
 }

--- a/stdlib/public/Concurrency/ExecutorBridge.swift
+++ b/stdlib/public/Concurrency/ExecutorBridge.swift
@@ -78,6 +78,10 @@ internal func _jobDeallocate(_ job: Builtin.Job,
 internal func _jobGetPriority(_ job: Builtin.Job) -> UInt8
 
 @available(StdlibDeploymentTarget 6.2, *)
+@_silgen_name("swift_job_setPriority")
+internal func _jobSetPriority(_ job: Builtin.Job, _ priority: UInt8)
+
+@available(StdlibDeploymentTarget 6.2, *)
 @_silgen_name("swift_job_getKind")
 internal func _jobGetKind(_ job: Builtin.Job) -> UInt8
 

--- a/test/abi/Inputs/macOS/arm64/concurrency/baseline
+++ b/test/abi/Inputs/macOS/arm64/concurrency/baseline
@@ -471,6 +471,7 @@ _$ss11JobPriorityV2eeoiySbAB_ABtFZ
 _$ss11JobPriorityV2geoiySbAB_ABtFZ
 _$ss11JobPriorityV2leoiySbAB_ABtFZ
 _$ss11JobPriorityV2neoiySbAB_ABtFZ
+_$ss11JobPriorityV8rawValueABs5UInt8V_tcfC
 _$ss11JobPriorityV8rawValues5UInt8VvM
 _$ss11JobPriorityV8rawValues5UInt8Vvg
 _$ss11JobPriorityV8rawValues5UInt8VvpMV
@@ -480,6 +481,7 @@ _$ss11JobPriorityVMn
 _$ss11JobPriorityVN
 _$ss11JobPriorityVSLsMc
 _$ss11JobPriorityVSQsMc
+_$ss11JobPriorityVyABScPcfC
 _$ss12MainExecutorMp
 _$ss12MainExecutorPScfTb
 _$ss12MainExecutorPs07RunLoopB0Tb
@@ -1180,6 +1182,7 @@ __swift_concurrency_debug_non_future_adapter
 __swift_concurrency_debug_supportsPriorityEscalation
 __swift_concurrency_debug_task_future_wait_resume_adapter
 __swift_concurrency_debug_task_wait_throwing_resume_adapter
+__swift_createJobForTestingOnly
 _swift_asyncLet_begin
 _swift_asyncLet_consume
 _swift_asyncLet_consume_throwing

--- a/test/abi/Inputs/macOS/arm64/concurrency/baseline-asserts
+++ b/test/abi/Inputs/macOS/arm64/concurrency/baseline-asserts
@@ -471,6 +471,7 @@ _$ss11JobPriorityV2eeoiySbAB_ABtFZ
 _$ss11JobPriorityV2geoiySbAB_ABtFZ
 _$ss11JobPriorityV2leoiySbAB_ABtFZ
 _$ss11JobPriorityV2neoiySbAB_ABtFZ
+_$ss11JobPriorityV8rawValueABs5UInt8V_tcfC
 _$ss11JobPriorityV8rawValues5UInt8VvM
 _$ss11JobPriorityV8rawValues5UInt8Vvg
 _$ss11JobPriorityV8rawValues5UInt8VvpMV
@@ -480,6 +481,7 @@ _$ss11JobPriorityVMn
 _$ss11JobPriorityVN
 _$ss11JobPriorityVSLsMc
 _$ss11JobPriorityVSQsMc
+_$ss11JobPriorityVyABScPcfC
 _$ss12MainExecutorMp
 _$ss12MainExecutorPScfTb
 _$ss12MainExecutorPs07RunLoopB0Tb
@@ -1180,6 +1182,7 @@ __swift_concurrency_debug_non_future_adapter
 __swift_concurrency_debug_supportsPriorityEscalation
 __swift_concurrency_debug_task_future_wait_resume_adapter
 __swift_concurrency_debug_task_wait_throwing_resume_adapter
+__swift_createJobForTestingOnly
 _swift_asyncLet_begin
 _swift_asyncLet_consume
 _swift_asyncLet_consume_throwing

--- a/test/abi/Inputs/macOS/x86_64/concurrency/baseline
+++ b/test/abi/Inputs/macOS/x86_64/concurrency/baseline
@@ -471,6 +471,7 @@ _$ss11JobPriorityV2eeoiySbAB_ABtFZ
 _$ss11JobPriorityV2geoiySbAB_ABtFZ
 _$ss11JobPriorityV2leoiySbAB_ABtFZ
 _$ss11JobPriorityV2neoiySbAB_ABtFZ
+_$ss11JobPriorityV8rawValueABs5UInt8V_tcfC
 _$ss11JobPriorityV8rawValues5UInt8VvM
 _$ss11JobPriorityV8rawValues5UInt8Vvg
 _$ss11JobPriorityV8rawValues5UInt8VvpMV
@@ -480,6 +481,7 @@ _$ss11JobPriorityVMn
 _$ss11JobPriorityVN
 _$ss11JobPriorityVSLsMc
 _$ss11JobPriorityVSQsMc
+_$ss11JobPriorityVyABScPcfC
 _$ss12MainExecutorMp
 _$ss12MainExecutorPScfTb
 _$ss12MainExecutorPs07RunLoopB0Tb
@@ -1180,6 +1182,7 @@ __swift_concurrency_debug_non_future_adapter
 __swift_concurrency_debug_supportsPriorityEscalation
 __swift_concurrency_debug_task_future_wait_resume_adapter
 __swift_concurrency_debug_task_wait_throwing_resume_adapter
+__swift_createJobForTestingOnly
 _swift_asyncLet_begin
 _swift_asyncLet_consume
 _swift_asyncLet_consume_throwing

--- a/test/abi/Inputs/macOS/x86_64/concurrency/baseline-asserts
+++ b/test/abi/Inputs/macOS/x86_64/concurrency/baseline-asserts
@@ -471,6 +471,7 @@ _$ss11JobPriorityV2eeoiySbAB_ABtFZ
 _$ss11JobPriorityV2geoiySbAB_ABtFZ
 _$ss11JobPriorityV2leoiySbAB_ABtFZ
 _$ss11JobPriorityV2neoiySbAB_ABtFZ
+_$ss11JobPriorityV8rawValueABs5UInt8V_tcfC
 _$ss11JobPriorityV8rawValues5UInt8VvM
 _$ss11JobPriorityV8rawValues5UInt8Vvg
 _$ss11JobPriorityV8rawValues5UInt8VvpMV
@@ -480,6 +481,7 @@ _$ss11JobPriorityVMn
 _$ss11JobPriorityVN
 _$ss11JobPriorityVSLsMc
 _$ss11JobPriorityVSQsMc
+_$ss11JobPriorityVyABScPcfC
 _$ss12MainExecutorMp
 _$ss12MainExecutorPScfTb
 _$ss12MainExecutorPs07RunLoopB0Tb
@@ -1180,6 +1182,7 @@ __swift_concurrency_debug_non_future_adapter
 __swift_concurrency_debug_supportsPriorityEscalation
 __swift_concurrency_debug_task_future_wait_resume_adapter
 __swift_concurrency_debug_task_wait_throwing_resume_adapter
+__swift_createJobForTestingOnly
 _swift_asyncLet_begin
 _swift_asyncLet_consume
 _swift_asyncLet_consume_throwing


### PR DESCRIPTION
Added a couple of functions to allow for the testing of executors that aren't implemented inside the concurrency runtime itself.

rdar://154195821
