### PR TITLE
[6.2][Concurrency] Global actor isolated conformances are only allowed to …

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5408,13 +5408,12 @@ getIsolationFromConformances(NominalTypeDecl *nominal) {
 
     case ActorIsolation::GlobalActor:
       // If we encountered an explicit globally isolated conformance, allow it
-      // to override the nonisolated isolation kind.
+      // to override the _nonisolated_ isolation.
       if (!foundIsolation ||
-          conformance->getSourceKind() == ConformanceEntryKind::Explicit) {
-        foundIsolation = {
-          protoIsolation,
-          IsolationSource(proto, IsolationSource::Conformance)
-        };
+          (foundIsolation->isolation.isNonisolated() &&
+           conformance->getSourceKind() == ConformanceEntryKind::Explicit)) {
+        foundIsolation = {protoIsolation,
+                          IsolationSource(proto, IsolationSource::Conformance)};
         continue;
       }
 


### PR DESCRIPTION
…override `nonisolated`.

Cherry-pick of https://github.com/swiftlang/swift/pull/82465

---

- Explanation:

  Follow-up for https://github.com/swiftlang/swift/pull/79893.

  More than one global actor isolated conformance at any level creates a clash and conforming type should be inferred as `nonisolated`.

- Resolves: rdar://154202375

- Main Branch PR: https://github.com/swiftlang/swift/pull/82465

- Risk: Low. This is a narrow fix that only affects types that conform to protocols which have different global actor isolation.

- Reviewed By: @simanerush  

- Testing: Added new test-cases to the test suite.

(cherry picked from commit 2e1fe444a63e155c3f749585659adaaf5b1619aa)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
