### PR TITLE
[6.2][CSSimplify] Narrow down tuple wrapping for pack expansion matching

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7354,9 +7354,15 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
   // and `Optional<T>` which would be handled by optional injection.
   if (isTupleWithUnresolvedPackExpansion(origType1) ||
       isTupleWithUnresolvedPackExpansion(origType2)) {
+    auto isTypeVariableWrappedInOptional = [](Type type) {
+      if (type->getOptionalObjectType()) {
+        return type->lookThroughAllOptionalTypes()->isTypeVariableOrMember();
+      }
+      return false;
+    };
     if (isa<TupleType>(desugar1) != isa<TupleType>(desugar2) &&
-        !desugar1->getOptionalObjectType() &&
-        !desugar2->getOptionalObjectType() &&
+        !isTypeVariableWrappedInOptional(desugar1) &&
+        !isTypeVariableWrappedInOptional(desugar2) &&
         !desugar1->isAny() &&
         !desugar2->isAny()) {
       return matchTypes(

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -77,8 +77,8 @@ func badCallToZip<each T, each U>(t: repeat each T, u: repeat each U) {
   // expected-error@-2 {{pack expansion requires that 'each U' and 'each T' have the same shape}}
 }
 
-do {
-  func test<A, B, each C>(
+func variadicGenericsInOptionalContext(v: Int?) {
+  func test1<A, B, each C>(
     _: A,
     _: B,
     _: repeat each C
@@ -86,7 +86,19 @@ do {
     fatalError()
   }
 
+  func test2<A, B, each C>(
+    _: A,
+    _: B,
+    _: (repeat each C)
+  ) throws -> (A, B, repeat each C) {
+    fatalError()
+  }
+
   func test() {
-    guard let _ = try? test(1, 2, 3) else { return } // Ok
+    guard let _ = try? test1(1, 2, 3) else { return } // Ok
+    guard let _ = try? test1(1, 2, v) else { return } // Ok
+
+    guard let _ = try? test2(1, 2, 3) else { return } // Ok
+    guard let _ = try? test2(1, 2, v) else { return } // Ok
   }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/82467

---

- Explanation:

  Follow-up for https://github.com/swiftlang/swift/pull/82326.

  The optional injection is only viable is the wrapped type is not yet resolved, otherwise it's safe to wrap the optional.

- Resolves: rdar://154221449

- Main Branch PR: https://github.com/swiftlang/swift/pull/82467

- Risk: Low. This narrows down the check added by https://github.com/swiftlang/swift/pull/82326 to apply only to situations when optional types are resolved.

- Reviewed By: @hamishknight 

- Testing: Added new test-cases to the test suite.

(cherry picked from commit 4804f2131b45a32d4c10de97d7080a5afb38dd0d)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
