### PR TITLE
Disable surprising lifetime inference of implicit initializers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8377,6 +8377,9 @@ ERROR(lifetime_dependence_cannot_infer_scope_ownership, none,
 NOTE(lifetime_dependence_cannot_infer_inout_suggest, none,
      "use '@_lifetime(%0: copy %0) to forward the inout dependency",
      (StringRef))
+ERROR(lifetime_dependence_cannot_infer_implicit_init, none,
+      "cannot infer implicit initialization lifetime. Add an initializer with "
+      "'@_lifetime(...)' for each parameter the result depends on", ())
 
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Experimental Inference

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1075,9 +1075,13 @@ protected:
     return LifetimeDependenceKind::Scope;
   }
 
-  // Infer implicit initialization. The dependence kind can be inferred, similar
-  // to an implicit setter, because the implementation is simply an assignment
-  // to stored property.
+  // Infer implicit initialization. A non-Escapable initializer parameter can
+  // always be inferred, similar to an implicit setter, because the
+  // implementation is simply an assignment to stored property. Escapable
+  // parameters are ambiguous: they may either be borrowed or
+  // non-dependent. non-Escapable types often have incidental integer fields
+  // that are unrelated to lifetime. Avoid inferring any dependency on Escapable
+  // parameters unless it is the (unambiguously borrowed) sole parameter.
   void inferImplicitInit() {
     auto *afd = cast<AbstractFunctionDecl>(decl);
     if (afd->getParameters()->size() == 0) {
@@ -1097,15 +1101,28 @@ protected:
       if (paramTypeInContext->hasError()) {
         return;
       }
+      if (!paramTypeInContext->isEscapable()) {
+        // An implicitly initialized non-Escapable value always copies its
+        // dependency.
+        targetDeps = std::move(targetDeps).add(paramIndex,
+                                               LifetimeDependenceKind::Inherit);
+        continue;
+      }
+      if (afd->getParameters()->size() > 1 && !useLazyInference()) {
+        diagnose(param->getLoc(),
+                 diag::lifetime_dependence_cannot_infer_implicit_init);
+        return;
+      }
+      // A single Escapable parameter must be borrowed.
       auto kind = inferLifetimeDependenceKind(paramTypeInContext,
                                               param->getValueOwnership());
       if (!kind) {
         diagnose(returnLoc,
                  diag::lifetime_dependence_cannot_infer_scope_ownership,
                  param->getParameterName().str(), diagnosticQualifier());
-        return;
       }
-      targetDeps = std::move(targetDeps).add(paramIndex, *kind);
+      targetDeps = std::move(targetDeps).add(paramIndex,
+                                             LifetimeDependenceKind::Scope);
     }
     pushDeps(std::move(targetDeps));
   }

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -75,7 +75,7 @@ func immortalConflict(_ immortal: Int) -> NE { // expected-error{{conflict betwe
 }
 
 do {
-  struct Test: ~Escapable {
+  struct Test: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
     var v1: Int
     var v2: NE
   }

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -582,6 +582,54 @@ struct NonEscapableMutableSelf: ~Escapable {
 }
 
 // =============================================================================
+// Initializers
+// =============================================================================
+
+// Motivation: Non-escapable struct definitions often have inicidental integer fields that are unrelated to lifetime.
+// Without an explicit initializer, the compiler would infer these fields to be borrowed by the implicit intializer.
+// This inevitabely results in lifetime diagnostic errors elsewhere in the code that can't be tracked down at the use
+// site:
+//
+//     let span = CountedSpan(span: span, i: 3) // ERROR: span depends on the lifetime of this value
+//
+struct CountedSpan: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let span: Span<Int>
+  let i: Int
+}
+
+struct NE_Int: ~Escapable {
+  let i: Int
+}
+
+struct NE_C: ~Escapable { // expected-error{{cannot borrow the lifetime of 'c', which has consuming ownership on an implicit initializer}}
+  let c: C
+}
+
+struct NE_C_Int: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let c: C
+  let i: Int
+}
+
+struct NE_Int_Int: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let i: Int
+  let j: Int
+}
+
+struct NE_NE: ~Escapable {
+  let ne: NE
+}
+
+struct NE_NE_Int: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let ne: NE
+  let i: Int
+}
+
+struct NE_NE_C: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let ne: NE
+  let c: C
+}
+
+// =============================================================================
 // Handle common mistakes with inout parameter annotations
 // =============================================================================
 


### PR DESCRIPTION
Non-escapable struct definitions often have inicidental integer fields that are
unrelated to lifetime. Without an explicit initializer, the compiler would infer
these fields to be borrowed by the implicit intializer.

    struct CountedSpan: ~Escapable {
      let span: Span<Int>
      let i: Int

      /* infer: @lifetime(copy span, borrow i) init(...) */
    }

This was done because
- we always want to infer lifetimes of synthesized code if possible
- inferring a borrow dependence is always conservative

But this was the wrong decision because it inevitabely results in lifetime
diagnostic errors elsewhere in the code that can't be tracked down at the use
site:

    let span = CountedSpan(span: span, i: 3) // ERROR: span depends on the lifetime of this value

Instead, force the author of the data type to specify whether the type actually
depends on trivial fields or not. Such as:

    struct CountedSpan: ~Escapable {
      let span: Span<Int>
      let i: Int

      @lifetime(copy span) init(...) { ... }
    }

This fix enables stricter diagnostics, so we need it in 6.2.

Fixes rdar://152130977 ([nonescapable] confusing diagnostic message when a
synthesized initializer generates dependence on an Int parameter)
