### PR TITLE
[6.2] Disable surprising lifetime inference of implicit initializers

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8294,6 +8294,9 @@ ERROR(lifetime_dependence_cannot_infer_kind, none,
 ERROR(lifetime_dependence_cannot_infer_scope_ownership, none,
       "cannot borrow the lifetime of '%0', which has consuming ownership on %1",
       (StringRef, StringRef))
+ERROR(lifetime_dependence_cannot_infer_implicit_init, none,
+      "cannot infer implicit initialization lifetime. Add an initializer with "
+      "'@_lifetime(...)' for each parameter the result depends on", ())
 
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Experimental Inference

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -1046,9 +1046,13 @@ protected:
     return LifetimeDependenceKind::Scope;
   }
 
-  // Infer implicit initialization. The dependence kind can be inferred, similar
-  // to an implicit setter, because the implementation is simply an assignment
-  // to stored property.
+  // Infer implicit initialization. A non-Escapable initializer parameter can
+  // always be inferred, similar to an implicit setter, because the
+  // implementation is simply an assignment to stored property. Escapable
+  // parameters are ambiguous: they may either be borrowed or
+  // non-dependent. non-Escapable types often have incidental integer fields
+  // that are unrelated to lifetime. Avoid inferring any dependency on Escapable
+  // parameters unless it is the (unambiguously borrowed) sole parameter.
   void inferImplicitInit() {
     auto *afd = cast<AbstractFunctionDecl>(decl);
     if (afd->getParameters()->size() == 0) {
@@ -1068,15 +1072,28 @@ protected:
       if (paramTypeInContext->hasError()) {
         return;
       }
+      if (!paramTypeInContext->isEscapable()) {
+        // An implicitly initialized non-Escapable value always copies its
+        // dependency.
+        targetDeps = std::move(targetDeps).add(paramIndex,
+                                               LifetimeDependenceKind::Inherit);
+        continue;
+      }
+      if (afd->getParameters()->size() > 1 && !useLazyInference()) {
+        diagnose(param->getLoc(),
+                 diag::lifetime_dependence_cannot_infer_implicit_init);
+        return;
+      }
+      // A single Escapable parameter must be borrowed.
       auto kind = inferLifetimeDependenceKind(paramTypeInContext,
                                               param->getValueOwnership());
       if (!kind) {
         diagnose(returnLoc,
                  diag::lifetime_dependence_cannot_infer_scope_ownership,
                  param->getParameterName().str(), diagnosticQualifier());
-        return;
       }
-      targetDeps = std::move(targetDeps).add(paramIndex, *kind);
+      targetDeps = std::move(targetDeps).add(paramIndex,
+                                             LifetimeDependenceKind::Scope);
     }
     pushDeps(std::move(targetDeps));
   }

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -75,7 +75,7 @@ func immortalConflict(_ immortal: Int) -> NE { // expected-error{{conflict betwe
 }
 
 do {
-  struct Test: ~Escapable {
+  struct Test: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
     var v1: Int
     var v2: NE
   }

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -577,3 +577,39 @@ struct NonEscapableMutableSelf: ~Escapable {
   @_lifetime(&self)
   mutating func mutatingMethodOneParamBorrow(_: NE) {}
 }
+
+// =============================================================================
+// Initializers
+// =============================================================================
+
+struct NE_Int: ~Escapable {
+  let i: Int
+}
+
+struct NE_C: ~Escapable { // expected-error{{cannot borrow the lifetime of 'c', which has consuming ownership on an implicit initializer}}
+  let c: C
+}
+
+struct NE_C_Int: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let c: C
+  let i: Int
+}
+
+struct NE_Int_Int: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let i: Int
+  let j: Int
+}
+
+struct NE_NE: ~Escapable {
+  let ne: NE
+}
+
+struct NE_NE_Int: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let ne: NE
+  let i: Int
+}
+
+struct NE_NE_C: ~Escapable { // expected-error{{cannot infer implicit initialization lifetime. Add an initializer with '@_lifetime(...)' for each parameter the result depends on}}
+  let ne: NE
+  let c: C
+}


### PR DESCRIPTION
Non-escapable struct definitions often have inicidental integer fields that are
unrelated to lifetime. Without an explicit initializer, the compiler would infer
these fields to be borrowed by the implicit intializer.

    struct CountedSpan: ~Escapable {
      let span: Span<Int>
      let i: Int

      /* infer: @lifetime(copy span, borrow i) init(...) */
    }

This was done because
- we always want to infer lifetimes of synthesized code if possible
- inferring a borrow dependence is always conservative

But this was the wrong decision because it inevitabely results in lifetime
diagnostic errors elsewhere in the code that can't be tracked down at the use
site:

    let span = CountedSpan(span: span, i: 3) // ERROR: span depends on the lifetime of this value

Instead, force the author of the data type to specify whether the type actually
depends on trivial fields or not. Such as:

    struct CountedSpan: ~Escapable {
      let span: Span<Int>
      let i: Int

      @lifetime(copy span) init(...) { ... }
    }

This fix enables stricter diagnostics, so we need it in 6.2.

Fixes rdar://152130977 ([nonescapable] confusing diagnostic message when a
synthesized initializer generates dependence on an Int parameter)

(cherry picked from commit 8789a686fed869e3cd7bc4e748a443e71df464e1)

--- CCC ---

Explanation: Disable an inference rule that was unexpected and usually undesirable. See the discussion above.

Scope:  This only affects users of the experimental feature: Lifetimes.

Radar/SR Issue: rdar://152130977 ([nonescapable] confusing diagnostic message when a synthesized initializer generates
dependence on an Int parameter)

main PR: https://github.com/swiftlang/swift/pull/82472

Risk: Low.

This may initially break some code that adopts Lifetimes, but only cases in which the code was not doing what the author
intended. This is a *good* source break. Failing to make this change now means much worse source breaking change in a
later release.

Testing: Added several source-level unit tests

Reviewer: Meghana Gupta
