### PR TITLE
Promote feature NonescapableAccessorOnTrivial to be non-experimental

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -269,6 +269,7 @@ LANGUAGE_FEATURE(BuiltinSelect, 0, "Builtin.select")
 LANGUAGE_FEATURE(BuiltinInterleave, 0, "Builtin.interleave and Builtin.deinterleave")
 LANGUAGE_FEATURE(BuiltinVectorsExternC, 0, "Extern C support for Builtin vector types")
 LANGUAGE_FEATURE(AddressOfProperty, 0, "Builtin.unprotectedAddressOf properties")
+LANGUAGE_FEATURE(NonescapableAccessorOnTrivial, 0, "Support UnsafeMutablePointer.mutableSpan")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -530,9 +531,6 @@ EXPERIMENTAL_FEATURE(DefaultIsolationPerFile, false)
 
 /// Enable @_lifetime attribute
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
-
-/// Enable UnsafeMutablePointer.mutableSpan
-EXPERIMENTAL_FEATURE(NonescapableAccessorOnTrivial, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/test/ModuleInterface/lifetime_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_dependence_test.swift
@@ -48,7 +48,7 @@ import lifetime_dependence
 // CHECK:   public var span: Swift.Span<Element> {
 // CHECK:     @lifetime(borrow self)
 // CHECK:     @_alwaysEmitIntoClient get {
-// CHECK:   #if compiler(>=5.3) && $LifetimeDependence && $NonescapableAccessorOnTrivial
+// CHECK:   #if compiler(>=5.3) && $NonescapableAccessorOnTrivial && $LifetimeDependence
 // CHECK:   public var mutableSpan: Swift.MutableSpan<Element> {
 // CHECK:     @lifetime(borrow self)
 // CHECK:     @_alwaysEmitIntoClient get {


### PR DESCRIPTION
This flag was not experimental for any good reason; it should always be
enabled. The flag only exists so we can introduce a new API:
UnsafeMutablePointer.mutableSpan. Supported compilers cannot handle the new API.

rdar://154247502 (Promote feature NonescapableAccessorOnTrivial to be
non-experimental)
