### PR TITLE
[6.2] Promote feature NonescapableAccessorOnTrivial to be non-experimental

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -266,6 +266,7 @@ LANGUAGE_FEATURE(ValueGenericsNameLookup, 452, "Value generics appearing as stat
 SUPPRESSIBLE_LANGUAGE_FEATURE(ABIAttributeSE0479, 479, "@abi attribute on functions, initializers, properties, and subscripts")
 LANGUAGE_FEATURE(BuiltinSelect, 0, "Builtin.select")
 LANGUAGE_FEATURE(AlwaysInheritActorContext, 472, "@_inheritActorContext(always)")
+LANGUAGE_FEATURE(NonescapableAccessorOnTrivial, 0, "Support UnsafeMutablePointer.mutableSpan")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
@@ -528,9 +529,6 @@ EXPERIMENTAL_FEATURE(DefaultIsolationPerFile, false)
 
 /// Enable @_lifetime attribute
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
-
-/// Enable UnsafeMutablePointer.mutableSpan
-EXPERIMENTAL_FEATURE(NonescapableAccessorOnTrivial, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/test/ModuleInterface/lifetime_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_dependence_test.swift
@@ -48,7 +48,7 @@ import lifetime_dependence
 // CHECK:   public var span: Swift.Span<Element> {
 // CHECK:     @lifetime(borrow self)
 // CHECK:     @_alwaysEmitIntoClient get {
-// CHECK:   #if compiler(>=5.3) && $LifetimeDependence && $NonescapableAccessorOnTrivial
+// CHECK:   #if compiler(>=5.3) && $NonescapableAccessorOnTrivial && $LifetimeDependence
 // CHECK:   public var mutableSpan: Swift.MutableSpan<Element> {
 // CHECK:     @lifetime(borrow self)
 // CHECK:     @_alwaysEmitIntoClient get {


### PR DESCRIPTION
This flag was not experimental for any good reason; it should always be
enabled. The flag only exists so we can introduce a new API:
UnsafeMutablePointer.mutableSpan. Supported compilers cannot handle the new API.

rdar://154247502 (Promote feature NonescapableAccessorOnTrivial to be
non-experimental)

(cherry picked from commit 3dc0e622bac5576bdb29ab343b46f6492dd4b9ff)

--- CCC ---

Explanation: Promote feature NonescapableAccessorOnTrivial to be
non-experimental

Scope: This does not affect existing code. It blocks introduction of new standard library APIs.

Radar/SR Issue: rdar://154247502 (Promote feature
NonescapableAccessorOnTrivial to be non-experimental)

main PR: https://github.com/swiftlang/swift/pull/82474

Risk: Low. The only change here is that the standard library can now
make use of this pre-existing feature without adding a new build flag.

Testing: Tests already exist for this feature.

Reviewer: Allan Shortlidge
