### PR TITLE
[cxx-interop] Allow virtual methods to be renamed with SWIFT_NAME

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1531,6 +1531,11 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   if (isa<clang::ObjCCategoryDecl>(D))
     return ImportedName();
 
+  // C++ interop was not available in Swift 2
+  if (!swift3OrLaterName && isa<clang::CXXMethodDecl>(D)) {
+    return ImportedName();
+  }
+
   // Dig out the definition, if there is one.
   if (auto def = getDefinitionForClangTypeDecl(D)) {
     if (*def)

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2125,6 +2125,8 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
     // convention.
     newMethod->addAttr(clang::CFReturnsRetainedAttr::CreateImplicit(clangCtx));
   }
+  if (auto swiftNameAttr = method->getAttr<clang::SwiftNameAttr>())
+    newMethod->addAttr(swiftNameAttr->clone(clangCtx));
 
   llvm::SmallVector<clang::ParmVarDecl *, 4> params;
   for (size_t i = 0; i < method->getNumParams(); ++i) {

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -6,6 +6,8 @@ inline void testFunctionCollected() {
 
 struct Base {
   virtual void foo() = 0;
+  virtual void virtualRename() const
+      __attribute__((swift_name("swiftVirtualRename()")));
 };
 
 struct Base2 { virtual int f() = 0; };
@@ -49,48 +51,3 @@ struct DerivedFromCallsPureMethod : CallsPureMethod {
 };
 
 struct DerivedFromDerivedFromCallsPureMethod : DerivedFromCallsPureMethod {};
-
-struct HasDestructor {
-  ~HasDestructor() {}
-};
-
-// MARK: Reference Types:
-
-#define IMMORTAL_FRT                                                           \
-  __attribute__((swift_attr("import_reference")))                              \
-  __attribute__((swift_attr("retain:immortal")))                               \
-  __attribute__((swift_attr("release:immortal")))
-
-struct IMMORTAL_FRT ImmortalBase {
-  int value = 0;
-
-  virtual int get42() const { return 42; }
-  virtual int getOverridden42() const { return 123; }
-  virtual int getIntValue() const { return value; }
-};
-
-struct IMMORTAL_FRT Immortal : public ImmortalBase {
-  static Immortal *_Nonnull create() { return new Immortal(); }
-
-  virtual int getOverridden42() const override { return 42; }
-  virtual void setIntValue(int newValue) { this->value = newValue; }
-};
-
-struct IMMORTAL_FRT DerivedFromImmortal : public Immortal {
-  static DerivedFromImmortal *_Nonnull create() { return new DerivedFromImmortal(); }
-};
-
-struct IMMORTAL_FRT Immortal2 {
-public:
-  virtual void virtualMethod(HasDestructor) = 0;
-};
-
-inline const ImmortalBase *_Nonnull castToImmortalBase(
-    const Immortal *_Nonnull immortal) {
-  return static_cast<const ImmortalBase *>(immortal);
-}
-
-inline const Immortal *_Nonnull castToImmortal(
-    const DerivedFromImmortal *_Nonnull immortal) {
-  return static_cast<const Immortal *>(immortal);
-}

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -28,8 +28,6 @@
 // CHECK-NEXT:   public static func staticInBase() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func swiftRenamed(input i: Int32) -> Int32
-// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
-// CHECK-NEXT:   public mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   @_effects(readonly) public func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
@@ -64,8 +62,6 @@
 // CHECK-NEXT:   public func returnsNonTrivialInBase() -> NonTrivial
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func swiftRenamed(input i: Int32) -> Int32
-// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
-// CHECK-NEXT:   public mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   @_effects(readonly) public func pure() -> Int32
 // CHECK-NEXT:   @discardableResult
@@ -96,8 +92,6 @@
 // CHECK-NEXT:   public func returnsNonTrivialInBase() -> NonTrivial
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   public mutating func swiftRenamed(input i: Int32) -> Int32
-// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "swiftRenamed(input:)")
-// CHECK-NEXT:   public mutating func renamed(_ i: Int32) -> Int32
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   @_effects(readonly) public func pure() -> Int32
 // CHECK-NEXT:   @discardableResult

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -7,6 +7,7 @@
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   @available(*, unavailable, message: "virtual function is not available in Swift because it is pure")
 // CHECK-NEXT:   mutating func foo()
+// CHECK-NEXT:   func swiftVirtualRename()
 // CHECK: }
 
 // CHECK: struct Base3 {
@@ -25,12 +26,3 @@
 // CHECK: struct VirtualNonAbstractBase {
 // CHECK-NEXT:  init()
 // CHECK-NEXT:  func nonAbstractMethod()
-
-// CHECK: class ImmortalBase {
-// CHECK:  func get42() -> Int32
-// CHECK:  func getOverridden42() -> Int32
-// CHECK: }
-// CHECK: class Immortal {
-// CHECK:  func getOverridden42() -> Int32
-// CHECK:  func get42() -> Int32
-// CHECK: }

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -15,25 +15,7 @@ let _ = DerivedFromDerived2()
 
 VirtualNonAbstractBase().nonAbstractMethod()
 
-@available(SwiftStdlib 5.8, *)
-func takesImmortalBase(_ i: ImmortalBase) {
-  let _ = i.get42()
-  let _ = i.getOverridden42()
-  let _ = i.getIntValue()
-}
-
-@available(SwiftStdlib 5.8, *)
-func takesImmortal(_ i: Immortal) {
-  let _ = i.get42()
-  let _ = i.getOverridden42()
-  let _ = i.getIntValue()
-  i.setIntValue(1)
-}
-
-@available(SwiftStdlib 5.8, *)
-func takesDerivedFromImmortal(_ i: DerivedFromImmortal) {
-  let _ = i.get42()
-  let _ = i.getOverridden42()
-  let _ = i.getIntValue()
-  i.setIntValue(1)
+func callVirtualRenamedMethod(_ b: Base) {
+  b.virtualRename()  // expected-error {{value of type 'Base' has no member 'virtualRename'}}
+  b.swiftVirtualRename()
 }

--- a/test/Interop/Cxx/class/inheritance/virtual-methods.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods.swift
@@ -29,39 +29,4 @@ VirtualMethodsTestSuite.test("value type") {
   expectEqual(789, d6.getPureInt())
 }
 
-if #available(SwiftStdlib 5.8, *) {
-  VirtualMethodsTestSuite.test("immortal reference type") {
-    let i = Immortal.create()
-    expectEqual(42, i.get42())
-    expectEqual(0, i.getIntValue())
-
-    let base = castToImmortalBase(i)
-    expectEqual(42, base.get42())
-    expectEqual(42, base.getOverridden42())
-    expectEqual(0, base.getIntValue())
-
-    i.setIntValue(566)
-    expectEqual(566, i.getIntValue())
-    expectEqual(566, base.getIntValue())
-
-    let d = DerivedFromImmortal.create()
-    expectEqual(42, d.get42())
-    expectEqual(42, d.getOverridden42())
-    d.setIntValue(321)
-    expectEqual(321, d.getIntValue())
-    let base2 = castToImmortalBase(castToImmortal(d))
-    expectEqual(321, base2.getIntValue())
-  }
-}
-
-#if !os(Windows) 
-// FIXME in Windows, non-trivial C++ class with trivial ABI is not yet available in Swift
-VirtualMethodsTestSuite.test("C++ virtual method with complex parameter") {
-  @available(SwiftStdlib 5.8, *)
-  func f(simpleClass: HasDestructor, immortalClass: Immortal2) {
-    immortalClass.virtualMethod(simpleClass)
-  }
-}
-#endif
-
 runAllTests()

--- a/test/Interop/Cxx/foreign-reference/Inputs/member-inheritance.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/member-inheritance.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define FRT                                       \
+#define IMMORTAL_FRT                              \
   __attribute__((swift_attr("import_reference"))) \
   __attribute__((swift_attr("retain:immortal")))  \
   __attribute__((swift_attr("release:immortal")))
@@ -28,7 +28,7 @@ public:
     }
 private:
     int x;
-} FRT;
+} IMMORTAL_FRT;
 
 class CopyTrackedDerivedClass: public CopyTrackedBaseClass {
 public:
@@ -37,7 +37,7 @@ public:
     int getDerivedX() const {
         return getX();
     }
-} FRT;
+} IMMORTAL_FRT;
 
 CopyTrackedDerivedClass *makeCopyTrackedDerivedClass(int x) {
     return new CopyTrackedDerivedClass(x);
@@ -50,12 +50,12 @@ public:
     }
 private:
     int y = 11;
-} FRT;
+} IMMORTAL_FRT;
 
 class CopyTrackedDerivedDerivedClass: public NonEmptyBase, public CopyTrackedDerivedClass {
 public:
     CopyTrackedDerivedDerivedClass(int x) : CopyTrackedDerivedClass(x) {}
-} FRT;
+} IMMORTAL_FRT;
 
 CopyTrackedDerivedDerivedClass *makeCopyTrackedDerivedDerivedClass(int x) {
     return new CopyTrackedDerivedDerivedClass(x);
@@ -66,15 +66,14 @@ public:
     CopyTrackedDerivedClass &operator[](int x) const {
         return *new CopyTrackedDerivedClass(x);
     }
-} FRT;
+} IMMORTAL_FRT;
 
 BaseReturningFRTFromSubscript *makeBaseReturningFRTFromSubscript() {
     return new BaseReturningFRTFromSubscript();
 }
 
-class DerivedFromBaseReturningFRTFromSubscript: public BaseReturningFRTFromSubscript {
-public:
-} FRT;
+class DerivedFromBaseReturningFRTFromSubscript
+    : public BaseReturningFRTFromSubscript{public : } IMMORTAL_FRT;
 
 DerivedFromBaseReturningFRTFromSubscript *makeDerivedFromBaseReturningFRTFromSubscript() {
     return new DerivedFromBaseReturningFRTFromSubscript();
@@ -90,12 +89,53 @@ public:
 
 private:
     CopyTrackedDerivedClass *value;
-} FRT;
+} IMMORTAL_FRT;
 
-class DerivedFromBaseReturningFRTFromSubscriptPointer: public BaseReturningFRTFromSubscriptPointer {
-public:
-} FRT;
+class DerivedFromBaseReturningFRTFromSubscriptPointer
+    : public BaseReturningFRTFromSubscriptPointer{public : } IMMORTAL_FRT;
 
 DerivedFromBaseReturningFRTFromSubscriptPointer *makeDerivedFromBaseReturningFRTFromSubscriptPointer() {
     return new DerivedFromBaseReturningFRTFromSubscriptPointer();
+}
+
+struct IMMORTAL_FRT ImmortalBase {
+  int value = 0;
+
+  virtual int get42() const { return 42; }
+  virtual int getOverridden42() const { return 123; }
+  virtual int getIntValue() const { return value; }
+};
+
+struct IMMORTAL_FRT Immortal : public ImmortalBase {
+  static Immortal *_Nonnull create() { return new Immortal(); }
+
+  virtual int getOverridden42() const override { return 42; }
+  virtual void setIntValue(int newValue) { this->value = newValue; }
+};
+
+struct IMMORTAL_FRT DerivedFromImmortal : public Immortal {
+  static DerivedFromImmortal *_Nonnull create() {
+    return new DerivedFromImmortal();
+  }
+};
+
+struct HasDestructor {
+  ~HasDestructor() {}
+};
+
+struct IMMORTAL_FRT Immortal2 {
+public:
+  virtual void virtualMethod(HasDestructor) = 0;
+  virtual void virtualRename() const
+      __attribute__((swift_name("swiftVirtualRename()")));
+};
+
+inline const ImmortalBase *_Nonnull castToImmortalBase(
+    const Immortal *_Nonnull immortal) {
+  return static_cast<const ImmortalBase *>(immortal);
+}
+
+inline const Immortal *_Nonnull castToImmortal(
+    const DerivedFromImmortal *_Nonnull immortal) {
+  return static_cast<const Immortal *>(immortal);
 }

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-module-interface.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-5.9 -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=swift-6 -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -cxx-interoperability-mode=upcoming-swift -print-implicit-attrs -module-to-print=MemberInheritance -I %S/Inputs -source-filename=x | %FileCheck %s
+
+// CHECK: class ImmortalBase {
+// CHECK:  func get42() -> Int32
+// CHECK:  func getOverridden42() -> Int32
+// CHECK: }
+// CHECK: class Immortal {
+// CHECK:  func getOverridden42() -> Int32
+// CHECK:  func get42() -> Int32
+// CHECK: }
+
+// CHECK: class Immortal2 {
+// CHECK-NEXT: final func virtualMethod(_: HasDestructor)
+// CHECK-NEXT: final func swiftVirtualRename()
+// CHECK: }

--- a/test/Interop/Cxx/foreign-reference/member-inheritance-typechecker.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance-typechecker.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-5.9
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -cxx-interoperability-mode=swift-6
+
+import MemberInheritance
+
+@available(SwiftStdlib 5.8, *)
+func takesImmortalBase(_ i: ImmortalBase) {
+  let _ = i.get42()
+  let _ = i.getOverridden42()
+  let _ = i.getIntValue()
+}
+
+@available(SwiftStdlib 5.8, *)
+func takesImmortal(_ i: Immortal) {
+  let _ = i.get42()
+  let _ = i.getOverridden42()
+  let _ = i.getIntValue()
+  i.setIntValue(1)
+}
+
+@available(SwiftStdlib 5.8, *)
+func takesDerivedFromImmortal(_ i: DerivedFromImmortal) {
+  let _ = i.get42()
+  let _ = i.getOverridden42()
+  let _ = i.getIntValue()
+  i.setIntValue(1)
+}
+
+@available(SwiftStdlib 5.8, *)
+func callsRenamedVirtualMethodsInFRT(_ i: Immortal2) {
+  i.virtualRename()  // expected-error {{value of type 'Immortal2' has no member 'virtualRename'}}
+  i.swiftVirtualRename()
+}

--- a/test/Interop/Cxx/foreign-reference/member-inheritance.swift
+++ b/test/Interop/Cxx/foreign-reference/member-inheritance.swift
@@ -1,11 +1,14 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop -Xcc -fignore-exceptions)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-5.9)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-g -I %S/Inputs -cxx-interoperability-mode=default)
 //
 // REQUIRES: executable_test
 
 import StdlibUnittest
 import MemberInheritance
 
-var FunctionsTestSuite = TestSuite("Calling functions in base foreign reference classes")
+var FunctionsTestSuite = TestSuite("Calling functions in foreign reference classes")
 
 FunctionsTestSuite.test("base member FRT calls do not require copying") {
   let derived = makeCopyTrackedDerivedClass(42)!
@@ -66,6 +69,49 @@ FunctionsTestSuite.test("base member FRT subscript accessing reference FRT throu
   let derived = makeDerivedFromBaseReturningFRTFromSubscriptPointer()!
   frt = derived[1]!
   expectEqual(frt.getX(), 0)
+}
+
+if #available(SwiftStdlib 5.8, *) {
+  FunctionsTestSuite.test("virtual members in FRT") {
+    let i = Immortal.create()
+    expectEqual(42, i.get42())
+    expectEqual(0, i.getIntValue())
+
+    let base = castToImmortalBase(i)
+    expectEqual(42, base.get42())
+    expectEqual(42, base.getOverridden42())
+    expectEqual(0, base.getIntValue())
+
+    i.setIntValue(566)
+    expectEqual(566, i.getIntValue())
+    expectEqual(566, base.getIntValue())
+
+    let d = DerivedFromImmortal.create()
+    expectEqual(42, d.get42())
+    expectEqual(42, d.getOverridden42())
+    d.setIntValue(321)
+    expectEqual(321, d.getIntValue())
+    let base2 = castToImmortalBase(castToImmortal(d))
+    expectEqual(321, base2.getIntValue())
+  }
+}
+
+#if !os(Windows) 
+// FIXME in Windows, non-trivial C++ class with trivial ABI is not yet available in Swift
+FunctionsTestSuite.test("C++ virtual method with complex parameter") {
+  @available(SwiftStdlib 5.8, *)
+  func f(simpleClass: HasDestructor, immortalClass: Immortal2) {
+    immortalClass.virtualMethod(simpleClass)
+  }
+}
+#endif
+
+if #available(SwiftStdlib 5.8, *) {
+  FunctionsTestSuite.test("renamed C++ virtual method") {
+    func f(immortalClass: Immortal2) {
+      immortalClass.swiftVirtualRename()
+    }
+  } 
 }
 
 runAllTests()


### PR DESCRIPTION
The `swift_name` attribute can now be used to rename virtual methods. 

rdar://152583825
