### PR TITLE
[SILGen] Fix the type of closure thunks that are passed const reference structs

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1456,6 +1456,16 @@ DestructureTupleExpr::create(ASTContext &ctx,
                                          srcExpr, dstExpr, ty);
 }
 
+FunctionConversionExpr::FunctionConversionExpr(Expr *subExpr, Type type)
+    : ImplicitConversionExpr(ExprKind::FunctionConversion, subExpr, type) {
+  while (auto *PE = dyn_cast<ParenExpr>(subExpr))
+    subExpr = PE->getSubExpr();
+  if (auto *CLE = dyn_cast<CaptureListExpr>(subExpr))
+    subExpr = CLE->getClosureBody();
+  if (auto *CE = dyn_cast<ClosureExpr>(subExpr))
+    CE->setConvertedTo(this);
+}
+
 SourceRange TupleExpr::getSourceRange() const {
   auto start = LParenLoc;
   if (start.isInvalid()) {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -16,6 +16,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/AST/Expr.h"
+#include "swift/AST/Type.h"
 #define DEBUG_TYPE "libsil"
 
 #include "swift/AST/AnyFunctionRef.h"
@@ -4321,12 +4323,10 @@ static CanSILFunctionType getUncachedSILFunctionTypeForConstant(
   // The type of the native-to-foreign thunk for a swift closure.
   if (constant.isForeign && constant.hasClosureExpr() &&
       shouldStoreClangType(TC.getDeclRefRepresentation(constant))) {
-    auto clangType = TC.Context.getClangFunctionType(
-        origLoweredInterfaceType->getParams(),
-        origLoweredInterfaceType->getResult(),
-        FunctionTypeRepresentation::CFunctionPointer);
-    AbstractionPattern pattern =
-        AbstractionPattern(origLoweredInterfaceType, clangType);
+    assert(!extInfoBuilder.getClangTypeInfo().empty() &&
+           "clang type not found");
+    AbstractionPattern pattern = AbstractionPattern(
+        origLoweredInterfaceType, extInfoBuilder.getClangTypeInfo().getType());
     return getSILFunctionTypeForAbstractCFunction(
         TC, pattern, origLoweredInterfaceType, extInfoBuilder, constant);
   }
@@ -4834,9 +4834,21 @@ getAbstractionPatternForConstant(ASTContext &ctx, SILDeclRef constant,
   if (!constant.isForeign)
     return AbstractionPattern(fnType);
 
+  if (const auto *closure = constant.getClosureExpr()) {
+    if (const auto *convertedTo = closure->getConvertedTo()) {
+      auto clangInfo = convertedTo->getType()
+                           ->castTo<AnyFunctionType>()
+                           ->getExtInfo()
+                           .getClangTypeInfo();
+      if (!clangInfo.empty())
+        return AbstractionPattern(fnType, clangInfo.getType());
+    }
+  }
+
   auto bridgedFn = getBridgedFunction(constant);
   if (!bridgedFn)
     return AbstractionPattern(fnType);
+
   const clang::Decl *clangDecl = bridgedFn->getClangDecl();
   if (!clangDecl)
     return AbstractionPattern(fnType);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -8495,9 +8495,6 @@ public:
 
 llvm::Expected<const clang::Type *>
 ModuleFile::getClangType(ClangTypeID TID) {
-  if (!getContext().LangOpts.UseClangFunctionTypes)
-    return nullptr;
-
   if (TID == 0)
     return nullptr;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/AutoDiff.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Expr.h"
@@ -41,6 +42,7 @@
 #include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeVisitor.h"
+#include "swift/AST/Types.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/FileSystem.h"
@@ -5546,6 +5548,31 @@ static TypeAliasDecl *findTypeAliasForBuiltin(ASTContext &Ctx, Type T) {
   return cast<TypeAliasDecl>(CurModuleResults[0]);
 }
 
+namespace {
+struct ImplementationOnlyWalker : TypeWalker {
+  bool hadImplementationOnlyDecl = false;
+  const ModuleDecl *currentModule;
+  ImplementationOnlyWalker(const ModuleDecl *M) : currentModule(M) {}
+  Action walkToTypePre(Type ty) override {
+    if (auto *typeAlias = dyn_cast<TypeAliasType>(ty)) {
+      if (importedImplementationOnly(typeAlias->getDecl()))
+        return Action::Stop;
+    } else if (auto *nominal = ty->getAs<NominalType>()) {
+      if (importedImplementationOnly(nominal->getDecl()))
+        return Action::Stop;
+    }
+    return Action::Continue;
+  }
+  bool importedImplementationOnly(const Decl *D) {
+    if (currentModule->isImportedImplementationOnly(D->getModuleContext())) {
+      hadImplementationOnlyDecl = true;
+      return true;
+    }
+    return false;
+  }
+};
+} // namespace
+
 class Serializer::TypeSerializer : public TypeVisitor<TypeSerializer> {
   Serializer &S;
 
@@ -5899,10 +5926,23 @@ public:
     using namespace decls_block;
 
     auto resultType = S.addTypeRef(fnTy->getResult());
-    auto clangType =
-      S.getASTContext().LangOpts.UseClangFunctionTypes
-      ? S.addClangTypeRef(fnTy->getClangTypeInfo().getType())
-      : ClangTypeID(0);
+    bool shouldSerializeClangType = true;
+    if (S.hadImplementationOnlyImport && S.M &&
+        S.M->getResilienceStrategy() != ResilienceStrategy::Resilient) {
+      // Deserializing clang types from implementation only modules could crash
+      // as the transitive clang module might not be available to retrieve the
+      // declarations from. In an optimal world we would make the deseriaization
+      // more resilient to these problems but the failure is in Clang's
+      // deserialization code path that is not architected with potentially
+      // missing declarations in mind.
+      ImplementationOnlyWalker walker{S.M};
+      Type(const_cast<FunctionType *>(fnTy)).walk(walker);
+      if (walker.hadImplementationOnlyDecl)
+        shouldSerializeClangType = false;
+    }
+    auto clangType = shouldSerializeClangType
+                         ? S.addClangTypeRef(fnTy->getClangTypeInfo().getType())
+                         : ClangTypeID(0);
 
     auto isolation = encodeIsolation(fnTy->getIsolation());
 
@@ -6984,8 +7024,13 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
     nextFile->getTopLevelDeclsWithAuxiliaryDecls(fileDecls);
 
     for (auto D : fileDecls) {
-      if (isa<ImportDecl>(D) || isa<MacroExpansionDecl>(D) ||
-          isa<TopLevelCodeDecl>(D) || isa<UsingDecl>(D)) {
+      if (const auto *ID = dyn_cast<ImportDecl>(D)) {
+        if (ID->getAttrs().hasAttribute<ImplementationOnlyAttr>())
+          hadImplementationOnlyImport = true;
+        continue;
+      }
+      if (isa<MacroExpansionDecl>(D) || isa<TopLevelCodeDecl>(D) ||
+          isa<UsingDecl>(D)) {
         continue;
       }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -116,6 +116,8 @@ class Serializer : public SerializerBase {
   /// an error in the AST.
   bool hadError = false;
 
+  bool hadImplementationOnlyImport = false;
+
   /// Helper for serializing entities in the AST block object graph.
   ///
   /// Keeps track of assigning IDs to newly-seen entities, and collecting

--- a/test/Interop/Cxx/class/Inputs/closure.h
+++ b/test/Interop/Cxx/class/Inputs/closure.h
@@ -10,6 +10,10 @@ struct NonTrivial {
   int *p;
 };
 
+struct Trivial {
+  int i;
+};
+
 void cfunc(void (^ _Nonnull block)(NonTrivial)) noexcept {
   block(NonTrivial());
 }
@@ -74,5 +78,14 @@ inline void releaseSharedRef(SharedRef *_Nonnull x) {
     delete x;
   }
 }
+
+void cfuncConstRefNonTrivial(void (*_Nonnull)(const NonTrivial &));
+void cfuncConstRefTrivial(void (*_Nonnull)(const Trivial &));
+void blockConstRefNonTrivial(void (^_Nonnull)(const NonTrivial &));
+void blockConstRefTrivial(void (^_Nonnull)(const Trivial &));
+#if __OBJC__
+void cfuncConstRefStrong(void (*_Nonnull)(const ARCStrong &));
+void blockConstRefStrong(void (^_Nonnull)(const ARCStrong &));
+#endif
 
 #endif // __CLOSURE__

--- a/test/Interop/Cxx/class/closure-thunk-macosx.swift
+++ b/test/Interop/Cxx/class/closure-thunk-macosx.swift
@@ -35,3 +35,101 @@ public func testClosureToFuncPtr() {
 public func testClosureToBlockReturnNonTrivial() {
   cfuncReturnNonTrivial({() -> NonTrivial in return NonTrivial() })
 }
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main22testConstRefNonTrivialyyFySo0eF0VcfU_To : $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+// CHECK: %[[V1:.*]] = alloc_stack $NonTrivial
+// CHECK: copy_addr %[[V0]] to [init] %[[V1]] : $*NonTrivial
+// CHECK: %[[V3:.*]] = function_ref @$s4main22testConstRefNonTrivialyyFySo0eF0VcfU_ : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V4:.*]] = apply %[[V3]](%[[V1]]) : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: destroy_addr %[[V1]] : $*NonTrivial
+// CHECK: dealloc_stack %[[V1]] : $*NonTrivial
+// CHECK: return %[[V4]] : $()
+
+public func testConstRefNonTrivial() {
+  cfuncConstRefNonTrivial({S in });
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main23testConstRefNonTrivial2yyFySo0E7TrivialVcfU_To : $@convention(c) (@in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*NonTrivial):
+// CHECK: %[[V1:.*]] = alloc_stack $NonTrivial
+// CHECK: copy_addr %[[V0]] to [init] %[[V1]] : $*NonTrivial
+// CHECK: %[[V3:.*]] = function_ref @$s4main23testConstRefNonTrivial2yyFySo0E7TrivialVcfU_ : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V4:.*]] = apply %[[V3]](%[[V1]]) : $@convention(thin) (@in_guaranteed NonTrivial) -> ()
+// CHECK: destroy_addr %[[V1]] : $*NonTrivial
+// CHECK: dealloc_stack %[[V1]] : $*NonTrivial
+// CHECK: return %[[V4]] : $()
+public func testConstRefNonTrivial2() {
+  cfuncConstRefNonTrivial(({S in }));
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main19testConstRefTrivialyyFySo0E0VcfU_To : $@convention(c) (@in_guaranteed Trivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*Trivial):
+// CHECK: %[[V1:.*]] = load [trivial] %[[V0]] : $*Trivial
+// CHECK: %[[V2:.*]] = function_ref @$s4main19testConstRefTrivialyyFySo0E0VcfU_ : $@convention(thin) (Trivial) -> ()
+// CHECK: %[[V3:.*]] = apply %[[V2]](%[[V1]]) : $@convention(thin) (Trivial) -> ()
+// CHECK: return %[[V3]] : $()
+
+public func testConstRefTrivial() {
+  cfuncConstRefTrivial({S in });
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s4main18testConstRefStrongyyFySo9ARCStrongVcfU_To : $@convention(c) (@in_guaranteed ARCStrong) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*ARCStrong):
+// CHECK: %[[V1:.*]] = alloc_stack $ARCStrong
+// CHECK: copy_addr %[[V0]] to [init] %[[V1]] : $*ARCStrong
+// CHECK: %[[V3:.*]] = load [copy] %[[V1]] : $*ARCStrong
+// CHECK: %[[V4:.*]] = begin_borrow %[[V3]] : $ARCStrong
+// CHECK: %[[V5:.*]] = function_ref @$s4main18testConstRefStrongyyFySo9ARCStrongVcfU_ : $@convention(thin) (@guaranteed ARCStrong) -> ()
+// CHECK: %[[V6:.*]] = apply %[[V5]](%[[V4]]) : $@convention(thin) (@guaranteed ARCStrong) -> ()
+// CHECK: end_borrow %[[V4]] : $ARCStrong
+// CHECK: destroy_value %[[V3]] : $ARCStrong
+// CHECK: destroy_addr %[[V1]] : $*ARCStrong
+// CHECK: dealloc_stack %[[V1]] : $*ARCStrong
+// CHECK: return %[[V6]] : $()
+
+public func testConstRefStrong() {
+  cfuncConstRefStrong({S in });
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo10NonTrivialVIegn_ABIeyBn_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@in_guaranteed NonTrivial) -> (), @in_guaranteed NonTrivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*@block_storage @callee_guaranteed (@in_guaranteed NonTrivial) -> (), %[[V1:.*]] : $*NonTrivial):
+// CHECK: %[[V2:.*]] = project_block_storage %[[V0]] : $*@block_storage @callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V3:.*]] = load [copy] %[[V2]] : $*@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: %[[V4:.*]] = begin_borrow %[[V3]] : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: apply %[[V4]](%[[V1]]) : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: end_borrow %[[V4]] : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+// CHECK: destroy_value %[[V3]] : $@callee_guaranteed (@in_guaranteed NonTrivial) -> ()
+
+public func testBlockConstRefNonTrivial() {
+  blockConstRefNonTrivial({S in });
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo7TrivialVIegy_ABIeyBn_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (Trivial) -> (), @in_guaranteed Trivial) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*@block_storage @callee_guaranteed (Trivial) -> (), %[[V1:.*]] : $*Trivial):
+// CHECK: %[[V2:.*]] = project_block_storage %[[V0]] : $*@block_storage @callee_guaranteed (Trivial) -> ()
+// CHECK: %[[V3:.*]] = load [copy] %[[V2]] : $*@callee_guaranteed (Trivial) -> ()
+// CHECK: %[[V4:.*]] = load [trivial] %[[V1]] : $*Trivial
+// CHECK: %[[V5:.*]] = begin_borrow %[[V3]] : $@callee_guaranteed (Trivial) -> ()
+// CHECK: apply %[[V5]](%[[V4]]) : $@callee_guaranteed (Trivial) -> ()
+// CHECK: end_borrow %[[V5]] : $@callee_guaranteed (Trivial) -> ()
+// CHECK: destroy_value %[[V3]] : $@callee_guaranteed (Trivial) -> ()
+
+public func testBlockConstRefTrivial() {
+  blockConstRefTrivial({S in });
+}
+
+// CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sSo9ARCStrongVIegg_ABIeyBn_TR : $@convention(c) (@inout_aliasable @block_storage @callee_guaranteed (@guaranteed ARCStrong) -> (), @in_guaranteed ARCStrong) -> () {
+// CHECK: bb0(%[[V0:.*]] : $*@block_storage @callee_guaranteed (@guaranteed ARCStrong) -> (), %[[V1:.*]] : $*ARCStrong):
+// CHECK: %[[V2:.*]] = project_block_storage %[[V0]] : $*@block_storage @callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: %[[V3:.*]] = load [copy] %[[V2]] : $*@callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: %[[V4:.*]] = load_borrow %[[V1]] : $*ARCStrong
+// CHECK: %[[V5:.*]] = begin_borrow %[[V3]] : $@callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: apply %[[V5]](%[[V4]]) : $@callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: end_borrow %[[V5]] : $@callee_guaranteed (@guaranteed ARCStrong) -> ()
+// CHECK: end_borrow %[[V4]] : $ARCStrong
+// CHECK: destroy_value %[[V3]] : $@callee_guaranteed (@guaranteed ARCStrong) -> ()
+
+public func testBlockConstRefStrong() {
+  blockConstRefStrong({S in });
+}

--- a/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxx-module-transitively.swift
+++ b/test/Interop/Cxx/implementation-only-imports/import-implementation-only-cxx-module-transitively.swift
@@ -1,0 +1,60 @@
+// Crash reproducer from https://github.com/swiftlang/swift/issues/77047#issuecomment-2440103712
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: mkdir %t/artifacts
+
+// RUN: %target-swift-frontend -c %t/ChibiStdlib.swift -parse-stdlib -emit-module -emit-module-path %t/sdk/usr/lib/swift/Swift.swiftmodule/%module-target-triple.swiftmodule -module-name Swift -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -o %t/artifacts
+// RUN: %target-swift-frontend -c %t/XMLParser.swift -parse-as-library -emit-module -emit-module-path %t/sdk/usr/lib/swift/MyFoundationXML.swiftmodule/%module-target-triple.swiftmodule -module-name MyFoundationXML -module-link-name MyFoundationXML -resource-dir %t/sdk -O -I %t/include -o %t/artifacts  -sdk %t/sdk
+// RUN: %target-swift-frontend -c %t/Check.swift -o %t/artifacts -index-store-path %t/index-store -index-system-modules -resource-dir %t/sdk -parse-stdlib -sdk %t/sdk
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: mkdir %t/artifacts
+
+// RUN: %target-swift-frontend -c %t/ChibiStdlib.swift -parse-stdlib -emit-module -emit-module-path %t/sdk/usr/lib/swift/Swift.swiftmodule/%module-target-triple.swiftmodule -module-name Swift -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -o %t/artifacts
+// RUN: %target-swift-frontend -c %t/XMLParser.swift -enable-library-evolution -parse-as-library -emit-module -emit-module-path %t/sdk/usr/lib/swift/MyFoundationXML.swiftmodule/%module-target-triple.swiftmodule -module-name MyFoundationXML -module-link-name MyFoundationXML -resource-dir %t/sdk -O -I %t/include -o %t/artifacts  -sdk %t/sdk
+// RUN: %target-swift-frontend -c %t/Check.swift -o %t/artifacts -index-store-path %t/index-store -index-system-modules -resource-dir %t/sdk -parse-stdlib -sdk %t/sdk
+
+
+//--- Check.swift
+import MyFoundationXML
+
+//--- XMLParser.swift
+@_implementationOnly import _MyCFXMLInterface
+
+func _NSXMLParserExternalEntityWithURL(originalLoaderFunction: _CFXMLInterfaceExternalEntityLoader) {}
+
+//--- include/module.modulemap
+module _MyCFXMLInterface {
+  header "MyCFXMLInterface.h"
+}
+
+//--- include/MyCFXMLInterface.h
+#if !defined(__COREFOUNDATION_CFXMLINTERFACE__)
+#define __COREFOUNDATION_CFXMLINTERFACE__ 1
+
+typedef struct _xmlParserCtxt *_CFXMLInterfaceParserContext;
+typedef void (*_CFXMLInterfaceExternalEntityLoader)(_CFXMLInterfaceParserContext);
+
+#endif
+
+//--- ChibiStdlib.swift
+precedencegroup AssignmentPrecedence {
+  assignment: true
+  associativity: right
+}
+
+public typealias Void = ()
+
+@frozen
+public struct OpaquePointer {
+  @usableFromInline
+  internal var _rawValue: Builtin.RawPointer
+
+  @usableFromInline @_transparent
+  internal init(_ v: Builtin.RawPointer) {
+    self._rawValue = v
+  }
+}

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -69,12 +69,11 @@ StdFunctionTestSuite.test("FunctionStringToString init from closure and pass as 
   expectEqual(std.string("prefixabcabc"), res)
 }
 
-// FIXME: assertion for address-only closure params (rdar://124501345)
-//StdFunctionTestSuite.test("FunctionStringToStringConstRef init from closure and pass as parameter") {
-//  let res = invokeFunctionTwiceConstRef(.init({ $0 + std.string("abc") }),
-//                                        std.string("prefix"))
-//  expectEqual(std.string("prefixabcabc"), res)
-//}
+StdFunctionTestSuite.test("FunctionStringToStringConstRef init from closure and pass as parameter") {
+  let res = invokeFunctionTwiceConstRef(.init({ $0 + std.string("abc") }),
+                                        std.string("prefix"))
+  expectEqual(std.string("prefixabcabc"), res)
+}
 #endif
 
 runAllTests()

--- a/test/Serialization/Inputs/convention_c_function.swift
+++ b/test/Serialization/Inputs/convention_c_function.swift
@@ -1,0 +1,3 @@
+public func foo(fn: @convention(c) () -> ()) -> () {
+  fn()
+}

--- a/test/Serialization/clang-function-types-convention-c.swift
+++ b/test/Serialization/clang-function-types-convention-c.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %S/Inputs/convention_c_function.swift
+// RUN: llvm-bcanalyzer %t/convention_c_function.swiftmodule | %FileCheck -check-prefix=CHECK-BCANALYZER %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -I %t %s | %FileCheck %s
+
+import convention_c_function
+
+// CHECK-BCANALYZER-LABEL: (INDEX_BLOCK):
+// CHECK-BCANALYZER: CLANG_TYPE_OFFSETS
+
+// Test that the assertion in SILDeclRef doesn't fail.
+
+// CHECK-LABEL: sil [ossa] @$s4main3baryyF : $@convention(thin) () -> () {
+// CHECK: %[[V0:.*]] = function_ref @$s4main3baryyFyycfU_To : $@convention(c) () -> ()
+// CHECK: %[[V1:.*]] = function_ref @$s21convention_c_function3foo2fnyyyXC_tF : $@convention(thin) (@convention(c) () -> ()) -> ()
+// CHECK: apply %[[V1]](%[[V0]]) : $@convention(thin) (@convention(c) () -> ()) -> ()
+
+public func bar() {
+  foo(fn : {})
+}
+


### PR DESCRIPTION
This PR is another attempt at landing #76903. The changes compared to the original PR:
* Instead of increasing the size of SILDeclRef, store the necessary type information in the conversion AST nodes.
* The PR above introduced a crash during indexing system modules that references foreign types coming from modules imported as implementation only. These entities are implementation details so they do not need to be included during serialization. This PR adds a test and adds logic to exclude such declarations in the serialization process.

rdar://131321096&141786724
