### PR TITLE
[Effects] Ensure that we properly substitute function types in ByClosure checks

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -1848,6 +1848,8 @@ public:
         FunctionType *fnSubstType = nullptr;
         if (auto *fnGenericType = fnInterfaceType->getAs<GenericFunctionType>())
           fnSubstType = fnGenericType->substGenericArgs(fnRef.getSubstitutions());
+        else if (fnRef.getSubstitutions())
+          fnSubstType = fnInterfaceType.subst(fnRef.getSubstitutions())->getAs<FunctionType>();
         else
           fnSubstType = fnInterfaceType->getAs<FunctionType>();
 

--- a/test/stmt/errors.swift
+++ b/test/stmt/errors.swift
@@ -256,3 +256,17 @@ func takesClosure(_: (() -> ())) throws -> Int {}
 func passesClosure() {
     _ = try takesClosure { } // expected-error {{errors thrown from here are not handled}}
 }
+
+// Parameter packs checking
+struct S {
+  static func packTest<each T>(_ values: repeat (each T).Type, shouldThrow: Bool) throws -> Bool {
+    if (shouldThrow) {
+      throw MSV.Foo
+    }
+    return true
+  }
+
+  static func test() -> Bool {
+    return try packTest(String.self, String.self, shouldThrow: true) // expected-error{{errors thrown from here are not handled}}
+  }
+}


### PR DESCRIPTION
We weren't substituting generic arguments into function types. In the presence of parameter packs, this could mean that the parameter and argument lists no longer match up, which would cause the effects checker to prematurely bail out after treating this as "invalid" code. The overall effect is that we would not properly check for throwing behavior in this case, allowing invalid code (as in the example) and miscompiling valid code by not treating the call as throwing.

Fixes rdar://153926820.