### PR TITLE
[cxx-interop] Allow import-as-member for types in namespaces

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.h
+++ b/lib/ClangImporter/SwiftLookupTable.h
@@ -593,7 +593,7 @@ private:
 public:
   /// Lookup an unresolved context name and resolve it to a Clang
   /// named declaration.
-  clang::NamedDecl *resolveContext(StringRef unresolvedName);
+  const clang::NamedDecl *resolveContext(StringRef unresolvedName);
 
   /// Lookup the set of entities with the given base name.
   ///

--- a/test/APINotes/Inputs/broken-modules/BrokenAPINotes.apinotes
+++ b/test/APINotes/Inputs/broken-modules/BrokenAPINotes.apinotes
@@ -13,4 +13,4 @@ Functions:
   - Name: ZXSpectrumSetMisnamedRegister
     SwiftName: 'setter:ZXSpectrum.misnamedRegister(self:newValue:)'
   - Name: ZXSpectrumHelperReset
-    SwiftName: 'ZXSpectrum.Helper.reset()'
+    SwiftName: 'ZXSpectrum::Helper.reset()'

--- a/test/Interop/Cxx/namespace/Inputs/import-as-member.h
+++ b/test/Interop/Cxx/namespace/Inputs/import-as-member.h
@@ -1,0 +1,26 @@
+#define SWIFT_NAME(name) __attribute__((swift_name(name)))
+
+namespace MyNS {
+struct NestedStruct {
+  int value = 123;
+};
+}
+
+int nestedStruct_method(MyNS::NestedStruct p) SWIFT_NAME("MyNS.NestedStruct.method(self:)") { return p.value; }
+int nestedStruct_methodConstRef(const MyNS::NestedStruct &p) SWIFT_NAME("MyNS.NestedStruct.methodConstRef(self:)") { return p.value + 1; }
+
+namespace MyNS {
+namespace MyDeepNS {
+struct DeepNestedStruct {
+  int value = 456;
+};
+}
+}
+
+int deepNestedStruct_method(MyNS::MyDeepNS::DeepNestedStruct p) SWIFT_NAME("MyNS.MyDeepNS.DeepNestedStruct.method(self:)") { return p.value; }
+int deepNestedStruct_methodConstRef(const MyNS::MyDeepNS::DeepNestedStruct &p) SWIFT_NAME("MyNS.MyDeepNS.DeepNestedStruct.methodConstRef(self:)") { return p.value + 2; }
+
+typedef MyNS::MyDeepNS::DeepNestedStruct DeepNestedStructTypedef;
+
+int deepNestedStructTypedef_method(DeepNestedStructTypedef p) SWIFT_NAME("DeepNestedStructTypedef.methodTypedef(self:)") { return p.value + 3; }
+int deepNestedStructTypedef_methodQualName(MyNS::MyDeepNS::DeepNestedStruct p) SWIFT_NAME("DeepNestedStructTypedef.methodTypedefQualName(self:)") { return p.value + 4; }

--- a/test/Interop/Cxx/namespace/Inputs/module.modulemap
+++ b/test/Interop/Cxx/namespace/Inputs/module.modulemap
@@ -60,6 +60,12 @@ module Enums {
   requires cplusplus
 }
 
+module ImportAsMember {
+  header "import-as-member.h"
+  export *
+  requires cplusplus
+}
+
 module MembersDirect {
   header "members-direct.h"
   requires cplusplus

--- a/test/Interop/Cxx/namespace/import-as-member-module-interface.swift
+++ b/test/Interop/Cxx/namespace/import-as-member-module-interface.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ImportAsMember -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK:      extension MyNS.NestedStruct {
+// CHECK-NEXT:   func method() -> Int32
+// CHECK-NEXT:   func methodConstRef() -> Int32
+// CHECK-NEXT: }
+
+// CHECK:      extension MyNS.MyDeepNS.DeepNestedStruct {
+// CHECK-NEXT:   func method() -> Int32
+// CHECK-NEXT:   func methodConstRef() -> Int32
+// CHECK-NEXT:   func methodTypedef() -> Int32
+// CHECK-NEXT:   func methodTypedefQualName() -> Int32
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/namespace/import-as-member-typechecker.swift
+++ b/test/Interop/Cxx/namespace/import-as-member-typechecker.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -cxx-interoperability-mode=upcoming-swift
+
+import ImportAsMember
+
+func takesNestedStruct(_ s: MyNS.NestedStruct) {
+  _ = s.method()
+  _ = s.methodConstRef()
+
+  _ = nestedStruct_method(s) // expected-error {{'nestedStruct_method' has been replaced by instance method 'MyNS.NestedStruct.method()'}}
+}
+
+func takesDeepNestedStruct(_ s: MyNS.MyDeepNS.DeepNestedStruct) {
+  _ = s.method()
+  _ = s.methodConstRef()
+  _ = s.methodTypedef()
+  _ = s.methodTypedefQualName()
+
+  _ = deepNestedStruct_method(s) // expected-error {{'deepNestedStruct_method' has been replaced by instance method 'MyNS.MyDeepNS.DeepNestedStruct.method()'}}
+}

--- a/test/Interop/Cxx/namespace/import-as-member.swift
+++ b/test/Interop/Cxx/namespace/import-as-member.swift
@@ -1,0 +1,24 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import ImportAsMember
+
+var NamespacesTestSuite = TestSuite("Import as member of namespace")
+
+NamespacesTestSuite.test("Struct in a namespace") {
+  let s = MyNS.NestedStruct()
+  expectEqual(123, s.method())
+  expectEqual(124, s.methodConstRef())
+}
+
+NamespacesTestSuite.test("Struct in a deep namespace") {
+  let s = MyNS.MyDeepNS.DeepNestedStruct()
+  expectEqual(456, s.method())
+  expectEqual(458, s.methodConstRef())
+  expectEqual(459, s.methodTypedef())
+  expectEqual(460, s.methodTypedefQualName())
+}
+
+runAllTests()


### PR DESCRIPTION
This adds support for `swift_name` attribute being used with C++ types that are declared within namespaces, e.g.
```
__attribute__((swift_name("MyNamespace.MyType.my_method()")))
```

Previously import-as-member would only accept a top-level unqualified type name.

This relies on https://github.com/swiftlang/llvm-project/pull/10899.

rdar://138934888

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
