### PR TITLE
ABI checker: drop usage of AllowDeserializingImplementationOnly option

### DIFF
--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -2457,8 +2457,6 @@ public:
     InitInvoke.getLangOptions().EnableObjCInterop =
         InitInvoke.getLangOptions().Target.isOSDarwin();
     InitInvoke.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
-    // Module recovery issue shouldn't bring down the tool.
-    InitInvoke.getLangOptions().AllowDeserializingImplementationOnly = true;
 
     if (!SwiftVersion.empty()) {
       using version::Version;


### PR DESCRIPTION
AllowDeserializingImplementationOnly was historically added as a defensive
check against deserialization issues introduced by @implementationOnly imports.
It's no longer specified by other tools, thus the ABI checker should drop
it as well.

rdar://153683760