### PR TITLE
[test] Fix or disable tests for 32-bit platforms

### DIFF
--- a/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
+++ b/test/ClangImporter/pcm-emit-direct-cc1-mode.swift
@@ -15,5 +15,7 @@
 // CHECK-CLANG-SAME: '-fmodules'
 // CHECK-CLANG-NOT: clang importer driver args
 
+// XFAIL: OS=linux-androideabi
+
 import script
 var _ : ScriptTy

--- a/test/IRGen/abitypes_arm.swift
+++ b/test/IRGen/abitypes_arm.swift
@@ -11,6 +11,6 @@ class Foo {
   }
 }
 
-// armv7: define internal void @makeOne(ptr noalias sret({{.*}}) align 4 %agg.result, float{{( noundef)?}} %f, float{{( noundef)?}} %s)
+// armv7: define internal void @makeOne(ptr{{( dead_on_unwind)?}} noalias{{( writable)?}} sret({{.*}}) align 4 %agg.result, float{{( noundef)?}} %f, float{{( noundef)?}} %s)
 // armv7s: define internal void @makeOne(ptr noalias sret({{.*}}) align 4 %agg.result, float %f, float %s)
 // armv7k: define internal %struct.One @makeOne(float {{.*}}%f, float {{.*}}%s)

--- a/test/Interop/Cxx/class/constructors-copy-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-copy-module-interface.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// XFAIL: OS=linux-androideabi
 
 // CHECK: struct TemplatedCopyConstructor
 // CHECK: struct TemplatedCopyConstructorWithExtraArg

--- a/test/Interop/Cxx/class/constructors-diagnostics.swift
+++ b/test/Interop/Cxx/class/constructors-diagnostics.swift
@@ -2,6 +2,7 @@
 
 // This test uses -verify-additional-file, which do not work well on Windows.
 // UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=linux-androideabi
 
 import Constructors
 

--- a/test/Interop/Cxx/class/constructors-module-interface.swift
+++ b/test/Interop/Cxx/class/constructors-module-interface.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=Constructors -I %S/Inputs/ -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// XFAIL: OS=linux-androideabi
 
 // CHECK:      struct ExplicitDefaultConstructor {
 // CHECK-NEXT:   init()

--- a/test/Interop/Cxx/class/constructors-silgen.swift
+++ b/test/Interop/Cxx/class/constructors-silgen.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swiftxx-frontend -I %S/Inputs -Xllvm -sil-print-types -emit-silgen %s | %FileCheck %s
+// XFAIL: OS=linux-androideabi
 
 import Constructors
 

--- a/test/Interop/Cxx/class/constructors-typechecker.swift
+++ b/test/Interop/Cxx/class/constructors-typechecker.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-experimental-cxx-interop
+// XFAIL: OS=linux-androideabi
 
 import Constructors
 

--- a/test/Interop/Cxx/class/custom-new-operator-irgen.swift
+++ b/test/Interop/Cxx/class/custom-new-operator-irgen.swift
@@ -5,4 +5,4 @@ import CustomNewOperator
 var x = callsCustomNew()
 
 // Make sure the definition of `operator new` is emitted.
-// CHECK: define {{.*}} @{{_ZnwmPv15container_new_t|"\?\?2@YAPEAX_KPEAXUcontainer_new_t@@@Z"}}
+// CHECK: define {{.*}} @{{_Znw(j|m)Pv15container_new_t|"\?\?2@YAPEAX_KPEAXUcontainer_new_t@@@Z"}}

--- a/test/SILOptimizer/package-cmo-serialize-tables.swift
+++ b/test/SILOptimizer/package-cmo-serialize-tables.swift
@@ -19,7 +19,7 @@
 
 // Temporarily disabling on watchOS (both arm64_32 & armv7k):
 // rdar://140330692 (🟠 OSS Swift CI: oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed...
-// UNSUPPORTED: OS=watchos
+// UNSUPPORTED: OS=watchos, OS=linux-androideabi
 
 //--- main.swift
 

--- a/test/SILOptimizer/throws_prediction.swift
+++ b/test/SILOptimizer/throws_prediction.swift
@@ -16,7 +16,7 @@
 // RUN:   -sil-verify-all -module-name=test -emit-sil \
 // RUN:       | %FileCheck --check-prefix CHECK-DISABLED %s
 
-// UNSUPPORTED: CPU=armv7k || CPU=arm64_32
+// UNSUPPORTED: CPU=armv7k, CPU=arm64_32, CPU=armv7
 
 // CHECK-DISABLED-NOT: normal_count
 


### PR DESCRIPTION
Fix one PCM and two IRGen tests that are failing on Android armv7 and disable two SILOptimizer tests that were already failing on other 32-bit platforms.

As part of the upcoming official Android SDK bundle, #80788, we're running the non-executable compiler validation suite for Android armv7 again before including the armv7 Swift stdlib, and I see [10 tests failing in both the trunk 6.3](https://github.com/swift-android-sdk/swift-docker/actions/runs/15872353798/job/44751721740) and 6.2 branches.

This pull fixes or disables half of them, whereas the other half are all C++ Interop constructor tests that fail because they cannot build that C module with `size_t` issues:
```
<unknown>:0: error: fatal error encountered while in -verify mode
/home/finagolfin/swift/test/Interop/Cxx/class/constructors-typechecker.swift:3:8: error: unexpected error produced: could not build C module 'Constructors'
import Constructors
       ^
/home/finagolfin/swift/test/Interop/Cxx/class/constructors-typechecker.swift:11:51: error: expected warning not produced
let deletedImplicitly = ConstructorWithParam() // expected-warning {{'init()' is deprecated}}
                                              ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<--- snip irrelevant errors --->
/home/finagolfin/swift/test/Interop/Cxx/class
/home/finagolfin/swift/test/Interop/Cxx/class/Inputs/constructors.h:253:9: error: diagnostic produced elsewhere: 'operator new' takes type size_t ('unsigned int') as first parameter
  void *operator new(size_t, void *ptr) { return ptr; }
        ^
<module-includes>:1:10: note: diagnostic produced elsewhere: in file included from <module-includes>:1:
#include "constructors.h"
         ^
/home/finagolfin/swift/test/Interop/Cxx/class/Inputs/constructors.h:263:8: warning: diagnostic produced elsewhere: pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)
  void *operator new(size_t);
       ^
/home/finagolfin/swift/test/Interop/Cxx/class/Inputs/constructors.h:263:8: note: diagnostic produced elsewhere: insert '_Nullable' if the pointer may be null
  void *operator new(size_t);
       ^
/home/finagolfin/swift/test/Interop/Cxx/class/Inputs/constructors.h:263:8: note: diagnostic produced elsewhere: insert '_Nonnull' if the pointer should never be null
  void *operator new(size_t);
       ^
<module-includes>:1:10: note: diagnostic produced elsewhere: in file included from <module-includes>:1:
#include "constructors.h"
         ^
/home/finagolfin/swift/test/Interop/Cxx/class/Inputs/constructors.h:263:9: error: diagnostic produced elsewhere: 'operator new' takes type size_t ('unsigned int') as first parameter
  void *operator new(size_t);
        ^
```
@egorzhdan or @fahadnayyar, any idea what that 32-bit C++ Interop issue is or should I just disable those five tests for Android armv7?