### PR TITLE
Revert "Test Interop/Cxx/stdlib/overlay/custom-collection.swift fails on bots"

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar143950805
-
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)


### PR DESCRIPTION
I'm not able to reproduce the CI issue reported in rdar://143950805 locally. I don't have access to the logs from the failing bot link: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RD_test-simulator/5086.

So, I'm trying to re-enable this test and do some custom PR testing to see if the bot is still failing.

rdar://143950805