### PR TITLE
remote-run: Find rsync

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2522,19 +2522,16 @@ check_runtime_libs(runtime_libs)
 
 config.substitutions.append(('%target-objc-interop', run_objc_interop))
 
-# For testing the remote-run utility itself, see if we can find an sftp-server
-# binary.
-def find_sftp_server():
-    paths_to_try = ['/usr/libexec/sftp-server', '/usr/lib/sftp-server',
-                    '/usr/libexec/openssh/sftp-server',
-                    '/usr/lib/openssh/sftp-server']
-    return next((path for path in paths_to_try if os.path.isfile(path)), None)
 
-sftp_server_path = find_sftp_server()
-if sftp_server_path:
-    config.available_features.add('sftp_server')
-config.substitutions.append(('%sftp-server',
-                             sftp_server_path or 'no-sftp-server'))
+def find_rsync():
+    for path in os.getenv("PATH").split(":"):
+        rsync_path = os.path.join(path, "rsync")
+        if os.path.isfile(rsync_path):
+            return rsync_path
+
+
+if find_rsync():
+    config.available_features.add("rsync")
 
 subst_target_repl_run_simple_swift = ""
 if 'swift_repl' in config.available_features:

--- a/test/remote-run/custom-options.test-sh
+++ b/test/remote-run/custom-options.test-sh
@@ -20,7 +20,7 @@ CHECK-SAME: 'cp'
 
 CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}
 
-CHECK-NEXT: /usr/bin/rsync
+CHECK-NEXT: rsync
 CHECK-DAG: '-p' '12345'
 CHECK-DAG: '-o' 'FIRST_OPT' '-o' 'SECOND_OPT'
 CHECK-SAME: some_user@some_host

--- a/test/remote-run/custom-options.test-sh
+++ b/test/remote-run/custom-options.test-sh
@@ -1,3 +1,5 @@
+REQUIRES: rsync
+
 RUN: %remote-run -n --remote-dir /xyz-REMOTE -o FIRST_OPT -o SECOND_OPT --output-prefix %/t some_user@some_host:12345 cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck %s
 
 CHECK: /usr/bin/ssh -n

--- a/test/remote-run/download.test-sh
+++ b/test/remote-run/download.test-sh
@@ -1,4 +1,4 @@
-REQUIRES: sftp_server
+REQUIRES: rsync
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t-REMOTE)

--- a/test/remote-run/dry-run-remote.test-sh
+++ b/test/remote-run/dry-run-remote.test-sh
@@ -1,7 +1,9 @@
+REQUIRES: rsync
+
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --input-prefix %S/Inputs/ some_user@some_host ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-INPUT %s
 
 CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/input'
-CHECK-INPUT-NEXT: /usr/bin/rsync
+CHECK-INPUT-NEXT: rsync
 CHECK-INPUT-SAME: some_user@some_host
 
 CHECK-INPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' {{.*}}'ls'
@@ -12,11 +14,11 @@ RUN: touch %t/nested/input %t/nested/BAD
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_host cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output'
-CHECK-OUTPUT-NEXT: /usr/bin/rsync
+CHECK-OUTPUT-NEXT: rsync
 CHECK-OUTPUT-SAME: some_user@some_host
 
 CHECK-OUTPUT: /usr/bin/ssh -n some_user@some_host -- '/usr/bin/env' {{.*}}'cp'
 CHECK-OUTPUT-NEXT: {{^}}/bin/mkdir -p {{.+}}
-CHECK-OUTPUT-NEXT: /usr/bin/rsync
+CHECK-OUTPUT-NEXT: rsync
 CHECK-OUTPUT-SAME: some_user@some_host
 

--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -1,3 +1,4 @@
+REQUIRES: rsync
 REQUIRES: shell
 
 RUN: %empty-directory(%t)

--- a/test/remote-run/dry-run.test-sh
+++ b/test/remote-run/dry-run.test-sh
@@ -6,7 +6,7 @@ RUN: test -z "`ls %t`"
 RUN: test ! -e %t-REMOTE
 
 CHECK-INPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input
-CHECK-INPUT-NEXT: /usr/bin/rsync
+CHECK-INPUT-NEXT: rsync
 CHECK-INPUT: /usr/bin/env {{.*}}ls
 
 RUN: %empty-directory(%t)
@@ -16,8 +16,8 @@ RUN: %debug-remote-run -n --output-prefix %t cp %t/nested/input %t/nested/output
 RUN: test ! -e %t-REMOTE
 
 CHECK-OUTPUT: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/output/nested
-CHECK-OUTPUT: /usr/bin/rsync
+CHECK-OUTPUT: rsync
 CHECK-OUTPUT: /usr/bin/env {{.*}}cp
 CHECK-OUTPUT-NEXT: {{^}}/bin/mkdir -p {{.+}}
-CHECK-OUTPUT-NEXT: /usr/bin/rsync
+CHECK-OUTPUT-NEXT: rsync
 

--- a/test/remote-run/env.test-sh
+++ b/test/remote-run/env.test-sh
@@ -1,3 +1,4 @@
+REQUIRES: rsync
 REQUIRES: shell
 
 RUN: env REMOTE_RUN_CHILD_FOO=foo REMOTE_RUN_CHILD_BAR=bar %debug-remote-run sh -c 'echo ":${FOO}:" ":${BAR}:"' | %FileCheck %s

--- a/test/remote-run/exit-code.test-sh
+++ b/test/remote-run/exit-code.test-sh
@@ -1,3 +1,4 @@
+REQUIRES: rsync
 REQUIRES: shell
 
 RUN: export SWIFT_BACKTRACE=

--- a/test/remote-run/identity.test-sh
+++ b/test/remote-run/identity.test-sh
@@ -1,3 +1,5 @@
+REQUIRES: rsync
+
 RUN: %remote-run -n --remote-dir /xyz-REMOTE -i spiderman --output-prefix %/t some_user@some_host:12345 cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck %s
 
 CHECK: /usr/bin/ssh -n

--- a/test/remote-run/identity.test-sh
+++ b/test/remote-run/identity.test-sh
@@ -17,7 +17,7 @@ CHECK-SAME: some_user@some_host -- '/usr/bin/env' {{.*}}'cp'
 
 CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}
 
-CHECK-NEXT: /usr/bin/rsync
+CHECK-NEXT: rsync
 CHECK-DAG: '-p' '12345'
 CHECK-DAG: '-i' 'spiderman'
 CHECK-SAME: some_user@some_host

--- a/test/remote-run/port.test-sh
+++ b/test/remote-run/port.test-sh
@@ -3,6 +3,6 @@ RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_
 CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'
 CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' {{.*}}'cp'
 CHECK-NEXT: {{^}}/bin/mkdir -p {{.+}}
-CHECK-NEXT: /usr/bin/rsync
+CHECK-NEXT: rsync
 CHECK-SAME: '-p' '12345'
 CHECK-SAME: some_user@some_host

--- a/test/remote-run/port.test-sh
+++ b/test/remote-run/port.test-sh
@@ -1,3 +1,5 @@
+REQUIRES: rsync
+
 RUN: %remote-run -n --remote-dir /xyz-REMOTE --output-prefix %/t some_user@some_host:12345 cp %/t/nested/input %/t/nested/output 2>&1 >/dev/null | %FileCheck %s
 
 CHECK: /usr/bin/ssh -n -p 12345 some_user@some_host -- '/usr/bin/env' '/bin/mkdir' '-p' '{{.+}}-REMOTE/output/nested'

--- a/test/remote-run/run-only.test-sh
+++ b/test/remote-run/run-only.test-sh
@@ -1,3 +1,4 @@
+REQUIRES: rsync
 REQUIRES: shell
 
 RUN: %debug-remote-run echo hello | %FileCheck %s

--- a/test/remote-run/stderr.test-sh
+++ b/test/remote-run/stderr.test-sh
@@ -1,3 +1,4 @@
+REQUIRES: rsync
 REQUIRES: shell
 
 RUN: %debug-remote-run sh -c "echo hello; echo goodbye >&2" > %t.stdout.txt 2> %t.stderr.txt

--- a/test/remote-run/upload-and-download.test-sh
+++ b/test/remote-run/upload-and-download.test-sh
@@ -1,4 +1,4 @@
-REQUIRES: sftp_server
+REQUIRES: rsync
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t-REMOTE)

--- a/test/remote-run/upload-and-download.test-sh
+++ b/test/remote-run/upload-and-download.test-sh
@@ -27,10 +27,10 @@ RUN: ls %t-REMOTE/output/nested/ | %FileCheck -check-prefix CHECK-REMOTE %s
 RUN: %debug-remote-run -v --output-prefix %t cp %t/nested/input %t/nested/output 2>&1 >/dev/null | %FileCheck -check-prefix VERBOSE %s
 
 VERBOSE: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/output/nested
-VERBOSE: /usr/bin/rsync
+VERBOSE: rsync
 VERBOSE: /usr/bin/env {{.*}}cp
 VERBOSE-NEXT: {{^}}/bin/mkdir -p {{.+}}
-VERBOSE-NEXT: /usr/bin/rsync
+VERBOSE-NEXT: rsync
 
 RUN: %empty-directory(%t)
 RUN: touch %t/xyz-1before

--- a/test/remote-run/upload-stderr.test-sh
+++ b/test/remote-run/upload-stderr.test-sh
@@ -1,4 +1,4 @@
-REQUIRES: sftp_server
+REQUIRES: rsync
 
 RUN: %empty-directory(%t)
 RUN: %empty-directory(%t/REMOTE/input)

--- a/test/remote-run/upload.test-sh
+++ b/test/remote-run/upload.test-sh
@@ -34,5 +34,5 @@ CHECK-NEXT: {{^3.txt$}}
 CHECK-NOT: BAD
 
 VERBOSE-NESTED: /usr/bin/env /bin/mkdir -p {{.+}}-REMOTE/input
-VERBOSE-NESTED-NEXT: /usr/bin/rsync
+VERBOSE-NESTED-NEXT: rsync
 VERBOSE-NESTED: /usr/bin/env {{.*}}ls

--- a/test/remote-run/upload.test-sh
+++ b/test/remote-run/upload.test-sh
@@ -1,4 +1,4 @@
-REQUIRES: sftp_server
+REQUIRES: rsync
 
 RUN: env REMOTE_RUN_CHILD_FOO=%S/Inputs/upload/3.txt %debug-remote-run --input-prefix %S/Inputs/upload/ ls %S/Inputs/upload/1.txt %S/Inputs/upload/2.txt | %FileCheck -check-prefix CHECK-REMOTE %s
 RUN: ls %t-REMOTE/input/ | %FileCheck %s

--- a/utils/remote-run
+++ b/utils/remote-run
@@ -203,7 +203,7 @@ class RemoteCommandRunner(CommandRunner):
                 [quote(arg) for arg in command])
 
     def rsync_invocation(self, source, dest):
-        return ['/usr/bin/rsync', '-arRz', '--files-from=-',
+        return ['rsync', '-arRz', '--files-from=-',
                 '-e', ' '.join([quote(x) for x in
                                 ['/usr/bin/ssh'] +
                                 self.common_options(port_flag='-p')]),
@@ -221,7 +221,7 @@ class LocalCommandRunner(CommandRunner):
         return command
 
     def rsync_invocation(self, source, dest):
-        return ['/usr/bin/rsync', '-arz', '--files-from=-', source, dest]
+        return ['rsync', '-arz', '--files-from=-', source, dest]
 
     def rsync_from_invocation(self, source, dest):
         return self.rsync_invocation(source, dest)


### PR DESCRIPTION
FreeBSD installs rsync to `/usr/local/bin` instead of `/usr/bin`, which caused the remote-run tests to fail when they should have run fine because `rsync` was installed. `remote-run` should be able to grab an `rsync` on the path if it exists.

Also replacing the `sftp_server` in the available features with `rsync` and migrated the remote-run tests off of requiring an `sftp_server` since the tests no longer use it. 