### PR TITLE
Unversioned clang resource OS name

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -334,10 +334,9 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
     SmallString<128> LibProfile(SharedResourceDirPath);
     llvm::sys::path::remove_filename(LibProfile); // remove platform name
     llvm::sys::path::append(LibProfile, "clang", "lib");
-
-    llvm::sys::path::append(LibProfile, getTriple().getOSName(),
-                            Twine("libclang_rt.profile-") +
-                                getTriple().getArchName() + ".a");
+    llvm::sys::path::append(
+        LibProfile, getUnversionedTriple(getTriple()).getOSName(),
+        Twine("libclang_rt.profile-") + getTriple().getArchName() + ".a");
     Arguments.push_back(context.Args.MakeArgString(LibProfile));
     Arguments.push_back(context.Args.MakeArgString(
         Twine("-u", llvm::getInstrProfRuntimeHookVarName())));


### PR DESCRIPTION
The clang resource directory generally does not use a versioned form of the platform name. This aligns the old driver behavior with the new driver for FreeBSD support.

https://github.com/swiftlang/swift-driver/blob/a7f32bd005de1b998495ddc052bf78fc3cebdaa5/Sources/SwiftDriver/Jobs/GenericUnixToolchain%2BLinkerSupport.swift#L309