### PR TITLE
Sema: Fix the -warn-long-expression-type-checking flag

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -847,6 +847,9 @@ def downgrade_typecheck_interface_error : Flag<["-"], "downgrade-typecheck-inter
 def enable_volatile_modules : Flag<["-"], "enable-volatile-modules">,
   HelpText<"Load Swift modules in memory">;
 
+def solver_memory_threshold_EQ : Joined<["-"], "solver-memory-threshold=">,
+  HelpText<"Set the upper bound for memory consumption, in bytes, by the constraint solver">;
+
 def solver_expression_time_threshold_EQ : Joined<["-"], "solver-expression-time-threshold=">,
   HelpText<"Expression type checking timeout, in seconds">;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -799,10 +799,6 @@ def import_cf_types : Flag<["-"], "import-cf-types">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Recognize and import CF types as class types">;
 
-def solver_memory_threshold : Separate<["-"], "solver-memory-threshold">,
-  Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Set the upper bound for memory consumption, in bytes, by the constraint solver">;
-
 def solver_shrink_unsolved_threshold : Separate<["-"], "solver-shrink-unsolved-threshold">,
 Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
 HelpText<"Set The upper bound to number of sub-expressions unsolved before termination of the shrink phrase">;

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -247,6 +247,8 @@ private:
   bool PrintWarning;
 
 public:
+  const static unsigned NoLimit = (unsigned) -1;
+
   ExpressionTimer(AnchorType Anchor, ConstraintSystem &CS,
                   unsigned thresholdInSecs);
 
@@ -272,6 +274,9 @@ public:
   /// Return the remaining process time in seconds until the
   /// threshold specified during construction is reached.
   unsigned getRemainingProcessTimeInSeconds() const {
+    if (ThresholdInSecs == NoLimit)
+      return NoLimit;
+
     auto elapsed = unsigned(getElapsedProcessTimeInFractionalSeconds());
     return elapsed >= ThresholdInSecs ? 0 : ThresholdInSecs - elapsed;
   }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -312,7 +312,6 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_nostdlibimport);
   inputArgs.AddLastArg(arguments, options::OPT_parse_stdlib);
   inputArgs.AddLastArg(arguments, options::OPT_resource_dir);
-  inputArgs.AddLastArg(arguments, options::OPT_solver_memory_threshold);
   inputArgs.AddLastArg(arguments, options::OPT_value_recursion_threshold);
   inputArgs.AddLastArg(arguments, options::OPT_warn_swift3_objc_inference);
   inputArgs.AddLastArg(arguments, options::OPT_Rpass_EQ);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1944,7 +1944,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
                              Opts.SwitchCheckingInvocationThreshold);
   setUnsignedIntegerArgument(OPT_debug_constraints_attempt,
                              Opts.DebugConstraintSolverAttempt);
-  setUnsignedIntegerArgument(OPT_solver_memory_threshold,
+  setUnsignedIntegerArgument(OPT_solver_memory_threshold_EQ,
                              Opts.SolverMemoryThreshold);
   setUnsignedIntegerArgument(OPT_solver_scope_threshold_EQ,
                              Opts.SolverScopeThreshold);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -73,7 +73,6 @@ Solution ConstraintSystem::finalize() {
   Solution solution(*this, CurrentScore);
 
   // Update the best score we've seen so far.
-  auto &ctx = getASTContext();
   assert(!solverState->BestScore || CurrentScore <= *solverState->BestScore);
 
   if (!solverState->BestScore || CurrentScore <= *solverState->BestScore) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -141,9 +141,18 @@ ConstraintSystem::~ConstraintSystem() {
 void ConstraintSystem::startExpressionTimer(ExpressionTimer::AnchorType anchor) {
   ASSERT(!Timer);
 
-  unsigned timeout = getASTContext().TypeCheckerOpts.ExpressionTimeoutThreshold;
-  if (timeout == 0)
-    return;
+  const auto &opts = getASTContext().TypeCheckerOpts;
+  unsigned timeout = opts.ExpressionTimeoutThreshold;
+
+  // If either the timeout is set, or we're asked to emit warnings,
+  // start the timer. Otherwise, don't start the timer, it's needless
+  // overhead.
+  if (timeout == 0) {
+    if (opts.WarnLongExpressionTypeChecking == 0)
+      return;
+
+    timeout = ExpressionTimer::NoLimit;
+  }
 
   Timer.emplace(anchor, *this, timeout);
 }

--- a/test/Constraints/issue-52724.swift
+++ b/test/Constraints/issue-52724.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify %s
-
-// REQUIRES: rdar65007946
+// RUN: %target-swift-frontend -typecheck -verify -disable-constraint-solver-performance-hacks %s
 
 // https://github.com/apple/swift/issues/52724
 

--- a/test/Constraints/warn_long_compile.swift
+++ b/test/Constraints/warn_long_compile.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1
-// REQUIRES: rdar44305428
+// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -disable-constraint-solver-performance-hacks -warn-long-function-bodies=1 -solver-expression-time-threshold=60
+// FIXME: -solver-expression-time-threshold=60 should not be needed
 @_silgen_name("generic_foo")
 func foo<T>(_ x: T) -> T
 
@@ -8,6 +8,6 @@ func foo(_ x: Int) -> Int
 
 func test(m: Double) -> Int {
   // expected-warning@-1 {{global function 'test(m:)' took}}
-  return Int(foo(Float(m) / 20) * 20 - 2) + 10
+  return ~(~(~(~(~(~(~(~(~(~(~(~(0))))))))))))
   // expected-warning@-1 {{expression took}}
 }

--- a/test/Constraints/warn_long_compile.swift
+++ b/test/Constraints/warn_long_compile.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -disable-constraint-solver-performance-hacks -warn-long-function-bodies=1 -solver-expression-time-threshold=60
-// FIXME: -solver-expression-time-threshold=60 should not be needed
+// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -disable-constraint-solver-performance-hacks -warn-long-function-bodies=1
 @_silgen_name("generic_foo")
 func foo<T>(_ x: T) -> T
 

--- a/test/Interpreter/objc_protocols.swift
+++ b/test/Interpreter/objc_protocols.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar107343134
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/Misc/expression_too_complex_2.swift
+++ b/test/Misc/expression_too_complex_2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -solver-memory-threshold 32000
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold=32000
 // REQUIRES: OS=ios
 import UIKit
 class MyViewCell: UITableViewCell {

--- a/test/Misc/prioritize_solver_memory_threshold.swift
+++ b/test/Misc/prioritize_solver_memory_threshold.swift
@@ -1,3 +1,3 @@
-// RUN: %target-typecheck-verify-swift -solver-memory-threshold 1
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold=1
 
 func foo() { _ = 1 } // expected-error {{the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions}}


### PR DESCRIPTION
Fixes rdar://152998878.

This flag regressed because the test for it has been disabled since 2018. Re-enable it, "fixing" rdar://44305428.