### PR TITLE
[6.2] Sema: Fix -warn-long-expression-type-checking when expression timer is disabled

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -249,6 +249,8 @@ private:
   bool PrintWarning;
 
 public:
+  const static unsigned NoLimit = (unsigned) -1;
+
   ExpressionTimer(AnchorType Anchor, ConstraintSystem &CS,
                   unsigned thresholdInSecs);
 
@@ -274,6 +276,9 @@ public:
   /// Return the remaining process time in seconds until the
   /// threshold specified during construction is reached.
   unsigned getRemainingProcessTimeInSeconds() const {
+    if (ThresholdInSecs == NoLimit)
+      return NoLimit;
+
     auto elapsed = unsigned(getElapsedProcessTimeInFractionalSeconds());
     return elapsed >= ThresholdInSecs ? 0 : ThresholdInSecs - elapsed;
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -141,9 +141,18 @@ ConstraintSystem::~ConstraintSystem() {
 void ConstraintSystem::startExpressionTimer(ExpressionTimer::AnchorType anchor) {
   ASSERT(!Timer);
 
-  unsigned timeout = getASTContext().TypeCheckerOpts.ExpressionTimeoutThreshold;
-  if (timeout == 0)
-    return;
+  const auto &opts = getASTContext().TypeCheckerOpts;
+  unsigned timeout = opts.ExpressionTimeoutThreshold;
+
+  // If either the timeout is set, or we're asked to emit warnings,
+  // start the timer. Otherwise, don't start the timer, it's needless
+  // overhead.
+  if (timeout == 0) {
+    if (opts.WarnLongExpressionTypeChecking == 0)
+      return;
+
+    timeout = ExpressionTimer::NoLimit;
+  }
 
   Timer.emplace(anchor, *this, timeout);
 }

--- a/test/Constraints/warn_long_compile.swift
+++ b/test/Constraints/warn_long_compile.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -warn-long-function-bodies=1
-// REQUIRES: rdar44305428
+// RUN: %target-typecheck-verify-swift -warn-long-expression-type-checking=1 -solver-disable-shrink -warn-long-function-bodies=1
 @_silgen_name("generic_foo")
 func foo<T>(_ x: T) -> T
 
@@ -8,6 +7,6 @@ func foo(_ x: Int) -> Int
 
 func test(m: Double) -> Int {
   // expected-warning@-1 {{global function 'test(m:)' took}}
-  return Int(foo(Float(m) / 20) * 20 - 2) + 10
+  return ~(~(~(~(~(~(~(~(~(~(~(~(0))))))))))))
   // expected-warning@-1 {{expression took}}
 }


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82506

* **Description:** The 600-second expression timeout was a source of overhead so it was turned off in 6.2 (https://github.com/swiftlang/swift/pull/78975) but this regressed the `-warn-long-expression-type-checking` flag. We need to start the timer if either the global timeout is enabled, or the warning is on.

* **Reviewed by:** @xedin 

* **Risk:** Very low.

* **Radar:** rdar://152998878 