### PR TITLE
[IRGen] Sign these function pointers.

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1252,8 +1252,7 @@ static void addValueWitness(IRGenModule &IGM, ConstantStructBuilder &B,
       if (auto *enumDecl = boundGenericCharacteristics->concreteType
                                .getEnumOrBoundGenericEnum())
         if (IGM.getMetadataLayout(enumDecl).hasPayloadSizeOffset())
-          return B.add(llvm::ConstantExpr::getBitCast(
-              IGM.getGetMultiPayloadEnumTagSinglePayloadFn(), IGM.Int8PtrTy));
+          return addFunction(IGM.getGetMultiPayloadEnumTagSinglePayloadFn());
     goto standard;
   }
   case ValueWitness::StoreEnumTagSinglePayload: {
@@ -1261,8 +1260,7 @@ static void addValueWitness(IRGenModule &IGM, ConstantStructBuilder &B,
       if (auto *enumDecl = boundGenericCharacteristics->concreteType
                                .getEnumOrBoundGenericEnum())
         if (IGM.getMetadataLayout(enumDecl).hasPayloadSizeOffset())
-          return B.add(llvm::ConstantExpr::getBitCast(
-              IGM.getStoreMultiPayloadEnumTagSinglePayloadFn(), IGM.Int8PtrTy));
+          return addFunction(IGM.getStoreMultiPayloadEnumTagSinglePayloadFn());
     goto standard;
   }
 

--- a/test/IRGen/prespecialized-metadata/mpenum-ptrauth-vw.swift
+++ b/test/IRGen/prespecialized-metadata/mpenum-ptrauth-vw.swift
@@ -1,0 +1,30 @@
+// RUN: %swift -prespecialize-generic-metadata -target %module-target-future -emit-irgen %s | %IRGenFileCheck %s
+
+// REQUIRES: CPU=arm64e
+
+public enum R<X> {
+case a(X)
+case b(Any)
+}
+
+@inline(never)
+func consume<T>(_ t: T) {}
+
+// CHECK:      @"$s4main1ROySiGWV" = {{.*}}%swift.enum_vwtable {
+//           :   ptr @"$s4main1ROwCP.ptrauth.1",
+//           :   ptr @"$s4main1ROwxx.ptrauth.2",
+//           :   ptr @"$s4main1ROwcp.ptrauth.3",
+//           :   ptr @"$s4main1ROwca.ptrauth.4",
+//           :   ptr @"$s4main1ROwtk.ptrauth.5",
+//           :   ptr @"$s4main1ROwta.ptrauth.6",
+// CHECK-SAME:   ptr @swift_getMultiPayloadEnumTagSinglePayload.ptrauth,
+// CHECK-SAME:   ptr @swift_storeMultiPayloadEnumTagSinglePayload.ptrauth,
+//           :   i64 33,
+//           :   i64 40,
+//           :   i32 2293767,
+//           :   i32 254,
+//           :   ptr @"$s4main1ROwug.ptrauth.7",
+//           :   ptr @"$s4main1ROwup.ptrauth.8",
+//           :   ptr @"$s4main1ROwui.ptrauth.9"
+//           : }
+consume(R<Int>.self)


### PR DESCRIPTION
Value witness tables for prespecialized metadata for multi payload enums contain references to `swift_getMultiPayloadEnumTagSinglePayload` and `swift_storeMultiPayloadEnumTagSinglePayload`.  On platforms with ptrauth, those functions must be signed.  Use the same helper when adding these functions to the table as is used to add every single other function to the table.

rdar://80334865
