### PR TITLE
[6.2] Fix diagnostics for missing or invalid @_lifetime annotations on inout params

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2140,7 +2140,7 @@ ERROR(expected_lparen_after_lifetime_dependence, PointsToFirstBadToken,
 
 ERROR(expected_identifier_or_index_or_self_after_lifetime_dependence,
       PointsToFirstBadToken,
-      "expected identifier, index or self in lifetime dependence specifier",
+      "expected 'copy', 'borrow', or '&' followed by an identifier, index or 'self' in lifetime dependence specifier",
       ())
 
 ERROR(expected_rparen_after_lifetime_dependence, PointsToFirstBadToken,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8260,10 +8260,10 @@ ERROR(lifetime_dependence_feature_required_return, none,
 ERROR(lifetime_dependence_feature_required_mutating, none,
       "%0 cannot have a ~Escapable 'self'", (StringRef))
 ERROR(lifetime_dependence_feature_required_inout, none,
-      "%0 cannot have a ~Escapable 'inout' parameter %1",
+      "%0 cannot have a ~Escapable 'inout' parameter '%1'",
       // this arg list must be compatible with
       // lifetime_dependence_cannot_infer_inout
-      (StringRef, Identifier))
+      (StringRef, StringRef))
 
 ERROR(lifetime_dependence_cannot_infer_return, none,
       "%0 with a ~Escapable result requires '@_lifetime(...)'", (StringRef))
@@ -8271,7 +8271,7 @@ ERROR(lifetime_dependence_cannot_infer_mutating, none,
       "%0 with a ~Escapable 'self' requires '@_lifetime(self: ...)'", (StringRef))
 ERROR(lifetime_dependence_cannot_infer_inout, none,
       "%0 with a ~Escapable 'inout' parameter requires '@_lifetime(%1: ...)'",
-      (StringRef, Identifier))
+      (StringRef, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Inference - refinements to the requirements above

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8244,7 +8244,7 @@ ERROR(lifetime_dependence_cannot_use_default_escapable_consuming, none,
       "invalid lifetime dependence on an Escapable value with %0 ownership",
       (StringRef))
 ERROR(lifetime_dependence_cannot_use_parsed_borrow_inout, none,
-      "invalid use of borrow dependence on the same inout parameter",
+      "invalid use of inout dependence on the same inout parameter",
       ())
 ERROR(lifetime_dependence_duplicate_target, none,
       "invalid duplicate target lifetime dependencies on function", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8260,7 +8260,7 @@ ERROR(lifetime_dependence_feature_required_return, none,
 ERROR(lifetime_dependence_feature_required_mutating, none,
       "%0 cannot have a ~Escapable 'self'", (StringRef))
 ERROR(lifetime_dependence_feature_required_inout, none,
-      "%0 cannot have a ~Escapable 'inout' parameter '%1'",
+      "%0 cannot have a ~Escapable 'inout' parameter '%1' in addition to other ~Escapable parameters",
       // this arg list must be compatible with
       // lifetime_dependence_cannot_infer_inout
       (StringRef, StringRef))
@@ -8297,6 +8297,9 @@ ERROR(lifetime_dependence_cannot_infer_scope_ownership, none,
 ERROR(lifetime_dependence_cannot_infer_implicit_init, none,
       "cannot infer implicit initialization lifetime. Add an initializer with "
       "'@_lifetime(...)' for each parameter the result depends on", ())
+NOTE(lifetime_dependence_cannot_infer_inout_suggest, none,
+     "use '@_lifetime(%0: copy %0) to forward the inout dependency",
+     (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Experimental Inference

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -910,17 +910,21 @@ protected:
       if (!paramDeclAndIndex.has_value()) {
         return std::nullopt;
       }
-      auto lifetimeKind =
-        getDependenceKindFromDescriptor(source, paramDeclAndIndex->first);
+      auto *param = paramDeclAndIndex->first;
+      unsigned sourceIndex = paramDeclAndIndex->second;
+      auto lifetimeKind = getDependenceKindFromDescriptor(source, param);
       if (!lifetimeKind.has_value()) {
         return std::nullopt;
       }
-      unsigned sourceIndex = paramDeclAndIndex->second;
       if (lifetimeKind == LifetimeDependenceKind::Scope
-          && paramDeclAndIndex->first->isInOut()
+          && param->isInOut()
           && sourceIndex == targetIndex) {
         diagnose(source.getLoc(),
                  diag::lifetime_dependence_cannot_use_parsed_borrow_inout);
+        ctx.Diags.diagnose(source.getLoc(),
+                           diag::lifetime_dependence_cannot_infer_inout_suggest,
+                           param->getName().str());
+
         return std::nullopt;
       }
       bool hasError =

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -917,6 +917,7 @@ protected:
       }
       unsigned sourceIndex = paramDeclAndIndex->second;
       if (lifetimeKind == LifetimeDependenceKind::Scope
+          && paramDeclAndIndex->first->isInOut()
           && sourceIndex == targetIndex) {
         diagnose(source.getLoc(),
                  diag::lifetime_dependence_cannot_use_parsed_borrow_inout);

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -554,7 +554,7 @@ protected:
                         })) {
         ctx.Diags.diagnose(param->getLoc(), diagID,
                            {StringRef(diagnosticQualifier()),
-                            param->getName()});
+                            param->getName().str()});
       }
     }
   }

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -555,6 +555,12 @@ protected:
         ctx.Diags.diagnose(param->getLoc(), diagID,
                            {StringRef(diagnosticQualifier()),
                             param->getName().str()});
+        if (diagID == diag::lifetime_dependence_cannot_infer_inout.ID) {
+          ctx.Diags.diagnose(
+            param->getLoc(),
+            diag::lifetime_dependence_cannot_infer_inout_suggest,
+            param->getName().str());
+        }
       }
     }
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4989,6 +4989,7 @@ ParserResult<LifetimeEntry> Parser::parseLifetimeEntry(SourceLoc loc) {
   SmallVector<LifetimeDescriptor> sources;
   SourceLoc rParenLoc;
   bool foundParamId = false;
+  bool invalidSourceDescriptor = false;
   status = parseList(
       tok::r_paren, lParenLoc, rParenLoc, /*AllowSepAfterLast=*/false,
       diag::expected_rparen_after_lifetime_dependence, [&]() -> ParserStatus {
@@ -5005,6 +5006,7 @@ ParserResult<LifetimeEntry> Parser::parseLifetimeEntry(SourceLoc loc) {
         auto sourceDescriptor =
             parseLifetimeDescriptor(*this, lifetimeDependenceKind);
         if (!sourceDescriptor) {
+          invalidSourceDescriptor = true;
           listStatus.setIsParseError();
           return listStatus;
         }
@@ -5012,6 +5014,10 @@ ParserResult<LifetimeEntry> Parser::parseLifetimeEntry(SourceLoc loc) {
         return listStatus;
       });
 
+  if (invalidSourceDescriptor) {
+    status.setIsParseError();
+    return status;
+  }
   if (!foundParamId) {
     diagnose(
         Tok,

--- a/test/Parse/lifetime_attr.swift
+++ b/test/Parse/lifetime_attr.swift
@@ -24,7 +24,7 @@ func testMissingLParenError(_ ne: NE) -> NE { // expected-error{{cannot infer th
   ne
 }
 
-@_lifetime() // expected-error{{expected identifier, index or self in lifetime dependence specifier}}
+@_lifetime() // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier, index or 'self' in lifetime dependence specifier}}
 func testMissingDependence(_ ne: NE) -> NE { // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
   ne
 }

--- a/test/Sema/lifetime_attr_nofeature.swift
+++ b/test/Sema/lifetime_attr_nofeature.swift
@@ -8,3 +8,9 @@ struct NE : ~Escapable { // expected-error{{an implicit initializer cannot retur
 func derive(_ ne: NE) -> NE { // expected-error{{a function cannot return a ~Escapable result}}
   ne
 }
+
+func f_inout_infer(a: inout MutableRawSpan) {}
+
+func f_inout_no_infer(a: inout MutableRawSpan, b: RawSpan) {}
+// expected-error @-1{{a function cannot have a ~Escapable 'inout' parameter 'a' in addition to other ~Escapable parameters}}
+

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -625,3 +625,8 @@ struct NE_NE_C: ~Escapable { // expected-error{{cannot infer implicit initializa
 func f_inout_no_infer(a: inout MutNE, b: NE) {} // expected-error{{a function with a ~Escapable 'inout' parameter requires '@_lifetime(a: ...)'}}
 // expected-note @-1{{use '@_lifetime(a: copy a) to forward the inout dependency}}
 
+// Invalid keyword for the dependence kind.
+//
+@_lifetime(a: inout a) // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier, index or 'self' in lifetime dependence specifier}}
+func f_inout_bad_keyword(a: inout MutableRawSpan) {}
+

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -15,6 +15,8 @@ struct NEImmortal: ~Escapable {
   init() {}
 }
 
+struct MutNE: ~Copyable & ~Escapable {}
+
 // =============================================================================
 // Handle non-Escapable results with 'self'
 // =============================================================================
@@ -613,3 +615,13 @@ struct NE_NE_C: ~Escapable { // expected-error{{cannot infer implicit initializa
   let ne: NE
   let c: C
 }
+
+// =============================================================================
+// Handle common mistakes with inout parameter annotations
+// =============================================================================
+
+// Unable to infer an 'inout' dependency. Provide valid guidance.
+//
+func f_inout_no_infer(a: inout MutNE, b: NE) {} // expected-error{{a function with a ~Escapable 'inout' parameter requires '@_lifetime(a: ...)'}}
+// expected-note @-1{{use '@_lifetime(a: copy a) to forward the inout dependency}}
+

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -565,7 +565,7 @@ struct NonEscapableMutableSelf: ~Escapable {
   @_lifetime(self: copy self) // OK
   mutating func mutatingMethodNoParamCopy() {}
 
-  @_lifetime(self: &self) // expected-error{{invalid use of borrow dependence on the same inout parameter}}
+  @_lifetime(self: &self) // expected-error{{invalid use of inout dependence on the same inout parameter}}
   mutating func mutatingMethodNoParamBorrow() {}
 
   mutating func mutatingMethodOneParam(_: NE) {} // expected-error{{a mutating method with a ~Escapable 'self' requires '@_lifetime(self: ...)'}}


### PR DESCRIPTION
- **Fix LifetimeDependence diagnostic formatting**
  Remove incorrectly nested single quotes from the suggested fix.
  
  (cherry picked from commit 465d6a82e77b782e2f1348fb19204a726f6e24f0)
  

- **Lifetime diagnostics: clarify @_lifetime usage for inout parameters**
  This comes up often when passing a MutableSpan as an 'inout' argument.  The
  vague diagnostic was causing developers to attempt incorrect @_lifetime
  annotations. Be clear about why the annotation is needed and which annotation
  should be used.
  
  (cherry picked from commit df0b81c88df5bbc9a30a4e16a5d07381f77523b1)
  

- **Fix misleading Lifetime diagnostics for inout parameters**
  Correctly diagnose this as:
  "invalid use of inout dependence on the same inout parameter
  
      @_lifetime(a: &a)
      func f_inout_useless(a: inout MutableRawSpan) {}
  
  Correctly diagnose this as:
  "lifetime-dependent parameter must be 'inout'":
  
      @_lifetime(a: borrow a)
      func f_inout_useless(a: borrowing MutableRawSpan) {}
  
  (cherry picked from commit 05fa82b7a7a4dc80ba2c903970efede32d7ce356)
  

- **Fix a compiler crash with '@'_lifetime(inout x), add diagnostic**
  This is a common mistake made more common be suggestions of existing diagnostic
  that tell users not to use a 'copy' dependency.
  
  Report a diagnostic error rather than crashing the compiler. Fix the diagnostic
  output to make sense relative to the source location.
  
  Fixes rdar://154136015 ([nonescapable] compiler assertion with @_lifetime(x: inout x))
  
  (cherry picked from commit 080b68292d0cfcd95b2c15bad5b0da4b9774627e)
  

- **Diagnostic note for invalid @_lifetime annotations on inout params**
  Users commonly try to write a lifetime dependency on an 'inout' parameters as:
  
      @_lifetime(a: &a)
      func f_inout_useless(a: inout MutableRawSpan) {}
  
  This is useless. Guide them toward what they really wanted:
  
      @_lifetime(a: copy a)
  
  Fixes rdar://151618856 (@lifetime(..) gives inconsistent error messages)
  
  (cherry picked from commit 87f2510a27063c34bff31fc3630ef9b27698e5e3)
  
--- CCC ---

Explanation: Fix diagnostics for missing or invalid @_lifetime annotations on inout params

Scope: This primarily affects adopters of the supported experimental Lifetimes feature but also improves diagnostic for regular non-experimental uses of MutableSpan.

Radar/SR Issue:
rdar://151618856 (@lifetime(...) gives inconsistent error messages)
rdar://154136015 ([nonescapable] compiler assertion with @_lifetime(x: inout x))

main PR: https://github.com/swiftlang/swift/pull/82505

Risk: Low. This eliminates a compiler crash and improves the quality of the diagnostic messages.

Testing: Added source-level unit tests.

Reviewer: Meghana Gupta
