### PR TITLE
[6.2🍒] fix calls to llvm prefix mapping functions to use space-separated option format

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -499,7 +499,7 @@ public:
   bool SkipSDKImportPaths = false;
 
   /// Scanner Prefix Mapper.
-  std::vector<std::string> ScannerPrefixMapper;
+  std::vector<std::pair<std::string, std::string>> ScannerPrefixMapper;
 
   /// Verify resolved plugin is not changed.
   bool ResolvedPluginVerification = false;

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -742,12 +742,8 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   if (!ScannerPrefixMapper.empty()) {
     Mapper = std::make_unique<llvm::PrefixMapper>();
     SmallVector<llvm::MappedPrefix, 4> Prefixes;
-    if (auto E = llvm::MappedPrefix::transformJoined(ScannerPrefixMapper,
-                                                     Prefixes)) {
-      Instance.getDiags().diagnose(SourceLoc(), diag::error_prefix_mapping,
-                                   toString(std::move(E)));
-      return true;
-    }
+    llvm::MappedPrefix::transformPairs(ScannerPrefixMapper,
+                                       Prefixes);
     Mapper->addRange(Prefixes);
     Mapper->sort();
   }

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -40,8 +40,9 @@ using namespace clang::tooling::dependencies;
 static void addScannerPrefixMapperInvocationArguments(
     std::vector<std::string> &invocationArgStrs, ASTContext &ctx) {
   for (const auto &arg : ctx.SearchPathOpts.ScannerPrefixMapper) {
-    std::string prefixMapArg = "-fdepscan-prefix-map=" + arg;
-    invocationArgStrs.push_back(prefixMapArg);
+    invocationArgStrs.push_back("-fdepscan-prefix-map");
+    invocationArgStrs.push_back(arg.first);
+    invocationArgStrs.push_back(arg.second);
   }
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -35,6 +35,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/LineIterator.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/VersionTuple.h"
 #include "llvm/Support/WithColor.h"
@@ -2452,7 +2453,11 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts, ArgList &Args,
     Opts.DeserializedPathRecoverer.addMapping(SplitMap.first, SplitMap.second);
   }
   for (StringRef Opt : Args.getAllArgValues(OPT_scanner_prefix_map)) {
-    Opts.ScannerPrefixMapper.push_back(Opt.str());
+    if (auto Mapping = llvm::MappedPrefix::getFromJoined(Opt)) {
+      Opts.ScannerPrefixMapper.push_back({Mapping->Old, Mapping->New});
+    } else {
+      Diags.diagnose(SourceLoc(), diag::error_prefix_mapping, Opt);
+    }
   }
 
   Opts.ResolvedPluginVerification |=


### PR DESCRIPTION
Explanation: Use the new space-separated format for the `-fdepscan-prefix-map` flag when calling LLVM from Swift, as well as using the new API used to implement that option which uses `std::pair` instead of single strings.

Scope: This should not cause any backward compatibility issues since it is not changing any option for Swift itself, it is just adjusting it to use the new option introduced in https://github.com/swiftlang/llvm-project/pull/10740.

Issues: rdar://129434789

Original PRs: https://github.com/swiftlang/swift/pull/81792

Risk: Low, does not change Swift's API or CLI flags.

Testing: The new functionality is implemented and tested in the corresponding LLVM PR https://github.com/swiftlang/llvm-project/pull/10740, there are no tests added in this PR.

Reviewers: @akyrtzi @cachemeifyoucan @benlangmuir