### PR TITLE
Use SWIFT_COMPILER_VERSION before SWIFT_TOOLCHAIN_VERSION if it exists

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -167,15 +167,17 @@ updated without updating swift.py?")
     def _version_flags(self):
         r = CMakeOptions()
         if self.args.swift_compiler_version is not None:
-            swift_compiler_version = self.args.swift_compiler_version
-            r.define('SWIFT_COMPILER_VERSION', str(swift_compiler_version))
+            swift_compiler_version = str(self.args.swift_compiler_version)
+            r.define('SWIFT_COMPILER_VERSION', swift_compiler_version)
+            r.define('SWIFT_TOOLCHAIN_VERSION', "swiftlang-" + swift_compiler_version)
+        else:
+            toolchain_version = os.environ.get('TOOLCHAIN_VERSION')
+            if toolchain_version:
+                r.define('SWIFT_TOOLCHAIN_VERSION', toolchain_version)
+
         if self.args.clang_compiler_version is not None:
             clang_compiler_version = self.args.clang_compiler_version
             r.define('CLANG_COMPILER_VERSION', str(clang_compiler_version))
-
-        toolchain_version = os.environ.get('TOOLCHAIN_VERSION')
-        if toolchain_version:
-            r.define('SWIFT_TOOLCHAIN_VERSION', toolchain_version)
 
         return r
 


### PR DESCRIPTION
We should eventually split these, but for now SWIFT_COMPILER_VERSION matches SWIFT_TOOLCHAIN_VERSION when it's actually set. Just use it in preference to SWIFT_TOOLCHAIN_VERSION.