### PR TITLE
[6.2] Use SWIFT_COMPILER_VERSION before SWIFT_TOOLCHAIN_VERSION if it exists

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swift.py
+++ b/utils/swift_build_support/swift_build_support/products/swift.py
@@ -165,15 +165,17 @@ updated without updating swift.py?")
     def _version_flags(self):
         r = CMakeOptions()
         if self.args.swift_compiler_version is not None:
-            swift_compiler_version = self.args.swift_compiler_version
-            r.define('SWIFT_COMPILER_VERSION', str(swift_compiler_version))
+            swift_compiler_version = str(self.args.swift_compiler_version)
+            r.define('SWIFT_COMPILER_VERSION', swift_compiler_version)
+            r.define('SWIFT_TOOLCHAIN_VERSION', "swiftlang-" + swift_compiler_version)
+        else:
+            toolchain_version = os.environ.get('TOOLCHAIN_VERSION')
+            if toolchain_version:
+                r.define('SWIFT_TOOLCHAIN_VERSION', toolchain_version)
+
         if self.args.clang_compiler_version is not None:
             clang_compiler_version = self.args.clang_compiler_version
             r.define('CLANG_COMPILER_VERSION', str(clang_compiler_version))
-
-        toolchain_version = os.environ.get('TOOLCHAIN_VERSION')
-        if toolchain_version:
-            r.define('SWIFT_TOOLCHAIN_VERSION', toolchain_version)
 
         return r
 


### PR DESCRIPTION
Explanation: Uses SWIFT_COMPILER_VERSION in replacement of TOOLCHAIN_VERSION if it has been set. SWIFT_COMPILER_VERSION is currently set for all release tags vs TOOLCHAIN_VERSION which is set for all.

Scope: An extra field in `-print-target-info`

Original PRs: https://github.com/swiftlang/swift/pull/82514

Risk: Low/none - the only risk here is that `swiftCompilerTag` ends up being removed from `-print-target-info`, but nothing is currently using it.