### PR TITLE
[stdlib] improve `mutableSpan` accessor declarations

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1744,9 +1744,9 @@ extension Array {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1301,9 +1301,9 @@ extension ArraySlice {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -173,9 +173,9 @@ extension CollectionOfOne {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       let pointer = unsafe UnsafeMutablePointer<Element>(
         Builtin.addressOfBorrow(self)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1243,9 +1243,9 @@ extension ContiguousArray {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -587,9 +587,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
   @unsafe
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @_transparent
     get {
       unsafe MutableSpan(_unsafeElements: self)
     }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -575,12 +575,12 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
   @unsafe
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @_transparent
     get {
-      let span = unsafe Span(_unsafeElements: self)
-      return unsafe _overrideLifetime(span, borrowing: self)
+      unsafe Span(_unsafeElements: self)
     }
   }
 %if Mutable:

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1185,12 +1185,12 @@ extension Unsafe${Mutable}RawBufferPointer {
 
   @unsafe
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var bytes: RawSpan {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @_transparent
     get {
-      let span = unsafe RawSpan(_unsafeBytes: self)
-      return unsafe _overrideLifetime(span, borrowing: self)
+      unsafe RawSpan(_unsafeBytes: self)
     }
   }
 }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1164,9 +1164,10 @@ extension Unsafe${Mutable}RawBufferPointer {
 
   @unsafe
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableBytes: MutableRawSpan {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @_transparent
     get {
       unsafe MutableRawSpan(_unsafeBytes: self)
     }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -933,8 +933,6 @@ Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
-Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
-Added: _$sSw12mutableBytess14MutableRawSpanVvr
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -928,12 +928,6 @@ Added: _$ss14MutableRawSpanVN
 Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvg
 Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
 
-// SE-0467 mutableSpan properties
-Added: _$sSa11mutableSpans07MutableB0VyxGvr
-Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
-Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
-Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
-
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
 Added: _$ss13_SwiftifyExprO6returnyA2BmFWC

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -929,12 +929,6 @@ Added: _$ss14MutableRawSpanVN
 Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvg
 Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
 
-// SE-0467 mutableSpan properties
-Added: _$sSa11mutableSpans07MutableB0VyxGvr
-Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
-Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
-Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
-
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
 Added: _$ss13_SwiftifyExprO6returnyA2BmFWC

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -934,8 +934,6 @@ Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
-Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
-Added: _$sSw12mutableBytess14MutableRawSpanVvr
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC


### PR DESCRIPTION
Improves the declaration of the `mutableSpan` and `mutableBytes` properties to eliminate unnecessary ABI