### PR TITLE
[NFC][RBI]: rename some utility methods & add more RBI logging

### DIFF
--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -2064,7 +2064,8 @@ public:
       // At this point, check if our sent value is not disconnected. If so, emit
       // a sent never sendable helper.
       if (sentRegionIsolation && !sentRegionIsolation.isDisconnected()) {
-        return handleSendNeverSentHelper(op, op.getOpArg1(), sentRegionIsolation);
+        return handleSentNeverSendableHelper(op, op.getOpArg1(),
+                                             sentRegionIsolation);
       }
 
       // Next see if we are disconnected and have the same isolation. In such a
@@ -2405,7 +2406,7 @@ private:
 
   // Private helper that squelches the error if our send instruction and our
   // use have the same isolation.
-  void handleSendNeverSentHelper(
+  void handleSentNeverSendableHelper(
       const PartitionOp &op, Element elt,
       SILDynamicMergedIsolationInfo dynamicMergedIsolationInfo) {
     if (shouldTryToSquelchErrors()) {

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -1882,8 +1882,17 @@ public:
     // assign an actor introducing inst.
     auto rep = getRepresentativeValue(op.getOpArg2()).getValue();
     if (dynamicRegionIsolation.isDisconnected() ||
-        staticRegionIsolation.isUnsafeNonIsolated())
+        staticRegionIsolation.isUnsafeNonIsolated()) {
+      REGIONBASEDISOLATION_VERBOSE_LOG(
+          llvm::dbgs()
+          << "    * Note: Eliding assign-into-sending-result error. "
+             "Reason: "
+          << (dynamicRegionIsolation.isDisconnected()
+                  ? "assigned region is disconnected"
+                  : "assigned value is nonisolated(unsafe)")
+          << "\n");
       return;
+    }
 
     handleError(AssignNeverSendableIntoSendingResultError(
         op, op.getOpArg1(), fArg, op.getOpArg2(), rep, dynamicRegionIsolation));
@@ -1957,8 +1966,12 @@ public:
         // invariant when looking at other values in the region that are not
         // marked as nonisolated(unsafe).
         if (getIsolationRegionInfo(srcElement).isUnsafeNonIsolated() ||
-            getIsolationRegionInfo(destElement).isUnsafeNonIsolated())
+            getIsolationRegionInfo(destElement).isUnsafeNonIsolated()) {
+          REGIONBASEDISOLATION_VERBOSE_LOG(
+              llvm::dbgs() << "    * Note: Eliding merge error. Reason: "
+                              "src or dest element is nonisolated(unsafe)\n");
           return;
+        }
         return handleError(IncompatibleRegionMergeError(
             op, srcElement, srcRegIsolation, destElement, destIsolation,
             RegionMergeReason::Assign));
@@ -1996,8 +2009,12 @@ public:
         // invariant when looking at other values in the region that are not
         // marked as nonisolated(unsafe).
         if (getIsolationRegionInfo(srcElement).isUnsafeNonIsolated() ||
-            getIsolationRegionInfo(destElement).isUnsafeNonIsolated())
+            getIsolationRegionInfo(destElement).isUnsafeNonIsolated()) {
+          REGIONBASEDISOLATION_VERBOSE_LOG(
+              llvm::dbgs() << "    * Note: Eliding merge error. Reason: "
+                              "src or dest element is nonisolated(unsafe)\n");
           return;
+        }
         return handleError(IncompatibleRegionMergeError(
             op, srcElement, srcRegIsolation, destElement, destIsolation,
             RegionMergeReason::Assign));
@@ -2032,6 +2049,9 @@ public:
       // element. In such a case, this is also not a real send point.
       Element sentElement = op.getOpArg1();
       if (getIsolationRegionInfo(sentElement).isUnsafeNonIsolated()) {
+        REGIONBASEDISOLATION_VERBOSE_LOG(
+            llvm::dbgs() << "    * Note: Eliding send. Reason: "
+                            "sent element is nonisolated(unsafe)\n");
         return;
       }
 
@@ -2058,8 +2078,12 @@ public:
       // If our callee and region are both actor isolated and part of the same
       // isolation domain, do not treat this as a send.
       if (calleeIsolationInfo.isActorIsolated() &&
-          sentRegionIsolation.hasSameIsolation(calleeIsolationInfo))
+          sentRegionIsolation.hasSameIsolation(calleeIsolationInfo)) {
+        REGIONBASEDISOLATION_VERBOSE_LOG(
+            llvm::dbgs() << "    * Note: Eliding send. Reason: "
+                            "callee and sent region share actor isolation\n");
         return;
+      }
 
       // At this point, check if our sent value is not disconnected. If so, emit
       // a sent never sendable helper.
@@ -2076,8 +2100,13 @@ public:
         if (auto fas = FullApplySite::isa(sourceInst);
             (!fas || !fas.isSending(*op.getSourceOp())) &&
             sentRegionIsolation.isDisconnected() && calleeIsolationInfo &&
-            sentRegionIsolation.hasSameIsolation(calleeIsolationInfo))
+            sentRegionIsolation.hasSameIsolation(calleeIsolationInfo)) {
+          REGIONBASEDISOLATION_VERBOSE_LOG(
+              llvm::dbgs()
+              << "    * Note: Eliding send. Reason: disconnected value with "
+                 "matching isolation passed to a non-sending parameter\n");
           return;
+        }
       }
 
       // Mark op.getOpArg1() as sent.
@@ -2122,8 +2151,12 @@ public:
         // invariant when looking at other values in the region that are not
         // marked as nonisolated(unsafe).
         if (getIsolationRegionInfo(srcElement).isUnsafeNonIsolated() ||
-            getIsolationRegionInfo(destElement).isUnsafeNonIsolated())
+            getIsolationRegionInfo(destElement).isUnsafeNonIsolated()) {
+          REGIONBASEDISOLATION_VERBOSE_LOG(
+              llvm::dbgs() << "    * Note: Eliding merge error. Reason: "
+                              "src or dest element is nonisolated(unsafe)\n");
           return;
+        }
         return handleError(IncompatibleRegionMergeError(
             op, srcElement, srcRegIsolation, destElement, destRegIsolation,
             op.getRegionMergeReason()));
@@ -2274,7 +2307,13 @@ public:
       }
 
       // If we did not, then handle the direct return case.
-      handleDirectReturn();
+      if (!handleDirectReturn()) {
+        REGIONBASEDISOLATION_VERBOSE_LOG(
+            llvm::dbgs()
+            << "    * Note: Accepting disconnected 'inout sending' value at "
+               "exit. Reason: no conflicting return value in the same "
+               "region\n");
+      }
       return;
     }
     case PartitionOpKind::UnknownPatternError:
@@ -2377,6 +2416,12 @@ private:
             if (auto elt = getElement(value)) {
               SILIsolationInfo eltIsolationInfo = getIsolationRegionInfo(*elt);
               if (eltIsolationInfo.isUnsafeNonIsolated()) {
+                REGIONBASEDISOLATION_VERBOSE_LOG(
+                    llvm::dbgs()
+                    << "    * Note: Suppressing LocalUseAfterSend error. "
+                       "Reason: "
+                       "temporary alloc_stack initialized with unsafe "
+                       "nonisolated value\n");
                 return;
               }
             }
@@ -2385,8 +2430,13 @@ private:
 
         // See if we have a convert function from a `@Sendable` type. In this
         // case, we want to squelch the error.
-        if (isHiddenSendableFunctionType(equivalenceClassRep))
+        if (isHiddenSendableFunctionType(equivalenceClassRep)) {
+          REGIONBASEDISOLATION_VERBOSE_LOG(
+              llvm::dbgs()
+              << "    * Note: Suppressing LocalUseAfterSend error. Reason: "
+                 "hidden sendable function type\n");
           return;
+        }
       }
 
       // If our instruction does not have any isolation info associated with it,
@@ -2396,8 +2446,13 @@ private:
           sentOp->getUser()->getFunction()->getActorIsolation();
       if (functionIsolation.isActorIsolated() &&
           SILIsolationInfo::get(sentOp->getUser())
-              .hasSameIsolation(functionIsolation))
+              .hasSameIsolation(functionIsolation)) {
+        REGIONBASEDISOLATION_VERBOSE_LOG(
+            llvm::dbgs()
+            << "    * Note: Suppressing LocalUseAfterSend error. Reason: "
+               "function isolation matches sent operand isolation\n");
         return;
+      }
     }
 
     // Ok, we actually need to emit a call to the callback.
@@ -2421,6 +2476,11 @@ private:
             if (auto elt = getElement(value)) {
               SILIsolationInfo eltIsolationInfo = getIsolationRegionInfo(*elt);
               if (eltIsolationInfo.isUnsafeNonIsolated()) {
+                REGIONBASEDISOLATION_VERBOSE_LOG(
+                    llvm::dbgs()
+                    << "    * Note: Suppressing SentNeverSendable error. "
+                       "Reason: temporary alloc_stack initialized with unsafe "
+                       "nonisolated value\n");
                 return;
               }
             }
@@ -2429,8 +2489,13 @@ private:
 
         // See if we have a convert function from a `@Sendable` type. In this
         // case, we want to squelch the error.
-        if (isHiddenSendableFunctionType(equivalenceClassRep))
+        if (isHiddenSendableFunctionType(equivalenceClassRep)) {
+          REGIONBASEDISOLATION_VERBOSE_LOG(
+              llvm::dbgs()
+              << "    * Note: Suppressing SentNeverSendable error. Reason: "
+                 "hidden sendable function type\n");
           return;
+        }
       }
     }
 


### PR DESCRIPTION
Two changes:
1. Rename the `handleSendNeverSentHelper` method to `handleSentNeverSendableHelper` to make more sense and more closely match existing terminology
2. Add additional verbose RBI logging for squelched errors and some early-return code paths to help with debugging

Example output from a squelched error case:

```
Applying: send %%3:   %7 = apply %6(%5) : $@convention(thin) (@sil_sending @owned @callee_guaranteed () -> ()) -> ()
    Before: [(main actor-isolated: 1)(main actor-isolated: 3)]
    * Note: Suppressing SentNeverSendable error. Reason: hidden sendable function type
    After:  [(main actor-isolated: 1)(main actor-isolated: 3)]
    Working Partition: [(1)(3)]
    Exit Partition: [(1)(3)]
    Updated Partition: yes
```
