### PR TITLE
Revert "ClangImporter: Refactor Clang invocation path remapping after…

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -27,7 +27,6 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsClangImporter.h"
-#include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/IRGenOptions.h"
@@ -4236,19 +4235,8 @@ ClangImporter::getSwiftExplicitModuleDirectCC1Args() const {
   if (!Impl.SwiftContext.SearchPathOpts.ScannerPrefixMapper.empty()) {
     // Remap all the paths if requested.
     llvm::PrefixMapper Mapper;
-    SmallVector<llvm::MappedPrefix> Prefixes;
-    if (auto E = llvm::MappedPrefix::transformJoined(
-            Impl.SwiftContext.SearchPathOpts.ScannerPrefixMapper, Prefixes)) {
-      // Take permanent ownership of this string. In general the diagnostic
-      // might outlive this function.
-      auto errorMessage =
-          Impl.SwiftContext.AllocateCopy(llvm::toString(std::move(E)));
-      Impl.SwiftContext.Diags.diagnose(SourceLoc(), diag::error_prefix_mapping,
-                                       errorMessage);
-    }
-    Mapper.addRange(Prefixes);
-    Mapper.sort();
-
+    clang::tooling::dependencies::DepscanPrefixMapping::configurePrefixMapper(
+        Impl.SwiftContext.SearchPathOpts.ScannerPrefixMapper, Mapper);
     clang::tooling::dependencies::DepscanPrefixMapping::remapInvocationPaths(
         instance, Mapper);
     instance.getFrontendOpts().PathPrefixMappings.clear();


### PR DESCRIPTION
… change to..."

This reverts commit 7f8415bd363d309aec6d3cbd5a39747257f91e2b.

The LLVM change this was intended for has since been cherry-picked to the current stable branch and dealt with differently on Swift main in https://github.com/swiftlang/swift/pull/81792.