### PR TITLE
[demangling] add new wrapper API

### DIFF
--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -281,6 +281,11 @@ std::string demangleSymbolAsString(const char *MangledName,
                                     Options);
 }
 
+void demangleSymbolAsString(StringRef MangledName, NodePrinter &Printer) {
+  Context Ctx;
+  return Ctx.demangleSymbolAsString(MangledName, Printer);
+}
+
 std::string demangleTypeAsString(const char *MangledName,
                                  size_t MangledNameLength,
                                  const DemangleOptions &Options) {


### PR DESCRIPTION
Add a new wrapper API for `Context:: demangleSymbolAsString`. A similar API exists for another variant of `Context::demangleSymbolAsString`, this one is similar.