### PR TITLE
ClosureSpecializer: don't specialize captures of stack-allocated Objective-C blocks

### DIFF
--- a/test/SILOptimizer/closure_specialize_block.swift
+++ b/test/SILOptimizer/closure_specialize_block.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -parse-as-library -O %s -emit-sil | %FileCheck %s
+
+func callClosure<R>(_ body: () -> R) -> R {
+  return body()
+}
+
+// Check that after removing a copy_block, no retains+releases are inserted for the block.
+// CHECK-LABEL: sil {{.*}}@testit :
+// CHECK-NOT:     retain
+// CHECK-NOT:     release
+// CHECK:       } // end sil function 'testit'
+@_cdecl("testit")
+public func testit(_ block: (_ index: Int) -> Int) -> Bool {
+  @inline(never)
+  func c() -> Bool {
+	  return block(0) != 0
+  }
+
+	return callClosure(c)
+}


### PR DESCRIPTION
Bail if the closure captures an ObjectiveC block which might _not_ be copied onto the heap, i.e optimized by SimplifyCopyBlock. We can't do this because the optimization inserts retains+releases for captured arguments. That's not possible for stack-allocated blocks.

Fixes a mis-compile
rdar://154241245
