### PR TITLE
[CSSimplify] Skip transitive conformance check if argument is `CGFloat` or `Double`

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9248,11 +9248,11 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
     return formUnsolved();
 
   // There is an implicit conversion between `CGFloat` and `Double` types
-  // so if `CGFloat` argument doesn't satisfy the requirement it's possible
-  // that the generic parameter it's passed to be inferred as a `Double`
-  // from context and the requirement to be satisfied through this implicit
-  // conversion.
-  if (resolvedTy->isCGFloat())
+  // so if `CGFloat`/`Double` argument doesn't satisfy the requirement it's
+  // possible that the generic parameter it's passed to be inferred as a
+  // the other type from context and the requirement to be satisfied through
+  // this implicit conversion.
+  if (resolvedTy->isCGFloat() || resolvedTy->isDouble())
     return SolutionKind::Solved;
 
   // If the composition consists of a class + protocol,

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9247,6 +9247,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
   if (resolvedTy->isTypeVariableOrMember())
     return formUnsolved();
 
+  // There is an implicit conversion between `CGFloat` and `Double` types
+  // so if `CGFloat` argument doesn't satisfy the requirement it's possible
+  // that the generic parameter it's passed to be inferred as a `Double`
+  // from context and the requirement to be satisfied through this implicit
+  // conversion.
+  if (resolvedTy->isCGFloat())
+    return SolutionKind::Solved;
+
   // If the composition consists of a class + protocol,
   // we can't check conformance of the argument because
   // parameter could pick one of the components.

--- a/test/Constraints/transitive_conformances_and_cgfloat.swift
+++ b/test/Constraints/transitive_conformances_and_cgfloat.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -debug-constraints -verify %s 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
+// REQUIRES: objc_interop
+
+// rdar://153461854
+
+import CoreGraphics
+
+// There is no better way to check this at the moment because diagnostic mode would produce
+// a valid solution for this example. We need to make sure that the solution is produced in
+// normal mode instead.
+
+ let _ = { (point: CGFloat) in
+   let _: SIMD2<Double>? = SIMD2(point, point)
+ }
+
+// CHECK-NOT: failed constraint CGFloat transitive conformance to SIMDScalar
+// CHECK-NOT: Attempting to salvage

--- a/test/Constraints/transitive_conformances_and_cgfloat_double.swift
+++ b/test/Constraints/transitive_conformances_and_cgfloat_double.swift
@@ -18,3 +18,17 @@ import CoreGraphics
 
 // CHECK-NOT: failed constraint CGFloat transitive conformance to SIMDScalar
 // CHECK-NOT: Attempting to salvage
+
+protocol P {}
+extension CGFloat: P {}
+
+struct S<T> {}
+
+func foo<T: P>(_ x: T) -> S<T> { .init() }
+
+_ = { (x: Double) in
+  let _: S<CGFloat> = foo(x)
+}
+
+// CHECK-NOT: failed constraint CGFloat transitive conformance to SIMDScalar
+// CHECK-NOT: Attempting to salvage


### PR DESCRIPTION
There is an implicit conversion between `CGFloat` and `Double` types 
so if `CGFloat`/`Double` argument doesn't satisfy the requirement it's
possible that the generic parameter it's passed to be inferred as a the
other type from context and the requirement to be satisfied through this 
implicit conversion.

Resolves: rdar://153461854

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
