### PR TITLE
[6.2] ABI checker: drop usage of AllowDeserializingImplementationOnly

### DIFF
--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -2453,8 +2453,6 @@ public:
     InitInvoke.getLangOptions().EnableObjCInterop =
         InitInvoke.getLangOptions().Target.isOSDarwin();
     InitInvoke.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
-    // Module recovery issue shouldn't bring down the tool.
-    InitInvoke.getLangOptions().AllowDeserializingImplementationOnly = true;
 
     if (!SwiftVersion.empty()) {
       using version::Version;


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82499

- Description: AllowDeserializingImplementationOnly was historically added as a defensive
check against deserialization issues introduced by @implementationOnly imports.
It's no longer specified by other tools, thus the ABI checker should drop
it as well.

- Origination: A binary module deserialization issue triggered by this legacy option.

- Scope of the issue: Fixes potential module deserialization issue during ABI checking

- Radar: rdar://153683760.

- Risk: Very Low.

- Reviewed by: @xymus 