### PR TITLE
[6.2] [SILGen] Ensure that we don't emit a skipped isolated deinit

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1633,7 +1633,7 @@ void SILGenModule::emitObjCAllocatorDestructor(ClassDecl *cd,
   // Emit the isolated deallocating destructor.
   // If emitted, it implements actual deallocating and deallocating destructor
   // only switches executor
-  if (dd->hasBody() && isActorIsolated) {
+  if (dd->hasBody() && !dd->isBodySkipped() && isActorIsolated) {
     SILDeclRef dealloc(dd, SILDeclRef::Kind::IsolatedDeallocator);
     emitFunctionDefinition(dealloc, getFunction(dealloc, ForDefinition));
   }

--- a/test/Concurrency/deinit_isolation_objc.swift
+++ b/test/Concurrency/deinit_isolation_objc.swift
@@ -2,6 +2,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-future-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck %s
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-future-triple -parse-as-library -emit-silgen -DSILGEN %s | %FileCheck -check-prefix=CHECK-SYMB %s
 
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -disable-implicit-string-processing-module-import -target %target-future-triple -parse-as-library -emit-module -DSILGEN -experimental-skip-non-inlinable-function-bodies-without-types %s
+
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
- **Explanation**: Use of isolated `deinit` with Objective-C-derived classes would crash when generating a Swift module, because SILGen would attempt to emit the definition even when it was deliberately skipped. Align the logic here so we don't emit the definition when it's not needed.
- **Scope**: Limited to Swift module file generation when using the new `nonisolated deinit` feature.
- **Issues**: rdar://154373088 / issue https://github.com/swiftlang/swift/issues/82523
- **Original PRs**: https://github.com/swiftlang/swift/pull/82545
- **Risk**: Very low. Targeted fix for a new feature.
- **Testing**: CI, new project
- **Reviewers**: @ktoso 
