### PR TITLE
[CSFix] Fix `getConcurrencyFixBehavior` to account for non-decl overl…

### DIFF
--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -300,7 +300,7 @@ getConcurrencyFixBehavior(ConstraintSystem &cs, ConstraintKind constraintKind,
       if (auto *argument = getAsExpr(simplifyLocatorToAnchor(argLoc))) {
         if (auto overload = cs.findSelectedOverloadFor(
                 argument->getSemanticsProvidingExpr())) {
-          auto *decl = overload->choice.getDecl();
+          auto *decl = overload->choice.getDeclOrNull();
           if (decl && decl->isStatic())
             return FixBehavior::DowngradeToWarning;
         }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -526,3 +526,11 @@ func sendablePacks<each Element: Sendable>(
 
 @available(SwiftStdlib 5.1, *)
 func sendPack<each Element>(_: repeat each Element) async {}
+
+// rdar://153083848 - crash in `getConcurrencyFixBehavior` when member comes from a tuple
+func test(value: (_: Int, _: () -> Void)) {
+  func takesSendable(_: @Sendable () -> Void) {}
+
+  takesSendable(value.1) // Ok
+  // expected-warning@-1 {{converting non-Sendable function value to '@Sendable () -> Void' may introduce data races}}
+}


### PR DESCRIPTION
…oads

Adjust the downgrade check for static member references to account for the fact that argument could come of a tuple or some other reference that doesn't have a declaration associated with it.

Resolves: rdar://153083848

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
