### PR TITLE
Revert "Fix a compiler crash with '@'_lifetime(inout x), add diagnostic"

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2147,7 +2147,7 @@ ERROR(expected_lparen_after_lifetime_dependence, PointsToFirstBadToken,
 
 ERROR(expected_identifier_or_index_or_self_after_lifetime_dependence,
       PointsToFirstBadToken,
-      "expected 'copy', 'borrow', or '&' followed by an identifier, index or 'self' in lifetime dependence specifier",
+      "expected identifier, index or self in lifetime dependence specifier",
       ())
 
 ERROR(expected_rparen_after_lifetime_dependence, PointsToFirstBadToken,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5014,7 +5014,6 @@ ParserResult<LifetimeEntry> Parser::parseLifetimeEntry(SourceLoc loc) {
   SmallVector<LifetimeDescriptor> sources;
   SourceLoc rParenLoc;
   bool foundParamId = false;
-  bool invalidSourceDescriptor = false;
   status = parseList(
       tok::r_paren, lParenLoc, rParenLoc, /*AllowSepAfterLast=*/false,
       diag::expected_rparen_after_lifetime_dependence, [&]() -> ParserStatus {
@@ -5031,7 +5030,6 @@ ParserResult<LifetimeEntry> Parser::parseLifetimeEntry(SourceLoc loc) {
         auto sourceDescriptor =
             parseLifetimeDescriptor(*this, lifetimeDependenceKind);
         if (!sourceDescriptor) {
-          invalidSourceDescriptor = true;
           listStatus.setIsParseError();
           return listStatus;
         }
@@ -5039,10 +5037,6 @@ ParserResult<LifetimeEntry> Parser::parseLifetimeEntry(SourceLoc loc) {
         return listStatus;
       });
 
-  if (invalidSourceDescriptor) {
-    status.setIsParseError();
-    return status;
-  }
   if (!foundParamId) {
     diagnose(
         Tok,

--- a/test/Parse/lifetime_attr.swift
+++ b/test/Parse/lifetime_attr.swift
@@ -24,7 +24,7 @@ func testMissingLParenError(_ ne: NE) -> NE { // expected-error{{cannot infer th
   ne
 }
 
-@_lifetime() // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier, index or 'self' in lifetime dependence specifier}}
+@_lifetime() // expected-error{{expected identifier, index or self in lifetime dependence specifier}}
 func testMissingDependence(_ ne: NE) -> NE { // expected-error{{cannot infer the lifetime dependence scope on a function with a ~Escapable parameter, specify '@_lifetime(borrow ne)' or '@_lifetime(copy ne)'}}
   ne
 }

--- a/test/Sema/lifetime_depend_infer.swift
+++ b/test/Sema/lifetime_depend_infer.swift
@@ -591,11 +591,6 @@ func f_inout_no_infer(a: inout MutNE, b: NE) {}
 // expected-error @-1{{a function with a ~Escapable 'inout' parameter requires '@_lifetime(a: ...)'}}
 // expected-note  @-2{{use '@_lifetime(a: copy a) to forward the inout dependency}}
 
-// Invalid keyword for the dependence kind.
-//
-@_lifetime(a: inout a) // expected-error{{expected 'copy', 'borrow', or '&' followed by an identifier, index or 'self' in lifetime dependence specifier}}
-func f_inout_bad_keyword(a: inout MutableRawSpan) {}
-
 // Don't allow a useless borrow dependency on an inout param--it is misleading.
 //
 @_lifetime(a: &a) // expected-error{{invalid use of inout dependence on the same inout parameter}}


### PR DESCRIPTION
This reverts commit 080b68292d0cfcd95b2c15bad5b0da4b9774627e.

commit 080b68292d0cfcd95b2c15bad5b0da4b9774627e
Author: Andrew Trick <atrick@apple.com>
Date:   Wed Jun 25 12:26:51 2025

    Fix a compiler crash with '@'_lifetime(inout x), add diagnostic

While we investigate:

rdar://154382881 (🟠 OSS Swift CI:
oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed: error:
compile command failed due to signal 11)

rdar://154413718 (🟠 OSS Swift CI:
oss-swift_tools-RA_stdlib-DA_test-device-non_executable failed:
[2025-06-26T17:38:36.076Z] SIL verification failed: operand value
isn't used by operand: isOperandInValueUses(&operand))
