### PR TITLE
[Dependency Scanning] Discard and diagnose discovered binary modules built for an incompatible target

### DIFF
--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -185,6 +185,7 @@ protected:
                                         bool isFramework,
                                         bool isRequiredOSSAModules,
                                         StringRef SDKName,
+                                        const llvm::Triple &target,
                                         StringRef packageName,
                                         llvm::vfs::FileSystem *fileSystem,
                                         PathObfuscator &recoverer);

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -23,10 +23,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-
-namespace llvm {
-class Triple;
-}
+#include "llvm/TargetParser/Triple.h"
 
 namespace swift {
 
@@ -296,6 +293,8 @@ struct SearchPath {
 /// compiled with -enable-ossa-modules.
 /// \param requiredSDK If not empty, only accept modules built with
 /// a compatible SDK. The StringRef represents the canonical SDK name.
+/// \param target The target triple of the current compilation for
+/// validating that the module we are attempting to load is compatible.
 /// \param[out] extendedInfo If present, will be populated with additional
 /// compilation options serialized into the AST at build time that may be
 /// necessary to load it properly.
@@ -307,7 +306,8 @@ ValidationInfo validateSerializedAST(
     ExtendedValidationInfo *extendedInfo = nullptr,
     SmallVectorImpl<SerializationOptions::FileDependency> *dependencies =
         nullptr,
-    SmallVectorImpl<SearchPath> *searchPaths = nullptr);
+    SmallVectorImpl<SearchPath> *searchPaths = nullptr,
+    std::optional<llvm::Triple> target = std::nullopt);
 
 /// Emit diagnostics explaining a failure to load a serialized AST.
 ///

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -427,8 +427,8 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
       "", "", std::move(newBuf), nullptr, nullptr,
       /*isFramework=*/isFramework, Ctx.SILOpts.EnableOSSAModules,
-      Ctx.LangOpts.SDKName, Ctx.SearchPathOpts.DeserializedPathRecoverer,
-      loadedModuleFile);
+      Ctx.LangOpts.SDKName, Ctx.LangOpts.Target,
+      Ctx.SearchPathOpts.DeserializedPathRecoverer, loadedModuleFile);
   Name = loadedModuleFile->Name.str();
   return std::move(moduleBuf.get());
 }

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -444,6 +444,7 @@ private:
       bool isFramework,
       bool requiresOSSAModules,
       StringRef requiredSDK,
+      std::optional<llvm::Triple> target,
       serialization::ValidationInfo &info, PathObfuscator &pathRecoverer);
 
   /// Change the status of the current module.
@@ -571,6 +572,10 @@ public:
   /// linking purposes.
   /// \param requiresOSSAModules If true, this requires dependent modules to be
   /// compiled with -enable-ossa-modules.
+  /// \param requiredSDK A string denoting the name of the currently-used SDK,
+  /// to ensure that the loaded module was built with a compatible SDK.
+  /// \param target The target triple of the current compilation for
+  /// validating that the module we are attempting to load is compatible.
   /// \param[out] theModule The loaded module.
   /// \returns Whether the module was successfully loaded, or what went wrong
   ///          if it was not.
@@ -580,13 +585,14 @@ public:
        std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
        std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
        bool isFramework, bool requiresOSSAModules,
-       StringRef requiredSDK, PathObfuscator &pathRecoverer,
+       StringRef requiredSDK, std::optional<llvm::Triple> target,
+       PathObfuscator &pathRecoverer,
        std::shared_ptr<const ModuleFileSharedCore> &theModule) {
     serialization::ValidationInfo info;
     auto *core = new ModuleFileSharedCore(
         std::move(moduleInputBuffer), std::move(moduleDocInputBuffer),
         std::move(moduleSourceInfoInputBuffer), isFramework,
-        requiresOSSAModules, requiredSDK, info,
+        requiresOSSAModules, requiredSDK, target, info,
         pathRecoverer);
     if (!moduleInterfacePath.empty()) {
       ArrayRef<char> path;

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -214,8 +214,8 @@ SwiftModuleScanner::scanInterfaceFile(Identifier moduleID,
             auto adjacentBinaryModulePackageOnlyImports =
                 getMatchingPackageOnlyImportsOfModule(
                     *adjacentBinaryModule, isFramework, isRequiredOSSAModules(),
-                    Ctx.LangOpts.SDKName, ScannerPackageName,
-                    Ctx.SourceMgr.getFileSystem().get(),
+                    Ctx.LangOpts.SDKName, Ctx.LangOpts.Target,
+                    ScannerPackageName, Ctx.SourceMgr.getFileSystem().get(),
                     Ctx.SearchPathOpts.DeserializedPathRecoverer);
 
             if (!adjacentBinaryModulePackageOnlyImports)
@@ -255,7 +255,7 @@ llvm::ErrorOr<ModuleDependencyInfo> SwiftModuleScanner::scanBinaryModuleFile(
   std::shared_ptr<const ModuleFileSharedCore> loadedModuleFile;
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
       "", "", std::move(moduleBuf.get()), nullptr, nullptr, isFramework,
-      isRequiredOSSAModules(), Ctx.LangOpts.SDKName,
+      isRequiredOSSAModules(), Ctx.LangOpts.SDKName, Ctx.LangOpts.Target,
       Ctx.SearchPathOpts.DeserializedPathRecoverer, loadedModuleFile);
 
   if (Ctx.SearchPathOpts.ScannerModuleValidation) {

--- a/test/ScanDependencies/wrong_target_candidate_diagnostic.swift
+++ b/test/ScanDependencies/wrong_target_candidate_diagnostic.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/moduleInputs)
+// RUN: split-file %s %t
+
+// ERROR: error: unable to resolve Swift module dependency to a compatible module: 'FooBar'
+// ERROR: note: found incompatible module '{{.*}}{{/|\\}}moduleInputs{{/|\\}}FooBar.swiftmodule': compiled for a different target platform
+
+// RUN: %target-swift-frontend -emit-module %t/FooBar.swift -emit-module-path %t/moduleInputs/FooBar.swiftmodule -module-name FooBar -target x86_64-unknown-linux-gnu -parse-stdlib
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/main.swift -o %t/deps.json -I %t/moduleInputs -I %t/moduleInputs2 -diagnostic-style llvm -scanner-module-validation -target arm64e-apple-macosx11.0 2>&1 | %FileCheck %s -check-prefix=ERROR
+
+//--- main.swift
+import FooBar
+
+//--- FooBar.swift
+public func fooBar() {}


### PR DESCRIPTION
Previously the scanner accepted binary modules regardless of what triple they were built for.