### PR TITLE
[nonisolated-nonsending] Make the AST not consider nonisolated(nonsending) to be an actor isolation crossing point.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1005,11 +1005,11 @@ NOTE(regionbasedisolation_type_use_after_send_callee, none,
      (Type, StringRef, const ValueDecl *, StringRef))
 
 NOTE(regionbasedisolation_named_info_send_yields_race, none,
-     "sending %1%0 to %2 callee risks causing data races between %2 and local %3 uses",
-     (Identifier, StringRef, StringRef, StringRef))
+     "sending %select{%2 |}0%1 to %3 callee risks causing data races between %3 and local %4 uses",
+     (bool, Identifier, StringRef, StringRef, StringRef))
 NOTE(regionbasedisolation_named_info_send_yields_race_callee, none,
-     "sending %1%0 to %2 %kind3 risks causing data races between %2 and local %4 uses",
-     (Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
+     "sending %select{%2 |}0%1 to %3 %kind4 risks causing data races between %3 and local %5 uses",
+     (bool, Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
 
 // Use after send closure.
 NOTE(regionbasedisolation_type_isolated_capture_yields_race, none,
@@ -1025,8 +1025,8 @@ NOTE(regionbasedisolation_named_value_used_after_explicit_sending, none,
       "%0 used after being passed as a 'sending' parameter; Later uses could race",
       (Identifier))
 NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
-      "%0%1 is captured by a %2 closure. %2 uses in closure may race against later %3 uses",
-      (StringRef, Identifier, StringRef, StringRef))
+      "%select{%1 |}0%2 is captured by a %3 closure. %3 uses in closure may race against later %4 uses",
+      (bool, StringRef, Identifier, StringRef, StringRef))
 
 NOTE(regionbasedisolation_typed_use_after_sending, none,
       "Passing value of non-Sendable type %0 as a 'sending' argument risks causing races in between local and caller code",
@@ -1039,19 +1039,19 @@ NOTE(regionbasedisolation_typed_use_after_sending_callee, none,
 // Sending Never Sendable Emitter
 
 NOTE(regionbasedisolation_named_send_never_sendable, none,
-      "sending %1%0 to %2 callee risks causing data races between %2 and %3 uses",
-      (Identifier, StringRef, StringRef, StringRef))
+      "sending %select{%2 |}0%1 to %3 callee risks causing data races between %3 and %4 uses",
+      (bool, Identifier, StringRef, StringRef, StringRef))
 NOTE(regionbasedisolation_named_send_never_sendable_callee, none,
-      "sending %1%0 to %2 %kind3 risks causing data races between %2 and %4 uses",
-      (Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
+      "sending %select{%2 |}0%1 to %3 %kind4 risks causing data races between %3 and %5 uses",
+      (bool, Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
 
 NOTE(regionbasedisolation_named_send_into_sending_param, none,
-     "%0%1 is passed as a 'sending' parameter; Uses in callee may race with "
-     "later %0uses",
-     (StringRef, Identifier))
+     "%select{%1 |}0%2 is passed as a 'sending' parameter; Uses in callee may race with "
+     "later %1 uses",
+     (bool, StringRef, Identifier))
 NOTE(regionbasedisolation_named_nosend_send_into_result, none,
-     "%0%1 cannot be a 'sending' result. %2 uses may race with caller uses",
-     (StringRef, Identifier, StringRef))
+     "%select{%1 |}0%2 cannot be a 'sending' result. %3 uses may race with caller uses",
+     (bool, StringRef, Identifier, StringRef))
 NOTE(regionbasedisolation_typed_tns_passed_to_sending, none,
      "Passing %0 value of non-Sendable type %1 as a 'sending' parameter risks "
      "causing races inbetween %0 uses and uses reachable from the callee",
@@ -1109,10 +1109,10 @@ NOTE(regionbasedisolation_inout_sending_must_be_reinitialized, none,
      "'inout sending' parameter must be reinitialized before function exit with a non-actor-isolated value",
      ())
 ERROR(regionbasedisolation_inout_sending_cannot_be_actor_isolated, none,
-      "'inout sending' parameter %0 cannot be %1at end of function",
+      "'inout sending' parameter %0 cannot be %1 at end of function",
       (Identifier, StringRef))
 NOTE(regionbasedisolation_inout_sending_cannot_be_actor_isolated_note, none,
-      "%1%0 risks causing races in between %1uses and caller uses since caller assumes value is not actor isolated",
+      "%1 %0 risks causing races in between %1 uses and caller uses since caller assumes value is not actor isolated",
       (Identifier, StringRef))
 
 //===

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -998,23 +998,23 @@ GROUPED_ERROR(regionbasedisolation_type_send_yields_race, SendingRisksDataRace, 
       (Type))
 NOTE(regionbasedisolation_type_use_after_send, none,
       "sending value of non-Sendable type %0 to %1 callee risks causing data races between %1 and local %2 uses",
-      (Type, ActorIsolation, ActorIsolation))
+      (Type, StringRef, StringRef))
 NOTE(regionbasedisolation_type_use_after_send_callee, none,
      "sending value of non-Sendable type %0 to %1 %kind2 risks causing data "
      "races between %1 and local %3 uses",
-     (Type, ActorIsolation, const ValueDecl *, ActorIsolation))
+     (Type, StringRef, const ValueDecl *, StringRef))
 
 NOTE(regionbasedisolation_named_info_send_yields_race, none,
      "sending %1%0 to %2 callee risks causing data races between %2 and local %3 uses",
-     (Identifier, StringRef, ActorIsolation, ActorIsolation))
+     (Identifier, StringRef, StringRef, StringRef))
 NOTE(regionbasedisolation_named_info_send_yields_race_callee, none,
      "sending %1%0 to %2 %kind3 risks causing data races between %2 and local %4 uses",
-     (Identifier, StringRef, ActorIsolation, const ValueDecl *, ActorIsolation))
+     (Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
 
 // Use after send closure.
 NOTE(regionbasedisolation_type_isolated_capture_yields_race, none,
       "sending value of non-Sendable type %0 to %1 closure due to closure capture risks causing races in between %1 and %2 uses",
-      (Type, ActorIsolation, ActorIsolation))
+      (Type, StringRef, StringRef))
 
 // Value captured in async let and reused.
 NOTE(regionbasedisolation_named_nonisolated_asynclet_name, none,
@@ -1026,7 +1026,7 @@ NOTE(regionbasedisolation_named_value_used_after_explicit_sending, none,
       (Identifier))
 NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
       "%0%1 is captured by a %2 closure. %2 uses in closure may race against later %3 uses",
-      (StringRef, Identifier, ActorIsolation, ActorIsolation))
+      (StringRef, Identifier, StringRef, StringRef))
 
 NOTE(regionbasedisolation_typed_use_after_sending, none,
       "Passing value of non-Sendable type %0 as a 'sending' argument risks causing races in between local and caller code",
@@ -1040,10 +1040,10 @@ NOTE(regionbasedisolation_typed_use_after_sending_callee, none,
 
 NOTE(regionbasedisolation_named_send_never_sendable, none,
       "sending %1%0 to %2 callee risks causing data races between %2 and %3 uses",
-      (Identifier, StringRef, ActorIsolation, StringRef))
+      (Identifier, StringRef, StringRef, StringRef))
 NOTE(regionbasedisolation_named_send_never_sendable_callee, none,
       "sending %1%0 to %2 %kind3 risks causing data races between %2 and %4 uses",
-      (Identifier, StringRef, ActorIsolation, const ValueDecl *, StringRef))
+      (Identifier, StringRef, StringRef, const ValueDecl *, StringRef))
 
 NOTE(regionbasedisolation_named_send_into_sending_param, none,
      "%0%1 is passed as a 'sending' parameter; Uses in callee may race with "
@@ -1092,10 +1092,10 @@ NOTE(regionbasedisolation_named_send_nt_asynclet_capture, none,
       (Identifier, StringRef))
 NOTE(regionbasedisolation_typed_sendneversendable_via_arg, none,
       "sending %0 value of non-Sendable type %1 to %2 callee risks causing races in between %0 and %2 uses",
-      (StringRef, Type, ActorIsolation))
+      (StringRef, Type, StringRef))
 NOTE(regionbasedisolation_typed_sendneversendable_via_arg_callee, none,
       "sending %0 value of non-Sendable type %1 to %2 %kind3 risks causing races in between %0 and %2 uses",
-      (StringRef, Type, ActorIsolation, const ValueDecl *))
+      (StringRef, Type, StringRef, const ValueDecl *))
 
 // Error that is only used when the send non sendable emitter cannot discover any
 // information to give a better diagnostic.
@@ -1137,10 +1137,10 @@ NOTE(regionbasedisolation_out_sending_cannot_be_actor_isolated_note_named, none,
 // Example: returning main-actor isolated result to a custom-actor isolated context risks causing data races
 ERROR(rbi_isolation_crossing_result, none,
       "non-Sendable %0-typed result can not be returned from %1 %kind2 to %3 context",
-      (Type, ActorIsolation, const ValueDecl *, ActorIsolation))
+      (Type, StringRef, const ValueDecl *, StringRef))
 ERROR(rbi_isolation_crossing_result_no_decl, none,
       "non-Sendable %0-typed result can not be returned from %1 function to %2 context",
-      (Type, ActorIsolation, ActorIsolation))
+      (Type, StringRef, StringRef))
 NOTE(rbi_non_sendable_nominal,none,
      "%kind0 does not conform to the 'Sendable' protocol",
       (const ValueDecl *))

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -230,7 +230,7 @@ public:
 private:
   bool isOperatorSlow() const;
 };
-  
+
 class DeclName;
 class DeclNameRef;
 class ObjCSelector;

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -179,16 +179,16 @@ public:
 
   void removeFlag(TrackableValueFlag flag) { flagSet -= flag; }
 
-  void print(llvm::raw_ostream &os) const {
+  void print(SILFunction *fn, llvm::raw_ostream &os) const {
     os << "TrackableValueState[id: " << id
        << "][is_no_alias: " << (isNoAlias() ? "yes" : "no")
        << "][is_sendable: " << (isSendable() ? "yes" : "no")
        << "][region_value_kind: ";
-    getIsolationRegionInfo().printForOneLineLogging(os);
+    getIsolationRegionInfo().printForOneLineLogging(fn, os);
     os << "].";
   }
 
-  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+  SWIFT_DEBUG_DUMPER(dump(SILFunction *fn)) { print(fn, llvm::dbgs()); }
 
 private:
   bool hasIsolationRegionInfo() const { return bool(regionInfo); }
@@ -249,26 +249,26 @@ public:
   /// parameter.
   bool isSendingParameter() const;
 
-  void printIsolationInfo(SmallString<64> &outString) const {
+  void printIsolationInfo(SILFunction *fn, SmallString<64> &outString) const {
     llvm::raw_svector_ostream os(outString);
-    getIsolationRegionInfo().printForDiagnostics(os);
+    getIsolationRegionInfo().printForDiagnostics(fn, os);
   }
 
-  void print(llvm::raw_ostream &os) const {
+  void print(SILFunction *fn, llvm::raw_ostream &os) const {
     os << "TrackableValue. State: ";
-    valueState.print(os);
+    valueState.print(fn, os);
     os << "\n    Rep Value: ";
     getRepresentative().print(os);
   }
 
-  void printVerbose(llvm::raw_ostream &os) const {
+  void printVerbose(SILFunction *fn, llvm::raw_ostream &os) const {
     os << "TrackableValue. State: ";
-    valueState.print(os);
+    valueState.print(fn, os);
     os << "\n    Rep Value: " << getRepresentative();
   }
 
-  SWIFT_DEBUG_DUMP {
-    print(llvm::dbgs());
+  SWIFT_DEBUG_DUMPER(dump(SILFunction *fn)) {
+    print(fn, llvm::dbgs());
     llvm::dbgs() << '\n';
   }
 };
@@ -288,8 +288,8 @@ struct regionanalysisimpl::TrackableValueLookupResult {
   /// TrackableValue.
   std::optional<TrackableValue> base;
 
-  void print(llvm::raw_ostream &os) const;
-  SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
+  void print(SILFunction *fn, llvm::raw_ostream &os) const;
+  SWIFT_DEBUG_DUMPER(dumper(SILFunction *fn)) { print(fn, llvm::dbgs()); }
 };
 
 class RegionAnalysis;
@@ -389,6 +389,8 @@ public:
   SILValue getRepresentative(SILValue value) const {
     return getUnderlyingTrackedValue(value).value;
   }
+
+  SILFunction *getFunction() const { return fn; }
 
   /// Returns the value for this instruction if it isn't a fake "represenative
   /// value" to inject actor isolation. Asserts in such a case.

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -332,7 +332,15 @@ public:
   /// form of diagnostic than other cases.
   void printForCodeDiagnostic(SILFunction *fn, llvm::raw_ostream &os) const;
 
+  /// Overload of printForCodeDiagnostics that returns an interned StringRef
+  /// owned by the AST.
+  StringRef printForCodeDiagnostic(SILFunction *fn) const;
+
   void printForDiagnostics(SILFunction *fn, llvm::raw_ostream &os) const;
+
+  /// Overload of printForDiagnostics that returns an interned StringRef owned
+  /// by the AST.
+  StringRef printForDiagnostics(SILFunction *fn) const;
 
   SWIFT_DEBUG_DUMPER(dumpForDiagnostics(SILFunction *fn)) {
     printForDiagnostics(fn, llvm::dbgs());
@@ -524,6 +532,12 @@ public:
       SILFunction *fn, ActorIsolation iso, llvm::raw_ostream &os,
       StringRef openingQuotationMark = "'", bool asNoun = false);
 
+  /// Overload for printActorIsolationForDiagnostics that produces a StringRef.
+  static StringRef
+  printActorIsolationForDiagnostics(SILFunction *fn, ActorIsolation iso,
+                                    StringRef openingQuotationMark = "'",
+                                    bool asNoun = false);
+
   void Profile(llvm::FoldingSetNodeID &id) const;
 
 private:
@@ -593,12 +607,20 @@ public:
     innerInfo.printForDiagnostics(fn, os);
   }
 
+  StringRef printForDiagnostics(SILFunction *fn) const {
+    return innerInfo.printForDiagnostics(fn);
+  }
+
   SWIFT_DEBUG_DUMPER(dumpForDiagnostics(SILFunction *fn)) {
     innerInfo.dumpForDiagnostics(fn);
   }
 
   void printForCodeDiagnostic(SILFunction *fn, llvm::raw_ostream &os) const {
     innerInfo.printForCodeDiagnostic(fn, os);
+  }
+
+  StringRef printForCodeDiagnostic(SILFunction *fn) const {
+    return innerInfo.printForCodeDiagnostic(fn);
   }
 
   void printForOneLineLogging(SILFunction *fn, llvm::raw_ostream &os) const {

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -494,6 +494,14 @@ public:
   /// that the isolation and the isolated value match.
   bool isEqual(const SILIsolationInfo &other) const;
 
+  /// A helper function that prints ActorIsolation like we normally do except
+  /// that it prints nonisolated(nonsending) as nonisolated. This is needed in
+  /// certain cases when talking about use-after-free uses in send non sendable.
+  static void
+  printActorIsolationForDiagnostics(ActorIsolation iso, llvm::raw_ostream &os,
+                                    StringRef openingQuotationMark = "'",
+                                    bool asNoun = false);
+
   void Profile(llvm::FoldingSetNodeID &id) const;
 
 private:

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -289,16 +289,16 @@ public:
     return self;
   }
 
-  void print(llvm::raw_ostream &os) const;
+  void print(SILFunction *fn, llvm::raw_ostream &os) const;
 
   /// Print a textual representation of the text info that is meant to be
   /// included in other logging output for types that compose with
   /// SILIsolationInfo. As a result, we only print state that can fit on
   /// one line.
-  void printForOneLineLogging(llvm::raw_ostream &os) const;
+  void printForOneLineLogging(SILFunction *fn, llvm::raw_ostream &os) const;
 
-  SWIFT_DEBUG_DUMP {
-    print(llvm::dbgs());
+  SWIFT_DEBUG_DUMPER(dump(SILFunction *fn)) {
+    print(fn, llvm::dbgs());
     llvm::dbgs() << '\n';
   }
 
@@ -307,12 +307,12 @@ public:
   ///
   /// We do this programatically since task-isolated code needs a very different
   /// form of diagnostic than other cases.
-  void printForCodeDiagnostic(llvm::raw_ostream &os) const;
+  void printForCodeDiagnostic(SILFunction *fn, llvm::raw_ostream &os) const;
 
-  void printForDiagnostics(llvm::raw_ostream &os) const;
+  void printForDiagnostics(SILFunction *fn, llvm::raw_ostream &os) const;
 
-  SWIFT_DEBUG_DUMPER(dumpForDiagnostics()) {
-    printForDiagnostics(llvm::dbgs());
+  SWIFT_DEBUG_DUMPER(dumpForDiagnostics(SILFunction *fn)) {
+    printForDiagnostics(fn, llvm::dbgs());
     llvm::dbgs() << '\n';
   }
 
@@ -497,10 +497,9 @@ public:
   /// A helper function that prints ActorIsolation like we normally do except
   /// that it prints nonisolated(nonsending) as nonisolated. This is needed in
   /// certain cases when talking about use-after-free uses in send non sendable.
-  static void
-  printActorIsolationForDiagnostics(ActorIsolation iso, llvm::raw_ostream &os,
-                                    StringRef openingQuotationMark = "'",
-                                    bool asNoun = false);
+  static void printActorIsolationForDiagnostics(
+      SILFunction *fn, ActorIsolation iso, llvm::raw_ostream &os,
+      StringRef openingQuotationMark = "'", bool asNoun = false);
 
   void Profile(llvm::FoldingSetNodeID &id) const;
 
@@ -565,43 +564,25 @@ public:
         SILIsolationInfo::getDisconnected(isUnsafeNonIsolated));
   }
 
-  SWIFT_DEBUG_DUMP { innerInfo.dump(); }
+  SWIFT_DEBUG_DUMPER(dump(SILFunction *fn)) { innerInfo.dump(fn); }
 
-  void printForDiagnostics(llvm::raw_ostream &os) const {
-    innerInfo.printForDiagnostics(os);
+  void printForDiagnostics(SILFunction *fn, llvm::raw_ostream &os) const {
+    innerInfo.printForDiagnostics(fn, os);
   }
 
-  SWIFT_DEBUG_DUMPER(dumpForDiagnostics()) {
-    innerInfo.dumpForDiagnostics();
+  SWIFT_DEBUG_DUMPER(dumpForDiagnostics(SILFunction *fn)) {
+    innerInfo.dumpForDiagnostics(fn);
   }
 
-  void printForCodeDiagnostic(llvm::raw_ostream &os) const {
-    innerInfo.printForCodeDiagnostic(os);
+  void printForCodeDiagnostic(SILFunction *fn, llvm::raw_ostream &os) const {
+    innerInfo.printForCodeDiagnostic(fn, os);
   }
 
-  void printForOneLineLogging(llvm::raw_ostream &os) const {
-    innerInfo.printForOneLineLogging(os);
+  void printForOneLineLogging(SILFunction *fn, llvm::raw_ostream &os) const {
+    innerInfo.printForOneLineLogging(fn, os);
   }
 };
 
 } // namespace swift
-
-namespace llvm {
-
-inline llvm::raw_ostream &
-operator<<(llvm::raw_ostream &os,
-           const swift::SILIsolationInfo &isolationInfo) {
-  isolationInfo.printForOneLineLogging(os);
-  return os;
-}
-
-inline llvm::raw_ostream &
-operator<<(llvm::raw_ostream &os,
-           const swift::SILDynamicMergedIsolationInfo &isolationInfo) {
-  isolationInfo.printForOneLineLogging(os);
-  return os;
-}
-
-} // namespace llvm
 
 #endif

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -185,6 +185,10 @@ public:
     /// parameter and should be allowed to merge into a self parameter.
     UnappliedIsolatedAnyParameter = 0x2,
 
+    /// If set, this was a TaskIsolated value from a nonisolated(nonsending)
+    /// parameter.
+    NonisolatedNonsendingTaskIsolated = 0x4,
+
     /// The maximum number of bits used by a Flag.
     MaxNumBits = 2,
   };
@@ -265,6 +269,25 @@ public:
     } else {
       self.options =
           self.getOptions().toRaw() & ~Options(Flag::UnsafeNonIsolated).toRaw();
+    }
+    return self;
+  }
+
+  bool isNonisolatedNonsendingTaskIsolated() const {
+    return getOptions().contains(Flag::NonisolatedNonsendingTaskIsolated);
+  }
+
+  SILIsolationInfo
+  withNonisolatedNonsendingTaskIsolated(bool newValue = true) const {
+    assert(*this && "Cannot be unknown");
+    assert(isTaskIsolated() && "Can only be task isolated");
+    auto self = *this;
+    if (newValue) {
+      self.options =
+          (self.getOptions() | Flag::NonisolatedNonsendingTaskIsolated).toRaw();
+    } else {
+      self.options = self.getOptions().toRaw() &
+                     ~Options(Flag::NonisolatedNonsendingTaskIsolated).toRaw();
     }
     return self;
   }

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -695,16 +695,29 @@ public:
       }
     }
 
+    SmallString<64> calleeIsolationStr;
+    {
+      llvm::raw_svector_ostream os(calleeIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCalleeIsolation(), os);
+    }
+
+    SmallString<64> callerIsolationStr;
+    {
+      llvm::raw_svector_ostream os(callerIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCallerIsolation(), os);
+    }
+
     if (auto callee = getSendingCallee()) {
       diagnoseNote(
           loc, diag::regionbasedisolation_named_info_send_yields_race_callee,
-          name, descriptiveKindStr, isolationCrossing.getCalleeIsolation(),
-          callee.value(), isolationCrossing.getCallerIsolation());
+          name, descriptiveKindStr, calleeIsolationStr, callee.value(),
+          callerIsolationStr);
     } else {
       diagnoseNote(loc, diag::regionbasedisolation_named_info_send_yields_race,
-                   name, descriptiveKindStr,
-                   isolationCrossing.getCalleeIsolation(),
-                   isolationCrossing.getCallerIsolation());
+                   name, descriptiveKindStr, calleeIsolationStr,
+                   callerIsolationStr);
     }
     emitRequireInstDiagnostics();
   }
@@ -729,10 +742,24 @@ public:
       }
     }
 
-    diagnoseNote(
-        loc, diag::regionbasedisolation_named_info_send_yields_race_callee,
-        name, descriptiveKindStr, isolationCrossing.getCalleeIsolation(),
-        callee, isolationCrossing.getCallerIsolation());
+    SmallString<64> calleeIsolationStr;
+    {
+      llvm::raw_svector_ostream os(calleeIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCalleeIsolation(), os);
+    }
+
+    SmallString<64> callerIsolationStr;
+    {
+      llvm::raw_svector_ostream os(callerIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCallerIsolation(), os);
+    }
+
+    diagnoseNote(loc,
+                 diag::regionbasedisolation_named_info_send_yields_race_callee,
+                 name, descriptiveKindStr, calleeIsolationStr, callee,
+                 callerIsolationStr);
     emitRequireInstDiagnostics();
   }
 
@@ -755,14 +782,27 @@ public:
         .highlight(loc.getSourceRange())
         .limitBehaviorIf(getBehaviorLimit());
 
+    SmallString<64> calleeIsolationStr;
+    {
+      llvm::raw_svector_ostream os(calleeIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCalleeIsolation(), os);
+    }
+
+    SmallString<64> callerIsolationStr;
+    {
+      llvm::raw_svector_ostream os(callerIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCallerIsolation(), os);
+    }
+
     if (auto callee = getSendingCallee()) {
       diagnoseNote(loc, diag::regionbasedisolation_type_use_after_send_callee,
-                   inferredType, isolationCrossing.getCalleeIsolation(),
-                   callee.value(), isolationCrossing.getCallerIsolation());
+                   inferredType, calleeIsolationStr, callee.value(),
+                   callerIsolationStr);
     } else {
       diagnoseNote(loc, diag::regionbasedisolation_type_use_after_send,
-                   inferredType, isolationCrossing.getCalleeIsolation(),
-                   isolationCrossing.getCallerIsolation());
+                   inferredType, calleeIsolationStr, callerIsolationStr);
     }
     emitRequireInstDiagnostics();
   }
@@ -817,10 +857,23 @@ public:
       }
     }
 
+    SmallString<64> calleeIsolationStr;
+    {
+      llvm::raw_svector_ostream os(calleeIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCalleeIsolation(), os);
+    }
+
+    SmallString<64> callerIsolationStr;
+    {
+      llvm::raw_svector_ostream os(callerIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCallerIsolation(), os);
+    }
+
     diagnoseNote(
         loc, diag::regionbasedisolation_named_isolated_closure_yields_race,
-        descriptiveKindStr, name, isolationCrossing.getCalleeIsolation(),
-        isolationCrossing.getCallerIsolation())
+        descriptiveKindStr, name, calleeIsolationStr, callerIsolationStr)
         .highlight(loc.getSourceRange());
     emitRequireInstDiagnostics();
   }
@@ -832,10 +885,24 @@ public:
                   inferredType)
         .highlight(loc.getSourceRange())
         .limitBehaviorIf(getBehaviorLimit());
+
+    SmallString<64> calleeIsolationStr;
+    {
+      llvm::raw_svector_ostream os(calleeIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCalleeIsolation(), os);
+    }
+
+    SmallString<64> callerIsolationStr;
+    {
+      llvm::raw_svector_ostream os(callerIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCallerIsolation(), os);
+    }
+
     diagnoseNote(loc,
                  diag::regionbasedisolation_type_isolated_capture_yields_race,
-                 inferredType, isolationCrossing.getCalleeIsolation(),
-                 isolationCrossing.getCallerIsolation());
+                 inferredType, calleeIsolationStr, callerIsolationStr);
     emitRequireInstDiagnostics();
   }
 
@@ -1358,16 +1425,22 @@ public:
       getIsolationRegionInfo().printForDiagnostics(os);
     }
 
+    SmallString<64> calleeIsolationStr;
+    {
+      llvm::raw_svector_ostream os(calleeIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          crossing.getCalleeIsolation(), os);
+    }
+
     if (auto callee = getSendingCallee()) {
       diagnoseNote(
           loc,
           diag::regionbasedisolation_typed_sendneversendable_via_arg_callee,
-          descriptiveKindStr, inferredType, crossing.getCalleeIsolation(),
-          callee.value());
+          descriptiveKindStr, inferredType, calleeIsolationStr, callee.value());
     } else {
-      diagnoseNote(
-          loc, diag::regionbasedisolation_typed_sendneversendable_via_arg,
-          descriptiveKindStr, inferredType, crossing.getCalleeIsolation());
+      diagnoseNote(loc,
+                   diag::regionbasedisolation_typed_sendneversendable_via_arg,
+                   descriptiveKindStr, inferredType, calleeIsolationStr);
     }
   }
 
@@ -1382,10 +1455,24 @@ public:
         os << ' ';
       }
     }
-    diagnoseNote(loc,
-                 diag::regionbasedisolation_named_isolated_closure_yields_race,
-                 descriptiveKindStr, name, crossing.getCalleeIsolation(),
-                 crossing.getCallerIsolation())
+
+    SmallString<64> calleeIsolationStr;
+    {
+      llvm::raw_svector_ostream os(calleeIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          crossing.getCalleeIsolation(), os);
+    }
+
+    SmallString<64> callerIsolationStr;
+    {
+      llvm::raw_svector_ostream os(callerIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          crossing.getCallerIsolation(), os);
+    }
+
+    diagnoseNote(
+        loc, diag::regionbasedisolation_named_isolated_closure_yields_race,
+        descriptiveKindStr, name, calleeIsolationStr, callerIsolationStr)
         .highlight(loc.getSourceRange());
   }
 
@@ -1605,16 +1692,23 @@ public:
         descriptiveKindStrWithSpace.push_back(' ');
       }
     }
+
+    SmallString<64> calleeIsolationStr;
+    {
+      llvm::raw_svector_ostream os(calleeIsolationStr);
+      SILIsolationInfo::printActorIsolationForDiagnostics(
+          isolationCrossing.getCalleeIsolation(), os);
+    }
+
     if (auto callee = getSendingCallee()) {
       diagnoseNote(loc,
                    diag::regionbasedisolation_named_send_never_sendable_callee,
-                   name, descriptiveKindStrWithSpace,
-                   isolationCrossing.getCalleeIsolation(), callee.value(),
-                   descriptiveKindStr);
+                   name, descriptiveKindStrWithSpace, calleeIsolationStr,
+                   callee.value(), descriptiveKindStr);
     } else {
       diagnoseNote(loc, diag::regionbasedisolation_named_send_never_sendable,
-                   name, descriptiveKindStrWithSpace,
-                   isolationCrossing.getCalleeIsolation(), descriptiveKindStr);
+                   name, descriptiveKindStrWithSpace, calleeIsolationStr,
+                   descriptiveKindStr);
     }
   }
 
@@ -2605,17 +2699,31 @@ void NonSendableIsolationCrossingResultDiagnosticEmitter::emit() {
   if (!isolationCrossing)
     return emitUnknownPatternError();
 
+  SmallString<64> calleeIsolationStr;
+  {
+    llvm::raw_svector_ostream os(calleeIsolationStr);
+    SILIsolationInfo::printActorIsolationForDiagnostics(
+        isolationCrossing->getCalleeIsolation(), os);
+  }
+
+  SmallString<64> callerIsolationStr;
+  {
+    llvm::raw_svector_ostream os(callerIsolationStr);
+    SILIsolationInfo::printActorIsolationForDiagnostics(
+        isolationCrossing->getCallerIsolation(), os);
+  }
+
   auto type = getType();
   if (getCalledDecl()) {
-    diagnoseError(error.op->getSourceInst(), diag::rbi_isolation_crossing_result,
-                  type, isolationCrossing->getCalleeIsolation(), getCalledDecl(),
-                  isolationCrossing->getCallerIsolation())
-      .limitBehaviorIf(getBehaviorLimit());
+    diagnoseError(error.op->getSourceInst(),
+                  diag::rbi_isolation_crossing_result, type, calleeIsolationStr,
+                  getCalledDecl(), callerIsolationStr)
+        .limitBehaviorIf(getBehaviorLimit());
   } else {
-    diagnoseError(error.op->getSourceInst(), diag::rbi_isolation_crossing_result_no_decl,
-                  type, isolationCrossing->getCalleeIsolation(),
-                  isolationCrossing->getCallerIsolation())
-      .limitBehaviorIf(getBehaviorLimit());
+    diagnoseError(error.op->getSourceInst(),
+                  diag::rbi_isolation_crossing_result_no_decl, type,
+                  calleeIsolationStr, callerIsolationStr)
+        .limitBehaviorIf(getBehaviorLimit());
   }
   if (type->is<FunctionType>()) {
     diagnoseNote(error.op->getSourceInst(),

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -690,7 +690,7 @@ public:
     {
       if (!namedValuesIsolationInfo.isDisconnected()) {
         llvm::raw_svector_ostream os(descriptiveKindStr);
-        namedValuesIsolationInfo.printForDiagnostics(os);
+        namedValuesIsolationInfo.printForDiagnostics(getFunction(), os);
         os << ' ';
       }
     }
@@ -699,14 +699,14 @@ public:
     {
       llvm::raw_svector_ostream os(calleeIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCalleeIsolation(), os);
+          getFunction(), isolationCrossing.getCalleeIsolation(), os);
     }
 
     SmallString<64> callerIsolationStr;
     {
       llvm::raw_svector_ostream os(callerIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCallerIsolation(), os);
+          getFunction(), isolationCrossing.getCallerIsolation(), os);
     }
 
     if (auto callee = getSendingCallee()) {
@@ -737,7 +737,7 @@ public:
     {
       if (!namedValuesIsolationInfo.isDisconnected()) {
         llvm::raw_svector_ostream os(descriptiveKindStr);
-        namedValuesIsolationInfo.printForDiagnostics(os);
+        namedValuesIsolationInfo.printForDiagnostics(getFunction(), os);
         os << ' ';
       }
     }
@@ -746,14 +746,14 @@ public:
     {
       llvm::raw_svector_ostream os(calleeIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCalleeIsolation(), os);
+          getFunction(), isolationCrossing.getCalleeIsolation(), os);
     }
 
     SmallString<64> callerIsolationStr;
     {
       llvm::raw_svector_ostream os(callerIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCallerIsolation(), os);
+          getFunction(), isolationCrossing.getCallerIsolation(), os);
     }
 
     diagnoseNote(loc,
@@ -786,14 +786,14 @@ public:
     {
       llvm::raw_svector_ostream os(calleeIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCalleeIsolation(), os);
+          getFunction(), isolationCrossing.getCalleeIsolation(), os);
     }
 
     SmallString<64> callerIsolationStr;
     {
       llvm::raw_svector_ostream os(callerIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCallerIsolation(), os);
+          getFunction(), isolationCrossing.getCallerIsolation(), os);
     }
 
     if (auto callee = getSendingCallee()) {
@@ -852,7 +852,7 @@ public:
     {
       if (!namedValuesIsolationInfo.isDisconnected()) {
         llvm::raw_svector_ostream os(descriptiveKindStr);
-        namedValuesIsolationInfo.printForDiagnostics(os);
+        namedValuesIsolationInfo.printForDiagnostics(getFunction(), os);
         os << ' ';
       }
     }
@@ -861,14 +861,14 @@ public:
     {
       llvm::raw_svector_ostream os(calleeIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCalleeIsolation(), os);
+          getFunction(), isolationCrossing.getCalleeIsolation(), os);
     }
 
     SmallString<64> callerIsolationStr;
     {
       llvm::raw_svector_ostream os(callerIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCallerIsolation(), os);
+          getFunction(), isolationCrossing.getCallerIsolation(), os);
     }
 
     diagnoseNote(
@@ -890,14 +890,14 @@ public:
     {
       llvm::raw_svector_ostream os(calleeIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCalleeIsolation(), os);
+          getFunction(), isolationCrossing.getCalleeIsolation(), os);
     }
 
     SmallString<64> callerIsolationStr;
     {
       llvm::raw_svector_ostream os(callerIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCallerIsolation(), os);
+          getFunction(), isolationCrossing.getCallerIsolation(), os);
     }
 
     diagnoseNote(loc,
@@ -1422,14 +1422,14 @@ public:
     SmallString<64> descriptiveKindStr;
     {
       llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().printForDiagnostics(os);
+      getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
     }
 
     SmallString<64> calleeIsolationStr;
     {
       llvm::raw_svector_ostream os(calleeIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          crossing.getCalleeIsolation(), os);
+          getFunction(), crossing.getCalleeIsolation(), os);
     }
 
     if (auto callee = getSendingCallee()) {
@@ -1451,7 +1451,7 @@ public:
     {
       if (!getIsolationRegionInfo().isDisconnected()) {
         llvm::raw_svector_ostream os(descriptiveKindStr);
-        getIsolationRegionInfo().printForDiagnostics(os);
+        getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
         os << ' ';
       }
     }
@@ -1460,14 +1460,14 @@ public:
     {
       llvm::raw_svector_ostream os(calleeIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          crossing.getCalleeIsolation(), os);
+          getFunction(), crossing.getCalleeIsolation(), os);
     }
 
     SmallString<64> callerIsolationStr;
     {
       llvm::raw_svector_ostream os(callerIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          crossing.getCallerIsolation(), os);
+          getFunction(), crossing.getCallerIsolation(), os);
     }
 
     diagnoseNote(
@@ -1486,7 +1486,7 @@ public:
     SmallString<64> descriptiveKindStr;
     {
       llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().printForDiagnostics(os);
+      getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
     }
 
     if (auto callee = getSendingCallee()) {
@@ -1508,7 +1508,8 @@ public:
     SmallString<64> descriptiveKindStr;
     {
       llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().getIsolationInfo().printForCodeDiagnostic(os);
+      getIsolationRegionInfo().getIsolationInfo().printForCodeDiagnostic(
+          getFunction(), os);
     }
 
     diagnoseError(partialApplyOp,
@@ -1520,7 +1521,8 @@ public:
     descriptiveKindStr.clear();
     {
       llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().getIsolationInfo().printForDiagnostics(os);
+      getIsolationRegionInfo().getIsolationInfo().printForDiagnostics(
+          getFunction(), os);
     }
     diagnoseNote(actualUse, diag::regionbasedisolation_closure_captures_actor,
                  fArg->getDecl()->getName(), descriptiveKindStr);
@@ -1539,7 +1541,8 @@ public:
     SmallString<64> descriptiveKindStr;
     {
       llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().getIsolationInfo().printForCodeDiagnostic(os);
+      getIsolationRegionInfo().getIsolationInfo().printForCodeDiagnostic(
+          getFunction(), os);
     }
 
     diagnoseError(partialApplyOp,
@@ -1567,7 +1570,7 @@ public:
     descriptiveKindStr.clear();
     {
       llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().printForDiagnostics(os);
+      getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
     }
 
     auto diag = diag::
@@ -1588,7 +1591,7 @@ public:
     SmallString<64> descriptiveKindStr;
     {
       llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo()->printForCodeDiagnostic(os);
+      getIsolationRegionInfo()->printForCodeDiagnostic(getFunction(), os);
     }
 
     auto emitMainError = [&] {
@@ -1624,7 +1627,7 @@ public:
       descriptiveKindStr.clear();
       {
         llvm::raw_svector_ostream os(descriptiveKindStr);
-        getIsolationRegionInfo().printForDiagnostics(os);
+        getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
       }
       auto diag = diag::
           regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_region;
@@ -1669,7 +1672,7 @@ public:
     SmallString<64> descriptiveKindStr;
     {
       llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().printForDiagnostics(os);
+      getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
     }
 
     diagnoseNote(loc, diag::regionbasedisolation_named_send_nt_asynclet_capture,
@@ -1686,7 +1689,7 @@ public:
       if (!getIsolationRegionInfo().isDisconnected()) {
         {
           llvm::raw_svector_ostream os(descriptiveKindStr);
-          getIsolationRegionInfo().printForDiagnostics(os);
+          getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
         }
         descriptiveKindStrWithSpace = descriptiveKindStr;
         descriptiveKindStrWithSpace.push_back(' ');
@@ -1697,7 +1700,7 @@ public:
     {
       llvm::raw_svector_ostream os(calleeIsolationStr);
       SILIsolationInfo::printActorIsolationForDiagnostics(
-          isolationCrossing.getCalleeIsolation(), os);
+          getFunction(), isolationCrossing.getCalleeIsolation(), os);
     }
 
     if (auto callee = getSendingCallee()) {
@@ -1719,7 +1722,7 @@ public:
     {
       if (!getIsolationRegionInfo().isDisconnected()) {
         llvm::raw_svector_ostream os(descriptiveKindStr);
-        getIsolationRegionInfo().printForDiagnostics(os);
+        getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
         os << ' ';
       }
     }
@@ -1735,7 +1738,7 @@ public:
       if (!getIsolationRegionInfo().isDisconnected()) {
         {
           llvm::raw_svector_ostream os(descriptiveKindStr);
-          getIsolationRegionInfo().printForDiagnostics(os);
+          getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
         }
         descriptiveKindStrWithSpace = descriptiveKindStr;
         descriptiveKindStrWithSpace.push_back(' ');
@@ -2298,7 +2301,7 @@ void InOutSendingNotDisconnectedDiagnosticEmitter::emit() {
   SmallString<64> descriptiveKindStr;
   {
     llvm::raw_svector_ostream os(descriptiveKindStr);
-    actorIsolatedRegionInfo.printForDiagnostics(os);
+    actorIsolatedRegionInfo.printForDiagnostics(getFunction(), os);
     os << ' ';
   }
 
@@ -2458,7 +2461,7 @@ void AssignIsolatedIntoSendingResultDiagnosticEmitter::emit() {
   SmallString<64> descriptiveKindStr;
   {
     llvm::raw_svector_ostream os(descriptiveKindStr);
-    isolatedValueIsolationRegionInfo.printForDiagnostics(os);
+    isolatedValueIsolationRegionInfo.printForDiagnostics(getFunction(), os);
   }
 
   // Grab the var name if we can find it.
@@ -2583,6 +2586,10 @@ struct NonSendableIsolationCrossingResultDiagnosticEmitter {
       : valueMap(valueMap), error(error),
         representative(valueMap.getRepresentative(error.returnValueElement)) {}
 
+  SILFunction *getFunction() const {
+    return error.op->getSourceInst()->getFunction();
+  }
+
   void emit();
 
   ASTContext &getASTContext() const {
@@ -2703,14 +2710,14 @@ void NonSendableIsolationCrossingResultDiagnosticEmitter::emit() {
   {
     llvm::raw_svector_ostream os(calleeIsolationStr);
     SILIsolationInfo::printActorIsolationForDiagnostics(
-        isolationCrossing->getCalleeIsolation(), os);
+        getFunction(), isolationCrossing->getCalleeIsolation(), os);
   }
 
   SmallString<64> callerIsolationStr;
   {
     llvm::raw_svector_ostream os(callerIsolationStr);
     SILIsolationInfo::printActorIsolationForDiagnostics(
-        isolationCrossing->getCallerIsolation(), os);
+        getFunction(), isolationCrossing->getCallerIsolation(), os);
   }
 
   auto type = getType();

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -686,37 +686,24 @@ public:
         .limitBehaviorIf(getBehaviorLimit());
 
     // Then emit the note with greater context.
-    SmallString<64> descriptiveKindStr;
-    {
-      if (!namedValuesIsolationInfo.isDisconnected()) {
-        llvm::raw_svector_ostream os(descriptiveKindStr);
-        namedValuesIsolationInfo.printForDiagnostics(getFunction(), os);
-        os << ' ';
-      }
-    }
+    auto descriptiveKindStr =
+        namedValuesIsolationInfo.printForDiagnostics(getFunction());
+    auto calleeIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCalleeIsolation());
+    auto callerIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCallerIsolation());
 
-    SmallString<64> calleeIsolationStr;
-    {
-      llvm::raw_svector_ostream os(calleeIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCalleeIsolation(), os);
-    }
-
-    SmallString<64> callerIsolationStr;
-    {
-      llvm::raw_svector_ostream os(callerIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCallerIsolation(), os);
-    }
-
+    bool isDisconnected = namedValuesIsolationInfo.isDisconnected();
     if (auto callee = getSendingCallee()) {
       diagnoseNote(
           loc, diag::regionbasedisolation_named_info_send_yields_race_callee,
-          name, descriptiveKindStr, calleeIsolationStr, callee.value(),
-          callerIsolationStr);
+          isDisconnected, name, descriptiveKindStr, calleeIsolationStr,
+          callee.value(), callerIsolationStr);
     } else {
       diagnoseNote(loc, diag::regionbasedisolation_named_info_send_yields_race,
-                   name, descriptiveKindStr, calleeIsolationStr,
+                   isDisconnected, name, descriptiveKindStr, calleeIsolationStr,
                    callerIsolationStr);
     }
     emitRequireInstDiagnostics();
@@ -733,33 +720,20 @@ public:
         .limitBehaviorIf(getBehaviorLimit());
 
     // Then emit the note with greater context.
-    SmallString<64> descriptiveKindStr;
-    {
-      if (!namedValuesIsolationInfo.isDisconnected()) {
-        llvm::raw_svector_ostream os(descriptiveKindStr);
-        namedValuesIsolationInfo.printForDiagnostics(getFunction(), os);
-        os << ' ';
-      }
-    }
-
-    SmallString<64> calleeIsolationStr;
-    {
-      llvm::raw_svector_ostream os(calleeIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCalleeIsolation(), os);
-    }
-
-    SmallString<64> callerIsolationStr;
-    {
-      llvm::raw_svector_ostream os(callerIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCallerIsolation(), os);
-    }
+    auto descriptiveKindStr =
+        namedValuesIsolationInfo.printForDiagnostics(getFunction());
+    auto calleeIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCalleeIsolation());
+    auto callerIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCallerIsolation());
+    bool isDisconnected = namedValuesIsolationInfo.isDisconnected();
 
     diagnoseNote(loc,
                  diag::regionbasedisolation_named_info_send_yields_race_callee,
-                 name, descriptiveKindStr, calleeIsolationStr, callee,
-                 callerIsolationStr);
+                 isDisconnected, name, descriptiveKindStr, calleeIsolationStr,
+                 callee, callerIsolationStr);
     emitRequireInstDiagnostics();
   }
 
@@ -782,19 +756,12 @@ public:
         .highlight(loc.getSourceRange())
         .limitBehaviorIf(getBehaviorLimit());
 
-    SmallString<64> calleeIsolationStr;
-    {
-      llvm::raw_svector_ostream os(calleeIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCalleeIsolation(), os);
-    }
-
-    SmallString<64> callerIsolationStr;
-    {
-      llvm::raw_svector_ostream os(callerIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCallerIsolation(), os);
-    }
+    auto calleeIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCalleeIsolation());
+    auto callerIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCallerIsolation());
 
     if (auto callee = getSendingCallee()) {
       diagnoseNote(loc, diag::regionbasedisolation_type_use_after_send_callee,
@@ -848,32 +815,19 @@ public:
         .highlight(loc.getSourceRange())
         .limitBehaviorIf(getBehaviorLimit());
 
-    SmallString<64> descriptiveKindStr;
-    {
-      if (!namedValuesIsolationInfo.isDisconnected()) {
-        llvm::raw_svector_ostream os(descriptiveKindStr);
-        namedValuesIsolationInfo.printForDiagnostics(getFunction(), os);
-        os << ' ';
-      }
-    }
-
-    SmallString<64> calleeIsolationStr;
-    {
-      llvm::raw_svector_ostream os(calleeIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCalleeIsolation(), os);
-    }
-
-    SmallString<64> callerIsolationStr;
-    {
-      llvm::raw_svector_ostream os(callerIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCallerIsolation(), os);
-    }
-
-    diagnoseNote(
-        loc, diag::regionbasedisolation_named_isolated_closure_yields_race,
-        descriptiveKindStr, name, calleeIsolationStr, callerIsolationStr)
+    auto descriptiveKindStr =
+        namedValuesIsolationInfo.printForDiagnostics(getFunction());
+    auto calleeIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCalleeIsolation());
+    auto callerIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCallerIsolation());
+    bool isDisconnected = namedValuesIsolationInfo.isDisconnected();
+    diagnoseNote(loc,
+                 diag::regionbasedisolation_named_isolated_closure_yields_race,
+                 isDisconnected, descriptiveKindStr, name, calleeIsolationStr,
+                 callerIsolationStr)
         .highlight(loc.getSourceRange());
     emitRequireInstDiagnostics();
   }
@@ -886,19 +840,12 @@ public:
         .highlight(loc.getSourceRange())
         .limitBehaviorIf(getBehaviorLimit());
 
-    SmallString<64> calleeIsolationStr;
-    {
-      llvm::raw_svector_ostream os(calleeIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCalleeIsolation(), os);
-    }
-
-    SmallString<64> callerIsolationStr;
-    {
-      llvm::raw_svector_ostream os(callerIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCallerIsolation(), os);
-    }
+    auto calleeIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCalleeIsolation());
+    auto callerIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCallerIsolation());
 
     diagnoseNote(loc,
                  diag::regionbasedisolation_type_isolated_capture_yields_race,
@@ -1419,18 +1366,11 @@ public:
         .highlight(loc.getSourceRange())
         .limitBehaviorIf(getBehaviorLimit());
 
-    SmallString<64> descriptiveKindStr;
-    {
-      llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-    }
-
-    SmallString<64> calleeIsolationStr;
-    {
-      llvm::raw_svector_ostream os(calleeIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), crossing.getCalleeIsolation(), os);
-    }
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
+    auto calleeIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), crossing.getCalleeIsolation());
 
     if (auto callee = getSendingCallee()) {
       diagnoseNote(
@@ -1447,32 +1387,20 @@ public:
   void emitNamedFunctionArgumentClosure(SILLocation loc, Identifier name,
                                         ApplyIsolationCrossing crossing) {
     emitNamedOnlyError(loc, name);
-    SmallString<64> descriptiveKindStr;
-    {
-      if (!getIsolationRegionInfo().isDisconnected()) {
-        llvm::raw_svector_ostream os(descriptiveKindStr);
-        getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-        os << ' ';
-      }
-    }
 
-    SmallString<64> calleeIsolationStr;
-    {
-      llvm::raw_svector_ostream os(calleeIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), crossing.getCalleeIsolation(), os);
-    }
-
-    SmallString<64> callerIsolationStr;
-    {
-      llvm::raw_svector_ostream os(callerIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), crossing.getCallerIsolation(), os);
-    }
-
-    diagnoseNote(
-        loc, diag::regionbasedisolation_named_isolated_closure_yields_race,
-        descriptiveKindStr, name, calleeIsolationStr, callerIsolationStr)
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
+    auto calleeIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), crossing.getCalleeIsolation());
+    auto callerIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), crossing.getCallerIsolation());
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
+    diagnoseNote(loc,
+                 diag::regionbasedisolation_named_isolated_closure_yields_race,
+                 isDisconnected, descriptiveKindStr, name, calleeIsolationStr,
+                 callerIsolationStr)
         .highlight(loc.getSourceRange());
   }
 
@@ -1483,11 +1411,8 @@ public:
         .highlight(loc.getSourceRange())
         .limitBehaviorIf(getBehaviorLimit());
 
-    SmallString<64> descriptiveKindStr;
-    {
-      llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-    }
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
 
     if (auto callee = getSendingCallee()) {
       diagnoseNote(
@@ -1505,12 +1430,8 @@ public:
   void emitClosureErrorWithCapturedActor(Operand *partialApplyOp,
                                          Operand *actualUse,
                                          SILArgument *fArg) {
-    SmallString<64> descriptiveKindStr;
-    {
-      llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().getIsolationInfo().printForCodeDiagnostic(
-          getFunction(), os);
-    }
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForCodeDiagnostic(getFunction());
 
     diagnoseError(partialApplyOp,
                   diag::regionbasedisolation_typed_tns_passed_sending_closure,
@@ -1518,12 +1439,8 @@ public:
         .limitBehaviorIf(getDiagnosticBehaviorLimitForOperands(
             actualUse->getFunction(), {actualUse}));
 
-    descriptiveKindStr.clear();
-    {
-      llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().getIsolationInfo().printForDiagnostics(
-          getFunction(), os);
-    }
+    descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
     diagnoseNote(actualUse, diag::regionbasedisolation_closure_captures_actor,
                  fArg->getDecl()->getName(), descriptiveKindStr);
   }
@@ -1538,12 +1455,8 @@ public:
   void emitSendingClosureParamDirectlyIsolated(Operand *partialApplyOp,
                                                Operand *actualUse,
                                                SILArgument *fArg) {
-    SmallString<64> descriptiveKindStr;
-    {
-      llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().getIsolationInfo().printForCodeDiagnostic(
-          getFunction(), os);
-    }
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForCodeDiagnostic(getFunction());
 
     diagnoseError(partialApplyOp,
                   diag::regionbasedisolation_typed_tns_passed_sending_closure,
@@ -1567,11 +1480,8 @@ public:
       return;
     }
 
-    descriptiveKindStr.clear();
-    {
-      llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-    }
+    descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
 
     auto diag = diag::
         regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value;
@@ -1588,11 +1498,8 @@ public:
       return;
     }
 
-    SmallString<64> descriptiveKindStr;
-    {
-      llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo()->printForCodeDiagnostic(getFunction(), os);
-    }
+    auto descriptiveKindStr =
+        getIsolationRegionInfo()->printForCodeDiagnostic(getFunction());
 
     auto emitMainError = [&] {
       auto behaviorLimit = getDiagnosticBehaviorLimitForOperands(
@@ -1624,11 +1531,8 @@ public:
       }
 
       emitMainError();
-      descriptiveKindStr.clear();
-      {
-        llvm::raw_svector_ostream os(descriptiveKindStr);
-        getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-      }
+      descriptiveKindStr =
+          getIsolationRegionInfo().printForDiagnostics(getFunction());
       auto diag = diag::
           regionbasedisolation_typed_tns_passed_to_sending_closure_helper_have_value_region;
       diagnoseNote(actualUseInfo->first, diag, descriptiveKindStr,
@@ -1669,11 +1573,8 @@ public:
            "Should never be disconnected?!");
     emitNamedOnlyError(loc, name);
 
-    SmallString<64> descriptiveKindStr;
-    {
-      llvm::raw_svector_ostream os(descriptiveKindStr);
-      getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-    }
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
 
     diagnoseNote(loc, diag::regionbasedisolation_named_send_nt_asynclet_capture,
                  name, descriptiveKindStr)
@@ -1683,34 +1584,22 @@ public:
   void emitNamedIsolation(SILLocation loc, Identifier name,
                           ApplyIsolationCrossing isolationCrossing) {
     emitNamedOnlyError(loc, name);
-    SmallString<64> descriptiveKindStr;
-    SmallString<64> descriptiveKindStrWithSpace;
-    {
-      if (!getIsolationRegionInfo().isDisconnected()) {
-        {
-          llvm::raw_svector_ostream os(descriptiveKindStr);
-          getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-        }
-        descriptiveKindStrWithSpace = descriptiveKindStr;
-        descriptiveKindStrWithSpace.push_back(' ');
-      }
-    }
 
-    SmallString<64> calleeIsolationStr;
-    {
-      llvm::raw_svector_ostream os(calleeIsolationStr);
-      SILIsolationInfo::printActorIsolationForDiagnostics(
-          getFunction(), isolationCrossing.getCalleeIsolation(), os);
-    }
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
+    auto calleeIsolationStr =
+        SILIsolationInfo::printActorIsolationForDiagnostics(
+            getFunction(), isolationCrossing.getCalleeIsolation());
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
 
     if (auto callee = getSendingCallee()) {
       diagnoseNote(loc,
                    diag::regionbasedisolation_named_send_never_sendable_callee,
-                   name, descriptiveKindStrWithSpace, calleeIsolationStr,
+                   isDisconnected, name, descriptiveKindStr, calleeIsolationStr,
                    callee.value(), descriptiveKindStr);
     } else {
       diagnoseNote(loc, diag::regionbasedisolation_named_send_never_sendable,
-                   name, descriptiveKindStrWithSpace, calleeIsolationStr,
+                   isDisconnected, name, descriptiveKindStr, calleeIsolationStr,
                    descriptiveKindStr);
     }
   }
@@ -1718,34 +1607,21 @@ public:
   void emitNamedSendingNeverSendableToSendingParam(SILLocation loc,
                                                    Identifier varName) {
     emitNamedOnlyError(loc, varName);
-    SmallString<64> descriptiveKindStr;
-    {
-      if (!getIsolationRegionInfo().isDisconnected()) {
-        llvm::raw_svector_ostream os(descriptiveKindStr);
-        getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-        os << ' ';
-      }
-    }
+
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
     auto diag = diag::regionbasedisolation_named_send_into_sending_param;
-    diagnoseNote(loc, diag, descriptiveKindStr, varName);
+    diagnoseNote(loc, diag, isDisconnected, descriptiveKindStr, varName);
   }
 
   void emitNamedSendingReturn(SILLocation loc, Identifier varName) {
     emitNamedOnlyError(loc, varName);
-    SmallString<64> descriptiveKindStr;
-    SmallString<64> descriptiveKindStrWithSpace;
-    {
-      if (!getIsolationRegionInfo().isDisconnected()) {
-        {
-          llvm::raw_svector_ostream os(descriptiveKindStr);
-          getIsolationRegionInfo().printForDiagnostics(getFunction(), os);
-        }
-        descriptiveKindStrWithSpace = descriptiveKindStr;
-        descriptiveKindStrWithSpace.push_back(' ');
-      }
-    }
+    auto descriptiveKindStr =
+        getIsolationRegionInfo().printForDiagnostics(getFunction());
+    bool isDisconnected = getIsolationRegionInfo().isDisconnected();
     auto diag = diag::regionbasedisolation_named_nosend_send_into_result;
-    diagnoseNote(loc, diag, descriptiveKindStrWithSpace, varName,
+    diagnoseNote(loc, diag, isDisconnected, descriptiveKindStr, varName,
                  descriptiveKindStr);
   }
 
@@ -2060,7 +1936,6 @@ bool SentNeverSendableDiagnosticInferrer::run() {
           return true;
 
         // See if we can infer a name from the value.
-        SmallString<64> resultingName;
         if (auto varName = inferNameHelper(op->get())) {
           diagnosticEmitter.emitNamedSendingNeverSendableToSendingParam(
               loc, *varName);
@@ -2101,7 +1976,6 @@ bool SentNeverSendableDiagnosticInferrer::run() {
     }
 
     // See if we can infer a name from the value.
-    SmallString<64> resultingName;
     if (auto name = inferNameHelper(op->get())) {
       diagnosticEmitter.emitNamedIsolation(loc, *name, *isolation);
       return true;
@@ -2149,7 +2023,6 @@ bool SentNeverSendableDiagnosticInferrer::run() {
                           }) &&
              "All result info must be the same... if that changes... update "
              "this code!");
-      SmallString<64> resultingName;
       if (auto name = inferNameHelper(op->get())) {
         diagnosticEmitter.emitNamedSendingReturn(loc, *name);
         return true;
@@ -2298,12 +2171,8 @@ void InOutSendingNotDisconnectedDiagnosticEmitter::emit() {
   }
 
   // Then emit the note with greater context.
-  SmallString<64> descriptiveKindStr;
-  {
-    llvm::raw_svector_ostream os(descriptiveKindStr);
-    actorIsolatedRegionInfo.printForDiagnostics(getFunction(), os);
-    os << ' ';
-  }
+  auto descriptiveKindStr =
+      actorIsolatedRegionInfo.printForDiagnostics(getFunction());
 
   diagnoseError(
       functionExitingInst,
@@ -2458,11 +2327,8 @@ static SILValue findOutParameter(SILValue v) {
 
 void AssignIsolatedIntoSendingResultDiagnosticEmitter::emit() {
   // Then emit the note with greater context.
-  SmallString<64> descriptiveKindStr;
-  {
-    llvm::raw_svector_ostream os(descriptiveKindStr);
-    isolatedValueIsolationRegionInfo.printForDiagnostics(getFunction(), os);
-  }
+  auto descriptiveKindStr =
+      isolatedValueIsolationRegionInfo.printForDiagnostics(getFunction());
 
   // Grab the var name if we can find it.
   if (auto varName = VariableNameInferrer::inferName(srcOperand->get())) {
@@ -2706,19 +2572,10 @@ void NonSendableIsolationCrossingResultDiagnosticEmitter::emit() {
   if (!isolationCrossing)
     return emitUnknownPatternError();
 
-  SmallString<64> calleeIsolationStr;
-  {
-    llvm::raw_svector_ostream os(calleeIsolationStr);
-    SILIsolationInfo::printActorIsolationForDiagnostics(
-        getFunction(), isolationCrossing->getCalleeIsolation(), os);
-  }
-
-  SmallString<64> callerIsolationStr;
-  {
-    llvm::raw_svector_ostream os(callerIsolationStr);
-    SILIsolationInfo::printActorIsolationForDiagnostics(
-        getFunction(), isolationCrossing->getCallerIsolation(), os);
-  }
+  auto calleeIsolationStr = SILIsolationInfo::printActorIsolationForDiagnostics(
+      getFunction(), isolationCrossing->getCalleeIsolation());
+  auto callerIsolationStr = SILIsolationInfo::printActorIsolationForDiagnostics(
+      getFunction(), isolationCrossing->getCallerIsolation());
 
   auto type = getType();
   if (getCalledDecl()) {

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -46,7 +46,7 @@ void PartitionOpError::SentNeverSendableError::print(
      << "        ID:  %%" << sentElement << "\n"
      << "        Rep: " << *info.getRepresentative(sentElement)
      << "        Dynamic Isolation Region: ";
-  isolationRegionInfo.printForOneLineLogging(os);
+  isolationRegionInfo.printForOneLineLogging(info.getFunction(), os);
   os << '\n';
   if (auto isolatedValue = isolationRegionInfo->maybeGetIsolatedValue()) {
     os << "        Isolated Value: " << isolatedValue;
@@ -90,7 +90,7 @@ void PartitionOpError::InOutSendingNotDisconnectedAtExitError::print(
      << "        ID:  %%" << inoutSendingElement << "\n"
      << "        Rep: " << valueMap.getRepresentativeValue(inoutSendingElement)
      << "        Dynamic Isolation Region: ";
-  isolationInfo.printForOneLineLogging(os);
+  isolationInfo.printForOneLineLogging(valueMap.getFunction(), os);
   os << '\n';
 }
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1089,6 +1089,14 @@ void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
   llvm::interleave(data, os, ", ");
 }
 
+/// We want to treat nonisolated(nonsending) just like nonisolated. So we use
+/// this with composition.
+void SILIsolationInfo::printActorIsolationForDiagnostics(
+    ActorIsolation iso, llvm::raw_ostream &os, StringRef openingQuotationMark,
+    bool asNoun) {
+  return iso.printForDiagnostics(os, openingQuotationMark, asNoun);
+}
+
 void SILIsolationInfo::print(llvm::raw_ostream &os) const {
   switch (Kind(*this)) {
   case Unknown:
@@ -1136,7 +1144,7 @@ void SILIsolationInfo::print(llvm::raw_ostream &os) const {
       }
     }
 
-    getActorIsolation().printForDiagnostics(os);
+    printActorIsolationForDiagnostics(getActorIsolation(), os);
     printOptions(os);
     return;
   case Task:
@@ -1256,7 +1264,7 @@ void SILIsolationInfo::printForDiagnostics(llvm::raw_ostream &os) const {
       }
     }
 
-    getActorIsolation().printForDiagnostics(os);
+    printActorIsolationForDiagnostics(getActorIsolation(), os);
     return;
   case Task:
     os << "task-isolated";
@@ -1299,7 +1307,7 @@ void SILIsolationInfo::printForCodeDiagnostic(llvm::raw_ostream &os) const {
       }
     }
 
-    getActorIsolation().printForDiagnostics(os);
+    printActorIsolationForDiagnostics(getActorIsolation(), os);
     os << " code";
     return;
   case Task:
@@ -1348,7 +1356,7 @@ void SILIsolationInfo::printForOneLineLogging(llvm::raw_ostream &os) const {
       }
     }
 
-    getActorIsolation().printForDiagnostics(os);
+    printActorIsolationForDiagnostics(getActorIsolation(), os);
     printOptions(os);
     return;
   case Task:

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1096,6 +1096,19 @@ void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
   llvm::interleave(data, os, ", ");
 }
 
+StringRef SILIsolationInfo::printActorIsolationForDiagnostics(
+    SILFunction *fn, ActorIsolation iso, StringRef openingQuotationMark,
+    bool asNoun) {
+  SmallString<64> string;
+  {
+    llvm::raw_svector_ostream os(string);
+    printActorIsolationForDiagnostics(fn, iso, os, openingQuotationMark,
+                                      asNoun);
+  }
+
+  return fn->getASTContext().getIdentifier(string).str();
+}
+
 void SILIsolationInfo::printActorIsolationForDiagnostics(
     SILFunction *fn, ActorIsolation iso, llvm::raw_ostream &os,
     StringRef openingQuotationMark, bool asNoun) {
@@ -1250,6 +1263,16 @@ void SILIsolationInfo::Profile(llvm::FoldingSetNodeID &id) const {
   }
 }
 
+StringRef SILIsolationInfo::printForDiagnostics(SILFunction *fn) const {
+  SmallString<64> string;
+  {
+    llvm::raw_svector_ostream os(string);
+    printForDiagnostics(fn, os);
+  }
+
+  return fn->getASTContext().getIdentifier(string).str();
+}
+
 void SILIsolationInfo::printForDiagnostics(SILFunction *fn,
                                            llvm::raw_ostream &os) const {
   switch (Kind(*this)) {
@@ -1307,6 +1330,16 @@ void SILIsolationInfo::printForDiagnostics(SILFunction *fn,
     os << "task-isolated";
     return;
   }
+}
+
+StringRef SILIsolationInfo::printForCodeDiagnostic(SILFunction *fn) const {
+  SmallString<64> string;
+  {
+    llvm::raw_svector_ostream os(string);
+    printForCodeDiagnostic(fn, os);
+  }
+
+  return fn->getASTContext().getIdentifier(string).str();
 }
 
 void SILIsolationInfo::printForCodeDiagnostic(SILFunction *fn,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4034,6 +4034,10 @@ namespace {
       Expr *argForIsolatedParam = nullptr;
       auto calleeDecl = apply->getCalledValue(/*skipFunctionConversions=*/true);
 
+      if (calleeDecl &&
+          calleeDecl->getAttrs().hasAttribute<UnsafeInheritExecutorAttr>())
+        return false;
+
       auto fnTypeIsolation = fnType->getIsolation();
       if (fnTypeIsolation.isGlobalActor()) {
         // If the function type is global-actor-qualified, determine whether
@@ -4079,10 +4083,6 @@ namespace {
           calleeDecl = memberRef->first.getDecl();
           argForIsolatedParam = selfApplyFn->getBase();
         }
-      } else if (calleeDecl &&
-                 calleeDecl->getAttrs()
-                     .hasAttribute<UnsafeInheritExecutorAttr>()) {
-        return false;
       }
 
       // Check for isolated parameters.
@@ -4133,11 +4133,25 @@ namespace {
         break;
       }
 
-      // If we're calling an async function that's nonisolated, and we're in
-      // an isolated context, then we're exiting the actor context.
-      if (mayExitToNonisolated && fnType->isAsync() &&
-          getContextIsolation().isActorIsolated())
-        unsatisfiedIsolation = ActorIsolation::forNonisolated(/*unsafe=*/false);
+      // If we're calling an async function that's nonisolated, and we're in an
+      // isolated context, then we're exiting the actor context unless we have
+      // nonisolated(nonsending) isolation.
+      //
+      // NOTE: We do not check fnTypeIsolation since that is the AST level
+      // actual isolation which does not have nonisolated(nonsending) added to
+      // it yet. Instead, we want the direct callee including casts since those
+      // casts is what would add the nonisolated(nonsending) bit to the function
+      // type isolation.
+      if (mayExitToNonisolated && fnType->isAsync()) {
+        if (getContextIsolation().isActorIsolated() &&
+            !fnTypeIsolation.isNonIsolatedCaller())
+          unsatisfiedIsolation =
+              ActorIsolation::forNonisolated(/*unsafe=*/false);
+        else if (getContextIsolation().isCallerIsolationInheriting() &&
+                 fnTypeIsolation.isNonIsolated())
+          unsatisfiedIsolation =
+              ActorIsolation::forNonisolated(/*unsafe=*/false);
+      }
 
       // If there was no unsatisfied actor isolation, we're done.
       if (!unsatisfiedIsolation)
@@ -8005,12 +8019,14 @@ ActorReferenceResult ActorReferenceResult::forReference(
   // When the declaration is not actor-isolated, it can always be accessed
   // directly.
   if (!declIsolation.isActorIsolated()) {
+    if (declRef.getDecl()->getAttrs().hasAttribute<UnsafeInheritExecutorAttr>())
+      return forSameConcurrencyDomain(declIsolation, options);
+
     // If the declaration is asynchronous and we are in an actor-isolated
-    // context (of any kind), then we exit the actor to the nonisolated context.
-    if (decl->isAsync() && contextIsolation.isActorIsolated() &&
-        !declRef.getDecl()
-             ->getAttrs()
-             .hasAttribute<UnsafeInheritExecutorAttr>())
+    // context (of any kind) or it is a caller isolation inheriting, then
+    // we exit the actor to the nonisolated context.
+    if (decl->isAsync() && (contextIsolation.isActorIsolated() ||
+                            contextIsolation.isCallerIsolationInheriting()))
       return forExitsActorToNonisolated(contextIsolation, options);
 
     // Otherwise, we stay in the same concurrency domain, whether on an actor

--- a/test/ClangImporter/Inputs/regionbasedisolation.h
+++ b/test/ClangImporter/Inputs/regionbasedisolation.h
@@ -13,6 +13,9 @@ NS_ASSUME_NONNULL_BEGIN
     (void (^)(NSArray<NSObject *> *_Nullable,
                                NSError *_Nullable))completionHandler;
 
+- (void)useValue:(id)object
+    withCompletionHandler:(void (^)(NSObject *_Nullable))completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/test/ClangImporter/regionbasedisolation.swift
+++ b/test/ClangImporter/regionbasedisolation.swift
@@ -3,6 +3,7 @@
 // RUN: %target-swift-frontend %s -import-objc-header %S/Inputs/regionbasedisolation.h -emit-silgen -swift-version 6 | %FileCheck %s
 
 // REQUIRES: objc_interop
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 extension ObjCObject {
   // CHECK-LABEL: sil hidden [ossa] @$sSo10ObjCObjectC20regionbasedisolationE11sendObjectsSaySo8NSObjectCGyYaKF : $@convention(method) @async (@guaranteed ObjCObject) -> (@sil_sending @owned Array<NSObject>, @error any Error) {

--- a/test/ClangImporter/regionbasedisolation.swift
+++ b/test/ClangImporter/regionbasedisolation.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend %s -import-objc-header %S/Inputs/regionbasedisolation.h -verify -c -swift-version 6
+// RUN: %target-swift-frontend %s -import-objc-header %S/Inputs/regionbasedisolation.h -verify -verify-additional-prefix ni- -c -swift-version 6
+// RUN: %target-swift-frontend %s -import-objc-header %S/Inputs/regionbasedisolation.h -verify -verify-additional-prefix ni-ns- -c -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
 // RUN: %target-swift-frontend %s -import-objc-header %S/Inputs/regionbasedisolation.h -emit-silgen -swift-version 6 | %FileCheck %s
 
 // REQUIRES: objc_interop
@@ -122,4 +123,40 @@ extension ObjCObject {
     // sending [NSObject].
     try await loadObjects2()
   } // expected-error {{task or actor-isolated value cannot be sent}}
+}
+
+@concurrent func useValueConcurrently<T>(_ t: T) async {}
+@MainActor func useValueMainActor<T>(_ t: T) async {}
+nonisolated(nonsending) func useValueNonIsolatedNonSending<T>(_ t: T) async {}
+
+@MainActor func testMainActorMerging(_ y: NSObject) async {
+  let x = ObjCObject()
+  await x.useValue(y)
+  await useValueConcurrently(x)  // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'x' to nonisolated global function 'useValueConcurrently' risks causing data races between nonisolated and main actor-isolated uses}}
+}
+
+func testTaskLocal(_ y: NSObject) async {
+  let x = ObjCObject()
+  await x.useValue(y)
+  await useValueConcurrently(x) // expected-ni-ns-error {{sending 'x' risks causing data races}}
+  // expected-ni-ns-note @-1 {{sending task-isolated 'x' to nonisolated global function 'useValueConcurrently' risks causing data races between nonisolated and task-isolated uses}}
+
+  // This is not safe since we merge x into y's region making x task
+  // isolated. We then try to send it to a main actor function.
+  await useValueMainActor(x) // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated 'x' to main actor-isolated global function 'useValueMainActor' risks causing data races between main actor-isolated and task-isolated uses}}
+}
+
+actor MyActor {
+  var field = NSObject()
+
+  // This is safe since x.useValue is going to be nonisolated(nonsending) so we
+  // are going to merge x into the actor. And useValueNonIsolatedNonSending
+  // inherits from the context.
+  func test() async {
+    let x = ObjCObject()
+    await x.useValue(field)
+    await useValueNonIsolatedNonSending(x)
+  }  
 }

--- a/test/ClangImporter/regionbasedisolation.swift
+++ b/test/ClangImporter/regionbasedisolation.swift
@@ -134,14 +134,15 @@ nonisolated(nonsending) func useValueNonIsolatedNonSending<T>(_ t: T) async {}
   let x = ObjCObject()
   await x.useValue(y)
   await useValueConcurrently(x)  // expected-error {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending main actor-isolated 'x' to nonisolated global function 'useValueConcurrently' risks causing data races between nonisolated and main actor-isolated uses}}
+  // expected-ni-note @-1 {{sending main actor-isolated 'x' to nonisolated global function 'useValueConcurrently' risks causing data races between nonisolated and main actor-isolated uses}}
+  // expected-ni-ns-note @-2 {{sending main actor-isolated 'x' to @concurrent global function 'useValueConcurrently' risks causing data races between @concurrent and main actor-isolated uses}}
 }
 
 func testTaskLocal(_ y: NSObject) async {
   let x = ObjCObject()
   await x.useValue(y)
   await useValueConcurrently(x) // expected-ni-ns-error {{sending 'x' risks causing data races}}
-  // expected-ni-ns-note @-1 {{sending task-isolated 'x' to nonisolated global function 'useValueConcurrently' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-ni-ns-note @-1 {{sending task-isolated 'x' to @concurrent global function 'useValueConcurrently' risks causing data races between @concurrent and task-isolated uses}}
 
   // This is not safe since we merge x into y's region making x task
   // isolated. We then try to send it to a main actor function.

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -1,9 +1,11 @@
 // RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -DALLOW_TYPECHECKER_ERRORS -verify-additional-prefix typechecker- -verify-additional-prefix tns-allow-typechecker-
 
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix tns-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix tns-ni- -verify-additional-prefix tns-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix tns-ni-ns- -verify-additional-prefix tns- -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 class NotConcurrent { } // expected-note 12{{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}
 // expected-tns-allow-typechecker-note @-1 {{class 'NotConcurrent' does not conform to the 'Sendable' protocol}}

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -1,8 +1,10 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-ns- -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 import Foundation
 

--- a/test/Concurrency/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation.swift
@@ -289,13 +289,13 @@ func unspecifiedCallingVariousNonisolated(_ x: NonSendableKlass) async {
   await x.nonisolatedCaller()
   await x.nonisolatedNonSendingCaller()
   await x.concurrentCaller() // expected-enabled-error {{sending 'x' risks causing data races}}
-  // expected-enabled-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'concurrentCaller()' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-enabled-note @-1 {{sending task-isolated 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent and task-isolated uses}}
 
   await unspecifiedAsyncUse(x)
   await nonisolatedAsyncUse(x)
   await nonisolatedNonSendingAsyncUse(x)
   await concurrentAsyncUse(x) // expected-enabled-error {{sending 'x' risks causing data races}}
-  // expected-enabled-note @-1 {{sending task-isolated 'x' to nonisolated global function 'concurrentAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-enabled-note @-1 {{sending task-isolated 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent and task-isolated uses}}
 }
 
 nonisolated func nonisolatedCallingVariousNonisolated(_ x: NonSendableKlass) async {
@@ -303,31 +303,33 @@ nonisolated func nonisolatedCallingVariousNonisolated(_ x: NonSendableKlass) asy
   await x.nonisolatedCaller()
   await x.nonisolatedNonSendingCaller()
   await x.concurrentCaller() // expected-enabled-error {{sending 'x' risks causing data races}}
-  // expected-enabled-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'concurrentCaller()' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-enabled-note @-1 {{sending task-isolated 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent and task-isolated uses}}
 
   await unspecifiedAsyncUse(x)
   await nonisolatedAsyncUse(x)
   await nonisolatedNonSendingAsyncUse(x)
   await concurrentAsyncUse(x) // expected-enabled-error {{sending 'x' risks causing data races}}
-  // expected-enabled-note @-1 {{sending task-isolated 'x' to nonisolated global function 'concurrentAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-enabled-note @-1 {{sending task-isolated 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent and task-isolated uses}}
 }
 
 nonisolated(nonsending) func nonisolatedNonSendingCallingVariousNonisolated(_ x: NonSendableKlass) async {
   await x.unspecifiedCaller() // expected-disabled-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'unspecifiedCaller()' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated instance method 'unspecifiedCaller()' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
   await x.nonisolatedCaller() // expected-disabled-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'nonisolatedCaller()' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated instance method 'nonisolatedCaller()' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
   await x.nonisolatedNonSendingCaller()
   await x.concurrentCaller() // expected-error {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'concurrentCaller()' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated instance method 'concurrentCaller()' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
+  // expected-enabled-note @-2 {{sending task-isolated 'x' to @concurrent instance method 'concurrentCaller()' risks causing data races between @concurrent and task-isolated uses}}
 
   await unspecifiedAsyncUse(x) // expected-disabled-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending task-isolated 'x' to nonisolated global function 'unspecifiedAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'unspecifiedAsyncUse' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
   await nonisolatedAsyncUse(x) // expected-disabled-error {{sending 'x' risks causing data races}}
-  // expected-disabled-note @-1 {{sending task-isolated 'x' to nonisolated global function 'nonisolatedAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'nonisolatedAsyncUse' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
   await nonisolatedNonSendingAsyncUse(x)
   await concurrentAsyncUse(x) // expected-error {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending task-isolated 'x' to nonisolated global function 'concurrentAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+  // expected-disabled-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'concurrentAsyncUse' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
+  // expected-enabled-note @-2 {{sending task-isolated 'x' to @concurrent global function 'concurrentAsyncUse' risks causing data races between @concurrent and task-isolated uses}}
 }
 
 @concurrent func concurrentCallingVariousNonisolated(_ x: NonSendableKlass) async {

--- a/test/Concurrency/nonisolated_inherits_isolation.swift
+++ b/test/Concurrency/nonisolated_inherits_isolation.swift
@@ -13,7 +13,12 @@
 // Declarations //
 //////////////////
 
-class NonSendableKlass {}
+class NonSendableKlass {
+  func unspecifiedCaller() async {}
+  nonisolated func nonisolatedCaller() async {}
+  nonisolated(nonsending) func nonisolatedNonSendingCaller() async {}
+  @concurrent func concurrentCaller() async {}
+}
 
 nonisolated class NonIsolatedNonSendableKlass {
   func unspecifiedMethod() async {}
@@ -24,6 +29,8 @@ func unspecifiedSyncUse<T>(_ t: T) {}
 func unspecifiedAsyncUse<T>(_ t: T) async {}
 nonisolated func nonisolatedSyncUse<T>(_ t: T) {}
 nonisolated func nonisolatedAsyncUse<T>(_ t: T) async {}
+nonisolated(nonsending) func nonisolatedNonSendingAsyncUse<T>(_ t: T) async {}
+@concurrent func concurrentAsyncUse<T>(_ t: T) async {}
 
 func unspecifiedSyncUseWithResult<T>(_ t: T) -> T { t }
 func unspecifiedAsyncUseWithResult<T>(_ t: T) async -> T { t }
@@ -34,6 +41,8 @@ func unspecifiedSyncResult() -> NonSendableKlass { fatalError() }
 func unspecifiedAsyncResult() async -> NonSendableKlass { fatalError() }
 nonisolated func nonisolatedSyncResult() -> NonSendableKlass { fatalError() }
 nonisolated func nonisolatedAsyncResult() async -> NonSendableKlass { fatalError() }
+func sendingParameter<T>(_ t: sending T) async {}
+func useValue<T>(_ t: T) {}
 
 @MainActor func sendToMain<T>(_ t: T) async {}
 
@@ -48,6 +57,13 @@ struct CustomActor {
 }
 
 @CustomActor func sendToCustom<T>(_ t: T) async {}
+
+@MainActor
+final class MainActorKlass {
+  var ns = NonSendableKlass()
+
+  func useValueAsync(_ x: NonSendableKlass) async {}
+}
 
 ///////////
 // Tests //
@@ -90,22 +106,17 @@ actor ActorTest {
     await sendToMain(x1)
 
     let x2 = await unspecifiedAsyncResult()
-    await sendToMain(x2) // expected-enabled-error {{sending 'x2' risks causing data races}}
-    // expected-enabled-note @-1 {{sending 'self'-isolated 'x2' to main actor-isolated global function 'sendToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await sendToMain(x2)
 
     let x3 = nonisolatedSyncResult()
     await sendToMain(x3)
 
     let x4 = await nonisolatedAsyncResult()
-    await sendToMain(x4) // expected-enabled-error {{sending 'x4' risks causing data races}}
-    // expected-enabled-note @-1 {{sending 'self'-isolated 'x4' to main actor-isolated global function 'sendToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
+    await sendToMain(x4)
   }
 }
 
-@MainActor
-class MainActorKlass {
-  var ns = NonSendableKlass()
-
+extension MainActorKlass {
   func callNonIsolatedWithParam() async {
     unspecifiedSyncUse(ns)
     await unspecifiedAsyncUse(ns) // expected-disabled-error {{sending 'self.ns' risks causing data races}}
@@ -141,15 +152,13 @@ class MainActorKlass {
     await sendToCustom(x1)
 
     let x2 = await unspecifiedAsyncResult()
-    await sendToCustom(x2) // expected-enabled-error {{sending 'x2' risks causing data races}}
-    // expected-enabled-note @-1 {{sending main actor-isolated 'x2' to global actor 'CustomActor'-isolated global function 'sendToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+    await sendToCustom(x2)
 
     let x3 = nonisolatedSyncResult()
     await sendToCustom(x3)
 
     let x4 = await nonisolatedAsyncResult()
-    await sendToCustom(x4) // expected-enabled-error {{sending 'x4' risks causing data races}}
-    // expected-enabled-note @-1 {{sending main actor-isolated 'x4' to global actor 'CustomActor'-isolated global function 'sendToCustom' risks causing data races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
+    await sendToCustom(x4)
   }
 }
 
@@ -165,4 +174,170 @@ func validateNonisolatedOnClassMeansCallerIsolationInheritingOnFuncDecl(
   // expected-disabled-note @-1 {{sending main actor-isolated 'c' to nonisolated instance method 'unspecifiedMethod()' risks causing data races between nonisolated and main actor-isolated uses}}
   await c.nonisolatedMethod() // expected-disabled-error {{sending 'c' risks causing data races}}
   // expected-disabled-note @-1 {{sending main actor-isolated 'c' to nonisolated instance method 'nonisolatedMethod()' risks causing data races between nonisolated and main actor-isolated uses}}
+}
+
+// Shouldn't get an error here since we are not using after we send to main.
+func nonisolatedCallingNonIsolated() async {
+  let c = NonSendableKlass()
+
+  await unspecifiedAsyncUse(c)
+  await unspecifiedAsyncUse(c)
+
+  await sendToMain(c)
+}
+
+func nonisolatedCallingNonIsolated2() async {
+  let c = NonSendableKlass()
+
+  await unspecifiedAsyncUse(c)
+  await unspecifiedAsyncUse(c)
+
+  await sendToMain(c) // expected-error {{sending 'c' risks causing data races}}
+  // expected-note @-1 {{sending 'c' to main actor-isolated global function 'sendToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
+
+  await unspecifiedAsyncUse(c) // expected-note {{access can happen concurrently}}
+}
+
+// We should emit an error here despite the function context being @MainActor.
+@MainActor
+func sendingWithMainActor() async {
+  let c = NonSendableKlass()
+  await sendingParameter(c) // expected-error {{sending 'c' risks causing data races}}
+  // expected-note @-1 {{'c' used after being passed as a 'sending' parameter}}
+  useValue(c) // expected-note {{access can happen concurrently}}
+}
+
+// We should emit an error here despite the function context have an explicit
+// isolated parameter.
+func sendingWithIsolatedParam(_ a: isolated Optional<Actor>) async {
+  let c = NonSendableKlass()
+  await sendingParameter(c) // expected-error {{sending 'c' risks causing data races}}
+  // expected-note @-1 {{'c' used after being passed as a 'sending' parameter}}
+  useValue(c) // expected-note {{access can happen concurrently}}
+}
+
+// This errors only when disabled since the first time we call
+// unspecifiedAsyncUse we have a disconnected value and the second time we have
+// a value in a main actor isolated region and the unspecifiedAsyncUse runs on
+// the main actor.
+//
+// TODO: This doesn't error if we have a non-final class because of a known bug
+// where we infer isolation wrong for non-final class setters. That is why
+// MainActorKlass is made final so we can test this appropriately.
+@MainActor
+func testUnrolledLoop(_ a: MainActorKlass) async {
+  let k = NonSendableKlass()
+  await unspecifiedAsyncUse(k)
+  a.ns = k
+  await unspecifiedAsyncUse(k) // expected-disabled-error {{sending 'k' risks causing data races}}
+  // expected-disabled-note @-1 {{sending main actor-isolated 'k' to nonisolated global function 'unspecifiedAsyncUse' risks causing data races between nonisolated and main actor-isolated uses}}
+}
+
+// We emit an error in both modes since we are now in an @MainActor isolated
+// function.
+func testUnrolledLoop2(_ a: MainActorKlass) async {
+  let k = NonSendableKlass()
+  await unspecifiedAsyncUse(k)
+  await a.useValueAsync(k) // expected-error {{sending 'k' risks causing data races}}
+  // expected-note @-1 {{sending 'k' to main actor-isolated instance method 'useValueAsync' risks causing data races between main actor-isolated and local nonisolated uses}}
+  await unspecifiedAsyncUse(k) // expected-note {{access can happen concurrently}}
+}
+
+func testUnrolledLoopWithAsyncLet(_ a: MainActorKlass) async {
+  let k = NonSendableKlass()
+  await unspecifiedAsyncUse(k)
+  // This is valid since our valid is disconnected here.
+  async let value: () = await unspecifiedAsyncUse(k)
+  _ = await value
+
+  await a.useValueAsync(k) // expected-error {{sending 'k' risks causing data races}}
+  // expected-note @-1 {{sending 'k' to main actor-isolated instance method 'useValueAsync' risks causing data races between main actor-isolated and local nonisolated uses}}
+  async let value2: () = await unspecifiedAsyncUse(k) // expected-note {{access can happen concurrently}}
+  _ = await value2
+}
+
+@MainActor
+func testUnrolledLoopWithAsyncLet2(_ a: MainActorKlass) async {
+  let k = NonSendableKlass()
+  await unspecifiedAsyncUse(k)
+  // This is valid since our valid is disconnected here.
+  async let value: () = await unspecifiedAsyncUse(k)
+  _ = await value
+
+  await a.useValueAsync(k)
+  async let value2: () = await unspecifiedAsyncUse(k) // expected-error {{sending 'k' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'k' into async let risks causing data races between nonisolated and main actor-isolated uses}}
+  _ = await value2
+}
+
+@MainActor
+func testUnrolledLoopWithAsyncLet3(_ a: MainActorKlass) async {
+  let k = NonSendableKlass()
+  await unspecifiedAsyncUse(k)
+  // This is valid since our valid is disconnected here.
+  async let value: () = await unspecifiedAsyncUse(k)
+  _ = await value
+
+  await a.useValueAsync(k)
+  async let value2: () = await sendToMain(k) // expected-error {{sending 'k' risks causing data races}}
+  // expected-note @-1 {{sending main actor-isolated 'k' into async let risks causing data races between nonisolated and main actor-isolated uses}}
+  _ = await value2
+}
+
+func unspecifiedCallingVariousNonisolated(_ x: NonSendableKlass) async {
+  await x.unspecifiedCaller()
+  await x.nonisolatedCaller()
+  await x.nonisolatedNonSendingCaller()
+  await x.concurrentCaller() // expected-enabled-error {{sending 'x' risks causing data races}}
+  // expected-enabled-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'concurrentCaller()' risks causing data races between nonisolated and task-isolated uses}}
+
+  await unspecifiedAsyncUse(x)
+  await nonisolatedAsyncUse(x)
+  await nonisolatedNonSendingAsyncUse(x)
+  await concurrentAsyncUse(x) // expected-enabled-error {{sending 'x' risks causing data races}}
+  // expected-enabled-note @-1 {{sending task-isolated 'x' to nonisolated global function 'concurrentAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+}
+
+nonisolated func nonisolatedCallingVariousNonisolated(_ x: NonSendableKlass) async {
+  await x.unspecifiedCaller()
+  await x.nonisolatedCaller()
+  await x.nonisolatedNonSendingCaller()
+  await x.concurrentCaller() // expected-enabled-error {{sending 'x' risks causing data races}}
+  // expected-enabled-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'concurrentCaller()' risks causing data races between nonisolated and task-isolated uses}}
+
+  await unspecifiedAsyncUse(x)
+  await nonisolatedAsyncUse(x)
+  await nonisolatedNonSendingAsyncUse(x)
+  await concurrentAsyncUse(x) // expected-enabled-error {{sending 'x' risks causing data races}}
+  // expected-enabled-note @-1 {{sending task-isolated 'x' to nonisolated global function 'concurrentAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+}
+
+nonisolated(nonsending) func nonisolatedNonSendingCallingVariousNonisolated(_ x: NonSendableKlass) async {
+  await x.unspecifiedCaller() // expected-disabled-error {{sending 'x' risks causing data races}}
+  // expected-disabled-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'unspecifiedCaller()' risks causing data races between nonisolated and task-isolated uses}}
+  await x.nonisolatedCaller() // expected-disabled-error {{sending 'x' risks causing data races}}
+  // expected-disabled-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'nonisolatedCaller()' risks causing data races between nonisolated and task-isolated uses}}
+  await x.nonisolatedNonSendingCaller()
+  await x.concurrentCaller() // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated 'x' to nonisolated instance method 'concurrentCaller()' risks causing data races between nonisolated and task-isolated uses}}
+
+  await unspecifiedAsyncUse(x) // expected-disabled-error {{sending 'x' risks causing data races}}
+  // expected-disabled-note @-1 {{sending task-isolated 'x' to nonisolated global function 'unspecifiedAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+  await nonisolatedAsyncUse(x) // expected-disabled-error {{sending 'x' risks causing data races}}
+  // expected-disabled-note @-1 {{sending task-isolated 'x' to nonisolated global function 'nonisolatedAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+  await nonisolatedNonSendingAsyncUse(x)
+  await concurrentAsyncUse(x) // expected-error {{sending 'x' risks causing data races}}
+  // expected-note @-1 {{sending task-isolated 'x' to nonisolated global function 'concurrentAsyncUse' risks causing data races between nonisolated and task-isolated uses}}
+}
+
+@concurrent func concurrentCallingVariousNonisolated(_ x: NonSendableKlass) async {
+  await x.unspecifiedCaller()
+  await x.nonisolatedCaller()
+  await x.nonisolatedNonSendingCaller()
+  await x.concurrentCaller()
+
+  await unspecifiedAsyncUse(x)
+  await nonisolatedAsyncUse(x)
+  await nonisolatedNonSendingAsyncUse(x)
+  await concurrentAsyncUse(x)
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -71,6 +71,7 @@ final class FinalMainActorIsolatedKlass {
 func useInOut<T>(_ x: inout T) {}
 func useValue<T>(_ x: T) {}
 func useValueAsync<T>(_ x: T) async {}
+@concurrent func useValueAsyncConcurrent<T>(_ x: T) async {}
 
 @MainActor func transferToMain<T>(_ t: T) async {}
 
@@ -2101,3 +2102,10 @@ func inferLocationOfCapturedTaskIsolatedSelfCorrectly() {
   }
 }
 
+nonisolated(nonsending) func testCallNonisolatedNonsending(_ x: NonSendableKlass) async {
+  await useValueAsync(x) // expected-tns-ni-warning {{sending 'x' risks causing data races}}
+  // expected-tns-ni-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
+  await useValueAsyncConcurrent(x) // expected-tns-warning {{sending 'x' risks causing data races}}
+  // expected-tns-ni-note @-1 {{sending nonisolated(nonsending) task-isolated 'x' to nonisolated global function 'useValueAsyncConcurrent' risks causing data races between nonisolated and nonisolated(nonsending) task-isolated uses}}
+  // expected-tns-ni-ns-note @-2 {{sending task-isolated 'x' to @concurrent global function 'useValueAsyncConcurrent' risks causing data races between @concurrent and task-isolated uses}}
+}

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-ni- -verify-additional-prefix tns- %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-ni-ns- -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // This run validates that for specific test cases around closures, we properly
 // emit errors in the type checker before we run sns. This ensures that we know that
@@ -8,6 +9,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //
@@ -106,15 +108,15 @@ enum MyEnum<T> {
 extension MyActor {
   func warningIfCallingGetter() async {
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{sending 'self.klass' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-tns-ni-warning @-1 {{sending 'self.klass' risks causing data races}}
+    // expected-tns-ni-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
     await self.finalKlass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{sending 'self.finalKlass' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'self'-isolated 'self.finalKlass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-tns-ni-warning @-1 {{sending 'self.finalKlass' risks causing data races}}
+    // expected-tns-ni-note @-2 {{sending 'self'-isolated 'self.finalKlass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
 
   // We do not warn on this since we warn in the caller of our getter instead.
@@ -127,8 +129,8 @@ extension FinalActor {
   func warningIfCallingAsyncOnFinalField() async {
     // Since our whole class is final, we emit the error directly here.
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-Sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{sending 'self.klass' risks causing data races}}
-    // expected-tns-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-tns-ni-warning @-1 {{sending 'self.klass' risks causing data races}}
+    // expected-tns-ni-note @-2 {{sending 'self'-isolated 'self.klass' to nonisolated instance method 'asyncCall()' risks causing data races between nonisolated and 'self'-isolated uses}}
   }
 }
 
@@ -1572,8 +1574,12 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let a = MainActorIsolatedKlass()
   var c = NonSendableKlass()
   for _ in 0..<1024 {
-    await useValueAsync(c) // expected-tns-warning {{sending 'c' risks causing data races}}
-    // expected-tns-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+    // This works with nonisolated(nonsending) since the first time through the
+    // loop we are disconnected... meaning that we are ok. The second time
+    // through the loop, we are now main actor isolated, but again b/c we
+    // inherit isolation, we are ok.
+    await useValueAsync(c) // expected-tns-ni-warning {{sending 'c' risks causing data races}}
+    // expected-tns-ni-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klass
   }
@@ -1583,8 +1589,8 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let a = MainActorIsolatedKlass()
   var c = NonSendableKlass()
   for _ in 0..<1024 {
-    await useValueAsync(c) // expected-tns-warning {{sending 'c' risks causing data races}}
-    // expected-tns-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+    await useValueAsync(c) // expected-tns-ni-warning {{sending 'c' risks causing data races}}
+    // expected-tns-ni-note @-1 {{sending main actor-isolated 'c' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-Sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klassLet
   }
@@ -1832,8 +1838,8 @@ actor FunctionWithSendableResultAndIsolationActor {
 @MainActor
 func previouslyBrokenTestCase(ns: NonSendableKlass) async -> SendableGenericStruct? {
   return await { () -> SendableGenericStruct? in
-    return await ns.getSendableGenericStructAsync() // expected-tns-warning {{sending 'ns' risks causing data races}}
-    // expected-tns-note @-1 {{sending main actor-isolated 'ns' to nonisolated instance method 'getSendableGenericStructAsync()' risks causing data races between nonisolated and main actor-isolated uses}}
+    return await ns.getSendableGenericStructAsync() // expected-tns-ni-warning {{sending 'ns' risks causing data races}}
+    // expected-tns-ni-note @-1 {{sending main actor-isolated 'ns' to nonisolated instance method 'getSendableGenericStructAsync()' risks causing data races between nonisolated and main actor-isolated uses}}
   }()
 }
 

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -1,7 +1,9 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -verify-additional-prefix ni-
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault -verify-additional-prefix ni-ns-
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
@@ -86,7 +86,8 @@ struct TwoFieldKlassBox {
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
   useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
 }
@@ -94,7 +95,8 @@ func asyncLet_Let_ActorIsolated_Simple1() async {
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
 
   let _ = await y
@@ -104,7 +106,8 @@ func asyncLet_Let_ActorIsolated_Simple2() async {
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}  
 
   // TODO: We shouldn't emit the 2nd error here given the current implementation
   // since it is only accessible along the else path but we already hit
@@ -122,7 +125,8 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   if await booleanFlag {
     useValue(x) // expected-note {{access can happen concurrently}}
@@ -135,7 +139,8 @@ func asyncLet_Let_ActorIsolated_Simple4() async {
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   if await booleanFlag {
     let _ = await y
@@ -150,7 +155,8 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -159,7 +165,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x.field) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -168,7 +175,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
   async let y = transferToMainInt(x.field) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x.field2) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -179,7 +187,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -188,7 +197,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x.k1) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -197,7 +207,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k1) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x.k2) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -206,7 +217,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
   async let y = transferToMainInt(x.k2.field2) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x.k1.field) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -217,7 +229,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -226,7 +239,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x.1) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -235,7 +249,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.0.k1) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x.1.k2) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -244,7 +259,8 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
   async let y = transferToMainInt(x.1.k1.field2) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x.0.k2.field) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -255,9 +271,11 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-warning @-2 {{sending 'x2' risks causing data races}}
-  // expected-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-warning @-3 {{sending 'x2' risks causing data races}}
+  // expected-ni-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-5 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -269,9 +287,11 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-warning @-2 {{sending 'x2' risks causing data races}}
-  // expected-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-warning @-3 {{sending 'x2' risks causing data races}}
+  // expected-ni-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-5 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -284,9 +304,11 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-warning @-2 {{sending 'x2' risks causing data races}}
-  // expected-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-warning @-3 {{sending 'x2' risks causing data races}}
+  // expected-ni-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-5 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   // We only error on the first value captured if multiple values are captured
   // since we track a single partial_apply as a transfer instruction.
@@ -300,8 +322,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x))
   // expected-warning @-1:26 {{sending 'x' risks causing data races}}
-  // expected-note @-2:26 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-note @-3:49 {{access can happen concurrently}}
+  // expected-ni-note @-2:26 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-3:26 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-note @-4:49 {{access can happen concurrently}}
 
   let _ = await y
 }
@@ -313,8 +336,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr5() async {
 
   async let y = useValue(transferToMainInt(x) + transferToCustomInt(x))
   // expected-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-note @-3:49 {{access can happen concurrently}}
+  // expected-ni-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-note @-4:49 {{access can happen concurrently}}
 
   let _ = await y
 }
@@ -325,8 +349,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-note @-2:53 {{access can happen concurrently}}
+  // expected-ni-note @-1 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-note @-3:53 {{access can happen concurrently}}
 
   let _ = await y
   let _ = await z
@@ -349,7 +374,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-warning @-1 {{sending 'x2' risks causing data races}}
-  // expected-note @-2 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-2 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-3 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   useValue(x2) // expected-note {{access can happen concurrently}}
   let _ = await y
@@ -362,9 +388,11 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-warning @-3 {{sending 'x2' risks causing data races}}
-  // expected-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-warning @-4 {{sending 'x2' risks causing data races}}
+  // expected-ni-note @-5 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-6 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   let _ = await y
   let _ = await z
@@ -378,9 +406,11 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-warning @-3 {{sending 'x2' risks causing data races}}
-  // expected-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-warning @-4 {{sending 'x2' risks causing data races}}
+  // expected-ni-note @-5 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-6 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   let _ = await y
   useValue(x) // expected-note {{access can happen concurrently}}
@@ -394,9 +424,11 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
   // expected-warning @-1 {{sending 'x' risks causing data races}}
-  // expected-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
-  // expected-warning @-3 {{sending 'x2' risks causing data races}}
-  // expected-note @-4 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-2 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-3 {{sending 'x' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
+  // expected-warning @-4 {{sending 'x2' risks causing data races}}
+  // expected-ni-note @-5 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-6 {{sending 'x2' to main actor-isolated global function 'transferToMainInt' risks causing data races between main actor-isolated and local @concurrent uses}}
 
   let _ = await y
   useValue(x) // expected-note {{access can happen concurrently}}
@@ -724,7 +756,8 @@ func asyncLetWithoutCapture() async {
   //
   // NOTE: Error below will go away in next commit.
   async let x: NonSendableKlass = await returnValueFromMain()
-  // expected-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'returnValueFromMain()' to nonisolated context}}
+  // expected-ni-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'returnValueFromMain()' to nonisolated context}}
+  // expected-ni-ns-warning @-2 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'returnValueFromMain()' to @concurrent context}}
   let y = await x
   await transferToMain(y) // expected-warning {{sending 'y' risks causing data races}}
   // expected-note @-1 {{sending 'y' to main actor-isolated global function 'transferToMain' risks causing data races between main actor-isolated and local nonisolated uses}}
@@ -736,7 +769,8 @@ func asyncLet_Let_ActorIsolated_Method() async {
   let a = MyActor()
   let x = NonSendableKlass()
   async let y = a.useKlass(x) // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-ni-note @-1 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local nonisolated uses}}
+  // expected-ni-ns-note @-2 {{sending 'x' to actor-isolated instance method 'useKlass' risks causing data races between actor-isolated and local @concurrent uses}}
 
   useValue(x) // expected-note {{access can happen concurrently}}
   let _ = await y

--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -1,8 +1,11 @@
 // RUN: %target-swift-frontend -emit-sil -parse-as-library -target %target-swift-5.1-abi-triple -swift-version 5 -strict-concurrency=complete %s -o - | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -target %target-swift-5.1-abi-triple -swift-version 6 -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -target %target-swift-5.1-abi-triple -swift-version 6 -verify %s -o /dev/null -verify-additional-prefix ni-
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -target %target-swift-5.1-abi-triple -swift-version 5 -strict-concurrency=complete %s -o - -enable-upcoming-feature NonisolatedNonsendingByDefault | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -target %target-swift-5.1-abi-triple -swift-version 6 -verify %s -o /dev/null -enable-upcoming-feature NonisolatedNonsendingByDefault -verify-additional-prefix ni-ns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // This test validates the behavior of transfernonsendable around
 // closure literals
@@ -204,8 +207,8 @@ func test_CallerAsyncNormal_CalleeSyncNonIsolated() async {
 
     // CHECK-LABEL: closure #1 in test_CallerAsyncNormal_CalleeSyncNonIsolated()
     // CHECK-NEXT: Isolation: global_actor. type: CustomActor
-    await asyncNormalAcceptsClosure { } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-    // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' to nonisolated global function 'asyncNormalAcceptsClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
+    await asyncNormalAcceptsClosure { } // expected-ni-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
+    // expected-ni-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() -> ()' to nonisolated global function 'asyncNormalAcceptsClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
 
     // CHECK-LABEL: closure #2 in test_CallerAsyncNormal_CalleeSyncNonIsolated()
     // CHECK-NEXT: Isolation: nonisolated
@@ -244,8 +247,8 @@ func test_CallerAsyncNormal_CalleeAsyncNonIsolated() async {
 
     // CHECK-LABEL: closure #1 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
     // CHECK-NEXT: Isolation: global_actor. type: CustomActor
-    await asyncNormalAcceptsAsyncClosure { } // expected-error {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-    // expected-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
+    await asyncNormalAcceptsAsyncClosure { } // expected-ni-error {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+    // expected-ni-note @-1 {{sending global actor 'CustomActor'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between global actor 'CustomActor'-isolated and nonisolated uses}}
 
     // CHECK-LABEL: closure #2 in test_CallerAsyncNormal_CalleeAsyncNonIsolated()
     // CHECK-NEXT: Isolation: nonisolated
@@ -432,8 +435,8 @@ extension MyActor {
 
         // CHECK-LABEL: closure #1 in MyActor.test_CallerAsyncNormal_CalleeSyncNonIsolated()
         // CHECK-NEXT: Isolation: actor_instance. name: 'self'
-        await asyncNormalAcceptsClosure { print(self) } // expected-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
-        // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() -> ()' to nonisolated global function 'asyncNormalAcceptsClosure' risks causing races in between 'self'-isolated and nonisolated uses}}
+        await asyncNormalAcceptsClosure { print(self) } // expected-ni-error {{sending value of non-Sendable type '() -> ()' risks causing data races}}
+        // expected-ni-note @-1 {{sending 'self'-isolated value of non-Sendable type '() -> ()' to nonisolated global function 'asyncNormalAcceptsClosure' risks causing races in between 'self'-isolated and nonisolated uses}}
 
         // CHECK-LABEL: closure #2 in MyActor.test_CallerAsyncNormal_CalleeSyncNonIsolated()
         // CHECK-NEXT: Isolation: nonisolated
@@ -473,8 +476,8 @@ extension MyActor {
 
         // CHECK-LABEL: closure #1 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
         // CHECK-NEXT: Isolation: actor_instance. name: 'self'
-        await asyncNormalAcceptsAsyncClosure { print(self) } // expected-error {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
-        // expected-note @-1 {{sending 'self'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between 'self'-isolated and nonisolated uses}}
+        await asyncNormalAcceptsAsyncClosure { print(self) } // expected-ni-error {{sending value of non-Sendable type '() async -> ()' risks causing data races}}
+        // expected-ni-note @-1 {{sending 'self'-isolated value of non-Sendable type '() async -> ()' to nonisolated global function 'asyncNormalAcceptsAsyncClosure' risks causing races in between 'self'-isolated and nonisolated uses}}
 
         // CHECK-LABEL: closure #2 in MyActor.test_CallerAsyncNormal_CalleeAsyncNonIsolated()
         // CHECK-NEXT: Isolation: nonisolated

--- a/test/Concurrency/transfernonsendable_functionsubtyping.swift
+++ b/test/Concurrency/transfernonsendable_functionsubtyping.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -swift-version 6
+// RUN: %target-typecheck-verify-swift -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // READ THIS! This file only contains tests that validate that the relevant
 // function subtyping rules for sending work. Please do not put other tests in
@@ -6,6 +7,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_nonsendable.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // READ THIS: This test is testing specifically behavior around global actor
 // isolated types that are nonsendable. This is a bit of a corner case so we use
@@ -6,6 +7,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_global_actor_sending.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_sending.swift
@@ -1,8 +1,12 @@
 // RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library -enable-upcoming-feature NonisolatedNonsendingByDefault
+
 
 // README: Once we loosen the parser so that sending is rejected in Sema
 // instead of the parser, move into the normal
 // transfernonsendable_global_actor.swift
+
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_global_actor_swift6.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_swift6.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -parse-as-library
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix ni- %s -o /dev/null -parse-as-library
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix ni-ns- %s -o /dev/null -parse-as-library -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // README: This is testing specific patterns around global actors that are
 // slightly different in between swift 5 and swift 6. The normal global actor
@@ -6,6 +7,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //
@@ -44,22 +46,22 @@ var booleanFlag: Bool { false }
 
   let erased: () -> Void = closure
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-ni-error {{sending 'erased' risks causing data races}}
+  // expected-ni-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-ni-error {{sending 'erased' risks causing data races}}
+  // expected-ni-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
   let erased: (T) -> Void = useValueMainActor
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-ni-error {{sending 'erased' risks causing data races}}
+  // expected-ni-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedClassMethodError() async {
@@ -70,8 +72,8 @@ var booleanFlag: Bool { false }
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-ni-error {{sending 'erased' risks causing data races}}
+  // expected-ni-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedFinalClassMethodError() async {
@@ -82,6 +84,6 @@ var booleanFlag: Bool { false }
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-error {{sending 'erased' risks causing data races}}
-  // expected-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
+  await useValueAsync(erased) // expected-ni-error {{sending 'erased' risks causing data races}}
+  // expected-ni-note @-1 {{sending main actor-isolated 'erased' to nonisolated global function 'useValueAsync' risks causing data races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -swift-version 6 -verify %s -o /dev/null
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -swift-version 6 -verify %s -o /dev/null -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -swift-version 6 -verify -verify-additional-prefix ni- %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -swift-version 6 -verify -verify-additional-prefix ni-ns- %s -o /dev/null -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -36,7 +36,8 @@ actor ActorWithSynchronousNonIsolatedInit {
     // TODO: This should say actor isolated.
     let _ = { @MainActor in
       print(newK) // expected-error {{sending 'newK' risks causing data races}}
-      // expected-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-ni-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-ni-ns-note @-2 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -1,7 +1,9 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -swift-version 6 -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -swift-version 6 -verify %s -o /dev/null -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // This test validates the behavior of transfernonsendable around initializers.
 

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -1,7 +1,9 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // This test validates how we handle partial applies that are isolated to a
 // specific isolation domain (causing isolation crossings to occur).

--- a/test/Concurrency/transfernonsendable_nonisolated.swift
+++ b/test/Concurrency/transfernonsendable_nonisolated.swift
@@ -1,7 +1,9 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // This test validates behavior of transfernonsendable around nonisolated
 // functions and fields.

--- a/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
+++ b/test/Concurrency/transfernonsendable_nonisolatedunsafe.swift
@@ -1,10 +1,12 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -verify-additional-prefix tns-  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // READ THIS: This test is intended to centralize all tests that use
 // nonisolated(unsafe).
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_objc.swift
+++ b/test/Concurrency/transfernonsendable_objc.swift
@@ -1,8 +1,9 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -target %target-swift-5.1-abi-triple %s -o /dev/null -import-objc-header %S/Inputs/transfernonsendable_objc.h -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -o /dev/null -import-objc-header %S/Inputs/transfernonsendable_objc.h -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple %s -o /dev/null -import-objc-header %S/Inputs/transfernonsendable_objc.h -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: objc_interop
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
-// REQUIRES: swift_feature_RegionBasedIsolation
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 import Foundation
 

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify -enable-upcoming-feature GlobalActorIsolatedTypesUsability %s -o /dev/null -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // This test validates the behavior of transfer non sendable around ownership
 // constructs like non copyable types, consuming/borrowing parameters, and inout
@@ -6,6 +7,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_preconcurrency.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency.swift
@@ -11,9 +11,11 @@
 
 // Test swift 6
 // RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -target %target-swift-5.1-abi-triple -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // README: This test is meant to test the interaction of transfernonsendable and
 // preconcurrency. Please only keep such tests in this file.

--- a/test/Concurrency/transfernonsendable_preconcurrency_sending.swift
+++ b/test/Concurrency/transfernonsendable_preconcurrency_sending.swift
@@ -11,9 +11,11 @@
 
 // Test swift 6
 // RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -swift-version 6 %s -emit-sil -o /dev/null -verify -verify-additional-prefix swift-6- -parse-as-library -I %t -target %target-swift-5.1-abi-triple -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // README: This test is meant to test the interaction of transfernonsendable,
 // preconcurrency, and transferring. Please only keep such tests in this file.

--- a/test/Concurrency/transfernonsendable_rbi_result.swift
+++ b/test/Concurrency/transfernonsendable_rbi_result.swift
@@ -1,7 +1,9 @@
-// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-
+// RUN: %target-swift-frontend -target %target-swift-5.1-abi-triple -swift-version 6 -disable-availability-checking -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix ni-ns- -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ///////////////////////
 // MARK: Declaration //
@@ -20,8 +22,12 @@ struct CustomActor {
 class NonSendable {} // expected-note 3{{}}
 
 func passNonSendable(_: NonSendable) async { }
+func passTwoNonSendable(_: NonSendable, _: NonSendable) async { }
 
 func returnsNonSendable() async -> NonSendable { NonSendable() }
+
+@MainActor
+func sendToMain<T>(_ t: T) async {}
 
 @MainActor
 func mainActorPassNonSendable(_: NonSendable) async { }
@@ -93,9 +99,22 @@ actor A {
   func callNonisolatedFuncsFromActor(ns: NonSendable) async {
     // Non-sendable value passed from nonisolated to actor isolated
 
+    // We do not error in ni-ns since we just merge pass non sendable.
     await passNonSendable(ns)
-    // expected-error @-1 {{sending 'ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'ns' to nonisolated global function 'passNonSendable' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-ni-error @-1 {{sending 'ns' risks causing data races}}
+    // expected-ni-note @-2 {{sending 'self'-isolated 'ns' to nonisolated global function 'passNonSendable' risks causing data races between nonisolated and 'self'-isolated uses}}
+
+    // We error here in both modes but in different places. In NI mode, we error
+    // on passing ns to a nonisolated function. With ni-ns, we do not error
+    // there since we inherit isolation from the caller.
+    //
+    // In contrast, when ni-ns is enabled, we error on sendToMain since we merge
+    // ns2 into ns's region causing it to be self-isolated.
+    let ns2 = NonSendable()
+    await passTwoNonSendable(ns, ns2) // expected-ni-error {{sending 'ns' risks causing data races}}
+    // expected-ni-note @-1 {{sending 'self'-isolated 'ns' to nonisolated global function 'passTwoNonSendable' risks causing data races between nonisolated and 'self'-isolated uses}}
+    await sendToMain(ns2) // expected-ni-ns-error {{sending 'ns2' risks causing data races}}
+    // expected-ni-ns-note @-1 {{sending 'self'-isolated 'ns2' to main actor-isolated global function 'sendToMain' risks causing data races between main actor-isolated and 'self'-isolated uses}}
 
     _ = await returnsNonSendable()
   }

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -1,7 +1,9 @@
 // RUN: %target-swift-frontend  -strict-concurrency=complete -target %target-swift-5.1-abi-triple -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- %s -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend  -strict-concurrency=complete -target %target-swift-5.1-abi-triple -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- %s -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 /*
  This file tests the early features of the flow-sensitive Sendable checking implemented by the TransferNonSendable SIL pass.

--- a/test/Concurrency/transfernonsendable_sending_params.swift
+++ b/test/Concurrency/transfernonsendable_sending_params.swift
@@ -1,7 +1,9 @@
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -target %target-swift-5.1-abi-triple -strict-concurrency=complete -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -target %target-swift-5.1-abi-triple -strict-concurrency=complete -verify -verify-additional-prefix ni- %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -target %target-swift-5.1-abi-triple -strict-concurrency=complete -verify -verify-additional-prefix ni-ns- %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -verify-additional-prefix ni-
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault -verify-additional-prefix ni-ns-
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
@@ -143,7 +143,8 @@ func transferInAndOut(_ x: sending NonSendableKlass) -> sending NonSendableKlass
 
 func transferReturnArg(_ x: NonSendableKlass) -> sending NonSendableKlass {
   return x // expected-warning {{sending 'x' risks causing data races}}
-  // expected-note @-1 {{task-isolated 'x' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+  // expected-ni-note @-1 {{task-isolated 'x' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
+  // expected-ni-ns-note @-2 {{task-isolated 'x' cannot be a 'sending' result. task-isolated uses may race with caller uses}}
 }
 
 // TODO: This will be fixed once I represent @MainActor on func types.
@@ -240,7 +241,8 @@ func asyncLetReabstractionThunkTest() async {
 func asyncLetReabstractionThunkTest2() async {
   // We emit the error here since we are returning a MainActor-isolated value.
   async let newValue: NonSendableKlass = await getMainActorValueAsync()
-  // expected-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'getMainActorValueAsync()' to nonisolated context}}
+  // expected-ni-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'getMainActorValueAsync()' to nonisolated context}}
+  // expected-ni-ns-warning @-2 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'getMainActorValueAsync()' to @concurrent context}}
 
   let _ = await newValue
 
@@ -263,7 +265,8 @@ func asyncLetReabstractionThunkTest2() async {
 @MainActor func asyncLetReabstractionThunkTestGlobalActor2() async {
   // We emit the error here since we are returning a MainActor-isolated value.
   async let newValue: NonSendableKlass = await getMainActorValueAsync()
-  // expected-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'getMainActorValueAsync()' to nonisolated context}}
+  // expected-ni-warning @-1 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'getMainActorValueAsync()' to nonisolated context}}
+  // expected-ni-ns-warning @-2 {{non-Sendable 'NonSendableKlass'-typed result can not be returned from main actor-isolated global function 'getMainActorValueAsync()' to @concurrent context}}
 
   let _ = await newValue
 

--- a/test/Concurrency/transfernonsendable_sending_results.swift
+++ b/test/Concurrency/transfernonsendable_sending_results.swift
@@ -1,7 +1,9 @@
 // RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 ////////////////////////
 // MARK: Declarations //

--- a/test/Concurrency/transfernonsendable_typed_errors.swift
+++ b/test/Concurrency/transfernonsendable_typed_errors.swift
@@ -1,7 +1,9 @@
 // RUN: %target-swift-frontend -swift-version 6 -Xllvm -sil-regionbasedisolation-force-use-of-typed-errors -emit-sil -o /dev/null %s -verify -target %target-swift-5.1-abi-triple
+// RUN: %target-swift-frontend -swift-version 6 -Xllvm -sil-regionbasedisolation-force-use-of-typed-errors -emit-sil -o /dev/null %s -verify -target %target-swift-5.1-abi-triple -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // READ THIS: This test is only intended to test typed errors that are fallback
 // error paths that are only invoked if we can't find a name for the value being

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -1,8 +1,9 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -target %target-swift-5.1-abi-triple -verify  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify  %s -o /dev/null -enable-upcoming-feature GlobalActorIsolatedTypesUsability -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
 // REQUIRES: swift_feature_GlobalActorIsolatedTypesUsability
-// REQUIRES: swift_feature_RegionBasedIsolation
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // This test makes sure that we treat types with an unavailable Sendable
 // conformance as being non-Sendable.

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -swift-version 6
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -target %target-swift-5.1-abi-triple -verify %s -o /dev/null -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault
 
 // REQUIRES: concurrency
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
 // This test makes sure that all of our warnings are errors in swift6 mode.
 

--- a/test/Serialization/caller_isolation_inherit.swift
+++ b/test/Serialization/caller_isolation_inherit.swift
@@ -32,7 +32,7 @@ actor A {
   func test1a() async {
     await WithFeature.unspecifiedAsyncConcurrent(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'unspecifiedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent global function 'unspecifiedAsyncConcurrent' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // unspecifiedAsyncCaller<A>(_:)
@@ -48,7 +48,7 @@ actor A {
   func test2() async {
     await WithoutFeature.unspecifiedAsync(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'unspecifiedAsync' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent global function 'unspecifiedAsync' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // unspecifiedAsyncConcurrent<A>(_:)
@@ -59,7 +59,7 @@ actor A {
     // an error.
     await WithoutFeature.unspecifiedAsyncConcurrent(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'unspecifiedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent global function 'unspecifiedAsyncConcurrent' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // unspecifiedAsyncCaller<A>(_:)
@@ -82,7 +82,7 @@ actor A {
   func test3a() async {
     await WithFeature.nonisolatedAsyncConcurrent(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'nonisolatedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent global function 'nonisolatedAsyncConcurrent' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // nonisolatedAsyncCaller<A>(_:)
@@ -98,7 +98,7 @@ actor A {
   func test4() async {
     await WithoutFeature.nonisolatedAsync(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'nonisolatedAsync' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent global function 'nonisolatedAsync' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // nonisolatedAsyncConcurrent<A>(_:)
@@ -107,7 +107,7 @@ actor A {
   func test4a() async {
     await WithoutFeature.nonisolatedAsyncConcurrent(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated global function 'nonisolatedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent global function 'nonisolatedAsyncConcurrent' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // nonisolatedAsyncCaller<A>(_:)
@@ -132,7 +132,7 @@ actor A {
     let s = WithFeature.S()
     await s.unspecifiedAsyncConcurrent(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'unspecifiedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent instance method 'unspecifiedAsyncConcurrent' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // S.unspecifiedAsyncCaller<A>(_:)
@@ -158,7 +158,7 @@ actor A {
     let s = WithFeature.S()
     await s.nonisolatedAsyncConcurrent(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'nonisolatedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent instance method 'nonisolatedAsyncConcurrent' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // S.nonisolatedAsyncCaller<A>(_:)
@@ -176,7 +176,7 @@ actor A {
     let s = WithoutFeature.S()
     await s.unspecifiedAsync(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'unspecifiedAsync' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent instance method 'unspecifiedAsync' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // S.unspecifiedAsyncConcurrent<A>(_:)
@@ -186,7 +186,7 @@ actor A {
     let s = WithoutFeature.S()
     await s.unspecifiedAsyncConcurrent(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'unspecifiedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent instance method 'unspecifiedAsyncConcurrent' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // S.unspecifiedAsyncCaller<A>(_:)
@@ -204,7 +204,7 @@ actor A {
     let s = WithoutFeature.S()
     await s.nonisolatedAsync(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'nonisolatedAsync' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent instance method 'nonisolatedAsync' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // S.nonisolatedAsyncConcurrent<A>(_:)
@@ -214,7 +214,7 @@ actor A {
     let s = WithoutFeature.S()
     await s.nonisolatedAsyncConcurrent(ns)
     // expected-error @-1 {{sending 'self.ns' risks causing data races}}
-    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to nonisolated instance method 'nonisolatedAsyncConcurrent' risks causing data races between nonisolated and 'self'-isolated uses}}
+    // expected-note @-2 {{sending 'self'-isolated 'self.ns' to @concurrent instance method 'nonisolatedAsyncConcurrent' risks causing data races between @concurrent and 'self'-isolated uses}}
   }
 
   // CHECK-LABEL: // S.nonisolatedAsyncCaller<A>(_:)


### PR DESCRIPTION
We were effectively working around this previously at the SIL level. This caused
us not to obey the semantics of the actual evolution proposal. As an example of
this, in the following, x should not be considered main actor isolated:

```swift
nonisolated(nonsending) func useValue<T>(_ t: T) async {}
@MainActor func test() async {
  let x = NS()
  await useValue(x)
  print(x)
}
```

we should just consider this to be a merge and since useValue does not have any
MainActor isolated parameters, x should not be main actor isolated and we should
not emit an error here.

I also fixed a separate issue where we were allowing for parameters of
nonisolated(nonsending) functions to be passed to `@concurrent` functions. We
cannot allow for this to happen since the nonisolated(nonsending) parameters
/could/ be actor isolated. Of course, we have lost that static information at
this point so we cannot allow for it. Given that we have the actual dynamic
actor isolation information, we could dynamically allow for the parameters to be
passed... but that is something that is speculative and is definitely outside of
the scope of this patch.

rdar://154139237

