### PR TITLE
[Caching] Move per-query CAS state out of the SwiftDependencyScanningService

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -24,8 +24,6 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/SourceLoc.h"
-#include "clang/Basic/FileManager.h"
-#include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -38,11 +36,8 @@ class FileCollectorBase;
 class PrefixMapper;
 namespace vfs {
 class OutputBackend;
-}
-namespace cas {
-class CachingOnDiskFileSystem;
-}
-}
+} // namespace vfs
+} // namespace llvm
 
 namespace clang {
 class DependencyCollector;

--- a/include/swift/DependencyScan/ScanDependencies.h
+++ b/include/swift/DependencyScan/ScanDependencies.h
@@ -22,6 +22,9 @@
 
 namespace llvm {
 class StringSaver;
+namespace cas {
+class ObjectStore;
+} // namespace cas
 namespace vfs {
 class FileSystem;
 } // namespace vfs
@@ -77,8 +80,8 @@ namespace incremental {
 /// than the serialized dependency graph, it is considered invalidated and must
 /// be re-scanned.
 void validateInterModuleDependenciesCache(
-    const SwiftDependencyScanningService &service,
     const ModuleDependencyID &rootModuleID, ModuleDependenciesCache &cache,
+    std::shared_ptr<llvm::cas::ObjectStore> cas,
     const llvm::sys::TimePoint<> &cacheTimeStamp, llvm::vfs::FileSystem &fs,
     DiagnosticEngine &diags, bool emitRemarks = false);
 
@@ -86,9 +89,9 @@ void validateInterModuleDependenciesCache(
 /// with respect to their inputs. Upon encountering such a module, add it to the
 /// set of invalidated modules, along with the path from the root to this
 /// module.
-void outOfDateModuleScan(const SwiftDependencyScanningService &service,
-                         const ModuleDependencyID &sourceModuleID,
+void outOfDateModuleScan(const ModuleDependencyID &sourceModuleID,
                          const ModuleDependenciesCache &cache,
+                         std::shared_ptr<llvm::cas::ObjectStore> cas,
                          const llvm::sys::TimePoint<> &cacheTimeStamp,
                          llvm::vfs::FileSystem &fs, DiagnosticEngine &diags,
                          bool emitRemarks, ModuleDependencyIDSet &visited,
@@ -97,8 +100,8 @@ void outOfDateModuleScan(const SwiftDependencyScanningService &service,
 /// Validate whether all inputs of a given module dependency
 /// are older than the cache serialization time.
 bool verifyModuleDependencyUpToDate(
-    const SwiftDependencyScanningService &service,
     const ModuleDependencyID &moduleID, const ModuleDependenciesCache &cache,
+    std::shared_ptr<llvm::cas::ObjectStore> cas,
     const llvm::sys::TimePoint<> &cacheTimeStamp, llvm::vfs::FileSystem &fs,
     DiagnosticEngine &diags, bool emitRemarks);
 } // end namespace incremental

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -465,7 +465,7 @@ bool CompilerInstance::setupCASIfNeeded(ArrayRef<const char *> Args) {
     return false;
 
   const auto &Opts = getInvocation().getCASOptions();
-  auto MaybeDB= Opts.CASOpts.getOrCreateDatabases();
+  auto MaybeDB = Opts.CASOpts.getOrCreateDatabases();
   if (!MaybeDB) {
     Diagnostics.diagnose(SourceLoc(), diag::error_cas_initialization,
                          toString(MaybeDB.takeError()));

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -31,8 +31,6 @@
 #include "swift/Subsystems.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/SetOperations.h"
-#include "llvm/CAS/CachingOnDiskFileSystem.h"
-#include "llvm/Support/Error.h"
 #include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Threading.h"
 #include "llvm/Support/VirtualFileSystem.h"


### PR DESCRIPTION
Move per-query state out of ScanningService. There is still a check to make sure the CASOptions are matching between queries because of the requirement on clang scanner. Otherwise, the scanning service should contain no per-query information anymore.

Resolves: https://github.com/swiftlang/swift/issues/82490

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
