### PR TITLE
[Concurrency][docs] More docs about task groups being structured concurrency

### DIFF
--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -22,7 +22,7 @@ import Swift
 /// best applied in situations where the result of a child task is some form
 /// of side-effect.
 ///
-/// A group waits for all of its child tasks
+/// A group *always* waits for all of its child tasks
 /// to complete before it returns. Even cancelled tasks must run until
 /// completion before this function returns.
 /// Cancelled child tasks cooperatively react to cancellation and attempt
@@ -40,6 +40,8 @@ import Swift
 /// }
 /// // guaranteed that slow-task has completed and the group is empty & destroyed
 /// ```
+///
+/// Refer to ``TaskGroup`` documentation for detailed discussion of semantics shared between all task groups.
 ///
 /// Task Group Cancellation
 /// =======================
@@ -65,6 +67,7 @@ import Swift
 /// For tasks that need to handle cancellation by throwing an error,
 /// use the `withThrowingDiscardingTaskGroup(returning:body:)` method instead.
 ///
+/// - SeeAlso: ``TaskGroup``
 /// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:body:)``
 @available(SwiftStdlib 5.9, *)
 #if !hasFeature(Embedded)
@@ -131,9 +134,7 @@ public func _unsafeInheritExecutor_withDiscardingTaskGroup<GroupResult>(
 /// and mutation operations can't be performed
 /// from a concurrent execution context like a child task.
 ///
-/// ### Task execution order
-/// Tasks added to a task group execute concurrently, and may be scheduled in
-/// any order.
+/// Refer to ``TaskGroup`` documentation for detailed discussion of semantics shared between all task groups.
 ///
 /// ### Discarding behavior
 /// A discarding task group eagerly discards and releases its child tasks as
@@ -245,7 +246,7 @@ extension DiscardingTaskGroup: Sendable { }
 /// best applied in situations where the result of a child task is some form
 /// of side-effect.
 ///
-/// A group waits for all of its child tasks
+/// A group *always* waits for all of its child tasks
 /// to complete before it returns. Even cancelled tasks must run until
 /// completion before this function returns.
 /// Cancelled child tasks cooperatively react to cancellation and attempt
@@ -263,6 +264,8 @@ extension DiscardingTaskGroup: Sendable { }
 /// }
 /// // guaranteed that slow-task has completed and the group is empty & destroyed
 /// ```
+///
+/// Refer to ``TaskGroup`` documentation for detailed discussion of semantics shared between all task groups.
 ///
 /// Task Group Cancellation
 /// =======================
@@ -411,9 +414,7 @@ public func _unsafeInheritExecutor_withThrowingDiscardingTaskGroup<GroupResult>(
 /// and mutation operations can't be performed
 /// from a concurrent execution context like a child task.
 ///
-/// ### Task execution order
-/// Tasks added to a task group execute concurrently, and may be scheduled in
-/// any order.
+/// Refer to ``TaskGroup`` documentation for detailed discussion of semantics shared between all task groups.
 ///
 /// ### Discarding behavior
 /// A discarding task group eagerly discards and releases its child tasks as

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -23,7 +23,7 @@ import Swift
 /// of side-effect.
 ///
 /// A group *always* waits for all of its child tasks
-/// to complete before it returns. Even cancelled tasks must run until
+/// to complete before it returns. Even canceled tasks must run until
 /// completion before this function returns.
 /// Cancelled child tasks cooperatively react to cancellation and attempt
 /// to return as early as possible.
@@ -143,18 +143,18 @@ public func _unsafeInheritExecutor_withDiscardingTaskGroup<GroupResult>(
 /// be the case with a ``TaskGroup``.
 ///
 /// ### Cancellation behavior
-/// A discarding task group becomes cancelled in one of the following ways:
+/// A discarding task group becomes canceled in one of the following ways:
 ///
 /// - when ``cancelAll()`` is invoked on it,
-/// - when the ``Task`` running this task group is cancelled.
+/// - when the ``Task`` running this task group is canceled.
 ///
 /// Since a `DiscardingTaskGroup` is a structured concurrency primitive, cancellation is
 /// automatically propagated through all of its child-tasks (and their child
 /// tasks).
 ///
-/// A cancelled task group can still keep adding tasks, however they will start
-/// being immediately cancelled, and may act accordingly to this. To avoid adding
-/// new tasks to an already cancelled task group, use ``addTaskUnlessCancelled(priority:body:)``
+/// A canceled task group can still keep adding tasks, however they will start
+/// being immediately canceled, and may act accordingly to this. To avoid adding
+/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:body:)``
 /// rather than the plain ``addTask(priority:body:)`` which adds tasks unconditionally.
 ///
 /// For information about the language-level concurrency model that `DiscardingTaskGroup` is part of,
@@ -205,7 +205,7 @@ public struct DiscardingTaskGroup {
   /// If you add a task to a group after canceling the group,
   /// that task is canceled immediately after being added to the group.
   ///
-  /// Immediately cancelled child tasks should therefore cooperatively check for and
+  /// Immediately  canceled  child tasks should therefore cooperatively check for and
   /// react  to cancellation, e.g. by throwing an `CancellationError` at their
   /// earliest convenience, or otherwise handling the cancellation.
   ///
@@ -247,9 +247,9 @@ extension DiscardingTaskGroup: Sendable { }
 /// of side-effect.
 ///
 /// A group *always* waits for all of its child tasks
-/// to complete before it returns. Even cancelled tasks must run until
+/// to complete before it returns. Even canceled tasks must run until
 /// completion before this function returns.
-/// Cancelled child tasks cooperatively react to cancellation and attempt
+/// Canceled child tasks cooperatively react to cancellation and attempt
 /// to return as early as possible.
 /// After this function returns, the task group is always empty.
 ///
@@ -423,20 +423,20 @@ public func _unsafeInheritExecutor_withThrowingDiscardingTaskGroup<GroupResult>(
 /// be the case with a ``TaskGroup``.
 ///
 /// ### Cancellation behavior
-/// A throwing discarding task group becomes cancelled in one of the following ways:
+/// A throwing discarding task group becomes canceled in one of the following ways:
 ///
 /// - when ``cancelAll()`` is invoked on it,
 /// - when an error is thrown out of the `withThrowingDiscardingTaskGroup { ... }` closure,
-/// - when the ``Task`` running this task group is cancelled.
+/// - when the ``Task`` running this task group is  canceled .
 ///
 /// But also, and uniquely in *discarding* task groups:
 /// - when *any* of its child tasks throws.
 ///
-/// The group becoming cancelled automatically, and cancelling all of its child tasks,
+/// The group becoming canceled automatically, and cancelling all of its child tasks,
 /// whenever *any* child task throws an error is a behavior unique to discarding task groups,
 /// because achieving such semantics is not possible otherwise, due to the missing `next()` method
 /// on discarding groups. Accumulating task groups can implement this by manually polling `next()`
-/// and deciding to `cancelAll()` when they decide an error should cause the group to become cancelled,
+/// and deciding to `cancelAll()` when they decide an error should cause the group to become  canceled,
 /// however a discarding group cannot poll child tasks for results and therefore assumes that child
 /// task throws are an indication of a group wide failure. In order to avoid such behavior,
 /// use a ``DiscardingTaskGroup`` instead of a throwing one, or catch specific errors in
@@ -446,9 +446,9 @@ public func _unsafeInheritExecutor_withThrowingDiscardingTaskGroup<GroupResult>(
 /// automatically propagated through all of its child-tasks (and their child
 /// tasks).
 ///
-/// A cancelled task group can still keep adding tasks, however they will start
-/// being immediately cancelled, and may act accordingly to this. To avoid adding
-/// new tasks to an already cancelled task group, use ``addTaskUnlessCancelled(priority:body:)``
+/// A canceled task group can still keep adding tasks, however they will start
+/// being immediately  canceled, and may act accordingly to this. To avoid adding
+/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:body:)``
 /// rather than the plain ``addTask(priority:body:)`` which adds tasks unconditionally.
 ///
 /// For information about the language-level concurrency model that `DiscardingTaskGroup` is part of,
@@ -497,7 +497,7 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
   /// If you add a task to a group after canceling the group,
   /// that task is canceled immediately after being added to the group.
   ///
-  /// Immediately cancelled child tasks should therefore cooperatively check for and
+  /// Immediately canceled child tasks should therefore cooperatively check for and
   /// react  to cancellation, e.g. by throwing an `CancellationError` at their
   /// earliest convenience, or otherwise handling the cancellation.
   ///

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -110,9 +110,9 @@ public func _unsafeInheritExecutor_withTaskGroup<ChildTaskResult, GroupResult>(
 /// Starts a new scope that can contain a dynamic number of throwing child tasks.
 ///
 /// A group *always* waits for all of its child tasks
-/// to complete before it returns. Even cancelled tasks must run until
+/// to complete before it returns. Even canceled tasks must run until
 /// completion before this function returns.
-/// Cancelled child tasks cooperatively react to cancellation and attempt
+/// Canceled child tasks cooperatively react to cancellation and attempt
 /// to return as early as possible.
 /// After this function returns, the task group is always empty.
 ///
@@ -335,7 +335,7 @@ public func _unsafeInheritExecutor_withThrowingTaskGroup<ChildTaskResult, GroupR
 /// any order.
 ///
 /// ### Cancellation behavior
-/// A task group becomes cancelled in one of the following ways:
+/// A task group becomes canceled in one of the following ways:
 ///
 /// - when ``cancelAll()`` is invoked on it,
 /// - when the ``Task`` running this task group is cancelled.
@@ -344,9 +344,9 @@ public func _unsafeInheritExecutor_withThrowingTaskGroup<ChildTaskResult, GroupR
 /// automatically propagated through all of its child-tasks (and their child
 /// tasks).
 ///
-/// A cancelled task group can still keep adding tasks, however they will start
+/// A canceled task group can still keep adding tasks, however they will start
 /// being immediately cancelled, and may act accordingly to this. To avoid adding
-/// new tasks to an already cancelled task group, use ``addTaskUnlessCancelled(name:priority:body:)``
+/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(name:priority:body:)``
 /// rather than the plain ``addTask(name:priority:body:)`` which adds tasks unconditionally.
 ///
 /// For information about the language-level concurrency model that `TaskGroup` is part of,
@@ -478,7 +478,7 @@ public struct TaskGroup<ChildTaskResult: Sendable> {
   /// If you add a task to a group after canceling the group,
   /// that task is canceled immediately after being added to the group.
   ///
-  /// Immediately cancelled child tasks should therefore cooperatively check for and
+  /// Immediately canceled child tasks should therefore cooperatively check for and
   /// react  to cancellation, e.g. by throwing an `CancellationError` at their
   /// earliest convenience, or otherwise handling the cancellation.
   ///
@@ -543,7 +543,7 @@ extension TaskGroup: Sendable { }
 /// Refer to ``TaskGroup`` documentation for detailed discussion of semantics shared between all task groups.
 ///
 /// ### Cancellation behavior
-/// A task group becomes cancelled in one of the following ways:
+/// A task group becomes canceled in one of the following ways:
 ///
 /// - when ``cancelAll()`` is invoked on it,
 /// - when an error is thrown out of the `withThrowingTaskGroup(...) { }` closure,
@@ -553,9 +553,9 @@ extension TaskGroup: Sendable { }
 /// automatically propagated through all of its child-tasks (and their child
 /// tasks).
 ///
-/// A cancelled task group can still keep adding tasks, however they will start
+/// A canceled task group can still keep adding tasks, however they will start
 /// being immediately cancelled, and may act accordingly to this. To avoid adding
-/// new tasks to an already cancelled task group, use ``addTaskUnlessCancelled(priority:body:)``
+/// new tasks to an already canceled task group, use ``addTaskUnlessCancelled(priority:body:)``
 /// rather than the plain ``addTask(priority:body:)`` which adds tasks unconditionally.
 ///
 /// For information about the language-level concurrency model that `ThrowingTaskGroup` is part of,
@@ -804,7 +804,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// If you add a task to a group after canceling the group,
   /// that task is canceled immediately after being added to the group.
   ///
-  /// Immediately cancelled child tasks should therefore cooperatively check for and
+  /// Immediately canceled child tasks should therefore cooperatively check for and
   /// react  to cancellation, e.g. by throwing an `CancellationError` at their
   /// earliest convenience, or otherwise handling the cancellation.
   ///

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -272,13 +272,16 @@ public func _unsafeInheritExecutor_withThrowingTaskGroup<ChildTaskResult, GroupR
 /// A child task will inherit the parent's priority, task-local values, and will be structured in the sense that its
 /// lifetime will never exceed the lifetime of the parent task.
 ///
-/// A task group will *always* wait for all child tasks to complete before it is destroyed.
-/// Specifically any `with...TaskGroup` APIs, will not return until all the child tasks
+/// A child task inherits the parent's priority, task-local values, and will be structured in the sense that its
+/// lifetime never exceeds the lifetime of the parent task.
+///
+/// A task group *always* waits for all child tasks to complete before it's destroyed.
+/// Specifically, `with...TaskGroup` APIs don't return until all the child tasks
 /// created in the group's scope have completed running.
 ///
 /// Structured concurrency is a way to organize your program, and tasks, in such a way that
-/// tasks do not outlive the scope in which they are created. Within a structured task hierarchy,
-/// no child task will remain running longer than its parent task. This simplifies reasoning about resource usage,
+/// tasks don't outlive the scope in which they are created. Within a structured task hierarchy,
+/// no child task will remains running longer than its parent task. This simplifies reasoning about resource usage,
 /// and is a powerful mechanism that you can use to write well-behaved concurrent programs.
 ///
 /// Structured Concurrency APIs (including task groups and `async let`), will *always* await the
@@ -296,14 +299,15 @@ public func _unsafeInheritExecutor_withThrowingTaskGroup<ChildTaskResult, GroupR
 ///         } // the group will ALWAYS await the completion of all the actions (!)
 ///     }
 ///
-/// In the above example, even though we return the first collected integer from all actions added to the task group,
-/// the task group will *always*, automatically, await for the completion of all the resulting tasks.
+/// In the above example, even though the code returns the first collected integer from all actions added to the task group,
+/// the task group will *always*, automatically, waits for the completion of all the resulting tasks.
 ///
-/// You may use `group.cancelAll()` to signal cancellation to all the remaining in-progress tasks,
-/// however this will not interrupt their execution automatically, as the child tasks will need to cooperatively
-/// react to the cancellation, and potentially return early (if able to).
+/// You can use `group.cancelAll()` to signal cancellation to the remaining in-progress tasks,
+/// however this doesn't interrupt their execution automatically.
+/// Rather, the child tasks need to cooperatively react to the cancellation,
+/// and return early if that's possible.
 ///
-/// In order to create un-structured concurrency tasks, you can use ``Task.init``, ``Task.detached`` or ``Task.immediate``.
+/// To create unstructured concurrency tasks, you can use ``Task.init``, ``Task.detached`` or ``Task.immediate``.
 ///
 /// Task Group Cancellation
 /// =======================

--- a/utils/swift_snapshot_tool/Package.resolved
+++ b/utils/swift_snapshot_tool/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "80ba966d30db4d84324c2bda4f2b419b9e6fe208fa1f70080f74c7aa3d432a49",
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
And correct an incorrect statement specifically in the withTaskGroup API, while other APIs already had correct versions of the statement.

refs https://github.com/swiftlang/swift/issues/82396
resolves rdar://154000871

Would you mind having an editorial look @amartini51 ?