### PR TITLE
[6.2] ClosureSpecializer: don't specialize captures of stack-allocated Objective-C blocks

### DIFF
--- a/test/SILOptimizer/closure_specialize_block.swift
+++ b/test/SILOptimizer/closure_specialize_block.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature CopyBlockOptimization -O %s -emit-sil | %FileCheck %s
+
+// REQUIRES: swift_feature_CopyBlockOptimization
+
+func callClosure<R>(_ body: () -> R) -> R {
+  return body()
+}
+
+// Check that after removing a copy_block, no retains+releases are inserted for the block.
+// CHECK-LABEL: sil {{.*}}@testit :
+// CHECK-NOT:     retain
+// CHECK-NOT:     release
+// CHECK:       } // end sil function 'testit'
+@_cdecl("testit")
+public func testit(_ block: (_ index: Int) -> Int) -> Bool {
+  @inline(never)
+  func c() -> Bool {
+	  return block(0) != 0
+  }
+
+	return callClosure(c)
+}


### PR DESCRIPTION
* **Explanation**: This is a problem in the ClosureSpecializer pass which is triggered by https://github.com/swiftlang/swift/pull/81328. The ClosureSpecializer inserted retains+releases for stack-allocated Objective-C blocks. The fix is to bail if the closure captures an ObjectiveC block which might _not_ be copied onto the heap, i.e optimized by SimplifyCopyBlock.
* **Risk**: Low. It's a small change which makes CapturePropagation more conservative. It only affects ObjectiveC blocks.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://154241245
* **Reviewer**:  @aschwaighofer
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/82537
