### PR TITLE
🍒 [demangling] add new wrapper API

### DIFF
--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -281,6 +281,11 @@ std::string demangleSymbolAsString(const char *MangledName,
                                     Options);
 }
 
+void demangleSymbolAsString(StringRef MangledName, NodePrinter &Printer) {
+  Context Ctx;
+  return Ctx.demangleSymbolAsString(MangledName, Printer);
+}
+
 std::string demangleTypeAsString(const char *MangledName,
                                  size_t MangledNameLength,
                                  const DemangleOptions &Options) {


### PR DESCRIPTION
- **Explanation**:
Add a new wrapper API for `Context::demangleSymbolAsString`, avoiding to manually instantiate a `Context` object to use the method.
- **Scope**:
This change only adds a wrapper to an existing API, in the demangler.
- **Issues**:

- **Original PRs**:
  - https://github.com/swiftlang/swift/pull/82527
- **Risk**:
Low, the logic of the wrapper is simple.
- **Testing**:
Built against the LLVM patches which add demangling syntax highlighting.
- **Reviewers**:
  - @adrian-prantl