### PR TITLE
[Concurrency] Prevent negative sleeps from sleeping forever.

### DIFF
--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -333,7 +333,9 @@ void swift_dispatchEnqueueWithDeadline(bool global,
   }
 
   uint64_t deadline;
-  if (__builtin_mul_overflow(sec, NSEC_PER_SEC, &deadline)
+  if (sec < 0 || sec == 0 && nsec < 0)
+    deadline = 0;
+  else if (__builtin_mul_overflow(sec, NSEC_PER_SEC, &deadline)
       || __builtin_add_overflow(nsec, deadline, &deadline)) {
     deadline = UINT64_MAX;
   }
@@ -342,8 +344,10 @@ void swift_dispatchEnqueueWithDeadline(bool global,
 
   if (tnsec != -1) {
     uint64_t leeway;
-    if (__builtin_mul_overflow(tsec, NSEC_PER_SEC, &leeway)
-        || __builtin_add_overflow(tnsec, leeway, &leeway)) {
+    if (tsec < 0 || tsec == 0 && tnsec < 0)
+      leeway = 0;
+    else if (__builtin_mul_overflow(tsec, NSEC_PER_SEC, &leeway)
+             || __builtin_add_overflow(tnsec, leeway, &leeway)) {
       leeway = UINT64_MAX;
     }
 


### PR DESCRIPTION
Requests to sleep until a negative timestamp would result in sleeping until `UINT64_MAX` nanoseconds from the start of the relevant clock, which is about 585 years.

rdar://154346018
