### PR TITLE
[6.2] MandatoryPerformanceOptimization: don't recursive into referenced functions if they are not called

### DIFF
--- a/test/SILOptimizer/mandatory_perfopt_multimodule.swift
+++ b/test/SILOptimizer/mandatory_perfopt_multimodule.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -parse-as-library -enable-library-evolution %t/module.swift -emit-module-path=%t/Module.swiftmodule -module-name=Module
+// RUN: %target-swift-frontend -emit-sil -o /dev/null -parse-as-library %t/main.swift -I%t -enable-experimental-feature SymbolLinkageMarkers
+
+// REQUIRES: swift_feature_SymbolLinkageMarkers
+
+// Check that this compiles successfully
+
+//--- module.swift
+
+public struct X: ~Copyable {
+  public init() {}
+  deinit {
+    print("deinit")
+  }
+}
+
+//--- main.swift
+
+import Module
+
+@_section("__TEXT,__mysection")
+var g: () -> () = { _ = X() }

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -215,7 +215,7 @@ bb0(%0 : $Int, %1 : @owned $Builtin.NativeObject):
   return %8 : $Builtin.NativeObject
 }
 
-// CHECK-LABEL: sil [signature_optimized_thunk] [perf_constraint] [ossa] @metatype_arg :
+// CHECK-LABEL: sil [signature_optimized_thunk] [ossa] @metatype_arg :
 sil [ossa] @metatype_arg : $@convention(thin) (Int, @thick Int.Type, @owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : $Int, %1 : $@thick Int.Type, %2 : @owned $Builtin.NativeObject):
   fix_lifetime %1 : $@thick Int.Type
@@ -243,7 +243,7 @@ bb2(%13 : @owned $any Error):
   throw %13 : $any Error
 }
 
-// CHECK-LABEL: sil [signature_optimized_thunk] [perf_constraint] [ossa] @metatype_arg_throws :
+// CHECK-LABEL: sil [signature_optimized_thunk] [ossa] @metatype_arg_throws :
 sil [ossa] @metatype_arg_throws : $@convention(thin) (Int, @thick Int.Type, @owned Builtin.NativeObject) -> (@owned Builtin.NativeObject, @error any Error) {
 bb0(%0 : $Int, %1 : $@thick Int.Type, %2 : @owned $Builtin.NativeObject):
   fix_lifetime %1 : $@thick Int.Type


### PR DESCRIPTION
* **Explanation**: Fixes a false compiler error when referencing a function from a global with a section attribute. This pattern occurs in swift-testing.
* **Risk**: Low. It's a small change which only affects performance annotated functions or globals which are annotated with section attributes.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://154332540
* **Reviewer**:  @kubamracek (todo)
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/82561







