### PR TITLE
[IDE] Avoid macro expansions in `getEquivalentDeclContextFromSourceFile`

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -116,7 +116,7 @@ bool IDEInspectionSecondPassRequest::evaluate(
     IDEInspectionCallbacksFactory *Factory) const {
   // If we didn't find the code completion token, bail.
   auto *parserState = SF->getDelayedParserState();
-  if (!parserState->hasIDEInspectionDelayedDeclState())
+  if (!parserState || !parserState->hasIDEInspectionDelayedDeclState())
     return true;
 
   // Decrement the closure discriminator index by one so a top-level closure


### PR DESCRIPTION
Unfortunately haven't been able to come up with a test case for this, but there seem to be cases where we're incorrectly picking up a macro-expanded accessor from the cached AST when searching for the original decl. Make sure we only consider decls that have been written by the user.

rdar://151926231