### PR TITLE
Initial attempt to make `build-script` products `async`

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/benchmarks.py
+++ b/utils/swift_build_support/swift_build_support/products/benchmarks.py
@@ -44,7 +44,7 @@ class Benchmarks(product.Product):
     def should_build(self, host_target):
         return True
 
-    def build(self, host_target):
+    async def build(self, host_target):
         run_build_script_helper(host_target, self, self.args)
 
     def should_test(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -44,7 +44,7 @@ class CMark(cmake_product.CMakeProduct):
         """
         return self.args.build_cmark
 
-    def build(self, host_target):
+    async def build(self, host_target):
         """build() -> void
 
         Perform the build, for a non-build-script-impl product.

--- a/utils/swift_build_support/swift_build_support/products/curl.py
+++ b/utils/swift_build_support/swift_build_support/products/curl.py
@@ -77,7 +77,7 @@ class LibCurl(cmake_product.CMakeProduct):
         path = self.host_install_destdir(host_target)
         self.install_with_cmake(['install'], path)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self.cmake_options.define('BUILD_SHARED_LIBS', 'NO')
         self.cmake_options.define('CMAKE_POSITION_INDEPENDENT_CODE', 'YES')
 

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
@@ -65,7 +65,7 @@ class EarlySwiftDriver(product.Product):
     def clean(self, host_target):
         run_build_script_helper('clean', host_target, self, self.args)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         run_build_script_helper('build', host_target, self, self.args)
 
     def should_test(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/indexstoredb.py
+++ b/utils/swift_build_support/swift_build_support/products/indexstoredb.py
@@ -48,7 +48,7 @@ class IndexStoreDB(product.Product):
     def should_build(self, host_target):
         return True
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self.run_build_script_helper('build', host_target)
 
     def should_test(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/libxml2.py
+++ b/utils/swift_build_support/swift_build_support/products/libxml2.py
@@ -68,7 +68,7 @@ class LibXML2(cmake_product.CMakeProduct):
         path = self.host_install_destdir(host_target)
         self.install_with_cmake(['install'], path)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self.cmake_options.define('BUILD_SHARED_LIBS', 'NO')
         self.cmake_options.define('CMAKE_POSITION_INDEPENDENT_CODE', 'YES')
 

--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -226,7 +226,7 @@ class LLVM(cmake_product.CMakeProduct):
         # LLVM will always be built in part
         return True
 
-    def build(self, host_target):
+    async def build(self, host_target):
         """build() -> void
 
         Perform the build, for a non-build-script-impl product.

--- a/utils/swift_build_support/swift_build_support/products/minimalstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/minimalstdlib.py
@@ -36,7 +36,7 @@ class MinimalStdlib(cmake_product.CMakeProduct):
     def should_build(self, host_target):
         return platform.system() == 'Darwin'
 
-    def build(self, host_target):
+    async def build(self, host_target):
         build_variant = 'MinSizeRel'
         self.cmake_options.define('CMAKE_BUILD_TYPE:STRING', build_variant)
         self.cmake_options.define(

--- a/utils/swift_build_support/swift_build_support/products/playgroundsupport.py
+++ b/utils/swift_build_support/swift_build_support/products/playgroundsupport.py
@@ -52,7 +52,7 @@ class PlaygroundSupport(product.Product):
     def should_build(self, host_target):
         return self.args.build_playgroundsupport
 
-    def build(self, host_target):
+    async def build(self, host_target):
         root = os.path.dirname(os.path.dirname(self.toolchain.swiftc))
         swift_lib_dir = os.path.join(root, 'lib', 'swift')
         (host_os, host_arch) = host_target.split('-')

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -66,7 +66,7 @@ class Product(object):
         raise NotImplementedError
 
     @classmethod
-    def is_before_build_script_impl_product(cls):
+    def is_before_build_script_impl_product(cls) -> bool:
         """is_before_build_script_impl_product -> bool
 
         Whether this product is built before any build-script-impl products.
@@ -77,7 +77,7 @@ class Product(object):
         raise NotImplementedError
 
     @classmethod
-    def is_ignore_install_all_product(cls):
+    def is_ignore_install_all_product(cls) -> bool:
         """is_ignore_install_all_product -> bool
 
         Whether this product is to ignore the install-all directive
@@ -89,7 +89,7 @@ class Product(object):
         return False
 
     @classmethod
-    def is_swiftpm_unified_build_product(cls):
+    def is_swiftpm_unified_build_product(cls) -> bool:
         """is_swiftpm_unified_build_product -> bool
 
         Whether this product should be built in the unified build of SwiftPM
@@ -98,7 +98,7 @@ class Product(object):
         return False
 
     @classmethod
-    def is_nondarwin_only_build_product(cls):
+    def is_nondarwin_only_build_product(cls) -> bool:
         """Returns true if this target should be skipped in darwin builds when
         inferring dependencies.
         """
@@ -109,14 +109,14 @@ class Product(object):
         """Return a list of products that this product depends upon"""
         raise NotImplementedError
 
-    def should_clean(self, host_target):
+    def should_clean(self, host_target) -> bool:
         """should_clean() -> Bool
 
         Whether or not this product should be cleaned before being built
         """
         return False
 
-    def clean(self, host_target):
+    async def clean(self, host_target):
         """clean() -> void
 
         Perform the clean, for a non-build-script-impl product.
@@ -130,7 +130,7 @@ class Product(object):
         """
         raise NotImplementedError
 
-    def build(self, host_target):
+    async def build(self, host_target):
         """build() -> void
 
         Perform the build, for a non-build-script-impl product.
@@ -144,7 +144,7 @@ class Product(object):
         """
         raise NotImplementedError
 
-    def test(self, host_target):
+    async def test(self, host_target):
         """test() -> void
 
         Run the tests, for a non-build-script-impl product.
@@ -159,7 +159,7 @@ class Product(object):
         """
         raise NotImplementedError
 
-    def install(self, host_target):
+    async def install(self, host_target):
         """install() -> void
 
         Install to the toolchain, for a non-build-script-impl product.

--- a/utils/swift_build_support/swift_build_support/products/skstresstester.py
+++ b/utils/swift_build_support/swift_build_support/products/skstresstester.py
@@ -81,7 +81,7 @@ class SKStressTester(product.Product):
     def should_build(self, host_target):
         return True
 
-    def build(self, host_target):
+    async def build(self, host_target):
         if platform.system() != 'Darwin':
             raise RuntimeError("Unable to build {product} on a platform other "
                                "than Darwin".format(

--- a/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
+++ b/utils/swift_build_support/swift_build_support/products/sourcekitlsp.py
@@ -73,7 +73,7 @@ class SourceKitLSP(product.Product):
             for target in self.args.cross_compile_hosts:
                 body(target)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         if self.args.sourcekitlsp_verify_generated_files:
             self._run_swift_syntax_dev_utils(
                 host_target, 'verify-config-schema')

--- a/utils/swift_build_support/swift_build_support/products/staticswiftlinux.py
+++ b/utils/swift_build_support/swift_build_support/products/staticswiftlinux.py
@@ -89,7 +89,7 @@ class StaticSwiftLinuxConfig(product.Product):
         """
         return False
 
-    def build(self, host_target):
+    async def build(self, host_target):
         """build() -> void
 
         Perform the build, for a non-build-script-impl product.

--- a/utils/swift_build_support/swift_build_support/products/stdlib_docs.py
+++ b/utils/swift_build_support/swift_build_support/products/stdlib_docs.py
@@ -34,7 +34,7 @@ class StdlibDocs(product.Product):
     def should_build(self, host_target):
         return self.args.build_stdlib_docs
 
-    def build(self, host_target):
+    async def build(self, host_target):
         toolchain_path = self.install_toolchain_path(host_target)
         docc_path = os.path.join(toolchain_path, "bin", "docc")
 

--- a/utils/swift_build_support/swift_build_support/products/swift_testing.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing.py
@@ -82,7 +82,7 @@ class SwiftTesting(product.Product):
     def _build_with_cmake(self, host_target):
         self._cmake_product(host_target).build(host_target)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self._for_each_host_target(host_target, self._build_with_cmake)
 
     def _install_with_cmake(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/swift_testing_macros.py
+++ b/utils/swift_build_support/swift_build_support/products/swift_testing_macros.py
@@ -61,7 +61,7 @@ class SwiftTestingMacros(product.Product):
             source_dir=self.source_dir,
             build_dir=build_dir)
 
-    def _for_each_host_target(self, base_target, body):
+    async def _for_each_host_target(self, base_target, body):
         body(base_target)
 
         # For Darwin host, 'build' is only called for the builder.
@@ -73,27 +73,27 @@ class SwiftTestingMacros(product.Product):
     def _clean_with_cmake(self, host_target):
         self._cmake_product(host_target).clean(host_target)
 
-    def clean(self, host_target):
-        self._for_each_host_target(host_target, self._clean_with_cmake)
+    async def clean(self, host_target):
+        await self._for_each_host_target(host_target, self._clean_with_cmake)
 
-    def _build_with_cmake(self, host_target):
-        self._cmake_product(host_target).build(host_target)
+    async def _build_with_cmake(self, host_target):
+        await self._cmake_product(host_target).build(host_target)
 
-    def build(self, host_target):
-        self._for_each_host_target(host_target, self._build_with_cmake)
+    async def build(self, host_target):
+        await self._for_each_host_target(host_target, self._build_with_cmake)
 
     def _install_with_cmake(self, host_target):
         self._cmake_product(host_target).install(host_target)
 
-    def install(self, host_target):
-        self._for_each_host_target(host_target, self._install_with_cmake)
+    async def install(self, host_target):
+        await self._for_each_host_target(host_target, self._install_with_cmake)
 
 
 class SwiftTestingMacrosCMakeShim(cmake_product.CMakeProduct):
     def clean(self, host_target):
         shell.rmtree(self.build_dir)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         override_deployment_version = None
         if host_target.startswith('macosx'):
             if Version(self.args.darwin_deployment_version_osx) < Version('10.15'):

--- a/utils/swift_build_support/swift_build_support/products/swiftdocc.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdocc.py
@@ -79,7 +79,7 @@ class SwiftDocC(product.Product):
     def should_build(self, host_target):
         return True
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self.run_build_script_helper('build', host_target)
 
     def should_test(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -62,7 +62,7 @@ class SwiftDriver(product.Product):
     def clean(self, host_target):
         run_build_script_helper('clean', host_target, self, self.args)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         run_build_script_helper('build', host_target, self, self.args)
 
     def should_test(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/swiftformat.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftformat.py
@@ -101,7 +101,7 @@ class SwiftFormat(product.Product):
     def should_build(self, host_target):
         return True
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self.run_build_script_helper('build', host_target)
         if self.args.sourcekitlsp_lint:
             self.lint_sourcekitlsp()

--- a/utils/swift_build_support/swift_build_support/products/swiftinspect.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftinspect.py
@@ -44,7 +44,7 @@ class SwiftInspect(product.Product):
     def should_build(self, host_target):
         return True
 
-    def build(self, host_target):
+    async def build(self, host_target):
         run_build_script_helper(host_target, self, self.args)
 
     def should_test(self, host_target):

--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -117,7 +117,7 @@ class SwiftPM(product.Product):
 
         shell.call(helper_cmd)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self.run_bootstrap_script(
             'build',
             host_target,

--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -111,7 +111,7 @@ class SwiftSyntax(product.Product):
 
         shell.call(run_cmd, env=env)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         if self.args.swiftsyntax_verify_generated_files:
             self.run_swift_syntax_dev_utils(
                 host_target,

--- a/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
+++ b/utils/swift_build_support/swift_build_support/products/tsan_libdispatch.py
@@ -45,7 +45,7 @@ class TSanLibDispatch(product.Product):
     def should_build(self, host_target):
         return True
 
-    def build(self, host_target):
+    async def build(self, host_target):
         """Build TSan runtime (compiler-rt)."""
         rt_source_dir = join_path(
             self.source_dir, os.pardir,

--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -59,7 +59,7 @@ class WasmKit(product.Product):
         bin_path = run_swift_build(host_target, self, 'wasmkit-cli', set_installation_rpath=True)
         shutil.copy(bin_path, build_toolchain_path + '/wasmkit')
 
-    def build(self, host_target):
+    async def build(self, host_target):
         bin_path = run_swift_build(host_target, self, 'wasmkit-cli')
         print("Built wasmkit-cli at: " + bin_path)
         # Copy the built binary to ./bin

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -40,7 +40,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
     def should_test(self, host_target):
         return self.args.test_wasmstdlib
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self._build(host_target, 'wasm32-wasi', 'wasi-wasm32')
 
     def _build(self, host_target, target_triple, short_triple):
@@ -224,7 +224,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         }
         self.test_with_cmake(None, [test_target], self._build_variant, [], test_env=env)
 
-    def should_test_executable(self):
+    def should_test_executable(self) -> bool:
         return True
 
     @property
@@ -256,7 +256,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
 
 
 class WasmThreadsStdlib(WasmStdlib):
-    def build(self, host_target):
+    async def build(self, host_target):
         self._build(host_target, 'wasm32-wasip1-threads', 'wasip1-threads-wasm32')
 
     def should_test_executable(self):

--- a/utils/swift_build_support/swift_build_support/products/zlib.py
+++ b/utils/swift_build_support/swift_build_support/products/zlib.py
@@ -69,7 +69,7 @@ class Zlib(cmake_product.CMakeProduct):
         path = self.host_install_destdir(host_target)
         self.install_with_cmake(['install'], path)
 
-    def build(self, host_target):
+    async def build(self, host_target):
         self.cmake_options.define('BUILD_SHARED_LIBS', 'NO')
         self.cmake_options.define('CMAKE_POSITION_INDEPENDENT_CODE', 'YES')
 

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -207,7 +207,7 @@ class Haiku(GenericUnix):
         super(Haiku, self)
 
 
-def host_toolchain(**kwargs):
+def host_toolchain(**kwargs) -> Toolchain:
     sys = platform.system()
     if sys == 'Darwin':
         return MacOSX(kwargs.pop('xcrun_toolchain', 'default'))


### PR DESCRIPTION
This would allow concurrent build/test/install/clean invocations on products that don't depend on each other, which should lead to significant speed ups, since a lot of these steps consume only a single CPU core.