### PR TITLE
[6.2] [IDE] Avoid macro expansions in `getEquivalentDeclContextFromSourceFile`

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -116,7 +116,7 @@ bool IDEInspectionSecondPassRequest::evaluate(
     IDEInspectionCallbacksFactory *Factory) const {
   // If we didn't find the code completion token, bail.
   auto *parserState = SF->getDelayedParserState();
-  if (!parserState->hasIDEInspectionDelayedDeclState())
+  if (!parserState || !parserState->hasIDEInspectionDelayedDeclState())
     return true;
 
   // Decrement the closure discriminator index by one so a top-level closure


### PR DESCRIPTION
*6.2 cherry-pick of #82568*

- Explanation: Avoids crashing in the case where we somehow pick up a macro expanded decl from the original AST when doing a cached completion
- Scope: Affects code completion
- Issue: rdar://151926231
- Risk: Low, changes the logic to ignore macro expansion decls, and adds a null check to ensure we don't crash
- Testing: Haven't been able to come up with a reproducer, passes existing tests
- Reviewer: Ben Barham, Rintaro Ishizaki