### PR TITLE
[Runtimes] lay down nested swift modules ahead of CMake 4.1

### DIFF
--- a/Runtimes/Core/CMakeLists.txt
+++ b/Runtimes/Core/CMakeLists.txt
@@ -30,6 +30,11 @@
 # Install *.abi.json, swiftdoc, and swiftsourceinfo
 
 cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
 
 set(CMAKE_C_VISIBILITY_PRESET "hidden")
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")

--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -8,26 +8,41 @@
 function(emit_swift_interface target)
   # Generate the target-variant binary swift module when performing zippered
   # build
-  if(SwiftCore_VARIANT_MODULE_TRIPLE)
-    set(variant_module_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}")
-    file(MAKE_DIRECTORY "${variant_module_tmp_dir}")
-    target_compile_options(${target} PRIVATE
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${variant_module_tmp_dir}/${target}.swiftmodule>")
+  # Clean this up once CMake has nested swiftmodules in the build directory:
+  # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10664
+  # https://cmake.org/cmake/help/git-stage/policy/CMP0195.html
+
+  # We can't expand the Swift_MODULE_NAME target property in a generator
+  # expression or it will fail saying that the target doesn't exist.
+  get_target_property(module_name ${target} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${target})
   endif()
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  target_compile_options(${target} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule>")
+  if(SwiftCore_VARIANT_MODULE_TRIPLE)
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule>")
+  endif()
+  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule"
+    DEPENDS ${target})
+  target_sources(${target}
+    INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule>)
 
   # Generate textual swift interfaces is library-evolution is enabled
   if(SwiftCore_ENABLE_LIBRARY_EVOLUTION)
     target_compile_options(${target} PRIVATE
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface>
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.private.swiftinterface>)
+    if(SwiftCore_VARIANT_MODULE_TRIPLE)
+      target_compile_options(${target} PRIVATE
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
+    endif()
+    target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>
       $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend$<SEMICOLON>-require-explicit-availability=ignore>)
-
-      # Emit catalyst swiftmodules and interfaces
-      if(SwiftCore_VARIANT_MODULE_TRIPLE)
-        target_compile_options(${target} PRIVATE
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${variant_module_tmp_dir}/${target}.swiftinterface>"
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${variant_module_tmp_dir}/${target}.private.swiftinterface>")
-      endif()
   endif()
 endfunction()

--- a/Runtimes/Core/cmake/modules/InstallSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/InstallSwiftInterface.cmake
@@ -1,51 +1,13 @@
 
 # Install the generated swift interface files for the target.
 function(install_swift_interface target)
-  # Install binary swift modules
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-    RENAME "${SwiftCore_MODULE_TRIPLE}.swiftmodule"
-    DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+  # Swiftmodules are already in the directory structure
+  get_target_property(module_name ${target} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${target})
+  endif()
+
+  install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
+    DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}"
     COMPONENT SwiftCore_development)
-  if(SwiftCore_VARIANT_MODULE_TRIPLE)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftmodule"
-      RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftmodule"
-      DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT SwiftCore_development)
-  endif()
-
-  # Install Swift interfaces if library-evolution is enabled
-  if(SwiftCore_ENABLE_LIBRARY_EVOLUTION)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface"
-      RENAME "${SwiftCore_MODULE_TRIPLE}.swiftinterface"
-      DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT SwiftCore_development)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface"
-      RENAME "${SwiftCore_MODULE_TRIPLE}.private.swiftinterface"
-      DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT SwiftCore_development)
-
-    # Install catalyst interface files
-    if(SwiftCore_VARIANT_MODULE_TRIPLE)
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftinterface"
-        RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftinterface"
-        DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-        COMPONENT SwiftCore_development)
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.private.swiftinterface"
-        RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.private.swiftinterface"
-        DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-        COMPONENT SwiftCore_development)
-    endif()
-  endif()
-
-  # Install Swift documentation interface files.
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftdoc"
-    RENAME "${SwiftCore_MODULE_TRIPLE}.swiftdoc"
-    DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-    COMPONENT SwiftCore_development)
-  if(SwiftCore_VARIANT_MODULE_TRIPLE)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftCore_VARIANT_MODULE_TRIPLE}/${target}.swiftdoc"
-      RENAME "${SwiftCore_VARIANT_MODULE_TRIPLE}.swiftdoc"
-      DESTINATION "${SwiftCore_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT SwiftCore_development)
-  endif()
 endfunction()

--- a/Runtimes/Overlay/CMakeLists.txt
+++ b/Runtimes/Overlay/CMakeLists.txt
@@ -1,5 +1,10 @@
 
 cmake_minimum_required(VERSION 3.26...3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
 
 set(CMAKE_C_VISIBILITY_PRESET "hidden")
 set(CMAKE_CXX_VISIBILITY_PRESET "hidden")

--- a/Runtimes/Overlay/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Overlay/cmake/modules/EmitSwiftInterface.cmake
@@ -8,26 +8,41 @@
 function(emit_swift_interface target)
   # Generate the target-variant binary swift module when performing zippered
   # build
-  if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
-    set(variant_module_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftOverlay_VARIANT_MODULE_TRIPLE}")
-    file(MAKE_DIRECTORY "${variant_module_tmp_dir}")
-    target_compile_options(${target} PRIVATE
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${variant_module_tmp_dir}/${target}.swiftmodule>")
+  # Clean this up once CMake has nested swiftmodules in the build directory:
+  # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10664
+  # https://cmake.org/cmake/help/git-stage/policy/CMP0195.html
+
+  # We can't expand the Swift_MODULE_NAME target property in a generator
+  # expression or it will fail saying that the target doesn't exist.
+  get_target_property(module_name ${target} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${target})
   endif()
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  target_compile_options(${target} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule>")
+  if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftmodule>")
+  endif()
+  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule"
+    DEPENDS ${target})
+  target_sources(${target}
+    INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule>)
 
   # Generate textual swift interfaces is library-evolution is enabled
   if(SwiftOverlay_ENABLE_LIBRARY_EVOLUTION)
     target_compile_options(${target} PRIVATE
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface>
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.private.swiftinterface>)
+    if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
+      target_compile_options(${target} PRIVATE
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftinterface>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
+    endif()
+    target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>
       $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend$<SEMICOLON>-require-explicit-availability=ignore>)
-
-      # Emit catalyst swiftmodules and interfaces
-      if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
-        target_compile_options(${target} PRIVATE
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${variant_module_tmp_dir}/${target}.swiftinterface>"
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${variant_module_tmp_dir}/${target}.private.swiftinterface>")
-      endif()
   endif()
 endfunction()

--- a/Runtimes/Overlay/cmake/modules/InstallSwiftInterface.cmake
+++ b/Runtimes/Overlay/cmake/modules/InstallSwiftInterface.cmake
@@ -1,46 +1,13 @@
 
 # Install the generated swift interface files for the target.
 function(install_swift_interface target)
-  # Install binary swift modules
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-    RENAME "${SwiftOverlay_MODULE_TRIPLE}.swiftmodule"
-    DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
-  if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftOverlay_VARIANT_MODULE_TRIPLE}/${target}.swiftmodule"
-      RENAME "${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftmodule"
-      DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
+  # Swiftmodules are already in the directory structure
+  get_target_property(module_name ${target} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${target})
   endif()
 
-  # Install Swift interfaces if library-evolution is enabled
-  if(SwiftOverlay_ENABLE_LIBRARY_EVOLUTION)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface"
-      RENAME "${SwiftOverlay_MODULE_TRIPLE}.swiftinterface"
-      DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
-
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface"
-      RENAME "${SwiftOverlay_MODULE_TRIPLE}.private.swiftinterface"
-      DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
-
-    # Install catalyst interface files
-    if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftOverlay_VARIANT_MODULE_TRIPLE}/${target}.swiftinterface"
-        RENAME "${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftinterface"
-        DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftOverlay_VARIANT_MODULE_TRIPLE}/${target}.private.swiftinterface"
-        RENAME "${SwiftOverlay_VARIANT_MODULE_TRIPLE}.private.swiftinterface"
-        DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule")
-    endif()
-  endif()
-
-  # Install Swift documentation interface files.
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftdoc"
-    RENAME "${SwiftOverlay_MODULE_TRIPLE}.swiftdoc"
-    DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+  install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
+    DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}"
     COMPONENT SwiftOverlay_development)
-  if(SwiftOverlay_VARIANT_MODULE_TRIPLE)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${SwiftOverlay_VARIANT_MODULE_TRIPLE}/${target}.swiftdoc"
-      RENAME "${SwiftOverlay_VARIANT_MODULE_TRIPLE}.swiftdoc"
-      DESTINATION "${SwiftOverlay_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT SwiftOverlay_development)
-  endif()
 endfunction()

--- a/Runtimes/Supplemental/CMakeLists.txt
+++ b/Runtimes/Supplemental/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
 
 project(SwiftRuntime LANGUAGES Swift C CXX)
 

--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
 
 if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)

--- a/Runtimes/Supplemental/Synchronization/CMakeLists.txt
+++ b/Runtimes/Supplemental/Synchronization/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.29)
+# TODO before requiring CMake 4.1 or later
+# and/or enforcing CMP0195, please check/update
+# the implementation  of `emit_swift_interface`
+# in `EmitSwiftInterface.cmake`
+# to ensure it keeps laying down nested swiftmodule folders
 
 if(POLICY CMP0157 AND CMAKE_Swift_COMPILER_USE_OLD_DRIVER)
   cmake_policy(SET CMP0157 OLD)

--- a/Runtimes/Supplemental/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Supplemental/cmake/modules/EmitSwiftInterface.cmake
@@ -8,26 +8,41 @@
 function(emit_swift_interface target)
   # Generate the target-variant binary swift module when performing zippered
   # build
-  if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
-    set(variant_module_tmp_dir "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}")
-    file(MAKE_DIRECTORY "${variant_module_tmp_dir}")
-    target_compile_options(${target} PRIVATE
-      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${variant_module_tmp_dir}/${target}.swiftmodule>")
+  # Clean this up once CMake has nested swiftmodules in the build directory:
+  # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10664
+  # https://cmake.org/cmake/help/git-stage/policy/CMP0195.html
+
+  # We can't expand the Swift_MODULE_NAME target property in a generator
+  # expression or it will fail saying that the target doesn't exist.
+  get_target_property(module_name ${target} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${target})
   endif()
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  target_compile_options(${target} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule>")
+  if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
+    target_compile_options(${target} PRIVATE
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.swiftmodule>")
+  endif()
+  add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule"
+    DEPENDS ${target})
+  target_sources(${target}
+    INTERFACE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule>)
 
   # Generate textual swift interfaces is library-evolution is enabled
   if(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION)
     target_compile_options(${target} PRIVATE
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface>
-      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftinterface>
+      $<$<COMPILE_LANGUAGE:Swift>:-emit-private-module-interface-path$<SEMICOLON>${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.private.swiftinterface>)
+    if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
+      target_compile_options(${target} PRIVATE
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.swiftinterface>"
+        "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.private.swiftinterface>")
+    endif()
+    target_compile_options(${target} PRIVATE
       $<$<COMPILE_LANGUAGE:Swift>:-library-level$<SEMICOLON>api>
       $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend$<SEMICOLON>-require-explicit-availability=ignore>)
-
-      # Emit catalyst swiftmodules and interfaces
-      if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
-        target_compile_options(${target} PRIVATE
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-module-interface-path ${variant_module_tmp_dir}/${target}.swiftinterface>"
-          "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-variant-private-module-interface-path ${variant_module_tmp_dir}/${target}.private.swiftinterface>")
-      endif()
   endif()
 endfunction()

--- a/Runtimes/Supplemental/cmake/modules/InstallSwiftInterface.cmake
+++ b/Runtimes/Supplemental/cmake/modules/InstallSwiftInterface.cmake
@@ -1,51 +1,13 @@
 
 # Install the generated swift interface files for the target.
 function(install_swift_interface target)
-  # Install binary swift modules
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-    RENAME "${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule"
-    DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
+  # Swiftmodules are already in the directory structure
+  get_target_property(module_name ${target} Swift_MODULE_NAME)
+  if(NOT module_name)
+    set(module_name ${target})
+  endif()
+
+  install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
+    DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}"
     COMPONENT ${PROJECT_NAME}_development)
-  if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}/${target}.swiftmodule"
-      RENAME "${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.swiftmodule"
-      DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT ${PROJECT_NAME}_development)
-  endif()
-
-  # Install Swift interfaces if library-evolution is enabled
-  if(${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftinterface"
-      RENAME "${${PROJECT_NAME}_MODULE_TRIPLE}.swiftinterface"
-      DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT ${PROJECT_NAME}_development)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.private.swiftinterface"
-      RENAME "${${PROJECT_NAME}_MODULE_TRIPLE}.private.swiftinterface"
-      DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT ${PROJECT_NAME}_development)
-
-    # Install catalyst interface files
-    if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}/${target}.swiftinterface"
-        RENAME "${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.swiftinterface"
-        DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-        COMPONENT ${PROJECT_NAME}_development)
-      install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}/${target}.private.swiftinterface"
-        RENAME "${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.private.swiftinterface"
-        DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-        COMPONENT ${PROJECT_NAME}_development)
-    endif()
-  endif()
-
-  # Install Swift documentation interface files.
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftdoc"
-    RENAME "${${PROJECT_NAME}_MODULE_TRIPLE}.swiftdoc"
-    DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-    COMPONENT ${PROJECT_NAME}_development)
-  if(SwiftCore_VARIANT_MODULE_TRIPLE)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}-${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}/${target}.swiftdoc"
-      RENAME "${${PROJECT_NAME}_VARIANT_MODULE_TRIPLE}.swiftdoc"
-      DESTINATION "${${PROJECT_NAME}_INSTALL_SWIFTMODULEDIR}/$<TARGET_PROPERTY:${target},Swift_MODULE_NAME>.swiftmodule"
-      COMPONENT ${PROJECT_NAME}_development)
-  endif()
 endfunction()


### PR DESCRIPTION
This is needed in order to build target variants properly with a SwiftDriver that has https://github.com/swiftlang/swift-driver/pull/1856 enabled.

Addresses rdar://154410676