### PR TITLE
[test] Fix duplicate LABEL directive in recently reenabled test

### DIFF
--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -24,7 +24,6 @@ entry:
 // CHECK-arm64e-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 // CHECK-aarch64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 // CHECK-arm64_32-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-arm64e-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 // CHECK-wasm32-LABEL:  define swiftcc void @does_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 sil @does_throw : $@convention(thin) () -> @error Error {
   // CHECK: [[T0:%.*]] = call swiftcc ptr @create_error()
@@ -48,7 +47,6 @@ sil @does_throw : $@convention(thin) () -> @error Error {
 // CHECK-arm64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 // CHECK-arm64e-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 // CHECK-aarch64-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
-// CHECK-arm64e-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 // CHECK-arm64_32-LABEL:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 // CHECK-wasm32-LABEL: define swiftcc void @doesnt_throw(ptr swiftself %0, ptr noalias{{( nocapture)?}} swifterror{{( captures\(none\))?}} dereferenceable({{.}}) %1) {{.*}} {
 sil @doesnt_throw : $@convention(thin) () -> @error Error {


### PR DESCRIPTION
This test was partially reenabled by fixing misspelled FileCheck directives in https://github.com/swiftlang/swift/pull/81426. I had failed to notice that some arm64e checks are duplicated.