### PR TITLE
Runtimes: add interface include directories for _Concurrency

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -122,6 +122,9 @@ target_include_directories(swift_Concurrency PRIVATE
   # FIXME: grant access to `runtime/CMakeConfig.h` which should be available
   # through the swiftRuntime target.
   "${PROJECT_BINARY_DIR}/include")
+# FIXME: Why is this not implicitly in the interface flags?
+target_include_directories(swift_Concurrency INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${SwiftCore_INSTALL_SWIFTMODULEDIR}>>")
 target_link_libraries(swift_Concurrency PRIVATE
   swiftShims
   swiftConcurrencyInternalShims


### PR DESCRIPTION
Ensure that the _Concurrency module is properly made available to the users who link against it.