### PR TITLE
Runtimes: adjust the linking to `_Concurrency`

### DIFF
--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -47,6 +47,7 @@ option(${PROJECT_NAME}_ENABLE_PRESPECIALIZATION "Enable generic metadata prespec
 add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_LIBRARY_EVOLUTION}>,$<COMPILE_LANGUAGE:Swift>>:-enable-library-evolution>"
   "$<$<AND:$<BOOL:${${PROJECT_NAME}_ENABLE_PRESPECIALIZATION}>,$<COMPILE_LANGUAGE:Swift>>:SHELL:-Xfrontend -prespecialize-generic-metadata>")

--- a/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
@@ -31,7 +31,8 @@ add_library(swift_RegexParser
   Utility/Errors.swift
   Utility/MissingUnicode.swift)
 
-target_link_libraries(swift_RegexParser PRIVATE swiftCore)
+target_link_libraries(swift_RegexParser PRIVATE
+  swiftCore)
 
 set_target_properties(swift_RegexParser PROPERTIES
   Swift_MODULE_NAME _RegexParser)


### PR DESCRIPTION
`_Concurrency` is being implicitly imported and then linked into the runtime (and is required for the asynchronous code). Ensure that we explicitly link against the concurrency runtime to use the correct declarations and ensure that the autolinking works properly for static and dynamic variants of the runtime.