### PR TITLE
Runtimes: avoid ODR violations in _Concurrency

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(swift_Concurrency
 
 include(${SwiftCore_CONCURRENCY_GLOBAL_EXECUTOR}.cmake)
 target_compile_definitions(swift_Concurrency PRIVATE
+  $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_RUNTIME>
   $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_TARGET_LIBRARY_NAME=swift_Concurrency>
   # NOTE: VS2017 <15.8 would round clamp alignment to alignof(max_align_t) which
   # was non-conformant. Indicate that we wish to use extended alignment.


### PR DESCRIPTION
When building the standard libraries with the LLVM ADT types, we use the local definition which have been modified to avoid ODR violations. However, due to the intermingling of the compiler and runtime implementations, we cannot isolate the headers properly to ensure that the right definition is used. We need to ensure that we pass along `SWIFT_RUNTIME` when processing headers to avoid references to the unsafe references to the LLVM Support library.