### PR TITLE
[cxx-interop] Allow import-as-member for functions declared within a namespace

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -10230,9 +10230,11 @@ ClangImporter::Implementation::importDeclContextOf(
   if (!importedDC) return nullptr;
 
   // If the declaration was not global to start with, we're done.
-  bool isGlobal =
-    decl->getDeclContext()->getRedeclContext()->isTranslationUnit();
-  if (!isGlobal) return importedDC;
+  bool isRenamedGlobal =
+      decl->getDeclContext()->getRedeclContext()->isTranslationUnit() ||
+      (context.getKind() == EffectiveClangContext::UnresolvedContext &&
+          decl->getDeclContext()->getRedeclContext()->isNamespace());
+  if (!isRenamedGlobal) return importedDC;
 
   // If the resulting declaration context is not a nominal type,
   // we're done.

--- a/test/Interop/Cxx/namespace/Inputs/import-as-member.h
+++ b/test/Interop/Cxx/namespace/Inputs/import-as-member.h
@@ -25,3 +25,8 @@ typedef MyNS::MyDeepNS::DeepNestedStruct DeepNestedStructTypedef;
 
 int deepNestedStructTypedef_method(DeepNestedStructTypedef p) SWIFT_NAME("DeepNestedStructTypedef.methodTypedef(self:)") { return p.value + 3; }
 int deepNestedStructTypedef_methodQualName(MyNS::MyDeepNS::DeepNestedStruct p) SWIFT_NAME("DeepNestedStructTypedef.methodTypedefQualName(self:)") { return p.value + 4; }
+
+namespace MyNS {
+int nestedStruct_nestedMethod(MyNS::NestedStruct p) SWIFT_NAME("MyNS.NestedStruct.nestedMethod(self:)") { return p.value + 3; }
+inline int nestedStruct_nestedMethodInline(MyNS::NestedStruct p) SWIFT_NAME("MyNS.NestedStruct.nestedMethodInline(self:)") { return p.value + 4; }
+}

--- a/test/Interop/Cxx/namespace/import-as-member-module-interface.swift
+++ b/test/Interop/Cxx/namespace/import-as-member-module-interface.swift
@@ -4,6 +4,8 @@
 // CHECK-NEXT:   func method() -> Int32
 // CHECK-NEXT:   func methodConstRef() -> Int32
 // CHECK-NEXT:   func methodInline() -> Int32
+// CHECK-NEXT:   func nestedMethod() -> Int32
+// CHECK-NEXT:   func nestedMethodInline() -> Int32
 // CHECK-NEXT: }
 
 // CHECK:      extension MyNS.MyDeepNS.DeepNestedStruct {

--- a/test/Interop/Cxx/namespace/import-as-member-typechecker.swift
+++ b/test/Interop/Cxx/namespace/import-as-member-typechecker.swift
@@ -5,6 +5,8 @@ import ImportAsMember
 func takesNestedStruct(_ s: MyNS.NestedStruct) {
   _ = s.method()
   _ = s.methodConstRef()
+  _ = s.nestedMethod()
+  _ = s.nestedMethodInline()
 
   _ = nestedStruct_method(s) // expected-error {{'nestedStruct_method' has been replaced by instance method 'MyNS.NestedStruct.method()'}}
 }
@@ -17,3 +19,6 @@ func takesDeepNestedStruct(_ s: MyNS.MyDeepNS.DeepNestedStruct) {
 
   _ = deepNestedStruct_method(s) // expected-error {{'deepNestedStruct_method' has been replaced by instance method 'MyNS.MyDeepNS.DeepNestedStruct.method()'}}
 }
+
+MyNS.method() // expected-error {{type 'MyNS' has no member 'method'}}
+MyNS.nestedMethod() // expected-error {{type 'MyNS' has no member 'nestedMethod'}}

--- a/test/Interop/Cxx/namespace/import-as-member.swift
+++ b/test/Interop/Cxx/namespace/import-as-member.swift
@@ -22,4 +22,10 @@ NamespacesTestSuite.test("Struct in a deep namespace") {
   expectEqual(460, s.methodTypedefQualName())
 }
 
+NamespacesTestSuite.test("Struct and function in a namespace") {
+  let s = MyNS.NestedStruct()
+  expectEqual(126, s.nestedMethod())
+  expectEqual(127, s.nestedMethodInline())
+}
+
 runAllTests()


### PR DESCRIPTION
This makes it possible to use trigger import-as-member for C++ functions declared within namespaces. Previously only functions declared at the file level were supported.

rdar://138930205

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
