### PR TITLE
AST: Better cope with UnboundGenericType in TypeBase::getSuperclass()

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2289,9 +2289,23 @@ Type TypeBase::getSuperclass(bool useArchetypes) {
   Type superclassTy = classDecl->getSuperclass();
 
   // If there's no superclass, or it is fully concrete, we're done.
-  if (!superclassTy || !superclassTy->hasTypeParameter() ||
-      hasUnboundGenericType())
+  if (!superclassTy || !superclassTy->hasTypeParameter())
     return superclassTy;
+
+  auto hasUnboundGenericType = [&]() {
+    Type t(this);
+    while (t) {
+      if (t->is<UnboundGenericType>())
+        return true;
+      t = t->getNominalParent();
+    }
+    return false;
+  };
+
+  // If we started with an UnboundGenericType, we cannot apply the
+  // context substitution map. Return the unbound form of the superclass.
+  if (hasUnboundGenericType())
+    return superclassTy->getAnyNominal()->getDeclaredType();
 
   // Gather substitutions from the self type, and apply them to the original
   // superclass type to form the substituted superclass type.

--- a/test/decl/typealias/dependent_types.swift
+++ b/test/decl/typealias/dependent_types.swift
@@ -65,6 +65,7 @@ let _: GenericStruct.ReferencesConcrete = foo()
 
 class SuperG<T, U> {
   typealias Composed = (T, U)
+  typealias Concrete = Int
 }
 
 class SubG<T> : SuperG<T, T> { }
@@ -73,4 +74,17 @@ typealias SubGX<T> = SubG<T?>
 
 func checkSugar(gs: SubGX<Int>.Composed) {
   let i4: Int = gs // expected-error{{cannot convert value of type 'SubGX<Int>.Composed' (aka '(Optional<Int>, Optional<Int>)') to specified type 'Int'}}
+}
+
+// https://github.com/swiftlang/swift/issues/82160
+
+let x1: SuperG.Concrete = 123
+let x2: SubG.Concrete = 123
+
+func f1() -> SuperG.Concrete {
+  return 123
+}
+
+func f2() -> SubG.Concrete {
+  return 123
 }


### PR DESCRIPTION
Returning the unsubstituted superclass type is not correct, because it may contain type parameters. Let's form a new UnboundGenericType instead.

- Fixes https://github.com/swiftlang/swift/issues/82160.
- Fixes rdar://152989888.