### PR TITLE
Runtimes: fix a couple of runtime build bugs

### DIFF
--- a/Runtimes/Core/Concurrency/CMakeLists.txt
+++ b/Runtimes/Core/Concurrency/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(swift_Concurrency
 
 include(${SwiftCore_CONCURRENCY_GLOBAL_EXECUTOR}.cmake)
 target_compile_definitions(swift_Concurrency PRIVATE
+  $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_RUNTIME>
   $<$<COMPILE_LANGUAGE:C,CXX>:-DSWIFT_TARGET_LIBRARY_NAME=swift_Concurrency>
   # NOTE: VS2017 <15.8 would round clamp alignment to alignof(max_align_t) which
   # was non-conformant. Indicate that we wish to use extended alignment.

--- a/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/CMakeLists.txt
@@ -27,6 +27,7 @@ include(AvailabilityMacros)
 add_compile_options(
   $<$<COMPILE_LANGUAGE:Swift>:-explicit-module-build>
   $<$<COMPILE_LANGUAGE:Swift>:-nostdlibimport>
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-concurrency-module-import>"
   "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
 
 add_subdirectory(_RegexParser)

--- a/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
+++ b/Runtimes/Supplemental/StringProcessing/_RegexParser/CMakeLists.txt
@@ -31,7 +31,8 @@ add_library(swift_RegexParser
   Utility/Errors.swift
   Utility/MissingUnicode.swift)
 
-target_link_libraries(swift_RegexParser PRIVATE swiftCore)
+target_link_libraries(swift_RegexParser PRIVATE
+  swiftCore)
 
 set_target_properties(swift_RegexParser PROPERTIES
   Swift_MODULE_NAME _RegexParser)


### PR DESCRIPTION
- **Explanation**:
  This avoids the introduction of ODR violations in the Concurrency runtime builds due to missing build flags. It also cleans up the overlinking of `swift_Concurrency` into `swift_StringProcessing`.
- **Scope**:
  This impacts the builds of `swift_Concurrency` and `swift_StringProcessing` when built with the new build system.
- **Issues**:
- **Original PRs**:
  #82577 #82578 
- **Risk**:
  These are relatively low risk changes - they only impact how we build the libraries.
- **Testing**:
  Built the runtime libraries on Windows at desk and CI.
- **Reviewers**:
  @etcwilde 