### PR TITLE
"nonisolated deinit" does not have back-deployment constraints

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7727,8 +7727,6 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
     }
   }
 
-  diagnoseIsolatedDeinitInValueTypes(attr);
-
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     //'nonisolated(unsafe)' is meaningless for computed properties, functions etc.
     auto var = dyn_cast<VarDecl>(VD);
@@ -7762,8 +7760,6 @@ void AttributeChecker::visitGlobalActorAttr(GlobalActorAttr *attr) {
                            "task-to-thread concurrency model");
     return;
   }
-
-  diagnoseIsolatedDeinitInValueTypes(attr);
 
   (void)nominal->isGlobalActor();
 }

--- a/test/Concurrency/deinit_isolation_in_value_types.swift
+++ b/test/Concurrency/deinit_isolation_in_value_types.swift
@@ -19,7 +19,7 @@ struct CS: ~Copyable {
 }
 
 struct DS: ~Copyable {
-  nonisolated deinit {} // expected-error {{only classes and actors can have isolated deinit}}
+  nonisolated deinit {}
 }
 
 struct ES: ~Copyable {
@@ -47,7 +47,7 @@ enum CE: ~Copyable {
 enum DE: ~Copyable {
   case dummy
   // expected-error@+1 {{deinitializers are not yet supported on noncopyable enums}}
-  nonisolated deinit {} // expected-error {{only classes and actors can have isolated deinit}}
+  nonisolated deinit {}
 }
 
 enum EE: ~Copyable {

--- a/test/Concurrency/nonisolated_deinit.swift
+++ b/test/Concurrency/nonisolated_deinit.swift
@@ -1,0 +1,23 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 %s -strict-concurrency=complete -target %target-swift-5.1-abi-triple
+
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+class NotSendable {}
+
+@MainActor class C {
+  var x: Int = 0
+
+  nonisolated deinit {
+    print(x)
+  }
+}
+
+// expected-note@+1{{add '@available' attribute to enclosing class}}
+@MainActor class C2 {
+  var x: Int = 0
+
+  isolated deinit { // expected-error{{isolated deinit is only available in macOS 15.4.0 or newer}}
+    print(x)
+  }
+}


### PR DESCRIPTION
- **Explanation**: Due to an accident in the way the availability check for `isolated deinit` was implemented, `nonisolated deinit` was being diagnostics as requiring newer OS availability. `nonisolated deinit` is what's been implemented forever, so stop doing that.
- **Scope**: Tiny. Disables an incorrect diagnostic.
- **Issues**: rdar://150484159
- **Original PRs**: https://github.com/swiftlang/swift/pull/82584
- **Risk**: Very very very very low. 
- **Testing**: CI
- **Reviewers**:
