### PR TITLE
[6.2] AST: Better cope with UnboundGenericType in TypeBase::getSuperclass()

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -10,8 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implements validation for Swift types, emitting semantic errors as
-// appropriate and checking default initializer values.
+// This file implements type resolution, which converts syntactic type
+// representations into semantic types, emitting diagnostics as appropriate.
 //
 //===----------------------------------------------------------------------===//
 
@@ -6344,14 +6344,23 @@ Type TypeChecker::substMemberTypeWithBase(TypeDecl *member,
                               : member->getDeclaredInterfaceType();
   SubstitutionMap subs;
   if (baseTy) {
-    // Cope with the presence of unbound generic types, which are ill-formed
-    // at this point but break the invariants of getContextSubstitutionMap().
+    // If the base type contains an unbound generic type, we cannot
+    // proceed to the getContextSubstitutionMap() call below.
+    //
+    // In general, this means the user program is ill-formed, but we
+    // do allow type aliases to be referenced with an unbound generic
+    // type as the base, if the underlying type of the type alias
+    // does not contain type parameters.
     if (baseTy->hasUnboundGenericType()) {
       memberType = memberType->getReducedType(aliasDecl->getGenericSignature());
 
+      // This is the error case. The diagnostic is emitted elsewhere,
+      // in TypeChecker::isUnsupportedMemberTypeAccess().
       if (memberType->hasTypeParameter())
         return ErrorType::get(memberType);
 
+      // Otherwise, there's no substitution to be performed, so we
+      // just drop the base type.
       return memberType;
     }
 

--- a/test/decl/typealias/dependent_types.swift
+++ b/test/decl/typealias/dependent_types.swift
@@ -65,6 +65,7 @@ let _: GenericStruct.ReferencesConcrete = foo()
 
 class SuperG<T, U> {
   typealias Composed = (T, U)
+  typealias Concrete = Int
 }
 
 class SubG<T> : SuperG<T, T> { }
@@ -73,4 +74,17 @@ typealias SubGX<T> = SubG<T?>
 
 func checkSugar(gs: SubGX<Int>.Composed) {
   let i4: Int = gs // expected-error{{cannot convert value of type 'SubGX<Int>.Composed' (aka '(Optional<Int>, Optional<Int>)') to specified type 'Int'}}
+}
+
+// https://github.com/swiftlang/swift/issues/82160
+
+let x1: SuperG.Concrete = 123
+let x2: SubG.Concrete = 123
+
+func f1() -> SuperG.Concrete {
+  return 123
+}
+
+func f2() -> SubG.Concrete {
+  return 123
 }


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82581.

* **Description:** Fixes a crash when referencing a typealias member of a generic type without supplying generic arguments. We're supposed to accept this when the underlying type of the typealias does not involve type parameters.

* **Origination:** Regression in 6.2.

* **Risk:** Low.

* **Reviewed by:** @AnthonyLatsis 

* **Issue:** Fixes https://github.com/swiftlang/swift/issues/82160.

* **Radar:** Fixes rdar://152989888.