### PR TITLE
[stdlib, 6.2] Handle String's 32-bit inline representation for Span

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -79,8 +79,11 @@ internal struct _SmallString {
 extension _SmallString {
   @inlinable @inline(__always)
   internal static var capacity: Int {
-#if _pointerBitWidth(_32) || _pointerBitWidth(_16)
+#if _pointerBitWidth(_32) && os(watchOS)
     return 10
+#elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
+    // Note: changed from 10 for contiguous storage.
+    return 8
 #elseif os(Android) && arch(arm64)
     return 14
 #elseif _pointerBitWidth(_64)

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -93,6 +93,15 @@ extension _SmallString {
 #endif
   }
 
+  @_alwaysEmitIntoClient @inline(__always)
+  internal static func contiguousCapacity() -> Int {
+#if _pointerBitWidth(_32) && os(watchOS)
+    return capacity &- 2
+#else
+    return capacity
+#endif
+  }
+
   // Get an integer equivalent to the _StringObject.discriminatedObjectRawBits
   // computed property.
   @inlinable @inline(__always)

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -330,7 +330,7 @@ extension String.UTF8View {
       let span = unsafe Span(_unsafeStart: start, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
-#endif
+#endif // _runtime(_ObjC)
     let count = _guts.count
     if _guts.isSmall {
       let a = Builtin.addressOfBorrow(self)
@@ -384,7 +384,7 @@ extension String.UTF8View {
       span
     }
   }
-#else
+#else // !(os(watchOS) && _pointerBitWidth(_32))
   @available(watchOS, unavailable)
   public var span: Span<UTF8.CodeUnit> {
     @lifetime(borrow self)
@@ -415,7 +415,7 @@ extension String.UTF8View {
       return _underlyingSpan()
     }
   }
-#endif
+#endif // !(os(watchOS) && _pointerBitWidth(_32))
 }
 
 // Index conversions

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -317,8 +317,35 @@ extension String.UTF8View {
   }
 }
 
+@available(SwiftStdlib 6.2, *)
 extension String.UTF8View {
 
+  @lifetime(borrow self)
+  internal borrowing func _underlyingSpan() -> Span<UTF8.CodeUnit> {
+#if _runtime(_ObjC)
+    // handle non-UTF8 Objective-C bridging cases here
+    if !_guts.isFastUTF8, _guts._object.hasObjCBridgeableObject {
+      let storage = _guts._getOrAllocateAssociatedStorage()
+      let (start, count) = unsafe (storage.start, storage.count)
+      let span = unsafe Span(_unsafeStart: start, count: count)
+      return unsafe _overrideLifetime(span, borrowing: self)
+    }
+#endif
+    let count = _guts.count
+    if _guts.isSmall {
+      let a = Builtin.addressOfBorrow(self)
+      let address = unsafe UnsafePointer<UTF8.CodeUnit>(a)
+      let span = unsafe Span(_unsafeStart: address, count: count)
+      return unsafe _overrideLifetime(span, borrowing: self)
+    }
+    let isFastUTF8 = _guts.isFastUTF8
+    _precondition(isFastUTF8, "String must be contiguous UTF8")
+    let buffer = unsafe _guts._object.fastUTF8
+    let span = unsafe Span(_unsafeElements: buffer)
+    return unsafe _overrideLifetime(span, borrowing: self)
+  }
+
+#if !(os(watchOS) && _pointerBitWidth(_32))
   /// A span over the UTF8 code units that make up this string.
   ///
   /// - Note: In the case of bridged UTF16 String instances (on Apple
@@ -334,29 +361,61 @@ extension String.UTF8View {
   public var span: Span<UTF8.CodeUnit> {
     @lifetime(borrow self)
     borrowing get {
-#if _runtime(_ObjC)
-      // handle non-UTF8 Objective-C bridging cases here
-      if !_guts.isFastUTF8, _guts._object.hasObjCBridgeableObject {
-        let storage = _guts._getOrAllocateAssociatedStorage()
-        let (start, count) = unsafe (storage.start, storage.count)
-        let span = unsafe Span(_unsafeStart: start, count: count)
-        return unsafe _overrideLifetime(span, borrowing: self)
-      }
-#endif
-      let count = _guts.count
-      if _guts.isSmall {
-        let a = Builtin.addressOfBorrow(self)
-        let address = unsafe UnsafePointer<UTF8.CodeUnit>(a)
-        let span = unsafe Span(_unsafeStart: address, count: count)
-        return unsafe _overrideLifetime(span, borrowing: self)
-      }
-      let isFastUTF8 = _guts.isFastUTF8
-      _precondition(isFastUTF8, "String must be contiguous UTF8")
-      let buffer = unsafe _guts._object.fastUTF8
-      let span = unsafe Span(_unsafeElements: buffer)
-      return unsafe _overrideLifetime(span, borrowing: self)
+      _underlyingSpan()
     }
   }
+
+  /// A span over the UTF8 code units that make up this string.
+  ///
+  /// - Note: In the case of bridged UTF16 String instances (on Apple
+  /// platforms,) this property transcodes the code units the first time
+  /// it is called. The transcoded buffer is cached, and subsequent calls
+  /// to `span` can reuse the buffer.
+  ///
+  ///  Returns: a `Span` over the UTF8 code units of this String.
+  ///
+  ///  Complexity: O(1) for native UTF8 Strings,
+  ///  amortized O(1) for bridged UTF16 Strings.
+  @available(SwiftStdlib 6.2, *)
+  public var _span: Span<UTF8.CodeUnit>? {
+    @_alwaysEmitIntoClient @inline(__always)
+    @lifetime(borrow self)
+    borrowing get {
+      span
+    }
+  }
+#else
+  @available(watchOS, unavailable)
+  public var span: Span<UTF8.CodeUnit> {
+    @lifetime(borrow self)
+    borrowing get {
+      fatalError("\(#function) unavailable on 32-bit watchOS")
+    }
+  }
+
+  /// A span over the UTF8 code units that make up this string.
+  ///
+  /// - Note: In the case of bridged UTF16 String instances (on Apple
+  /// platforms,) this property transcodes the code units the first time
+  /// it is called. The transcoded buffer is cached, and subsequent calls
+  /// to `span` can reuse the buffer.
+  ///
+  ///  Returns: a `Span` over the UTF8 code units of this String, or `nil`
+  ///           if the String does not have a contiguous representation.
+  ///
+  ///  Complexity: O(1) for native UTF8 Strings,
+  ///  amortized O(1) for bridged UTF16 Strings.
+  @available(SwiftStdlib 6.2, *)
+  public var _span: Span<UTF8.CodeUnit>? {
+    @lifetime(borrow self)
+    borrowing get {
+      if _guts.isSmall && _guts.count > (_SmallString.capacity &- 2) {
+        return nil
+      }
+      return _underlyingSpan()
+    }
+  }
+#endif
 }
 
 // Index conversions

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -409,7 +409,7 @@ extension String.UTF8View {
   public var _span: Span<UTF8.CodeUnit>? {
     @lifetime(borrow self)
     borrowing get {
-      if _guts.isSmall && _guts.count > (_SmallString.capacity &- 2) {
+      if _guts.isSmall, _guts.count > _SmallString.contiguousCapacity() {
         return nil
       }
       return _underlyingSpan()

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -749,8 +749,38 @@ extension Substring.UTF8View: BidirectionalCollection {
   }
 }
 
+@available(SwiftStdlib 6.2, *)
 extension Substring.UTF8View {
 
+  @lifetime(borrow self)
+  private borrowing func _underlyingSpan() -> Span<UTF8.CodeUnit> {
+#if _runtime(_ObjC)
+    // handle non-UTF8 Objective-C bridging cases here
+    if !_wholeGuts.isFastUTF8, _wholeGuts._object.hasObjCBridgeableObject {
+      let base: String.UTF8View = self._base
+      let first = base._foreignDistance(from: base.startIndex, to: startIndex)
+      let count = base._foreignDistance(from: startIndex, to: endIndex)
+      let span = base._underlyingSpan()._extracting(first..<(first &+ count))
+      return unsafe _overrideLifetime(span, borrowing: self)
+    }
+#endif
+    let first = _slice._startIndex._encodedOffset
+    let end = _slice._endIndex._encodedOffset
+    if _wholeGuts.isSmall {
+      let a = Builtin.addressOfBorrow(self)
+      let offset = first &+ (2 &* MemoryLayout<String.Index>.stride)
+      let start = unsafe UnsafePointer<UTF8.CodeUnit>(a).advanced(by: offset)
+      let span = unsafe Span(_unsafeStart: start, count: end &- first)
+      return unsafe _overrideLifetime(span, borrowing: self)
+    }
+    let isFastUTF8 = _wholeGuts.isFastUTF8
+    _precondition(isFastUTF8, "Substring must be contiguous UTF8")
+    var span = unsafe Span(_unsafeElements: _wholeGuts._object.fastUTF8)
+    span = span._extracting(first..<end)
+    return unsafe _overrideLifetime(span, borrowing: self)
+  }
+
+#if !(os(watchOS) && _pointerBitWidth(_32))
   /// A span over the UTF8 code units that make up this substring.
   ///
   /// - Note: In the case of bridged UTF16 String instances (on Apple
@@ -776,32 +806,79 @@ extension Substring.UTF8View {
   public var span: Span<UTF8.CodeUnit> {
     @lifetime(borrow self)
     borrowing get {
-#if _runtime(_ObjC)
-      // handle non-UTF8 Objective-C bridging cases here
-      if !_wholeGuts.isFastUTF8, _wholeGuts._object.hasObjCBridgeableObject {
-        let base: String.UTF8View = self._base
-        let first = base._foreignDistance(from: base.startIndex, to: startIndex)
-        let count = base._foreignDistance(from: startIndex, to: endIndex)
-        let span = unsafe base.span._extracting(first..<(first &+ count))
-        return unsafe _overrideLifetime(span, borrowing: self)
-      }
-#endif
-      let first = _slice._startIndex._encodedOffset
-      let end = _slice._endIndex._encodedOffset
-      if _wholeGuts.isSmall {
-        let a = Builtin.addressOfBorrow(self)
-        let offset = first &+ (2 &* MemoryLayout<String.Index>.stride)
-        let start = unsafe UnsafePointer<UTF8.CodeUnit>(a).advanced(by: offset)
-        let span = unsafe Span(_unsafeStart: start, count: end &- first)
-        return unsafe _overrideLifetime(span, borrowing: self)
-      }
-      let isFastUTF8 = _wholeGuts.isFastUTF8
-      _precondition(isFastUTF8, "Substring must be contiguous UTF8")
-      var span = unsafe Span(_unsafeElements: _wholeGuts._object.fastUTF8)
-      span = span._extracting(first..<end)
-      return unsafe _overrideLifetime(span, borrowing: self)
+      _underlyingSpan()
     }
   }
+
+  /// A span over the UTF8 code units that make up this substring.
+  ///
+  /// - Note: In the case of bridged UTF16 String instances (on Apple
+  /// platforms,) this property needs to transcode the code units every time
+  /// it is called.
+  /// For example, if `string` has the bridged UTF16 representation,
+  ///     for word in string.split(separator: " ") {
+  ///         useSpan(word.span)
+  ///     }
+  ///  is accidentally quadratic because of this issue. A workaround is to
+  ///  explicitly convert the string into its native UTF8 representation:
+  ///      var nativeString = consume string
+  ///      nativeString.makeContiguousUTF8()
+  ///      for word in nativeString.split(separator: " ") {
+  ///          useSpan(word.span)
+  ///      }
+  ///  This second option has linear time complexity, as expected.
+  ///
+  ///  Returns: a `Span` over the UTF8 code units of this Substring.
+  ///
+  ///  Complexity: O(1) for native UTF8 Strings, O(n) for bridged UTF16 Strings.
+  @available(SwiftStdlib 6.2, *)
+  public var _span: Span<UTF8.CodeUnit>? {
+    @_alwaysEmitIntoClient @inline(__always)
+    @lifetime(borrow self)
+    borrowing get {
+      span
+    }
+  }
+#else
+  @available(watchOS, unavailable)
+  public var span: Span<UTF8.CodeUnit> {
+    fatalError("\(#function) unavailable on 32-bit watchOS")
+  }
+
+  /// A span over the UTF8 code units that make up this substring.
+  ///
+  /// - Note: In the case of bridged UTF16 String instances (on Apple
+  /// platforms,) this property needs to transcode the code units every time
+  /// it is called.
+  /// For example, if `string` has the bridged UTF16 representation,
+  ///     for word in string.split(separator: " ") {
+  ///         useSpan(word.span)
+  ///     }
+  ///  is accidentally quadratic because of this issue. A workaround is to
+  ///  explicitly convert the string into its native UTF8 representation:
+  ///      var nativeString = consume string
+  ///      nativeString.makeContiguousUTF8()
+  ///      for word in nativeString.split(separator: " ") {
+  ///          useSpan(word.span)
+  ///      }
+  ///  This second option has linear time complexity, as expected.
+  ///
+  ///  Returns: a `Span` over the UTF8 code units of this Substring, or `nil`
+  ///           if the Substring does not have a contiguous representation.
+  ///
+  ///  Complexity: O(1) for native UTF8 Strings, O(n) for bridged UTF16 Strings.
+  @available(SwiftStdlib 6.2, *)
+  public var _span: Span<UTF8.CodeUnit>? {
+    @lifetime(borrow self)
+    borrowing get {
+      if _wholeGuts.isSmall && _wholeGuts.count > (_SmallString.capacity &- 2) {
+        // substring is spannable only when the whole string is spannable.
+        return nil
+      }
+      return _underlyingSpan()
+    }
+  }
+#endif
 }
 
 extension Substring {

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -871,7 +871,8 @@ extension Substring.UTF8View {
   public var _span: Span<UTF8.CodeUnit>? {
     @lifetime(borrow self)
     borrowing get {
-      if _wholeGuts.isSmall && _wholeGuts.count > (_SmallString.capacity &- 2) {
+      if _wholeGuts.isSmall,
+         _wholeGuts.count > _SmallString.contiguousCapacity() {
         // substring is spannable only when the whole string is spannable.
         return nil
       }

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -763,7 +763,7 @@ extension Substring.UTF8View {
       let span = base._underlyingSpan()._extracting(first..<(first &+ count))
       return unsafe _overrideLifetime(span, borrowing: self)
     }
-#endif
+#endif // _runtime(_ObjC)
     let first = _slice._startIndex._encodedOffset
     let end = _slice._endIndex._encodedOffset
     if _wholeGuts.isSmall {
@@ -839,7 +839,7 @@ extension Substring.UTF8View {
       span
     }
   }
-#else
+#else // !(os(watchOS) && _pointerBitWidth(_32))
   @available(watchOS, unavailable)
   public var span: Span<UTF8.CodeUnit> {
     fatalError("\(#function) unavailable on 32-bit watchOS")
@@ -878,7 +878,7 @@ extension Substring.UTF8View {
       return _underlyingSpan()
     }
   }
-#endif
+#endif // !(os(watchOS) && _pointerBitWidth(_32))
 }
 
 extension Substring {

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -291,7 +291,7 @@ extension String {
   public var _utf8Span: UTF8Span? {
     @lifetime(borrow self)
     borrowing get {
-      if _guts.isSmall && _guts.count > (_SmallString.capacity &- 2) {
+      if _guts.isSmall, _guts.count > _SmallString.contiguousCapacity() {
         return nil
       }
       return unsafe UTF8Span(
@@ -426,7 +426,8 @@ extension Substring {
   public var _utf8Span: UTF8Span? {
     @lifetime(borrow self)
     borrowing get {
-      if _wholeGuts.isSmall && _wholeGuts.count > (_SmallString.capacity &- 2) {
+      if _wholeGuts.isSmall,
+         _wholeGuts.count > _SmallString.contiguousCapacity() {
         // substring is spannable only when the whole string is spannable.
         return nil
       }

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -213,7 +213,7 @@ extension String {
       let span = unsafe Span(_unsafeStart: start, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
-#endif
+#endif // _runtime(_ObjC)
     let count = _guts.count
     if _guts.isSmall {
       let a = Builtin.addressOfBorrow(self)
@@ -269,7 +269,7 @@ extension String {
       utf8Span
     }
   }
-#else
+#else // !(os(watchOS) && _pointerBitWidth(_32))
   @available(watchOS, unavailable)
   public var utf8Span: UTF8Span {
     fatalError("\(#function) unavailable on 32-bit watchOS")
@@ -299,7 +299,7 @@ extension String {
       )
     }
   }
-#endif
+#endif // !(os(watchOS) && _pointerBitWidth(_32))
 }
 
 @available(SwiftStdlib 6.2, *)
@@ -316,7 +316,7 @@ extension Substring {
       let span = base._underlyingSpan()._extracting(first..<(first &+ count))
       return unsafe _overrideLifetime(span, borrowing: self)
     }
-#endif
+#endif // _runtime(_ObjC)
     let first = _slice._startIndex._encodedOffset
     let end = _slice._endIndex._encodedOffset
     if _wholeGuts.isSmall {
@@ -394,7 +394,7 @@ extension Substring {
       utf8Span
     }
   }
-#else
+#else // !(os(watchOS) && _pointerBitWidth(_32))
   @available(watchOS, unavailable)
   public var utf8Span: UTF8Span {
     fatalError("\(#function) unavailable on 32-bit watchOS")
@@ -435,5 +435,5 @@ extension Substring {
       )
     }
   }
-#endif
+#endif // !(os(watchOS) && _pointerBitWidth(_32))
 }

--- a/test/stdlib/Span/StringUTF8SpanProperty.swift
+++ b/test/stdlib/Span/StringUTF8SpanProperty.swift
@@ -10,11 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %target-run-stdlib-swift(-enable-experimental-feature LifetimeDependence -enable-experimental-feature AddressableTypes)
+// RUN: %target-run-stdlib-swift
 
 // REQUIRES: executable_test
-// REQUIRES: swift_feature_LifetimeDependence
-// REQUIRES: swift_feature_AddressableTypes
 
 import StdlibUnittest
 
@@ -25,9 +23,15 @@ suite.test("Span from Small String")
 .require(.stdlib_6_2).code {
   guard #available(SwiftStdlib 6.2, *) else { return }
 
-  let s = "A small string.".utf8
+  var s = "123456789".utf8
   let u = Array(s)
-  let span = s.span
+#if os(watchOS) && _pointerBitWidth(_32)
+  expectNil(s._span)
+#endif
+  var string = String(s)
+  string.reserveCapacity(12)
+  s = (consume string).utf8
+  guard let span = expectNotNil(s._span) else { return }
 
   let count = span.count
   expectEqual(count, s.count)
@@ -43,7 +47,7 @@ suite.test("Span from Large Native String")
 
   let s = "A long string that is altogether not smol.".utf8
   let u = Array(s)
-  let span = s.span
+  guard let span = expectNotNil(s._span) else { return }
 
   let count = span.count
   expectEqual(count, s.count)
@@ -59,7 +63,7 @@ suite.test("Span from Small String's Substring")
 
   let s = "A small string.".dropFirst(8).utf8
   let u = Array("string.".utf8)
-  let span = s.span
+  guard let span = expectNotNil(s._span) else { return }
 
   let count = span.count
   expectEqual(count, s.count)
@@ -76,7 +80,7 @@ suite.test("Span from Large Native String's Substring")
   let t = "A long string that is altogether not smol."
   let s = t.dropFirst(22).prefix(10).utf8
   let u = Array("altogether".utf8)
-  let span = s.span
+  guard let span = expectNotNil(s._span) else { return }
 
   let count = span.count
   expectEqual(count, s.count)
@@ -91,10 +95,10 @@ suite.test("Span from String.utf8Span")
   guard #available(SwiftStdlib 6.2, *) else { return }
 
   let s = String(200)
-  let utf8span = s.utf8Span
+  guard let utf8span = expectNotNil(s._utf8Span) else { return }
   let span1 = utf8span.span
   let utf8view = s.utf8
-  let span2 = utf8view.span
+  guard let span2 = expectNotNil(utf8view._span) else { return }
   expectEqual(span1.count, span2.count)
   for (i,j) in zip(span1.indices, span2.indices) {
     expectEqual(span1[i], span2[j])
@@ -106,7 +110,7 @@ suite.test("UTF8Span from Span")
   guard #available(SwiftStdlib 6.2, *) else { return }
 
   let s = String(200).utf8
-  let span1 = s.span
+  guard let span1 = expectNotNil(s._span) else { return }
   guard let utf8 = expectNotNil(try? UTF8Span(validating: span1)) else { return }
 
   let span2 = utf8.span
@@ -118,10 +122,10 @@ suite.test("Span from Substring.utf8Span")
   guard #available(SwiftStdlib 6.2, *) else { return }
 
   let s = String(22000).dropFirst().dropLast()
-  let utf8span = s.utf8Span
+  guard let utf8span = expectNotNil(s._utf8Span) else { return }
   let span1 = utf8span.span
   let utf8view = s.utf8
-  let span2 = utf8view.span
+  guard let span2 = expectNotNil(utf8view._span) else { return }
   expectEqual(span1.count, span2.count)
   for (i,j) in zip(span1.indices, span2.indices) {
     expectEqual(span1[i], span2[j])

--- a/test/stdlib/StringDeconstruction.swift
+++ b/test/stdlib/StringDeconstruction.swift
@@ -94,8 +94,10 @@ func id<T>(_ a: T) -> T { a }
 StringDeconstructTests.test("deconstruct") {
   let smallASCII = "abcd"
 
-#if _pointerBitWidth(_32)
+#if _pointerBitWidth(_32) && os(watchOS)
   let smallUTF8 = "ジッパ"
+#elseif _pointerBitWidth(_32)
+  let smallUTF8 = "ジッ"
 #else
   let smallUTF8 = "ジッパー"
 #endif


### PR DESCRIPTION
String's inline representation is currently non-contiguous on 32-bit platforms. Furthermore, that representation is baked in ABI for watchOS's 32-bit variant. This PR implements mitigations.

A. For 32-bit platforms without ABI stability, we reduce the size of the inline representation to 8 UTF-8 code units (from 10).

B. For 32-bit watchOS, we add an optional property var _span: Span<UTF8.CodeUnit>? that returns nil when the representation of the String is non-contiguous, that is when it is 9 or 10 UTF-8 code units.

All platforms will get this underscored property, so that code that supports 32-bit watchOS doesn't have to be specific to it.

Scope: Bug fix for 32-bit platforms

Radar/SR Issue: rdar://147500261

Main PR: https://github.com/swiftlang/swift/pull/82442

Risk: Low

Testing: Covered by unit tests

Reviewer: @lorentey