### PR TITLE
[6.2] [SE-0466 experimental amendment] Don't infer @mainactor on types conforming to Sendable

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -530,6 +530,10 @@ EXPERIMENTAL_FEATURE(DefaultIsolationPerFile, false)
 /// Enable @_lifetime attribute
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
 
+/// Disable @MainActor inference when the primary definition of a type conforms
+/// to SendableMetatype (or Sendable).
+EXPERIMENTAL_FEATURE(SendableProhibitsMainActorInference, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -127,6 +127,7 @@ UNINTERESTING_FEATURE(MacrosOnImports)
 UNINTERESTING_FEATURE(ExtensibleEnums)
 UNINTERESTING_FEATURE(NonisolatedNonsendingByDefault)
 UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
+UNINTERESTING_FEATURE(SendableProhibitsMainActorInference)
 
 static bool usesFeatureNonescapableTypes(Decl *decl) {
   auto containsNonEscapable =

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -155,14 +155,16 @@ addImplicitCodingKeys(NominalTypeDecl *target,
   enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);
 
-  switch (C.LangOpts.DefaultIsolationBehavior) {
-  case DefaultIsolation::MainActor:
-    enumDecl->getAttrs().add(NonisolatedAttr::createImplicit(C));
-    break;
+  if (!C.LangOpts.hasFeature(Feature::SendableProhibitsMainActorInference)) {
+    switch (C.LangOpts.DefaultIsolationBehavior) {
+    case DefaultIsolation::MainActor:
+      enumDecl->getAttrs().add(NonisolatedAttr::createImplicit(C));
+      break;
 
-  case DefaultIsolation::Nonisolated:
-    // Nothing to do.
-    break;
+    case DefaultIsolation::Nonisolated:
+      // Nothing to do.
+      break;
+    }
   }
 
   // For classes which inherit from something Encodable or Decodable, we

--- a/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift5- -enable-experimental-feature SendableProhibitsMainActorInference
+// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift6- -enable-experimental-feature SendableProhibitsMainActorInference
+
+// REQUIRES: swift_feature_SendableProhibitsMainActorInference
+
+// Ensure that a Sendable-conforming protocol suppresses @MainActor inference
+// for a type.
+enum CK: CodingKey {
+  case one
+
+  func f() { }
+}
+
+nonisolated func testCK(x: CK) {
+  x.f() // okay, because CK and CK.f are not @MainActor.
+}

--- a/test/Macros/default_main_actor_nonisolated.swift
+++ b/test/Macros/default_main_actor_nonisolated.swift
@@ -1,0 +1,26 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Check for errors
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -swift-version 6 -default-isolation MainActor -enable-experimental-feature SendableProhibitsMainActorInference
+
+
+@attached(extension, conformances: Sendable)
+macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableMacro")
+
+@AddSendable
+final class SendableClass {
+  var property: Int { 0 }
+
+  func f() { }
+}
+
+nonisolated func acceptSendable<T: Sendable>(_: T) { }
+
+@concurrent func test(sc: SendableClass) async {
+  acceptSendable(sc) // SendableClass is Sendable
+  acceptSendable(\SendableClass.property) // so is its property
+  sc.f() // not on the main actor, so this is okay
+}

--- a/test/Macros/default_main_actor_nonisolated.swift
+++ b/test/Macros/default_main_actor_nonisolated.swift
@@ -6,6 +6,7 @@
 // Check for errors
 // RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -swift-version 6 -default-isolation MainActor -enable-experimental-feature SendableProhibitsMainActorInference
 
+// REQUIRES: swift_feature_SendableProhibitsMainActorInference
 
 @attached(extension, conformances: Sendable)
 macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableMacro")


### PR DESCRIPTION
- **Explanation**: When the default isolation is main-actor, don't infer `@MainActor` for a type that conforms to a protocol `P` in its primary definition when `P` inherits from `SendableMetatype`. Such types should remain non-isolated
because they're highly unlikely to be able to implement the `P` conformance (which cannot be isolated). This feature is under an active pitch, so for now it is behind the experimental flag `SendableProhibitsMainActorInference`.
- **Scope**: Fairly narrow. Affects the inference rules for main-actor-by-default mode.
- **Issues**: rdar://151029300 + lots of dupes where this is needed to get existing or sensible code compiling under main-actor-by-default mode.
- **Original PRs**: https://github.com/swiftlang/swift/pull/81468
- **Risk**: Low. Only affects a new opt-in mode, tuning some inference rules.
- **Testing**: CI, some projects that have adopted main-actor-by-default mode.
- **Reviewers**: