### PR TITLE
[Concurrency] Fix a crash caused by misuse of `isolated` modifier

### DIFF
--- a/test/Concurrency/issue-80363.swift
+++ b/test/Concurrency/issue-80363.swift
@@ -1,0 +1,47 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/80363
+
+class C {}
+
+func testLocal() {
+  isolated let c = C()
+  // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+  _ = c
+
+  isolated func test() {
+    // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+  }
+}
+
+isolated var x: Int = 42
+// expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+
+isolated class Test {
+  // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+}
+
+struct TestMembers {
+  isolated var q: String {
+    // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+    get {
+      "ultimate question"
+    }
+
+    isolated set {
+      // expected-error@-1 {{expected 'get', 'set', 'willSet', or 'didSet' keyword to start an accessor definition}}
+    }
+  }
+
+  isolated let a: Int = 42
+  // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+
+  isolated subscript(x: Int) -> Bool {
+    // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+    get { true }
+  }
+
+  isolated func test() {
+    // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+  }
+}

--- a/validation-test/compiler_crashers_2_fixed/ab146c5c26ca113.swift
+++ b/validation-test/compiler_crashers_2_fixed/ab146c5c26ca113.swift
@@ -1,3 +1,3 @@
 // {"signature":"getIsolationFromAttributes(swift::Decl const*, bool, bool)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 isolated let a


### PR DESCRIPTION
Adjust isolation checking to handle misused `isolated` attribute and let attribute checker property diagnose it.

Resolves: rdar://148076903
Resolves: https://github.com/swiftlang/swift/issues/80363

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
