### PR TITLE
Cherry-pick [Swiftify] Don't import counted_by with suffixed integer literals (#82469)

### DIFF
--- a/test/Interop/C/swiftify-import/Inputs/counted-by.h
+++ b/test/Interop/C/swiftify-import/Inputs/counted-by.h
@@ -52,3 +52,13 @@ void floatCastToInt(float meters, int * __counted_by((int) meters) p);
 void pointerCastToInt(int *square, int * __counted_by((int) square) p);
 
 void nanAsInt(int * __counted_by((int) (0 / 0)) p);
+
+void unsignedLiteral(int * __counted_by(2u) p);
+
+void longLiteral(int * __counted_by(2l) p);
+
+void hexLiteral(int * __counted_by(0xfa) p);
+
+void binaryLiteral(int * __counted_by(0b10) p);
+
+void octalLiteral(int * __counted_by(0777) p);

--- a/test/Interop/C/swiftify-import/Inputs/sized-by-noescape.h
+++ b/test/Interop/C/swiftify-import/Inputs/sized-by-noescape.h
@@ -2,7 +2,9 @@
 
 #include <stdint.h>
 
+#ifndef __sized_by
 #define __sized_by(x) __attribute__((__sized_by__(x)))
+#endif
 #define __noescape __attribute__((noescape))
 
 void simple(int len, const void * __sized_by(len) __noescape p);

--- a/test/Interop/C/swiftify-import/counted-by-no-swiftify.swift
+++ b/test/Interop/C/swiftify-import/counted-by-no-swiftify.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast  | %FileCheck %s
 
 // REQUIRES: swift_feature_SafeInteropWrappers
 
@@ -12,3 +12,7 @@
 // CHECK-NOT: @_alwaysEmitIntoClient {{.*}} floatCastToInt
 // CHECK-NOT: @_alwaysEmitIntoClient {{.*}} pointerCastToInt
 // CHECK-NOT: @_alwaysEmitIntoClient {{.*}} nanAsInt
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} unsignedLiteral
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} longLiteral
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} sizeofType
+// CHECK-NOT: @_alwaysEmitIntoClient {{.*}} sizeofParam

--- a/test/Interop/C/swiftify-import/counted-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/counted-by-noescape.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -Xcc -Wno-nullability-completeness | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -Xcc -Werror -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature Lifetimes -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by __noescape parameters.
 

--- a/test/Interop/C/swiftify-import/counted-by.swift
+++ b/test/Interop/C/swiftify-import/counted-by.swift
@@ -1,10 +1,10 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CountedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedBy.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/CountedBy.swiftmodule -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness -Xcc -Wno-div-by-zero -Xcc -Wno-pointer-to-int-cast %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __counted_by parameters.
 
@@ -12,6 +12,9 @@ import CountedByClang
 
 
 // CHECK:      /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func binaryLiteral(_ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func bitshift(_ m: Int32, _ n: Int32, _ o: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -27,6 +30,9 @@ import CountedByClang
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func constInt(_ p: UnsafeMutableBufferPointer<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func hexLiteral(_ p: UnsafeMutableBufferPointer<Int32>)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nonnull(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
@@ -34,6 +40,9 @@ import CountedByClang
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func nullable(_  p: UnsafeMutableBufferPointer<Int{{.*}}>?)
+
+// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func octalLiteral(_ p: UnsafeMutableBufferPointer<Int32>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func offByOne(_ len: Int32, _ p: UnsafeMutableBufferPointer<Int32>)
@@ -57,17 +66,26 @@ import CountedByClang
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func simpleFlipped(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
 
 // CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func sizeofParam(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
-
-// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
-// CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func sizeofType(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
-
-// CHECK-NEXT: /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @_alwaysEmitIntoClient @_disfavoredOverload public func swiftAttr(_  p: UnsafeMutableBufferPointer<Int{{.*}}>)
+
+@inlinable
+public func callBitshift(_ m: CInt, n: CInt, o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe bitshift(m, n, o, p)
+}
+
+@inlinable
+public func callBitwise(_ m: CInt, n: CInt, o: CInt, _ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe bitwise(m, n, o, p)
+}
 
 @inlinable
 public func callComplexExpr(_ p: UnsafeMutableBufferPointer<CInt>) {
   unsafe complexExpr(CInt(p.count), 1, p)
+}
+
+@inlinable
+public func callConstFloatCastedToInt(_ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe constFloatCastedToInt(p)
 }
 
 @inlinable
@@ -91,8 +109,18 @@ public func callNullable(_ p: UnsafeMutableBufferPointer<CInt>?) {
 }
 
 @inlinable
+public func callOctalLiteral(_ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe octalLiteral(p)
+}
+
+@inlinable
 public func callOffByOne(_ p: UnsafeMutableBufferPointer<CInt>) {
   unsafe offByOne(0, p)
+}
+
+@inlinable
+public func callOffBySome(_ p: UnsafeMutableBufferPointer<CInt>) {
+  unsafe offBySome(0, 1, p)
 }
 
 @inlinable

--- a/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
+++ b/test/Interop/C/swiftify-import/sized-by-lifetimebound.swift
@@ -1,7 +1,7 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByLifetimeboundClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByLifetimeboundClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Werror -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)

--- a/test/Interop/C/swiftify-import/sized-by-noescape.swift
+++ b/test/Interop/C/swiftify-import/sized-by-noescape.swift
@@ -1,11 +1,11 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 // REQUIRES: swift_feature_Lifetimes
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature Lifetimes -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByNoEscapeClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature Lifetimes -enable-experimental-feature SafeInteropWrappers -Xcc -Werror -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature Lifetimes -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s
+// RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -o %t/SizedByNoEscape.swiftmodule -I %S/Inputs -enable-experimental-feature Lifetimes -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-ignored-attributes -Xcc -Wno-nullability-completeness %s
 
 // Check that ClangImporter correctly infers and expands @_SwiftifyImport macros for functions with __sized_by __noescape parameters.
 import SizedByNoEscapeClang

--- a/test/Interop/C/swiftify-import/sized-by.swift
+++ b/test/Interop/C/swiftify-import/sized-by.swift
@@ -1,6 +1,6 @@
 // REQUIRES: swift_feature_SafeInteropWrappers
 
-// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Wno-nullability-completeness | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=SizedByClang -plugin-path %swift-plugin-dir -I %S/Inputs -source-filename=x -enable-experimental-feature SafeInteropWrappers -Xcc -Werror -Xcc -Wno-nullability-completeness | %FileCheck %s
 
 // swift-ide-test doesn't currently typecheck the macro expansions, so run the compiler as well
 // RUN: %target-swift-frontend -emit-module -plugin-path %swift-plugin-dir -I %S/Inputs -enable-experimental-feature SafeInteropWrappers -strict-memory-safety -warnings-as-errors -Xcc -Werror -Xcc -Wno-nullability-completeness %s


### PR DESCRIPTION
- **Explanation**:
C/C++ integer literal expressions with types that are not of type `int` are printed with a suffix to indicate the type (e.g. `123U` or `456L` for `unsigned` and `long`). This is not valid syntax for integer literals in Swift, so until we fully translate the count expr syntax to Swift we need to avoid importing these count expressions.
- **Scope**:
This patch skips attaching a macro in cases where it would previously cause a compilation error, which practically corresponds when an integer literal (or constant folded integer expression) has a type that isn't `int` - e.g. `char`, `short`, `unsigned`, `long` etc.
- **Issues**:
rdar://154141719
- **Original PRs**:
https://github.com/swiftlang/swift/pull/82469
- **Risk**:
Low
- **Testing**:
Added regression tests
- **Reviewers**:
@Xazax-hun 
@j-hui 