### PR TITLE
[CS] Fix a couple of use-after-frees

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -116,7 +116,7 @@ Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
       } else if (!type->is<PackType>())
         type = PackType::getSingletonPackExpansion(type);
     }
-    replacementTypes.push_back(type);
+    replacementTypes.push_back(simplifyType(type));
   }
 
   auto lookupConformanceFn =
@@ -146,9 +146,9 @@ Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
     return conformance;
   };
 
-  return SubstitutionMap::get(sig,
-                              replacementTypes,
-                              lookupConformanceFn);
+  auto subs = SubstitutionMap::get(sig, replacementTypes, lookupConformanceFn);
+  ASSERT(!subs.getRecursiveProperties().isSolverAllocated());
+  return subs;
 }
 
 // Lazily instantiate function definitions for class template specializations.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3880,7 +3880,8 @@ bool NonOptionalUnwrapFailure::diagnoseAsError() {
     diagnostic = diag::invalid_force_unwrap;
 
   auto range = getSourceRange();
-  emitDiagnostic(diagnostic, BaseType).highlight(range).fixItRemove(range.End);
+  emitDiagnostic(diagnostic, resolveType(BaseType))
+    .highlight(range).fixItRemove(range.End);
   return true;
 }
 

--- a/test/Constraints/rdar154553285.swift
+++ b/test/Constraints/rdar154553285.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -disable-experimental-parser-round-trip
+
+// Make sure we don't crash
+func testInvalidInInterpolation(_ x: Int) {
+  _ = "\((x, \[]))" // expected-error {{invalid component of Swift key path}}
+}

--- a/validation-test/compiler_crashers_2/b33dbab8ed3643.swift
+++ b/validation-test/compiler_crashers_2/b33dbab8ed3643.swift
@@ -1,7 +1,0 @@
-// {"signature":"swift::TypeBase::computeCanonicalType()"}
-// RUN: env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: OS=macosx
-// REQUIRES: target-same-as-host
-// REQUIRES: no_asan
-func a (Int -> Int = { $0 func b( () = {}? ) func b {
-    / 1

--- a/validation-test/compiler_crashers_2_fixed/4c84d3d852cdd1d4.swift
+++ b/validation-test/compiler_crashers_2_fixed/4c84d3d852cdd1d4.swift
@@ -1,7 +1,4 @@
 // {"signature":"swift::ProtocolConformanceRef::forAbstract(swift::Type, swift::ProtocolDecl*)"}
-// RUN: env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: OS=macosx
-// REQUIRES: target-same-as-host
-// REQUIRES: no_asan
+// RUN: not %target-swift-frontend -typecheck %s
 var sixDoubles
     : Double "six has the value [\( ( sixDoubles \[]) }0 \0\0 \0 \sixDoubles)"

--- a/validation-test/compiler_crashers_2_fixed/89bcf379b8d4d092.swift
+++ b/validation-test/compiler_crashers_2_fixed/89bcf379b8d4d092.swift
@@ -1,5 +1,5 @@
 // {"signature":"swift::FunctionType::get(llvm::ArrayRef<swift::AnyFunctionType::Param>, swift::Type, std::__1::optional<swift::ASTExtInfo>)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 struct a < b : FixedWidthInteger extension a : Sequence {
   c {
     { for

--- a/validation-test/compiler_crashers_2_fixed/b33dbab8ed3643.swift
+++ b/validation-test/compiler_crashers_2_fixed/b33dbab8ed3643.swift
@@ -1,0 +1,4 @@
+// {"signature":"swift::TypeBase::computeCanonicalType()"}
+// RUN: not %target-swift-frontend -typecheck %s
+func a (Int -> Int = { $0 func b( () = {}? ) func b {
+    / 1


### PR DESCRIPTION
Make sure we call `simplifyType` for the opened type bindings in `computeSubstitutions` to ensure holes get converted to UnresolvedType. Also make sure we use the resolved type in `NonOptionalUnwrapFailure::diagnoseAsError` since diagnostics can outlive the ConstraintSystem itself if we have a diagnostic transaction for e.g `typeCheckParameterDefault`, so make sure we don't try to use a solver-allocated type as an argument.

rdar://154553285