### PR TITLE
[6.2, stdlib] Remove _withUnsafeBufferPointer APIs on InlineArray

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1744,9 +1744,9 @@ extension Array {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1301,9 +1301,9 @@ extension ArraySlice {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
-    @lifetime(/*inout*/&self)
-    @_alwaysEmitIntoClient
+    @lifetime(&self)
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -173,9 +173,9 @@ extension CollectionOfOne {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       let pointer = unsafe UnsafeMutablePointer<Element>(
         Builtin.addressOfBorrow(self)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1243,9 +1243,9 @@ extension ContiguousArray {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       // _makeMutableAndUnique*() inserts begin_cow_mutation.
       // LifetimeDependence analysis inserts call to end_cow_mutation_addr since we cannot schedule it in the stdlib for mutableSpan property.

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -89,7 +89,11 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal var _protectedAddress: UnsafePointer<Element> {
+#if $AddressOfProperty
+    unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(_storage))
+#else
     unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(self))
+#endif
   }
 
   /// Returns a buffer pointer over the entire array while performing stack
@@ -137,7 +141,11 @@ extension InlineArray where Element: ~Copyable {
   @_transparent
   internal var _protectedMutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
+#if $AddressOfProperty
+      unsafe UnsafeMutablePointer<Element>(Builtin.addressof(&_storage))
+#else
       unsafe UnsafeMutablePointer<Element>(Builtin.addressof(&self))
+#endif
     }
   }
 
@@ -518,6 +526,7 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
+    @_transparent
     borrowing get {
       let span = unsafe Span(_unsafeStart: _protectedAddress, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
@@ -528,6 +537,7 @@ extension InlineArray where Element: ~Copyable {
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
+    @_transparent
     mutating get {
       let span = unsafe MutableSpan(
         _unsafeStart: _protectedMutableAddress,

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -137,7 +137,7 @@ extension InlineArray where Element: ~Copyable {
   @_transparent
   internal var _protectedMutableAddress: UnsafeMutablePointer<Element> {
     mutating get {
-      unsafe UnsafeMutablePointer<Element>(Builtin.addressOf(&self))
+      unsafe UnsafeMutablePointer<Element>(Builtin.addressof(&self))
     }
   }
 

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -515,7 +515,6 @@ extension InlineArray where Element: ~Copyable {
 @available(SwiftStdlib 6.2, *)
 extension InlineArray where Element: ~Copyable {
   @available(SwiftStdlib 6.2, *)
-  @_addressableSelf
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)

--- a/stdlib/public/core/InlineArray.swift
+++ b/stdlib/public/core/InlineArray.swift
@@ -514,11 +514,11 @@ extension InlineArray where Element: ~Copyable {
 
 @available(SwiftStdlib 6.2, *)
 extension InlineArray where Element: ~Copyable {
-
   @available(SwiftStdlib 6.2, *)
+  @_addressableSelf
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
     borrowing get {
       let span = unsafe Span(_unsafeStart: _protectedAddress, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
@@ -526,9 +526,9 @@ extension InlineArray where Element: ~Copyable {
   }
 
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
-    @_alwaysEmitIntoClient
     mutating get {
       let span = unsafe MutableSpan(
         _unsafeStart: _protectedMutableAddress,

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -587,9 +587,10 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
   @unsafe
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @_transparent
     get {
       unsafe MutableSpan(_unsafeElements: self)
     }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -575,12 +575,12 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
   @unsafe
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @_transparent
     get {
-      let span = unsafe Span(_unsafeElements: self)
-      return unsafe _overrideLifetime(span, borrowing: self)
+      unsafe Span(_unsafeElements: self)
     }
   }
 %if Mutable:

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1185,12 +1185,12 @@ extension Unsafe${Mutable}RawBufferPointer {
 
   @unsafe
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var bytes: RawSpan {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @_transparent
     get {
-      let span = unsafe RawSpan(_unsafeBytes: self)
-      return unsafe _overrideLifetime(span, borrowing: self)
+      unsafe RawSpan(_unsafeBytes: self)
     }
   }
 }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1164,9 +1164,10 @@ extension Unsafe${Mutable}RawBufferPointer {
 
   @unsafe
   @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var mutableBytes: MutableRawSpan {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
+    @_transparent
     get {
       unsafe MutableRawSpan(_unsafeBytes: self)
     }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -931,7 +931,6 @@ Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
 Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
-Added: _$ss11InlineArrayVsRi__rlE11mutableSpans07MutableD0Vyq_Gvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
 Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
 Added: _$sSw12mutableBytess14MutableRawSpanVvr
@@ -1085,3 +1084,8 @@ Added: _$ss8UTF8SpanV9_asciiBits6UInt64VvpZMV
 
 // printing foreign reference types requires a new displayStyle: .foreign
 Added: _$ss6MirrorV12DisplayStyleO16foreignReferenceyA2DmFWC
+
+// var InlineArray._protectedBuffer
+// var InlineArray._protectedAddress
+Added: _$ss11InlineArrayVsRi__rlE16_protectedBufferSRyq_GvpMV
+Added: _$ss11InlineArrayVsRi__rlE17_protectedAddressSPyq_GvpMV

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -927,12 +927,6 @@ Added: _$ss14MutableRawSpanVN
 Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvg
 Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
 
-// SE-0467 mutableSpan properties
-Added: _$sSa11mutableSpans07MutableB0VyxGvr
-Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
-Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
-Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
-
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
 Added: _$ss13_SwiftifyExprO6returnyA2BmFWC

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -932,8 +932,6 @@ Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
-Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
-Added: _$sSw12mutableBytess14MutableRawSpanVvr
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -932,7 +932,6 @@ Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
 Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
-Added: _$ss11InlineArrayVsRi__rlE11mutableSpans07MutableD0Vyq_Gvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
 Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
 Added: _$sSw12mutableBytess14MutableRawSpanVvr
@@ -1085,3 +1084,8 @@ Added: _$ss8UTF8SpanV9_asciiBits6UInt64VvpZMV
 
 // printing foreign reference types requires a new displayStyle: .foreign
 Added: _$ss6MirrorV12DisplayStyleO16foreignReferenceyA2DmFWC
+
+// var InlineArray._protectedBuffer
+// var InlineArray._protectedAddress
+Added: _$ss11InlineArrayVsRi__rlE16_protectedBufferSRyq_GvpMV
+Added: _$ss11InlineArrayVsRi__rlE17_protectedAddressSPyq_GvpMV

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -933,8 +933,6 @@ Added: _$sSa11mutableSpans07MutableB0VyxGvr
 Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
 Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
-Added: _$sSrsRi_zrlE11mutableSpans07MutableB0VyxGvr
-Added: _$sSw12mutableBytess14MutableRawSpanVvr
 
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -928,12 +928,6 @@ Added: _$ss14MutableRawSpanVN
 Added: _$sSS8UTF8ViewV4spans4SpanVys5UInt8VGvg
 Added: _$sSs8UTF8ViewV4spans4SpanVys5UInt8VGvg
 
-// SE-0467 mutableSpan properties
-Added: _$sSa11mutableSpans07MutableB0VyxGvr
-Added: _$ss10ArraySliceV11mutableSpans07MutableD0VyxGvr
-Added: _$ss15ContiguousArrayV11mutableSpans07MutableD0VyxGvr
-Added: _$ss15CollectionOfOneV11mutableSpans07MutableE0VyxGvr
-
 // _SwiftifyInfo enum for _SwiftifyImports macro
 Added: _$ss13_SwiftifyExprO5paramyABSicABmFWC
 Added: _$ss13_SwiftifyExprO6returnyA2BmFWC


### PR DESCRIPTION
- Explanation:
  - Removes unsafe functions previously added (with underscores) until the `span` properties were present
  - Adds stack protection for the `mutableSpan` property
  - Removes unnecessary ABI by changing how some `@_alwaysEmitIntoClient` properties are declared.

- Resolves: rdar://145487409 (also a followup to rdar://153219174)

- Main Branch PRs: https://github.com/swiftlang/swift/pull/80858, https://github.com/swiftlang/swift/pull/82517

- Risk: Low.

- Review by: @glessard for 80858, @DougGregor for 82517.

- Testing: existing tests pass, ABI reduction verified.