### PR TITLE
[ScanDependencies] Fix a bug in rewrite from #81454

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -143,11 +143,11 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
     if (!ctx.CASOpts.EnableCaching) {
       auto &overlayFiles = invocation.getMutHeaderSearchOpts().VFSOverlayFiles;
       for (auto overlay : overlayFiles) {
+        if (llvm::is_contained(ctx.SearchPathOpts.VFSOverlayFiles, overlay))
+          continue;
         swiftArgs.push_back("-vfsoverlay");
         swiftArgs.push_back(overlay);
       }
-      // Clear overlay files since they are forwarded from swift to clang.
-      overlayFiles.clear();
     }
 
     // Add args reported by the scanner.

--- a/test/ScanDependencies/preserve_used_vfs.swift
+++ b/test/ScanDependencies/preserve_used_vfs.swift
@@ -2,11 +2,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/module-cache)
 // RUN: %empty-directory(%t/inputs)
+// RUN: %empty-directory(%t/inputs-2)
 // RUN: split-file %s %t
 
 // RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%t/inputs|g" %t/overlay_template.yaml > %t/overlay.yaml
+// RUN: sed -e "s|OUT_DIR|%t/redirects-2|g"  -e "s|IN_DIR|%t/inputs-2|g" %t/overlay_template_2.yaml > %t/overlay-2.yaml
 
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -Xcc -ivfsoverlay -Xcc %t/overlay.yaml
+/// Put some files in RealFileSystem that need to be over shadow by VFS.
+// RUN: touch %t/inputs/module.modulemap
+// RUN: touch %t/inputs-2/module.modulemap
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -I %t/inputs-2 -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -Xcc -ivfsoverlay -Xcc %t/overlay.yaml -Xcc -ivfsoverlay -Xcc %t/overlay-2.yaml
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
@@ -15,6 +21,8 @@
 // RUN: %swift_frontend_plain @%t/swift.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json SwiftOnoneSupport > %t/onone.cmd
 // RUN: %swift_frontend_plain @%t/onone.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:Indirect > %t/Indirect.cmd
+// RUN: %swift_frontend_plain @%t/Indirect.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:F > %t/F.cmd
 // RUN: %swift_frontend_plain @%t/F.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json F > %t/SwiftF.cmd
@@ -28,15 +36,25 @@
 // RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/map.json\"" >> %t/MyApp.cmd
 
-// RUN: %target-swift-frontend @%t/MyApp.cmd %t/test.swift -Xcc -ivfsoverlay -Xcc %t/overlay.yaml \
+// RUN: %target-swift-frontend @%t/MyApp.cmd %t/test.swift -Xcc -ivfsoverlay -Xcc %t/overlay.yaml -Xcc -ivfsoverlay -Xcc %t/overlay-2.yaml \
 // RUN:   -emit-module -o %t/Test.swiftmodule
 
 //--- redirects/RedirectedF.h
+#include "Indirect_2.h"
 void funcRedirectedF(void);
 
 //--- redirects/modulemap
 module F {
   header "F_2.h"
+  export *
+}
+
+//--- redirects-2/RedirectedIndirect.h
+void funcRedirectedIndirect(void);
+
+//--- redirects-2/modulemap
+module Indirect {
+  header "Indirect_2.h"
   export *
 }
 
@@ -59,10 +77,30 @@ module F {
   ]
 }
 
+//--- overlay_template_2.yaml
+{
+  'version': 0,
+  'use-external-names': false,
+  'roots': [
+    {
+      'name': 'IN_DIR', 'type': 'directory',
+      'contents': [
+        { 'name': 'Indirect_2.h', 'type': 'file',
+          'external-contents': 'OUT_DIR/RedirectedIndirect.h'
+        },
+        { 'name': 'module.modulemap', 'type': 'file',
+          'external-contents': 'OUT_DIR/modulemap'
+        }
+      ]
+    },
+  ]
+}
+
 //--- test.swift
 import F
 
 func testF() { funcRedirectedF() }
+func testIndirect() { funcRedirectedIndirect() }
 
 // CHECK: "mainModuleName": "deps"
 /// --------Main module
@@ -94,6 +132,10 @@ func testF() { funcRedirectedF() }
 // CHECK: "-ivfsoverlay",
 // CHECK-NEXT: "-Xcc",
 // CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
 // CHECK: ],
 
 /// --------Clang module F
@@ -101,4 +143,22 @@ func testF() { funcRedirectedF() }
 // CHECK: "commandLine": [
 // CHECK: "-vfsoverlay",
 // CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
-// CHECK: ],
+// CHECK-NEXT: "-vfsoverlay",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK: ]
+
+/// --------Clang module Indirect
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Indirect-{{.*}}.pcm",
+// CHECK-NOT: overlay.yaml
+// CHECK: "-vfsoverlay",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",


### PR DESCRIPTION
When improving the speed of dependency scanning when the new clang API to speed up bridging, some unintended change was introduced. This restore the scanner to the behavior before #81454

rdar://153851818

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
