### PR TITLE
[Distributed] Cleanup branch to avoid merge conflicts in future

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1000,7 +1000,7 @@ namespace {
 
       // Emit the dispatch thunk.
       auto shouldEmitDispatchThunk =
-          (Resilient || IGM.getOptions().WitnessMethodElimination);
+          Resilient || IGM.getOptions().WitnessMethodElimination;
       if (shouldEmitDispatchThunk) {
         IGM.emitDispatchThunk(func);
       }

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -108,6 +108,7 @@ public:
 
   void addDispatchThunk(SILDeclRef declRef) override {
     auto entity = LinkEntity::forDispatchThunk(declRef);
+
     addLinkEntity(entity);
 
     if (declRef.getAbstractFunctionDecl()->hasAsync())

--- a/test/TBD/distributed_library_evolution.swift
+++ b/test/TBD/distributed_library_evolution.swift
@@ -22,14 +22,14 @@
 // RUN:     -validate-tbd-against-ir=all                                       \
 // RUN:     -emit-module-interface-path %t/Library.swiftinterface
 
-// RUN: %target-swift-frontend %t/actor.swift                               \
-// RUN:     -enable-library-evolution \
+// RUN: %target-swift-frontend %t/actor.swift -enable-library-evolution     \
+// RUN:     -enable-library-evolution                                       \
 // RUN:     -disable-availability-checking -emit-ir -o %t/test.ll -emit-tbd \
 // RUN:     -emit-tbd-path %t/actor.tbd -I %t -tbd-install_name actor
 
-// RUN: %target-swift-frontend %t/actor.swift  \
-// RUN:     -I %t                   \
-// RUN:     -disable-availability-checking \
+// RUN: %target-swift-frontend %t/actor.swift                              \
+// RUN:     -I %t                                                          \
+// RUN:     -disable-availability-checking                                 \
 // RUN:     -emit-module                                                   \
 // RUN:     -package-name Package                                          \
 // RUN:     -enable-library-evolution                                      \


### PR DESCRIPTION
This cleans up the main branch to avoid merge conflicts in the future.

We had some revert adventures with TBD fixes during which minor differences and a test update were added to other branches. Make the main branch have the same changes so we won't run into un-necessary merge conflicts.