### PR TITLE
[cxx-interop] Add attribute to hide Swift declarations from interop

### DIFF
--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -99,6 +99,7 @@ enum class ENUM_EXTENSIBILITY_ATTR(closed) EffectsKind : uint8_t {
 /// This enum represents the possible values of the @_expose attribute.
 enum class ENUM_EXTENSIBILITY_ATTR(closed) ExposureKind : uint8_t {
   Cxx SWIFT_NAME("cxx"),
+  NotCxx SWIFT_NAME("notcxx"),
   Wasm SWIFT_NAME("wasm"),
   Last_ExposureKind = Wasm
 };

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2174,6 +2174,8 @@ ERROR(expose_only_non_other_attr,none,
 ERROR(expose_inside_unexposed_decl,none,
       "'@_expose' cannot be applied inside of unexposed declaration %0",
       (const ValueDecl *))
+ERROR(expose_redundant_name_provided, none,
+      "'@_expose(!Cxx)' does not accept a name argument", ())
 ERROR(expose_invalid_name_pattern_init,none,
       "invalid declaration name '%0' specified in '@_expose'; "
       "exposed initializer name must start with 'init'", (StringRef))

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1249,6 +1249,9 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     case ExposureKind::Cxx:
       Printer << "(Cxx";
       break;
+    case ExposureKind::NotCxx:
+      Printer << "(!Cxx";
+      break;
     }
     if (!cast<ExposeAttr>(this)->Name.empty())
       Printer << ", \"" << cast<ExposeAttr>(this)->Name << "\"";

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3079,13 +3079,22 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
                  "Cxx");
         ParseSymbolName = false;
       };
+      bool isNegated = false;
+      if (Tok.is(tok::oper_prefix) && Tok.getText() == "!") {
+        isNegated = true;
+        consumeToken(tok::oper_prefix);
+      }
       if (Tok.isNot(tok::identifier)) {
         diagnoseExpectOption();
         return makeParserSuccess();
       }
       if (Tok.getText() == "Cxx") {
-        ExpKind = ExposureKind::Cxx;
+        ExpKind = isNegated ? ExposureKind::NotCxx : ExposureKind::Cxx;
       } else if (Tok.getText() == "wasm") {
+        if (isNegated) {
+          diagnoseExpectOption();
+          return makeParserSuccess();
+        }
         ExpKind = ExposureKind::Wasm;
       } else {
         diagnoseExpectOption();

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/ASTVisitor.h"
+#include "swift/AST/Attr.h"
 #include "swift/AST/ClangSwiftTypeCorrespondence.h"
 #include "swift/AST/Comment.h"
 #include "swift/AST/ConformanceLookup.h"
@@ -2976,6 +2977,17 @@ static bool excludeForObjCImplementation(const ValueDecl *VD) {
   return false;
 }
 
+bool swift::hasExposeNotCxxAttr(const ValueDecl *VD) {
+  for (const auto *attr : VD->getAttrs().getAttributes<ExposeAttr>())
+    if (attr->getExposureKind() == ExposureKind::NotCxx)
+      return true;
+  if (const auto *NMT = dyn_cast<NominalTypeDecl>(VD->getDeclContext()))
+    return hasExposeNotCxxAttr(NMT);
+  if (const auto *ED = dyn_cast<ExtensionDecl>(VD->getDeclContext()))
+    return hasExposeNotCxxAttr(ED->getExtendedNominal());
+  return false;
+}
+
 static bool isExposedToThisModule(const ModuleDecl &M, const ValueDecl *VD,
                                   const llvm::StringSet<> &exposedModules) {
   if (VD->hasClangNode())
@@ -3025,6 +3037,9 @@ bool DeclAndTypePrinter::shouldInclude(const ValueDecl *VD) {
     return false;
 
   if (requiresExposedAttribute && !hasExposeAttr(VD))
+    return false;
+
+  if (hasExposeNotCxxAttr(VD))
     return false;
 
   if (!isVisible(VD))

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -160,6 +160,8 @@ public:
 
 bool isStringNestedType(const ValueDecl *VD, StringRef Typename);
 
+bool hasExposeNotCxxAttr(const ValueDecl *VD);
+
 } // end namespace swift
 
 #endif

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -1063,7 +1063,8 @@ public:
     // library. Also skip structs from the standard library, they can cause
     // ambiguities because of the arithmetic types that conflict with types we
     // already have in `swift::` namespace. Also skip `Error` protocol from
-    // stdlib, we have experimental support for it.
+    // stdlib, we have experimental support for it. Also skip explicitly exluded
+    // declarations.
     removedVDList.erase(
         llvm::remove_if(
             removedVDList,
@@ -1073,7 +1074,8 @@ public:
                       vd->getBaseIdentifier().hasUnderscoredNaming()) ||
                      (vd->isStdlibDecl() && isa<StructDecl>(vd)) ||
                      (vd->isStdlibDecl() &&
-                      vd->getASTContext().getErrorDecl() == vd);
+                      vd->getASTContext().getErrorDecl() == vd) ||
+                     swift::hasExposeNotCxxAttr(vd);
             }),
         removedVDList.end());
     // Sort the unavaiable decls by their name and kind.

--- a/test/Interop/SwiftToCxx/expose-attr/hidden-decls.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/hidden-decls.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name SwiftPrivate -clang-header-expose-decls=all-public -typecheck -verify -emit-clang-header-path %t/swiftprivate.h
+// RUN: %FileCheck %s < %t/swiftprivate.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/swiftprivate.h  -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY)
+
+public struct Exposed {
+    public var x: Int
+    @_expose(!Cxx)
+    public var notExposedField: Int
+}
+
+@_expose(!Cxx)
+public struct NotExposed {
+   public var x: Int  
+}
+
+extension NotExposed {
+    func notExposed() {}
+}
+
+@_expose(!Cxx)
+public func NotExposedfunction() {}
+
+@MainActor
+@_expose(!Cxx)
+public class UnavailableClass {
+}
+
+// CHECK-NOT: NotExposed
+// CHECK-NOT: notExposed
+// CHECK: Exposed
+// CHECK-NOT: UnavailableClass

--- a/test/attr/attr_expose.swift
+++ b/test/attr/attr_expose.swift
@@ -15,6 +15,15 @@ func incorrectLangSpecifier() {}
 @_expose(Cxx) @_cdecl("test") // expected-error {{'@_expose' cannot be applied to an '@_cdecl' declaration}}
 func cdeclAndExpose() {}
 
+@_expose(Cxx) @_expose(!Cxx)  // expected-error {{'@_expose' cannot be applied to an '@_expose(Cxx)' declaration}}
+func contradictingExpose() {}
+
+@_expose(!Cxx) @_expose(Cxx)  // expected-error {{'@_expose' cannot be applied to an '@_expose(Cxx)' declaration}}
+func contradictingExpose2() {}
+
+@_expose(!Cxx, "name")  // expected-error {{'@_expose(!Cxx)' does not accept a name argument}}
+func notExposeWithName() {}
+
 func hasNested() {
   @_expose(Cxx) // expected-error{{can only be used in a non-local scope}}
   func nested() { }


### PR DESCRIPTION
This can help work around problems when the names of a C++ declaration and a Swift declaration would collide, or to temporarily work around compiler bugs.

rdar://152838988&140802127&158843666
