### PR TITLE
[6.2] [CS] Fix a couple of use-after-frees

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -146,7 +146,7 @@ Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
   };
 
   auto subs = SubstitutionMap::get(sig, replacementTypes, lookupConformanceFn);
-  ASSERT(!subs.getRecursiveProperties().isSolverAllocated());
+  CONDITIONAL_ASSERT(!subs.getRecursiveProperties().isSolverAllocated());
   return subs;
 }
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -116,7 +116,7 @@ Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
       } else if (!type->is<PackType>())
         type = PackType::getSingletonPackExpansion(type);
     }
-    replacementTypes.push_back(type);
+    replacementTypes.push_back(simplifyType(type));
   }
 
   auto lookupConformanceFn =
@@ -145,9 +145,9 @@ Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
     return conformance;
   };
 
-  return SubstitutionMap::get(sig,
-                              replacementTypes,
-                              lookupConformanceFn);
+  auto subs = SubstitutionMap::get(sig, replacementTypes, lookupConformanceFn);
+  ASSERT(!subs.getRecursiveProperties().isSolverAllocated());
+  return subs;
 }
 
 // Lazily instantiate function definitions for class template specializations.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3880,7 +3880,8 @@ bool NonOptionalUnwrapFailure::diagnoseAsError() {
     diagnostic = diag::invalid_force_unwrap;
 
   auto range = getSourceRange();
-  emitDiagnostic(diagnostic, BaseType).highlight(range).fixItRemove(range.End);
+  emitDiagnostic(diagnostic, resolveType(BaseType))
+    .highlight(range).fixItRemove(range.End);
   return true;
 }
 

--- a/test/Constraints/rdar154553285.swift
+++ b/test/Constraints/rdar154553285.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -disable-experimental-parser-round-trip
+
+// Make sure we don't crash
+func testInvalidInInterpolation(_ x: Int) {
+  _ = "\((x, \[]))" // expected-error {{invalid component of Swift key path}}
+}

--- a/validation-test/compiler_crashers_2_fixed/4c84d3d852cdd1d4.swift
+++ b/validation-test/compiler_crashers_2_fixed/4c84d3d852cdd1d4.swift
@@ -1,0 +1,4 @@
+// {"signature":"swift::ProtocolConformanceRef::forAbstract(swift::Type, swift::ProtocolDecl*)"}
+// RUN: not %target-swift-frontend -typecheck %s
+var sixDoubles
+    : Double "six has the value [\( ( sixDoubles \[]) }0 \0\0 \0 \sixDoubles)"

--- a/validation-test/compiler_crashers_2_fixed/89bcf379b8d4d092.swift
+++ b/validation-test/compiler_crashers_2_fixed/89bcf379b8d4d092.swift
@@ -1,0 +1,6 @@
+// {"signature":"swift::FunctionType::get(llvm::ArrayRef<swift::AnyFunctionType::Param>, swift::Type, std::__1::optional<swift::ASTExtInfo>)"}
+// RUN: not %target-swift-frontend -typecheck %s
+struct a < b : FixedWidthInteger extension a : Sequence {
+  c {
+    { for
+        d self { b(truncatingIfNeeded : d

--- a/validation-test/compiler_crashers_2_fixed/b33dbab8ed3643.swift
+++ b/validation-test/compiler_crashers_2_fixed/b33dbab8ed3643.swift
@@ -1,0 +1,4 @@
+// {"signature":"swift::TypeBase::computeCanonicalType()"}
+// RUN: not %target-swift-frontend -typecheck %s
+func a (Int -> Int = { $0 func b( () = {}? ) func b {
+    / 1


### PR DESCRIPTION
*6.2 cherry-pick of #82596*

- Explanation: Fixes a couple of cases where we would let solver-allocated types escape the constraint system, leading to use-after-free crashers later in type-checking.
- Scope: Affects type-checking.
- Issue: rdar://154553285
- Risk: Low, the fixes are straightforward and the previous behavior was unsound
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich