### PR TITLE
[6.2][Concurrency] Deprecate extractIsolation

### DIFF
--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -125,6 +125,7 @@ public macro Task(
 #if $IsolatedAny
 @_alwaysEmitIntoClient
 @available(SwiftStdlib 5.1, *)
+@available(*, deprecated, message: "Use `.isolation` on @isolated(any) closure values instead.")
 public func extractIsolation<each Arg, Result>(
   _ fn: @escaping @isolated(any) (repeat each Arg) async throws -> Result
 ) -> (any Actor)? {

--- a/test/Concurrency/isolated_any.swift
+++ b/test/Concurrency/isolated_any.swift
@@ -88,12 +88,12 @@ func testConvertIsolatedAnyToMainActor(fn: @Sendable @isolated(any) () -> ()) {
 }
 
 func extractFunctionIsolation(_ fn: @isolated(any) @Sendable @escaping () async -> Void) {
-  let _: (any Actor)? = extractIsolation(fn)
+  let _: (any Actor)? = extractIsolation(fn) // expected-warning{{'extractIsolation' is deprecated: Use `.isolation` on @isolated(any) closure values instead.}}
 
   let myActor = A()
-  let _: (any Actor)? = extractIsolation(myActor.asyncActorFunction)
-  let _: (any Actor)? = extractIsolation(myActor.asyncThrowsActorFunction)
-  let _: (any Actor)? = extractIsolation(myActor.actorFunctionWithArgs(value:))
+  let _: (any Actor)? = extractIsolation(myActor.asyncActorFunction) // expected-warning{{'extractIsolation' is deprecated: Use `.isolation` on @isolated(any) closure values instead.}}
+  let _: (any Actor)? = extractIsolation(myActor.asyncThrowsActorFunction) // expected-warning{{'extractIsolation' is deprecated: Use `.isolation` on @isolated(any) closure values instead.}}
+  let _: (any Actor)? = extractIsolation(myActor.actorFunctionWithArgs(value:)) // expected-warning{{'extractIsolation' is deprecated: Use `.isolation` on @isolated(any) closure values instead.}}
 }
 
 func extractFunctionIsolationExpr(


### PR DESCRIPTION
**Description**: The public `extractIsolation` method was quickly replaced by #isolation and `.isolation` and therefore this special magic method should be deprecated.
**Scope/Impact**: Just deprecation.
**Risk:** Low, just adds deprecation warning.
**Testing**: CI testing
**Reviewed by**: @hborla

**Original PR:** https://github.com/swiftlang/swift/pull/82227/files