### PR TITLE
[cxx-interop] NFC: Move a header from `include` into `lib`

### DIFF
--- a/lib/ClangImporter/CXXMethodBridging.h
+++ b/lib/ClangImporter/CXXMethodBridging.h
@@ -4,9 +4,10 @@
 #include "swift/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "llvm/ADT/StringRef.h"
-
 #include <string>
+
 namespace swift {
+
 struct CXXMethodBridging {
   enum class Kind { unknown, getter, setter, subscript };
 
@@ -165,5 +166,7 @@ private:
            loweredName == "get" || loweredName == "set";
   }
 };
+
 } // namespace swift
+
 #endif // SWIFT_CXXMETHODBRIDGING_H

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CFTypeInfo.h"
+#include "CXXMethodBridging.h"
 #include "ClangDerivedConformances.h"
 #include "ImporterImpl.h"
 #include "SwiftDeclSynthesizer.h"
@@ -50,7 +51,6 @@
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/StringExtras.h"
 #include "swift/Basic/Version.h"
-#include "swift/ClangImporter/CXXMethodBridging.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangImporterRequests.h"
 #include "swift/ClangImporter/ClangModule.h"

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "CXXMethodBridging.h"
 #include "SwiftDeclSynthesizer.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/AttrKind.h"
@@ -20,7 +21,6 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/Assertions.h"
-#include "swift/ClangImporter/CXXMethodBridging.h"
 #include "clang/AST/Mangle.h"
 #include "clang/Sema/DelayedDiagnostic.h"
 


### PR DESCRIPTION
CXXMethodBridging.h isn't supposed to be used outside of ClangImporter, so let's keep it inside of ClangImporter's implementation.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
