### PR TITLE
[cxx-interop] Do not crash for `void begin()`

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4133,11 +4133,11 @@ void MissingMemberFailure::diagnoseUnsafeCxxMethod(SourceLoc loc,
                                                           scratch);
     };
 
-    auto returnTypeStr = cast<FuncDecl>(found)
-                             ->getResultInterfaceType()
-                             ->getAnyNominal()
-                             ->getName()
-                             .str();
+    auto returnTy =
+        cast<FuncDecl>(found)->getResultInterfaceType()->getAnyNominal();
+    if (!returnTy)
+      continue;
+    auto returnTypeStr = returnTy->getName().str();
 
     auto methodClangLoc = cxxMethod->getLocation();
     auto methodSwiftLoc =

--- a/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
+++ b/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
@@ -23,6 +23,11 @@ struct M {
   StringLiteral stringLiteral() const { return StringLiteral{"M"}; }
 };
 
+struct HasNonIteratorBeginMethod {
+  void begin() const;
+  void end() const;
+};
+
 //--- test.swift
 
 import Test
@@ -47,4 +52,9 @@ public func test(x: M) {
 
   // CHECK-NOT: error: value of type 'M' has no member 'stringLiteral'
   x.stringLiteral()
+}
+
+public func test(_ x: HasNonIteratorBeginMethod) {
+  x.begin()
+  x.end()
 }


### PR DESCRIPTION
When importing C++ methods, Swift always assumes that methods named `begin()` and `end()` are unsafe, since these methods commonly return iterator types that are inherently unsafe in Swift.

Some additional logic in Sema tries to diagnose usages of `.begin()` and `.end()` from Swift and suggest safe alternatives. That logic had a null pointer dereference bug.

rdar://153814676 / resolves https://github.com/swiftlang/swift/issues/82361

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
