### PR TITLE
Fix some outdated doc comments in PlatformConditionKinds.def

### DIFF
--- a/include/swift/AST/PlatformConditionKinds.def
+++ b/include/swift/AST/PlatformConditionKinds.def
@@ -34,13 +34,13 @@ PLATFORM_CONDITION_(Endianness, "endian")
 /// The active arch target pointer bit width (_32 or _64)
 PLATFORM_CONDITION_(PointerBitWidth, "pointerBitWidth")
 
-/// Runtime support (_ObjC or _Native)
+/// Runtime support (_ObjC, _Native, or _multithreaded)
 PLATFORM_CONDITION_(Runtime, "runtime")
 
 /// Conditional import of module
 PLATFORM_CONDITION(CanImport, "canImport")
 
-/// Target Environment (currently just 'simulator' or absent)
+/// Target Environment ('simulator', 'macCatalyst', or absent)
 PLATFORM_CONDITION(TargetEnvironment, "targetEnvironment")
 
 /// Pointer authentication enabled


### PR DESCRIPTION
This is a documentation-only change.

I was looking for definitive lists of valid arguments for `#if os()`, `#if targetEnvironment()`, etc. and found these outdated values in the doc comments.

I copied the valid values for each compilation condition from [`LangOptions.cpp`](https://github.com/swiftlang/swift/blob/main/lib/Basic/LangOptions.cpp), which looks like the definitive source to me.

Alternatively, we could refer directly to that file in the doc comments of `PlatformConditionKinds.def` to avoid them running out of sync in the future. Let me know if you prefer that.