### PR TITLE
Add `--single-arch` option to `build-toolchain`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ of the form: ``swift-LOCAL-YYYY-MM-DD-a-osx.tar.gz``.
 Beyond building the toolchain, ``build-toolchain`` also supports the 
 following (non-exhaustive) set of useful options:
 
-- ``--single-arch``: Save time by only building for the local architecture.
+- ``--single-arch``: Save time by only building for the host architecture.
 - ``--dry-run``: Perform a dry run build. This is off by default.
 - ``--test``: Test the toolchain after it has been compiled. This is off by default.
 - ``--distcc``: Use distcc to speed up the build by distributing the C++ part of

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ of the form: ``swift-LOCAL-YYYY-MM-DD-a-osx.tar.gz``.
 Beyond building the toolchain, ``build-toolchain`` also supports the 
 following (non-exhaustive) set of useful options:
 
-- ``--single-arch``: Save time by only building for the host architecture.
+- ``--single-arch``: Only build for the host architecture on macOS for faster builds or to work around issues with Homebrew dependencies not supporting cross-compilation for universal macOS binaries.
 - ``--dry-run``: Perform a dry run build. This is off by default.
 - ``--test``: Test the toolchain after it has been compiled. This is off by default.
 - ``--distcc``: Use distcc to speed up the build by distributing the C++ part of

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ of the form: ``swift-LOCAL-YYYY-MM-DD-a-osx.tar.gz``.
 Beyond building the toolchain, ``build-toolchain`` also supports the 
 following (non-exhaustive) set of useful options:
 
+- ``--single-arch``: Save time by only building for the local architecture.
 - ``--dry-run``: Perform a dry run build. This is off by default.
 - ``--test``: Test the toolchain after it has been compiled. This is off by default.
 - ``--distcc``: Use distcc to speed up the build by distributing the C++ part of

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -19,7 +19,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;libexec;
 [preset: mixin_buildbot_install_components_with_clang]
 
 swift-install-components=autolink-driver;back-deployment;compiler;clang-resource-dir-symlink;libexec;stdlib;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file;lld
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;dsymutil;LTO;clang-features-file;lld
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.
@@ -424,6 +424,8 @@ mixin-preset=buildbot_incremental_base
 # on Foundation, so that is built as well. On OS X, Foundation is built as part
 # of the XCTest Xcode project.
 xctest
+swift-testing
+swift-testing-macros
 
 build-swift-stdlib-unittest-extra
 
@@ -441,6 +443,8 @@ skip-test-foundation
 release
 assertions
 xctest
+swift-testing
+swift-testing-macros
 test
 
 skip-test-cmark
@@ -625,6 +629,8 @@ swiftformat
 swift-driver
 indexstore-db
 sourcekit-lsp
+swift-testing
+swift-testing-macros
 # Failing to build in CI: rdar://78408440
 # swift-inspect
 install-llvm
@@ -635,6 +641,8 @@ install-swiftpm
 install-swiftsyntax
 install-swift-driver
 install-swiftformat
+install-swift-testing
+install-swift-testing-macros
 
 # We need to build the unittest extras so we can test
 build-swift-stdlib-unittest-extra
@@ -669,7 +677,11 @@ skip-test-sourcekit-lsp
 skip-test-swiftpm
 skip-test-llbuild
 
-extra-cmake-options=-DSWIFT_ENABLE_NEW_RUNTIME_BUILD=YES
+enable-new-runtime-build
+
+# Escalate certain C++ warnings to errors for Swift.
+extra-swift-cmake-options=
+   -DCMAKE_CXX_FLAGS="-Werror=unused"
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
@@ -836,7 +848,7 @@ no-swift-stdlib-assertions
 [preset: mixin_linux_install_components_with_clang]
 
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;libexec;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld;LTO;clang-features-file
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;lld;LTO;clang-features-file
 
 [preset: mixin_linux_installation]
 mixin-preset=
@@ -913,6 +925,7 @@ indexstore-db
 sourcekit-lsp
 swiftdocc
 lit-args=-v --time-tests
+foundation-tests-build-type=Debug
 
 # rdar://problem/31454823
 lldb-test-swift-only
@@ -934,6 +947,11 @@ mixin-preset=
     buildbot_linux_base
 
 skip-test-swiftdocc
+
+[preset: buildbot_linux,release_foundation_tests]
+mixin-preset=buildbot_linux
+
+foundation-tests-build-type=Release
 
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux
@@ -1094,6 +1112,8 @@ install-swiftformat
 reconfigure
 test-optimized
 skip-test-swiftdocc
+lldb-test-swift-only
+foundation-tests-build-type=Debug
 
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
 # Use the clang that we install in the path for macros
@@ -1123,6 +1143,8 @@ lldb
 foundation
 swiftpm
 swift-driver
+swift-testing
+swift-testing-macros
 xctest
 
 build-subdir=buildbot_linux
@@ -1136,6 +1158,8 @@ install-foundation
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
+install-swift-testing
+install-swift-testing-macros
 install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;libexec;stdlib;swift-remote-mirror;sdk-overlay;dev
@@ -1202,6 +1226,7 @@ swiftsyntax
 swiftformat
 indexstore-db
 sourcekit-lsp
+foundation-tests-build-type=Debug
 
 install-llvm
 install-static-linux-config
@@ -1345,6 +1370,7 @@ playgroundsupport
 indexstore-db
 sourcekit-lsp
 swiftdocc
+wasmkit
 
 # Build with debug info, this allows us to symbolicate crashes from
 # production builds.
@@ -1836,8 +1862,11 @@ skip-test-foundation
 #===------------------------------------------------------------------------===#
 # Mixins for LLBuild, SwiftPM and downstream package project PR tests.
 #===------------------------------------------------------------------------===#
+# Base of SwiftPM and packages
 [preset: mixin_swiftpm_base]
-mixin-preset=buildbot_incremental_base
+mixin-preset=
+    buildbot_incremental_base
+    mixin_buildbot_install_components_with_clang
 build-subdir=buildbot_incremental
 
 libcxx
@@ -1857,15 +1886,15 @@ install-swift-testing-macros
 
 skip-test-swift
 
+# SwiftPM base
 [preset: mixin_swiftpm_macos_platform]
-mixin-preset=
-    mixin_swiftpm_base
-    mixin_buildbot_install_components_with_clang
+mixin-preset=mixin_swiftpm_base
 
+infer-cross-compile-hosts-on-darwin
+
+# SwiftPM base
 [preset: mixin_swiftpm_linux_platform]
-mixin-preset=
-    mixin_swiftpm_base
-    mixin_linux_install_components_with_clang
+mixin-preset=mixin_swiftpm_base
 
 libdispatch
 foundation
@@ -1883,9 +1912,9 @@ skip-test-xctest
 llvm-cmake-options=
   -DCLANG_DEFAULT_LINKER=gold
 
-# Builds enough of the toolchain to build a swift package on macOS.
+# SwiftPM package base
 [preset: mixin_swiftpm_package_macos_platform]
-mixin-preset=mixin_swiftpm_macos_platform
+mixin-preset=mixin_swiftpm_base
 
 # We don't need to build the benchmark if we just want SwiftPM
 skip-build-benchmarks
@@ -1898,10 +1927,22 @@ skip-watchos
 skip-test-llbuild
 skip-test-swiftpm
 
-# Builds enough of the toolchain to build a swift package on Linux.
+# SwiftPM package base
 [preset: mixin_swiftpm_package_linux_platform]
-mixin-preset=mixin_swiftpm_linux_platform
+mixin-preset=mixin_swiftpm_base
 
+libdispatch
+foundation
+xctest
+libcxx=false
+
+install-foundation
+install-libdispatch
+install-xctest
+
+skip-test-foundation
+skip-test-libdispatch
+skip-test-xctest
 skip-test-llbuild
 skip-test-swiftpm
 
@@ -2010,7 +2051,6 @@ swiftsyntax
 swiftsyntax-enable-rawsyntax-validation
 swiftsyntax-enable-test-fuzzing
 swiftsyntax-verify-generated-files
-swiftsyntax-lint
 swiftformat
 skstresstester
 sourcekit-lsp
@@ -2039,7 +2079,6 @@ assertions
 swiftsyntax
 swiftformat
 install-swiftformat
-swiftsyntax-lint
 sourcekit-lsp-lint
 
 [preset: buildbot_swiftformat_linux]
@@ -2048,7 +2087,6 @@ release
 assertions
 swiftsyntax
 swiftformat
-swiftsyntax-lint
 
 #===------------------------------------------------------------------------===#
 # Test Swift Stress Tester
@@ -2148,6 +2186,8 @@ mixin-preset=
 llbuild
 swiftpm
 xctest
+swift-testing
+swift-testing-macros
 foundation
 libdispatch
 indexstore-db
@@ -2168,6 +2208,8 @@ install-llbuild
 install-swiftpm
 install-swiftsyntax
 install-xctest
+install-swift-testing
+install-swift-testing-macros
 install-sourcekit-lsp
 install-swiftformat
 
@@ -2996,7 +3038,7 @@ darwin-toolchain-display-name-short=Swift Development Snapshot
 darwin-toolchain-display-name=Swift Development Snapshot
 darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT
 darwin-toolchain-version=3.999.999
-llvm-install-components=clang;clang-resource-headers;compiler-rt;libclang;libclang-headers;dsymutil;clang-features-file
+llvm-install-components=clang;clang-resource-headers;builtins;runtimes;libclang;libclang-headers;dsymutil;clang-features-file
 swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;libexec;sdk-overlay;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers
 symbols-package=%(symbols_package)s
 install-symroot=%(install_symroot)s
@@ -3007,8 +3049,12 @@ build-subdir=compat_linux
 foundation
 libdispatch
 xctest
+swift-testing
+swift-testing-macros
 install-foundation
 install-libdispatch
+install-swift-testing
+install-swift-testing-macros
 install-xctest
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
 
@@ -3102,3 +3148,168 @@ skip-test-foundation
 
 llvm-cmake-options=
   -DCLANG_DEFAULT_LINKER=gold
+
+#===------------------------------------------------------------------------===#
+# Toolchain Bootstrapping Stages
+#===------------------------------------------------------------------------===#
+# Build Requirements:
+#   - C and C++ compiler
+# Toolchain Outputs:
+#   - Swift Compiler (-SwiftDriver, -macros, -SwiftSilOpts)
+# Runtime Outputs:
+#   - Swift Standard Library (-macros)
+[preset: bootstrap_stage0]
+mixin-preset=
+  mixin_buildbot_linux,no_test
+
+swift-include-tests=0
+llvm-include-tests=0
+
+release
+libdispatch
+
+skip-early-swiftsyntax
+skip-early-swift-driver
+skip-build-benchmarks
+build-swift-examples=0
+
+build-runtime-with-host-compiler=0
+build-swift-libexec=0
+build-swift-remote-mirror=0
+build-swift-static-sdk-overlay=0
+build-swift-static-stdlib=0
+enable-experimental-concurrency=1
+enable-experimental-distributed=0
+enable-experimental-observation=0
+enable-experimental-differentiable-programming=0
+
+extra-llvm-cmake-options=
+  -DLLVM_TARGETS_TO_BUILD=AArch64;X86
+
+extra-swift-cmake-options=
+  -DSWIFT_ENABLE_SWIFT_IN_SWIFT:BOOL=NO
+  -DSWIFT_INCLUDE_DOCS:BOOL=NO
+  -DSWIFT_BUILD_EXAMPLES:BOOL=OFF
+
+build-subdir=%(build_subdir)s
+install-destdir=%(install_destdir)s
+
+swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;toolchain-tools
+llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;builtins;runtimes;clang-features-file;llvm-symbolizer
+
+install-llvm
+install-swift
+install-libdispatch
+
+# Build Toolchain Requirements:
+# - C/C++ compiler
+# - Swift Compiler (-SwiftDriver, -macros, -SwiftSilOpts)
+# Toolchain Outputs:
+# - Swift Compiler (-SwiftDriver, +macros, +SwiftSilOpts)
+# Runtime Outputs:
+# - Standard Library (+macros)
+# - Dispatch
+# - Foundation (+macros)
+[preset: bootstrap_stage1]
+mixin-preset=mixin_buildbot_linux,no_test
+bootstrapping=hosttools
+
+release
+foundation
+libdispatch
+
+skip-early-swift-driver
+skip-build-benchmarks
+
+enable-experimental-concurrency=1
+
+extra-cmake-options=
+  -DLLVM_TARGETS_TO_BUILD=AArch64;X86
+
+swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;toolchain-tools;license
+llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;builtins;runtimes;clang-features-file;lld
+
+build-subdir=%(build_subdir)s
+install-destdir=%(install_destdir)s
+
+install-llvm
+install-swift
+install-foundation
+install-libdispatch
+
+[preset: bootstrap_stage2]
+mixin-preset=mixin_buildbot_linux,no_test
+bootstrapping=hosttools
+
+release
+
+skip-early-swift-driver
+
+llbuild
+xctest
+swift-testing
+swift-testing-macros
+swiftpm
+
+swift-include-tests=0
+llvm-include-tests=0
+
+
+foundation
+libdispatch
+
+skip-build-benchmarks
+skip-test-cmark
+
+build-subdir=%(build_subdir)s
+install-destdir=%(install_destdir)s
+
+swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;toolchain-tools;license
+llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;builtins;runtimes;clang-features-file;lld
+
+install-llvm
+install-swift
+install-foundation
+install-libdispatch
+install-llbuild
+install-swiftpm
+install-swift-testing
+install-swift-testing-macros
+install-xctest
+
+# For local use only. This allows quickly rebuilding and testing Wasm stdlib
+# end-to-end without rebuilding the whole toolchain.
+[preset: wasm_stdlib_incremental]
+
+assertions
+swift-enable-ast-verifier=0
+no-swift-stdlib-assertions
+build-embedded-stdlib-cross-compiling
+build-wasm-stdlib
+release-debuginfo
+test
+lit-args=-v --time-tests
+skip-test-swiftdocc
+skip-test-cmark
+skip-test-lldb
+skip-test-swift
+skip-test-llbuild
+skip-test-swiftpm
+skip-test-swift-driver
+skip-test-xctest
+skip-test-foundation
+skip-test-libdispatch
+skip-test-playgroundsupport
+skip-test-indexstore-db
+skip-test-sourcekit-lsp
+skip-test-swiftformat
+skip-build-llvm
+skip-build-swift
+skip-early-swift-driver
+skip-build-cmark
+install-destdir=%(install_destdir)s
+
+[preset: wasm_stdlib_incremental,macos]
+
+mixin-preset=wasm_stdlib_incremental
+build-subdir=buildbot_osx

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1349,7 +1349,7 @@ llvm-targets-to-build=X86;ARM;AArch64;WebAssembly
 #===------------------------------------------------------------------------===#
 # OS X Package Builders
 #===------------------------------------------------------------------------===#
-[preset: mixin_osx_package_root]
+[preset: mixin_osx_package_base]
 mixin-preset=mixin_buildbot_install_components_with_clang
 ios
 tvos
@@ -1376,6 +1376,9 @@ wasmkit
 # production builds.
 release-debuginfo
 compiler-vendor=apple
+
+# Cross compile for Apple Silicon
+infer-cross-compile-hosts-on-darwin
 
 lldb-use-system-debugserver
 lldb-build-type=Release
@@ -1450,13 +1453,6 @@ darwin-toolchain-name=%(darwin_toolchain_xctoolchain_name)s
 darwin-toolchain-version=%(darwin_toolchain_version)s
 darwin-toolchain-alias=%(darwin_toolchain_alias)s
 darwin-toolchain-require-use-os-runtime=0
-
-[preset: mixin_osx_package_base]
-mixin-preset=
-    mixin_osx_package_root
-
-# Cross compile for Apple Silicon
-infer-cross-compile-hosts-on-darwin
 
 [preset: mixin_osx_package_test]
 build-subdir=buildbot_osx
@@ -1612,12 +1608,6 @@ mixin-preset=
     buildbot_osx_package
     mixin_buildbot_osx_package,no_test
     mixin_osx_package,use_os_runtime
-
-[preset: buildbot_osx_package,no_test,single_arch]
-build-subdir=buildbot_osx
-mixin-preset=
-    mixin_osx_package_root
-    mixin_buildbot_osx_package,no_test
 
 #===------------------------------------------------------------------------===#
 # LLDB build configurations

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -19,7 +19,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;libexec;
 [preset: mixin_buildbot_install_components_with_clang]
 
 swift-install-components=autolink-driver;back-deployment;compiler;clang-resource-dir-symlink;libexec;stdlib;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;dsymutil;LTO;clang-features-file;lld
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file;lld
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.
@@ -424,8 +424,6 @@ mixin-preset=buildbot_incremental_base
 # on Foundation, so that is built as well. On OS X, Foundation is built as part
 # of the XCTest Xcode project.
 xctest
-swift-testing
-swift-testing-macros
 
 build-swift-stdlib-unittest-extra
 
@@ -443,8 +441,6 @@ skip-test-foundation
 release
 assertions
 xctest
-swift-testing
-swift-testing-macros
 test
 
 skip-test-cmark
@@ -629,8 +625,6 @@ swiftformat
 swift-driver
 indexstore-db
 sourcekit-lsp
-swift-testing
-swift-testing-macros
 # Failing to build in CI: rdar://78408440
 # swift-inspect
 install-llvm
@@ -641,8 +635,6 @@ install-swiftpm
 install-swiftsyntax
 install-swift-driver
 install-swiftformat
-install-swift-testing
-install-swift-testing-macros
 
 # We need to build the unittest extras so we can test
 build-swift-stdlib-unittest-extra
@@ -677,11 +669,7 @@ skip-test-sourcekit-lsp
 skip-test-swiftpm
 skip-test-llbuild
 
-enable-new-runtime-build
-
-# Escalate certain C++ warnings to errors for Swift.
-extra-swift-cmake-options=
-   -DCMAKE_CXX_FLAGS="-Werror=unused"
+extra-cmake-options=-DSWIFT_ENABLE_NEW_RUNTIME_BUILD=YES
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx,flto]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
@@ -848,7 +836,7 @@ no-swift-stdlib-assertions
 [preset: mixin_linux_install_components_with_clang]
 
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;libexec;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;lld;LTO;clang-features-file
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld;LTO;clang-features-file
 
 [preset: mixin_linux_installation]
 mixin-preset=
@@ -925,7 +913,6 @@ indexstore-db
 sourcekit-lsp
 swiftdocc
 lit-args=-v --time-tests
-foundation-tests-build-type=Debug
 
 # rdar://problem/31454823
 lldb-test-swift-only
@@ -947,11 +934,6 @@ mixin-preset=
     buildbot_linux_base
 
 skip-test-swiftdocc
-
-[preset: buildbot_linux,release_foundation_tests]
-mixin-preset=buildbot_linux
-
-foundation-tests-build-type=Release
 
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux
@@ -1112,8 +1094,6 @@ install-swiftformat
 reconfigure
 test-optimized
 skip-test-swiftdocc
-lldb-test-swift-only
-foundation-tests-build-type=Debug
 
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
 # Use the clang that we install in the path for macros
@@ -1143,8 +1123,6 @@ lldb
 foundation
 swiftpm
 swift-driver
-swift-testing
-swift-testing-macros
 xctest
 
 build-subdir=buildbot_linux
@@ -1158,8 +1136,6 @@ install-foundation
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
-install-swift-testing
-install-swift-testing-macros
 install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;libexec;stdlib;swift-remote-mirror;sdk-overlay;dev
@@ -1226,7 +1202,6 @@ swiftsyntax
 swiftformat
 indexstore-db
 sourcekit-lsp
-foundation-tests-build-type=Debug
 
 install-llvm
 install-static-linux-config
@@ -1349,7 +1324,7 @@ llvm-targets-to-build=X86;ARM;AArch64;WebAssembly
 #===------------------------------------------------------------------------===#
 # OS X Package Builders
 #===------------------------------------------------------------------------===#
-[preset: mixin_osx_package_base]
+[preset: mixin_osx_package_root]
 mixin-preset=mixin_buildbot_install_components_with_clang
 ios
 tvos
@@ -1370,15 +1345,11 @@ playgroundsupport
 indexstore-db
 sourcekit-lsp
 swiftdocc
-wasmkit
 
 # Build with debug info, this allows us to symbolicate crashes from
 # production builds.
 release-debuginfo
 compiler-vendor=apple
-
-# Cross compile for Apple Silicon
-infer-cross-compile-hosts-on-darwin
 
 lldb-use-system-debugserver
 lldb-build-type=Release
@@ -1453,6 +1424,13 @@ darwin-toolchain-name=%(darwin_toolchain_xctoolchain_name)s
 darwin-toolchain-version=%(darwin_toolchain_version)s
 darwin-toolchain-alias=%(darwin_toolchain_alias)s
 darwin-toolchain-require-use-os-runtime=0
+
+[preset: mixin_osx_package_base]
+mixin-preset=
+    mixin_osx_package_root
+
+# Cross compile for Apple Silicon
+infer-cross-compile-hosts-on-darwin
 
 [preset: mixin_osx_package_test]
 build-subdir=buildbot_osx
@@ -1608,6 +1586,11 @@ mixin-preset=
     buildbot_osx_package
     mixin_buildbot_osx_package,no_test
     mixin_osx_package,use_os_runtime
+
+[preset: buildbot_osx_package,no_test,single_arch]
+mixin-preset=
+    mixin_osx_package_root
+    mixin_buildbot_osx_package,no_test
 
 #===------------------------------------------------------------------------===#
 # LLDB build configurations
@@ -1853,11 +1836,8 @@ skip-test-foundation
 #===------------------------------------------------------------------------===#
 # Mixins for LLBuild, SwiftPM and downstream package project PR tests.
 #===------------------------------------------------------------------------===#
-# Base of SwiftPM and packages
 [preset: mixin_swiftpm_base]
-mixin-preset=
-    buildbot_incremental_base
-    mixin_buildbot_install_components_with_clang
+mixin-preset=buildbot_incremental_base
 build-subdir=buildbot_incremental
 
 libcxx
@@ -1877,15 +1857,15 @@ install-swift-testing-macros
 
 skip-test-swift
 
-# SwiftPM base
 [preset: mixin_swiftpm_macos_platform]
-mixin-preset=mixin_swiftpm_base
+mixin-preset=
+    mixin_swiftpm_base
+    mixin_buildbot_install_components_with_clang
 
-infer-cross-compile-hosts-on-darwin
-
-# SwiftPM base
 [preset: mixin_swiftpm_linux_platform]
-mixin-preset=mixin_swiftpm_base
+mixin-preset=
+    mixin_swiftpm_base
+    mixin_linux_install_components_with_clang
 
 libdispatch
 foundation
@@ -1903,9 +1883,9 @@ skip-test-xctest
 llvm-cmake-options=
   -DCLANG_DEFAULT_LINKER=gold
 
-# SwiftPM package base
+# Builds enough of the toolchain to build a swift package on macOS.
 [preset: mixin_swiftpm_package_macos_platform]
-mixin-preset=mixin_swiftpm_base
+mixin-preset=mixin_swiftpm_macos_platform
 
 # We don't need to build the benchmark if we just want SwiftPM
 skip-build-benchmarks
@@ -1918,22 +1898,10 @@ skip-watchos
 skip-test-llbuild
 skip-test-swiftpm
 
-# SwiftPM package base
+# Builds enough of the toolchain to build a swift package on Linux.
 [preset: mixin_swiftpm_package_linux_platform]
-mixin-preset=mixin_swiftpm_base
+mixin-preset=mixin_swiftpm_linux_platform
 
-libdispatch
-foundation
-xctest
-libcxx=false
-
-install-foundation
-install-libdispatch
-install-xctest
-
-skip-test-foundation
-skip-test-libdispatch
-skip-test-xctest
 skip-test-llbuild
 skip-test-swiftpm
 
@@ -2042,6 +2010,7 @@ swiftsyntax
 swiftsyntax-enable-rawsyntax-validation
 swiftsyntax-enable-test-fuzzing
 swiftsyntax-verify-generated-files
+swiftsyntax-lint
 swiftformat
 skstresstester
 sourcekit-lsp
@@ -2070,6 +2039,7 @@ assertions
 swiftsyntax
 swiftformat
 install-swiftformat
+swiftsyntax-lint
 sourcekit-lsp-lint
 
 [preset: buildbot_swiftformat_linux]
@@ -2078,6 +2048,7 @@ release
 assertions
 swiftsyntax
 swiftformat
+swiftsyntax-lint
 
 #===------------------------------------------------------------------------===#
 # Test Swift Stress Tester
@@ -2177,8 +2148,6 @@ mixin-preset=
 llbuild
 swiftpm
 xctest
-swift-testing
-swift-testing-macros
 foundation
 libdispatch
 indexstore-db
@@ -2199,8 +2168,6 @@ install-llbuild
 install-swiftpm
 install-swiftsyntax
 install-xctest
-install-swift-testing
-install-swift-testing-macros
 install-sourcekit-lsp
 install-swiftformat
 
@@ -3029,7 +2996,7 @@ darwin-toolchain-display-name-short=Swift Development Snapshot
 darwin-toolchain-display-name=Swift Development Snapshot
 darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT
 darwin-toolchain-version=3.999.999
-llvm-install-components=clang;clang-resource-headers;builtins;runtimes;libclang;libclang-headers;dsymutil;clang-features-file
+llvm-install-components=clang;clang-resource-headers;compiler-rt;libclang;libclang-headers;dsymutil;clang-features-file
 swift-install-components=back-deployment;compiler;clang-builtin-headers;stdlib;libexec;sdk-overlay;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers
 symbols-package=%(symbols_package)s
 install-symroot=%(install_symroot)s
@@ -3040,12 +3007,8 @@ build-subdir=compat_linux
 foundation
 libdispatch
 xctest
-swift-testing
-swift-testing-macros
 install-foundation
 install-libdispatch
-install-swift-testing
-install-swift-testing-macros
 install-xctest
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;libexec;swift-remote-mirror;sdk-overlay;license
 
@@ -3139,168 +3102,3 @@ skip-test-foundation
 
 llvm-cmake-options=
   -DCLANG_DEFAULT_LINKER=gold
-
-#===------------------------------------------------------------------------===#
-# Toolchain Bootstrapping Stages
-#===------------------------------------------------------------------------===#
-# Build Requirements:
-#   - C and C++ compiler
-# Toolchain Outputs:
-#   - Swift Compiler (-SwiftDriver, -macros, -SwiftSilOpts)
-# Runtime Outputs:
-#   - Swift Standard Library (-macros)
-[preset: bootstrap_stage0]
-mixin-preset=
-  mixin_buildbot_linux,no_test
-
-swift-include-tests=0
-llvm-include-tests=0
-
-release
-libdispatch
-
-skip-early-swiftsyntax
-skip-early-swift-driver
-skip-build-benchmarks
-build-swift-examples=0
-
-build-runtime-with-host-compiler=0
-build-swift-libexec=0
-build-swift-remote-mirror=0
-build-swift-static-sdk-overlay=0
-build-swift-static-stdlib=0
-enable-experimental-concurrency=1
-enable-experimental-distributed=0
-enable-experimental-observation=0
-enable-experimental-differentiable-programming=0
-
-extra-llvm-cmake-options=
-  -DLLVM_TARGETS_TO_BUILD=AArch64;X86
-
-extra-swift-cmake-options=
-  -DSWIFT_ENABLE_SWIFT_IN_SWIFT:BOOL=NO
-  -DSWIFT_INCLUDE_DOCS:BOOL=NO
-  -DSWIFT_BUILD_EXAMPLES:BOOL=OFF
-
-build-subdir=%(build_subdir)s
-install-destdir=%(install_destdir)s
-
-swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;toolchain-tools
-llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;builtins;runtimes;clang-features-file;llvm-symbolizer
-
-install-llvm
-install-swift
-install-libdispatch
-
-# Build Toolchain Requirements:
-# - C/C++ compiler
-# - Swift Compiler (-SwiftDriver, -macros, -SwiftSilOpts)
-# Toolchain Outputs:
-# - Swift Compiler (-SwiftDriver, +macros, +SwiftSilOpts)
-# Runtime Outputs:
-# - Standard Library (+macros)
-# - Dispatch
-# - Foundation (+macros)
-[preset: bootstrap_stage1]
-mixin-preset=mixin_buildbot_linux,no_test
-bootstrapping=hosttools
-
-release
-foundation
-libdispatch
-
-skip-early-swift-driver
-skip-build-benchmarks
-
-enable-experimental-concurrency=1
-
-extra-cmake-options=
-  -DLLVM_TARGETS_TO_BUILD=AArch64;X86
-
-swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;toolchain-tools;license
-llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;builtins;runtimes;clang-features-file;lld
-
-build-subdir=%(build_subdir)s
-install-destdir=%(install_destdir)s
-
-install-llvm
-install-swift
-install-foundation
-install-libdispatch
-
-[preset: bootstrap_stage2]
-mixin-preset=mixin_buildbot_linux,no_test
-bootstrapping=hosttools
-
-release
-
-skip-early-swift-driver
-
-llbuild
-xctest
-swift-testing
-swift-testing-macros
-swiftpm
-
-swift-include-tests=0
-llvm-include-tests=0
-
-
-foundation
-libdispatch
-
-skip-build-benchmarks
-skip-test-cmark
-
-build-subdir=%(build_subdir)s
-install-destdir=%(install_destdir)s
-
-swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;toolchain-tools;license
-llvm-install-components=llvm-ar;llvm-ranlib;clang;clang-resource-headers;builtins;runtimes;clang-features-file;lld
-
-install-llvm
-install-swift
-install-foundation
-install-libdispatch
-install-llbuild
-install-swiftpm
-install-swift-testing
-install-swift-testing-macros
-install-xctest
-
-# For local use only. This allows quickly rebuilding and testing Wasm stdlib
-# end-to-end without rebuilding the whole toolchain.
-[preset: wasm_stdlib_incremental]
-
-assertions
-swift-enable-ast-verifier=0
-no-swift-stdlib-assertions
-build-embedded-stdlib-cross-compiling
-build-wasm-stdlib
-release-debuginfo
-test
-lit-args=-v --time-tests
-skip-test-swiftdocc
-skip-test-cmark
-skip-test-lldb
-skip-test-swift
-skip-test-llbuild
-skip-test-swiftpm
-skip-test-swift-driver
-skip-test-xctest
-skip-test-foundation
-skip-test-libdispatch
-skip-test-playgroundsupport
-skip-test-indexstore-db
-skip-test-sourcekit-lsp
-skip-test-swiftformat
-skip-build-llvm
-skip-build-swift
-skip-early-swift-driver
-skip-build-cmark
-install-destdir=%(install_destdir)s
-
-[preset: wasm_stdlib_incremental,macos]
-
-mixin-preset=wasm_stdlib_incremental
-build-subdir=buildbot_osx

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1614,6 +1614,7 @@ mixin-preset=
     mixin_osx_package,use_os_runtime
 
 [preset: buildbot_osx_package,no_test,single_arch]
+build-subdir=buildbot_osx
 mixin-preset=
     mixin_osx_package_root
     mixin_buildbot_osx_package,no_test

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -60,8 +60,7 @@ NO_TEST=",no_test"
 USE_OS_RUNTIME=
 MACOS_ONLY=
 NO_ASSERTIONS=
-PRESET_FILE=utils/build-presets.ini
-SINGLE_ARCH_PRESET_FILE=utils/build-toolchain-presets.ini
+SINGLE_ARCH=
 
 case $(uname -s) in
   Darwin)
@@ -97,7 +96,6 @@ while [ $# -ne 0 ]; do
     --preset-file)
       shift
       PRESET_FILE_FLAGS="${PRESET_FILE_FLAGS} --preset-file=$1"
-      PRESET_FILE=$1
   ;;
     --preset-prefix)
       shift
@@ -113,9 +111,7 @@ while [ $# -ne 0 ]; do
       NO_ASSERTIONS=",no_assertions"
   ;;
     --single-arch)
-      grep -v infer-cross-compile-hosts-on-darwin $PRESET_FILE >$SINGLE_ARCH_PRESET_FILE
-      PRESET_FILE_FLAGS="--preset-file=$SINGLE_ARCH_PRESET_FILE"
-      PRESET_FILE=$SINGLE_ARCH_PRESET_FILE
+      SINGLE_ARCH=",single_arch"
   ;;
   -h|--help)
     usage
@@ -167,7 +163,7 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
 
 ./utils/build-script ${DRY_RUN} ${DISTCC_FLAG} ${PRESET_FILE_FLAGS} \
         ${SCCACHE_FLAG} \
-        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_ASSERTIONS}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}" \
+        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_ASSERTIONS}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}${SINGLE_ARCH}" \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \
@@ -180,7 +176,3 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
         darwin_toolchain_version="${TOOLCHAIN_VERSION}" \
         darwin_toolchain_alias="Local" \
         darwin_toolchain_require_use_os_runtime="${REQUIRE_USE_OS_RUNTIME}"
-
-if [ "$PRESET_FILE" = "$SINGLE_ARCH_PRESET_FILE" ]; then
-  rm -r "$SINGLE_ARCH_PRESET_FILE" ../swift-nightly-{install,symroot}
-fi

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -60,6 +60,8 @@ NO_TEST=",no_test"
 USE_OS_RUNTIME=
 MACOS_ONLY=
 NO_ASSERTIONS=
+PRESET_FILE=utils/build-presets.ini
+SINGLE_ARCH_PRESET_FILE=utils/build-toolchain-presets.ini
 
 case $(uname -s) in
   Darwin)
@@ -95,6 +97,7 @@ while [ $# -ne 0 ]; do
     --preset-file)
       shift
       PRESET_FILE_FLAGS="${PRESET_FILE_FLAGS} --preset-file=$1"
+      PRESET_FILE=$1
   ;;
     --preset-prefix)
       shift
@@ -110,24 +113,9 @@ while [ $# -ne 0 ]; do
       NO_ASSERTIONS=",no_assertions"
   ;;
     --single-arch)
-      SINGLE_ARCH=1
-      git apply <<SINGLE_ARCH
-diff --git a/utils/build-presets.ini b/utils/build-presets.ini
-index d3e88a1107f..a8be5551f14 100644
---- a/utils/build-presets.ini
-+++ b/utils/build-presets.ini
-@@ -1352,7 +1352,9 @@ release-debuginfo
- compiler-vendor=apple
- 
- # Cross compile for Apple Silicon
--infer-cross-compile-hosts-on-darwin
-+# Temporarilly commented out for
-+# build-toolchain <id> --single-arch
-+#infer-cross-compile-hosts-on-darwin
- 
- lldb-use-system-debugserver
- lldb-build-type=Release
-SINGLE_ARCH
+      grep -v infer-cross-compile-hosts-on-darwin $PRESET_FILE >$SINGLE_ARCH_PRESET_FILE
+      PRESET_FILE_FLAGS="--preset-file=$SINGLE_ARCH_PRESET_FILE"
+      PRESET_FILE=$SINGLE_ARCH_PRESET_FILE
   ;;
   -h|--help)
     usage
@@ -193,7 +181,6 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
         darwin_toolchain_alias="Local" \
         darwin_toolchain_require_use_os_runtime="${REQUIRE_USE_OS_RUNTIME}"
 
-if [ "$SINGLE_ARCH" != "" ]; then
-  git checkout utils/build-presets.ini
-  rm -r ../swift-nightly-{install,symroot}
+if [ "$PRESET_FILE" = "$SINGLE_ARCH_PRESET_FILE" ]; then
+  rm -r "$SINGLE_ARCH_PRESET_FILE" ../swift-nightly-{install,symroot}
 fi

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -109,6 +109,26 @@ while [ $# -ne 0 ]; do
     -a|--no-assert)
       NO_ASSERTIONS=",no_assertions"
   ;;
+    --single-arch)
+      SINGLE_ARCH=1
+      git apply <<SINGLE_ARCH
+diff --git a/utils/build-presets.ini b/utils/build-presets.ini
+index d3e88a1107f..a8be5551f14 100644
+--- a/utils/build-presets.ini
++++ b/utils/build-presets.ini
+@@ -1352,7 +1352,9 @@ release-debuginfo
+ compiler-vendor=apple
+ 
+ # Cross compile for Apple Silicon
+-infer-cross-compile-hosts-on-darwin
++# Temporarilly commented out for
++# build-toolchain <id> --single-arch
++#infer-cross-compile-hosts-on-darwin
+ 
+ lldb-use-system-debugserver
+ lldb-build-type=Release
+SINGLE_ARCH
+  ;;
   -h|--help)
     usage
     exit 0
@@ -172,3 +192,8 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
         darwin_toolchain_version="${TOOLCHAIN_VERSION}" \
         darwin_toolchain_alias="Local" \
         darwin_toolchain_require_use_os_runtime="${REQUIRE_USE_OS_RUNTIME}"
+
+if [ "$SINGLE_ARCH" != "" ]; then
+  git checkout utils/build-presets.ini
+  rm -r ../swift-nightly-{install,symroot}
+fi

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -60,7 +60,8 @@ NO_TEST=",no_test"
 USE_OS_RUNTIME=
 MACOS_ONLY=
 NO_ASSERTIONS=
-SINGLE_ARCH=
+PRESET_FILE=utils/build-presets.ini
+SINGLE_ARCH_PRESET_FILE=utils/build-toolchain-presets.ini
 
 case $(uname -s) in
   Darwin)
@@ -96,6 +97,7 @@ while [ $# -ne 0 ]; do
     --preset-file)
       shift
       PRESET_FILE_FLAGS="${PRESET_FILE_FLAGS} --preset-file=$1"
+      PRESET_FILE=$1
   ;;
     --preset-prefix)
       shift
@@ -111,9 +113,11 @@ while [ $# -ne 0 ]; do
       NO_ASSERTIONS=",no_assertions"
   ;;
     --single-arch)
-      SINGLE_ARCH=",single_arch"
+      grep -v infer-cross-compile-hosts-on-darwin $PRESET_FILE >$SINGLE_ARCH_PRESET_FILE
+      PRESET_FILE_FLAGS="--preset-file=$SINGLE_ARCH_PRESET_FILE"
+      PRESET_FILE=$SINGLE_ARCH_PRESET_FILE
   ;;
-  -h|--help)
+    -h|--help)
     usage
     exit 0
   ;;
@@ -163,7 +167,7 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
 
 ./utils/build-script ${DRY_RUN} ${DISTCC_FLAG} ${PRESET_FILE_FLAGS} \
         ${SCCACHE_FLAG} \
-        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_ASSERTIONS}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}${SINGLE_ARCH}" \
+        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_ASSERTIONS}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}" \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \
@@ -176,3 +180,7 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
         darwin_toolchain_version="${TOOLCHAIN_VERSION}" \
         darwin_toolchain_alias="Local" \
         darwin_toolchain_require_use_os_runtime="${REQUIRE_USE_OS_RUNTIME}"
+
+if [ "$PRESET_FILE" = "$SINGLE_ARCH_PRESET_FILE" ]; then
+  rm -r "$SINGLE_ARCH_PRESET_FILE" ../swift-nightly-{install,symroot}
+fi


### PR DESCRIPTION
Add --single-arch option.

Hi Apple, this patch is a follow up to the [conversation on S/E](https://forums.swift.org/t/unable-to-build-toolchain-due-to-thin-libzstd-dylib/67043/14) related to the difficulty of using the `utils/build-toolchain` script since the introduction of Macs with Apple silicon. This adds an option `--single-arch` which by temporally removing the `infer-cross-compile-hosts-on-darwin` option from the `mixin_osx_package_base` preset allows users's to build a toolchain for their current architecture only.

This should probably be the default for this script but as how it goes about it is a little untidy I'll leave it as it as an option.

Cheers