### PR TITLE
[Backtracing][Linux] Fix crash handler for musl.

### DIFF
--- a/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
+++ b/stdlib/public/RuntimeModule/SymbolicatedBacktrace.swift
@@ -466,9 +466,6 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
     for frame in backtrace.frames {
       let address = frame.adjustedProgramCounter
       if let imageNdx = theImages.indexOfImage(at: address) {
-        let relativeAddress = ImageSource.Address(
-          address - theImages[imageNdx].baseAddress
-        )
         let name = theImages[imageNdx].name ?? "<unknown>"
         var symbol: Symbol = Symbol(imageIndex: imageNdx,
                                     imageName: name,
@@ -527,6 +524,9 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
         if let hit = cache.lookup(path: theImages[imageNdx].path) {
           switch hit {
             case let .elf32Image(image):
+              let relativeAddress = ImageSource.Address(
+                address - theImages[imageNdx].baseAddress
+              ) + image.imageBase
               if let theSymbol = lookupSymbol(image: image,
                                               at: imageNdx,
                                               named: name,
@@ -534,6 +534,9 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
                 symbol = theSymbol
               }
             case let .elf64Image(image):
+              let relativeAddress = ImageSource.Address(
+                address - theImages[imageNdx].baseAddress
+              ) + image.imageBase
               if let theSymbol = lookupSymbol(image: image,
                                               at: imageNdx,
                                               named: name,


### PR DESCRIPTION
Musl's `clone()` wrapper returns `EINVAL` if you try to use `CLONE_THREAD`, which seems a bit wrong (certainly it is in this particular application, since we *really* don't care whether the thread is a valid C library thread at this point).

Also properly support ELF images that are built with a base address other than zero (this typically isn't an issue for dynamically linked programs, as they will be relocated at runtime anyway, but for statically linked binaries it's very common to set the base address to a non-zero value).

rdar://154282813
