### PR TITLE
CHERRYPICK: Fix repeated words in documentation

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -1209,7 +1209,7 @@ extension UnsafeMutableBufferPointer {
 }
 
 extension UnsafeMutableBufferPointer where Element: ~Copyable {
-  /// Updates this buffer's initialized memory initialized memory by moving
+  /// Updates this buffer's initialized memory by moving
   /// every element from the source buffer, leaving the source memory
   /// uninitialized.
   ///

--- a/stdlib/public/core/UnsafeBufferPointerSlice.swift
+++ b/stdlib/public/core/UnsafeBufferPointerSlice.swift
@@ -949,7 +949,7 @@ extension Slice {
     return unsafe startIndex.advanced(by: distance)
   }
 
-  /// Updates this buffer slice's initialized memory initialized memory by
+  /// Updates this buffer slice's initialized memory by
   /// moving every element from the source buffer,
   /// leaving the source memory uninitialized.
   ///


### PR DESCRIPTION
Cherry-picked from https://github.com/swiftlang/swift/pull/82635

Fixes: rdar://154473231