### PR TITLE
[6.2][ScanDependencies] Fix a bug in rewrite from #81454

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -144,11 +144,11 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
     if (!ctx.CASOpts.EnableCaching) {
       auto &overlayFiles = invocation.getMutHeaderSearchOpts().VFSOverlayFiles;
       for (auto overlay : overlayFiles) {
+        if (llvm::is_contained(ctx.SearchPathOpts.VFSOverlayFiles, overlay))
+          continue;
         swiftArgs.push_back("-vfsoverlay");
         swiftArgs.push_back(overlay);
       }
-      // Clear overlay files since they are forwarded from swift to clang.
-      overlayFiles.clear();
     }
 
     // Add args reported by the scanner.

--- a/test/ScanDependencies/preserve_used_vfs.swift
+++ b/test/ScanDependencies/preserve_used_vfs.swift
@@ -2,11 +2,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/module-cache)
 // RUN: %empty-directory(%t/inputs)
+// RUN: %empty-directory(%t/inputs-2)
 // RUN: split-file %s %t
 
 // RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%t/inputs|g" %t/overlay_template.yaml > %t/overlay.yaml
+// RUN: sed -e "s|OUT_DIR|%t/redirects-2|g"  -e "s|IN_DIR|%t/inputs-2|g" %t/overlay_template_2.yaml > %t/overlay-2.yaml
 
-// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -Xcc -ivfsoverlay -Xcc %t/overlay.yaml
+/// Put some files in RealFileSystem that need to be over shadow by VFS.
+// RUN: touch %t/inputs/module.modulemap
+// RUN: touch %t/inputs-2/module.modulemap
+
+// RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -I %t/inputs-2 -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -Xcc -ivfsoverlay -Xcc %t/overlay.yaml -Xcc -ivfsoverlay -Xcc %t/overlay-2.yaml
 // RUN: %validate-json %t/deps.json | %FileCheck %s
 
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
@@ -15,6 +21,8 @@
 // RUN: %swift_frontend_plain @%t/swift.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json SwiftOnoneSupport > %t/onone.cmd
 // RUN: %swift_frontend_plain @%t/onone.cmd
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:Indirect > %t/Indirect.cmd
+// RUN: %swift_frontend_plain @%t/Indirect.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:F > %t/F.cmd
 // RUN: %swift_frontend_plain @%t/F.cmd
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json F > %t/SwiftF.cmd
@@ -28,15 +36,25 @@
 // RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/map.json\"" >> %t/MyApp.cmd
 
-// RUN: %target-swift-frontend @%t/MyApp.cmd %t/test.swift -Xcc -ivfsoverlay -Xcc %t/overlay.yaml \
+// RUN: %target-swift-frontend @%t/MyApp.cmd %t/test.swift -Xcc -ivfsoverlay -Xcc %t/overlay.yaml -Xcc -ivfsoverlay -Xcc %t/overlay-2.yaml \
 // RUN:   -emit-module -o %t/Test.swiftmodule
 
 //--- redirects/RedirectedF.h
+#include "Indirect_2.h"
 void funcRedirectedF(void);
 
 //--- redirects/modulemap
 module F {
   header "F_2.h"
+  export *
+}
+
+//--- redirects-2/RedirectedIndirect.h
+void funcRedirectedIndirect(void);
+
+//--- redirects-2/modulemap
+module Indirect {
+  header "Indirect_2.h"
   export *
 }
 
@@ -59,10 +77,30 @@ module F {
   ]
 }
 
+//--- overlay_template_2.yaml
+{
+  'version': 0,
+  'use-external-names': false,
+  'roots': [
+    {
+      'name': 'IN_DIR', 'type': 'directory',
+      'contents': [
+        { 'name': 'Indirect_2.h', 'type': 'file',
+          'external-contents': 'OUT_DIR/RedirectedIndirect.h'
+        },
+        { 'name': 'module.modulemap', 'type': 'file',
+          'external-contents': 'OUT_DIR/modulemap'
+        }
+      ]
+    },
+  ]
+}
+
 //--- test.swift
 import F
 
 func testF() { funcRedirectedF() }
+func testIndirect() { funcRedirectedIndirect() }
 
 // CHECK: "mainModuleName": "deps"
 /// --------Main module
@@ -94,6 +132,10 @@ func testF() { funcRedirectedF() }
 // CHECK: "-ivfsoverlay",
 // CHECK-NEXT: "-Xcc",
 // CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
 // CHECK: ],
 
 /// --------Clang module F
@@ -101,4 +143,22 @@ func testF() { funcRedirectedF() }
 // CHECK: "commandLine": [
 // CHECK: "-vfsoverlay",
 // CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
-// CHECK: ],
+// CHECK-NEXT: "-vfsoverlay",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK: ]
+
+/// --------Clang module Indirect
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Indirect-{{.*}}.pcm",
+// CHECK-NOT: overlay.yaml
+// CHECK: "-vfsoverlay",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",
+// CHECK: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay-2.yaml",


### PR DESCRIPTION
- **Explanation**: In the previous rewrite to speed to bridging clang dependency scanning, it causes a regression that `-ivfsoverlay` arguments are dropped from `-emit-pcm` jobs. This can sometimes cause build failure due to VFS overlay are not overlaying existing files on the file system.
  <!--
  A description of the changes. This can be brief, but it should be clear.
  -->
- **Scope**: Regression fix for unintended functional change and potential build failures.
  <!--
  An assessment of the impact and importance of the changes. For example, can
  the changes break existing code?
  -->
- **Issues**: rdar://153851818
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**: https://github.com/swiftlang/swift/pull/82608
  <!--
  Links to mainline branch pull requests in which the changes originated.
  -->
- **Risk**: Low. Restore to old behavior
  <!--
  The (specific) risk to the release for taking the changes.
  -->
- **Testing**: Improved unit testing that covers VFS overlaying on top of existing files.
  <!--
  The specific testing that has been done or needs to be done to further
  validate any impact of the changes.
  -->
- **Reviewers**: @artemcm 
  <!--
  The code owners that GitHub-approved the original changes in the mainline
  branch pull requests. If an original change has not been GitHub-approved by
  a respective code owner, provide a reason. Technical review can be delegated
  by a code owner or otherwise requested as deemed appropriate or useful.
  -->