### PR TITLE
Support LLVM optimization remarks in WMO mode

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -316,6 +316,10 @@ public:
   /// records.
   std::string OptRecordFile;
 
+  /// The names of the auxiliar files to which the backend should save optimization
+  /// records for the remaining (other than the main one) LLVMModules.
+  std::vector<std::string> AuxOptRecordFiles;
+
   /// The regex that filters the passes that should be saved to the optimization
   /// records.
   std::string OptRecordPasses;

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -254,6 +254,9 @@ public:
   getPrimarySpecificPathsForAtMostOnePrimary() const;
 
   const PrimarySpecificPaths &
+  getPrimarySpecificPathsForRemaining(unsigned i) const;
+
+  const PrimarySpecificPaths &
       getPrimarySpecificPathsForPrimary(StringRef) const;
 
   bool hasSupplementaryOutputPath(

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.h
@@ -180,7 +180,8 @@ private:
   std::string determineSupplementaryOutputFilename(
       options::ID emitOpt, std::string pathFromArgumentsOrFilelists,
       file_types::ID type, StringRef mainOutputIfUsable,
-      StringRef defaultSupplementaryOutputPathExcludingExtension) const;
+      StringRef defaultSupplementaryOutputPathExcludingExtension,
+      bool forceDefaultSupplementaryOutputPathExcludingExtension = false) const;
 
   void deriveModulePathParameters(StringRef mainOutputFile,
                                   options::ID &emitOption,

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -380,13 +380,23 @@ void FrontendInputsAndOutputs::setMainAndSupplementaryOutputs(
     }
     return;
   }
-  assert(supplementaryOutputs.size() == 1 &&
-         "WMO only ever produces one set of supplementary outputs");
+
+  assert(supplementaryOutputs.size() == 1 ||
+         supplementaryOutputs.size() == AllInputs.size() &&
+             "WMO produces wrong number of sets of supplementary outputs");
   if (outputFiles.size() == 1) {
-    AllInputs.front().setPrimarySpecificPaths(PrimarySpecificPaths(
-        outputFiles.front(), outputFilesForIndexUnits.front(),
-        firstInputProducingOutput().getFileName(),
-        supplementaryOutputs.front()));
+    for (auto i : indices(AllInputs)) {
+      if (i == 0)
+        AllInputs[i].setPrimarySpecificPaths(PrimarySpecificPaths(
+            outputFiles.front(), outputFilesForIndexUnits.front(),
+            firstInputProducingOutput().getFileName(),
+            supplementaryOutputs.front()));
+      else
+        AllInputs[i].setPrimarySpecificPaths(PrimarySpecificPaths(
+            "", "", "",
+            supplementaryOutputs.size() == 1 ? SupplementaryOutputPaths()
+                                             : supplementaryOutputs[i]));
+    }
     return;
   }
   assert(outputFiles.size() == AllInputs.size() &&
@@ -394,7 +404,8 @@ void FrontendInputsAndOutputs::setMainAndSupplementaryOutputs(
   for (auto i : indices(AllInputs))
     AllInputs[i].setPrimarySpecificPaths(PrimarySpecificPaths(
         outputFiles[i], outputFilesForIndexUnits[i], outputFiles[i],
-        i == 0 ? supplementaryOutputs.front() : SupplementaryOutputPaths()));
+        supplementaryOutputs.size() == 1 && i != 0 ? SupplementaryOutputPaths()
+                                                   : supplementaryOutputs[i]));
 }
 
 std::vector<std::string> FrontendInputsAndOutputs::copyOutputFilenames() const {
@@ -486,6 +497,14 @@ FrontendInputsAndOutputs::getPrimarySpecificPathsForAtMostOnePrimary() const {
   static auto emptyPaths = PrimarySpecificPaths();
   return hasInputs() ? firstInputProducingOutput().getPrimarySpecificPaths()
                      : emptyPaths;
+}
+
+const PrimarySpecificPaths &
+FrontendInputsAndOutputs::getPrimarySpecificPathsForRemaining(unsigned i) const {
+  static auto emptyPaths = PrimarySpecificPaths();
+  unsigned firstProducingIdx = getIndexOfFirstOutputProducingInput();
+  return (hasInputs()  && i > 0) ?
+    AllInputs[firstProducingIdx+i].getPrimarySpecificPaths() : emptyPaths;
 }
 
 const PrimarySpecificPaths &

--- a/test/Frontend/Inputs/opt-record-2.swift
+++ b/test/Frontend/Inputs/opt-record-2.swift
@@ -1,0 +1,24 @@
+open class C {
+    var x = 1
+    var y = 2
+
+    public init() {
+    }
+
+    public func method() {
+        print("x: \(x)")
+    }
+
+    public func method2() {
+        print("x2: \(y)")
+    }
+}
+
+@_assemblyVision
+@inline(never)
+public func runSomeTest(_ c: C) {
+  for i in 0..<100 {
+    c.method()
+    c.method2()
+  }
+}

--- a/test/Frontend/opt-record-supplemental.swift
+++ b/test/Frontend/opt-record-supplemental.swift
@@ -2,11 +2,17 @@
 // RUN: echo '"%s": { yaml-opt-record: "%t/foo.opt.yaml" }' > %t/filemap.yaml.yaml
 // RUN: echo '"%s": { bitstream-opt-record: "%t/foo.opt.bitstream" }' > %t/filemap.bitstream.yaml
 
-// RUN: %target-swift-frontend -c -O -wmo -save-optimization-record=bitstream %s -module-name foo -o %t/foo.o -supplementary-output-file-map %t/filemap.bitstream.yaml
+// RUN: %target-swift-frontend -c -O -num-threads 2 -save-optimization-record=bitstream %s %S/Inputs/opt-record-2.swift -module-name foo -o %t/foo.o  -o %t/opt-record-2.o -supplementary-output-file-map %t/filemap.bitstream.yaml
 // RUN: llvm-bcanalyzer -dump "%t/foo.opt.bitstream" | %FileCheck -check-prefix=BITSTREAM %s
+// RUN: llvm-bcanalyzer -dump "%t/opt-record-2.opt.bitstream" | %FileCheck -check-prefix=BITSTREAM2 %s
 
-// RUN: %target-swift-frontend -c -O -wmo -save-optimization-record=yaml %s -module-name foo -o %t/foo.o -supplementary-output-file-map %t/filemap.yaml.yaml
+// RUN: %empty-directory(%t)
+// RUN: echo '"%s": { yaml-opt-record: "%t/foo.opt.yaml" }' > %t/filemap.yaml.yaml
+// RUN: echo '"%s": { bitstream-opt-record: "%t/foo.opt.bitstream" }' > %t/filemap.bitstream.yaml
+
+// RUN: %target-swift-frontend -c -O -num-threads 2 -save-optimization-record=yaml %s %S/Inputs/opt-record-2.swift -module-name foo -o %t/foo.o -o %t/opt-record-2.o -supplementary-output-file-map %t/filemap.yaml.yaml
 // RUN: %FileCheck %s -check-prefix=YAML --input-file=%t/foo.opt.yaml
+// RUN: %FileCheck %s -check-prefix=YAML2 --input-file=%t/opt-record-2.opt.yaml
 
 // REQUIRES: VENDOR=apple
 
@@ -18,10 +24,19 @@ func foo() {
 }
 #sourceLocation() // reset
 
+@_assemblyVision
 public func bar() {
   foo()
+
+  runSomeTest(C())
   // BITSTREAM: <Remark NumWords=13 BlockCodeSize=4>
   // BITSTREAM: </Remark>
 
+  // BITSTREAM2: <Remark NumWords={{[0-9]+}} BlockCodeSize={{[0-9]*}}>
+  // BITSTREAM2: </Remark>
+
   // YAML: sil-assembly-vision-remark-gen
+
+  // YAML2: Pass: asm-printer
+  // YAML2: Name: InstructionCount
 }

--- a/test/Frontend/parseable_output_emit_module.swift
+++ b/test/Frontend/parseable_output_emit_module.swift
@@ -36,6 +36,14 @@
 // CHECK-NEXT:       {
 // CHECK-NEXT:         "type": "abi-baseline-json",
 // CHECK-NEXT:         "path": "{{.*[\\/]}}parseable_output_emit_module.swift.tmp.abi.json"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:        "type": "yaml-opt-record",
+// CHECK-NEXT:        "path": "parseable_output_emit_module.opt.yaml"
+// CHECK-NEXT:       },
+// CHECK-NEXT:       {
+// CHECK-NEXT:        "type": "bitstream-opt-record",
+// CHECK-NEXT:        "path": "parseable_output_emit_module.opt.bitstream"
 // CHECK-NEXT:       }
 // CHECK-NEXT:     ],
 // CHECK-NEXT:     "pid": [[PID:[0-9]*]]


### PR DESCRIPTION
Add code to create llvm::RemarkStreamer objects for all the LLVMModules in WMO mode.
This way we can collect optimization remarks from the LLVM optimizer and backend.

rdar://154403078