### PR TITLE
[6.2][Concurrency] Fix a crash caused by misuse of `isolated` modifier

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5064,7 +5064,13 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
                            bool onlyExplicit = false) {
   // Look up attributes on the declaration that can affect its actor isolation.
   // If any of them are present, use that attribute.
-  auto isolatedAttr = decl->getAttrs().getAttribute<IsolatedAttr>();
+
+  // 'isolated` attribute in the declaration context currently applies
+  // only to `deinit` declarations, invalid uses are going to
+  // be diagnosed as part of attribute checking.
+  auto isolatedAttr = isa<DestructorDecl>(decl)
+                          ? decl->getAttrs().getAttribute<IsolatedAttr>()
+                          : nullptr;
   auto nonisolatedAttr = decl->getAttrs().getAttribute<NonisolatedAttr>();
   auto globalActorAttr = decl->getGlobalActorAttr();
   auto concurrentAttr = decl->getAttrs().getAttribute<ConcurrentAttr>();
@@ -5117,10 +5123,8 @@ getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
   }
 
   // If the declaration is explicitly marked 'isolated', infer actor isolation
-  // from the context. Currently applies only to DestructorDecl
+  // from the context. Currently applies only to DestructorDecl.
   if (isolatedAttr) {
-    assert(isa<DestructorDecl>(decl));
-
     auto dc = decl->getDeclContext();
     auto selfTypeDecl = dc->getSelfNominalTypeDecl();
     std::optional<ActorIsolation> result;

--- a/test/Concurrency/issue-80363.swift
+++ b/test/Concurrency/issue-80363.swift
@@ -1,0 +1,47 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/swiftlang/swift/issues/80363
+
+class C {}
+
+func testLocal() {
+  isolated let c = C()
+  // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+  _ = c
+
+  isolated func test() {
+    // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+  }
+}
+
+isolated var x: Int = 42
+// expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+
+isolated class Test {
+  // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+}
+
+struct TestMembers {
+  isolated var q: String {
+    // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+    get {
+      "ultimate question"
+    }
+
+    isolated set {
+      // expected-error@-1 {{expected 'get', 'set', 'willSet', or 'didSet' keyword to start an accessor definition}}
+    }
+  }
+
+  isolated let a: Int = 42
+  // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+
+  isolated subscript(x: Int) -> Bool {
+    // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+    get { true }
+  }
+
+  isolated func test() {
+    // expected-error@-1 {{'isolated' may only be used on 'deinit' declarations}}
+  }
+}


### PR DESCRIPTION
- Explanation:

  Adjust isolation checking to handle misused `isolated` attribute and let attribute checker property diagnose it.

- Resolves: rdar://148076903, https://github.com/swiftlang/swift/issues/80363

- Main Branch PR: https://github.com/swiftlang/swift/pull/82593

- Risk: Very Low.  This a very particular incorrect use of `isolated` that currently cases a crash but shouldn't be accepted by the compiler.
 
- Reviewed By: @bnbarham @ktoso

- Testing: Added new test-cases to the test suite.



(cherry picked from commit 358067917eb6fa00983fd34b01a5d51370fdd399)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
