### PR TITLE
[Reflection] Cache the various DataQuery values.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -422,12 +422,8 @@ public:
   }
 
   StoredPointer queryPtrAuthMask() {
-    StoredPointer QueryResult;
-    if (Reader->queryDataLayout(DataLayoutQueryType::DLQ_GetPtrAuthMask,
-                                nullptr, &QueryResult)) {
-      return QueryResult;
-    }
-    return ~StoredPointer(0);
+    auto QueryResult = Reader->getPtrAuthMask();
+    return QueryResult.value_or(~StoredPointer(0));
   }
 
   template <class... T>


### PR DESCRIPTION
We can end up querying the pointer size and similar things very frequently, which can be slow. These values don't change for any given reader, so call them once and cache the values locally instead.

rdar://150221008