### PR TITLE
[Serialization] A temporary fix for `LocatableType`

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5608,8 +5608,8 @@ public:
     llvm_unreachable("error union types do not persist in the AST");
   }
 
-  void visitLocatableType(const LocatableType *) {
-    llvm_unreachable("locatable types do not persist in the AST");
+  void visitLocatableType(const LocatableType *LT) {
+    visit(LT->getSinglyDesugaredType());
   }
 
   void visitBuiltinTypeImpl(Type ty) {

--- a/test/Serialization/transitive_conformances_and_cgfloat_double.swift
+++ b/test/Serialization/transitive_conformances_and_cgfloat_double.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module %s -o %t
+
+// REQUIRES: objc_interop
+
+// rdar://153461854
+
+import CoreGraphics
+
+@resultBuilder
+public struct Builder {
+  public static func buildBlock<T1>(_ t1: T1) -> (T1) {
+    return (t1)
+  }
+}
+
+protocol P {
+}
+
+struct Proxy: P {
+  let to: (CGFloat?) -> Void
+}
+
+struct Test {
+  @Builder var proxy: some P {
+    Proxy { point in
+      if let point {
+        let _: SIMD2<Double>? = SIMD2(point, point)
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
Gracefully handle `LocatableType` types if they show up during serialization. This is a temporary fix until we can remove `TransitivelyConformsTo` constraint from the solver which is the underlying cause of the issue (see https://github.com/swiftlang/swift/pull/82541).

Resolves: rdar://153461854

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
