### PR TITLE
[SE-0470] Check uses of isolated conformances in collection literals

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3480,6 +3480,13 @@ namespace {
             getDeclContext(), RefineConformances{*this});
       }
 
+      if (auto *collectionExpr = dyn_cast<CollectionExpr>(expr)) {
+        checkIsolatedConformancesInContext(
+            collectionExpr->getInitializer(),
+            collectionExpr->getLoc(),
+            getDeclContext(), RefineConformances{*this});
+      }
+
       return Action::Continue(expr);
     }
 

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -215,3 +215,21 @@ actor MyActor2 {
   // NonIsolated and not if print was inferred to be main actor.
   print("123")
 }
+
+// https://github.com/swiftlang/swift/issues/82168 - used to fail
+nonisolated protocol P {
+  associatedtype AT
+  static var at: AT { get }
+}
+
+nonisolated struct KP<R: P, V> {
+  init(keyPath: KeyPath<R, V>) {}
+}
+
+struct S: P {
+  let p: Int
+  struct AT {
+    let kp = KP(keyPath: \S.p)
+  }
+  static let at = AT() // used to fail here
+}

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -235,3 +235,12 @@ func testIsolatedConformancesOnAssociatedTypes(hc: HoldsC, c: C) {
   // associated type.
   HoldsC.acceptSendableAliased(C.self)
 }
+
+
+struct MyHashable: @MainActor Hashable {
+  var counter = 0
+}
+
+@concurrent func testMyHashableSet() async {
+  let _: Set<MyHashable> = [] // expected-warning{{main actor-isolated conformance of 'MyHashable' to 'Hashable' cannot be used in nonisolated context}}
+}


### PR DESCRIPTION
Closes up a soundness hole with isolated conformances. Fixes rdar://151646584.