### PR TITLE
[6.2] [SE-0470] Check uses of isolated conformances in collection literals

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3496,6 +3496,13 @@ namespace {
             getDeclContext(), RefineConformances{*this});
       }
 
+      if (auto *collectionExpr = dyn_cast<CollectionExpr>(expr)) {
+        checkIsolatedConformancesInContext(
+            collectionExpr->getInitializer(),
+            collectionExpr->getLoc(),
+            getDeclContext(), RefineConformances{*this});
+      }
+
       return Action::Continue(expr);
     }
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -186,3 +186,12 @@ func testIsolatedConformancesOnAssociatedTypes(hc: HoldsC, c: C) {
   // associated type.
   HoldsC.acceptSendableAliased(C.self)
 }
+
+
+struct MyHashable: @MainActor Hashable {
+  var counter = 0
+}
+
+@concurrent func testMyHashableSet() async {
+  let _: Set<MyHashable> = [] // expected-warning{{main actor-isolated conformance of 'MyHashable' to 'Hashable' cannot be used in nonisolated context}}
+}


### PR DESCRIPTION
- **Explanation**: The actor isolation checker was failing to look for misuses of isolated conformances specifically in collection literals. This introduced a soundness hole for isolated conformances. Add the appropriate checking.
- **Scope**: Narrow. Limited to actor isolation checking.
- **Issues**: rdar://151646584
- **Original PRs**: https://github.com/swiftlang/swift/pull/82654
- **Risk**: Very low. Adds an existing check along a new path, where the diagnostic severity is downgrade in Swift < 6.
- **Testing**: CI
- **Reviewers**:
