### PR TITLE
[6.2] Sema: Fix the insertion location for conformances attributes

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1330,10 +1330,10 @@ public:
   getNormalConformance(Type conformingType,
                        ProtocolDecl *protocol,
                        SourceLoc loc,
+                       TypeRepr *inheritedTypeRepr,
                        DeclContext *dc,
                        ProtocolConformanceState state,
-                       ProtocolConformanceOptions options,
-                       SourceLoc preconcurrencyLoc = SourceLoc());
+                       ProtocolConformanceOptions options);
 
   /// Produce a self-conformance for the given protocol.
   SelfProtocolConformance *

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -604,6 +604,11 @@ void forEachPotentialAttachedMacro(
 
 /// Describes an inherited nominal entry.
 struct InheritedNominalEntry : Located<NominalTypeDecl *> {
+  /// The `TypeRepr` of the inheritance clause entry from which this nominal was
+  /// sourced, if any. For example, if this is a conformance to `Y` declared as
+  /// `struct S: X, Y & Z {}`, this is the `TypeRepr` for `Y & Z`.
+  TypeRepr *inheritedTypeRepr;
+
   ConformanceAttributes attributes;
 
   /// Whether this inherited entry was suppressed via "~".
@@ -612,10 +617,10 @@ struct InheritedNominalEntry : Located<NominalTypeDecl *> {
   InheritedNominalEntry() { }
 
   InheritedNominalEntry(NominalTypeDecl *item, SourceLoc loc,
-                        ConformanceAttributes attributes,
-                        bool isSuppressed)
-      : Located(item, loc), attributes(attributes),
-        isSuppressed(isSuppressed) {}
+                        TypeRepr *inheritedTypeRepr,
+                        ConformanceAttributes attributes, bool isSuppressed)
+      : Located(item, loc), inheritedTypeRepr(inheritedTypeRepr),
+        attributes(attributes), isSuppressed(isSuppressed) {}
 };
 
 /// Retrieve the set of nominal type declarations that are directly

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -586,10 +586,17 @@ class NormalProtocolConformance : public RootProtocolConformance,
   SourceLoc Loc;
 
   /// The location of the protocol name within the conformance.
+  ///
+  /// - Important: This is not a valid insertion location for an attribute.
+  /// Use `applyConformanceAttribute` instead.
   SourceLoc ProtocolNameLoc;
 
-  /// The location of the `@preconcurrency` attribute, if any.
-  SourceLoc PreconcurrencyLoc;
+  /// The `TypeRepr` of the inheritance clause entry that declares this
+  /// conformance, if any. For example, if this is a conformance to `Y`
+  /// declared as `struct S: X, Y & Z {}`, this is the `TypeRepr` for `Y & Z`.
+  ///
+  /// - Important: The value can be valid only for an explicit conformance.
+  TypeRepr *inheritedTypeRepr;
 
   /// The declaration context containing the ExtensionDecl or
   /// NominalTypeDecl that declared the conformance.
@@ -625,22 +632,26 @@ class NormalProtocolConformance : public RootProtocolConformance,
   // Record the explicitly-specified global actor isolation.
   void setExplicitGlobalActorIsolation(TypeExpr *typeExpr);
 
+  /// Return the `TypeRepr` of the inheritance clause entry that declares this
+  /// conformance, if any. For example, if this is a conformance to `Y`
+  /// declared as `struct S: X, Y & Z {}`, this is the `TypeRepr` for `Y & Z`.
+  ///
+  /// - Important: The value can be valid only for an explicit conformance.
+  TypeRepr *getInheritedTypeRepr() const { return inheritedTypeRepr; }
+
 public:
   NormalProtocolConformance(Type conformingType, ProtocolDecl *protocol,
-                            SourceLoc loc, DeclContext *dc,
-                            ProtocolConformanceState state,
-                            ProtocolConformanceOptions options,
-                            SourceLoc preconcurrencyLoc)
+                            SourceLoc loc, TypeRepr *inheritedTypeRepr,
+                            DeclContext *dc, ProtocolConformanceState state,
+                            ProtocolConformanceOptions options)
       : RootProtocolConformance(ProtocolConformanceKind::Normal,
                                 conformingType),
         Protocol(protocol), Loc(extractNearestSourceLoc(dc)),
-        ProtocolNameLoc(loc), PreconcurrencyLoc(preconcurrencyLoc),
+        ProtocolNameLoc(loc), inheritedTypeRepr(inheritedTypeRepr),
         Context(dc) {
     assert(!conformingType->hasArchetype() &&
            "ProtocolConformances should store interface types");
-    assert((preconcurrencyLoc.isInvalid() ||
-            options.contains(ProtocolConformanceFlags::Preconcurrency)) &&
-           "Cannot have a @preconcurrency location without isPreconcurrency");
+
     setState(state);
     Bits.NormalProtocolConformance.IsInvalid = false;
     Bits.NormalProtocolConformance.IsPreconcurrencyEffectful = false;
@@ -650,6 +661,9 @@ public:
         unsigned(ConformanceEntryKind::Explicit);
     Bits.NormalProtocolConformance.HasExplicitGlobalActor = false;
     setExplicitGlobalActorIsolation(options.getGlobalActorIsolationType());
+
+    assert((!getPreconcurrencyLoc() || isPreconcurrency()) &&
+           "Cannot have a @preconcurrency location without isPreconcurrency");
   }
 
   /// Get the protocol being conformed to.
@@ -659,6 +673,9 @@ public:
   SourceLoc getLoc() const { return Loc; }
 
   /// Retrieve the name of the protocol location.
+  ///
+  /// - Important: This is not a valid insertion location for an attribute.
+  ///   Use `applyConformanceAttribute` instead.
   SourceLoc getProtocolNameLoc() const { return ProtocolNameLoc; }
 
   /// Get the declaration context that contains the conforming extension or
@@ -729,7 +746,9 @@ public:
 
   /// Retrieve the location of `@preconcurrency`, if there is one and it is
   /// known.
-  SourceLoc getPreconcurrencyLoc() const { return PreconcurrencyLoc; }
+  ///
+  /// - Important: The value can be valid only for an explicit conformance.
+  SourceLoc getPreconcurrencyLoc() const;
 
   /// Query whether this conformance was explicitly declared to be safe or
   /// unsafe.
@@ -852,6 +871,15 @@ public:
 
   /// Triggers a request that resolves all of the conformance's value witnesses.
   void resolveValueWitnesses() const;
+
+  /// If the necessary source location information is found, attaches a fix-it
+  /// to the given diagnostic for applying the given attribute to the
+  /// conformance.
+  ///
+  /// \param attrStr A conformance attribute as a string, e.g. "@unsafe" or
+  /// "nonisolated".
+  void applyConformanceAttribute(InFlightDiagnostic &diag,
+                                 std::string attrStr) const;
 
   /// Determine whether the witness for the given type requirement
   /// is the default definition.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2911,10 +2911,10 @@ NormalProtocolConformance *
 ASTContext::getNormalConformance(Type conformingType,
                                  ProtocolDecl *protocol,
                                  SourceLoc loc,
+                                 TypeRepr *inheritedTypeRepr,
                                  DeclContext *dc,
                                  ProtocolConformanceState state,
-                                 ProtocolConformanceOptions options,
-                                 SourceLoc preconcurrencyLoc) {
+                                 ProtocolConformanceOptions options) {
   assert(dc->isTypeContext());
 
   llvm::FoldingSetNodeID id;
@@ -2928,8 +2928,7 @@ ASTContext::getNormalConformance(Type conformingType,
 
   // Build a new normal protocol conformance.
   auto result = new (*this) NormalProtocolConformance(
-      conformingType, protocol, loc, dc, state,
-      options, preconcurrencyLoc);
+      conformingType, protocol, loc, inheritedTypeRepr, dc, state, options);
   normalConformances.InsertNode(result, insertPos);
 
   return result;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -4091,7 +4091,8 @@ void swift::getDirectlyInheritedNominalTypeDecls(
 
   // Form the result.
   for (auto nominal : nominalTypes) {
-    result.push_back({nominal, loc, attributes, isSuppressed});
+    result.push_back({nominal, loc, inheritedTypes.getTypeRepr(i), attributes,
+                      isSuppressed});
   }
 }
 
@@ -4124,8 +4125,8 @@ swift::getDirectlyInheritedNominalTypeDecls(
     ConformanceAttributes attributes;
     if (attr->isUnchecked())
       attributes.uncheckedLoc = loc;
-    result.push_back(
-        {attr->getProtocol(), loc, attributes, /*isSuppressed=*/false});
+    result.push_back({attr->getProtocol(), loc, /*inheritedTypeRepr=*/nullptr,
+                      attributes, /*isSuppressed=*/false});
   }
 
   // Else we have access to this information on the where clause.
@@ -4136,7 +4137,8 @@ swift::getDirectlyInheritedNominalTypeDecls(
   // FIXME: Refactor SelfBoundsFromWhereClauseRequest to dig out
   // the source location.
   for (auto inheritedNominal : selfBounds.decls)
-    result.emplace_back(inheritedNominal, SourceLoc(), ConformanceAttributes(),
+    result.emplace_back(inheritedNominal, SourceLoc(),
+                        /*inheritedTypeRepr=*/nullptr, ConformanceAttributes(),
                         /*isSuppressed=*/false);
 
   return result;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8842,9 +8842,9 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
         if (lookupConformance(ty, protocol))
           continue;
         auto conformance = SwiftContext.getNormalConformance(
-            ty, protocol, nominal->getLoc(), nominal->getDeclContextForModule(),
-            ProtocolConformanceState::Complete,
-            ProtocolConformanceOptions());
+            ty, protocol, nominal->getLoc(), /*inheritedTypeRepr=*/nullptr,
+            nominal->getDeclContextForModule(),
+            ProtocolConformanceState::Complete, ProtocolConformanceOptions());
         conformance->setSourceKindAndImplyingConformance(
             ConformanceEntryKind::Synthesized, nullptr);
 
@@ -10724,9 +10724,8 @@ void ClangImporter::Implementation::loadAllConformances(
       options |= ProtocolConformanceFlags::Unchecked;
 
     auto conformance = SwiftContext.getNormalConformance(
-        dc->getDeclaredInterfaceType(),
-        protocol, SourceLoc(), dc,
-        ProtocolConformanceState::Incomplete,
+        dc->getDeclaredInterfaceType(), protocol, SourceLoc(),
+        /*inheritedTypeRepr=*/nullptr, dc, ProtocolConformanceState::Incomplete,
         options);
     conformance->setLazyLoader(this, /*context*/0);
     conformance->setState(ProtocolConformanceState::Complete);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3602,7 +3602,8 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
     for (auto protocol : missingProtocols) {
       // Create a fake conformance for this type to the given protocol.
       auto conformance = getASTContext().getNormalConformance(
-          nominal->getSelfInterfaceType(), protocol, SourceLoc(), nominal,
+          nominal->getSelfInterfaceType(), protocol, SourceLoc(),
+          /*inheritedTypeRepr=*/nullptr, nominal,
           ProtocolConformanceState::Incomplete, ProtocolConformanceOptions());
 
       // Resolve the conformance to generate fixits.

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -816,10 +816,9 @@ addDistributedActorCodableConformance(
   }
 
   auto conformance = C.getNormalConformance(
-      actor->getDeclaredInterfaceType(), proto,
-      actor->getLoc(), /*dc=*/actor,
-      ProtocolConformanceState::Incomplete,
-      ProtocolConformanceOptions());
+      actor->getDeclaredInterfaceType(), proto, actor->getLoc(),
+      /*inheritedTypeRepr=*/nullptr, /*dc=*/actor,
+      ProtocolConformanceState::Incomplete, ProtocolConformanceOptions());
   conformance->setSourceKindAndImplyingConformance(
       ConformanceEntryKind::Synthesized, nullptr);
   actor->registerProtocolConformance(conformance, /*synthesized=*/true);
@@ -1081,8 +1080,9 @@ GetDistributedActorAsActorConformanceRequest::evaluate(
                                                     ctx);
 
   auto distributedActorAsActorConformance = ctx.getNormalConformance(
-      Type(genericParam), actorProto, SourceLoc(), ext,
-      ProtocolConformanceState::Incomplete, ProtocolConformanceOptions());
+      Type(genericParam), actorProto, SourceLoc(),
+      /*inheritedTypeRepr=*/nullptr, ext, ProtocolConformanceState::Incomplete,
+      ProtocolConformanceOptions());
   // NOTE: Normally we "register" a conformance, but here we don't
   // because we cannot (currently) register them in a protocol,
   // since they do not have conformance tables.

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -377,8 +377,8 @@ NormalProtocolConformance *
 DeriveImplicitBitwiseCopyableConformance::synthesizeConformance(
     DeclContext *dc) {
   auto conformance = context.getNormalConformance(
-      nominal->getDeclaredInterfaceType(), protocol, nominal->getLoc(), dc,
-      ProtocolConformanceState::Complete,
+      nominal->getDeclaredInterfaceType(), protocol, nominal->getLoc(),
+      /*inheritedTypeRepr=*/nullptr, dc, ProtocolConformanceState::Complete,
       ProtocolConformanceOptions());
   conformance->setSourceKindAndImplyingConformance(
       ConformanceEntryKind::Synthesized, nullptr);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -7315,7 +7315,8 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
       options |= ProtocolConformanceFlags::Unchecked;
     auto conformance = ctx.getNormalConformance(
         nominal->getDeclaredInterfaceType(), proto, nominal->getLoc(),
-        conformanceDC, ProtocolConformanceState::Complete, options);
+        /*inheritedTypeRepr=*/nullptr, conformanceDC,
+        ProtocolConformanceState::Complete, options);
     conformance->setSourceKindAndImplyingConformance(
         ConformanceEntryKind::Synthesized, nullptr);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5002,16 +5002,19 @@ static void diagnoseConformanceIsolationErrors(
     if (potentialIsolation && potentialIsolation->isGlobalActor() &&
         !conformance->isIsolated()) {
       bool isMainActor = false;
-      Type globalActorIsolation = potentialIsolation->getGlobalActor();
-      if (auto nominal = globalActorIsolation->getAnyNominal())
+      Type globalActorType = potentialIsolation->getGlobalActor();
+      if (auto nominal = globalActorType->getAnyNominal())
         isMainActor = nominal->isMainActor();
 
-      auto diag = ctx.Diags.diagnose(
-          conformance->getProtocolNameLoc(),
-          diag::note_isolate_conformance_to_global_actor, globalActorIsolation,
-          isMainActor, globalActorIsolation.getString());
-      conformance->applyConformanceAttribute(
-          diag, "@" + globalActorIsolation.getString());
+      // Take permanent ownership of the string. The diagnostic may outlive this
+      // function call.
+      auto globalActorTypeStr = ctx.AllocateCopy(globalActorType.getString());
+      auto diag =
+          ctx.Diags.diagnose(conformance->getProtocolNameLoc(),
+                             diag::note_isolate_conformance_to_global_actor,
+                             globalActorType, isMainActor, globalActorTypeStr);
+      conformance->applyConformanceAttribute(diag,
+                                             "@" + globalActorTypeStr.str());
     }
 
     // If marking witnesses as 'nonisolated' could work, suggest that.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1065,7 +1065,7 @@ ProtocolConformanceDeserializer::readNormalProtocolConformance(
   }
 
   auto conformance = ctx.getNormalConformance(
-      conformingType, proto, SourceLoc(), dc,
+      conformingType, proto, SourceLoc(), /*inheritedTypeRepr=*/nullptr, dc,
       ProtocolConformanceState::Incomplete,
       ProtocolConformanceOptions(rawOptions, globalActorTypeExpr));
 

--- a/test/Concurrency/isolated_conformance_migrate.swift
+++ b/test/Concurrency/isolated_conformance_migrate.swift
@@ -31,3 +31,31 @@ struct MA4: @MainActor P { }
 @MainActor
 struct MA5: nonisolated P { }
 
+// Make sure we correctly apply the conformance attribute for more complex
+// inheritance entries.
+do {
+  @MainActor protocol MainActorP { }
+  enum Nested {
+    protocol P { }
+    protocol Q { }
+  }
+  do {
+    @MainActor struct S: Nested.P { }
+    // expected-warning@-1 {{conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{26-26=nonisolated }}
+  }
+  do {
+    // Modifier inserted *after* '@unsafe'.
+    @MainActor struct S: @unsafe Nested.P { }
+    // expected-warning@-1 {{conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{34-34=nonisolated }}
+  }
+  do {
+    @MainActor struct S: Nested.P & Nested.Q { }
+    // expected-warning@-1 {{conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{26-26=nonisolated }}
+    // expected-warning@-2 {{conformance of 'S' to 'Q' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{26-26=nonisolated }}
+  }
+  do {
+    // FIXME: We shouldn't be applying nonisolated to both protocols.
+    @MainActor struct S: Nested.P & MainActorP { }
+    // expected-warning@-1 {{conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'}}{{26-26=nonisolated }}
+  }
+}


### PR DESCRIPTION
- **Explanation**:

  We were using `ProtocolNameLoc` for the insertion location, which is not necessarily the start location of the `TypeRepr` associated with the conformance:

  ```
  warning: conformance of 'S' to 'P' should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances' [isolated_conformance_will_become_nonisolated] [#IsolatedConformances]
  @MainActor struct S: @unsafe Nested.P {}
                                      ^
                                      nonisolated
  ```

  This fix is important for error-free automatic migration to `StrictMemorySafety` and `InferIsolatedConformances`.
- **Scope**: Diagnostics QoI for fix-its that insert a conformance attribute.
- **Issues**: rdar://132570262
- **Original PRs**: https://github.com/swiftlang/swift/pull/82452
- **Risk**: Low
- **Testing**: Smoke test. Added regression tests.
- **Reviewers**: @DougGregor
