### PR TITLE
Optimizer: revert to legacy alloc-box-to-stack optimization

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -116,12 +116,13 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // Select access kind after capture promotion and before stack promotion.
   // This guarantees that stack-promotable boxes have [static] enforcement.
   P.addAccessEnforcementSelection();
-
+/* Temporarily disabled: rdar://154686063, rdar://154713388
 #ifdef SWIFT_ENABLE_SWIFT_IN_SWIFT
   P.addMandatoryAllocBoxToStack();
 #else
+*/
   P.addLegacyAllocBoxToStack();
-#endif
+//#endif
   P.addNoReturnFolding();
   P.addBooleanLiteralFolding();
   addDefiniteInitialization(P);
@@ -417,7 +418,8 @@ void addHighLevelLoopOptPasses(SILPassPipelinePlan &P) {
 void addFunctionPasses(SILPassPipelinePlan &P,
                        OptimizationLevelKind OpLevel) {
   // Promote box allocations to stack allocations.
-  P.addAllocBoxToStack();
+  // TODO: change this to add addAllocBoxToStack once rdar://154686063, rdar://154713388 is fixed
+  P.addLegacyAllocBoxToStack();
 
   if (P.getOptions().DestroyHoisting == DestroyHoistingOption::On) {
     P.addDestroyAddrHoisting();

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -27,10 +27,9 @@ func dup<T>(_ x: T) -> (T, T) { var x = x; return (x,x) }
 //   Copy 'x' into the first result.
 // CHECK-NEXT: call ptr [[WITNESS]](ptr noalias %0, ptr noalias [[X_ALLOCA]], ptr %T)
 //   Copy 'x' into the second element.
+// CHECK-NEXT: [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 4
+// CHECK-NEXT: [[WITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]], align 8
 // CHECK-NEXT: call ptr [[WITNESS]](ptr noalias %1, ptr noalias [[X_ALLOCA]], ptr %T)
-// CHECK-NEXT: [[WITNESS_ADDR:%.*]] = getelementptr inbounds ptr, ptr [[VWT]], i32 1
-// CHECK-NEXT: [[DESTROYWITNESS:%.*]] = load ptr, ptr [[WITNESS_ADDR]], align 8
-// CHECK-NEXT: call void [[DESTROYWITNESS]](ptr noalias [[X_ALLOCA]],
 
 struct S {}
 

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -99,8 +99,7 @@ struct AddressOnlyStruct : TriviallyConstructible {
 // CHECK-NEXT: apply [[FN]]<AddressOnlyStruct>([[SELF_BOX]], %1, [[METATYPE]])
 // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [init] [[SELF]]
 // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT: copy_addr [[SELF]] to [init] %0
-// CHECK-NEXT: destroy_addr [[SELF]]
+// CHECK-NEXT: copy_addr [take] [[SELF]] to [init] %0
 // CHECK-NEXT: dealloc_stack [[SELF]]
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: return [[RESULT]]


### PR DESCRIPTION
The new implementation causes some problems
rdar://154686063, rdar://154713388
