### PR TITLE
[SE-0466] Infer isolated deinit in main-actor-by-default mode

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6061,10 +6061,9 @@ computeDefaultInferredActorIsolation(ValueDecl *value) {
           sendableConformanceRequiresNonisolated(nominalTypeDecl))
         return { };
 
-      // FIXME: deinit should be implicitly MainActor too.
       if (isa<TypeDecl>(value) || isa<ExtensionDecl>(value) ||
-          isa<AbstractStorageDecl>(value) || isa<FuncDecl>(value) ||
-          isa<ConstructorDecl>(value)) {
+          isa<AbstractStorageDecl>(value) ||
+          isa<AbstractFunctionDecl>(value)) {
           // Preconcurrency here is used to stage the diagnostics
           // when users select `@MainActor` default isolation with
           // non-strict concurrency modes (pre Swift 6).

--- a/test/Concurrency/assume_mainactor.swift
+++ b/test/Concurrency/assume_mainactor.swift
@@ -8,13 +8,14 @@
 class Klass {
   // Implicit deinit
   // CHECK: // Klass.deinit
-  // CHECK-NEXT: // Isolation: unspecified
+  // CHECK-NEXT: // Isolation: global_actor. type: MainActor
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor5KlassCfd : $@convention(method) (@guaranteed Klass) -> @owned Builtin.NativeObject {
 
   // Implicit deallocating deinit
   // CHECK: // Klass.__deallocating_deinit
   // CHECK-NEXT: // Isolation: nonisolated
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor5KlassCfD : $@convention(method) (@owned Klass) -> () {
+  // CHECK: swift_task_deinitOnExecutor
 
   // Implicit allocating init
   // CHECK: // Klass.__allocating_init()
@@ -64,6 +65,16 @@ struct NonIsolatedStructContainingKlass {
   // CHECK: // NonIsolatedStructContainingKlass.init()
   // CHECK-NEXT: // Isolation: nonisolated
   // CHECK-NEXT: sil hidden [ossa] @$s16assume_mainactor32NonIsolatedStructContainingKlassVACycfC : $@convention(method) (@thin NonIsolatedStructContainingKlass.Type) -> @owned NonIsolatedStructContainingKlass {
+}
+
+struct NonCopyableStruct: ~Copyable {
+  var x: Int
+  var y: Int
+
+  // CHECK: NonCopyableStruct.deinit
+  // CHECK-NEXT: Isolation: nonisolated
+  deinit {
+  }
 }
 
 @globalActor


### PR DESCRIPTION
Now that main-actor-isolated deinit can be back-deployed, enable inference of isolated deinit within main-actor-by-default mode.

Implements rdar://154729369.
