### PR TITLE
SILGen: Fix `if #unavailable` mis-compile for zippered libraries

### DIFF
--- a/include/swift/AST/AvailabilityQuery.h
+++ b/include/swift/AST/AvailabilityQuery.h
@@ -1,0 +1,128 @@
+//===--- AvailabilityQuery.h - Swift Availability Query ASTs ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the availability query AST classes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_AVAILABILITY_QUERY_H
+#define SWIFT_AST_AVAILABILITY_QUERY_H
+
+#include "swift/AST/AvailabilityDomain.h"
+#include "swift/AST/AvailabilityRange.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/VersionTuple.h"
+
+namespace swift {
+/// Represents the information needed to evaluate an `#if available` query
+/// (either at runtime or compile-time).
+class AvailabilityQuery final {
+  AvailabilityDomain domain;
+  std::optional<AvailabilityRange> primaryRange;
+  std::optional<AvailabilityRange> variantRange;
+
+  enum class ResultKind : uint8_t {
+    /// The result of the query is true at compile-time.
+    ConstTrue = 0,
+    /// The result of the query is false at compile-time.
+    ConstFalse = 1,
+    /// The result of the query must be determined at runtime.
+    Dynamic = 2,
+  };
+  ResultKind kind;
+
+  bool unavailable;
+
+  AvailabilityQuery(AvailabilityDomain domain, ResultKind kind,
+                    bool isUnavailable,
+                    const std::optional<AvailabilityRange> &primaryRange,
+                    const std::optional<AvailabilityRange> &variantRange)
+      : domain(domain), primaryRange(primaryRange), variantRange(variantRange),
+        kind(kind), unavailable(isUnavailable) {};
+
+public:
+  /// Returns an `AvailabilityQuery` for a query that evaluates to true or
+  /// false at compile-time.
+  static AvailabilityQuery constant(AvailabilityDomain domain,
+                                    bool isUnavailable, bool value) {
+    return AvailabilityQuery(
+        domain, value ? ResultKind::ConstTrue : ResultKind::ConstFalse,
+        isUnavailable, std::nullopt, std::nullopt);
+  }
+
+  /// Returns an `AvailabilityQuery` for a query that must be evaluated at
+  /// runtime with the given arguments, which may be zero, one, or two version
+  /// tuples that should be passed to the query function.
+  static AvailabilityQuery
+  dynamic(AvailabilityDomain domain, bool isUnavailable,
+          const std::optional<AvailabilityRange> &primaryRange,
+          const std::optional<AvailabilityRange> &variantRange) {
+    return AvailabilityQuery(domain, ResultKind::Dynamic, isUnavailable,
+                             primaryRange, variantRange);
+  }
+
+  /// Returns the domain that the query applies to.
+  AvailabilityDomain getDomain() const { return domain; }
+
+  /// Returns true if the query's result is determined at compile-time.
+  bool isConstant() const { return kind != ResultKind::Dynamic; }
+
+  /// Returns true if the query was spelled `#unavailable`.
+  bool isUnavailability() const { return unavailable; }
+
+  /// Returns the boolean result of the query if it is known at compile-time, or
+  /// `std::nullopt` otherwise. The returned value accounts for whether the
+  /// query was spelled `#unavailable`.
+  std::optional<bool> getConstantResult() const {
+    switch (kind) {
+    case ResultKind::ConstTrue:
+      return !unavailable;
+    case ResultKind::ConstFalse:
+      return unavailable;
+    case ResultKind::Dynamic:
+      return std::nullopt;
+    }
+  }
+
+  /// Returns the availability range that is the first argument to query
+  /// function.
+  std::optional<AvailabilityRange> getPrimaryRange() const {
+    return primaryRange;
+  }
+
+  /// Returns the version tuple that is the first argument to query function.
+  std::optional<llvm::VersionTuple> getPrimaryArgument() const {
+    if (!primaryRange)
+      return std::nullopt;
+    return primaryRange->getRawMinimumVersion();
+  }
+
+  /// Returns the availability range that is the second argument to query
+  /// function. This represents the `-target-variant` version when compiling a
+  /// zippered library.
+  std::optional<AvailabilityRange> getVariantRange() const {
+    return variantRange;
+  }
+
+  /// Returns the version tuple that is the second argument to query function.
+  /// This represents the `-target-variant` version when compiling a zippered
+  /// library.
+  std::optional<llvm::VersionTuple> getVariantArgument() const {
+    if (!variantRange)
+      return std::nullopt;
+    return variantRange->getRawMinimumVersion();
+  }
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -1,4 +1,4 @@
-//===--- AvailabilitySpec.h - Swift Availability Query ASTs -----*- C++ -*-===//
+//===--- AvailabilitySpec.h - Swift Availability Spec ASTs ------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5300,7 +5300,9 @@ GROUPED_ERROR(opaque_type_var_no_init,OpaqueTypeInference,none,
 GROUPED_ERROR(opaque_type_var_no_underlying_type,OpaqueTypeInference,none,
       "property declares an opaque return type, but cannot infer the "
       "underlying type from its initializer expression", ())
-
+GROUPED_ERROR(opaque_type_unsupported_availability,OpaqueTypeInference,none,
+      "opaque return type cannot depend on %0 availability",
+      (AvailabilityDomain))
 
 //------------------------------------------------------------------------------
 // MARK: Discard Statement

--- a/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceRawRepresentable.cpp
@@ -203,9 +203,9 @@ struct RuntimeVersionCheck {
   /// fails, e.g. "guard #available(iOS 10, *) else { return nil }".
   Stmt *createEarlyReturnStmt(ASTContext &C) const {
     // platformSpec = "\(attr.platform) \(attr.introduced)"
+    auto domain = AvailabilityDomain::forPlatform(Platform);
     auto platformSpec = AvailabilitySpec::createForDomain(
-        C, AvailabilityDomain::forPlatform(Platform), SourceLoc(), Version,
-        SourceLoc());
+        C, domain, SourceLoc(), Version, SourceLoc());
 
     // wildcardSpec = "*"
     auto wildcardSpec = AvailabilitySpec::createWildcard(C, SourceLoc());
@@ -217,7 +217,9 @@ struct RuntimeVersionCheck {
 
     // This won't be filled in by TypeCheckAvailability because we have
     // invalid SourceLocs in this area of the AST.
-    availableInfo->setAvailableRange(getVersionRange());
+    availableInfo->setAvailabilityQuery(AvailabilityQuery::dynamic(
+        domain, /*isUnavailable=*/false, AvailabilityRange(getVersionRange()),
+        std::nullopt));
 
     // earlyReturnBody = "{ return nil }"
     auto earlyReturn = new (C) FailStmt(SourceLoc(), SourceLoc());

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -1588,6 +1588,9 @@ class _ParentProcess {
         _testSuiteFailedCallback()
       } else {
         print("\(testSuite.name): All tests passed")
+        if testSuite._tests.isEmpty {
+          print("WARNING: SUITE '\(testSuite.name)' CONTAINED NO TESTS! NO TESTS WERE EXECUTED!")
+        }
       }
     }
     let (failed: failedOnShutdown, ()) = _shutdownChild()

--- a/test/Availability/availability_custom_domains.swift
+++ b/test/Availability/availability_custom_domains.swift
@@ -193,3 +193,19 @@ struct EnabledDomainAvailable {
     unavailableInDisabledDomain() // expected-error {{'unavailableInDisabledDomain()' is unavailable}}
   }
 }
+
+protocol P { }
+
+@available(EnabledDomain)
+struct AvailableInEnabledDomain: P { }
+
+@available(EnabledDomain, unavailable)
+struct UnavailableInEnabledDomain: P { }
+
+func testOpaqueReturnType() -> some P {
+  if #available(EnabledDomain) { // expected-error {{opaque return type cannot depend on EnabledDomain availability}}
+    return AvailableInEnabledDomain()
+  } else {
+    return UnavailableInEnabledDomain()
+  }
+}

--- a/test/IRGen/availability_custom_domains_maccatalyst_zippered.swift
+++ b/test/IRGen/availability_custom_domains_maccatalyst_zippered.swift
@@ -41,17 +41,16 @@ if #available(DisabledDomain) {
   always()
 }
 
-// FIXME: [availability] These CHECK lines for if #unavailable are inverted (rdar://147929876)
-// CHECK-NOT: call swiftcc void @always()
-// CHECK: call swiftcc void @never()
+// CHECK: call swiftcc void @always()
+// CHECK-NOT: call swiftcc void @never()
 if #unavailable(EnabledDomain) {
   never()
 } else {
   always()
 }
 
-// CHECK-NOT: call swiftcc void @always()
-// CHECK: call swiftcc void @never()
+// CHECK: call swiftcc void @always()
+// CHECK-NOT: call swiftcc void @never()
 if #unavailable(DisabledDomain) {
   always()
 } else {

--- a/test/SILGen/availability_disabled.swift
+++ b/test/SILGen/availability_disabled.swift
@@ -1,5 +1,0 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s -verify
-
-func foo() {
-    if #available(macOS 10.15, *) {}
-}

--- a/test/SILGen/availability_disabled_zippered.swift
+++ b/test/SILGen/availability_disabled_zippered.swift
@@ -1,6 +1,0 @@
-// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -disable-availability-checking %s -verify
-// REQUIRES: OS=macosx
-
-func foo() {
-    if #available(macOS 10.15, *) {}
-}

--- a/test/SILGen/availability_query_disabled.swift
+++ b/test/SILGen/availability_query_disabled.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking %s -verify
+// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+
+// CHECK-LABEL: // available()
+func available() {
+  // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK: cond_br [[TRUE]]
+  if #available(macOS 10.15, *) {}
+}
+
+// CHECK-LABEL: // unavailable()
+func unavailable() {
+  // CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK: cond_br [[FALSE]]
+  if #unavailable(macOS 10.15) {}
+}

--- a/test/SILGen/availability_query_disabled_zippered.swift
+++ b/test/SILGen/availability_query_disabled_zippered.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -disable-availability-checking %s -verify
+// RUN: %target-swift-emit-silgen -target-variant %target-cpu-apple-macosx13 -target %target-cpu-apple-ios16-macabi -disable-availability-checking %s -verify
+
+// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target-variant %target-cpu-apple-macosx13 -target %target-cpu-apple-ios16-macabi -disable-availability-checking %s | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=maccatalyst
+
+// CHECK-LABEL: // available()
+func available() {
+  // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK: cond_br [[TRUE]]
+  if #available(macOS 10.15, *) {}
+}
+
+// CHECK-LABEL: // unavailable()
+func unavailable() {
+  // CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK: cond_br [[FALSE]]
+  if #unavailable(macOS 10.15) {}
+}

--- a/test/SILGen/availability_query_maccatalyst_zippered.swift
+++ b/test/SILGen/availability_query_maccatalyst_zippered.swift
@@ -26,8 +26,26 @@
 // CHECK: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: cond_br [[QUERY_RESULT]]
 func zippered() {
   if #available(OSX 10.53.8, iOS 51.1.2, *) {
+  }
+}
+
+// CHECK-LABEL: // zippered_unavailable()
+// CHECK: [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+// CHECK: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 53
+// CHECK: [[MACOS_PATCH:%.*]] = integer_literal $Builtin.Word, 8
+// CHECK: [[IOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 51
+// CHECK: [[IOS_MINOR:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
+// CHECK: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: [[MINUSONE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: [[QUERY_INVERSION:%.*]] = builtin "xor_Int1"([[QUERY_RESULT]], [[MINUSONE]]) : $Builtin.Int1
+// CHECK: cond_br [[QUERY_INVERSION]]
+func zippered_unavailable() {
+  if #unavailable(OSX 10.53.8, iOS 51.1.2) {
   }
 }
 
@@ -42,6 +60,7 @@ func zippered() {
 // CHECK: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 5
 // CHECK: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: cond_br [[QUERY_RESULT]]
 func macCatalystWins() {
   if #available(OSX 10.53.8, iOS 51.1.2, macCatalyst 52.3.5, *) {
   }
@@ -57,17 +76,40 @@ func noMatch() {
   }
 }
 
+// CHECK-LABEL: // noMatch_unavailable()
+// CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK: cond_br [[FALSE]]
+func noMatch_unavailable() {
+  if #unavailable(tvOS 9.0) {
+  }
+}
+
 // CHECK-LABEL: // macOSOnly()
 // CHECK: [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 54
 // CHECK: [[MACOS_PATCH:%.*]] = integer_literal $Builtin.Word, 3
 // CHECK: [[QUERY_FUNC:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK: [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: cond_br [[QUERY_RESULT]]
 // The '*' matches for iOS, so we only need to check to check the
 // macOS version and thus use the primary target version check
 // entrypoint.
 func macOSOnly() {
   if #available(macOS 10.54.3, *) {
+  }
+}
+
+// CHECK-LABEL: // macOSOnly_unavailable()
+// CHECK: [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+// CHECK: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 54
+// CHECK: [[MACOS_PATCH:%.*]] = integer_literal $Builtin.Word, 3
+// CHECK: [[QUERY_FUNC:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: [[MINUSONE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: [[QUERY_INVERSION:%.*]] = builtin "xor_Int1"([[QUERY_RESULT]], [[MINUSONE]]) : $Builtin.Int1
+// CHECK: cond_br [[QUERY_INVERSION]]
+func macOSOnly_unavailable() {
+  if #unavailable(macOS 10.54.3) {
   }
 }
 
@@ -77,6 +119,7 @@ func macOSOnly() {
 // CHECK-NO-BACKDEPLOY-NEXT: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK-NO-BACKDEPLOY: [[QUERY_FUNC:%.*]] = function_ref @$ss33_stdlib_isVariantOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK-NO-BACKDEPLOY: [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]([[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK-NO-BACKDEPLOY: cond_br [[QUERY_RESULT]]
 
 // CHECK-BACKDEPLOY-MAC:      [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK-BACKDEPLOY-MAC-NEXT: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 14
@@ -86,6 +129,7 @@ func macOSOnly() {
 // CHECK-BACKDEPLOY-MAC-NEXT: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK-BACKDEPLOY-MAC: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK-BACKDEPLOY-MAC: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK-BACKDEPLOY-MAC: cond_br [[QUERY_RESULT]]
 // The '*' matches for macOS, so we only need to check to check the
 // iOS version and thus use the variant target version check
 // entrypoint.
@@ -100,6 +144,32 @@ func iOSOnly() {
   }
 }
 
+// CHECK-LABEL: // iOSOnly_unavailable()
+// CHECK-NO-BACKDEPLOY-MAC:  [[IOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 54
+// CHECK-NO-BACKDEPLOY-NEXT: [[IOS_MINOR:%.*]] = integer_literal $Builtin.Word, 7
+// CHECK-NO-BACKDEPLOY-NEXT: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
+// CHECK-NO-BACKDEPLOY: [[QUERY_FUNC:%.*]] = function_ref @$ss33_stdlib_isVariantOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK-NO-BACKDEPLOY: [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]([[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK-NO-BACKDEPLOY: [[MINUSONE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK-NO-BACKDEPLOY: [[QUERY_INVERSION:%.*]] = builtin "xor_Int1"([[QUERY_RESULT]], [[MINUSONE]]) : $Builtin.Int1
+// CHECK-NO-BACKDEPLOY: cond_br [[QUERY_INVERSION]]
+
+// CHECK-BACKDEPLOY-MAC:      [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+// CHECK-BACKDEPLOY-MAC-NEXT: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 14
+// CHECK-BACKDEPLOY-MAC-NEXT: [[MACOS_PATCH:%.*]] = integer_literal $Builtin.Word, 4
+// CHECK-BACKDEPLOY-MAC-NEXT: [[IOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 54
+// CHECK-BACKDEPLOY-MAC-NEXT: [[IOS_MINOR:%.*]] = integer_literal $Builtin.Word, 7
+// CHECK-BACKDEPLOY-MAC-NEXT: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
+// CHECK-BACKDEPLOY-MAC: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK-BACKDEPLOY-MAC: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK-BACKDEPLOY-MAC: [[MINUSONE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK-BACKDEPLOY-MAC: [[QUERY_INVERSION:%.*]] = builtin "xor_Int1"([[QUERY_RESULT]], [[MINUSONE]]) : $Builtin.Int1
+// CHECK-BACKDEPLOY-MAC: cond_br [[QUERY_INVERSION]]
+func iOSOnly_unavailable() {
+  if #unavailable(iOS 54.7.2) {
+  }
+}
+
 // CHECK-LABEL: // backdeployMacExplicit()
 // CHECK:      [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
 // CHECK-NEXT: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 14
@@ -109,6 +179,7 @@ func iOSOnly() {
 // CHECK-NEXT: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
 // CHECK: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
 // CHECK: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK: cond_br [[QUERY_RESULT]]
 func backdeployMacExplicit() {
   if #available(iOS 54.7.2, macOS 10.14.5, *) {
   }


### PR DESCRIPTION
Inverted availability queries were mis-compiled for zippered libraries because the code that emits calls to `isOSVersionAtLeastOrVariantVersionAtLeast()` was not updated when the `if #unavailable` syntax was introduced (at that time support for zippered libraries had not yet been upstreamed). The result of these calls is now inverted when appropriate.

To make it easier to manage the growing complexity of supporting availability queries, Sema now models the relevant information about an availability query with the new `AvailabilityQuery` type. It encapsulates the domain for the query, the result if it is known at compile time, and the version tuple arguments to pass to a runtime invocation if applicable.

Additionally, diagnose opaque return types that depend on the availability of a custom domain, which isn't supported yet.

Resolves rdar://147929876.