### PR TITLE
[6.2][Concurrency] Forego Sendable checking if conversion doesn't change t…

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2865,6 +2865,14 @@ namespace {
               break;
 
             case FunctionTypeIsolation::Kind::GlobalActor:
+              // If the isolation is the same it means that conversion
+              // covers loss of `@Sendable` or some other attribute and
+              // we don't need Sendable checking because there is no
+              // boundary crossing here.
+              if (fromIsolation.getGlobalActorType()->isEqual(
+                      toIsolation.getGlobalActorType()))
+                break;
+
               diagnoseNonSendableParametersAndResult(
                   toFnType, version::Version::getFutureMajorLanguageVersion());
               break;


### PR DESCRIPTION
…he global actor

- Explanation:

  `FunctionConversionExpr` is allowed to modify different attributes of a type, sometimes it could strip `@Sendable` but keep the same global actor attribute in place, that needs to be handled explicitly before performing Sendable checking because in this case there is going to be no isolation context change for arguments or results.

- Resolves: rdar://153646123

- Main Branch PR: https://github.com/swiftlang/swift/pull/82645

- Risk: Very Low.  A small tweak to a check where both from and to function types have a global actor isolation in a function conversion expression.
 
- Reviewed By: @ktoso

- Testing: Added new test-cases to the test suite.

(cherry picked from commit 053199eb127d1def102abd9b3fb2c2e1c07d354b)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
