### PR TITLE
SILBridging: remove OptionalBridgedSILDebugVariable

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -127,15 +127,15 @@ public struct Builder {
                                hasDynamicLifetime: Bool = false,
                                isLexical: Bool = false, isFromVarDecl: Bool = false,
                                usesMoveableValueDebugInfo: Bool = false) -> AllocStackInst {
-    let bridgedDebugVar: OptionalBridgedSILDebugVariable
+    let allocStack: BridgedInstruction
     if let debugVariable = debugVariable {
-      bridgedDebugVar = OptionalBridgedSILDebugVariable(debugVariable)
+      allocStack = bridged.createAllocStack(type.bridged, debugVariable, hasDynamicLifetime, isLexical,
+                                            isFromVarDecl, usesMoveableValueDebugInfo)
     } else {
-      bridgedDebugVar = OptionalBridgedSILDebugVariable()
+      allocStack = bridged.createAllocStack(type.bridged, hasDynamicLifetime, isLexical,
+                                            isFromVarDecl, usesMoveableValueDebugInfo)
     }
-    let dr = bridged.createAllocStack(type.bridged, bridgedDebugVar, hasDynamicLifetime, isLexical,
-                                      isFromVarDecl, usesMoveableValueDebugInfo)
-    return notifyNew(dr.getAs(AllocStackInst.self))
+    return notifyNew(allocStack.getAs(AllocStackInst.self))
   }
 
   @discardableResult

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -636,14 +636,6 @@ struct BridgedSILDebugVariable {
   BRIDGED_INLINE swift::SILDebugVariable unbridge() const;
 };
 
-struct OptionalBridgedSILDebugVariable {
-  BridgedSILDebugVariable debugVar;
-  bool hasDebugVar = false;
-
-  OptionalBridgedSILDebugVariable() {}
-  OptionalBridgedSILDebugVariable(BridgedSILDebugVariable d) : debugVar(d), hasDebugVar(true) {}
-};
-
 struct BridgedInstruction {
   SwiftObject obj;
 
@@ -1170,8 +1162,10 @@ struct BridgedBuilder{
     BridgedSILTypeArray elementTypes, BridgedValueArray elementCountOperands) const;
 
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
-  createAllocStack(BridgedType type, OptionalBridgedSILDebugVariable debugVar,
+  createAllocStack(BridgedType type, BridgedSILDebugVariable debugVar,
                    bool hasDynamicLifetime, bool isLexical, bool isFromVarDecl, bool wasMoved) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction
+  createAllocStack(BridgedType type, bool hasDynamicLifetime, bool isLexical, bool isFromVarDecl, bool wasMoved) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createAllocVector(BridgedValue capacity,
                                                                           BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createDeallocStack(BridgedValue operand) const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -2184,16 +2184,25 @@ BridgedInstruction BridgedBuilder::createAllocRef(BridgedType type,
 }
 
 BridgedInstruction BridgedBuilder::createAllocStack(BridgedType type,
-                                                    OptionalBridgedSILDebugVariable debugVar,
+                                                    BridgedSILDebugVariable debugVar,
                                                     bool hasDynamicLifetime,
                                                     bool isLexical,
                                                     bool isFromVarDecl,
                                                     bool wasMoved) const {
-  std::optional<swift::SILDebugVariable> var = std::nullopt;
-  if (debugVar.hasDebugVar)
-    var = debugVar.debugVar.unbridge();
   return {unbridged().createAllocStack(
-      regularLoc(), type.unbridged(), var,
+      regularLoc(), type.unbridged(), debugVar.unbridge(),
+      swift::HasDynamicLifetime_t(hasDynamicLifetime),
+      swift::IsLexical_t(isLexical), swift::IsFromVarDecl_t(isFromVarDecl),
+      swift::UsesMoveableValueDebugInfo_t(wasMoved), /*skipVarDeclAssert=*/ true)};
+}
+
+BridgedInstruction BridgedBuilder::createAllocStack(BridgedType type,
+                                                    bool hasDynamicLifetime,
+                                                    bool isLexical,
+                                                    bool isFromVarDecl,
+                                                    bool wasMoved) const {
+  return {unbridged().createAllocStack(
+      regularLoc(), type.unbridged(), std::nullopt,
       swift::HasDynamicLifetime_t(hasDynamicLifetime),
       swift::IsLexical_t(isLexical), swift::IsFromVarDecl_t(isFromVarDecl),
       swift::UsesMoveableValueDebugInfo_t(wasMoved), /*skipVarDeclAssert=*/ true)};


### PR DESCRIPTION
This didn't work because the BridgedSILDebugVariable destructor was called even in the "none" case.

Fixes a compiler crash
rdar://154689481
