### PR TITLE
MoveOnlyWrappedTypeEliminator: handle `end_cow_mutation_addr` instruction

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -234,6 +234,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(BridgeObjectToRef)
   NO_UPDATE_NEEDED(BeginAccess)
   NO_UPDATE_NEEDED(EndAccess)
+  NO_UPDATE_NEEDED(EndCOWMutationAddr)
   NO_UPDATE_NEEDED(ClassMethod)
   NO_UPDATE_NEEDED(FixLifetime)
   NO_UPDATE_NEEDED(AddressToPointer)

--- a/test/SILOptimizer/span.swift
+++ b/test/SILOptimizer/span.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend %s -parse-as-library -disable-availability-checking -emit-ir -o /dev/null
+
+// Check that the MoveOnlyWrappedTypeEliminator doesn't crash
+func consumingArray(_ arr: consuming [Int]) {
+  let s = arr.mutableSpan;
+  _ = consume s
+}
+


### PR DESCRIPTION
fixes a compiler crash
rdar://154416511
