### PR TITLE
[cxx-interop] Enable foreign reference types in C interop

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -355,8 +355,6 @@ namespace swift {
       return CXXStdlib == PlatformDefaultCXXStdlib;
     }
 
-    bool CForeignReferenceTypes = false;
-
     /// Imports getters and setters as computed properties.
     bool CxxInteropGettersSettersAsProperties = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -867,7 +867,7 @@ def cxx_interoperability_mode :
 def experimental_c_foreign_reference_types :
   Flag<["-"], "experimental-c-foreign-reference-types">,
   Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption]>,
-  HelpText<"Enable experimental C foreign references types (with reference counting).">;
+  HelpText<"Enable experimental C foreign references types. Deprecated, has no effect.">;
 
 def experimental_hermetic_seal_at_link:
   Flag<["-"], "experimental-hermetic-seal-at-link">,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -169,10 +169,6 @@ void ClangImporter::Implementation::makeComputed(AbstractStorageDecl *storage,
 bool importer::recordHasReferenceSemantics(
     const clang::RecordDecl *decl,
     ClangImporter::Implementation *importerImpl) {
-  if (!isa<clang::CXXRecordDecl>(decl) &&
-      !importerImpl->SwiftContext.LangOpts.CForeignReferenceTypes)
-    return false;
-
   // At this point decl might not be fully imported into Swift yet, which
   // means we might not have asked Clang to generate its implicit members, such
   // as copy or move constructors. This would cause CxxRecordSemanticsRequest to

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1580,8 +1580,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       Args.hasFlag(OPT_enable_objc_interop, OPT_disable_objc_interop,
                    Target.isOSDarwin() && !Opts.hasFeature(Feature::Embedded));
 
-  Opts.CForeignReferenceTypes =
-      Args.hasArg(OPT_experimental_c_foreign_reference_types);
+  if (Args.hasArg(OPT_experimental_c_foreign_reference_types))
+    Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
+                   "-experimental-c-foreign-reference-types");
 
   Opts.CxxInteropGettersSettersAsProperties = Args.hasArg(OPT_cxx_interop_getters_setters_as_properties);
   Opts.RequireCxxInteropToImportCxxInteropModule =

--- a/test/Interop/C/struct/foreign-reference-flag-deprecated.swift
+++ b/test/Interop/C/struct/foreign-reference-flag-deprecated.swift
@@ -1,0 +1,5 @@
+// RUN: %target-build-swift %s -I %S/Inputs/ -Xfrontend -experimental-c-foreign-reference-types 2>&1 | %FileCheck %s
+
+// CHECK: <unknown>:0: warning: flag '-experimental-c-foreign-reference-types' is deprecated
+
+import ForeignReference

--- a/test/Interop/C/struct/foreign-reference.swift
+++ b/test/Interop/C/struct/foreign-reference.swift
@@ -1,9 +1,10 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -validate-tbd-against-ir=none -Xfrontend -experimental-c-foreign-reference-types -Onone -D NO_OPTIMIZATIONS)
-// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -validate-tbd-against-ir=none -Xfrontend -experimental-c-foreign-reference-types -O)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -validate-tbd-against-ir=none -Onone -D NO_OPTIMIZATIONS)
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -validate-tbd-against-ir=none -O)
 //
 // REQUIRES: executable_test
-// TODO: This should work without ObjC interop in the future rdar://97497120
-// REQUIRES: objc_interop
+
+// XFAIL: OS=windows-msvc
+// FIXME: Runtime support for C++ foreign reference types is missing on Windows (https://github.com/swiftlang/swift/issues/82643)
 
 import StdlibUnittest
 import ForeignReference


### PR DESCRIPTION
Most of the logic for C++ foreign reference types can be applied to C types as well. Swift had a compiler flag `-Xfrontend -experimental-c-foreign-reference-types` for awhile now which enables foreign reference types without having to enable C++ interop. This change makes it the default behavior.

Since we don't expect anyone to pass `experimental-c-foreign-reference-types` currently, this also removes the frontend flag.

rdar://150308819

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
