### PR TITLE
[OSSACanonicalizeOwned] Dead-end destroys don't end copy-extended lifetime.

### DIFF
--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -472,7 +472,8 @@ private:
   bool respectsDeadEnds() const {
     // TODO: OSSALifetimeCompletion: Once lifetimes are always complete, delete
     //                               this method.
-    return !endingLifetimeAtExplicitEnds();
+    return !endingLifetimeAtExplicitEnds() &&
+           !currentDef->getType().isMoveOnly();
   }
 
   bool respectsDeinitBarriers() const {

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -333,6 +333,8 @@ void CanonicalizeOSSALifetime::extendLivenessToDeadEnds() {
   for (auto destroy : destroys) {
     if (liveness->isWithinBoundary(destroy, /*deadEndBlocks=*/nullptr))
       continue;
+    if (deadEndBlocksAnalysis->get(function)->isDeadEnd(destroy->getParent()))
+      continue;
     completeLiveness.updateForUse(destroy, /*lifetimeEnding*/ true);
   }
 

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -406,7 +406,11 @@ die:
 
 // CHECK-LABEL: begin running test {{.*}} on preserve_dead_end_4
 // CHECK-LABEL: sil [ossa] @preserve_dead_end_4 : {{.*}} {
-// CHECK-NOT:     destroy_value [dead_end]
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[DIE:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_value {{%[^,]+}}
+// CHECK:       [[DIE]]:
+// CHECK:         destroy_value [dead_end] {{%[^,]+}}
 // CHECK-LABEL: } // end sil function 'preserve_dead_end_4'
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_4
 sil [ossa] @preserve_dead_end_4 : $@convention(thin) () -> () {
@@ -436,7 +440,8 @@ die:
 
 // CHECK-LABEL: begin running test {{.*}} on preserve_dead_end_5
 // CHECK-LABEL: sil [ossa] @preserve_dead_end_5 : {{.*}} {
-// CHECK-NOT:     destroy_value [dead_end]
+// CHECK:         apply {{%[^,]+}}()
+// CHECK:         destroy_value [dead_end]
 // CHECK-LABEL: } // end sil function 'preserve_dead_end_5'
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_5
 sil [ossa] @preserve_dead_end_5 : $@convention(thin) () -> () {
@@ -488,7 +493,11 @@ die2:
 
 // CHECK-LABEL: begin running test {{.*}} on preserve_dead_end_7
 // CHECK-LABEL: sil [ossa] @preserve_dead_end_7 : {{.*}} {
-// CHECK-NOT:     destroy_value [dead_end]
+// CHECK:         cond_br undef, [[DIE1:bb[0-9]+]], [[DIE2:bb[0-9]+]]
+// CHECK:       [[DIE1]]:
+// CHECK:         destroy_value {{%[^,]+}}
+// CHECK:       [[DIE2]]:
+// CHECK:         destroy_value [dead_end] {{%[^,]+}}
 // CHECK-LABEL: } // end sil function 'preserve_dead_end_7'
 // CHECK-LABEL: end running test {{.*}} on preserve_dead_end_7
 sil [ossa] @preserve_dead_end_7 : $@convention(thin) () -> () {
@@ -998,4 +1007,42 @@ entry:
   destroy_value %c
   %retval = tuple ()
   return %retval : $()
+}
+
+// A final destroy in a dead-end region may not actually end the copy-extended
+// lifetime.
+// CHECK-LABEL: begin running test {{.*}} on dont_end_lifetimes_at_final_destroys_in_unreachable
+// CHECK-LABEL: sil [ossa] @dont_end_lifetimes_at_final_destroys_in_unreachable : {{.*}} {
+// CHECK:         [[C:%[^,]+]] = apply undef()
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[C]]
+// CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NEXT:    fix_lifetime [[BORROW]]
+// CHECK-NEXT:    unreachable
+// CHECK:       [[EXIT]]:
+// CHECK:         fix_lifetime [[BORROW]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK:         destroy_value [[C]]
+// CHECK-LABEL: } // end sil function 'dont_end_lifetimes_at_final_destroys_in_unreachable'
+// CHECK-LABEL: end running test {{.*}} on dont_end_lifetimes_at_final_destroys_in_unreachable: canonicalize_ossa_lifetime with: true, false, true, %c
+sil [ossa] @dont_end_lifetimes_at_final_destroys_in_unreachable : $@convention(thin) () -> () {
+  %c = apply undef() : $@convention(thin) () -> (@owned C)
+  specify_test "canonicalize_ossa_lifetime true false true %c"
+  %copy = copy_value %c
+  %borrow = begin_borrow %copy
+  cond_br undef, exit, die
+
+die:
+  // NOTE: copy-extended lifetime does NOT end here!
+  destroy_value %c
+  fix_lifetime %borrow
+  unreachable
+
+exit:
+  destroy_value %c
+  fix_lifetime %borrow
+  end_borrow %borrow
+  destroy_value %copy
+  %retval = tuple ()
+  return %retval
 }

--- a/test/SILOptimizer/mem2reg_lifetime.sil
+++ b/test/SILOptimizer/mem2reg_lifetime.sil
@@ -1695,7 +1695,6 @@ exit:
 // CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = move_value [lexical] [[ONE]]
 // CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[RIGHT]]:
-// CHECK:         destroy_value [[ONE]]
 // CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = move_value [lexical] [[TWO]]
 // CHECK:         unreachable
 // CHECK:       [[EXIT]]:
@@ -1730,7 +1729,6 @@ exit:
 // CHECK:         [[LIFETIME_OWNED_1:%[^,]+]] = move_value [lexical] [[ONE]]
 // CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[RIGHT]]:
-// CHECK:         destroy_value [[ONE]]
 // CHECK:         [[LIFETIME_OWNED_2:%[^,]+]] = move_value [lexical] [[TWO]]
 // CHECK:         unreachable
 // CHECK:       [[EXIT]]:


### PR DESCRIPTION
The utility operates on the copy-extended lifetime of a value.  In non-dead-end region, the last destroy seen on any path must end that copy-extended lifetime.  In dead-end regions, however, while we continue to lack complete lifetimes, the final destroy may not actually end the copy-extended lifetime: copies may leak into the dead-end past that destroy.

When extending lifetimes into dead-ends, the utility constructs a second, temporary instance of liveness to which the final destroys are added.  This temporary instance is used to discover which dead-ends the lifetime extends into.  The second, temporary, destroy-extended instance of liveness is necessary because it includes the full copy-extended lifetime of the value--away from dead-ends--which enables discovering dead-ends which are part of the copy-extended lifetime.

Previously, all destroys which were the final destroys on some path were added to that second, temporary instance of liveness.  But the means by which it is determined whether a destroy is a "final destroy" is just by checking whether it is within the boundary of the second, temporary liveness instance.  This is correct for destroys in non-dead-end regions.  But because copies may leak into the dead-end past, a destroy seen in a dead-end region, the last destroy we happen to see in a dead-end region may not be the final destroy.

Here, destroys in dead-end regions are not added to the second, temporary liveness instance.  The result is to include the full dead-end region in which such destroys appear as part of the copy-extended lifetime of the value.

This change revealed an issue where the move-checker's use of the utility was incorrectly respecting dead-ends, which is also fixed here.

rdar://154476285
