### PR TITLE
Mark the concrete SIMD/Scalar comparisons disfavored

### DIFF
--- a/stdlib/public/core/SIMDFloatConcreteOperations.swift.gyb
+++ b/stdlib/public/core/SIMDFloatConcreteOperations.swift.gyb
@@ -122,7 +122,7 @@ compares = [
   ///   result[i] = (a[i] ${op} b)
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent
+  @_alwaysEmitIntoClient @_transparent @_disfavoredOverload
   public static func .${op}(a: Self, b: Scalar) -> SIMDMask<MaskStorage> {
     a .${op} Self(repeating: b)
   }
@@ -139,7 +139,7 @@ compares = [
   ///   result[i] = (a ${op} b[i])
   /// }
   /// ```
-  @_alwaysEmitIntoClient @_transparent
+  @_alwaysEmitIntoClient @_transparent @_disfavoredOverload
   public static func .${op}(a: Scalar, b: Self) -> SIMDMask<MaskStorage> {
     Self(repeating: a) .${op} b
   }


### PR DESCRIPTION
Adding the concrete versions (https://github.com/swiftlang/swift/pull/81892) introduced an ambiguity for concrete vec .<= .zero comparisons; previously the concrete SIMD .<= SIMD operation would win (because we didn't have a concrete overload for SIMD .<= SIMD.Scalar). We can restore the old behavior by marking these disfavored.