### PR TITLE
[Concurency] Allow declarations with `@isolated(any)` parameters be m…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8735,11 +8735,6 @@ ERROR(execution_behavior_incompatible_isolated_parameter,none,
       "an isolated parameter: %2",
       (DeclAttribute, ValueDecl *, ValueDecl *))
 
-ERROR(execution_behavior_incompatible_dynamically_isolated_parameter,none,
-      "cannot use %0 on %kind1 because it has "
-      "a dynamically isolated parameter: %2",
-      (DeclAttribute, ValueDecl *, ValueDecl *))
-
 ERROR(execution_behavior_attr_incompatible_with_global_isolation,none,
       "cannot use %0 because function type is isolated to a global actor %1",
       (DeclAttribute, Type))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -228,17 +228,6 @@ public:
             attr, decl, P);
         return;
       }
-
-      if (auto *attrType = dyn_cast<AttributedTypeRepr>(repr)) {
-        if (attrType->has(TypeAttrKind::Isolated)) {
-          diagnoseAndRemoveAttr(
-              attr,
-              diag::
-                  execution_behavior_incompatible_dynamically_isolated_parameter,
-              attr, decl, P);
-          return;
-        }
-      }
     }
   }
 

--- a/test/attr/execution_behavior_attrs.swift
+++ b/test/attr/execution_behavior_attrs.swift
@@ -94,9 +94,7 @@ struct TestAttributeCollisions {
   }
 
   @concurrent func testIsolationAny(arg: @isolated(any) () -> Void) async {}
-  // expected-error@-1 {{cannot use @concurrent on instance method 'testIsolationAny(arg:)' because it has a dynamically isolated parameter: 'arg'}}
   @concurrent subscript(testIsolationAny arg: @isolated(any) () -> Void) -> Int {
-  // expected-error@-1 {{cannot use @concurrent on subscript 'subscript(testIsolationAny:)' because it has a dynamically isolated parameter: 'arg'}}
     get async {}
   }
 
@@ -157,4 +155,14 @@ do {
       try await invocation.throwingFn()
     })
   }
+}
+
+do {
+  nonisolated(nonsending)
+  func testOnDecl(_: @isolated(any) () -> Void) async {} // Ok
+
+  func testOnType1(_: nonisolated(nonsending) @isolated(any) () async -> Void) {}
+  // expected-error@-1 {{cannot use 'nonisolated(nonsending)' together with '@isolated(any)'}}
+  func testOnType2(_: @concurrent @isolated(any) () async -> Void) {}
+  // expected-error@-1 {{cannot use '@concurrent' together with '@isolated(any)'}}
 }


### PR DESCRIPTION
…arked as `@concurrent`/`nonisolated(nonsending)`

It's shouldn't be possible to use these attributes directly on the function type that is `@isolated(any)` as per SE-0461 proposal but it shouldn't preclude declarations that have parameters with `@isolated(any)` from using them.

Resolves: rdar://154754939

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
