### PR TITLE
Sema: Improve the 'protocol method can't impose new requirements on Self' check

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -401,6 +401,12 @@ namespace swift {
     /// until the next major language version.
     InFlightDiagnostic &warnUntilFutureSwiftVersion();
 
+    InFlightDiagnostic &warnUntilFutureSwiftVersionIf(bool shouldLimit) {
+      if (!shouldLimit)
+        return *this;
+      return warnUntilFutureSwiftVersion();
+    }
+
     /// Limit the diagnostic behavior to warning until the specified version.
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings

--- a/test/decl/protocol/req/unsatisfiable.swift
+++ b/test/decl/protocol/req/unsatisfiable.swift
@@ -97,3 +97,32 @@ class C7<T>: P7 { // expected-error {{type 'C7<T>' does not conform to protocol 
 // expected-note@-1 {{add stubs for conformance}}
   typealias A = T
 }
+
+// This used to just crash.
+protocol LayoutConstraint {
+  associatedtype A
+
+  func f<T>(_: T) where A: AnyObject
+  // expected-error@-1 {{instance method requirement 'f' cannot add constraint 'Self.A: AnyObject' on 'Self'}}
+}
+
+protocol Q {
+  associatedtype A3
+}
+
+// We missed these cases originally.
+protocol ComplexDerivation {
+  associatedtype A1
+  associatedtype A2: Q
+
+  func bad1<B: Equatable>(_: B) where B == Self.A1
+  // expected-warning@-1 {{instance method requirement 'bad1' cannot add constraint 'Self.A1: Equatable' on 'Self'; this will be an error in a future Swift language mode}}
+
+  func bad2<B>(_: B) where A1 == [B]
+  // expected-warning@-1 {{instance method requirement 'bad2' cannot add constraint 'Self.A1 == [B]' on 'Self'; this will be an error in a future Swift language mode}}
+
+  func good<B>(_: B) where A2 == B  // This is fine
+
+  func bad3<B, C>(_: B, _: C) where A2 == B, B.A3 == [C]
+  // expected-warning@-1 {{instance method requirement 'bad3' cannot add constraint 'Self.A2.A3 == Array<C>' on 'Self'; this will be an error in a future Swift language mode}}
+}

--- a/validation-test/compiler_crashers_2_fixed/16638651735c2c8.swift
+++ b/validation-test/compiler_crashers_2_fixed/16638651735c2c8.swift
@@ -1,5 +1,5 @@
 // {"kind":"typecheck","signature":"swift::TypeChecker::checkProtocolSelfRequirements(swift::ValueDecl*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 protocol a {
   associatedtype b
   func c () where b : AnyObject


### PR DESCRIPTION
This check had two problems. First, it would assert upon encountering a layout requirement, due to an unimplemented code path.

A more fundamental issue is that the logic wasn't fully sound, because it would miss certain cases, for example:

    protocol P {
      associatedtype A

      func run<B: Equatable>(_: B) where B == Self.A
    }

Here, the reduced type of `Self.A` is `B`, and at first glance, the requirement `B: Equatable` appears to be fine. However, this is actually a new requirement on `Self`, and the protocol be rejected.

Now that we can change the reduction order by assigning weights to generic parameters (https://github.com/swiftlang/swift/pull/81171), this check can be implemented in a better way, by building a new generic signature first, where all generic parameters introduced by the protocol method, like 'B' above, are assigned a non-zero weight.

With this reduction order, any type that is equivalent to a member type of `Self` will have a reduced type rooted in `Self`, at which point the previous syntactic check becomes sound.

Since this may cause us to reject code we accepted previously, the type checker now performs the check twice: first on the original signature, which may miss certain cases, and then again on the new signature built with the weighted reduction order.

If the first check fails, we diagnose an error. If the second check fails, we only diagnose a warning.

However, I'd like to rip out the first check and turn the warning from the second check into an error soon. It really can cause compiler crashes and miscompiles to have a malformed protocol like this.

Fixes rdar://116938972.
