### PR TITLE
[cxx-interop] Fix generated header for Swift closures using `CF_OPTIONS` types

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/LazyResolver.h"
@@ -58,9 +59,15 @@ getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
   if (auto clangDecl = dyn_cast_or_null<clang::NamedDecl>(VD->getClangDecl())) {
     if (const clang::IdentifierInfo *II = clangDecl->getIdentifier())
       return II->getName();
-    if (auto *anonDecl = dyn_cast<clang::TagDecl>(clangDecl))
+    if (auto *anonDecl = dyn_cast<clang::TagDecl>(clangDecl)) {
       if (auto *anonTypedef = anonDecl->getTypedefNameForAnonDecl())
         return anonTypedef->getIdentifier()->getName();
+      if (auto *cfOptionsTy =
+              VD->getASTContext()
+                  .getClangModuleLoader()
+                  ->getTypeDefForCXXCFOptionsDefinition(anonDecl))
+        return cfOptionsTy->getDecl()->getName();
+    }
   }
 
   return VD->getBaseIdentifier().str();

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -30,6 +30,16 @@
 - (void)method;
 @end
 
+typedef NS_OPTIONS(NSUInteger, ObjCKlassState) {
+  ObjCKlassStateNormal  = 0,
+};
+
+//--- ObjCTest.apinotes
+Name: ObjCTest
+Tags:
+- Name: ObjCKlassState
+  SwiftName: ObjCKlass.State
+
 //--- module.modulemap
 module ObjCTest {
     header "header.h"
@@ -37,6 +47,11 @@ module ObjCTest {
 
 //--- use-objc-types.swift
 import ObjCTest
+import Foundation
+
+@objc public class HasBlockField : NSObject {
+    @objc var foo: ((ObjCKlass.State) -> Void)?
+}
 
 public func retObjClass() -> ObjCKlass {
     return ObjCKlass()
@@ -72,6 +87,10 @@ public func retObjCProtocolNullable() -> ObjCProtocol? {
 public func retObjCClassArray() -> [ObjCKlass] {
     return []
 }
+
+// CHECK: @interface HasBlockField : NSObject
+// CHECK: @property (nonatomic, copy) void (^ _Nullable foo)(ObjCKlassState);
+// CHECK: @end
 
 // CHECK: SWIFT_EXTERN id <ObjCProtocol> _Nonnull $s9UseObjCTy03retB9CProtocolSo0bE0_pyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retObjCProtocol()
 // CHECK-NEXT: #endif


### PR DESCRIPTION
If a Swift class has a field, which has a closure type, which takes an instance of a `CF_OPTIONS`/`NS_OPTIONS` type as a parameter, the reverse interop logic would generate an invalid Objective-C++ header for such type.

This was discovered with UIKit's `UIControlState` type, which is declared with `NS_OPTIONS` in Objective-C, then renamed to `UIControl.State` with API Notes, and then re-exported to Objective-C++ via the generated header.

rdar://129622886

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
