### PR TITLE
[6.2] Concurrency: Move PackExpansionType check to swift::diagnoseNonSendableTypes()

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1053,10 +1053,16 @@ bool swift::diagnoseNonSendableTypes(
     Type type, SendableCheckContext fromContext,
     Type inDerivedConformance, SourceLoc loc,
     llvm::function_ref<bool(Type, DiagnosticBehavior)> diagnose) {
+  auto &ctx = type->getASTContext();
+
   // If the Sendable protocol is missing, do nothing.
-  auto proto = type->getASTContext().getProtocol(KnownProtocolKind::Sendable);
+  auto proto = ctx.getProtocol(KnownProtocolKind::Sendable);
   if (!proto)
     return false;
+
+  // Unwrap pack expansions here to allow packs of Sendable type.
+  if (auto *expansion = type->getAs<PackExpansionType>())
+    type = PackType::get(ctx, {expansion});
 
   // FIXME: More detail for unavailable conformances.
   auto conformance = lookupConformance(type, proto, /*allowMissing=*/true);
@@ -3070,12 +3076,6 @@ namespace {
         Type type = getDeclContext()
             ->mapTypeIntoContext(decl->getInterfaceType())
             ->getReferenceStorageReferent();
-
-        // Pack expansions are okay to capture as long as the pattern
-        // type is Sendable.
-        if (auto *expansion = type->getAs<PackExpansionType>()) {
-          type = expansion->getPatternType();
-        }
 
         if (type->hasError())
           continue;


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82692

* **Description:** This was added in #80220 to fix a related issue with captures of packs, but it's even better to sink this down into diagnoseNonSendableTypes(), so that we can handle packs in parameter position as well.
* **Scope of the issue:** In Swift 6 mode, an actor method could not witness a protocol requirement involving a parameter pack, because the Sendable check always failed.
* **Tested:** Tests added.
* **Risk:** Very low.
* **Issue:**  Fixes https://github.com/swiftlang/swift/issues/82614.
* **Radar:**  Fixes rdar://problem/154649522.
* **Reviewed by:** @DougGregor 