### PR TITLE
[6.2 🍒][AutoDiff] Use `LinkEntity::SecondaryPointer` for diff witness

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -132,7 +132,7 @@ class LinkEntity {
   /// ValueDecl*, SILFunction*, or TypeBase*, depending on Kind.
   void *Pointer;
 
-  /// ProtocolConformance*, depending on Kind.
+  /// ProtocolConformance* or SILDifferentiabilityWitness*, depending on Kind.
   void *SecondaryPointer;
 
   /// A hand-rolled bitfield with the following layout:
@@ -772,8 +772,8 @@ class LinkEntity {
   void
   setForDifferentiabilityWitness(Kind kind,
                                  const SILDifferentiabilityWitness *witness) {
-    Pointer = const_cast<void *>(static_cast<const void *>(witness));
-    SecondaryPointer = nullptr;
+    Pointer = nullptr;
+    SecondaryPointer = const_cast<void *>(static_cast<const void *>(witness));
     Data = LINKENTITY_SET_FIELD(Kind, unsigned(kind));
   }
 
@@ -1684,7 +1684,7 @@ public:
 
   SILDifferentiabilityWitness *getSILDifferentiabilityWitness() const {
     assert(getKind() == Kind::DifferentiabilityWitness);
-    return reinterpret_cast<SILDifferentiabilityWitness *>(Pointer);
+    return reinterpret_cast<SILDifferentiabilityWitness *>(SecondaryPointer);
   }
 
   const RootProtocolConformance *getRootProtocolConformance() const {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1441,7 +1441,7 @@ bool IRGenModule::IsWellKnownBuiltinOrStructralType(CanType T) const {
       T == Context.getAnyObjectType())
     return true;
 
-  if (auto IntTy = dyn_cast<BuiltinIntegerType>(T)) {
+  if (auto IntTy = dyn_cast_or_null<BuiltinIntegerType>(T)) {
     auto Width = IntTy->getWidth();
     if (Width.isPointerWidth())
       return true;


### PR DESCRIPTION
- **Explanation**:
  This cherry-pick addresses an unsafe `reinterpret_cast` in `IRGenModule::getAddrOfLLVMVariable` when handling certain `LinkEntity` kinds.

- **Scope**:
  This change is narrowly scoped to `setForDifferentiabilityWitness` and only affects code paths related to autodiff. 

- **Issues**:
  No public issue is filed. The fix resolves a latent bug triggered in certain compiler configurations or IR generation flows involving `SILDifferentiabilityWitness`.

- **Original PRs**:
https://github.com/swiftlang/swift/pull/82412

- **Risk**:
  Low. The patch follows existing patterns, and does not introduce new logic.

- **Testing**:
We have tested this change across an internal suite of projects that utilize autodiff features heavily.

- **Reviewers**:
@compnerd @asl @kovdan01 
