### PR TITLE
AST: Misc improvements to `@decl` enums: implicit names, code gen fix and more tests

### DIFF
--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -653,12 +653,13 @@ clang::QualType ClangTypeConverter::visitEnumType(EnumType *type) {
   if (type->isUninhabited())
     return convert(Context.TheEmptyTupleType);
 
-  if (!type->getDecl()->isObjC())
-    // Can't translate something not marked with @objc
+  auto ED = type->getDecl();
+  if (!ED->isObjC() && !ED->getAttrs().hasAttribute<CDeclAttr>())
+    // Can't translate something not marked with @objc or @cdecl.
     return clang::QualType();
 
   // @objc enums lower to their raw types.
-  return convert(type->getDecl()->getRawType());
+  return convert(ED->getRawType());
 }
 
 template <bool templateArgument>

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -50,7 +50,8 @@ getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
   }
 
   if (auto cdeclAttr = VD->getAttrs().getAttribute<CDeclAttr>())
-    return cdeclAttr->Name;
+    if (!customNamesOnly || !cdeclAttr->Name.empty())
+      return VD->getCDeclName();
 
   if (customNamesOnly)
     return StringRef();

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1298,7 +1298,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     }
 
     // Use a given cdecl name for native-to-foreign thunks.
-    if (auto CDeclA = getDecl()->getAttrs().getAttribute<CDeclAttr>())
+    if (getDecl()->getAttrs().hasAttribute<CDeclAttr>())
       if (isNativeToForeignThunk()) {
         // If this is an @implementation @_cdecl, mangle it like the clang
         // function it implements.

--- a/test/Interpreter/cdecl_official_run.swift
+++ b/test/Interpreter/cdecl_official_run.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+/// Generate an internal cdecl.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %t/Lib.swift -emit-module -verify -o %t -emit-module-doc \
+// RUN:   -emit-clang-header-path %t/cdecl.h \
+// RUN:   -enable-experimental-feature CDecl
+
+/// Build and run a binary from Swift and C code.
+// RUN: %clang-no-modules -c %t/Client.c -o %t/Client.o \
+// RUN:   -I %t -I %clang-include-dir -Werror -isysroot %sdk
+// RUN: %target-build-swift %t/Lib.swift %t/Client.o -O -o %t/a.out \
+// RUN:   -enable-experimental-feature CDecl -parse-as-library
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out > %t/run.log
+// RUN: %FileCheck %s --input-file %t/run.log
+
+// REQUIRES: swift_feature_CDecl
+// REQUIRES: executable_test
+
+//--- Lib.swift
+
+/// My documentation
+@cdecl(simple) public func simpleNameSwiftSide(x: CInt, bar y: CInt) -> CInt {
+    print(x, y)
+    return x
+}
+
+@cdecl func defaultName(x: Int) {
+    print(x)
+}
+
+@cdecl public func primitiveTypes(i: Int, ci: CInt, l: CLong, c: CChar, f: Float, d: Double, b: Bool) {
+    print(i, ci, l, c, f, d, b)
+}
+
+@cdecl enum CEnum: CInt { case A, B }
+
+@cdecl func useEnum(e: CEnum) -> CEnum {
+    print(e)
+    return e
+}
+
+//--- Client.c
+
+#include <stdio.h>
+#include "cdecl.h"
+
+int main() {
+    int x = simple(42, 43);
+    // CHECK: 42 43
+    printf("%d\n", x);
+    // CHECK-NEXT: 42
+
+    defaultName(121);
+    // CHECK-NEXT: 121
+
+    primitiveTypes(1, 2, 3, 'a', 1.0f, 2.0, true);
+    // CHECK-NEXT: 1 2 3 97 1.0 2.0 true
+
+    CEnum e = useEnum(CEnumB);
+    // CHECK-NEXT: B
+    printf("%d\n", e);
+    // CHECK-NEXT: 1
+}

--- a/test/PrintAsObjC/cdecl-enums.swift
+++ b/test/PrintAsObjC/cdecl-enums.swift
@@ -31,18 +31,18 @@ import Foundation
 // CHECK-NEXT:   ObjcEnumNamedHelloDolly = 4,
 // CHECK-NEXT: };
 
-@cdecl("ObjcEnumNamed") enum EnumNamed: Int {
+@cdecl(ObjcEnumNamed) enum EnumNamed: Int {
   case A, B, C, d, helloDolly
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(unsigned int, ExplicitValues, "ExplicitValues", closed) {
+// CHECK-LABEL: typedef SWIFT_ENUM(unsigned int, ExplicitValues, closed) {
 // CHECK-NEXT:   ExplicitValuesZim = 0,
 // CHECK-NEXT:   ExplicitValuesZang = 219,
 // CHECK-NEXT:   ExplicitValuesZung = 220,
 // CHECK-NEXT: };
 // NEGATIVE-NOT: ExplicitValuesDomain
 
-@cdecl("ExplicitValues") enum ExplicitValues: CUnsignedInt {
+@cdecl enum ExplicitValues: CUnsignedInt {
   case Zim, Zang = 219, Zung
 
   func methodNotExportedToC() {}

--- a/test/PrintAsObjC/cdecl-official-visibility.swift
+++ b/test/PrintAsObjC/cdecl-official-visibility.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+/// Generate cdecl.h for an app
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   %t/Lib.swift -emit-module -verify -o %t -emit-module-doc \
+// RUN:   -emit-clang-header-path %t/cdecl.h -package-name pkg \
+// RUN:   -enable-experimental-feature CDecl
+// RUN: %FileCheck %s --input-file %t/cdecl.h --check-prefixes PUBLIC-AND-INTERNAL,INTERNAL-ONLY
+// RUN: %check-in-clang-c %t/cdecl.h
+
+/// Generate cdecl.h for a library
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library \
+// RUN:   %t/Lib.swift -emit-module -verify -o %t -emit-module-doc \
+// RUN:   -emit-clang-header-path %t/cdecl.h -package-name pkg \
+// RUN:   -enable-experimental-feature CDecl
+// RUN: %FileCheck %s --input-file %t/cdecl.h --check-prefixes PUBLIC-AND-INTERNAL
+// RUN: %FileCheck %s --input-file %t/cdecl.h --implicit-check-not INTERNAL-ONLY
+// RUN: %check-in-clang-c %t/cdecl.h
+
+// REQUIRES: swift_feature_CDecl
+
+//--- Lib.swift
+
+@cdecl private enum PrivateEnum: CInt { case A, B }
+// PUBLIC-AND-INTERNAL-NOT: PrivateEnum
+
+@cdecl internal enum InternalEnum: CInt { case A, B }
+// INTERNAL-ONLY: typedef SWIFT_ENUM(int, InternalEnum, closed) {
+// INTERNAL-ONLY:   InternalEnumA = 0,
+// INTERNAL-ONLY:   InternalEnumB = 1,
+// INTERNAL-ONLY: };
+
+@cdecl package enum PackageEnum: CInt { case A, B }
+// INTERNAL-ONLY: typedef SWIFT_ENUM(int, PackageEnum, closed) {
+// INTERNAL-ONLY:   PackageEnumA = 0,
+// INTERNAL-ONLY:   PackageEnumB = 1,
+// INTERNAL-ONLY: };
+
+@cdecl public enum PublicEnum: CInt { case A, B }
+// PUBLIC-AND-INTERNAL: typedef SWIFT_ENUM(int, PublicEnum, closed) {
+// PUBLIC-AND-INTERNAL:   PublicEnumA = 0,
+// PUBLIC-AND-INTERNAL:   PublicEnumB = 1,
+// PUBLIC-AND-INTERNAL: };
+
+/// Private documentation
+@cdecl private func a_private() {}
+// PUBLIC-AND-INTERNAL-NOT: // Private documentation
+// PUBLIC-AND-INTERNAL-NOT: a_private
+
+/// Internal documentation
+@cdecl internal func b_internal() {}
+// INTERNAL-ONLY: // Internal documentation
+// INTERNAL-ONLY: b_internal
+
+/// Package documentation
+@cdecl package func c_package() {}
+// INTERNAL-ONLY: // Package documentation
+// INTERNAL-ONLY: c_package
+
+/// Public documentation
+@cdecl public func d_public() {}
+// PUBLIC-AND-INTERNAL: // Public documentation
+// PUBLIC-AND-INTERNAL: d_public

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -28,7 +28,7 @@
 // CHECK: #endif
 
 // CHECK: /// Enums
-// CHECK: typedef SWIFT_ENUM_NAMED(int, CEnum, "CEnum", closed) {
+// CHECK: typedef SWIFT_ENUM(int, CEnum, closed) {
 // CHECK:   CEnumA = 0,
 // CHECK:   CEnumB = 1,
 // CHECK: };
@@ -84,7 +84,7 @@ func g_nullablePointers(_ x: UnsafeMutableRawPointer,
 
 /// Enums
 
-@cdecl("CEnum")
+@cdecl
 enum CEnum: CInt { case A, B }
 
 @cdecl("CEnumRenamed_CName")

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -49,6 +49,8 @@ enum SwiftEnum { case A, B }
 @cdecl("CEnum") enum CEnum: Int { case A, B }
 #endif
 
+@cdecl enum CEnumDefaultName: CInt { case A, B }
+
 @cdecl("CEnumNoRawType") enum CEnumNoRawType { case A, B }
 // expected-error @-1 {{'@cdecl' enum must declare an integer raw type}}
 


### PR DESCRIPTION
Fix a few issues with `@cdecl` enums and add more tests.

- Converge on #82039 and #82194, add support for `@cdecl` enums without an explicit C name. The C name defaults to the Swift identifier. The generated code also changes to use the `SWIFT_ENUM` macro instead of `SWIFT_ENUM_NAMED`.
- Fix a crash in code gen when referencing a `@cdecl` enum. Add end-to-end test, including runtime testing.
- Test the access-level effect on the printed `@cdecl` decls. Comparing the internal/app compatibility header and the public/library one.