### PR TITLE
RemoteInspection: Skip unused ELF section headers

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -635,6 +635,9 @@ public:
             return {nullptr, 0};
           // Now for all the sections, find their name.
           for (const typename T::Section *Hdr : SecHdrVec) {
+            // Skip unused headers
+            if (Hdr->sh_type == llvm::ELF::SHT_NULL)
+              continue;
             uint32_t Offset = Hdr->sh_name;
             const char *Start = (const char *)StrTab + Offset;
             uint64_t StringSize = strnlen(Start, StrTabSize - Offset);


### PR DESCRIPTION
ELF section headers are allowed to be left uninitialized when the section is empty and unused. LLD on FreeBSD is a tad more aggressive about this. The ELF reader in the Swift runtime was a bit aggressive about converting the section headers to names and would not skip over these unused sections headers resulting in crashes due to operating on uninitialized memory in the `sh_name` field.

This patch teaches the ELF reader to skip over unused section header table entries.