### PR TITLE
ClangImporter: remove Darwin alias workaround, introduce feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -536,6 +536,9 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
 /// to SendableMetatype (or Sendable).
 EXPERIMENTAL_FEATURE(SendableProhibitsMainActorInference, true)
 
+/// Allow macro based aliases to be imported into Swift
+EXPERIMENTAL_FEATURE(ImportMacroAliases, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -126,6 +126,7 @@ UNINTERESTING_FEATURE(MacrosOnImports)
 UNINTERESTING_FEATURE(NonisolatedNonsendingByDefault)
 UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
 UNINTERESTING_FEATURE(SendableProhibitsMainActorInference)
+UNINTERESTING_FEATURE(ImportMacroAliases)
 
 // TODO: Return true for inlinable function bodies with module selectors in them
 UNINTERESTING_FEATURE(ModuleSelector)

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -377,10 +377,7 @@ namespace {
 ValueDecl *importDeclAlias(ClangImporter::Implementation &clang,
                            swift::DeclContext *DC, const clang::ValueDecl *D,
                            Identifier alias) {
-  if (DC->getASTContext().LangOpts.Target.isOSDarwin() &&
-      DC->getParentModule()->getName().str() == StringRef("_stdio") &&
-      llvm::any_of(llvm::ArrayRef<StringRef>{"stdin", "stdout", "stderr"},
-                   [alias = alias.str()](StringRef Id) { return alias == Id; }))
+  if (!DC->getASTContext().LangOpts.hasFeature(Feature::ImportMacroAliases))
     return nullptr;
 
   // Variadic functions cannot be imported into Swift.

--- a/test/ClangImporter/alias-invalid.swift
+++ b/test/ClangImporter/alias-invalid.swift
@@ -1,5 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules -enable-experimental-feature ImportMacroAliases
+
+// REQUIRES: swift_feature_ImportMacroAliases
 
 import Aliases
 

--- a/test/ClangImporter/alias.swift
+++ b/test/ClangImporter/alias.swift
@@ -1,8 +1,10 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules %s
-// RUN: %target-swift-frontend -I %S/Inputs/custom-modules -parse-as-library -module-name Alias -Osize -emit-ir -o - %s | %FileCheck %s -check-prefix CHECK-ANSI-IR
-// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules %s -Xcc -DUNICODE
-// RUN: %target-swift-frontend -I %S/Inputs/custom-modules -parse-as-library -module-name Alias -Osize -emit-ir -o - %s -Xcc -DUNICODE | %FileCheck %s -check-prefix CHECK-UNICODE-IR
-// RUN: not %target-swift-frontend -I %S/Inputs/custom-modules -parse-as-library -module-name Alias -c %s -DINVALID -o /dev/null 2>&1 | %FileCheck --dry-run %s -check-prefix CHECK-INVALID
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules %s -enable-experimental-feature ImportMacroAliases
+// RUN: %target-swift-frontend -I %S/Inputs/custom-modules -parse-as-library -module-name Alias -Osize -emit-ir -o - %s -enable-experimental-feature ImportMacroAliases | %FileCheck %s -check-prefix CHECK-ANSI-IR
+// RUN: %target-typecheck-verify-swift -I %S/Inputs/custom-modules %s -Xcc -DUNICODE -enable-experimental-feature ImportMacroAliases
+// RUN: %target-swift-frontend -I %S/Inputs/custom-modules -parse-as-library -module-name Alias -Osize -emit-ir -o - %s -Xcc -DUNICODE -enable-experimental-feature ImportMacroAliases | %FileCheck %s -check-prefix CHECK-UNICODE-IR
+// RUN: not %target-swift-frontend -I %S/Inputs/custom-modules -parse-as-library -module-name Alias -c %s -DINVALID -o /dev/null 2>&1 -enable-experimental-feature ImportMacroAliases | %FileCheck --dry-run %s -check-prefix CHECK-INVALID
+
+// REQUIRES: swift_feature_ImportMacroAliases
 
 // expected-no-diagnostics
 

--- a/test/ClangImporter/ignore-darwin-aliasing.swift
+++ b/test/ClangImporter/ignore-darwin-aliasing.swift
@@ -1,4 +1,0 @@
-// RUN: %target-typecheck-verify-swift %s
-// REQUIRES: VENDOR=apple
-
-import var Darwin.stderr

--- a/test/ClangImporter/versioning.swift
+++ b/test/ClangImporter/versioning.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift %s -I %S/Inputs/custom-modules
+// RUN: %target-typecheck-verify-swift %s -I %S/Inputs/custom-modules -enable-experimental-feature ImportMacroAliases
 // XFAIL: *
+
+// REQUIRES: swift_feature_ImportMacroAliases
 
 // expected-no-diagnostics
 

--- a/test/SILGen/variadic.swift
+++ b/test/SILGen/variadic.swift
@@ -1,4 +1,6 @@
-// RUN: %swift_frontend_plain -emit-silgen %s -I %S/Inputs -o - -parse-as-library -verify | %FileCheck %s
+// RUN: %swift_frontend_plain -emit-silgen %s -I %S/Inputs -o - -parse-as-library -verify -enable-experimental-feature ImportMacroAliases | %FileCheck %s
+
+// REQUIRES: swift_feature_ImportMacroAliases
 
 import Variadic
 


### PR DESCRIPTION
Introduce a feature flag to add the importing of macro aliases. Remove the Darwin specific carve out.