### PR TITLE
6.2: [CSE] Fix combine of type_value.

### DIFF
--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -520,10 +520,7 @@ public:
   }
 
   hash_code visitTypeValueInst(TypeValueInst *X) {
-    OperandValueArrayRef Operands(X->getAllOperands());
-    return llvm::hash_combine(
-        X->getKind(), X->getType(),
-        llvm::hash_combine_range(Operands.begin(), Operands.end()));
+    return llvm::hash_combine(X->getKind(), X->getType(), X->getParamType());
   }
 };
 } // end anonymous namespace
@@ -567,6 +564,13 @@ bool llvm::DenseMapInfo<SimpleValue>::isEqual(SimpleValue LHS,
       return false;
 
     return true;
+  }
+  auto *ltvi = dyn_cast<TypeValueInst>(LHSI);
+  auto *rtvi = dyn_cast<TypeValueInst>(RHSI);
+  if (ltvi && rtvi) {
+    if (ltvi->getType() != rtvi->getType())
+      return false;
+    return ltvi->getParamType() == rtvi->getParamType();
   }
   auto opCmp = [&](const Operand *op1, const Operand *op2) -> bool {
     if (op1 == op2)

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -1447,4 +1447,3 @@ bb0:
   %r1 = tuple ()
   return %r1 : $()
 }
-

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -1351,3 +1351,16 @@ bb0(%0 : $*InlineArray<N, Int>, %1 : $Int):
   return %14
 }
 
+struct Pair<let x: Int, let y: Int> {}
+// CHECK-LABEL: sil [ossa] @dont_cse_different_type_values : {{.*}} {
+// CHECK:         type_value
+// CHECK:         type_value
+// CHECK-LABEL: } // end sil function 'dont_cse_different_type_values'
+sil [ossa] @dont_cse_different_type_values : $@convention(method) <let x : Int, let y : Int> (Pair<x, y>) -> (Int, Int) {
+[global: ]
+bb0(%0 : $Pair<x, y>):
+  %2 = type_value $Int for x
+  %3 = type_value $Int for y
+  %4 = tuple (%2, %3)
+  return %4
+}


### PR DESCRIPTION
**Explanation**: Fix a miscompile of value generics.

CSE deduplicates instructions, substituting one for another and deleting the other.  When doing this, it must prove that the instructions are the same.

Previously, it was determining that two `type_value` instructions were the same when they had the same type and the same operands.  But `type_value` has no operands; instead, it has a second "param type", which refers to the value generic in the function signature.  CSE was disregarding when two `type_value`s had different param types.  The result was to replace one value generic with another.

Here, this is fixed by considering the type and the param type both in hashing and equality checking.
**Scope**: Affects optimized code with value generics.
**Issue**: rdar://154652254
**Original PR**: https://github.com/swiftlang/swift/pull/82696
**Risk**: Low, this is a narrow fix that only affects value generics.
**Testing**: Added test.
**Reviewer**: Meghana Gupta ( @meg-gupta ), Andrew Trick ( @atrick )