### PR TITLE
[stdlibUnittest] generalize `expectNil(_:)`

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -739,15 +739,35 @@ public func expectDoesNotThrow(_ test: () throws -> Void,
   }
 }
 
-public func expectNil<T>(_ value: T?,
+public func expectNil<T>(
+  _ value: T?,
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
+  file: String = #file, line: UInt = #line
+) {
   if value != nil {
     expectationFailure(
-      "expected optional to be nil\nactual: \"\(value!)\"", trace: message(),
+      "expected optional to be nil\nactual: \"\(value!)\"",
+      trace: message(),
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+  }
+}
+
+@_lifetime(copy value)
+public func expectNil<T: ~Copyable & ~Escapable>(
+  _ value: borrowing T?,
+  _ message: @autoclosure () -> String = "",
+  stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+) {
+  if value != nil {
+    expectationFailure(
+      "expected optional to be nil",
+      trace: message(),
+      stackTrace: stackTrace.pushIf(showFrame, file: file, line: line)
+    )
   }
 }
 

--- a/test/stdlib/OptionalGeneralizations.swift
+++ b/test/stdlib/OptionalGeneralizations.swift
@@ -1,8 +1,7 @@
-// RUN: %target-run-simple-swift(-enable-experimental-feature NonescapableTypes -enable-experimental-feature LifetimeDependence)
+// RUN: %target-run-simple-swift(-enable-experimental-feature Lifetimes)
 // REQUIRES: executable_test
 // REQUIRES: reflection
-// REQUIRES: swift_feature_NonescapableTypes
-// REQUIRES: swift_feature_LifetimeDependence
+// REQUIRES: swift_feature_Lifetimes
 
 import StdlibUnittest
 import Swift
@@ -99,7 +98,7 @@ suite.test("expectNotNil()") {
   _ = expectNotNil(opt1(NoncopyableStruct()))
   _ = expectNotNil(opt1(RegularClass()))
 #if $NonescapableTypes
-  @lifetime(copy t)
+  @_lifetime(copy t)
   func opt2<T: ~Copyable & ~Escapable>(_ t: consuming T) -> T? { t }
 
   let ne = NonescapableStruct()
@@ -110,5 +109,25 @@ suite.test("expectNotNil()") {
 
   let nent = NonescapableNontrivialStruct()
   _ = expectNotNil(opt2(nent))
-#endif
+#endif // $NonescapableTypes
+}
+
+suite.test("expectNil()") {
+  func opt1<T: ~Copyable>(_ t: consuming T) -> T? { nil }
+  expectNil(opt1(TrivialStruct()))
+  expectNil(opt1(NoncopyableStruct()))
+  expectNil(opt1(RegularClass()))
+#if $NonescapableTypes
+  @_lifetime(copy t)
+  func opt2<T: ~Copyable & ~Escapable>(_ t: consuming T) -> T? { nil }
+
+  let ne = NonescapableStruct()
+  expectNil(opt2(ne))
+
+  let ncne = NoncopyableNonescapableStruct()
+  expectNil(opt2(ncne))
+
+  let nent = NonescapableNontrivialStruct()
+  expectNil(opt2(nent))
+#endif // $NonescapableTypes
 }


### PR DESCRIPTION
Generalize StdlibUnittest's expectNil(_:) function for non-copyable and non-escapable parameter types. Useful for testing failable UTF8Span initializers, for example.

This generalization adds an overload, because simply generalizing would remove functionality. The original version prints an unexpected value using string interpolation. The string interpolation machinery cannot handle a non-escapable or non-copyable parameter value yet, so we instead add a version that can handle such values but does not print. Merging these is left for future work.

Addresses rdar://154776967