### PR TITLE
Sema: Add `@cdecl @implementation` tests

### DIFF
--- a/test/IRGen/Inputs/objc_implementation.h
+++ b/test/IRGen/Inputs/objc_implementation.h
@@ -1,3 +1,4 @@
+#if __OBJC__
 #import <Foundation/Foundation.h>
 
 @interface ImplClass: NSObject <NSCopying>
@@ -31,11 +32,13 @@
 - (void)category2Method:(int)param;
 
 @end
+#endif
 
 extern void implFunc(int param);
 extern void implFuncCName(int param) __asm__("_implFuncAsmName");
+extern void implFuncRenamed_C(int param) __attribute__((swift_name("implFuncRenamed_Swift(param:)")));
 
-
+#if __OBJC__
 @interface NoImplClass
 
 - (void)noImplMethod:(int)param;
@@ -57,3 +60,4 @@ extern void implFuncCName(int param) __asm__("_implFuncAsmName");
 @property (assign) int afterInt;
 
 @end
+#endif

--- a/test/IRGen/cdecl_implementation.swift
+++ b/test/IRGen/cdecl_implementation.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   -enable-experimental-feature CImplementation \
+// RUN:   -enable-experimental-feature CDecl \
+// RUN:   -disable-objc-interop \
+// RUN:   -F %clang-importer-sdk-path/frameworks %s \
+// RUN:   -import-objc-header %S/Inputs/objc_implementation.h -emit-ir \
+// RUN:   -target %target-future-triple > %t.ir
+// RUN: %FileCheck --input-file %t.ir %s
+
+// REQUIRES: swift_feature_CImplementation
+// REQUIRES: swift_feature_CDecl
+
+@implementation @cdecl
+public func implFunc(_ param: Int32) {}
+
+@implementation @cdecl
+public func implFuncCName(_ param: Int32) {}
+
+@implementation @cdecl(implFuncRenamed_C)
+public func implFuncRenamed_Swift(param: Int32) {}
+
+public func fn() {
+  implFunc(2)
+  implFuncCName(3)
+  implFuncRenamed_Swift(param: 4)
+}
+
+/// implFunc(_:)
+// CHECK-LABEL: define{{.*}} void @implFunc
+
+// FIXME: We'd like this to be internal or hidden, not public.
+// CHECK: define{{.*}} swiftcc void @"$s20cdecl_implementation8implFuncyys5Int32VF"
+
+/// inplFuncCName(_:)
+// CHECK-LABEL: define{{.*}} void @"\01_implFuncAsmName"
+
+// FIXME: We'd like this to be internal or hidden, not public.
+// CHECK: define{{.*}} swiftcc void @"$s20cdecl_implementation13implFuncCNameyys5Int32VF"
+
+/// fn()
+// CHECK-LABEL: define{{.*}} swiftcc void @"$s20cdecl_implementation2fnyyF"
+// CHECK:   call void @implFunc
+// CHECK:   call void @"\01_implFuncAsmName"
+// CHECK:   call void @implFuncRenamed_C
+// CHECK:   ret void
+// CHECK: }
+

--- a/test/IRGen/objc_implementation.swift
+++ b/test/IRGen/objc_implementation.swift
@@ -185,11 +185,15 @@ public func implFunc(_ param: Int32) {}
 @_objcImplementation @_cdecl("implFuncCName")
 public func implFuncCName(_ param: Int32) {}
 
+@implementation @_cdecl("implFuncRenamed_C")
+public func implFuncRenamed_Swift(param: Int32) {}
+
 public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
   impl.mainMethod(0)
   swiftSub.mainMethod(1)
   implFunc(2)
   implFuncCName(3)
+  implFuncRenamed_Swift(param: 4)
 }
 
 // Swift calling convention -[ImplClass init]
@@ -329,12 +333,12 @@ public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
 // Swift calling convention SwiftSubclass.deinit (deallocating)
 // CHECK-LABEL: define swiftcc void @"$s19objc_implementation13SwiftSubclassCfD"
 
-// inplFunc(_:)
+// implFunc(_:)
 // CHECK-LABEL: define void @implFunc
 // FIXME: We'd like this to be internal or hidden, not public.
 // CHECK: define swiftcc void @"$s19objc_implementation8implFuncyys5Int32VF"
 
-// inplFuncCName(_:)
+// implFuncCName(_:)
 // CHECK-LABEL: define void @"\01_implFuncAsmName"
 // FIXME: We'd like this to be internal or hidden, not public.
 // CHECK: define swiftcc void @"$s19objc_implementation13implFuncCNameyys5Int32VF"
@@ -346,6 +350,7 @@ public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
 // CHECK:   [[SEL_2:%[^ ]+]] = load ptr, ptr @"\01L_selector(mainMethod:)", align 8
 // CHECK:   call void @objc_msgSend(ptr {{.*}}, ptr [[SEL_2]], i32 1)
 // CHECK:   call void @implFunc
+// CHECK:   call void @"\01_implFuncAsmName"
 // CHECK:   ret void
 // CHECK: }
 

--- a/test/Interpreter/cdecl_implementation_run.swift
+++ b/test/Interpreter/cdecl_implementation_run.swift
@@ -1,0 +1,94 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t --leading-lines
+
+/// Build Swift dylib and compatibility header.
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Lib)) %t/Lib.swift \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-clang-header-path %t/cdecl.h \
+// RUN:   -import-objc-header %t/BridgingHeader.h \
+// RUN:   -enable-experimental-feature CDecl \
+// RUN:   -enable-experimental-feature CImplementation
+// RUN: %target-codesign %t/%target-library-name(Lib)
+
+/// Build a C client against cdecl.h.
+// RUN: %clang-no-modules %t/Client.c -o %t/a.out \
+// RUN:   -I %clang-include-dir -Werror -isysroot %sdk \
+// RUN:   -I %t -l Lib -L %t %target-rpath(%t)
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out > %t/run.log
+// RUN: %FileCheck %t/Client.c --check-prefix=PRINTS --input-file %t/run.log
+
+/// Build a Swift client against cdecl.h.
+// RUN: %target-build-swift %t/Client.swift -o %t/a.out \
+// RUN:   -I %t -l Lib -L %t %target-rpath(%t)
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out > %t/run.log
+// RUN: %FileCheck %t/Client.swift --check-prefix=PRINTS --input-file %t/run.log
+
+// REQUIRES: swift_feature_CDecl
+// REQUIRES: swift_feature_CImplementation
+// REQUIRES: executable_test
+
+//--- BridgingHeader.h
+#include <stddef.h>
+#include <stdbool.h>
+
+extern int simple(int x, int y);
+
+extern void primitiveTypes(ptrdiff_t i, int ci, long l, char c, float f, double d, bool b);
+
+extern void sameName();
+
+__attribute__((swift_name("renamed_swiftSide(_:)")))
+extern void renamed_clangSide(ptrdiff_t arg);
+
+//--- Lib.swift
+
+@cdecl @implementation
+public func simple(_ x: Int32, _ y: Int32) -> Int32 {
+    print(x, y)
+    return x
+}
+
+@implementation @cdecl
+public func primitiveTypes(_ i: Int, _ ci: CInt, _ l: CLong, _ c: CChar, _ f: Float, _ d: Double, _ b: Bool) {
+    print(i, ci, l, c, f, d, b)
+}
+
+@cdecl(sameName) @implementation
+public func sameName() {
+    print("sameName")
+}
+
+@cdecl(renamed_clangSide) @implementation
+public func renamed_swiftSide(_ arg: Int) {
+    print(arg)
+}
+
+//--- Client.c
+
+#include "cdecl.h"
+#include "BridgingHeader.h"
+
+int main() {
+    ptrdiff_t x = simple(42, 43);
+    // PRINTS: 42 43
+    primitiveTypes(1, 2, 3, 'a', 1.0f, 2.0, true);
+    // PRINTS: 1 2 3 97 1.0 2.0 true
+    sameName();
+    // PRINTS: sameName
+    renamed_clangSide(11);
+    // PRINTS: 11
+}
+
+//--- Client.swift
+import Lib
+
+let _ = simple(42, 43)
+// PRINTS: 42 43
+primitiveTypes(1, 2, 3, 97, 1.0, 2.0, true)
+// PRINTS: 1 2 3 97 1.0 2.0 true
+sameName();
+// PRINTS: sameName
+renamed_swiftSide(11)
+// PRINTS: 11

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -231,6 +231,8 @@
 void CImplFunc1(int param);
 void CImplFunc2(int param);
 
+void CImplFuncRenamed_C(int param) __attribute__((swift_name("CImplFuncRenamed_Swift(arg:)")));
+
 void CImplFuncMismatch1(int param);
 void CImplFuncMismatch2(int param);
 

--- a/test/decl/ext/cdecl_official_implementation.swift
+++ b/test/decl/ext/cdecl_official_implementation.swift
@@ -1,0 +1,82 @@
+// RUN: %target-typecheck-verify-swift -target %target-stable-abi-triple \
+// RUN:   -import-bridging-header %S/Inputs/objc_implementation.h \
+// RUN:   -disable-objc-interop \
+// RUN:   -enable-experimental-feature CImplementation \
+// RUN:   -enable-experimental-feature CDecl
+
+// REQUIRES: swift_feature_CImplementation
+// REQUIRES: swift_feature_CDecl
+
+@implementation @cdecl
+func CImplFunc1(_: Int32) {
+  // OK
+}
+
+@implementation @cdecl(CImplFuncRenamed_C)
+func CImplFuncRenamed_Swift(arg: CInt) {
+  // OK
+}
+
+@implementation(BadCategory) @cdecl
+func CImplFunc2(_: Int32) {
+  // expected-error@-2 {{global function 'CImplFunc2' does not belong to an Objective-C category; remove the category name from this attribute}} {{16-29=}}
+}
+
+@implementation @cdecl
+func CImplFuncMissing(_: Int32) {
+  // expected-error@-2 {{could not find imported function 'CImplFuncMissing' matching global function 'CImplFuncMissing'; make sure your umbrella or bridging header imports the header that declares it}}
+}
+
+@implementation @cdecl
+func CImplFuncMismatch1(_: Float) {
+  // expected-error@-1 {{global function 'CImplFuncMismatch1' of type '(Float) -> ()' does not match type '(Int32) -> Void' declared by the header}}
+}
+
+@implementation @cdecl
+func CImplFuncMismatch2(_: Int32) -> Float {
+  // expected-error@-1 {{global function 'CImplFuncMismatch2' of type '(Int32) -> Float' does not match type '(Int32) -> Void' declared by the header}}
+}
+
+@implementation @cdecl(CImplFuncNameMismatch1)
+func mismatchedName1(_: Int32) {
+  // expected-error@-2 {{could not find imported function 'CImplFuncNameMismatch1' matching global function 'mismatchedName1'; make sure your umbrella or bridging header imports the header that declares it}}
+  // FIXME: Improve diagnostic for a partial match.
+}
+
+@implementation @cdecl(mismatchedName2)
+func CImplFuncNameMismatch2(_: Int32) {
+  // expected-error@-2 {{could not find imported function 'mismatchedName2' matching global function 'CImplFuncNameMismatch2'; make sure your umbrella or bridging header imports the header that declares it}}
+  // FIXME: Improve diagnostic for a partial match.
+}
+
+//
+// TODO: @cdecl for global functions imported as computed vars
+//
+var cImplComputedGlobal1: Int32 {
+  @implementation @cdecl(CImplGetComputedGlobal1)
+  get {
+    // FIXME: Lookup for vars isn't working yet
+    // expected-error@-3 {{could not find imported function 'CImplGetComputedGlobal1' matching getter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
+    return 0
+  }
+
+  @implementation @cdecl(CImplSetComputedGlobal1)
+  set {
+    // FIXME: Lookup for vars isn't working yet
+    // expected-error@-3 {{could not find imported function 'CImplSetComputedGlobal1' matching setter for var 'cImplComputedGlobal1'; make sure your umbrella or bridging header imports the header that declares it}}
+    print(newValue)
+  }
+}
+
+//
+// TODO: @cdecl for import-as-member functions
+//
+extension CImplStruct {
+  @implementation @cdecl(CImplStructStaticFunc1)
+  static func staticFunc1(_: Int32) {
+    // FIXME: Add underlying support for this
+    // expected-error@-3 {{@cdecl can only be applied to global functions}}
+    // FIXME: Lookup in an enclosing type is not working yet
+    // expected-error@-5 {{could not find imported function 'CImplStructStaticFunc1' matching static method 'staticFunc1'; make sure your umbrella or bridging header imports the header that declares it}}
+  }
+}


### PR DESCRIPTION
Add IRGen, type-checking and execution tests for `@cdecl @implementation`. This documents the current behavior from Becca's `CImplementation` feature, and covers the new `@cdecl` syntax with the implicit name.

A notable use case tested here is when a `@decl @implementation` function has a different name in Swift and C. This is currently supported if the C header declares the `swift_name` and the Swift implementation declares the C name with `@cdecl`.