### PR TITLE
[6.2][ClangImporter] Fix dangling reference

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -265,7 +265,8 @@ instantiateTemplatedOperator(ClangImporter::Implementation &impl,
       classDecl->getLocation(), clang::OverloadCandidateSet::CSK_Operator,
       clang::OverloadCandidateSet::OperatorRewriteInfo(opKind,
                                               clang::SourceLocation(), false));
-  clangSema.LookupOverloadedBinOp(candidateSet, opKind, ops, {arg, arg}, true);
+  std::array<clang::Expr *, 2> args{arg, arg};
+  clangSema.LookupOverloadedBinOp(candidateSet, opKind, ops, args, true);
 
   clang::OverloadCandidateSet::iterator best;
   switch (candidateSet.BestViableFunction(clangSema, clang::SourceLocation(),


### PR DESCRIPTION
- **Explanation**: LookupOverloadedBinOp stores `Args` for later use, so store the backing array on the stack instead of using a temporary. This fixes a crash that appeared under some build configurations.
- **Scope**: Clang importer
- **Original PRs**: https://github.com/swiftlang/swift/pull/82708
- **Risk**: Extremely low, just fixes the lifetime of the backing of an `ArrayRef`
- **Testing**: No longer crashes
- **Reviewers**: @Bigcheese 