### PR TITLE
[6.2] Correctly forward the implicit `nonisolated(nonsending)` parameter in thunks

### DIFF
--- a/lib/SILGen/SILGenAvailability.cpp
+++ b/lib/SILGen/SILGenAvailability.cpp
@@ -508,7 +508,9 @@ void SILGenFunction::emitBackDeploymentThunk(SILDeclRef thunk) {
   SmallVector<ManagedValue, 4> params;
   SmallVector<ManagedValue, 4> indirectParams;
   SmallVector<ManagedValue, 4> indirectErrorResults;
-  collectThunkParams(loc, params, &indirectParams, &indirectErrorResults);
+  ManagedValue implicitIsolationParam;
+  collectThunkParams(loc, params, &indirectParams, &indirectErrorResults,
+                     &implicitIsolationParam);
 
   // Build up the list of arguments that we're going to invoke the real
   // function with.
@@ -518,6 +520,9 @@ void SILGenFunction::emitBackDeploymentThunk(SILDeclRef thunk) {
   }
   for (auto indirectErrorResult : indirectErrorResults) {
     paramsForForwarding.emplace_back(indirectErrorResult.getLValueAddress());
+  }
+  if (implicitIsolationParam) {
+    paramsForForwarding.emplace_back(implicitIsolationParam.forward(*this));
   }
 
   for (auto param : params) {

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2623,7 +2623,8 @@ public:
   void collectThunkParams(
       SILLocation loc, SmallVectorImpl<ManagedValue> &params,
       SmallVectorImpl<ManagedValue> *indirectResultParams = nullptr,
-      SmallVectorImpl<ManagedValue> *indirectErrorParams = nullptr);
+      SmallVectorImpl<ManagedValue> *indirectErrorParams = nullptr,
+      ManagedValue *implicitIsolationParam = nullptr);
 
   /// Build the type of a function transformation thunk.
   CanSILFunctionType buildThunkType(CanSILFunctionType &sourceType,

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1304,8 +1304,9 @@ SILFunction *SILGenModule::emitDefaultOverride(SILDeclRef replacement,
   SmallVector<ManagedValue, 4> params;
   SmallVector<ManagedValue, 4> indirectResults;
   SmallVector<ManagedValue, 4> indirectErrors;
+  ManagedValue implicitIsolationParam;
   SGF.collectThunkParams(replacement.getDecl(), params, &indirectResults,
-                         &indirectErrors);
+                         &indirectErrors, &implicitIsolationParam);
 
   auto self = params.back();
 
@@ -1320,6 +1321,11 @@ SILFunction *SILGenModule::emitDefaultOverride(SILDeclRef replacement,
   SmallVector<SILValue> args;
   for (auto result : indirectResults) {
     args.push_back(result.forward(SGF));
+  }
+  // Indirect errors would go here, but we don't currently support
+  // throwing coroutines.
+  if (implicitIsolationParam.isValid()) {
+    args.push_back(implicitIsolationParam.forward(SGF));
   }
   for (auto param : params) {
     args.push_back(param.forward(SGF));

--- a/test/Concurrency/nonisolated_nonsending.swift
+++ b/test/Concurrency/nonisolated_nonsending.swift
@@ -1,0 +1,64 @@
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -swift-version 6 -enable-upcoming-feature NonisolatedNonsendingByDefault %s | %FileCheck %s
+
+// REQUIRES: swift_feature_NonisolatedNonsendingByDefault
+
+protocol P: Sendable {
+  func f() async
+}
+
+// Our map closure (abstracted as returning T) returns a function
+// value, which requires it to be reabstracted to the most general
+// abstraction pattern, i.e. from
+//     nonisolated(nonsending) () async -> ()
+// to
+//     nonisolated(nonsending) () async -> U, where U == ()
+// Note that we preserve nonisolated(nonsending).
+//
+// The thunk code did not expect the output function type to be
+// nonisolated(nonsending), so it didn't handle and propagate the
+// implicit isolation argument correctly.
+func testPartialApplication(p: [any P]) async {
+  _ = p.map { $0.f }
+}
+// CHECK-LABEL: sil private @$s22nonisolated_nonsending22testPartialApplication1pySayAA1P_pG_tYaFyyYaYbYCcAaD_pXEfU_ :
+// CHECK: function_ref @$sScA_pSgIeghHgIL_AAytIeghHgILr_TR :
+
+//   Reabstraction thunk from caller-isolated () -> () to caller-isolated () -> T
+// CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sScA_pSgIeghHgIL_AAytIeghHgILr_TR :
+// CHECK:       bb0(%0 : $*(), %1 : $Optional<any Actor>, %2 : $@Sendable @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>) -> ()):
+// CHECK-NEXT:    apply %2(%1) :
+
+func takesGenericAsyncFunction<T>(_ fn: nonisolated(nonsending) (T) async -> Void) {}
+
+// This is a more direct test of the partial-application code above.
+// Note that we have to make the functions explicitly nonisolated(nonsending)
+// because NonisolatedNonsendingByDefault only applies to declarations,
+// not function types in the abstract.
+func testReabstractionPreservingCallerIsolation(fn: nonisolated(nonsending) (Int) async -> Void) {
+  takesGenericAsyncFunction(fn)
+}
+// CHECK-LABEL: sil hidden @$s22nonisolated_nonsending42testReabstractionPreservingCallerIsolation2fnyySiYaYCXE_tF :
+// CHECK:       bb0(%0 : $@noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, Int) -> ()):
+// CHECK:         [[THUNK:%.*]] = function_ref @$sScA_pSgSiIgHgILy_AASiIegHgILn_TR :
+
+// CHECK-LABEL: sil shared [transparent] [reabstraction_thunk] @$sScA_pSgSiIgHgILy_AASiIegHgILn_TR :
+// CHECK:       bb0(%0 : $Optional<any Actor>, %1 : $*Int, %2 : $@noescape @async @callee_guaranteed (@sil_isolated @sil_implicit_leading_param @guaranteed Optional<any Actor>, Int) -> ()):
+// CHECK-NEXT:    %3 = load %1
+// CHECK-NEXT:    apply %2(%0, %3)
+
+func takesAsyncIsolatedAnyFunction(_ fn: @isolated(any) () async -> Void) {}
+func takesGenericAsyncIsolatedAnyFunction<T>(_ fn: @isolated(any) (T) async -> Void) {}
+
+// These would be good to test, but we apparently reject this conversion.
+#if false
+
+// The same bug, but converting to an @isolated(any) function type.
+func testConversionToIsolatedAny(fn: nonisolated(nonsending) () async -> Void) {
+  takesAsyncIsolatedAnyFunction(fn)
+}
+
+func testReabstractionToIsolatedAny(fn: nonisolated(nonsending) (Int) async -> Void) {
+  takesGenericAsyncIsolatedAnyFunction(fn)
+}
+
+#endif

--- a/test/SILGen/back_deployed_attr.swift
+++ b/test/SILGen/back_deployed_attr.swift
@@ -85,3 +85,18 @@ public func backDeployedCaller(_ s: inout S<Z>) {
   // CHECK: function_ref @$s11back_deploy1SV1xxvsTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()
   s.x = Z()
 }
+
+// The same bug from test/Concurrency/nonisolated_nonsending.swift also applied to
+// back-deployment thunks.
+
+// CHECK-LABEL: sil non_abi [serialized] [back_deployed_thunk] [ossa] @$s11back_deploy0A29DeployedNonisolatedNonsendingSiyYaFTwb :
+@backDeployed(before: macOS 10.52)
+nonisolated(nonsending)
+public func backDeployedNonisolatedNonsending() async -> Int {
+  // CHECK: bb0(%0 : @guaranteed $Optional<any Actor>):
+  // CHECK:   [[FALLBACK_FN:%.*]] = function_ref @$s11back_deploy0A29DeployedNonisolatedNonsendingSiyYaFTwB :
+  // CHECK:   apply [[FALLBACK_FN]](%0)
+  // CHECK:   [[SHIPPING_FN:%.*]] = function_ref @$s11back_deploy0A29DeployedNonisolatedNonsendingSiyYaF :
+  // CHECK:   apply [[SHIPPING_FN]](%0)
+  return 0
+}


### PR DESCRIPTION
Fixes rdar://154401813 and rdar://154137740. 6.2 version of #82705.

Description: There are several reasons that SILGen sometimes needs to generate "thunk" functions that wrap a call to another function. As part of their basic operation, these thunks must account for their parameters and forward them as arguments to the function they wrap. This requires them to understand all the parameters of both function signatures. `nonisolating(nonsending)` adds an implicit parameter, but several thunk emitters didn't know about it, so they blew up. I fixed the bug for several different kinds of thunks.

Scope: affects SIL generation for `nonisolating(nonsending)` functions and values of function type. This is a new feature in 6.2 and hasn't seen much adoption yet; there's an upcoming feature flag to turn it on by default, but a separate bug means that flag incorrectly isn't applying to function types, only to declared functions. So the code paths aren't seeing much exercise quite yet, but we expect that to change after Swift 6.2.
Risk: low; the patch is designed to not impact code patterns other than the ones that are very broken right now
Reviewer: Allan Shortlidge.
Testing: new regression tests