### PR TITLE
[cxx-interop] Support types nested in extensions

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -224,12 +224,6 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
       auto r = ctx.getIdentifier(os.str());
       return r.str();
     }
-
-    // FIXME: String.Index should be exposed as String::Index, not
-    // _String_Index.
-    if (VD->getBaseIdentifier().str() == "Index") {
-      return "String_Index";
-    }
   }
 
   return VD->getBaseIdentifier().str();

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -767,6 +767,10 @@ public:
       return false;
 
     (void)forwardDeclareMemberTypes(CD->getAllMembers(), CD);
+    for (const auto *ed :
+         printer.getInteropContext().getExtensionsForNominalType(CD)) {
+      (void)forwardDeclareMemberTypes(ed->getAllMembers(), CD);
+    }
     auto [it, inserted] =
         seenTypes.try_emplace(CD, EmissionState::NotYetDefined, false);
     if (outputLangMode == OutputLanguageMode::Cxx &&
@@ -868,6 +872,10 @@ public:
 
     if (outputLangMode == OutputLanguageMode::Cxx) {
       forwardDeclareMemberTypes(ED->getAllMembers(), ED);
+      for (const auto *ed :
+           printer.getInteropContext().getExtensionsForNominalType(ED)) {
+        (void)forwardDeclareMemberTypes(ed->getAllMembers(), ED);
+      }
       forwardDeclareCxxValueTypeIfNeeded(ED);
     }
 

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -86,8 +86,8 @@
 // CHECK: }
 // CHECK-NEXT:  static SWIFT_INLINE_THUNK String init() SWIFT_SYMBOL({{.*}});
 // CHECK:  SWIFT_INLINE_THUNK void append(const String& other)
-// CHECK:  SWIFT_INLINE_THUNK UTF8View getUtf8() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  SWIFT_INLINE_THUNK void setUtf8(const UTF8View& newValue) SWIFT_SYMBOL({{.*}});
+// CHECK:  SWIFT_INLINE_THUNK __StringNested::UTF8View getUtf8() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  SWIFT_INLINE_THUNK void setUtf8(const __StringNested::UTF8View& newValue) SWIFT_SYMBOL({{.*}});
 // CHECK:  SWIFT_INLINE_THUNK operator NSString * _Nonnull () const noexcept {
 // CHECK-NEXT:    return (__bridge_transfer NSString *)(_impl::$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF(_impl::swift_interop_passDirect_Swift_String(_getOpaquePointer())));
 // CHECK-NEXT:   }
@@ -120,11 +120,11 @@
 // CHECK: class SWIFT_SYMBOL({{.*}}) UTF8View final {
 // CHECK: SWIFT_INLINE_PRIVATE_HELPER UTF8View(UTF8View &&) noexcept {
 // CHECK: }
-// CHECK-NEXT: SWIFT_INLINE_THUNK String_Index getStartIndex() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:   SWIFT_INLINE_THUNK String_Index getEndIndex() const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK swift::Optional<String_Index> indexOffsetByLimitedBy(const String_Index& i, swift::Int n, const String_Index& limit) const SWIFT_SYMBOL({{.*}});
-// CHECK:   SWIFT_INLINE_THUNK swift::Int distanceFromTo(const String_Index& i, const String_Index& j) const SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK uint8_t operator [](const String_Index& i) const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: SWIFT_INLINE_THUNK __StringNested::Index getStartIndex() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   SWIFT_INLINE_THUNK __StringNested::Index getEndIndex() const SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK swift::Optional<__StringNested::Index> indexOffsetByLimitedBy(const __StringNested::Index& i, swift::Int n, const __StringNested::Index& limit) const SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK swift::Int distanceFromTo(const __StringNested::Index& i, const __StringNested::Index& j) const SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK uint8_t operator [](const __StringNested::Index& i) const SWIFT_SYMBOL({{.*}});
 // CHECK:   SWIFT_INLINE_THUNK String getDescription() const SWIFT_SYMBOL({{.*}});
 // CHECK:   SWIFT_INLINE_THUNK swift::Int getCount() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:

--- a/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/nested-structs-in-cxx.swift
@@ -73,6 +73,19 @@ extension RecordConfig.File {
     public func getFileExtension() -> String { ".wav" }
 }
 
+extension RecordConfig {
+    public struct NestedInExtension {
+        public var foo: Int
+    }
+}
+
+extension AudioFileType {
+    public struct NestedInExtension {
+        public var foo: Int
+    }
+}
+
+
 public func getFiles() -> [RecordConfig.File] {
     []
 }


### PR DESCRIPTION
The generated header did not compile due to a bug that prevented us from referencing the correct namespaces derived from the nominal type's name (an extension does not have a name). Moreover, we did not generate forward declarations for the members of the extensions for classes and enums (but we did for structs). This change also removes a workaround that emitted String::Index as _String_Index.

rdar://153221450
