### PR TITLE
Adjust .editorconfig for Python

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.py]
+indent_size = 4


### PR DESCRIPTION
The Python in the repo is written with 4-space indentation (as is standard for Python). Adjust the editorconfig to be consistent with that standard.