### PR TITLE
[cxx-interop] Add source location to instantiation error

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7103,8 +7103,9 @@ clang::FunctionDecl *ClangImporter::instantiateCXXFunctionTemplate(
     // TODO: Use the location of the apply here.
     // TODO: This error message should not reference implementation details.
     // See: https://github.com/apple/swift/pull/33053#discussion_r477003350
-    ctx.Diags.diagnose(SourceLoc(), diag::unable_to_convert_generic_swift_types,
-                       getFuncName(), failedTypesStr);
+    Impl.diagnose(HeaderLoc(func->getBeginLoc()),
+                  diag::unable_to_convert_generic_swift_types, getFuncName(),
+                  failedTypesStr);
     return nullptr;
   }
 
@@ -7123,9 +7124,9 @@ clang::FunctionDecl *ClangImporter::instantiateCXXFunctionTemplate(
                                       templateParamsStream,
                                       /*IncludeType*/ true);
                           });
-    ctx.Diags.diagnose(SourceLoc(),
-                       diag::unable_to_substitute_cxx_function_template,
-                       getFuncName(), templateParams);
+    Impl.diagnose(HeaderLoc(func->getBeginLoc()),
+                  diag::unable_to_substitute_cxx_function_template,
+                  getFuncName(), templateParams);
     return nullptr;
   }
   sema.InstantiateFunctionDefinition(clang::SourceLocation(), spec);

--- a/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
+++ b/test/Interop/Cxx/templates/function-template-typechecker-errors.swift
@@ -25,12 +25,12 @@ public protocol A { }
 public protocol B { }
 public protocol C { }
 
-// CHECK: error: unexpected error produced: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'passThrough' could not be converted: any A & B
+// CHECK: function-templates.h{{.*}}: error: diagnostic produced elsewhere: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'passThrough' could not be converted: any A & B
 public func caller1(x: A & B) -> A & B {
   return passThrough(x)
 }
 
-// CHECK: error: unexpected error produced: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'addMixedTypeParams' could not be converted: any A & B, any A & C
+// CHECK: function-templates.h{{.*}}: error: diagnostic produced elsewhere: could not generate C++ types from the generic Swift types provided; the following Swift type(s) provided to 'addMixedTypeParams' could not be converted: any A & B, any A & C
 public func caller2(x: A & B, y: A & C) -> A & B {
   return addMixedTypeParams(x, y)
 }


### PR DESCRIPTION
Previously, the diagnostic was emitted with an unknown location.
