### PR TITLE
[Concurrency] Unbreak priority tests so they actually run & fix them

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -1588,6 +1588,9 @@ class _ParentProcess {
         _testSuiteFailedCallback()
       } else {
         print("\(testSuite.name): All tests passed")
+        if testSuite._tests.isEmpty {
+          print("WARNING: SUITE '\(testSuite.name)' CONTAINED NO TESTS! NO TESTS WERE EXECUTED!")
+        }
       }
     }
     let (failed: failedOnShutdown, ()) = _shutdownChild()


### PR DESCRIPTION
if #available + -disable-availability-checking seems to have been broken
since... TBD since when exactly. This means that these tests were not
executing at all (!), and when available became fixed, they actually
started executing and seems they hanged.

This fixes the tests however we should look into any other tests which
may have suffered from this and also since when these tests started
hanging -- it likely is a change in how isolation was inferred.

resolves rdar://154765383

Unblocks https://github.com/swiftlang/swift/pull/82671 cc @tshortli 