### PR TITLE
[6.2][Concurrency] Move tsan_release to point before task gets destroyed

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -256,8 +256,6 @@ void swift::runJobInEstablishedExecutorContext(Job *job) {
 #if SWIFT_OBJC_INTEROP
   objc_autoreleasePoolPop(pool);
 #endif
-
-  _swift_tsan_release(job);
 }
 
 void swift::adoptTaskVoucher(AsyncTask *task) {

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -859,6 +859,8 @@ struct AsyncTask::PrivateStorage {
       }
     }
 
+    _swift_tsan_release(task);
+
     // Destroy and deallocate any remaining task local items since the task is
     // completed. We need to do this before we destroy the task local
     // deallocator.


### PR DESCRIPTION
Description: `runJobInEstablishedExecutorContext` contains an erroneous `_tsan_release`, which can mark memory that has already been freed as a synchronisation point for other threads. This patch moves the `_tsan_release` to a point before the deallocation.
Risk: Low, this change only affects thread sanitizer.
Testing: This issue was discovered by a failing debug check within TSan when applied to a large Xcode project. The debug check no longer fails with this patch applied; unfortunately any tests that would run in Swift CI would not have this debug check, as a release build of the TSan runtime is used.
Reviewed by: @ktoso 

Original PR: https://github.com/swiftlang/swift/pull/82158
Radar: rdar://152501929