### PR TITLE
[Backtracing][Linux] Ignore `SHT_NULL` sections.

### DIFF
--- a/stdlib/public/RuntimeModule/Elf.swift
+++ b/stdlib/public/RuntimeModule/Elf.swift
@@ -1463,6 +1463,11 @@ final class ElfImage<SomeElfTraits: ElfTraits>
       let stringSect = ElfStringSection(source: stringSource)
 
       for shdr in sectionHeaders {
+        // All other fields are undefined for SHT_NULL
+        if shdr.sh_type == .SHT_NULL {
+          continue
+        }
+
         guard let name = stringSect.getStringAt(index: Int(shdr.sh_name)) else {
           continue
         }
@@ -1600,6 +1605,11 @@ final class ElfImage<SomeElfTraits: ElfTraits>
         let stringSect = ElfStringSection(source: stringSource)
 
         for shdr in sectionHeaders {
+          // All other fields are undefined for SHT_NULL
+          if shdr.sh_type == .SHT_NULL {
+            continue
+          }
+
           guard let sname
                   = stringSect.getStringAt(index: Int(shdr.sh_name)) else {
             continue


### PR DESCRIPTION
The ELF specification says that if a section's type is set to `SHT_NULL`, _none_ of the other fields are valid, so we shouldn't even be trying to read the section name.

(We won't crash, because of how all of this code works, but we might read an incorrect name.)

rdar://154837649
