### PR TITLE
🍒[cxx-interop] Fix generated header for Swift closures using `CF_OPTIONS` types

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -16,6 +16,7 @@
 
 #include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/LazyResolver.h"
@@ -54,9 +55,15 @@ getNameForObjC(const ValueDecl *VD, CustomNamesOnly_t customNamesOnly) {
   if (auto clangDecl = dyn_cast_or_null<clang::NamedDecl>(VD->getClangDecl())) {
     if (const clang::IdentifierInfo *II = clangDecl->getIdentifier())
       return II->getName();
-    if (auto *anonDecl = dyn_cast<clang::TagDecl>(clangDecl))
+    if (auto *anonDecl = dyn_cast<clang::TagDecl>(clangDecl)) {
       if (auto *anonTypedef = anonDecl->getTypedefNameForAnonDecl())
         return anonTypedef->getIdentifier()->getName();
+      if (auto *cfOptionsTy =
+              VD->getASTContext()
+                  .getClangModuleLoader()
+                  ->getTypeDefForCXXCFOptionsDefinition(anonDecl))
+        return cfOptionsTy->getDecl()->getName();
+    }
   }
 
   return VD->getBaseIdentifier().str();

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -30,6 +30,16 @@
 - (void)method;
 @end
 
+typedef NS_OPTIONS(NSUInteger, ObjCKlassState) {
+  ObjCKlassStateNormal  = 0,
+};
+
+//--- ObjCTest.apinotes
+Name: ObjCTest
+Tags:
+- Name: ObjCKlassState
+  SwiftName: ObjCKlass.State
+
 //--- module.modulemap
 module ObjCTest {
     header "header.h"
@@ -37,6 +47,11 @@ module ObjCTest {
 
 //--- use-objc-types.swift
 import ObjCTest
+import Foundation
+
+@objc public class HasBlockField : NSObject {
+    @objc var foo: ((ObjCKlass.State) -> Void)?
+}
 
 public func retObjClass() -> ObjCKlass {
     return ObjCKlass()
@@ -72,6 +87,10 @@ public func retObjCProtocolNullable() -> ObjCProtocol? {
 public func retObjCClassArray() -> [ObjCKlass] {
     return []
 }
+
+// CHECK: @interface HasBlockField : NSObject
+// CHECK: @property (nonatomic, copy) void (^ _Nullable foo)(ObjCKlassState);
+// CHECK: @end
 
 // CHECK: SWIFT_EXTERN id <ObjCProtocol> _Nonnull $s9UseObjCTy03retB9CProtocolSo0bE0_pyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retObjCProtocol()
 // CHECK-NEXT: #endif


### PR DESCRIPTION
  - **Explanation**: If a Swift class has a field, which has a closure type, which takes an instance of a `CF_OPTIONS`/`NS_OPTIONS` type as a parameter, the reverse interop logic would generate an invalid Objective-C++ header for such type. This was discovered with UIKit's `UIControlState` type, which is declared with `NS_OPTIONS` in Objective-C, then renamed to `UIControl.State` with API Notes, and then re-exported to Objective-C++ via the generated header.
  - **Scope**: This changes the decl name translation logic from Swift into Objective-C++.
  - **Issues**: rdar://129622886
  - **Original PRs**: https://github.com/swiftlang/swift/pull/82691
  - **Risk**: Low, this only takes effect for `CF_OPTIONS` types which were previously mishandled.
  - **Testing**: Added a compiler test.
  - **Reviewers**: @Xazax-hun
