### PR TITLE
[Sema] Avoid applying diagnostic hack to caller-side expression macros

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -618,7 +618,10 @@ namespace swift {
 
     /// Figure out the Behavior for the given diagnostic, taking current
     /// state such as fatality into account.
-    DiagnosticBehavior determineBehavior(const Diagnostic &diag);
+    DiagnosticBehavior determineBehavior(const Diagnostic &diag) const;
+
+    /// Updates the diagnostic state for a diagnostic to emit.
+    void updateFor(DiagnosticBehavior behavior);
 
     bool hadAnyError() const { return anyErrorOccurred; }
     bool hasFatalErrorOccurred() const { return fatalErrorOccurred; }
@@ -646,7 +649,7 @@ namespace swift {
 
     /// Returns a Boolean value indicating whether warnings belonging to the
     /// diagnostic group identified by `id` should be escalated to errors.
-    bool getWarningsAsErrorsForDiagGroupID(DiagGroupID id) {
+    bool getWarningsAsErrorsForDiagGroupID(DiagGroupID id) const {
       return warningsAsErrors[(unsigned)id];
     }
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1287,7 +1287,8 @@ llvm::cl::opt<bool> AssertOnError("swift-diagnostics-assert-on-error",
 llvm::cl::opt<bool> AssertOnWarning("swift-diagnostics-assert-on-warning",
                                     llvm::cl::init(false));
 
-DiagnosticBehavior DiagnosticState::determineBehavior(const Diagnostic &diag) {
+DiagnosticBehavior
+DiagnosticState::determineBehavior(const Diagnostic &diag) const {
   // We determine how to handle a diagnostic based on the following rules
   //   1) Map the diagnostic to its "intended" behavior, applying the behavior
   //      limit for this particular emission
@@ -1334,21 +1335,23 @@ DiagnosticBehavior DiagnosticState::determineBehavior(const Diagnostic &diag) {
     if (suppressRemarks)
       lvl = DiagnosticBehavior::Ignore;
   }
+  return lvl;
+}
 
-  //   5) Update current state for use during the next diagnostic
-  if (lvl == DiagnosticBehavior::Fatal) {
+void DiagnosticState::updateFor(DiagnosticBehavior behavior) {
+  // Update current state for use during the next diagnostic
+  if (behavior == DiagnosticBehavior::Fatal) {
     fatalErrorOccurred = true;
     anyErrorOccurred = true;
-  } else if (lvl == DiagnosticBehavior::Error) {
+  } else if (behavior == DiagnosticBehavior::Error) {
     anyErrorOccurred = true;
   }
 
   ASSERT((!AssertOnError || !anyErrorOccurred) && "We emitted an error?!");
-  ASSERT((!AssertOnWarning || (lvl != DiagnosticBehavior::Warning)) &&
+  ASSERT((!AssertOnWarning || (behavior != DiagnosticBehavior::Warning)) &&
          "We emitted a warning?!");
 
-  previousBehavior = lvl;
-  return lvl;
+  previousBehavior = behavior;
 }
 
 void DiagnosticEngine::flushActiveDiagnostic() {
@@ -1393,6 +1396,8 @@ std::optional<DiagnosticInfo>
 DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic,
                                               bool includeDiagnosticName) {
   auto behavior = state.determineBehavior(diagnostic);
+  state.updateFor(behavior);
+
   if (behavior == DiagnosticBehavior::Ignore)
     return std::nullopt;
 

--- a/test/Macros/rdar154771596.swift
+++ b/test/Macros/rdar154771596.swift
@@ -1,0 +1,28 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -module-name Lib -emit-module-path %t/Lib.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %t %t/a.swift -primary-file %t/b.swift
+
+//--- Lib.swift
+
+@freestanding(expression)
+public macro magicFile() -> String = #externalMacro(module: "MacroDefinition", type: "MagicFileMacro")
+
+//--- a.swift
+
+import Lib
+
+func foo(x: String = #magicFile) {}
+
+//--- b.swift
+
+// We're missing the necessary import in this file, make sure we diagnose.
+func bar() {
+  foo() // expected-error {{no macro named 'magicFile'}}
+}


### PR DESCRIPTION
When type-checking a caller-side expression macro default argument in a context where name lookup is unable to resolve it (but _is_ able to resolve it in the parameter), we were previously exiting with a non-zero exit code _without_ emitting any diagnostic. This was due to the fact that `DiagnosticState::determineBehavior` is stateful, meaning that querying `DiagnosticTransaction::hasErrors` could flip the "had error" bit for the DiagnosticEngine even if the transaction got later aborted.

This PR splits off the stateful bit of `DiagnosticState::determineBehavior` into a new function that we call during diagnostic emission. This then exposed the actual underlying issue here, which is that the diagnostic hack we have for caller-side default arguments, where we expect them to fail in the parameter if they fail at the call-site, is unsound for expression macros since name lookup may differ depending on context. Limit the hack such that it only applies to simple literals (magic literals + `nil`, `[]`, and `[:]`).

rdar://154771596