### PR TITLE
[cxx-interop] Lifetime dependence on a class is unsafe

### DIFF
--- a/test/Interop/Cxx/class/safe-interop-mode.swift
+++ b/test/Interop/Cxx/class/safe-interop-mode.swift
@@ -64,9 +64,13 @@ View safeFunc(View v1 [[clang::noescape]], View v2 [[clang::lifetimebound]]);
 void unsafeFunc(View v1 [[clang::noescape]], View v2);
 
 class SharedObject {
+public:
+  View getView() const [[clang::lifetimebound]];
 private:
   int *p;
 } SWIFT_SHARED_REFERENCE(retainSharedObject, releaseSharedObject);
+
+View getViewFromSharedObject(SharedObject* p [[clang::lifetimebound]]);
 
 inline void retainSharedObject(SharedObject *) {}
 inline void releaseSharedObject(SharedObject *) {}
@@ -161,6 +165,10 @@ func useUnsafeLifetimeAnnotated(v: View) {
 func useSharedReference(frt: SharedObject, x: OwnedData) {
   let _ = frt
   x.takeSharedObject(frt)
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  let _ = frt.getView() // expected-note{{reference to unsafe instance method 'getView()'}}
+  // expected-warning@+1{{expression uses unsafe constructs but is not marked with 'unsafe'}}
+  let _ = getViewFromSharedObject(frt) // expected-note{{reference to unsafe global function 'getViewFromSharedObject'}}
 }
 
 @available(SwiftStdlib 5.8, *)

--- a/test/Interop/Cxx/stdlib/Inputs/std-span.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-span.h
@@ -65,6 +65,7 @@ inline SpanOfInt initSpan(int arr[], size_t size) {
 struct DependsOnSelf {
   std::vector<int> v;
   __attribute__((swift_name("get()")))
+  __attribute__((swift_attr("@safe")))
   ConstSpanOfInt get() const [[clang::lifetimebound]] { return ConstSpanOfInt(v.data(), v.size()); }
 };
 
@@ -180,5 +181,21 @@ inline void mutableKeyword(SpanOfInt copy [[clang::noescape]]) {}
 
 inline void spanWithoutTypeAlias(std::span<const int> s [[clang::noescape]]) {}
 inline void mutableSpanWithoutTypeAlias(std::span<int> s [[clang::noescape]]) {}
+
+#define IMMORTAL_FRT                                                           \
+  __attribute__((swift_attr("import_reference")))                              \
+  __attribute__((swift_attr("retain:immortal")))                               \
+  __attribute__((swift_attr("release:immortal")))
+
+struct IMMORTAL_FRT DependsOnSelfFRT {
+  std::vector<int> v;
+  __attribute__((swift_name("get()"))) ConstSpanOfInt get() const
+      [[clang::lifetimebound]] {
+    return ConstSpanOfInt(v.data(), v.size());
+  }
+  SpanOfInt getMutable() [[clang::lifetimebound]] {
+    return SpanOfInt(v.data(), v.size());
+  }
+};
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_SPAN_H

--- a/test/Interop/Cxx/stdlib/std-span-interface.swift
+++ b/test/Interop/Cxx/stdlib/std-span-interface.swift
@@ -37,6 +37,17 @@ import CxxStdlib
 // CHECK-NEXT:   mutating func otherTemplatedType2(_ copy: ConstSpanOfInt, _: UnsafeMutablePointer<S<CInt>>!)
 // CHECK-NEXT: }
 
+// CHECK: class DependsOnSelfFRT {
+// CHECK-NEXT:   init()
+// CHECK-NEXT:   /// This is an auto-generated wrapper for safer interop
+// CHECK-NEXT:   @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
+// CHECK-NEXT:   @_lifetime(borrow self)
+// CHECK-NEXT:   @_alwaysEmitIntoClient @_disfavoredOverload public borrowing func get() -> Span<CInt>
+// CHECK-NEXT:   borrowing func get() -> ConstSpanOfInt
+// CHECK-NEXT:   borrowing func {{(__)?}}getMutable{{(Unsafe)?}}() -> SpanOfInt
+// CHECK-NEXT:   var v: std.{{.*}}vector<CInt, std.{{.*}}allocator<CInt>>
+// CHECK-NEXT: }
+
 // CHECK:      /// This is an auto-generated wrapper for safer interop
 // CHECK-NEXT: @available(visionOS 1.0, tvOS 12.2, watchOS 5.2, iOS 12.2, macOS 10.14.4, *)
 // CHECK-NEXT: @_lifetime(s: copy s)


### PR DESCRIPTION
Swift cannot guarantee exclusivity of a class. On the other hand, lifetimebound annotations on the C++ side do not guarantee exclusivity. To resolve this issue, we ignore lifetime dependency annotations that introduce exclusive dependence on classes and import functions with ignored annotations as unsafe. Currently, Swift has no language feature to support these scenarios but it might get new features in the future to help people work around this problem.

rdar://153747746
