### PR TITLE
Build-Script: Don't divide by zero

### DIFF
--- a/utils/swift_build_support/swift_build_support/utils.py
+++ b/utils/swift_build_support/swift_build_support/utils.py
@@ -97,12 +97,13 @@ def log_analyzer():
         print("================ \t ==================== \t ===========",
               file=sys.stderr)
         event_row = '{:<17.1%} \t {:<21} \t {}'
-        for build_event in finish_events:
-            duration_percentage = \
-                (float(build_event["duration"]) / float(total_duration))
-            print(event_row.format(duration_percentage,
-                                   build_event["duration"],
-                                   build_event["command"]), file=sys.stderr)
+        if total_duration > 0:
+            for build_event in finish_events:
+                duration_percentage = \
+                    (float(build_event["duration"]) / float(total_duration))
+                print(event_row.format(duration_percentage,
+                                       build_event["duration"],
+                                       build_event["command"]), file=sys.stderr)
 
         hours, remainder = divmod(total_duration, 3600)
         minutes, seconds = divmod(remainder, 60)


### PR DESCRIPTION
If things crash very early on, build-script tries to divide by zero when computing the percent time spent in each project because the build time is zero. While this is a failure state, all it does is add more output to the crashing stack trace.