### PR TITLE
[SemanticARCOpts] Always heed subpass flags.

### DIFF
--- a/lib/SILOptimizer/SemanticARC/Context.h
+++ b/lib/SILOptimizer/SemanticARC/Context.h
@@ -129,16 +129,9 @@ struct LLVM_LIBRARY_VISIBILITY Context {
   void verify() const;
 
   bool shouldPerform(ARCTransformKind testKind) const {
-    // When asserts are enabled, we allow for specific arc transforms to be
-    // turned on/off via LLVM args. So check that if we have asserts, perform
-    // all optimizations otherwise.
-#ifndef NDEBUG
     if (transformKind == ARCTransformKind::Invalid)
       return false;
     return bool(testKind & transformKind);
-#else
-    return true;
-#endif
   }
 
   void reset() {

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
@@ -77,7 +77,6 @@ struct SemanticARCOpts : SILFunctionTransform {
   SemanticARCOpts(bool mandatoryOptsOnly)
       : mandatoryOptsOnly(mandatoryOptsOnly) {}
 
-#ifndef NDEBUG
   void performCommandlineSpecifiedTransforms(SemanticARCOptVisitor &visitor) {
     for (auto transform : TransformsToPerform) {
       visitor.ctx.transformKind = transform;
@@ -110,7 +109,6 @@ struct SemanticARCOpts : SILFunctionTransform {
       }
     }
   }
-#endif
 
   bool performPeepholesWithoutFixedPoint(SemanticARCOptVisitor &visitor) {
     // Add all the results of all instructions that we want to visit to the
@@ -162,13 +160,11 @@ struct SemanticARCOpts : SILFunctionTransform {
     SemanticARCOptVisitor visitor(f, getPassManager(), *deBlocksAnalysis->get(&f),
                                   mandatoryOptsOnly);
 
-#ifndef NDEBUG
     // If we are being asked for testing purposes to run a series of transforms
     // expressed on the command line, run that and return.
     if (!TransformsToPerform.empty()) {
       return performCommandlineSpecifiedTransforms(visitor);
     }
-#endif
 
     // Otherwise, perform our standard optimizations.
     bool didEliminateARCInsts = performPeepholes(visitor);

--- a/test/SILOptimizer/semantic-arc-opt-unchecked-ownership-conversion.sil
+++ b/test/SILOptimizer/semantic-arc-opt-unchecked-ownership-conversion.sil
@@ -1,7 +1,5 @@
 // RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -semantic-arc-opts -sil-semantic-arc-peepholes-ownership-conversion-elim -sil-semantic-arc-peepholes-lifetime-joining %s | %FileCheck %s
 
-// REQUIRES: asserts
-
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
+++ b/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
@@ -1,7 +1,4 @@
 // RUN: %target-sil-opt -sil-print-types -module-name Swift -enable-sil-verify-all -semantic-arc-opts -sil-semantic-arc-peepholes-lifetime-joining %s | %FileCheck %s
-//
-// Enabling specific ARC opts requires an asserts build.
-// REQUIRES: asserts
 
 // NOTE: Some of our tests here depend on borrow elimination /not/ running!
 // Please do not add it to clean up the IR like we did in


### PR DESCRIPTION
To get equivalent test coverage in asserts and noasserts builds, enable the code that triggers executing only specified subpasses in noasserts builds.

rdar://154499140
