### PR TITLE
6.2: [Test] Re-disable test in asserts builds.

### DIFF
--- a/test/SILOptimizer/semantic-arc-opts-redundantcopyopts.sil
+++ b/test/SILOptimizer/semantic-arc-opts-redundantcopyopts.sil
@@ -3,6 +3,9 @@
 // NOTE: Some of our tests here depend on borrow elimination /not/ running!
 // Please do not add it to clean up the IR like we did in
 // semanticarcopts-loadcopy-to-loadborrow!
+//
+// Enabling specific ARC opts requires an asserts build.
+// REQUIRES: asserts
 
 sil_stage canonical
 


### PR DESCRIPTION
**Explanation**: Re-disable a test in noasserts builds.

The test was reenabled in "this configuration" a week ago in https://github.com/swiftlang/swift/pull/82559/ .  But it still doesn't work in this configuration.

The test relies on the ability to control which subpass is run and that ability is compiled out in noasserts builds. That's changed here https://github.com/swiftlang/swift/pull/82736 .  

Rather than incur any risk from an NFCI change to fix a test, though, just redisable the test.
**Scope**: A test case.
**Issue**: rdar://154499140
**Original PR**: https://github.com/swiftlang/swift/pull/82736
**Risk**: None
**Testing**: Exactly.
**Reviewer**: Meghana Gupta ( @meg-gupta )
