### PR TITLE
[6.2 🍒][Dependency Scanning] On cycle via overlay, fix Clang dependency path reconstruction

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1110,7 +1110,7 @@ findClangDepPath(const ModuleDependencyID &from, const ModuleDependencyID &to,
     }
 
     // Otherwise, visit each child node.
-    for (const auto &succID : cache.getAllDependencies(moduleID)) {
+    for (const auto &succID : cache.getImportedClangDependencies(moduleID)) {
       stack.push(succID);
       visit(succID);
       stack.pop();

--- a/test/ScanDependencies/diagnose_dependency_cycle_overlay_source_target.swift
+++ b/test/ScanDependencies/diagnose_dependency_cycle_overlay_source_target.swift
@@ -1,0 +1,52 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -module-name CycleKit  &> %t/out.txt
+// RUN: %FileCheck %s < %t/out.txt
+
+// CHECK: error: module dependency cycle: 'CycleKit (Source Target) -> A.swiftinterface -> CycleKit.swiftinterface'
+// CHECK: note: Swift Overlay dependency of 'A' on 'CycleKit' via Clang module dependency: 'A.swiftinterface -> A.pcm -> B.pcm -> CycleKit.pcm'
+
+//--- test.swift
+import A
+
+//--- inputs/CycleKit.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name CycleKit -enable-library-evolution
+
+public func CycleKitFunc() {}
+
+//--- inputs/A.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name A -enable-library-evolution
+@_exported import A
+public func AFunc() {}
+
+//--- inputs/A.h
+#import <B.h>
+void funcA(void);
+
+//--- inputs/B.h
+#import <CycleKit.h>
+void funcA(void);
+
+//--- inputs/CycleKit.h
+void funcCycleKit(void);
+
+//--- inputs/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+
+module B {
+  header "B.h"
+  export *
+}
+
+module CycleKit {
+  header "CycleKit.h"
+  export *
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/82659
---------------------------------

- **Explanation**: When encountering a cycle in the module dependencies, the dependency scanner emits an error diagnostic and prints out the cycle. Oftentimes, the cycle involves a dependency from one Swift module to another (e.g .`A` -> `B`) which is not a direct import dependency but rather a Swift Overlay dependency via a transitive clang import. For example, if Swift `A` depends on Clang module `C`, which depends on clang module `B`, then `B`'s Swift overlay will be considered a Swift Overlay dependency of `A`. In those cases, the scanner will also emit a note to highlight the Clang overlay dependency path (here: `A->C->B`). When computing this path, the scanner should only consider Clang module dependencies and it previously mistakenly was not, which led to, at times, misleading notes emitted. This change fixes this path computation to only consider Clang module dependencies, instead of all dependencies.

- **Scope**: Builds which fail due to a module cycle which involves Swift Overlay dependencies.

- **Risk**: Low. This code path only affects builds which already fail and only affects computation of the contents for a helpful diagnostic note.

- **Reviewed By**: @cachemeifyoucan 

- **Original PR**: https://github.com/swiftlang/swift/pull/82659