### PR TITLE
[utils] Update Demangle::Node data formatter

### DIFF
--- a/utils/lldb/lldbSwiftDataFormatters.py
+++ b/utils/lldb/lldbSwiftDataFormatters.py
@@ -62,10 +62,10 @@ def SmallBitVectorSummaryProvider(valobj, internal_dict):
 
 class DemangleNodePayloadKind(Enum):
     NONE = 0
-    TEXT = 1
-    INDEX = 2
-    ONE_CHILD = 3
-    TWO_CHILDREN = 4
+    ONE_CHILD = 1
+    TWO_CHILDREN = 2
+    TEXT = 3
+    INDEX = 4
     MANY_CHILDREN = 5
 
 


### PR DESCRIPTION
Updates the lldb data formatter for `Demangle::Node` to reflect the current `PayloadKind` enum values (which were changed in https://github.com/swiftlang/swift/pull/72884).