### PR TITLE
[6.2] [AST] Use ErrorType for invalid value generic parameter

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -5261,7 +5261,7 @@ SourceLoc extractNearestSourceLoc(RegexLiteralPatternFeatureKind kind);
 
 class GenericTypeParamDeclGetValueTypeRequest
     : public SimpleRequest<GenericTypeParamDeclGetValueTypeRequest,
-                           Type(GenericTypeParamDecl *decl),
+                           Type(const GenericTypeParamDecl *decl),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -5269,7 +5269,7 @@ public:
 private:
   friend SimpleRequest;
 
-  Type evaluate(Evaluator &evaluator, GenericTypeParamDecl *decl) const;
+  Type evaluate(Evaluator &evaluator, const GenericTypeParamDecl *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -620,7 +620,7 @@ SWIFT_REQUEST(TypeChecker, CustomDerivativesRequest,
               Cached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, GenericTypeParamDeclGetValueTypeRequest,
-              Type(GenericTypeParamDecl *), Cached, NoLocationInfo)
+              Type(const GenericTypeParamDecl *), Cached, NoLocationInfo)
 
 SWIFT_REQUEST(TypeChecker, SemanticAvailableAttrRequest,
               std::optional<SemanticAvailableAttr>

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6102,9 +6102,13 @@ GenericTypeParamDecl *GenericTypeParamDecl::createImplicit(
 }
 
 Type GenericTypeParamDecl::getValueType() const {
-  return evaluateOrDefault(getASTContext().evaluator,
-                           GenericTypeParamDeclGetValueTypeRequest{this},
-                           Type());
+  if (!isValue())
+    return Type();
+
+  auto &ctx = getASTContext();
+  GenericTypeParamDeclGetValueTypeRequest req(this);
+  auto ty = evaluateOrDefault(ctx.evaluator, req, Type());
+  return ty ? ty : ErrorType::get(ctx);
 }
 
 SourceRange GenericTypeParamDecl::getSourceRange() const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6103,8 +6103,8 @@ GenericTypeParamDecl *GenericTypeParamDecl::createImplicit(
 
 Type GenericTypeParamDecl::getValueType() const {
   return evaluateOrDefault(getASTContext().evaluator,
-    GenericTypeParamDeclGetValueTypeRequest{const_cast<GenericTypeParamDecl *>(this)},
-    Type());
+                           GenericTypeParamDeclGetValueTypeRequest{this},
+                           Type());
 }
 
 SourceRange GenericTypeParamDecl::getSourceRange() const {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1723,7 +1723,10 @@ namespace {
     }
 
     Type visitTypeValueExpr(TypeValueExpr *E) {
-      return E->getParamDecl()->getValueType();
+      auto ty = E->getParamDecl()->getValueType();
+      if (!ty || ty->hasError())
+        return recordInvalidNode(E);
+      return ty;
     }
 
     Type visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *expr) {

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -487,8 +487,8 @@ Type ResultBuilderTypeRequest::evaluate(Evaluator &evaluator,
   return type->mapTypeOutOfContext();
 }
 
-Type GenericTypeParamDeclGetValueTypeRequest::evaluate(Evaluator &evaluator,
-                                             GenericTypeParamDecl *decl) const {
+Type GenericTypeParamDeclGetValueTypeRequest::evaluate(
+    Evaluator &evaluator, const GenericTypeParamDecl *decl) const {
   if (!decl->isValue())
     return Type();
 

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -489,10 +489,10 @@ Type ResultBuilderTypeRequest::evaluate(Evaluator &evaluator,
 
 Type GenericTypeParamDeclGetValueTypeRequest::evaluate(
     Evaluator &evaluator, const GenericTypeParamDecl *decl) const {
-  if (!decl->isValue())
-    return Type();
+  ASSERT(decl->isValue());
 
-  if (decl->getInherited().size() == 0) {
+  auto inherited = decl->getInherited();
+  if (inherited.empty()) {
     decl->diagnose(diag::missing_value_generic_type, decl->getName());
     return Type();
   }
@@ -503,12 +503,11 @@ Type GenericTypeParamDeclGetValueTypeRequest::evaluate(
   //
   // We should have 1 inherited type for 'N', 'Int', and have a 2nd generic
   // parameter called 'Bool'.
-  ASSERT(decl->getInherited().size() == 1);
+  ASSERT(inherited.size() == 1);
 
   // The value type of a generic parameter should never rely on the generic
   // signature of the generic parameter itself or any of the outside context.
-  return decl->getInherited().getResolvedType(0,
-                                              TypeResolutionStage::Structural);
+  return inherited.getResolvedType(0, TypeResolutionStage::Structural);
 }
 
 // Define request evaluation functions for each of the type checker requests.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -809,16 +809,16 @@ namespace {
       if (!paramType->isValue())
         return true;
 
-      // Both of these generic type parameters are values, but they may not have
-      // underlying value types associated with them. This can occur when a
-      // parameter doesn't declare a value type and we're going to diagnose it
-      // later.
-      if (!paramType->getValueType() || !secondType->getValueType())
+      // If either value type has an error, we've already diagnosed the issue.
+      auto paramValueTy = paramType->getValueType();
+      auto secondValueTy = secondType->getValueType();
+      if (!paramValueTy || paramValueTy->hasError() ||
+          !secondValueTy || secondValueTy->hasError()) {
         return true;
-
+      }
       // Otherwise, these are both value parameters and check that both their
       // value types are the same.
-      return paramType->getValueType()->isEqual(secondType->getValueType());
+      return paramValueTy->isEqual(secondValueTy);
     }
 
     bool alwaysMismatchTypeParameters() const { return true; }

--- a/test/Sema/value_generics.swift
+++ b/test/Sema/value_generics.swift
@@ -2,8 +2,10 @@
 
 protocol P {}
 
-func invalid<let N>() {} // expected-error {{value generic 'N' must have an explicit value type declared}}
-                         // expected-error@-1 {{generic parameter 'N' is not used in function signature}}
+func invalid<let N>() { // expected-error {{value generic 'N' must have an explicit value type declared}}
+                        // expected-error@-1 {{generic parameter 'N' is not used in function signature}}
+  let x: String = N // Fine, we bind to a hole.
+}
 func invalid<let N>(_: A<N>) {} // expected-error {{value generic 'N' must have an explicit value type declared}}
 
 struct A<let N: Int> {

--- a/validation-test/IDE/crashers_fixed/ab16c0e38dae31b3.swift
+++ b/validation-test/IDE/crashers_fixed/ab16c0e38dae31b3.swift
@@ -1,0 +1,4 @@
+// {"kind":"complete","signature":"swift::Mangle::ASTMangler::appendType(swift::Type, swift::GenericSignature, swift::ValueDecl const*)"}
+// RUN: %target-swift-ide-test -code-completion --code-completion-token=COMPLETE -source-filename %s
+func a<let b
+#^COMPLETE^#

--- a/validation-test/compiler_crashers_2_fixed/c232a2df5b6fffd.swift
+++ b/validation-test/compiler_crashers_2_fixed/c232a2df5b6fffd.swift
@@ -1,0 +1,8 @@
+// {"signature":"swift::constraints::ConstraintSystem::getTypeOfMemberReference(swift::Type, swift::ValueDecl*, swift::DeclContext*, bool, swift::FunctionRefInfo, swift::constraints::ConstraintLocator*, llvm::SmallVectorImpl<std::__1::pair<swift::GenericTypeParamType*, swift::TypeVariableType*>>*)"}
+// RUN: not %target-swift-frontend -typecheck %s
+struct a < let b > {
+  func
+  < (c : Self) {
+    c.b
+  }
+}


### PR DESCRIPTION
*6.2 cherry-pick of #82721, minus the last commit*

- Explanation: Fixes a crash that could occur when referencing or completing on a value generic parameter with an invalid value type
- Scope: Affects invalid value generic parameters
- Issue: rdar://154856417
- Risk: Low, only affects invalid code, switches a null Type with an ErrorType in invalid cases
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich