### PR TITLE
[6.2] [Sema] Avoid applying diagnostic hack to caller-side expression macros

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -995,7 +995,10 @@ namespace swift {
 
     /// Figure out the Behavior for the given diagnostic, taking current
     /// state such as fatality into account.
-    DiagnosticBehavior determineBehavior(const Diagnostic &diag);
+    DiagnosticBehavior determineBehavior(const Diagnostic &diag) const;
+
+    /// Updates the diagnostic state for a diagnostic to emit.
+    void updateFor(DiagnosticBehavior behavior);
 
     bool hadAnyError() const { return anyErrorOccurred; }
     bool hasFatalErrorOccurred() const { return fatalErrorOccurred; }
@@ -1023,7 +1026,7 @@ namespace swift {
 
     /// Returns a Boolean value indicating whether warnings belonging to the
     /// diagnostic group identified by `id` should be escalated to errors.
-    bool getWarningsAsErrorsForDiagGroupID(DiagGroupID id) {
+    bool getWarningsAsErrorsForDiagGroupID(DiagGroupID id) const {
       return warningsAsErrors[(unsigned)id];
     }
 

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -797,7 +797,7 @@ Expr *CallerSideDefaultArgExprRequest::evaluate(
       // simple literals.
       transaction.abort();
       (void)param->getTypeCheckedDefaultExpr();
-      ASSERT(ctx.Diags.hadAnyError());
+      CONDITIONAL_ASSERT(ctx.Diags.hadAnyError());
     }
     return new (ctx) ErrorExpr(initExpr->getSourceRange(), paramTy);
   }

--- a/test/Macros/rdar154771596.swift
+++ b/test/Macros/rdar154771596.swift
@@ -1,0 +1,28 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -module-name Lib -emit-module-path %t/Lib.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -verify -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %t %t/a.swift -primary-file %t/b.swift
+
+//--- Lib.swift
+
+@freestanding(expression)
+public macro magicFile() -> String = #externalMacro(module: "MacroDefinition", type: "MagicFileMacro")
+
+//--- a.swift
+
+import Lib
+
+func foo(x: String = #magicFile) {}
+
+//--- b.swift
+
+// We're missing the necessary import in this file, make sure we diagnose.
+func bar() {
+  foo() // expected-error {{no macro named 'magicFile'}}
+}


### PR DESCRIPTION
*6.2 cherry-pick of #82724*

- Explanation: Fixes an issue where we'd exit with a non-zero exit code without emitting any diagnostics when type-checking an invalid caller-side expression macro default argument
- Scope: Affects type-checking an invalid caller-side expression macro default argument
- Issue: rdar://154771596
- Risk: Low, only affects invalid code, and the fix is fairly straightforward
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich