### PR TITLE
Add `-scanner-prefix-map-paths` to the frontend

### DIFF
--- a/include/swift/AST/PluginLoader.h
+++ b/include/swift/AST/PluginLoader.h
@@ -53,11 +53,12 @@ private:
   llvm::DenseMap<swift::Identifier, PluginEntry> &getPluginMap();
 
   /// Resolved plugin path remappings.
-  std::vector<std::string> PathRemap;
+  std::vector<std::pair<std::string, std::string>> PathRemap;
 
 public:
   PluginLoader(ASTContext &Ctx, DependencyTracker *DepTracker,
-               std::optional<std::vector<std::string>> Remap = std::nullopt,
+               std::optional<std::vector<std::pair<std::string, std::string>>>
+                   Remap = std::nullopt,
                bool disableSandbox = false)
       : Ctx(Ctx), DepTracker(DepTracker), disableSandbox(disableSandbox) {
     if (Remap)

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -145,7 +145,7 @@ public:
   std::string VerifyGenericSignaturesInModule;
 
   /// CacheReplay PrefixMap.
-  std::vector<std::string> CacheReplayPrefixMap;
+  std::vector<std::pair<std::string, std::string>> CacheReplayPrefixMap;
 
   /// Number of retry opening an input file if the previous opening returns
   /// bad file descriptor error.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2224,8 +2224,12 @@ def sdk_module_cache_path : Separate<["-"], "sdk-module-cache-path">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Specifies the module cache path for explicitly-built SDK modules">;
 
-def scanner_prefix_map : Separate<["-"], "scanner-prefix-map">,
+def scanner_prefix_map_paths : MultiArg<["-"], "scanner-prefix-map-paths", 2>,
   Flags<[FrontendOption, NewDriverOnlyOption]>,
+  HelpText<"Remap paths reported by dependency scanner">, MetaVarName<"<prefix> <replacement>">;
+
+def scanner_prefix_map : Separate<["-"], "scanner-prefix-map">,
+  Flags<[NewDriverOnlyOption]>,
   HelpText<"Remap paths reported by dependency scanner">, MetaVarName<"<prefix=replacement>">;
 
 def scanner_prefix_map_sdk : Separate<["-"], "scanner-prefix-map-sdk">,
@@ -2236,9 +2240,9 @@ def scanner_prefix_map_toolchain : Separate<["-"], "scanner-prefix-map-toolchain
   Flags<[NewDriverOnlyOption]>,
   HelpText<"Remap paths within toolchain directory reported by dependency scanner">, MetaVarName<"<path>">;
 
-def cache_replay_prefix_map: Separate<["-"], "cache-replay-prefix-map">,
+def cache_replay_prefix_map: MultiArg<["-"], "cache-replay-prefix-map", 2>,
   Flags<[FrontendOption, NoDriverOption, CacheInvariant]>,
-  HelpText<"Remap paths when replaying outputs from cache">, MetaVarName<"<prefix=replacement>">;
+  HelpText<"Remap paths when replaying outputs from cache">, MetaVarName<"<prefix> <replacement>">;
 
 // END ONLY SUPPORTED IN NEW DRIVER
 

--- a/lib/AST/PluginLoader.cpp
+++ b/lib/AST/PluginLoader.cpp
@@ -100,7 +100,7 @@ PluginLoader::getPluginMap() {
   std::optional<llvm::PrefixMapper> mapper;
   if (!PathRemap.empty()) {
     SmallVector<llvm::MappedPrefix, 4> prefixes;
-    llvm::MappedPrefix::transformJoinedIfValid(PathRemap, prefixes);
+    llvm::MappedPrefix::transformPairs(PathRemap, prefixes);
     mapper.emplace();
     mapper->addRange(prefixes);
     mapper->sort();

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -31,6 +31,7 @@
 #include "llvm/Option/ArgList.h"
 #include "llvm/Option/Option.h"
 #include "llvm/Support/Compression.h"
+#include "llvm/Support/PrefixMapper.h"
 #include "llvm/Support/Process.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/LineIterator.h"
@@ -315,7 +316,9 @@ bool ArgsToFrontendOptionsConverter::convert(
     return true;
 
   Opts.DeterministicCheck |= Args.hasArg(OPT_enable_deterministic_check);
-  Opts.CacheReplayPrefixMap = Args.getAllArgValues(OPT_cache_replay_prefix_map);
+  for (const Arg *A : Args.filtered(OPT_cache_replay_prefix_map)) {
+    Opts.CacheReplayPrefixMap.push_back({A->getValue(0), A->getValue(1)});
+  }
 
   if (FrontendOptions::doesActionGenerateIR(Opts.RequestedAction)) {
     if (Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) ||

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -721,7 +721,7 @@ public:
             Instance.getInvocation().getFrontendOptions().InputsAndOutputs),
         Diags(Instance.getDiags()), CAS(*Instance.getSharedCASInstance()) {
     SmallVector<llvm::MappedPrefix, 4> Prefixes;
-    llvm::MappedPrefix::transformJoinedIfValid(
+    llvm::MappedPrefix::transformPairs(
         Instance.getInvocation().getFrontendOptions().CacheReplayPrefixMap,
         Prefixes);
     Mapper.addRange(Prefixes);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2473,12 +2473,9 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts, ArgList &Args,
     auto SplitMap = StringRef(A).split('=');
     Opts.DeserializedPathRecoverer.addMapping(SplitMap.first, SplitMap.second);
   }
-  for (StringRef Opt : Args.getAllArgValues(OPT_scanner_prefix_map)) {
-    if (auto Mapping = llvm::MappedPrefix::getFromJoined(Opt)) {
-      Opts.ScannerPrefixMapper.push_back({Mapping->Old, Mapping->New});
-    } else {
-      Diags.diagnose(SourceLoc(), diag::error_prefix_mapping, Opt);
-    }
+  
+  for (const Arg *A : Args.filtered(OPT_scanner_prefix_map_paths)) {
+    Opts.ScannerPrefixMapper.push_back({A->getValue(0), A->getValue(1)});
   }
 
   Opts.ResolvedPluginVerification |=

--- a/lib/Frontend/MakeStyleDependencies.cpp
+++ b/lib/Frontend/MakeStyleDependencies.cpp
@@ -95,12 +95,12 @@ reversePathSortedFilenames(const Container &elts) {
 static void emitMakeDependenciesFile(std::vector<std::string> &dependencies,
                                      const FrontendOptions &opts,
                                      const InputFile &input,
-                                     const std::vector<std::string> &prefixMap,
+                                     const std::vector<std::pair<std::string, std::string>> &prefixMap,
                                      llvm::raw_ostream &os) {
   // Prefix map all the path if needed.
   if (!prefixMap.empty()) {
     SmallVector<llvm::MappedPrefix, 4> prefixes;
-    llvm::MappedPrefix::transformJoinedIfValid(prefixMap, prefixes);
+    llvm::MappedPrefix::transformPairs(prefixMap, prefixes);
     llvm::PrefixMapper mapper;
     mapper.addRange(prefixes);
     mapper.sort();

--- a/test/CAS/block-list.swift
+++ b/test/CAS/block-list.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -blocklist-file %t/blocklist.yml -blocklist-file %t/empty.yml \
-// RUN:   -scanner-prefix-map %t=/^tmp -I %t/include \
+// RUN:   -scanner-prefix-map-paths %t /^tmp -I %t/include \
 // RUN:   %t/main.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas 
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
@@ -38,7 +38,7 @@
 // RUN:   -blocklist-file /^tmp/blocklist.yml -blocklist-file /^tmp/empty.yml \
 // RUN:   -enable-layout-string-value-witnesses -enable-layout-string-value-witnesses-instantiation \
 // RUN:   -enable-experimental-feature LayoutStringValueWitnesses -enable-experimental-feature LayoutStringValueWitnessesInstantiation \
-// RUN:   -cache-replay-prefix-map /^tmp=%t \
+// RUN:   -cache-replay-prefix-map /^tmp %t \
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd 2>&1 | %FileCheck %s --check-prefix CHECK-BLOCKED
 
 // REQUIRES: swift_feature_LayoutStringValueWitnesses

--- a/test/CAS/cached_diagnostics_remap.swift
+++ b/test/CAS/cached_diagnostics_remap.swift
@@ -4,14 +4,14 @@
 /// Check path remapping.
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -O -import-objc-header %t/objc.h -auto-bridging-header-chaining \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
-// RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -scanner-prefix-map %t=/^test -scanner-output-dir %t.noremap
+// RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -scanner-prefix-map-paths %t /^test -scanner-output-dir %t.noremap
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader > %t/header.cmd
 // RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix BRIDGE
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch > %t/keys.json
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/keys.json -- \
-// RUN:    %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch -cache-replay-prefix-map /^test=%t 2>&1 \
+// RUN:    %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules -O -o %t/objc.pch -cache-replay-prefix-map /^test %t 2>&1 \
 // RUN:    | %FileCheck %s -check-prefix BRIDGE -check-prefix BRIDGE-REMAP
 
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json > %t/key
@@ -33,7 +33,7 @@
 // RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift > %t/cache_key.json
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- %target-swift-frontend -cache-compile-job -module-name Test \
 // RUN:   -O -cas-path %t/cas @%t/MyApp.cmd \
-// RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift -cache-replay-prefix-map /^test=%t 2>&1 | %FileCheck %s --check-prefix REMAP
+// RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift -cache-replay-prefix-map /^test %t 2>&1 | %FileCheck %s --check-prefix REMAP
 
 // BRIDGE: /^test/objc.h:3:2: warning: warning in bridging header
 // BRIDGE-REMAP: BUILD_DIR{{.*}}{{/|\\}}objc.h:3:2: warning: warning in bridging header

--- a/test/CAS/dependency_file.swift
+++ b/test/CAS/dependency_file.swift
@@ -38,7 +38,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %t/main.swift -o %t/deps-1.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include -sdk %t/sdk \
-// RUN:   -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp -scanner-prefix-map %t/sdk=/^sdk
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp -scanner-prefix-map-paths %t/sdk /^sdk
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json A > %t/A1.cmd
 // RUN: %swift_frontend_plain @%t/A1.cmd
 // RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps-1.json > %t/map-1.json
@@ -50,7 +50,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   -cache-replay-prefix-map /^src %swift_src_root -cache-replay-prefix-map /^tmp %t -cache-replay-prefix-map /^sdk %t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp-1.cmd -emit-dependencies -emit-dependencies-path %t/main-3.d
 
 // RUN: %FileCheck %s --check-prefix=DEPS3 --input-file=%t/main-3.d -DTMP=%t
@@ -63,7 +63,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   -cache-replay-prefix-map /^src %swift_src_root -cache-replay-prefix-map /^tmp %t -cache-replay-prefix-map /^sdk %t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp-1.cmd -emit-dependencies -emit-dependencies-path %t/main-4.d > %t/key.casid
 
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
@@ -72,7 +72,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   -cache-replay-prefix-map /^src %swift_src_root -cache-replay-prefix-map /^tmp %t -cache-replay-prefix-map /^sdk %t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp-1.cmd -emit-dependencies -emit-dependencies-path %t/main-4.d 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT4
 // CACHE-HIT4: remark: replay output file '{{.*}}{{/|\\}}main-4.d': key 'llvmcas://{{.*}}'
 // RUN: %FileCheck %s --check-prefix=DEPS4 --input-file=%t/main-4.d -DTMP=%t

--- a/test/CAS/macro_plugin_external.swift
+++ b/test/CAS/macro_plugin_external.swift
@@ -50,7 +50,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-load-mode prefer-serialized -module-name MyApp -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %t/macro.swift -o %t/deps2.json -swift-version 5 -cache-compile-job -cas-path %t/cas -external-plugin-path %t/plugins#%swift-plugin-server \
-// RUN:   -scanner-prefix-map %t=/^test -scanner-prefix-map %swift-bin-dir=/^bin -resolved-plugin-verification
+// RUN:   -scanner-prefix-map-paths %t /^test -scanner-prefix-map-paths %swift-bin-dir /^bin -resolved-plugin-verification
 
 // RUN: %S/Inputs/SwiftDepsExtractor.py %t/deps2.json MyApp casFSRootID > %t/fs.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/fs.casid | %FileCheck %s --check-prefix=FS-REMAP -DLIB=%target-library-name(MacroDefinition)
@@ -77,7 +77,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map2.casid -Rmacro-loading -Rcache-compile-job \
-// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test=%t -cache-replay-prefix-map /^bin=%swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=REMARK
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test %t -cache-replay-prefix-map /^bin %swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=REMARK
 // REMAKR: remark: cache miss
 // REMARK: remark: loaded macro implementation module 'MacroDefinition' from compiler plugin server
 
@@ -92,7 +92,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map2.casid -Rmacro-loading -Rcache-compile-job \
-// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test=%t -cache-replay-prefix-map /^bin=%swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=NO-REMARK
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test %t -cache-replay-prefix-map /^bin %swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=NO-REMARK
 // NO-REMARK: remark: replay output file
 // NO-REMARK-NOT: remark: loaded macro implementation module 'MacroDefinition' from compiler plugin server
 
@@ -103,7 +103,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map2.casid -Rmacro-loading -Rcache-compile-job -cache-disable-replay \
-// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test=%t -cache-replay-prefix-map /^bin=%swift-bin-dir
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test %t -cache-replay-prefix-map /^bin %swift-bin-dir
 
 /// Change the dylib content, this will fail the build.
 // RUN: echo " " >> %t/plugins/%target-library-name(MacroDefinition)
@@ -112,7 +112,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map2.casid -Rmacro-loading -Rcache-compile-job -cache-disable-replay \
-// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test=%t -cache-replay-prefix-map /^bin=%swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=FAILED
+// RUN:   /^test/macro.swift @%t/MyApp2.cmd -cache-replay-prefix-map /^test %t -cache-replay-prefix-map /^bin %swift-bin-dir 2>&1 | %FileCheck %s --check-prefix=FAILED
 // FAILED: plugin has changed since dependency scanning
 
 //--- nomacro.swift

--- a/test/CAS/module_path_remap.swift
+++ b/test/CAS/module_path_remap.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json \
 // RUN:  -I %S/../ScanDependencies/Inputs/CHeaders -I %S/../ScanDependencies/Inputs/Swift -emit-dependencies \
 // RUN:  -import-objc-header %S/../ScanDependencies/Inputs/CHeaders/Bridging.h -swift-version 4 -cache-compile-job \
-// RUN:  -cas-path %t/cas -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp -scanner-output-dir %t -auto-bridging-header-chaining
+// RUN:  -cas-path %t/cas -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp -scanner-output-dir %t -auto-bridging-header-chaining
 
 // RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json deps casFSRootID > %t/deps.fs.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-include-tree-list @%t/deps.fs.casid | %FileCheck %s -check-prefix DEPS-FS

--- a/test/CAS/path_remap.swift
+++ b/test/CAS/path_remap.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include -sdk %t/sdk \
-// RUN:   -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t=/^tmp -scanner-prefix-map %t/sdk=/^sdk -enable-cross-import-overlays
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t /^tmp -scanner-prefix-map-paths %t/sdk /^sdk -enable-cross-import-overlays
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json A > %t/A.cmd
 // RUN: %swift_frontend_plain @%t/A.cmd
@@ -32,7 +32,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   -cache-replay-prefix-map /^src %swift_src_root -cache-replay-prefix-map /^tmp %t -cache-replay-prefix-map /^sdk %t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd -enable-cross-import-overlays
 
 // RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- \
@@ -41,7 +41,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   -cache-replay-prefix-map /^src %swift_src_root -cache-replay-prefix-map /^tmp %t -cache-replay-prefix-map /^sdk %t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd -enable-cross-import-overlays > %t/key.casid
 
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- \
@@ -50,7 +50,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   -cache-replay-prefix-map /^src %swift_src_root -cache-replay-prefix-map /^tmp %t -cache-replay-prefix-map /^sdk %t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp.cmd -enable-cross-import-overlays
 
 //--- main.swift

--- a/test/CAS/simlink_inputs.swift
+++ b/test/CAS/simlink_inputs.swift
@@ -26,7 +26,7 @@
 /// Test the same build but remapping the path.
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
-// RUN:   -scanner-prefix-map %swift_src_root=/^src -scanner-prefix-map %t/src=/^tmp -scanner-prefix-map %t/sdk=/^sdk \
+// RUN:   -scanner-prefix-map-paths %swift_src_root /^src -scanner-prefix-map-paths %t/src /^tmp -scanner-prefix-map-paths %t/sdk /^sdk \
 // RUN:   %t/src/main.swift -o %t/deps-1.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/src/include
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps-1.json clang:A > %t/A-1.cmd
@@ -42,7 +42,7 @@
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -module-name Test -explicit-swift-module-map-file @%t/map-1.casid \
-// RUN:   -cache-replay-prefix-map /^src=%swift_src_root -cache-replay-prefix-map /^tmp=%t/src -cache-replay-prefix-map /^sdk=%t/sdk \
+// RUN:   -cache-replay-prefix-map /^src %swift_src_root -cache-replay-prefix-map /^tmp %t/src -cache-replay-prefix-map /^sdk %t/sdk \
 // RUN:   /^tmp/main.swift @%t/MyApp-1.cmd
 
 //--- private/main.swift


### PR DESCRIPTION
The current command-line option for specifying prefix mappings for the dependency scanner does not handle paths containing equal signs. This PR adds a new option `-scanner-prefix-map-paths` that has a multiArg format instead of being `=`-separated and fixes this issue. The old `-scanner-prefix-map` option is still preserved, but is made driver-only and gets translated to the new option format by the driver.

Corresponding PR on Swift-Driver: https://github.com/swiftlang/swift-driver/pull/1949