### PR TITLE
[6.2] Native implementation of -lengthOfBytesUsingEncoding

### DIFF
--- a/benchmark/single-source/ObjectiveCBridging.swift
+++ b/benchmark/single-source/ObjectiveCBridging.swift
@@ -97,6 +97,27 @@ public let benchmarks = [
   BenchmarkInfo(name: "NSArray.bridged.repeatedBufferAccess",
                   runFunction: run_BridgedNSArrayRepeatedBufferAccess, tags: t,
                   setUpFunction: setup_bridgedArrays),
+  BenchmarkInfo(name: "NSDictionary.bridged.enumerate",
+                  runFunction: run_BridgedNSDictionaryEnumerate, tags: t,
+                  setUpFunction: setup_bridgedDictionaries),
+  BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.ascii",
+                  runFunction: run_BridgedNSStringLengthASCII_ASCII, tags: ts,
+                  setUpFunction: setup_bridgedStrings),
+  BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.utf8",
+                  runFunction: run_BridgedNSStringLengthASCII_UTF8, tags: ts,
+                  setUpFunction: setup_bridgedStrings),
+  BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.utf16",
+                  runFunction: run_BridgedNSStringLengthASCII_UTF16, tags: ts,
+                  setUpFunction: setup_bridgedStrings),
+  BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.macroman",
+                  runFunction: run_BridgedNSStringLengthASCII_MacRoman, tags: ts,
+                  setUpFunction: setup_bridgedStrings),
+  BenchmarkInfo(name: "NSString.bridged.byteCount.utf8.utf8",
+                  runFunction: run_BridgedNSStringLengthUTF8_UTF8, tags: ts,
+                  setUpFunction: setup_bridgedStrings),
+  BenchmarkInfo(name: "NSString.bridged.byteCount.utf8.utf16",
+                  runFunction: run_BridgedNSStringLengthUTF8_UTF16, tags: ts,
+                  setUpFunction: setup_bridgedStrings),
 ]
 
 #if _runtime(_ObjC)
@@ -797,6 +818,8 @@ var bridgedArray:NSArray! = nil
 var bridgedArrayMutableCopy:NSMutableArray! = nil
 var nsArray:NSArray! = nil
 var nsArrayMutableCopy:NSMutableArray! = nil
+var bridgedASCIIString:NSString! = nil
+var bridgedUTF8String:NSString! = nil
 #endif
 
 public func setup_bridgedArrays() {
@@ -806,6 +829,23 @@ public func setup_bridgedArrays() {
   bridgedArrayMutableCopy = (bridgedArray.mutableCopy() as! NSMutableArray)
   nsArray = NSArray(objects: &arr, count: 100)
   nsArrayMutableCopy = (nsArray.mutableCopy() as! NSMutableArray)
+  #endif
+}
+
+public func setup_bridgedDictionaries() {
+  var numDict = Dictionary<Int, Int>()
+  for i in 0 ..< 100 {
+    numDict[i] = i
+  }
+  bridgedDictionaryOfNumbersToNumbers = numDict as NSDictionary
+}
+
+public func setup_bridgedStrings() {
+  #if _runtime(_ObjC)
+  let str = Array(repeating: "The quick brown fox jumps over the lazy dog.", count: 100).joined()
+  bridgedASCIIString = str as NSString
+  let str2 = Array(repeating: "The quick brown fox jumps over the lazy dög.", count: 100).joined()
+  bridgedUTF8String = str2 as NSString
   #endif
 }
 
@@ -883,3 +923,40 @@ public func run_RealNSArrayMutableCopyObjectAtIndex(_ n: Int) {
   #endif
 }
 
+@inline(__always)
+fileprivate func run_BridgedNSStringLength(_ asciiBase: Bool, _ enc: UInt, _ n: Int) {
+  let str = asciiBase ? bridgedASCIIString : bridgedUTF8String
+  for _ in 0 ..< n * 100 {
+    blackHole(str!.lengthOfBytes(using: enc))
+  }
+}
+
+@inline(never)
+public func run_BridgedNSStringLengthASCII_ASCII(_ n: Int) {
+  run_BridgedNSStringLength(true, 1 /* NSASCIIStringEncoding */, n)
+}
+
+@inline(never)
+public func run_BridgedNSStringLengthASCII_UTF8(_ n: Int) {
+  run_BridgedNSStringLength(true, 4 /* NSUTF8StringEncoding */, n)
+}
+
+@inline(never)
+public func run_BridgedNSStringLengthASCII_UTF16(_ n: Int) {
+  run_BridgedNSStringLength(true, 10 /* NSUnicodeStringEncoding */, n)
+}
+
+@inline(never)
+public func run_BridgedNSStringLengthASCII_MacRoman(_ n: Int) {
+  run_BridgedNSStringLength(true, 30 /* NSMacOSRomanStringEncoding */, n)
+}
+
+@inline(never)
+public func run_BridgedNSStringLengthUTF8_UTF8(_ n: Int) {
+  run_BridgedNSStringLength(false, 4 /* NSUTF8StringEncoding */, n)
+}
+
+@inline(never)
+public func run_BridgedNSStringLengthUTF8_UTF16(_ n: Int) {
+  run_BridgedNSStringLength(false, 10 /* NSUnicodeStringEncoding */, n)
+}

--- a/benchmark/single-source/ObjectiveCBridging.swift
+++ b/benchmark/single-source/ObjectiveCBridging.swift
@@ -97,9 +97,6 @@ public let benchmarks = [
   BenchmarkInfo(name: "NSArray.bridged.repeatedBufferAccess",
                   runFunction: run_BridgedNSArrayRepeatedBufferAccess, tags: t,
                   setUpFunction: setup_bridgedArrays),
-  BenchmarkInfo(name: "NSDictionary.bridged.enumerate",
-                  runFunction: run_BridgedNSDictionaryEnumerate, tags: t,
-                  setUpFunction: setup_bridgedDictionaries),
   BenchmarkInfo(name: "NSString.bridged.byteCount.ascii.ascii",
                   runFunction: run_BridgedNSStringLengthASCII_ASCII, tags: ts,
                   setUpFunction: setup_bridgedStrings),
@@ -830,14 +827,6 @@ public func setup_bridgedArrays() {
   nsArray = NSArray(objects: &arr, count: 100)
   nsArrayMutableCopy = (nsArray.mutableCopy() as! NSMutableArray)
   #endif
-}
-
-public func setup_bridgedDictionaries() {
-  var numDict = Dictionary<Int, Int>()
-  for i in 0 ..< 100 {
-    numDict[i] = i
-  }
-  bridgedDictionaryOfNumbersToNumbers = numDict as NSDictionary
 }
 
 public func setup_bridgedStrings() {

--- a/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/CoreFoundationShims.h
@@ -35,6 +35,8 @@ typedef unsigned long _swift_shims_CFHashCode;
 typedef signed long _swift_shims_CFIndex;
 #endif
 
+typedef unsigned long _swift_shims_NSUInteger;
+
 // Consider creating SwiftMacTypes.h for these
 typedef unsigned char _swift_shims_Boolean;
 typedef __swift_uint8_t _swift_shims_UInt8;
@@ -79,6 +81,11 @@ SWIFT_RUNTIME_STDLIB_API
 const void * _Nullable
 _swift_stdlib_CreateIndirectTaggedPointerString(const __swift_uint8_t * _Nonnull bytes,
                                                 _swift_shims_CFIndex len);
+
+SWIFT_RUNTIME_STDLIB_API
+const _swift_shims_NSUInteger
+_swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline(id _Nonnull obj,
+                                                        unsigned long encoding);
 
 #endif // __OBJC2__
 

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -287,6 +287,13 @@ internal func _cocoaCStringUsingEncodingTrampoline(
   return _swift_stdlib_NSStringCStringUsingEncodingTrampoline(string, encoding)
 }
 
+@_effects(readonly)
+internal func _cocoaLengthOfBytesInEncodingTrampoline(
+  _ string: _CocoaString, _ encoding: UInt
+) -> UInt {
+  return _swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline(string, encoding)
+}
+
 @_effects(releasenone)
 internal func _cocoaGetCStringTrampoline(
   _ string: _CocoaString,

--- a/stdlib/public/stubs/FoundationHelpers.mm
+++ b/stdlib/public/stubs/FoundationHelpers.mm
@@ -106,6 +106,19 @@ _swift_stdlib_NSStringGetCStringTrampoline(id _Nonnull obj,
 
 }
 
+SWIFT_RUNTIME_STDLIB_API
+const _swift_shims_NSUInteger
+_swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline(id _Nonnull obj,
+                                                        unsigned long encoding) {
+  typedef _swift_shims_NSUInteger (*getLengthImplPtr)(id,
+                                                      SEL,
+                                                      unsigned long);
+  SEL sel = @selector(lengthOfBytesUsingEncoding:);
+  getLengthImplPtr imp = (getLengthImplPtr)class_getMethodImplementation([obj superclass], sel);
+  
+  return imp(obj, sel, encoding);
+}
+
 __swift_uint8_t
 _swift_stdlib_dyld_is_objc_constant_string(const void *addr) {
   return (SWIFT_RUNTIME_WEAK_CHECK(_dyld_is_objc_constant)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -1081,3 +1081,6 @@ Added: _$ss6MirrorV12DisplayStyleO16foreignReferenceyA2DmFWC
 // var InlineArray._protectedAddress
 Added: _$ss11InlineArrayVsRi__rlE16_protectedBufferSRyq_GvpMV
 Added: _$ss11InlineArrayVsRi__rlE17_protectedAddressSPyq_GvpMV
+
+// lengthOfBytes(using:)
+Added: __swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -1081,3 +1081,6 @@ Added: _$ss6MirrorV12DisplayStyleO16foreignReferenceyA2DmFWC
 // var InlineArray._protectedAddress
 Added: _$ss11InlineArrayVsRi__rlE16_protectedBufferSRyq_GvpMV
 Added: _$ss11InlineArrayVsRi__rlE17_protectedAddressSPyq_GvpMV
+
+// lengthOfBytes(using:)
+Added: __swift_stdlib_NSStringLengthOfBytesInEncodingTrampoline


### PR DESCRIPTION
This is a 6.2 PR for https://github.com/swiftlang/swift/pull/81791

Explanation:
`lengthOfBytes(using:)` is heavily used by the Swift implementation of URL, among others. Unfortunately, due to the way NSString works internally, our current implementation transcodes the String to UTF16, then transcodes back to UTF8, rather than just returning the count. This PR makes it roughly 100 times faster.

Resolves: rdar://154341146

Risk: Low. Straightforward changes, and any breakage in URL would show up immediately.

Main branch PR: https://github.com/swiftlang/swift/pull/81791

Review by: @jrflat 

Testing: existing URL and NSString test suite coverage. New benchmarks to make sure it doesn't regress in the future.