### PR TITLE
[stdlib, 6.2] add `span` properties for backdeployment

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -356,7 +356,7 @@ extension Array {
   }
 
 #if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
-  @inlinable
+  @_alwaysEmitIntoClient
   @_semantics("array.make_mutable")
   @_effects(notEscaping self.**)
   internal mutating func _makeMutableAndUniqueUnchecked() {

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1219,18 +1219,24 @@ extension ArraySlice {
   ) throws(E) -> R {
     return try unsafe _buffer.withUnsafeBufferPointer(body)
   }
+}
 
-  @available(SwiftStdlib 6.2, *)
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension ArraySlice {
+  @available(SwiftCompatibilitySpan 5.0, *)
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
     borrowing get {
       let (pointer, count) = unsafe (_buffer.firstElementAddress, _buffer.count)
       let span = unsafe Span(_unsafeStart: pointer, count: count)
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
+}
 
+extension ArraySlice {
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
   @_semantics("array.withUnsafeMutableBufferPointer")
@@ -1309,8 +1315,11 @@ extension ArraySlice {
     // Invoke the body.
     return try unsafe body(&inoutBufferPointer)
   }
+}
 
-  @available(SwiftStdlib 6.2, *)
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension ArraySlice {
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
@@ -1330,7 +1339,9 @@ extension ArraySlice {
       return unsafe _overrideLifetime(span, mutating: &self)
     }
   }
+}
 
+extension ArraySlice {
   @inlinable
   public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -169,6 +169,16 @@ extension ArraySlice {
     }
   }
   
+#if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
+  @_alwaysEmitIntoClient
+  @_semantics("array.make_mutable")
+  internal mutating func _makeMutableAndUniqueUnchecked() {
+    if _slowPath(!_buffer.beginCOWMutationUnchecked()) {
+      _buffer = _Buffer(copying: _buffer)
+    }
+  }
+#endif
+
   /// Marks the end of a mutation.
   ///
   /// After a call to `_endMutation` the buffer must not be mutated until a call

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -159,12 +159,13 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   }
 }
 
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension CollectionOfOne {
 
-  @available(SwiftStdlib 6.2, *)
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
     get {
       let pointer = unsafe UnsafePointer<Element>(Builtin.addressOfBorrow(self))
       let span = unsafe Span(_unsafeStart: pointer, count: 1)
@@ -172,7 +173,6 @@ extension CollectionOfOne {
     }
   }
 
-  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -1161,11 +1161,14 @@ extension ContiguousArray {
   ) throws(E) -> R {
     return try unsafe _buffer.withUnsafeBufferPointer(body)
   }
+}
 
-  @available(SwiftStdlib 6.2, *)
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension ContiguousArray {
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
     borrowing get {
       let pointer = unsafe _buffer.firstElementAddress
       let count = _buffer.immutableCount
@@ -1173,7 +1176,9 @@ extension ContiguousArray {
       return unsafe _overrideLifetime(span, borrowing: self)
     }
   }
+}
 
+extension ContiguousArray {
   // Superseded by the typed-throws version of this function, but retained
   // for ABI reasons.
   @_semantics("array.withUnsafeMutableBufferPointer")
@@ -1251,8 +1256,11 @@ extension ContiguousArray {
     // Invoke the body.
     return try unsafe body(&inoutBufferPointer)
   }
+}
 
-  @available(SwiftStdlib 6.2, *)
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension ContiguousArray {
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(&self)
@@ -1272,7 +1280,9 @@ extension ContiguousArray {
       return unsafe _overrideLifetime(span, mutating: &self)
     }
   }
+}
 
+extension ContiguousArray {
   @inlinable
   public __consuming func _copyContents(
     initializing buffer: UnsafeMutableBufferPointer<Element>

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -74,6 +74,16 @@ extension ContiguousArray {
     }
   }
 
+#if INTERNAL_CHECKS_ENABLED && COW_CHECKS_ENABLED
+  @_alwaysEmitIntoClient
+  @_semantics("array.make_mutable")
+  internal mutating func _makeMutableAndUniqueUnchecked() {
+    if _slowPath(!_buffer.beginCOWMutationUnchecked()) {
+      _buffer = _buffer._consumeAndCreateNew()
+    }
+  }
+#endif
+
   /// Marks the end of an Array mutation.
   ///
   /// After a call to `_endMutation` the buffer must not be mutated until a call

--- a/stdlib/public/core/KeyValuePairs.swift
+++ b/stdlib/public/core/KeyValuePairs.swift
@@ -125,12 +125,13 @@ extension KeyValuePairs: RandomAccessCollection {
   }
 }
 
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
 extension KeyValuePairs {
-  
-  @available(SwiftStdlib 6.2, *)
+  @available(SwiftCompatibilitySpan 5.0, *)
+  @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
-    @_alwaysEmitIntoClient
     get {
       let rp = unsafe UnsafeRawPointer(_elements._buffer.firstElementAddress)
       let span = unsafe Span(

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -572,9 +572,12 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   public func extracting(_ bounds: UnboundedRange) -> Self {
     unsafe self
   }
+}
 
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
   @unsafe
-  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var span: Span<Element> {
     @lifetime(borrow self)
@@ -586,7 +589,6 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 %if Mutable:
 
   @unsafe
-  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var mutableSpan: MutableSpan<Element> {
     @lifetime(borrow self)

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1162,17 +1162,6 @@ extension Unsafe${Mutable}RawBufferPointer {
     }
   }
 
-  @unsafe
-  @available(SwiftStdlib 6.2, *)
-  @_alwaysEmitIntoClient
-  public var mutableBytes: MutableRawSpan {
-    @lifetime(borrow self)
-    @_transparent
-    get {
-      unsafe MutableRawSpan(_unsafeBytes: self)
-    }
-  }
-
 %  end
   @_alwaysEmitIntoClient
   public func withContiguousStorageIfAvailable<R>(
@@ -1182,9 +1171,12 @@ extension Unsafe${Mutable}RawBufferPointer {
       try unsafe body(${ 'UnsafeBufferPointer<Element>($0)' if Mutable else '$0' })
     }
   }
-
+}
+  
+@available(SwiftCompatibilitySpan 5.0, *)
+@_originallyDefinedIn(module: "Swift;CompatibilitySpan", SwiftCompatibilitySpan 6.2)
+extension Unsafe${Mutable}RawBufferPointer {
   @unsafe
-  @available(SwiftStdlib 6.2, *)
   @_alwaysEmitIntoClient
   public var bytes: RawSpan {
     @lifetime(borrow self)
@@ -1193,6 +1185,18 @@ extension Unsafe${Mutable}RawBufferPointer {
       unsafe RawSpan(_unsafeBytes: self)
     }
   }
+%  if Mutable:
+
+  @unsafe
+  @_alwaysEmitIntoClient
+  public var mutableBytes: MutableRawSpan {
+    @lifetime(borrow self)
+    @_transparent
+    get {
+      unsafe MutableRawSpan(_unsafeBytes: self)
+    }
+  }
+% end
 }
 
 @_unavailableInEmbedded


### PR DESCRIPTION
- Explanation:
Makes as many of the `span`, `bytes`, `mutableSpan` and `mutableRawSpan` properties as possible available to backdeployed targets. This is possible when the implementation only relies on pre-existing code.

- Resolves: rdar://153654652 (https://forums.swift.org/t/80513)
- Risk: low
- Main branch PR: https://github.com/swiftlang/swift/pull/82598
- Reviewed by: @atrick 
- Testing: existing tests