### PR TITLE
[Distributed] Add explicit availability in test

### DIFF
--- a/test/Distributed/distributed_actor_adhoc_requirements_optimized_build.swift
+++ b/test/Distributed/distributed_actor_adhoc_requirements_optimized_build.swift
@@ -12,6 +12,7 @@ import Distributed
 public protocol Transferable: Sendable {}
 
 // NOT final on purpose
+@available(SwiftStdlib 5.7, *)
 public class TheSpecificResultHandlerWhichIsANonFinalClass: DistributedTargetInvocationResultHandler {
   public typealias SerializationRequirement = Transferable
 
@@ -28,6 +29,7 @@ public class TheSpecificResultHandlerWhichIsANonFinalClass: DistributedTargetInv
 }
 
 // NOT final on purpose
+@available(SwiftStdlib 5.7, *)
 public class FakeInvocationDecoder: DistributedTargetInvocationDecoder {
   public typealias SerializationRequirement = Transferable
 
@@ -49,6 +51,7 @@ public class FakeInvocationDecoder: DistributedTargetInvocationDecoder {
 }
 
 // NOT final on purpose
+@available(SwiftStdlib 5.7, *)
 public class FakeInvocationEncoder : DistributedTargetInvocationEncoder {
   public typealias SerializationRequirement = Transferable
 
@@ -70,6 +73,7 @@ public class FakeInvocationEncoder : DistributedTargetInvocationEncoder {
 }
 
 // NOT final on purpose
+@available(SwiftStdlib 5.7, *)
 public class NotFinalActorSystemForAdHocRequirementTest: DistributedActorSystem, @unchecked Sendable {
   public typealias ActorID = String
   public typealias InvocationEncoder = FakeInvocationEncoder


### PR DESCRIPTION
A bit unsure why this isn't failing in upstream here but these were missing availability annotations.

resolves rdar://149248790