### PR TITLE
[Observation] Ensure deinitialized Observable types don't leave active observations in memory

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -116,7 +116,7 @@ public struct ObservationRegistrar: Sendable {
       }
 
       var tracker: (@Sendable () -> Void)?
-      for (keyPath, ids) in lookups {
+      lookupIteration: for (keyPath, ids) in lookups {
         for id in ids {
           if let found = observations[id]?.willSetTracker {
             // convert the keyPath into its \Self.self version 
@@ -124,7 +124,7 @@ public struct ObservationRegistrar: Sendable {
             tracker = {
                found(selfKp)
             }
-            break
+            break lookupIteration
           }
         }
       }

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -287,6 +287,21 @@ final class CowTest {
   var container = CowContainer()
 }
 
+@Observable
+final class DeinitTriggeredObserver {
+  var property: Int = 3
+  let deinitTrigger: () -> Void
+
+  init(_ deinitTrigger: @escaping () -> Void) {
+    self.deinitTrigger = deinitTrigger
+  }
+
+  deinit {
+    deinitTrigger()
+  }
+}
+
+
 @main
 struct Validator {
   @MainActor
@@ -509,6 +524,22 @@ struct Validator {
       expectEqual(subject.container.id, startId)
       subject.container.mutate()
       expectEqual(subject.container.id, startId)
+    }
+
+    suite.test("weak container observation") {
+      let changed = CapturedState(state: false)
+      let deinitialized = CapturedState(state: false)
+      var test = DeinitTriggeredObserver {
+        deinitialized.state = true
+      }
+      withObservationTracking { [weak test] in
+        _blackHole(test?.property)
+      } onChange: {
+        changed.state = true
+      }
+      test = DeinitTriggeredObserver { }
+      expectEqual(deinitialized.state, true)
+      expectEqual(changed.state, true)
     }
 
     runAllTests()

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -290,6 +290,7 @@ final class CowTest {
 @Observable
 final class DeinitTriggeredObserver {
   var property: Int = 3
+  var property2: Int = 4
   let deinitTrigger: () -> Void
 
   init(_ deinitTrigger: @escaping () -> Void) {
@@ -528,17 +529,18 @@ struct Validator {
 
     suite.test("weak container observation") {
       let changed = CapturedState(state: false)
-      let deinitialized = CapturedState(state: false)
+      let deinitialized = CapturedState(state: 0)
       var test = DeinitTriggeredObserver {
-        deinitialized.state = true
+        deinitialized.state += 1
       }
       withObservationTracking { [weak test] in
         _blackHole(test?.property)
+        _blackHole(test?.property2)
       } onChange: {
         changed.state = true
       }
       test = DeinitTriggeredObserver { }
-      expectEqual(deinitialized.state, true)
+      expectEqual(deinitialized.state, 1) // ensure only one invocation is done per deinitialization
       expectEqual(changed.state, true)
     }
 


### PR DESCRIPTION
Explanation:
This ensures a potential leak with SwiftUI and other systems using Observation do not leak observation closures when the potential Observable instances used are only weakly referenced inside the tracking closure. 
 
Scope:
This is limited to the runtime behavior of Observable types and has no ABI or language level interactions.

Issues:
rdar://112167556

Original PRs:
https://github.com/swiftlang/swift/pull/79823
https://github.com/swiftlang/swift/pull/82307

Risk:
Low - This is very targeted to just Observation, however it is a behavioral change which does not make this a zero risk change.

Testing:
New unit tests were added to catch at least some of the potential cases this issue can occur with.