### PR TITLE
[6.1][Tests] Distributed: Use `%target-swift-6.0-abi-triple` to avoid availability issues

### DIFF
--- a/test/Distributed/distributed_actor_adhoc_requirements_optimized_build.swift
+++ b/test/Distributed/distributed_actor_adhoc_requirements_optimized_build.swift
@@ -1,11 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-ir -swift-version 6 -O -I %t %s
-// RUN: %target-swift-frontend -emit-sil -swift-version 6 -O -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-swift-6.0-abi-triple -emit-ir -swift-version 6 -O -I %t %s
+// RUN: %target-swift-frontend -target %target-swift-6.0-abi-triple -emit-sil -swift-version 6 -O -I %t %s | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: distributed
-
-// REQUIRES: OS=macosx || OS=ios
 
 import Distributed
 


### PR DESCRIPTION
This was a test failure which we picked up and fixed in April here: https://github.com/swiftlang/swift/pull/80551

However it somehow didn't make its way to 6.1 and therefore 6.1 validation jobs are now failing.

This only picks a fix to the test.

resolves rdar://149248790