### PR TITLE
[6.2] Sema: Fix leading dot with protocol composition or parameterized protocol contextual type

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1678,7 +1678,7 @@ namespace {
         // \endcode
         //
         // Here `P.foo` would be replaced with `S.foo`
-        if (!isExistentialMetatype && baseTy->is<ProtocolType>() &&
+        if (!isExistentialMetatype && baseTy->isConstraintType() &&
             member->isStatic()) {
           auto selfParam =
               overload.adjustedOpenedFullType->castTo<FunctionType>()->getParams()[0];

--- a/test/Constraints/issue-60552.swift
+++ b/test/Constraints/issue-60552.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-emit-silgen %s
+
+// rdar://150858005
+protocol P {}
+protocol Q {}
+
+struct MyP: P, Q {}
+
+extension P where Self == MyP {
+    static var myP: Self { return MyP() }
+}
+
+func test() {
+    let _: any P & Q = .myP
+}
+
+// rdar://148708774
+protocol Wrapper<Wrapped> {
+    associatedtype Wrapped
+}
+struct IntWrapper: Wrapper {
+    typealias Wrapped = Int
+}
+
+extension Wrapper where Self == IntWrapper {
+    static var int: Self { fatalError() }
+}
+
+let crashes: any Wrapper<Int> = .int
+let ok1: some Wrapper<Int> = .int
+let ok2: any Wrapper = .int


### PR DESCRIPTION
6.2 cherry-pick of https://github.com/swiftlang/swift/pull/82757

* **Description:** Fix a crash with implicit member references `.foo` where the contextual type was a protocol composition or parameterized protocol due to unhandled case.
* **Origination:** This never worked.
* **Risk:** Very low. Ending up in the code path with either of the other two types that answer true to `isConstraintType()` would have crashed, as demonstrated by the test case. I believe this fix is completely safe.
* **Issue:**  Fixes https://github.com/swiftlang/swift/issues/60552.
* **Radar:** Fixes rdar://problem/99699879.
* **Reviewed by:** @xedin and @AnthonyLatsis 
