### PR TITLE
[6.2] SILGen: Fix mis-compile of `#if available` with `-disable-availability-checking`

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -504,8 +504,7 @@ class alignas(8) PoundAvailableInfo final :
                      ArrayRef<AvailabilitySpec *> queries, SourceLoc RParenLoc,
                      bool isUnavailability)
       : PoundLoc(PoundLoc), LParenLoc(LParenLoc), RParenLoc(RParenLoc),
-        NumQueries(queries.size()), AvailableRange(VersionRange::empty()),
-        VariantAvailableRange(VersionRange::empty()), Flags() {
+        NumQueries(queries.size()), Flags() {
     Flags.isInvalid = false;
     Flags.isUnavailability = isUnavailability;
     std::uninitialized_copy(queries.begin(), queries.end(),

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -1608,6 +1608,9 @@ class _ParentProcess {
         _testSuiteFailedCallback()
       } else {
         print("\(testSuite.name): All tests passed")
+        if testSuite._tests.isEmpty {
+          print("WARNING: SUITE '\(testSuite.name)' CONTAINED NO TESTS! NO TESTS WERE EXECUTED!")
+        }
       }
     }
     let (failed: failedOnShutdown, ()) = _shutdownChild()

--- a/test/SILGen/availability_disabled.swift
+++ b/test/SILGen/availability_disabled.swift
@@ -1,5 +1,0 @@
-// RUN: %target-swift-emit-silgen -disable-availability-checking %s -verify
-
-func foo() {
-    if #available(macOS 10.15, *) {}
-}

--- a/test/SILGen/availability_disabled_zippered.swift
+++ b/test/SILGen/availability_disabled_zippered.swift
@@ -1,6 +1,0 @@
-// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -disable-availability-checking %s -verify
-// REQUIRES: OS=macosx
-
-func foo() {
-    if #available(macOS 10.15, *) {}
-}

--- a/test/SILGen/availability_query_disabled.swift
+++ b/test/SILGen/availability_query_disabled.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking %s -verify
+// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+
+// CHECK-LABEL: // available()
+func available() {
+  // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK: cond_br [[TRUE]]
+  if #available(macOS 10.15, *) {}
+}
+
+// CHECK-LABEL: // unavailable()
+func unavailable() {
+  // CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK: cond_br [[FALSE]]
+  if #unavailable(macOS 10.15) {}
+}

--- a/test/SILGen/availability_query_disabled_zippered.swift
+++ b/test/SILGen/availability_query_disabled_zippered.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -disable-availability-checking %s -verify
+// RUN: %target-swift-emit-silgen -target-variant %target-cpu-apple-macosx13 -target %target-cpu-apple-ios16-macabi -disable-availability-checking %s -verify
+
+// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -disable-availability-checking %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -target-variant %target-cpu-apple-macosx13 -target %target-cpu-apple-ios16-macabi -disable-availability-checking %s | %FileCheck %s
+
+// REQUIRES: OS=macosx || OS=maccatalyst
+
+// CHECK-LABEL: // available()
+func available() {
+  // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK: cond_br [[TRUE]]
+  if #available(macOS 10.15, *) {}
+}
+
+// CHECK-LABEL: // unavailable()
+func unavailable() {
+  // CHECK: [[FALSE:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK: cond_br [[FALSE]]
+  if #unavailable(macOS 10.15) {}
+}


### PR DESCRIPTION
- **Explanation:** Fixes a regression caused by https://github.com/swiftlang/swift/pull/80428 where `if #available` is mis-compiled when `-disable-availability-checking` is specified. Also fixes some tests which no were no longer running due to the mis-compile and therefore regressed.
- **Scope:** `-disable-availability-checking` is only designed for testing so this should only affect the test suite.
- **Issue/Radar:** rdar://154765383
- **Original PR:** https://github.com/swiftlang/swift/pull/82718/
- **Risk:** Low since in only changes behavior when `-disable-availability-checking` is specified.
- **Testing:** New tests.
- **Reviewer:** @ktoso 