### PR TITLE
[6.2][cxx-interop] Fix a crash when exposing @objc Swift classes

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -580,7 +580,8 @@ public:
         else if (isa<StructDecl>(TD) && NTD->hasClangNode())
           emitReferencedClangTypeMetadata(NTD);
         else if (const auto *cd = dyn_cast<ClassDecl>(TD))
-          if (cd->isObjC() || cd->isForeignReferenceType())
+          if ((cd->isObjC() && cd->getClangDecl()) ||
+              cd->isForeignReferenceType())
             emitReferencedClangTypeMetadata(NTD);
       } else if (auto TAD = dyn_cast<TypeAliasDecl>(TD)) {
         if (TAD->hasClangNode())

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -88,10 +88,17 @@ public func retObjCClassArray() -> [ObjCKlass] {
     return []
 }
 
+public class KVOCookieMonster {
+   public static func += (lhs: KVOCookieMonster, rhs: NSKeyValueObservation) {
+      lhs.cookies.append(rhs)
+   }
+
+   private var cookies = Array<NSKeyValueObservation>()
+}
+
 // CHECK: @interface HasBlockField : NSObject
 // CHECK: @property (nonatomic, copy) void (^ _Nullable foo)(ObjCKlassState);
 // CHECK: @end
-
 // CHECK: SWIFT_EXTERN id <ObjCProtocol> _Nonnull $s9UseObjCTy03retB9CProtocolSo0bE0_pyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retObjCProtocol()
 // CHECK-NEXT: #endif
 // CHECK-NEXT: #if defined(__OBJC__)


### PR DESCRIPTION
Explanation: There was a null pointer dereference in reverse interop when we wanted to expose an ObjC class written in Swift. There was a crash during generating the scaffolding we do for Clang types. Since the type is written in Swift, no such scaffolding is needed, this patch skips this operation avoiding the null dereference.
Scope: Reverse C++ interop when exposing @ObjC classes written in Swift.
Issues: rdar://154252454
Original PRs: #82684
Risk: Low, the fix is narrow to the affected scenario. Testing: Added a compiler test.
Reviewers: @egorzhdan
