### PR TITLE
[6.2] MandatoryPerformanceOptimizations: don't de-virtualize a generic class method call to specialized method

### DIFF
--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -76,7 +76,7 @@ bool canDevirtualizeClassMethod(FullApplySite AI, ClassDecl *CD,
                                 CanType ClassType,
                                 OptRemark::Emitter *ORE = nullptr,
                                 bool isEffectivelyFinalMethod = false);
-SILFunction *getTargetClassMethod(SILModule &M, ClassDecl *CD,
+SILFunction *getTargetClassMethod(SILModule &M, FullApplySite as, ClassDecl *CD,
                                   CanType ClassType, MethodInst *MI);
 CanType getSelfInstanceType(CanType ClassOrMetatypeType);
 

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -446,7 +446,7 @@ static bool tryToSpeculateTarget(SILPassManager *pm, FullApplySite AI, ClassHier
 
   // Try to devirtualize the static class of instance
   // if it is possible.
-  if (auto F = getTargetClassMethod(M, CD, ClassType, CMI)) {
+  if (auto F = getTargetClassMethod(M, AI, CD, ClassType, CMI)) {
     // Do not devirtualize if a method in the base class is marked
     // as non-optimizable. This way it is easy to disable the
     // devirtualization of this method in the base class and

--- a/test/embedded/devirt_generic_class_methods.swift
+++ b/test/embedded/devirt_generic_class_methods.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -Xllvm -sil-disable-pass=mandatory-inlining -emit-ir -o /dev/null
+
+// REQUIRES: swift_feature_Embedded
+
+
+// Check that the compiler doesn't crash
+
+public class Base<T> {
+  func foo(_ t: T) -> T {
+    return t
+  }
+}
+
+@_transparent
+func callee(_ i: Int, _ c: Base<Int>) -> Int {
+  return c.foo(i)
+}
+
+public func testit(_ i : Int) -> Int {
+  return callee(i, Base<Int>())
+}
+


### PR DESCRIPTION
* **Explanation**: Fixes a compiler crash in Embedded Swift related to generic classes. Fixes a problem where the compiler de-virtualizes a class method call and generates the wrong calling conventions for it.
* **Risk**: Low. It's a simple fix which only affects Embedded Swift.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://154631438
* **Reviewer**:  @kubamracek
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/82677
