### PR TITLE
[NFC][demangling] switch to using NodePrinter::printFunctionName

### DIFF
--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -3493,35 +3493,9 @@ NodePointer NodePrinter::printEntity(NodePointer Entity, unsigned depth,
     }
   }
 
-  if (hasName || !OverwriteName.empty()) {
-    if (!ExtraName.empty() && MultiWordName) {
-      Printer << ExtraName;
-      if (ExtraIndex >= 0)
-        Printer << ExtraIndex;
+  printFunctionName(hasName, OverwriteName, ExtraName, MultiWordName,
+                    ExtraIndex, Entity, depth);
 
-      Printer << " of ";
-      ExtraName = "";
-      ExtraIndex = -1;
-    }
-    size_t CurrentPos = Printer.getStringRef().size();
-    if (!OverwriteName.empty()) {
-      Printer << OverwriteName;
-    } else {
-      auto Name = Entity->getChild(1);
-      if (Name->getKind() != Node::Kind::PrivateDeclName)
-        print(Name, depth + 1);
-
-      if (auto PrivateName = getChildIf(Entity, Node::Kind::PrivateDeclName))
-        print(PrivateName, depth + 1);
-    }
-    if (Printer.getStringRef().size() != CurrentPos && !ExtraName.empty())
-      Printer << '.';
-  }
-  if (!ExtraName.empty()) {
-    Printer << ExtraName;
-    if (ExtraIndex >= 0)
-      Printer << ExtraIndex;
-  }
   if (TypePr != TypePrinting::NoType) {
     NodePointer type = getChildIf(Entity, Node::Kind::Type);
     assert(type && "malformed entity");


### PR DESCRIPTION
- **Explanation**:
In https://github.com/swiftlang/swift/pull/82479 we introduced `NodePrinter::printFunctionName`. This method extracts some logic from the demangler into a reusable helper function. The code that was extracted was never replaced by a call to the helper method.
This patch replaces it with the call to `printFunctionName`.
- **Scope**:
This patch is an NFC.
- **Issues**:
  <!--
  References to issues the changes resolve, if any.
  -->
- **Original PRs**:
  - https://github.com/swiftlang/swift/pull/82730
- **Risk**:
Very low, this is an NFC
- **Testing**:
Tested that it compiles against https://github.com/swiftlang/llvm-project/pull/10710 which is the root motivation for this change.
- **Reviewers**:
  - @Michael137 
  - @adrian-prantl 