### PR TITLE
[CS] Ensure type variables are eliminated by `Solution::simplifyType`

### DIFF
--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -798,3 +798,8 @@ do {
     }
   }
 }
+
+func testInvalidDecomposition() {
+  func id<T>(_ x: T) -> T {}
+  let (a, b) = id((repeat each undefined)) // expected-error {{cannot find 'undefined' in scope}}
+}

--- a/validation-test/IDE/crashers_fixed/6cef534b98d6b512.swift
+++ b/validation-test/IDE/crashers_fixed/6cef534b98d6b512.swift
@@ -1,0 +1,4 @@
+// {"kind":"complete","signature":"swift::constraints::Solution::simplifyType(swift::Type, bool) const"}
+// RUN: %target-swift-ide-test -code-completion --code-completion-token=COMPLETE -code-completion-diagnostics -source-filename %s
+for (a(b, d)) [
+#^COMPLETE^#, 0, (repeat.c)].enumerated(

--- a/validation-test/compiler_crashers_2_fixed/d84cbb5089113ba.swift
+++ b/validation-test/compiler_crashers_2_fixed/d84cbb5089113ba.swift
@@ -1,0 +1,4 @@
+// {"kind":"typecheck","signature":"swift::constraints::Solution::simplifyType(swift::Type, bool) const"}
+// RUN: not %target-swift-frontend -typecheck %s
+for (a(b, d)) in [(repeat .c)].enumerated(<#expression#>) {
+}

--- a/validation-test/compiler_crashers_2_fixed/dc3a3e26162b43be.swift
+++ b/validation-test/compiler_crashers_2_fixed/dc3a3e26162b43be.swift
@@ -1,5 +1,5 @@
 // {"signature":"(anonymous namespace)::SetExprTypes::walkToExprPost(swift::Expr*)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
+// RUN: not %target-swift-frontend -typecheck %s
 typealias a<b, c> = c
 struct d < each b {
   typealias e< c > =


### PR DESCRIPTION
`TypeSimplifier` may not eliminate type variables from e.g the pattern types of pattern expansion types since they can remain unresolved due to e.g having a placeholder count type. Make sure we eliminate any remaining type variables along with the placeholders. There's probably a more principled fix here, but this is a quick and low risk fix we can hopefully take for 6.2.

rdar://154954995