### PR TITLE
NFC: Fix doc comment typo in `productpipeline_list_builder.py`

### DIFF
--- a/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py
+++ b/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https:#swift.org/LICENSE.txt for license information
@@ -182,7 +182,7 @@ class ProductPipelineListBuilder(object):
         return (filtered_results, last_impl_pipeline_index)
 
     def finalize(self, shouldInfer):
-        """Product a final schedule and return a list of our product pipelines. Resets
+        """Produce a final schedule and return a list of our product pipelines. Resets
            the builder when done so is a consuming operation.
         """
         # Append the current pipeline if we have one.

--- a/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py
+++ b/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py
@@ -2,7 +2,7 @@
 #
 # This source file is part of the Swift.org open source project
 #
-# Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+# Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
 # Licensed under Apache License v2.0 with Runtime Library Exception
 #
 # See https:#swift.org/LICENSE.txt for license information


### PR DESCRIPTION
`Product a final schedule` -> `Produce a final schedule`

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
