### PR TITLE
[6.2 🍒][Dependency Scanning][C++ Interop] Do not skip lookup of 'CxxStdlib' overlay for the source module

### DIFF
--- a/test/ScanDependencies/cxx-overlay-source-lookup.swift
+++ b/test/ScanDependencies/cxx-overlay-source-lookup.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/deps)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %t/client.swift -I %t/deps -cxx-interoperability-mode=default -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import
+// RUN: cat %t/deps.json | %FileCheck %s
+
+/// --------Main module
+// CHECK-LABEL: "modulePath": "deps.swiftmodule",
+// CHECK-NEXT: "sourceFiles": [
+// CHECK-NEXT: cxx-overlay-source-lookup.swift
+// CHECK-NEXT: ],
+// CHECK: "directDependencies": [
+// CHECK-DAG: "swift": "Swift"
+// CHECK-DAG: "swift": "SwiftOnoneSupport"
+// CHECK-DAG: "swift": "Cxx"
+// CHECK-DAG: "swift": "CxxStdlib"
+// CHECK-DAG: "clang": "CxxShim"
+// CHECK-DAG: "clang": "Foo"
+// CHECK: ],
+
+//--- deps/bar.h
+void bar(void);
+
+//--- deps/foo.h
+#include "bar.h"
+void foo(void);
+
+//--- deps/module.modulemap
+module std_Bar [system] {
+  header "bar.h"
+  export *
+}
+
+module Foo {
+  header "foo.h"
+  export *
+}
+
+//--- client.swift
+import Foo


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift/pull/82751
--------------------------------------

- **Explanation**: A prior change ensured that we forego this query when looking up Swift overlays for a textual interface which was built without C++ interop. This change introduced a bug where it also caused us to skip this lookup for the main source module. This commit resolves that by preserving the fix above but also ensuring we perform the lookup for the main source module under scan.

- **Scope**: C++ Interop-enabled builds with explicitly-built modules where the source module relies on the presence of the C++ standard library Swift overlay

- **Risk**: Low. This code path only affects builds behind the combination of features (C++ Interop and EBM) which is currently opt-in. When this combination is enabled, this change simply adds a module dependency which is expected to always get resolved to a Swift module in the toolchain.

- **Reviewed By**: @nkcsgexi 

- **Original PR**: https://github.com/swiftlang/swift/pull/82751
