### PR TITLE
SILGen: Generalize availability query emission

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2925,7 +2925,7 @@ public:
       : DeclAttribute(DeclAttrKind::BackDeployed, AtLoc, Range, Implicit),
         Platform(Platform), Version(Version) {}
 
-  /// The platform the symbol is available for back deployment on.
+  /// The platform the decl is available for back deployment in.
   const PlatformKind Platform;
 
   /// The earliest platform version that may use the back deployed implementation.
@@ -2933,6 +2933,12 @@ public:
 
   /// Returns true if this attribute is active given the current platform.
   bool isActivePlatform(const ASTContext &ctx, bool forTargetVariant) const;
+
+  /// Returns the `AvailabilityDomain` that the decl is available for back
+  /// deployment in.
+  AvailabilityDomain getAvailabilityDomain() const {
+    return AvailabilityDomain::forPlatform(Platform);
+  }
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DeclAttrKind::BackDeployed;

--- a/include/swift/AST/AvailabilityQuery.h
+++ b/include/swift/AST/AvailabilityQuery.h
@@ -23,6 +23,9 @@
 #include "llvm/Support/VersionTuple.h"
 
 namespace swift {
+class ASTContext;
+class FuncDecl;
+
 /// Represents the information needed to evaluate an `#if available` query
 /// (either at runtime or compile-time).
 class AvailabilityQuery final {
@@ -121,6 +124,14 @@ public:
       return std::nullopt;
     return variantRange->getRawMinimumVersion();
   }
+
+  /// Returns the `FuncDecl *` that should be invoked at runtime to evaluate
+  /// the query, and populates `arguments` with the arguments to invoke it with
+  /// (the integer components of the version tuples that are being tested). If
+  /// the query does not have a dynamic result, returns `nullptr`.
+  FuncDecl *
+  getDynamicQueryDeclAndArguments(llvm::SmallVectorImpl<unsigned> &arguments,
+                                  ASTContext &ctx) const;
 };
 
 } // end namespace swift

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1115,11 +1115,11 @@ public:
   std::optional<llvm::VersionTuple>
   getIntroducedOSVersion(PlatformKind Kind) const;
 
-  /// Returns the OS version in which the decl became ABI as specified by the
-  /// `@backDeployed` attribute.
-  std::optional<llvm::VersionTuple>
-  getBackDeployedBeforeOSVersion(ASTContext &Ctx,
-                                 bool forTargetVariant = false) const;
+  /// Returns the active `@backDeployed` attribute and the `AvailabilityRange`
+  /// in which the decl is available as ABI.
+  std::optional<std::pair<const BackDeployedAttr *, AvailabilityRange>>
+  getBackDeployedAttrAndRange(ASTContext &Ctx,
+                              bool forTargetVariant = false) const;
 
   /// Returns true if the decl has an active `@backDeployed` attribute for the
   /// given context.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -365,8 +365,8 @@ bool AvailabilityInference::updateBeforeAvailabilityDomainForFallback(
     const BackDeployedAttr *attr, const ASTContext &ctx,
     AvailabilityDomain &domain, llvm::VersionTuple &platformVer) {
   bool hasRemap = false;
-  auto remappedDomain = AvailabilityDomain::forPlatform(attr->Platform)
-                            .getRemappedDomain(ctx, hasRemap);
+  auto remappedDomain =
+      attr->getAvailabilityDomain().getRemappedDomain(ctx, hasRemap);
   if (!hasRemap)
     return false;
 

--- a/lib/AST/AvailabilityQuery.cpp
+++ b/lib/AST/AvailabilityQuery.cpp
@@ -1,0 +1,144 @@
+//===--- AvailabilityQuery.cpp - Swift Availability Queries ---------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/AvailabilityQuery.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/Basic/Platform.h"
+
+using namespace swift;
+
+static void unpackVersion(const llvm::VersionTuple &version,
+                          llvm::SmallVectorImpl<unsigned> &arguments) {
+  arguments.push_back(version.getMajor());
+  arguments.push_back(version.getMinor().value_or(0));
+  arguments.push_back(version.getSubminor().value_or(0));
+}
+
+static FuncDecl *
+getOSVersionRangeCheck(const llvm::VersionTuple &version,
+                       llvm::SmallVectorImpl<unsigned> &arguments,
+                       ASTContext &ctx, bool forTargetVariant) {
+  unpackVersion(version, arguments);
+  return forTargetVariant ? ctx.getIsVariantOSVersionAtLeastDecl()
+                          : ctx.getIsOSVersionAtLeastDecl();
+}
+
+static FuncDecl *getOSVersionOrVariantVersionRangeCheck(
+    const llvm::VersionTuple &targetVersion,
+    const llvm::VersionTuple &variantVersion,
+    llvm::SmallVectorImpl<unsigned> &arguments, ASTContext &ctx) {
+  unpackVersion(targetVersion, arguments);
+  unpackVersion(variantVersion, arguments);
+  return ctx.getIsOSVersionAtLeastOrVariantVersionAtLeast();
+}
+
+static FuncDecl *
+getZipperedOSVersionRangeCheck(const AvailabilityQuery &query,
+                               llvm::SmallVectorImpl<unsigned> &arguments,
+                               ASTContext &ctx) {
+
+  auto targetVersion = query.getPrimaryArgument();
+  auto variantVersion = query.getVariantArgument();
+  DEBUG_ASSERT(targetVersion || variantVersion);
+
+  // We're building zippered, so we need to pass both macOS and iOS versions to
+  // the runtime version range check. At run time that check will determine what
+  // kind of process this code is loaded into. In a macOS process it will use
+  // the macOS version; in an macCatalyst process it will use the iOS version.
+  llvm::Triple targetTriple = ctx.LangOpts.Target;
+  llvm::Triple variantTriple = *ctx.LangOpts.TargetVariant;
+
+  // From perspective of the driver and most of the frontend, -target and
+  // -target-variant are symmetric. That is, the user can pass either:
+  //    -target x86_64-apple-macosx10.15 \
+  //    -target-variant x86_64-apple-ios13.1-macabi
+  // or:
+  //    -target x86_64-apple-ios13.1-macabi \
+  //    -target-variant x86_64-apple-macosx10.15
+  //
+  // However, the runtime availability-checking entry points need to compare
+  // against an actual running OS version and so can't be symmetric. Here we
+  // standardize on "target" means macOS version and "targetVariant" means iOS
+  // version.
+  if (tripleIsMacCatalystEnvironment(targetTriple)) {
+    DEBUG_ASSERT(variantTriple.isMacOSX());
+    // Normalize so that "variant" always means iOS version.
+    std::swap(targetVersion, variantVersion);
+    std::swap(targetTriple, variantTriple);
+  }
+
+  // The variant-only availability-checking entrypoint is not part of the
+  // Swift 5.0 ABI. It is only available in macOS 10.15 and above.
+  bool isVariantEntrypointAvailable = !targetTriple.isMacOSXVersionLT(10, 15);
+
+  // If there is no check for the target but there is for the variant, then we
+  // only need to emit code for the variant check.
+  if (isVariantEntrypointAvailable && !targetVersion && variantVersion)
+    return getOSVersionRangeCheck(*variantVersion, arguments, ctx,
+                                  /*forVariant=*/true);
+
+  // Similarly, if there is a check for the target but not for the target
+  // variant then we only to emit code for the target check.
+  if (targetVersion && !variantVersion)
+    return getOSVersionRangeCheck(*targetVersion, arguments, ctx,
+                                  /*forTargetVariant=*/false);
+
+  if (!isVariantEntrypointAvailable || (targetVersion && variantVersion)) {
+
+    // If the variant-only entrypoint isn't available (as is the case
+    // pre-macOS 10.15) we need to use the zippered entrypoint (which is part of
+    // the Swift 5.0 ABI) even when the macOS version is '*' (all). In this
+    // case, use the minimum macOS deployment version from the target triple.
+    // This ensures the check always passes on macOS.
+    if (!isVariantEntrypointAvailable && !targetVersion) {
+      DEBUG_ASSERT(targetTriple.isMacOSX());
+
+      llvm::VersionTuple macosVersion;
+      targetTriple.getMacOSXVersion(macosVersion);
+      targetVersion = macosVersion;
+    }
+
+    return getOSVersionOrVariantVersionRangeCheck(
+        *targetVersion, *variantVersion, arguments, ctx);
+  }
+
+  llvm_unreachable("Unhandled zippered configuration");
+}
+
+static FuncDecl *
+getOSAvailabilityDeclAndArguments(const AvailabilityQuery &query,
+                                  llvm::SmallVectorImpl<unsigned> &arguments,
+                                  ASTContext &ctx) {
+  if (ctx.LangOpts.TargetVariant)
+    return getZipperedOSVersionRangeCheck(query, arguments, ctx);
+
+  bool isMacCatalyst = tripleIsMacCatalystEnvironment(ctx.LangOpts.Target);
+  return getOSVersionRangeCheck(query.getPrimaryArgument().value(), arguments,
+                                ctx, isMacCatalyst);
+}
+
+FuncDecl *AvailabilityQuery::getDynamicQueryDeclAndArguments(
+    llvm::SmallVectorImpl<unsigned> &arguments, ASTContext &ctx) const {
+  switch (getDomain().getKind()) {
+  case AvailabilityDomain::Kind::Universal:
+  case AvailabilityDomain::Kind::SwiftLanguage:
+  case AvailabilityDomain::Kind::PackageDescription:
+  case AvailabilityDomain::Kind::Embedded:
+    return nullptr;
+  case AvailabilityDomain::Kind::Platform:
+    return getOSAvailabilityDeclAndArguments(*this, arguments, ctx);
+  case AvailabilityDomain::Kind::Custom:
+    // FIXME: [availability] Support custom domains.
+    return nullptr;
+  }
+}

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -30,6 +30,7 @@ add_swift_host_library(swiftAST STATIC
   AvailabilityConstraint.cpp
   AvailabilityContext.cpp
   AvailabilityDomain.cpp
+  AvailabilityQuery.cpp
   AvailabilityScope.cpp
   AvailabilityScopeBuilder.cpp
   AvailabilitySpec.cpp

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -607,9 +607,9 @@ Decl::getIntroducedOSVersion(PlatformKind Kind) const {
   return std::nullopt;
 }
 
-std::optional<llvm::VersionTuple>
-Decl::getBackDeployedBeforeOSVersion(ASTContext &Ctx,
-                                     bool forTargetVariant) const {
+std::optional<std::pair<const BackDeployedAttr *, AvailabilityRange>>
+Decl::getBackDeployedAttrAndRange(ASTContext &Ctx,
+                                  bool forTargetVariant) const {
   if (auto *attr = getAttrs().getBackDeployed(Ctx, forTargetVariant)) {
     auto version = attr->Version;
     AvailabilityDomain ignoredDomain;
@@ -618,26 +618,25 @@ Decl::getBackDeployedBeforeOSVersion(ASTContext &Ctx,
 
     // If the remap for fallback resulted in 1.0, then the
     // backdeployment prior to that is not meaningful.
-    if (version == clang::VersionTuple(1, 0, 0, 0))
+    if (version == llvm::VersionTuple(1, 0, 0, 0))
       return std::nullopt;
 
-    return version;
+    return std::make_pair(attr, AvailabilityRange(version));
   }
 
   // Accessors may inherit `@backDeployed`.
   if (auto *AD = dyn_cast<AccessorDecl>(this))
-    return AD->getStorage()->getBackDeployedBeforeOSVersion(Ctx,
-                                                            forTargetVariant);
+    return AD->getStorage()->getBackDeployedAttrAndRange(Ctx, forTargetVariant);
 
   return std::nullopt;
 }
 
 bool Decl::isBackDeployed(ASTContext &Ctx) const {
-  if (getBackDeployedBeforeOSVersion(Ctx))
+  if (getBackDeployedAttrAndRange(Ctx))
     return true;
 
   if (Ctx.LangOpts.TargetVariant) {
-    if (getBackDeployedBeforeOSVersion(Ctx, /*forTargetVariant=*/true))
+    if (getBackDeployedAttrAndRange(Ctx, /*forTargetVariant=*/true))
       return true;
   }
 
@@ -1463,8 +1462,8 @@ AvailabilityRange Decl::getAvailabilityForLinkage() const {
 
   // When computing availability for linkage, use the "before" version from
   // the @backDeployed attribute, if present.
-  if (auto backDeployVersion = getBackDeployedBeforeOSVersion(ctx))
-    return AvailabilityRange{*backDeployVersion};
+  if (auto backDeployedAttrAndRange = getBackDeployedAttrAndRange(ctx))
+    return backDeployedAttrAndRange->second;
 
   auto containingContext = AvailabilityInference::annotatedAvailableRange(this);
   if (containingContext.has_value()) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -5129,8 +5129,8 @@ void AttributeChecker::checkBackDeployedAttrs(
   std::map<PlatformKind, SourceLoc> seenPlatforms;
 
   const BackDeployedAttr *ActiveAttr = nullptr;
-  if (D->getBackDeployedBeforeOSVersion(Ctx))
-    ActiveAttr = D->getAttrs().getBackDeployed(Ctx, false);
+  if (auto AttrAndRange = D->getBackDeployedAttrAndRange(Ctx))
+    ActiveAttr = AttrAndRange->first;
 
   for (auto *Attr : Attrs) {
     // Back deployment only makes sense for public declarations.
@@ -5221,7 +5221,7 @@ void AttributeChecker::checkBackDeployedAttrs(
         D->getLoc(), D->getInnermostDeclContext());
 
     // Unavailable decls cannot be back deployed.
-    auto backDeployedDomain = AvailabilityDomain::forPlatform(Attr->Platform);
+    auto backDeployedDomain = Attr->getAvailabilityDomain();
     if (availability.containsUnavailableDomain(backDeployedDomain)) {
       auto domainForDiagnostics = backDeployedDomain;
       llvm::VersionTuple ignoredVersion;
@@ -5254,7 +5254,7 @@ void AttributeChecker::checkBackDeployedAttrs(
     // fallback could never be executed at runtime.
     if (auto availableRangeAttrPair =
             getSemanticAvailableRangeDeclAndAttr(VD)) {
-      auto beforeDomain = AvailabilityDomain::forPlatform(Attr->Platform);
+      auto beforeDomain = Attr->getAvailabilityDomain();
       auto beforeVersion = Attr->Version;
       auto availableAttr = availableRangeAttrPair.value().first;
       auto introVersion = availableAttr.getIntroduced().value();


### PR DESCRIPTION
Generalize SILGen for `if #available` checks by delegating the determination of the query function and its arguments to `AvailabilityQuery`. Update SILGen for `@backDeployed` thunks to use the same infrastructure.

These NFC changes build towards supporting SILGen for custom availability domains (rdar://138441312).
