### PR TITLE
[6.2] [CS] Ensure type variables are eliminated by `Solution::simplifyType`

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1809,7 +1809,7 @@ Type Solution::simplifyType(Type type, bool wantInterfaceType) const {
         });
   }
 
-  ASSERT(!resolvedType->getRecursiveProperties().isSolverAllocated());
+  CONDITIONAL_ASSERT(!resolvedType->getRecursiveProperties().isSolverAllocated());
   return resolvedType;
 }
 

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -798,3 +798,8 @@ do {
     }
   }
 }
+
+func testInvalidDecomposition() {
+  func id<T>(_ x: T) -> T {}
+  let (a, b) = id((repeat each undefined)) // expected-error {{cannot find 'undefined' in scope}}
+}

--- a/validation-test/IDE/crashers_fixed/6cef534b98d6b512.swift
+++ b/validation-test/IDE/crashers_fixed/6cef534b98d6b512.swift
@@ -1,0 +1,4 @@
+// {"kind":"complete","signature":"swift::constraints::Solution::simplifyType(swift::Type, bool) const"}
+// RUN: %target-swift-ide-test -code-completion --code-completion-token=COMPLETE -code-completion-diagnostics -source-filename %s
+for (a(b, d)) [
+#^COMPLETE^#, 0, (repeat.c)].enumerated(

--- a/validation-test/compiler_crashers_2_fixed/d84cbb5089113ba.swift
+++ b/validation-test/compiler_crashers_2_fixed/d84cbb5089113ba.swift
@@ -1,0 +1,4 @@
+// {"kind":"typecheck","signature":"swift::constraints::Solution::simplifyType(swift::Type, bool) const"}
+// RUN: not %target-swift-frontend -typecheck %s
+for (a(b, d)) in [(repeat .c)].enumerated(<#expression#>) {
+}

--- a/validation-test/compiler_crashers_2_fixed/dc3a3e26162b43be.swift
+++ b/validation-test/compiler_crashers_2_fixed/dc3a3e26162b43be.swift
@@ -1,0 +1,12 @@
+// {"signature":"(anonymous namespace)::SetExprTypes::walkToExprPost(swift::Expr*)"}
+// RUN: not %target-swift-frontend -typecheck %s
+typealias a<b, c> = c
+struct d < each b {
+  typealias e< c > =
+  (repeat a< each b, c >)
+  typealias f< each c > = (repeat e< each c >
+  func 1 {
+    typealias g = h
+    (g<
+    i >
+    typealias g< each c > = f< repeat each c >


### PR DESCRIPTION
*6.2 cherry-pick of #82770*

- Explanation: Fixes a use-after-free that could occur with an invalid pack expansion
- Scope: Affects invalid uses of pack expansions
- Issue: rdar://154954995
- Risk: Low, only affects invalid code, and any previous type variable escape here would have almost certainly resulted in a use-after-free
- Testing: Added tests to test suite
- Reviewer: Pavel Yaskevich