### PR TITLE
Fix typo in `reset` func in `productpipeline_list_builder.py`

### DIFF
--- a/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py
+++ b/utils/swift_build_support/swift_build_support/productpipeline_list_builder.py
@@ -91,7 +91,7 @@ class ProductPipelineListBuilder(object):
         self.current_count = 0
         self.current_pipeline = None
         self.is_current_pipeline_impl = False
-        self.pipelinst_list = []
+        self.pipeline_list = []
 
     def add_product(self, product_cls, is_enabled):
         """Add a non-impl product to the current pipeline begin constructed"""


### PR DESCRIPTION
`pipelinst_list` -> `pipeline_list`

There are no other uses of `pipelinst_list`, so it's clearly a typo when trying to refer to `pipeline_list`