### PR TITLE
[Mem2Reg] Don't promote proj(unchecked_addr_cast).

### DIFF
--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -29,6 +29,24 @@ struct Pair<T, U> {
   var u: U
 }
 
+class C {}
+
+struct J {
+  var c: C
+}
+
+struct I {
+  var j: J
+}
+
+struct S1 {
+  var i: I
+}
+
+struct S2 {
+  var t: (J, J)
+}
+
 ///////////
 // Tests //
 ///////////
@@ -577,4 +595,61 @@ bb0:
   %14 = tuple (%empty : $(), %13 : $())
   dealloc_stack %11 : $*Pair<T, ()>
   return undef : $()
+}
+
+// CHECK-LABEL: sil @promo_proj_uac_1 : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'promo_proj_uac_1'
+sil @promo_proj_uac_1 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S1)
+  %addr = alloc_stack $S1
+  store %s to %addr
+  %i_addr = unchecked_addr_cast %addr to $*I
+  %j_addr = struct_element_addr %i_addr, #I.j
+  %j = load %j_addr
+  retain_value %j
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil @promo_proj_uac_2 : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'promo_proj_uac_2'
+sil @promo_proj_uac_2 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S2)
+  %addr = alloc_stack $S2
+  store %s to %addr
+  %t_addr = unchecked_addr_cast %addr to $*(J, J)
+  %j_addr = tuple_element_addr %t_addr, 0
+  %j = load %j_addr
+  retain_value %j
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil @promo_proj_uac_3 : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'promo_proj_uac_3'
+sil @promo_proj_uac_3 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S1)
+  %addr = alloc_stack $S1
+  store %s to %addr
+  %i_addr = unchecked_addr_cast %addr to $*I
+  %j_addr = unchecked_addr_cast %i_addr to $*J
+  %j = load %j_addr
+  retain_value %j
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
 }

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -46,6 +46,22 @@ struct S {
   var field: C
 }
 
+struct J {
+  var c: C
+}
+
+struct I {
+  var j: J
+}
+
+struct S1 {
+  var i: I
+}
+
+struct S2 {
+  var t: (J, J)
+}
+
 ///////////
 // Tests //
 ///////////
@@ -760,4 +776,58 @@ entry(%instance : @owned $C):
   dealloc_stack %stack : $*C
   %retval = tuple ()
   return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @no_promo_proj_uac_1 : {{.*}} {
+// CHECK:         alloc_stack
+// CHECK-LABEL: } // end sil function 'no_promo_proj_uac_1'
+sil [ossa] @no_promo_proj_uac_1 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S1)
+  %addr = alloc_stack $S1
+  store %s to [init] %addr
+  %i_addr = unchecked_addr_cast %addr to $*I
+  %j_addr = struct_element_addr %i_addr, #I.j
+  %j = load [copy] %j_addr
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil [ossa] @no_promo_proj_uac_2 : {{.*}} {
+// CHECK:         alloc_stack
+// CHECK-LABEL: } // end sil function 'no_promo_proj_uac_2'
+sil [ossa] @no_promo_proj_uac_2 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S2)
+  %addr = alloc_stack $S2
+  store %s to [init] %addr
+  %t_addr = unchecked_addr_cast %addr to $*(J, J)
+  %j_addr = tuple_element_addr %t_addr, 0
+  %j = load [copy] %j_addr
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil [ossa] @promo_uac_uac : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'promo_uac_uac'
+sil [ossa] @promo_uac_uac : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S1)
+  %addr = alloc_stack $S1
+  store %s to [init] %addr
+  %i_addr = unchecked_addr_cast %addr to $*I
+  %j_addr = unchecked_addr_cast %i_addr to $*J
+  %j = load [copy] %j_addr
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
 }


### PR DESCRIPTION
In OSSA, the result of an `unchecked_bitwise_cast` must immediately be copied or `unchecked_bitwise_cast`'d again.  In particular, it is not permitted to borrow it.  For example, the result can't be borrowed for the purpose of performing additional projections (`struct_extract`, `tuple_extract`) on the borrowed value.  Consequently, we cannot promote an address if that promotion would result in such a pattern.  That means we can't promote an address `%addr` which is used like `struct_element_addr(unchecked_addr_cast(%addr))` or `tuple_element_addr(unchecked_addr_cast(%addr))`.  We can still promote `unchecked_addr_cast(unchecked_addr_cast(%addr))`.

In ownership-lowered SIL, this doesn't apply and we can still promote address with such projections.

rdar://153693915
