### PR TITLE
RequirementMachine: Increase default type differences limit to 13000

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -590,7 +590,7 @@ namespace swift {
 
     /// Maximum number of "type difference" structures for the requirement machine
     /// property map algorithm.
-    unsigned RequirementMachineMaxTypeDifferences = 4000;
+    unsigned RequirementMachineMaxTypeDifferences = 13000;
 
     /// Maximum number of attempts to make when splitting concrete equivalence
     /// classes.

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1893,7 +1893,6 @@ std::optional<unsigned>
 ExpandBodyMacroRequest::evaluate(Evaluator &evaluator,
                                  AnyFunctionRef fn) const {
   auto *dc = fn.getAsDeclContext();
-  auto &ctx = dc->getASTContext();
   std::optional<unsigned> bufferID;
   fn.forEachAttachedMacro(
       MacroRole::Body,

--- a/test/Generics/infinite_concrete_type.swift
+++ b/test/Generics/infinite_concrete_type.swift
@@ -3,7 +3,7 @@
 class G<T> {}
 
 protocol P1 { // expected-error {{cannot build rewrite system for protocol; concrete type difference limit exceeded}}
-// expected-note@-1 {{failed rewrite rule is [P1:B].[superclass: G<G<G<G<G<G<G<G<G<G<G<G<G<[P1].A>>>>>>>>>>>>>] => [P1:B]}}
+// expected-note@-1 {{failed rewrite rule is [P1:B].[superclass: G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<[P1].B>>>>>>>>>>>>>>>>>>>>>>] => [P1:B]}}
   associatedtype A where A == G<B>
   associatedtype B where B == G<A>
 }
@@ -18,4 +18,41 @@ protocol P2 {
 func useP2<T : P2>(_: T) {
   _ = T.A.self
   _ = T.B.self
+}
+
+protocol P3 {
+  associatedtype T : P3
+}
+
+struct S<U : P3> : P3 {
+  typealias T = S<S<U>>
+}
+
+protocol P4Base {
+  associatedtype T : P3
+  associatedtype U : P3
+}
+
+protocol P4 : P4Base where T == S<U> {
+// expected-error@-1 {{cannot build rewrite system for protocol; rule length limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is [P4:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[concrete: S<S<S<S<S<S<S<S<S<S<S<S<S<S<[P4:U]>>>>>>>>>>>>>>] => [P4:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T].[P3:T]}}
+}
+
+protocol Exponential {
+// expected-error@-1 {{cannot build rewrite system for protocol; concrete type size limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is }}
+  associatedtype A where A == (A, A)
+}
+
+class Base<T> {}
+
+class Derived<T, U> : Base<(T, U)> {}
+
+protocol TooManyDifferences {
+// expected-error@-1 {{cannot build rewrite system for protocol; concrete type difference limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is }}
+  associatedtype A1 where A1: Derived<B, C>, A2: Base<B>, A1 == A2
+  associatedtype A2
+  associatedtype B
+  associatedtype C
 }

--- a/test/Generics/non_fcrs.swift
+++ b/test/Generics/non_fcrs.swift
@@ -39,39 +39,6 @@ extension P1 where Self : P2 {}
 // expected-error@-1 {{cannot build rewrite system for generic signature; rule length limit exceeded}}
 // expected-note@-2 {{failed rewrite rule is τ_0_0.[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P2] => τ_0_0.[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T]}}
 
-struct S<U : P1> : P1 {
-  typealias T = S<S<U>>
-}
-
-protocol P3Base {
-  associatedtype T : P1
-  associatedtype U : P1
-}
-
-protocol P3 : P3Base where T == S<U> {
-// expected-error@-1 {{cannot build rewrite system for protocol; rule length limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[concrete: S<S<S<S<S<S<S<S<S<S<S<S<S<S<[P3:U]>>>>>>>>>>>>>>] => [P3:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T].[P1:T]}}
-}
-
-protocol Exponential {
-// expected-error@-1 {{cannot build rewrite system for protocol; concrete type size limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is }}
-  associatedtype A where A == (A, A)
-}
-
-class Base<T> {}
-
-class Derived<T, U> : Base<(T, U)> {}
-
-protocol TooManyDifferences {
-// expected-error@-1 {{cannot build rewrite system for protocol; concrete type difference limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is }}
-  associatedtype A1 where A1: Derived<B, C>, A2: Base<B>, A1 == A2
-  associatedtype A2
-  associatedtype B
-  associatedtype C
-}
-
 protocol M0 {
 // expected-error@-1 {{cannot build rewrite system for protocol; rule length limit exceeded}}
 // expected-note@-2 {{failed rewrite rule is }}

--- a/test/Generics/rdar90402519.swift
+++ b/test/Generics/rdar90402519.swift
@@ -23,5 +23,5 @@ protocol P1 : P0 where C == G1<I> {
 }
 
 protocol P2 : P1 where C == G2<I> {}
-// expected-error@-1 {{cannot build rewrite system for protocol; concrete type difference limit exceeded}}
-// expected-note@-2 {{failed rewrite rule is [P2:I].[concrete: G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<[P2:I]>>>>>>>>>>>>>>>>>>>>>>>>>> : Escapable] => [P2:I]}}
+// expected-error@-1 {{cannot build rewrite system for protocol; concrete type nesting limit exceeded}}
+// expected-note@-2 {{failed rewrite rule is [P2:I].[concrete: G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<G<[P2:I]>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] => [P2:I]}}


### PR DESCRIPTION
I added this in https://github.com/swiftlang/swift/pull/82321, but it was too low for one project. I had a hard time reducing a test case without pulling everything in though.

Fixes rdar://154684522.