### PR TITLE
[Tests] Temporarily disable `test/Concurrency/transfernonsendable_clo…

### DIFF
--- a/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
+++ b/test/Concurrency/transfernonsendable_closureliterals_isolationinference.swift
@@ -7,6 +7,8 @@
 // REQUIRES: asserts
 // REQUIRES: swift_feature_NonisolatedNonsendingByDefault
 
+// REQUIRES: rdar154969621
+
 // This test validates the behavior of transfernonsendable around
 // closure literals
 


### PR DESCRIPTION
…sureliterals_isolationinference.swift`

We are working on a fix but need to disable the test temporarily to unblock CI.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
