### PR TITLE
Fix a lifetime dependence diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8329,7 +8329,7 @@ ERROR(lifetime_dependence_cannot_use_parsed_borrow_inout, none,
 ERROR(lifetime_dependence_duplicate_target, none,
       "invalid duplicate target lifetime dependencies on function", ())
 ERROR(lifetime_parameter_requires_inout, none,
-      "lifetime-dependent parameter must be 'inout'", (Identifier))
+      "lifetime-dependent parameter '%0' must be 'inout'", (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Lifetime Dependence Requirements

--- a/lib/AST/LifetimeDependence.cpp
+++ b/lib/AST/LifetimeDependence.cpp
@@ -880,7 +880,7 @@ protected:
       if (!targetDeclAndIndex->first->isInOut()) {
         diagnose(targetDeclAndIndex->first,
                  diag::lifetime_parameter_requires_inout,
-                 targetDescriptor->getName());
+                 targetDescriptor->getString());
       }
       targetIndex = targetDeclAndIndex->second;
     } else {

--- a/test/Sema/lifetime_attr.swift
+++ b/test/Sema/lifetime_attr.swift
@@ -91,7 +91,7 @@ do {
 
 // rdar://146401190 ([nonescapable] implement non-inout parameter dependencies)
 @_lifetime(span: borrow holder)
-func testParameterDep(holder: AnyObject, span: Span<Int>) {}  // expected-error{{lifetime-dependent parameter must be 'inout'}}
+func testParameterDep(holder: AnyObject, span: Span<Int>) {}  // expected-error{{lifetime-dependent parameter 'span' must be 'inout'}}
 
 @_lifetime(&ne)
 func inoutLifetimeDependence(_ ne: inout NE) -> NE {
@@ -113,3 +113,16 @@ func dependOnEscapable(_ k: consuming Klass) -> NE {
   NE()
 }
 
+struct Wrapper : ~Escapable {
+  var _ne: NE
+
+  var ne: NE {
+    @_lifetime(copy self)
+    get {
+      _ne
+    }
+    @_lifetime(self: &self)
+    nonmutating _modify {// expected-error{{lifetime-dependent parameter 'self' must be 'inout'}}
+    }
+  }
+}


### PR DESCRIPTION
`LifetimeDescriptor::getName()` can crash if the descriptor had a `self`. Replace with `LifetimeDescriptor::getString()`

