### PR TITLE
6.2: [Mem2Reg] Don't promote proj(unchecked_addr_cast).

### DIFF
--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -29,6 +29,24 @@ struct Pair<T, U> {
   var u: U
 }
 
+class C {}
+
+struct J {
+  var c: C
+}
+
+struct I {
+  var j: J
+}
+
+struct S1 {
+  var i: I
+}
+
+struct S2 {
+  var t: (J, J)
+}
+
 ///////////
 // Tests //
 ///////////
@@ -577,4 +595,61 @@ bb0:
   %14 = tuple (%empty : $(), %13 : $())
   dealloc_stack %11 : $*Pair<T, ()>
   return undef : $()
+}
+
+// CHECK-LABEL: sil @promo_proj_uac_1 : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'promo_proj_uac_1'
+sil @promo_proj_uac_1 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S1)
+  %addr = alloc_stack $S1
+  store %s to %addr
+  %i_addr = unchecked_addr_cast %addr to $*I
+  %j_addr = struct_element_addr %i_addr, #I.j
+  %j = load %j_addr
+  retain_value %j
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil @promo_proj_uac_2 : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'promo_proj_uac_2'
+sil @promo_proj_uac_2 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S2)
+  %addr = alloc_stack $S2
+  store %s to %addr
+  %t_addr = unchecked_addr_cast %addr to $*(J, J)
+  %j_addr = tuple_element_addr %t_addr, 0
+  %j = load %j_addr
+  retain_value %j
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil @promo_proj_uac_3 : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'promo_proj_uac_3'
+sil @promo_proj_uac_3 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S1)
+  %addr = alloc_stack $S1
+  store %s to %addr
+  %i_addr = unchecked_addr_cast %addr to $*I
+  %j_addr = unchecked_addr_cast %i_addr to $*J
+  %j = load %j_addr
+  retain_value %j
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
 }

--- a/test/SILOptimizer/mem2reg_ossa.sil
+++ b/test/SILOptimizer/mem2reg_ossa.sil
@@ -46,6 +46,22 @@ struct S {
   var field: C
 }
 
+struct J {
+  var c: C
+}
+
+struct I {
+  var j: J
+}
+
+struct S1 {
+  var i: I
+}
+
+struct S2 {
+  var t: (J, J)
+}
+
 ///////////
 // Tests //
 ///////////
@@ -760,4 +776,58 @@ entry(%instance : @owned $C):
   dealloc_stack %stack : $*C
   %retval = tuple ()
   return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @no_promo_proj_uac_1 : {{.*}} {
+// CHECK:         alloc_stack
+// CHECK-LABEL: } // end sil function 'no_promo_proj_uac_1'
+sil [ossa] @no_promo_proj_uac_1 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S1)
+  %addr = alloc_stack $S1
+  store %s to [init] %addr
+  %i_addr = unchecked_addr_cast %addr to $*I
+  %j_addr = struct_element_addr %i_addr, #I.j
+  %j = load [copy] %j_addr
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil [ossa] @no_promo_proj_uac_2 : {{.*}} {
+// CHECK:         alloc_stack
+// CHECK-LABEL: } // end sil function 'no_promo_proj_uac_2'
+sil [ossa] @no_promo_proj_uac_2 : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S2)
+  %addr = alloc_stack $S2
+  store %s to [init] %addr
+  %t_addr = unchecked_addr_cast %addr to $*(J, J)
+  %j_addr = tuple_element_addr %t_addr, 0
+  %j = load [copy] %j_addr
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
+}
+
+// CHECK-LABEL: sil [ossa] @promo_uac_uac : {{.*}} {
+// CHECK-NOT:     alloc_stack
+// CHECK-LABEL: } // end sil function 'promo_uac_uac'
+sil [ossa] @promo_uac_uac : $@convention(thin) () -> () {
+bb0:
+  %s = apply undef() : $@convention(thin) () -> (@owned S1)
+  %addr = alloc_stack $S1
+  store %s to [init] %addr
+  %i_addr = unchecked_addr_cast %addr to $*I
+  %j_addr = unchecked_addr_cast %i_addr to $*J
+  %j = load [copy] %j_addr
+  destroy_addr %addr
+  dealloc_stack %addr
+  apply undef(%j) : $@convention(thin) (@owned J) -> ()
+  %retval = tuple ()
+  return %retval
 }


### PR DESCRIPTION
**Explanation**: Bail out of an optimization to fix an ownership verifier error.

Mem2Reg rewrites uses of an address with uses of values.  It rewrites a number of instructions in order to do so.  Among the instructions it rewrites is `unchecked_addr_cast` which it rewrites as `unchecked_bitwise_cast`.  

Legal uses of `unchecked_bitwise_cast` are quite constrained under OSSA:  For the most part, it must be immediately copied.  (An exception relevant here is that it can immediately be bitcasted again.)  In particular, it is not legal to borrow the result of an `unchecked_bitwise_cast`.  In particular, it is not legal to borrow the result of an `unchecked_bitwise_cast`.  (And since the borrow itself is illegal it is also not legal to perform subsequent projections on that borrow.)

Mem2Reg also rewrites `struct_element_addr` and `tuple_element_addr` as `struct_extract` and `tuple_extract` respectively, both enclosed within a borrow scope.  When Mem2Reg sees a sequence of projections each of which it can rewrite, it rewrites the whole sequence.

Previously, the result was that a `struct_element_addr(unchecked_addr_cast(%addr))` was rewritten as a `struct_extract(begin_borrow(unchecked_bitwise_cast))`.  And that is invalid.

Here, this is fixed by considering the base of a projection (`struct_element_addr`, `tuple_element_addr`, or `unchecked_addr_cast`) and bailing out of promotion if the base is an `unchecked_addr_cast` and the projection is not.

None of this applies in ownership-lowered SIL, so promotion of addresses whose use lists include such sequences proceeds as before.
**Scope**: Affects optimized code.
**Issue**: rdar://153693915
**Original PR**: https://github.com/swiftlang/swift/pull/82784
**Risk**: Low, makes the optimization being more cautious.
**Testing**: Added tests.
**Reviewer**: Andrew Trick ( @atrick )