### PR TITLE
Parser: Reject the old string syntax for `@cdecl` and allow the experimental feature in production

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -517,7 +517,7 @@ EXPERIMENTAL_FEATURE(ClosureBodyMacro, true)
 EXPERIMENTAL_FEATURE(AllowRuntimeSymbolDeclarations, true)
 
 /// Allow use of `@cdecl`
-EXPERIMENTAL_FEATURE(CDecl, false)
+EXPERIMENTAL_FEATURE(CDecl, true)
 
 /// Allow use of `@extensible` on public enums
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ExtensibleAttribute, false)

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3009,14 +3009,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   }
 
   case DeclAttrKind::CDecl: {
-    if (!AttrName.starts_with("_") &&
-
-        // Backwards support for @cdecl("stringId"). Remove before enabling in
-        // production so we accept only the identifier format.
-        lookahead<bool>(1, [&](CancellableBacktrackingScope &) {
-           return Tok.isNot(tok::string_literal);
-        })) {
-
+    if (!AttrName.starts_with("_")) {
       std::optional<StringRef> CName;
       if (consumeIfAttributeLParen()) {
         // Custom C name.
@@ -3127,10 +3120,9 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         Attributes.add(new (Context) SILGenNameAttr(AsmName.value(), Raw, AtLoc,
                                                 AttrRange, /*Implicit=*/false));
       else if (DK == DeclAttrKind::CDecl) {
-        bool underscored = AttrName.starts_with("_");
         Attributes.add(new (Context) CDeclAttr(AsmName.value(), AtLoc,
                                                AttrRange, /*Implicit=*/false,
-                                               /*isUnderscored*/underscored));
+                                               /*isUnderscored*/true));
       } else if (DK == DeclAttrKind::Expose) {
         for (auto *EA : Attributes.getAttributes<ExposeAttr>()) {
           // A single declaration cannot have two @_exported attributes with

--- a/test/PrintAsObjC/cdecl-enum-reference.swift
+++ b/test/PrintAsObjC/cdecl-enum-reference.swift
@@ -25,13 +25,13 @@
 // REQUIRES: swift_feature_CDecl
 
 //--- CoreLib.swift
-@cdecl("CEnum")
+@cdecl(CEnum)
 public enum CEnum: CInt { case A, B }
 
 //--- MiddleLib.swift
 import CoreLib
 
-@cdecl("CFunc")
+@cdecl(CFunc)
 public func CFunc(e: CEnum) {}
 // CHECK: typedef SWIFT_ENUM_FWD_DECL(int, CEnum)
 // CHECK: SWIFT_EXTERN void CFunc(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT;

--- a/test/PrintAsObjC/cdecl-enums.swift
+++ b/test/PrintAsObjC/cdecl-enums.swift
@@ -57,7 +57,7 @@ import Foundation
 // CHECK-NEXT: }
 
 /// Foo: A feer, a female feer.
-@cdecl("FooComments") public enum FooComments: CInt {
+@cdecl(FooComments) public enum FooComments: CInt {
   /// Zim: A zeer, a female zeer.
   case Zim
   case Zang, Zung
@@ -67,7 +67,7 @@ import Foundation
 // CHECK-NEXT:   Zang = -219,
 // CHECK-NEXT:   Zung = -218,
 // CHECK-NEXT: };
-@cdecl("NegativeValues") enum NegativeValues: Int16 {
+@cdecl(NegativeValues) enum NegativeValues: Int16 {
   case Zang = -219, Zung
 
   func methodNotExportedToC() {}
@@ -77,7 +77,7 @@ import Foundation
 // CHECK-NEXT:   SomeErrorBadness = 9001,
 // CHECK-NEXT:   SomeErrorWorseness = 9002,
 // CHECK-NEXT: };
-@cdecl("SomeError") enum SomeError: Int, Error {
+@cdecl(SomeError) enum SomeError: Int, Error {
   case Badness = 9001
   case Worseness
 }
@@ -85,32 +85,32 @@ import Foundation
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, SomeOtherError, "SomeOtherError", closed) {
 // CHECK-NEXT:   SomeOtherErrorDomain = 0,
 // CHECK-NEXT: };
-@cdecl("SomeOtherError") enum SomeOtherError: Int, Error {
+@cdecl(SomeOtherError) enum SomeOtherError: Int, Error {
   case Domain
 }
 
 // CHECK-LABEL: typedef SWIFT_ENUM_NAMED(ptrdiff_t, ObjcErrorType, "SomeRenamedErrorType", closed) {
 // CHECK-NEXT:   ObjcErrorTypeBadStuff = 0,
 // CHECK-NEXT: };
-@cdecl("ObjcErrorType") enum SomeRenamedErrorType: Int, Error {
+@cdecl(ObjcErrorType) enum SomeRenamedErrorType: Int, Error {
   case BadStuff
 }
 
-@cdecl("acceptMemberImported") func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
+@cdecl(acceptMemberImported) func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptMemberImported(enum MemberRaw a, enum MemberEnum b, MemberOptions c, enum MemberTypedef d, MemberAnon e, MemberAnon2 ee) SWIFT_NOEXCEPT;
 
-@cdecl("acceptPlainEnum") func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
+@cdecl(acceptPlainEnum) func acceptPlainEnum(_: NSMalformedEnumMissingTypedef) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptPlainEnum(enum NSMalformedEnumMissingTypedef) SWIFT_NOEXCEPT;
 
-@cdecl("acceptTopLevelImported") func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
+@cdecl(acceptTopLevelImported) func acceptTopLevelImported(a: TopLevelRaw, b: TopLevelEnum, c: TopLevelOptions, d: TopLevelTypedef, e: TopLevelAnon) {}
 // CHECK-LABEL: SWIFT_EXTERN void acceptTopLevelImported(enum TopLevelRaw a, TopLevelEnum b, TopLevelOptions c, TopLevelTypedef d, TopLevelAnon e) SWIFT_NOEXCEPT;
 
-@cdecl("takeAndReturnEnumC") func takeAndReturnEnumC(_ foo: FooComments) -> NegativeValues {
+@cdecl(takeAndReturnEnumC) func takeAndReturnEnumC(_ foo: FooComments) -> NegativeValues {
   return .Zung
 }
 // CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG NegativeValues takeAndReturnEnumC(SWIFT_ENUM_TAG FooComments foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("takeAndReturnRenamedEnum") func takeAndReturnRenamedEnum(_ foo: EnumNamed) -> EnumNamed {
+@cdecl(takeAndReturnRenamedEnum) func takeAndReturnRenamedEnum(_ foo: EnumNamed) -> EnumNamed {
   return .A
 }
 // CHECK-LABEL: SWIFT_EXTERN SWIFT_ENUM_TAG ObjcEnumNamed takeAndReturnRenamedEnum(SWIFT_ENUM_TAG ObjcEnumNamed foo) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;

--- a/test/PrintAsObjC/cdecl-includes-with-objc.swift
+++ b/test/PrintAsObjC/cdecl-includes-with-objc.swift
@@ -53,11 +53,11 @@ import Foundation
 // CHECK: extern "C" {
 // CHECK: #endif
 
-@cdecl("get_int_alias")
+@cdecl(get_int_alias)
 public func getIntAlias() -> IntFromCFramework { 42 }
 // CHECK: SWIFT_EXTERN IntFromCFramework get_int_alias(void) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("imports_cgpoint")
+@cdecl(imports_cgpoint)
 public func importsCGPoint(pt: CGPoint) {  }
 // CHECK: SWIFT_EXTERN void imports_cgpoint(CGPoint pt) SWIFT_NOEXCEPT;
 

--- a/test/PrintAsObjC/cdecl-includes.swift
+++ b/test/PrintAsObjC/cdecl-includes.swift
@@ -78,16 +78,16 @@ import CModule
 // CHECK: extern "C" {
 // CHECK: #endif
 
-@cdecl("mirror_struct")
+@cdecl(mirror_struct)
 public func a_mirrorStruct(_ a: CStruct) -> CStruct { a }
 // CHECK: SWIFT_EXTERN struct CStruct mirror_struct(struct CStruct a) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("mirror_union")
+@cdecl(mirror_union)
 public func b_mirrorStruct(_ a: CUnion) -> CUnion { a }
 // CHECK: SWIFT_EXTERN union CUnion mirror_union(union CUnion a) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
 
-@cdecl("TKGetDefaultToastSetting")
+@cdecl(TKGetDefaultToastSetting)
 public func c_defaultToastSetting() -> TKTimeSetting { TKTimeSettingNormal } // It would be nice to import TKTimeSettingNormal as a member.
 // CHECK: SWIFT_EXTERN TKTimeSetting TKGetDefaultToastSetting(void) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 

--- a/test/PrintAsObjC/cdecl-official.swift
+++ b/test/PrintAsObjC/cdecl-official.swift
@@ -53,22 +53,22 @@ func a0_simple(x: Int, bar y: Int) -> Int { return x }
 func a1_defaultName(x: Int) -> Int { return x }
 // CHECK-LABEL: SWIFT_EXTERN ptrdiff_t a1_defaultName(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("primitiveTypes")
+@cdecl(primitiveTypes)
 public func b_primitiveTypes(i: Int, ci: CInt, l: CLong, c: CChar, f: Float, d: Double, b: Bool) {}
 // CHECK-LABEL: SWIFT_EXTERN void primitiveTypes(ptrdiff_t i, int ci, long l, char c, float f, double d, bool b) SWIFT_NOEXCEPT;
 
-@cdecl("has_keyword_arg_names")
+@cdecl(has_keyword_arg_names)
 func c_keywordArgNames(auto: Int, union: Int) {}
 // CHECK-LABEL: SWIFT_EXTERN void has_keyword_arg_names(ptrdiff_t auto_, ptrdiff_t union_) SWIFT_NOEXCEPT;
 
-@cdecl("return_never")
+@cdecl(return_never)
 func d_returnNever() -> Never { fatalError() }
 // CHECK-LABEL: SWIFT_EXTERN void return_never(void) SWIFT_NOEXCEPT SWIFT_NORETURN;
 
 /// Pointer types
 // CHECK: /// Pointer types
 
-@cdecl("pointers")
+@cdecl(pointers)
 func f_pointers(_ x: UnsafeMutablePointer<Int>,
                   y: UnsafePointer<Int>,
                   z: UnsafeMutableRawPointer,
@@ -76,7 +76,7 @@ func f_pointers(_ x: UnsafeMutablePointer<Int>,
                   u: OpaquePointer) {}
 // CHECK: SWIFT_EXTERN void pointers(ptrdiff_t * _Nonnull x, ptrdiff_t const * _Nonnull y, void * _Nonnull z, void const * _Nonnull w, void * _Nonnull u) SWIFT_NOEXCEPT;
 
-@cdecl("nullable_pointers")
+@cdecl(nullable_pointers)
 func g_nullablePointers(_ x: UnsafeMutableRawPointer,
                           y: UnsafeMutableRawPointer?,
                           z: UnsafeMutableRawPointer!) {}
@@ -87,23 +87,23 @@ func g_nullablePointers(_ x: UnsafeMutableRawPointer,
 @cdecl
 enum CEnum: CInt { case A, B }
 
-@cdecl("CEnumRenamed_CName")
+@cdecl(CEnumRenamed_CName)
 enum CEnumRenamed: CLong { case A, B }
 
-@cdecl("use_enum")
+@cdecl(use_enum)
 func h_useCEnum(e: CEnum) -> CEnum { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG CEnum use_enum(SWIFT_ENUM_TAG CEnum e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("use_enum_renamed")
+@cdecl(use_enum_renamed)
 func i_useCEnumLong(e: CEnumRenamed) -> CEnumRenamed { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG CEnumRenamed_CName use_enum_renamed(SWIFT_ENUM_TAG CEnumRenamed_CName e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
-@cdecl("use_enum_late")
+@cdecl(use_enum_late)
 func j_useCEnumChar(e: zCEnumDefinedLate) -> zCEnumDefinedLate { return e }
 // CHECK: SWIFT_EXTERN SWIFT_ENUM_TAG zCEnumDefinedLate use_enum_late(SWIFT_ENUM_TAG zCEnumDefinedLate e) SWIFT_NOEXCEPT SWIFT_WARN_UNUSED_RESULT;
 
 /// Declare this enum late in the source file and in alphabetical order.
-@cdecl("zCEnumDefinedLate")
+@cdecl(zCEnumDefinedLate)
 enum zCEnumDefinedLate: CChar { case A, B }
 
 // CHECK:      #if defined(__cplusplus)

--- a/test/PrintAsObjC/cdecl-with-objc.swift
+++ b/test/PrintAsObjC/cdecl-with-objc.swift
@@ -18,7 +18,7 @@
 // REQUIRES: swift_feature_CDecl
 // REQUIRES: objc_interop
 
-@cdecl("cFunc")
+@cdecl
 func cFunc() { }
 // CHECK: cFunc
 // CHECK-NOT: cFunc

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -26,83 +26,83 @@
 
 @cdecl func defaultName() {}
 
-@cdecl("noBody")
+@cdecl(noBody)
 func noBody(x: Int) -> Int // expected-error{{expected '{' in body of function}}
 
-@cdecl("property") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
+@cdecl(property) // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
 var property: Int
 
 var computed: Int {
-  @cdecl("get_computed") get { return 0 }
-  @cdecl("set_computed") set { return }
+  @cdecl(get_computed) get { return 0 }
+  @cdecl(set_computed) set { return }
 }
 
-@cdecl("inout")
+@cdecl(`inout`)
 func noBody(x: inout Int) { } // expected-error{{global function cannot be marked '@cdecl' because inout parameters cannot be represented in C}}
 
 struct SwiftStruct { var x, y: Int }
 enum SwiftEnum { case A, B }
 
 #if os(Windows) && (arch(x86_64) || arch(arm64))
-@cdecl("CEnum") enum CEnum: Int32 { case A, B }
+@cdecl(CEnum) enum CEnum: Int32 { case A, B }
 #else
-@cdecl("CEnum") enum CEnum: Int { case A, B }
+@cdecl(CEnum) enum CEnum: Int { case A, B }
 #endif
 
 @cdecl enum CEnumDefaultName: CInt { case A, B }
 
-@cdecl("CEnumNoRawType") enum CEnumNoRawType { case A, B }
+@cdecl(CEnumNoRawType) enum CEnumNoRawType { case A, B }
 // expected-error @-1 {{'@cdecl' enum must declare an integer raw type}}
 
-@cdecl("CEnumStringRawType") enum CEnumStringRawType: String { case A, B }
+@cdecl(CEnumStringRawType) enum CEnumStringRawType: String { case A, B }
 // expected-error @-1 {{'@cdecl' enum raw type 'String' is not an integer type}}
 
-@cdecl("swiftStruct")
+@cdecl
 func swiftStruct(x: SwiftStruct) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift structs cannot be represented in C}}
 
-@cdecl("swiftEnum")
+@cdecl
 func swiftEnum(x: SwiftEnum) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift enums not marked '@cdecl' cannot be represented in C}}
 
-@cdecl("cEnum")
+@cdecl(cEnum)
 func cEnum(x: CEnum) {}
 
-@cdecl("CDeclAndObjC") // expected-error {{cannot apply both '@cdecl' and '@objc' to enum}}
+@cdecl(CDeclAndObjC) // expected-error {{cannot apply both '@cdecl' and '@objc' to enum}}
 @objc
 enum CDeclAndObjC: CInt { case A, B }
 
-@cdecl("TwoCDecls") // expected-note {{attribute already specified here}}
+@cdecl(TwoCDecls) // expected-note {{attribute already specified here}}
 @_cdecl("TwoCDecls") // expected-error {{duplicate attribute}}
 func TwoCDecls() {}
 
 class Foo {
-  @cdecl("Foo_foo") // expected-error{{@cdecl can only be applied to global functions}}
+  @cdecl(Foo_foo) // expected-error{{@cdecl can only be applied to global functions}}
   func foo(x: Int) -> Int { return x }
 
-  @cdecl("Foo_foo_2") // expected-error{{@cdecl can only be applied to global functions}}
+  @cdecl(Foo_foo_2) // expected-error{{@cdecl can only be applied to global functions}}
   static func foo(x: Int) -> Int { return x }
 
-  @cdecl("Foo_init") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
+  @cdecl(Foo_init) // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
   init() {}
 
-  @cdecl("Foo_deinit") // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
+  @cdecl(Foo_deinit) // expected-error{{'@cdecl' attribute cannot be applied to this declaration}}
   deinit {}
 }
 
-@cdecl("throwing") // expected-error{{raising errors from @cdecl functions is not supported}}
+@cdecl(throwing) // expected-error{{raising errors from @cdecl functions is not supported}}
 func throwing() throws { }
 
-@cdecl("acceptedPointers")
+@cdecl(acceptedPointers)
 func acceptedPointers(_ x: UnsafeMutablePointer<Int>,
                         y: UnsafePointer<Int>,
                         z: UnsafeMutableRawPointer,
                         w: UnsafeRawPointer,
                         u: OpaquePointer) {}
 
-@cdecl("rejectedPointers")
+@cdecl(rejectedPointers)
 func rejectedPointers( // expected-error 6 {{global function cannot be marked '@cdecl' because the type of the parameter}}
     x: UnsafePointer<String>, // expected-note {{Swift structs cannot be represented in C}}
     y: CVaListPointer, // expected-note {{Swift structs cannot be represented in C}}
@@ -111,90 +111,90 @@ func rejectedPointers( // expected-error 6 {{global function cannot be marked '@
     v: UnsafeRawBufferPointer, // expected-note {{Swift structs cannot be represented in C}}
     t: UnsafeMutableRawBufferPointer) {} // expected-note {{Swift structs cannot be represented in C}}
 
-@cdecl("genericParam")
+@cdecl
 func genericParam<I>(i: I) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because it has generic parameters}}
 
-@cdecl("variadic")
+@cdecl
 func variadic(_: Int...) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because it has a variadic parameter}}
 
-@cdecl("tupleParamEmpty")
+@cdecl
 func tupleParamEmpty(a: ()) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{empty tuple type cannot be represented in C}}
 
-@cdecl("tupleParam")
+@cdecl
 func tupleParam(a: (Int, Float)) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{tuples cannot be represented in C}}
 
-@cdecl("emptyTupleReturn")
+@cdecl(emptyTupleReturn)
 func emptyTupleReturn() -> () {}
 
-@cdecl("tupleReturn")
+@cdecl(tupleReturn)
 func tupleReturn() -> (Int, Float) { (1, 2.0) }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because its result type cannot be represented in C}}
 // expected-note @-2 {{tuples cannot be represented in C}}
 
-@cdecl("funcAcceptsThrowingFunc")
+@cdecl
 func funcAcceptsThrowingFunc(fn: (String) throws -> Int) { }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{throwing function types cannot be represented in C}}
 
-@cdecl("funcAcceptsThrowingFuncReturn")
+@cdecl
 func funcAcceptsThrowingFuncReturn() -> (String) throws -> Int { fatalError() }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because its result type cannot be represented in C}}
 // expected-note @-2 {{throwing function types cannot be represented in C}}
 
-@cdecl("bar")
+@cdecl
 func bar(f: (SwiftEnum) -> SwiftStruct) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("bas")
+@cdecl
 func bas(f: (SwiftEnum) -> ()) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("zim")
+@cdecl
 func zim(f: () -> SwiftStruct) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("zang")
+@cdecl
 func zang(f: (SwiftEnum, SwiftStruct) -> ()) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("zang_zang")
+@cdecl(zang_zang)
   func zangZang(f: (Int...) -> ()) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{function types cannot be represented in C unless their parameters and returns can be}}
 
-@cdecl("array")
+@cdecl
 func array(i: [Int]) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift structs cannot be represented in C}}
 
 class SwiftClass {}
-@cdecl("swiftClass")
+@cdecl
 func swiftClass(p: SwiftClass) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{classes cannot be represented in C}}
 
 protocol SwiftProtocol {}
-@cdecl("swiftProtocol")
+@cdecl
 func swiftProtocol(p: SwiftProtocol) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
-@cdecl("swiftErrorProtocol")
+@cdecl
 func swiftErrorProtocol(e: Error) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
-@cdecl("anyParam")
+@cdecl
 func anyParam(e:Any) {}
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}

--- a/test/attr/attr_cdecl_official.swift
+++ b/test/attr/attr_cdecl_official.swift
@@ -24,6 +24,10 @@
 // expected-error @-1 {{expected ')' in 'cdecl' attribute}}
 // expected-error @-2 {{expected declaration}}
 
+@cdecl("oldStringStyle") func oldStringStyle() {}
+// expected-error @-1 {{expected C identifier in 'cdecl' attribute}}
+// expected-error @-2 {{expected declaration}}
+
 @cdecl func defaultName() {}
 
 @cdecl(noBody)

--- a/test/attr/attr_cdecl_official_async.swift
+++ b/test/attr/attr_cdecl_official_async.swift
@@ -8,10 +8,10 @@
 @_cdecl("async") // expected-error{{@_cdecl global function cannot be asynchronous}}
 func asynchronous() async { }
 
-@cdecl("async2") // expected-error{{@cdecl global function cannot be asynchronous}}
+@cdecl(async2) // expected-error{{@cdecl global function cannot be asynchronous}}
 func asynchronous2() async { }
 
-@cdecl("asyncParam")
+@cdecl(asyncParam)
 func asynchronousParam(fn: (String) async -> Int) { }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{'async' function types cannot be represented in C}}

--- a/test/attr/attr_cdecl_official_rejected.swift
+++ b/test/attr/attr_cdecl_official_rejected.swift
@@ -4,9 +4,9 @@
 
 // REQUIRES: swift_feature_CDecl
 
-@cdecl("cdecl_foo") func foo() { } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
+@cdecl(cdecl_foo) func foo() { } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
 
 var computed: Int {
-  @cdecl("get_computed") get { return 0 } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
-  @cdecl("set_computed") set { } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
+  @cdecl(get_computed) get { return 0 } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
+  @cdecl(set_computed) set { } // expected-error {{'@cdecl' requires '-enable-experimental-feature CDecl'}}
 }

--- a/test/attr/attr_cdecl_official_with_objc.swift
+++ b/test/attr/attr_cdecl_official_with_objc.swift
@@ -9,11 +9,11 @@ import Foundation
 @objc
 class ObjCClass: NSObject { }
 
-@cdecl("objcClassReturn") func objcClassReturn() -> ObjCClass { fatalError() }
+@cdecl func objcClassReturn() -> ObjCClass { fatalError() }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because its result type cannot be represented in C}}
 // expected-note @-2 {{classes cannot be represented in C}}
 
-@cdecl("objcClassParams") func objcClassParams(a: ObjCClass, b: ObjCClass) { }
+@cdecl func objcClassParams(a: ObjCClass, b: ObjCClass) { }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter 1 cannot be represented in C}}
 // expected-error @-2 {{global function cannot be marked '@cdecl' because the type of the parameter 2 cannot be represented in C}}
 // expected-note @-3 2 {{classes cannot be represented in C}}
@@ -21,18 +21,18 @@ class ObjCClass: NSObject { }
 @objc
 protocol ObjCProtocol {}
 
-@cdecl("objcProtocol") func objcProtocol(a: ObjCProtocol) { }
+@cdecl func objcProtocol(a: ObjCProtocol) { }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{protocols cannot be represented in C}}
 
 @objc
 enum ObjCEnum: Int { case A, B }
-@cdecl("objcEnumUseInCDecl") func objcEnumUseInCDecl(a: ObjCEnum) { }
+@cdecl func objcEnumUseInCDecl(a: ObjCEnum) { }
 // expected-error @-1 {{global function cannot be marked '@cdecl' because the type of the parameter cannot be represented in C}}
 // expected-note @-2 {{Swift enums not marked '@cdecl' cannot be represented in C}}
 
 /// Objective-C accepts @cdecl enums.
-@cdecl("CEnum")
+@cdecl(CEnum)
 enum CEnum: Int { case A, B }
 @_cdecl("cdeclEnumUseInObjc") func cdeclEnumUseInObjc(a: CEnum) { }
 


### PR DESCRIPTION
Allow enabling the `CDecl` experimental feature in production. And restrict the use of `@cdecl` to the new identifier syntax: either the bare `@cdecl` or `@cdecl(cName)`. The parser now rejects the old string syntax: `@cdecl(“cName”)`.