### PR TITLE
[SwiftCompilerSources] Explicitly construct `StringRef` from a litera…

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -946,7 +946,7 @@ private extension Function {
   var canInitializeGlobal: Bool {
     return isGlobalInitOnceFunction ||
            // In non -parse-as-library mode globals are initialized in the `main` function.
-           name == "main"
+           name == StringRef("main")
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ObjCBridgingOptimization.swift
@@ -342,9 +342,9 @@ func isBridgeToSwiftCall(_ value: Value) -> ApplyInst? {
          //       in Foundation.
          //
          // String._unconditionallyBridgeFromObjectiveC(_:)
-         funcName == "$sSS10FoundationE36_unconditionallyBridgeFromObjectiveCySSSo8NSStringCSgFZ" ||
+         funcName == StringRef("$sSS10FoundationE36_unconditionallyBridgeFromObjectiveCySSSo8NSStringCSgFZ") ||
          // Array._unconditionallyBridgeFromObjectiveC(_:)
-         funcName == "$sSa10FoundationE36_unconditionallyBridgeFromObjectiveCySayxGSo7NSArrayCSgFZ" else {
+         funcName == StringRef("$sSa10FoundationE36_unconditionallyBridgeFromObjectiveCySayxGSo7NSArrayCSgFZ") else {
     return nil
   }
   guard bridgingCall.arguments.count == 2,

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
@@ -123,9 +123,9 @@ private func isEmptyCOWSingleton(_ value: Value) -> Bool {
         v = (v as! UnaryInstruction).operand.value
       case let globalAddr as GlobalAddrInst:
         let name = globalAddr.global.name
-        return name == "_swiftEmptyArrayStorage" ||
-               name == "_swiftEmptyDictionarySingleton" ||
-               name == "_swiftEmptySetSingleton"
+        return name == StringRef("_swiftEmptyArrayStorage") ||
+               name == StringRef("_swiftEmptyDictionarySingleton") ||
+               name == StringRef("_swiftEmptySetSingleton")
       default:
         return false
     }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyLoad.swift
@@ -136,7 +136,7 @@ extension LoadInst : OnoneSimplifiable, SILCombineSimplifiable {
         }
       case let sea as StructElementAddrInst:
         let structType = sea.struct.type
-        if structType.nominal!.name == "_SwiftArrayBodyStorage" {
+        if structType.nominal!.name == StringRef("_SwiftArrayBodyStorage") {
           guard let fields = structType.getNominalFields(in: parentFunction) else {
             return false
           }

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
@@ -34,9 +34,9 @@ let accessDumper = FunctionPass(name: "dump-access") {
         guard let callee = apply.referencedFunction else {
           break
         }
-        if callee.name == "_isDistinct" {
+        if callee.name == StringRef("_isDistinct") {
           checkAliasInfo(forArgumentsOf: apply, expectDistinct: true)
-        } else if callee.name == "_isNotDistinct" {
+        } else if callee.name == StringRef("_isNotDistinct") {
           checkAliasInfo(forArgumentsOf: apply, expectDistinct: false)
         }
       default:


### PR DESCRIPTION
…l when passing it to `==`

There are multiple types that get imported from C++ as conforming to `ExpressibleByStringLiteral`: `StringRef` and `StaticString` among them.

This results in ambiguity when using `==` operator because overloads are structured in a way that accepts both `StringRef` and `StaticString` on both sides, so for cases like:

```swift
func test(lhs: StringRef) {
  lhs == "<<test>>"
}
```

There are multiple solutions now because `<<test>>` could be passed to both `StringRef` and `StaticString` overload.

The type-checker used to pick `==(StringRef, StringRef)` overload in this case because it has homogenous parameter types but this is no longer the case because this behavior was too aggressive and led to sub-optimal choices by completely skipping other viable overloads.

Resolves: rdar://154719565

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
