### PR TITLE
[SwiftCompilerSources] Disfavor overload of `==` that takes `StringRef`

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -110,6 +110,10 @@ public struct StringRef : CustomStringConvertible, NoReflectionChildren, Express
     }
   }
 
+  /// This overload is disfavored to make sure that it's only used for cases that don't involve literals, for that
+  /// `==(StringRef, StaticString) -> Bool` is preferred. Otherwise these overloads are
+  /// going to be ambiguous because both StringRef, StaticString conform to `ExpressibleByStringLiteral`.
+  @_disfavoredOverload
   public static func ==(lhs: StringRef, rhs: StringRef) -> Bool {
     let lhsBuffer = UnsafeBufferPointer<UInt8>(start: lhs._bridged.data, count: lhs.count)
     let rhsBuffer = UnsafeBufferPointer<UInt8>(start: rhs._bridged.data, count: rhs.count)


### PR DESCRIPTION
This overload is disfavored to make sure that it's only used for cases that don't involve literals, for that `==(StringRef, StaticString) -> Bool` is preferred. Otherwise these overloads are going to be ambiguous because both `StringRef`, `StaticString` conform to `ExpressibleByStringLiteral`.

Consider the following example:

```swift
func test(lhs: StringRef) {
  lhs == "<<test>>"
}
```

The type-checker used to pick `==(StringRef, StringRef)` overload in this case because it has homogenous parameter types but this is no longer the case because this behavior was too aggressive and led to sub-optimal choices by completely skipping other viable overloads.

Since `StaticString` already represents literals it's better to use a standard library type and reserve the `(StringRef, StringRef)` overload to when the literals are not involved.

Resolves: rdar://154719565

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
