### PR TITLE
[Build] Temporarily add -j 1 to swift-corelibs-foundation Windows build

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2576,7 +2576,8 @@ function Test-Foundation {
       -Src $SourceCache\swift-corelibs-foundation `
       -Bin "$BinaryCache\$($BuildPlatform.Triple)\FoundationTests" `
       -Platform $BuildPlatform `
-      -Configuration $FoundationTestConfiguration
+      -Configuration $FoundationTestConfiguration `
+      -j 1
   }
 }
 


### PR DESCRIPTION
We haven't been able to reproduce with `-j 1` yet. While it's slower, at least we might be able to unblock CI while we continue to investigate.