### PR TITLE
Avoid dynamic executor checks when calling synchronous non-escaping closures

### DIFF
--- a/test/Concurrency/nonisolated_synchronous_avoid_executor_check.swift
+++ b/test/Concurrency/nonisolated_synchronous_avoid_executor_check.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -module-name output -emit-silgen -swift-version 6 | swift-demangle | %FileCheck %s
+
+// REQUIRES: concurrency
+
+@MainActor
+public func isEven(_ x: Int) -> Bool {
+    x.isMultiple(of: 2)
+}
+
+// CHECK: sil [ossa] @output.mainActorFunc(xs: [Swift.Int])
+// CHECK-NOT: _checkTaskExecutor
+// CHECK: end sil function 'output.mainActorFunc(xs: [Swift.Int]) -> Swift.Int'
+@MainActor
+public func mainActorFunc(xs: [Int]) -> Int {
+    xs.count { isEven($0) }
+}


### PR DESCRIPTION
The following code:

```swift

// In Module A
public func takesNonEscapingSyncClosure(_: () -> Void) { ... }

// In Module B

@MainActor
func mainActorFunc() {}

@MainActor
func passesNonEscapingSyncClosure() {
    takesNonEscapingSyncClosure { mainActorFunc() }
}
```

Would result in a call to `_checkTaskExecutor` in the closure argument's prologue to ensure `takesNonEscapingSyncClosure` doesn't dispatch the execution onto another actor.

My assumption here is that because the parameter is:
- Not isolated
- Synchronous
- Non-escaping

we know it will be executed synchronously on the caller's actor and will statically not be executed on another actor. As such, we can avoid inserting the task executor check.

Resolves #82733