### PR TITLE
Improve LocalVariableUtils.gatherKnownLifetimeUses; dead ends

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -648,12 +648,10 @@ extension AddressOwnershipLiveRange {
 let addressOwnershipLiveRangeTest = FunctionTest("address_ownership_live_range") {
   function, arguments, context in
   let address = arguments.takeValue()
+  let begin = arguments.takeInstruction()
   print("Address: \(address)")
   print("Base: \(address.accessBase)")
-  let begin = address.definingInstructionOrTerminator ?? {
-    assert(address is FunctionArgument)
-    return function.instructions.first!
-  }()
+  print("Begin: \(begin)")
   let localReachabilityCache = LocalVariableReachabilityCache()
   guard var ownershipRange = AddressOwnershipLiveRange.compute(for: address, at: begin,
                                                                localReachabilityCache, context) else {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -975,6 +975,8 @@ extension LifetimeDependenceDefUseWalker {
       return yieldedDependence(result: localAccess.operand!)
     case .incomingArgument:
       fatalError("Incoming arguments are never reachable")
+    case .deadEnd:
+      return .continueWalk
     }
   }
 

--- a/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
+++ b/test/SILOptimizer/lifetime_dependence/scope_fixup.sil
@@ -119,6 +119,13 @@ class C {
 
 sil @C_read : $@yield_once @convention(method) (@guaranteed C) -> @yields @guaranteed Optional<NCWrapper>
 
+struct S {
+  let c: C
+}
+struct MutNE: ~Copyable & ~Escapable {}
+
+sil @getMutNE : $@convention(thin) (@inout S) -> @lifetime(borrow 0) @owned MutNE
+
 // NCContainer.wrapper._read:
 //   var wrapper: Wrapper {
 //     _read {
@@ -789,4 +796,55 @@ bb2:
   destroy_value %2
   %42 = tuple ()
   return %42
+}
+
+// rdar://154406790 (Lifetime-dependent variable 'X' escapes its scope but only if actor/class is final)
+//
+// The end_access must be extended into the unreachable block past the end_borrow.
+//
+// CHECK-LABEL: sil hidden [ossa] @testInoutAtModify : $@convention(thin) (@inout S) -> () {
+// CHECK: bb0(%0 : $*S):
+// CHECK:   [[ACCESS:%[0-9]+]] = begin_access [modify] [unknown] %0
+// CHECK:   apply %{{.*}}([[ACCESS]]) : $@convention(thin) (@inout S) -> @lifetime(borrow 0) @owned MutNE
+// CHECK:   mark_dependence [unresolved] %{{.*}} on [[ACCESS]]
+// CHECK:   [[LB:%[0-9]+]] = load_borrow
+//
+// CHECK: bb1:
+// CHECK:   end_borrow [[LB]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   return %16
+//
+// CHECK: bb2:
+// CHECK:   end_borrow [[LB]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   unreachable
+// CHECK-LABEL: } // end sil function 'testInoutAtModify'
+sil hidden [ossa] @testInoutAtModify : $@convention(thin) (@inout S) -> () {
+bb0(%0 : $*S):
+  %1 = alloc_box ${ let MutNE }, let, name "ne"
+  %2 = begin_borrow [lexical] [var_decl] %1
+  %3 = project_box %2, 0
+  %4 = begin_access [modify] [unknown] %0
+
+  %6 = function_ref @getMutNE : $@convention(thin) (@inout S) -> @lifetime(borrow 0) @owned MutNE
+  %7 = apply %6(%4) : $@convention(thin) (@inout S) -> @lifetime(borrow 0) @owned MutNE
+  %8 = mark_dependence [unresolved] %7 on %4
+  store %8 to [init] %3
+  end_access %4
+  %11 = mark_unresolved_non_copyable_value [no_consume_or_assign] %3
+  %12 = load_borrow %11
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_borrow %12
+  end_borrow %2
+  destroy_value %1
+  %15 = tuple ()
+  return %15
+
+bb2:
+  end_borrow %12
+  end_borrow %2
+  dealloc_box [dead_end] %1
+  unreachable
 }

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -274,3 +274,16 @@ func testSwitchAddr<T>(holder: inout Holder, t: T) {
   mutate(&holder) // expected-note {{conflicting access is here}}
   mutableView.modify()
 }
+
+// =============================================================================
+// Throwing
+// =============================================================================
+
+@available(Span 0.1, *)
+func mutableSpanMayThrow(_: borrowing MutableSpan<Int>) throws {}
+
+@available(Span 0.1, *)
+func testSpanMayThrow(buffer: inout [Int]) {
+  let bufferSpan = buffer.mutableSpan
+  try! mutableSpanMayThrow(bufferSpan)
+}

--- a/test/SILOptimizer/ownership_utils/address_ownership_live_range.sil
+++ b/test/SILOptimizer/ownership_utils/address_ownership_live_range.sil
@@ -1,20 +1,33 @@
-// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -test-runner \
+// RUN: -enable-experimental-feature Lifetimes \
+// RUN: %s -o /dev/null 2>&1 | %FileCheck %s
 
-sil_stage canonical
+// REQUIRES: swift_feature_Lifetimes
+
+sil_stage raw
 
 import Builtin
+import Swift
 
 class C {}
 class D {
   var object: C
 }
 
+struct S {
+  let c: C
+}
+
+struct MutNE: ~Copyable & ~Escapable {}
+
+sil @getMutNE : $@convention(thin) (@inout S) -> @lifetime(borrow 0) @owned MutNE
+
 // An address live range can be extended by a dependent value.
 //
 // CHECK-LABEL: testMarkDepAddressBase: address_ownership_live_range with: %f0
 // CHECK-NEXT: Address:   [[F0:%.*]] = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: Base: class  -   [[F0]] = ref_element_addr %0 : $D, #D.object
-// CHECK-NEXT: borrow: functionArgument(%0 = argument of bb0 : $D
+// CHECK:      borrow: functionArgument(%0 = argument of bb0 : $D
 // CHECK-NEXT: begin:      [[F0]] = ref_element_addr %0 : $D, #D.object
 // CHECK-NEXT: ends:       end_borrow %{{.*}} : $C
 // CHECK-NEXT: exits:
@@ -26,10 +39,50 @@ sil [ossa] @testMarkDepAddressBase : $@convention(thin) (@guaranteed D, @guarant
 bb0(%0 : @guaranteed $D, %1 : @guaranteed $D):
   %f0 = ref_element_addr %0 : $D, #D.object
   %f1 = ref_element_addr %1 : $D, #D.object
-  specify_test "address_ownership_live_range %f0"
+  specify_test "address_ownership_live_range %f0 %f0"
   %dependence = mark_dependence %f1 on %f0
   %load = load_borrow %dependence
   end_borrow %load
   %99 = tuple()
   return %99 : $()
+}
+
+// CHECK-LABEL: testInoutAtModify: address_ownership_live_range
+// CHECK: Address: %0 = argument of bb0 : $*S
+// CHECK: Begin:   [[ACCESS:%[0-9]+]] = begin_access [modify] [unknown] %0 : $*S
+// CHECK: local:   %0 = argument of bb0 : $*S
+// CHECK: begin:   %{{.*}} = alloc_box ${ let MutNE }, let, name "ne"
+// CHECK: ends:    unreachable
+// CHECK:          return
+// CHECK: exits:
+// CHECK: interiors:  end_access
+// CHECK-LABEL: testInoutAtModify: address_ownership_live_range
+sil hidden [ossa] @testInoutAtModify : $@convention(thin) (@inout S) -> () {
+bb0(%0 : $*S):
+  %1 = alloc_box ${ let MutNE }, let, name "ne"
+  %2 = begin_borrow [lexical] [var_decl] %1
+  %3 = project_box %2, 0
+  %4 = begin_access [modify] [unknown] %0
+  specify_test "address_ownership_live_range %0 %4"
+
+  %6 = function_ref @getMutNE : $@convention(thin) (@inout S) -> @lifetime(borrow 0) @owned MutNE
+  %7 = apply %6(%4) : $@convention(thin) (@inout S) -> @lifetime(borrow 0) @owned MutNE
+  store %7 to [init] %3
+  end_access %4
+  %10 = mark_unresolved_non_copyable_value [no_consume_or_assign] %3
+  %11 = load_borrow %10
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_borrow %11
+  end_borrow %2
+  destroy_value %1
+  %15 = tuple ()
+  return %15
+
+bb2:
+  end_borrow %11
+  end_borrow %2
+  dealloc_box [dead_end] %1
+  unreachable
 }


### PR DESCRIPTION
Add a fake use for dead-end blocks. This allows gatherKnownLifetimeUses to be
used for local liveness by considering an "unreachable" instruction to generate
liveness. This is important when liveness is used as a boundary within which
access scopes may be extended. Otherwise, we are unable to extend access scopes
into dead-end blocks.

Fixes rdar://154406790 (Lifetime-dependent variable 'X' escapes its
scope but only if actor/class is final)
