### PR TITLE
[6.2] EscapeUtils: consider that a pointer argument can escape a function call

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -640,7 +640,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
     }
 
     // Indirect arguments cannot escape the function, but loaded values from such can.
-    if !followLoads(at: path) {
+    if argOp.value.type.isAddress && !followLoads(at: path) {
       if let beginApply = apply as? BeginApplyInst {
         // begin_apply can yield an address value.
         if !indirectResultEscapes(of: beginApply, path: path) {

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -956,3 +956,21 @@ bb0(%0 : $Int):
   %9 = tuple ()
   return %9 : $()
 }
+
+// CHECK-LABEL: Address escape information for escaping_pointer_through_function:
+// CHECK:       value:  %1 = alloc_stack $Int
+// CHECK-NEXT:    ==>   %4 = apply undef(%3) : $@convention(thin) (Builtin.RawPointer) -> UnsafeMutableRawBufferPointer
+// CHECK-NEXT:    ==>   %5 = apply undef(%4) : $@convention(thin) (UnsafeMutableRawBufferPointer) -> ()
+// CHECK-NEXT:  End function escaping_pointer_through_function
+sil [ossa] @escaping_pointer_through_function : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  %1 = alloc_stack $Int
+  fix_lifetime %1
+  %3 = address_to_pointer %1 to $Builtin.RawPointer
+  %4 = apply undef(%3) : $@convention(thin) (Builtin.RawPointer) -> UnsafeMutableRawBufferPointer
+  %5 = apply undef(%4) : $@convention(thin) (UnsafeMutableRawBufferPointer) -> ()
+  dealloc_stack %1
+  %7 = tuple ()
+  return %7
+}
+

--- a/test/SILOptimizer/redundant_load_elim_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_ossa.sil
@@ -1761,3 +1761,25 @@ bb0(%0 : $Int):
   dealloc_stack %3
   return %6
 }
+
+sil @forwardPtr : $@convention(thin) (Builtin.RawPointer) -> UnsafeMutableRawBufferPointer {
+[global: read]
+}
+
+// CHECK-LABEL: sil [ossa] @escaping_pointer_through_function :
+// CHECK:         [[LD:%.*]] = load [trivial] %1
+// CHECK:         return [[LD]]
+// CHECK-LABEL: } // end sil function 'escaping_pointer_through_function'
+sil [ossa] @escaping_pointer_through_function : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = alloc_stack $Int
+  store %0 to [trivial] %1
+  %3 = address_to_pointer %1 to $Builtin.RawPointer
+  %4 = function_ref @forwardPtr : $@convention(thin) (Builtin.RawPointer) -> UnsafeMutableRawBufferPointer
+  %5 = apply %4(%3) : $@convention(thin) (Builtin.RawPointer) -> UnsafeMutableRawBufferPointer
+  %6 = apply undef(%5) : $@convention(thin) (UnsafeMutableRawBufferPointer) -> ()
+  %7 = load [trivial] %1
+  dealloc_stack %1
+  return %7
+}
+


### PR DESCRIPTION
* **Explanation**: Fixes a mis-compile, caused by wrong escape-analysis results for unsafe pointers passed to a function and escaping that function.
* **Risk**: Low. It's a simple fix which makes the escape-analysis more conservative.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://154124497
* **Reviewer**:  @nate-chandler, @meg-gupta
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/82762
