### PR TITLE
[6.2] MandatoryPerformanceOptimizations: don't specialize vtables for thin class metatype instructions

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -122,7 +122,8 @@ private func optimize(function: Function, _ context: FunctionPassContext, _ modu
           }
         }
       case let metatype as MetatypeInst:
-        if context.options.enableEmbeddedSwift {
+        if context.options.enableEmbeddedSwift,
+           metatype.type.representationOfMetatype == .thick {
           let instanceType = metatype.type.loweredInstanceTypeOfMetatype(in: function)
           if instanceType.isClass {
             specializeVTable(forClassType: instanceType, errorLocation: metatype.location, moduleContext) {

--- a/test/embedded/cxx-import-reference.swift
+++ b/test/embedded/cxx-import-reference.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -I %t %t/Main.swift -enable-experimental-feature Embedded -cxx-interoperability-mode=default -c -o %t/a.o -Rmodule-loading
+
+// REQUIRES: swift_feature_Embedded
+
+// BEGIN header.h
+
+class C;
+
+void retainC(C * _Nonnull obj);
+void releaseC(C * _Nonnull obj);
+
+class C {
+public:
+  C(const C &) = delete;
+  C() {};
+  
+  virtual void foo();
+
+  static C * _Nonnull create () __attribute__((swift_attr("returns_retained")));
+}
+__attribute__((swift_attr("import_reference")))
+__attribute__((swift_attr("retain:retainC")))
+__attribute__((swift_attr("release:releaseC")));
+
+// BEGIN module.modulemap
+
+module MyModule {
+  header "header.h"
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+public func test()
+{
+  let c =  C.create()
+  c.foo()
+}


### PR DESCRIPTION
* **Explanation**: Fixes a wrong compiler error for imported C++ classes with custom reference counting.
* **Risk**: Low. It's a simple fix which only affects embedded swift.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://154947835
* **Reviewer**:  @kubamracek
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/82766
