### PR TITLE
[6.2] [Completion] Map failable initializer result type into context

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -901,7 +901,7 @@ static void addKeywordsAfterReturn(CodeCompletionResultSink &Sink, DeclContext *
       // Note that `TypeContext` must stay alive for the duration of
       // `~CodeCodeCompletionResultBuilder()`.
       ExpectedTypeContext TypeContext;
-      TypeContext.setPossibleTypes({resultType});
+      TypeContext.setPossibleTypes({DC->mapTypeIntoContext(resultType)});
 
       CodeCompletionResultBuilder Builder(Sink, CodeCompletionResultKind::Literal,
                                           SemanticContextKind::None);

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -377,6 +377,11 @@ struct InInit {
   init?() { #^IN_INIT_1?check=KW_DECL_STMT;check=KW_RETURN;check=KW_NO_IN^# }
 }
 
+struct InGenericTypeInit<T> {
+  init?() { return #^IN_INIT_2?check=KW_FAILABLE_INIT_NIL^# }
+  // KW_FAILABLE_INIT_NIL: Literal[Nil]/None: nil[#InGenericTypeInit<T>?#]; name=nil
+}
+
 struct InStruct {
   #^IN_NOMINAL_DECL_1?check=KW_DECL_TYPECONTEXT;check=KW_NO_INOUT^#
 }

--- a/validation-test/IDE/crashers_fixed/7068664dc48e3152.swift
+++ b/validation-test/IDE/crashers_fixed/7068664dc48e3152.swift
@@ -1,0 +1,3 @@
+// {"kind":"complete","signature":"swift::ide::CodeCompletionResultType::calculateTypeRelation(swift::ide::ExpectedTypeContext const*, swift::DeclContext const*, swift::ide::USRBasedTypeContext const*) const"}
+// RUN: %target-swift-ide-test -code-completion --code-completion-token=COMPLETE -source-filename %s
+class a<b { init ? { #^COMPLETE^#


### PR DESCRIPTION
*6.2 cherry-pick of #82802*

- Explanation: Fixes a crash that could occur when doing code completion at the top-level or in a return within a failable initializer
- Scope: Affects code completion
- Issue: rdar://155038769
- Risk: Low, only affects completion, and the fix is straightforward
- Testing: Added tests to test suite
- Reviewer: Ben Barham