### PR TITLE
lit.cfg: fix test subset error message

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -994,7 +994,7 @@ elif swift_test_subset == 'only_stress':
     config.limit_to_features.add("stress_test")
     config.limit_to_features.discard("executable_test")
 else:
-    lit_config.fatal("Unknown test mode %r" % swift_test_subset)
+    lit_config.fatal("Unknown test subset %r" % swift_test_subset)
 
 if 'swift_evolve' in lit_config.params:
     config.available_features.add("swift_evolve")


### PR DESCRIPTION
Currently when test subset is not specified, `lit.cfg` provides an error message that refers to test modes instead of tests subsets. Making error messages distinct makes it easier to backtrack in lit.cfg source code when diagnosing the root cause.
