### PR TITLE
[6.2] LetPropertyLowering: remove redundant phis after ssa-update

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
@@ -122,6 +122,8 @@ private func insertEndInitInstructions(
       use.set(to: ssaUpdater.getValue(atEndOf: use.instruction.parentBlock), context)
     }
   }
+  // This peephole optimization is required to avoid ownership errors.
+  replacePhisWithIncomingValues(phis: ssaUpdater.insertedPhis, context)
 }
 
 private func constructLetInitRegion(

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/SSAUpdater.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/SSAUpdater.swift
@@ -50,4 +50,14 @@ struct SSAUpdater<Context: MutatingContext> {
     context.notifyInstructionsChanged()
     return context._bridged.SSAUpdater_getValueInMiddleOfBlock(block.bridged).value
   }
+
+  var insertedPhis: [Phi] {
+    var phis = [Phi]()
+    let numPhis = context._bridged.SSAUpdater_getNumInsertedPhis()
+    phis.reserveCapacity(numPhis)
+    for idx in 0..<numPhis {
+      phis.append(Phi(context._bridged.SSAUpdater_getInsertedPhi(idx).value)!)
+    }
+    return phis
+  }
 }

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -367,6 +367,8 @@ struct BridgedPassContext {
   BRIDGED_INLINE void SSAUpdater_addAvailableValue(BridgedBasicBlock block, BridgedValue value) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue SSAUpdater_getValueAtEndOfBlock(BridgedBasicBlock block) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue SSAUpdater_getValueInMiddleOfBlock(BridgedBasicBlock block) const;
+  BRIDGED_INLINE SwiftInt SSAUpdater_getNumInsertedPhis() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue SSAUpdater_getInsertedPhi(SwiftInt idx) const;
 
   // Options
 

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -548,6 +548,14 @@ BridgedValue BridgedPassContext::SSAUpdater_getValueInMiddleOfBlock(BridgedBasic
       invocation->getSSAUpdater()->getValueInMiddleOfBlock(block.unbridged())};
 }
 
+SwiftInt BridgedPassContext::SSAUpdater_getNumInsertedPhis() const {
+  return (SwiftInt)invocation->getInsertedPhisBySSAUpdater().size();
+}
+
+BridgedValue BridgedPassContext::SSAUpdater_getInsertedPhi(SwiftInt idx) const {
+  return {invocation->getInsertedPhisBySSAUpdater()[idx]};
+}
+
 bool BridgedPassContext::enableStackProtection() const {
   swift::SILModule *mod = invocation->getPassManager()->getModule();
   return mod->getOptions().EnableStackProtection;

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -75,6 +75,7 @@ class SwiftPassInvocation {
   SILModule::SlabList allocatedSlabs;
 
   SILSSAUpdater *ssaUpdater = nullptr;
+  SmallVector<SILPhiArgument *, 4> insertedPhisBySSAUpdater;
 
   SwiftPassInvocation *nestedSwiftPassInvocation = nullptr;
 
@@ -178,8 +179,9 @@ public:
 
   void initializeSSAUpdater(SILFunction *fn, SILType type,
                             ValueOwnershipKind ownership) {
+    insertedPhisBySSAUpdater.clear();
     if (!ssaUpdater)
-      ssaUpdater = new SILSSAUpdater;
+      ssaUpdater = new SILSSAUpdater(&insertedPhisBySSAUpdater);
     ssaUpdater->initialize(fn, type, ownership);
   }
 
@@ -187,6 +189,8 @@ public:
     assert(ssaUpdater && "SSAUpdater not initialized");
     return ssaUpdater;
   }
+
+  ArrayRef<SILPhiArgument *> getInsertedPhisBySSAUpdater() { return insertedPhisBySSAUpdater; }
 
   SwiftPassInvocation *initializeNestedSwiftPassInvocation(SILFunction *newFunction) {
     assert(!nestedSwiftPassInvocation && "Nested Swift pass invocation already initialized");

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1562,6 +1562,7 @@ irgen::IRGenModule *SwiftPassInvocation::getIRGenModule() {
 }
 
 void SwiftPassInvocation::endPass() {
+  insertedPhisBySSAUpdater.clear();
   assert(allocatedSlabs.empty() && "StackList is leaking slabs");
   assert(numBlockSetsAllocated == 0 && "Not all BasicBlockSets deallocated");
   assert(numNodeSetsAllocated == 0 && "Not all NodeSets deallocated");

--- a/test/SILOptimizer/let-property-lowering.sil
+++ b/test/SILOptimizer/let-property-lowering.sil
@@ -311,3 +311,34 @@ bb1(%3a : @reborrow $C):
   return %2 : $C
 }
 
+
+// CHECK-LABEL: sil [ossa] @test_no_phis :
+// CHECK:         %3 = end_init_let_ref %2
+// CHECK:         return %3
+// CHECK:       } // end sil function 'test_no_phis'
+sil [ossa] @test_no_phis : $@convention(thin) (Int, @owned C) -> @owned C {
+bb0(%0 : $Int, %1 : @owned $C):
+  %2 = mark_uninitialized [rootself] %1
+  %3 = begin_borrow %2
+  cond_br undef, bb1, bb2
+bb1:
+  br bb7
+bb2:
+  cond_br undef, bb3, bb8
+bb3:
+  cond_br undef, bb4, bb5
+bb4:
+  br bb7
+bb5:
+  br bb6
+bb6:
+  end_borrow %3
+  return %2
+bb7:
+  br bb6
+bb8:
+  end_borrow %3
+  destroy_value [dead_end] %2
+  unreachable
+}
+


### PR DESCRIPTION
* **Explanation**: Fixes a SIL ownership verifier error. This fixes an old bug, which is now surfaced because we do ownership verification also in a non-assert compiler. The fix is to run a peephole transformation in the LetPropertyLowering  pass, as we do in LoopRotate, where we had the same problem.
* **Risk**: Low. It's a simple fix which runs a peephole transformation which already runs (and is tested in) LoopRotate.
* **Testing**: Tested by lit tests.
* **Issue**: rdar://153229472
* **Reviewer**:  @nate-chandler 
* **Main branch PR**:  https://github.com/swiftlang/swift/pull/82798
