### PR TITLE
[cxx-interop] Test `std::optional` with AddressableParameters

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -1,9 +1,11 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=swift-5.9)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -enable-experimental-feature AddressableParameters)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 //
 // REQUIRES: executable_test
+// REQUIRES: swift_feature_AddressableParameters
 
 // Undefined hidden symbol to C++ voidify in libcxx
 // rdar://121551667
@@ -62,10 +64,18 @@ StdOptionalTestSuite.test("std::optional init(_:Wrapped)") {
 
   // FIXME: making these variables immutable triggers a miscompile on Linux
   // (https://github.com/swiftlang/swift/issues/82765)
-  var optBoolT = StdOptionalBool(true)
-  var optBoolF = StdOptionalBool(false)
+  var optBoolTMutable = StdOptionalBool(true)
+  var optBoolFMutable = StdOptionalBool(false)
+  expectTrue(optBoolTMutable.pointee)
+  expectFalse(optBoolFMutable.pointee)
+
+  // If AddressableParameters are enabled, this issue does not happen.
+#if hasFeature(AddressableParameters)
+  let optBoolT = StdOptionalBool(true)
+  let optBoolF = StdOptionalBool(false)
   expectTrue(optBoolT.pointee)
   expectFalse(optBoolF.pointee)
+#endif
 
   let optString = StdOptionalString(std.string("abc"))
   expectEqual(std.string("abc"), optString.pointee)


### PR DESCRIPTION
Please see each commit for details.

This relies on https://github.com/swiftlang/swift/pull/82879.