### PR TITLE
[SE-0470] Extend region analysis to account for isolated conformances

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8681,6 +8681,9 @@ GROUPED_ERROR(isolated_conformance_wrong_domain,IsolatedConformances,none,
 GROUPED_WARNING(isolated_conformance_will_become_nonisolated,IsolatedConformances,none,
       "conformance of %0 to %1 should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'",
       (const ValueDecl *, const ValueDecl *))
+GROUPED_WARNING(isolated_conformance_to_sendable_metatype,IsolatedConformances,none,
+    "%0 conformance of %1 to SendableMetatype-inheriting %kind2 can never "
+    "be used with generic code", (ActorIsolation, Type, const ValueDecl *))
 
 //===----------------------------------------------------------------------===//
 // MARK: @_inheritActorContext

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -8280,6 +8280,10 @@ RawConformanceIsolationRequest::evaluate(
   if (conformance->getOptions().contains(ProtocolConformanceFlags::Nonisolated))
     return ActorIsolation::forNonisolated(false);
 
+  auto dc = conformance->getDeclContext();
+  ASTContext &ctx = dc->getASTContext();
+  auto proto = conformance->getProtocol();
+
   // If there is an explicitly-specified global actor on the isolation,
   // resolve it and report it.
   if (auto globalActorTypeExpr = conformance->getExplicitGlobalActorIsolation()) {
@@ -8299,15 +8303,26 @@ RawConformanceIsolationRequest::evaluate(
       globalActorTypeExpr->setType(MetatypeType::get(globalActorType));
     }
 
+    // Isolated conformance to a SendableMetatype-inheriting protocol can
+    // never be used generically. Warn about it.
+    if (auto sendableMetatype =
+            ctx.getProtocol(KnownProtocolKind::SendableMetatype)) {
+      if (proto->inheritsFrom(sendableMetatype) &&
+          !getActorIsolation(proto).preconcurrency()) {
+        ctx.Diags.diagnose(
+            conformance->getLoc(),
+            diag::isolated_conformance_to_sendable_metatype,
+            ActorIsolation::forGlobalActor(globalActorType),
+            conformance->getType(),
+            proto);
+      }
+    }
+
     // FIXME: Make sure the type actually is a global actor type, map it into
     // context, etc.
 
     return ActorIsolation::forGlobalActor(globalActorType);
   }
-
-  auto dc = conformance->getDeclContext();
-  ASTContext &ctx = dc->getASTContext();
-  auto proto = conformance->getProtocol();
 
   // If the protocol itself is isolated, don't infer isolation for the
   // conformance.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3488,6 +3488,13 @@ namespace {
             getDeclContext(), RefineConformances{*this});
       }
 
+      if (auto *collectionExpr = dyn_cast<CollectionExpr>(expr)) {
+        checkIsolatedConformancesInContext(
+            collectionExpr->getInitializer(),
+            collectionExpr->getLoc(),
+            getDeclContext(), RefineConformances{*this});
+      }
+
       return Action::Continue(expr);
     }
 

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -147,6 +147,15 @@ struct PSendableS: @MainActor PSendable { // expected-note{{requirement specifie
   func f() { }
 }
 
+protocol R: SendableMetatype {
+  func f()
+}
+
+// expected-warning@+1{{main actor-isolated conformance of 'RSendableSMainActor' to SendableMetatype-inheriting protocol 'R' can never be used with generic code}}
+@MainActor struct RSendableSMainActor: @MainActor R {
+  func f() { }
+}
+
 // ----------------------------------------------------------------------------
 // Use checking of isolated conformances.
 // ----------------------------------------------------------------------------

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -235,3 +235,12 @@ func testIsolatedConformancesOnAssociatedTypes(hc: HoldsC, c: C) {
   // associated type.
   HoldsC.acceptSendableAliased(C.self)
 }
+
+
+struct MyHashable: @MainActor Hashable {
+  var counter = 0
+}
+
+@concurrent func testMyHashableSet() async {
+  let _: Set<MyHashable> = [] // expected-warning{{main actor-isolated conformance of 'MyHashable' to 'Hashable' cannot be used in nonisolated context}}
+}

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -192,9 +192,9 @@ bb0:
   // expected-warning @-1 {{}}
   // expected-note @-2 {{}}
 
-  %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P
+  %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P // expected-note {{access can happen concurrently}}
   %f2 = function_ref @useP : $@convention(thin) (@in_guaranteed P) -> ()
-  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> () // expected-note {{access can happen concurrently}}
+  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> ()
   destroy_value %i : $P
 
   %9999 = tuple ()


### PR DESCRIPTION
When a conformance becomes part of a value, and that conformance could
potentially be isolated, the value cannot leave that particular
isolation domain. For example, if we perform a runtime lookup for a
conformance to P as part of a dynamic cast `as? any P`, the
conformance to P used in the cast could be isolated. Therefore, it is
not safe to transfer the resulting value to another concurrency domain.

Model this in region analysis by considering whether instructions that
add conformances could end up introducing isolated conformances. In
such cases, merge the regions with either the isolation of the
conformance itself (if known) or with the region of the task (making
them task-isolated). This prevents such values from being sent.

Note that `@concurrent` functions, which never dynamically execute on
an actor, cannot pick up isolated conformances.

Fixes issue https://github.com/swiftlang/swift/issues/82550 / rdar://154437489