### PR TITLE
[Runtime] Don't fail conformances when the global actor hook is missing

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1474,8 +1474,9 @@ static bool swift_isInConformanceExecutionContextImpl(
     return true;
 
   if (context->globalActorIsolationType) {
+    // If the hook is not installed, assume we're on the right actor.
     if (!_swift_task_isCurrentGlobalActorHook)
-      return false;
+      return true;
 
     // Check whether we are running on this global actor.
     if (!_swift_task_isCurrentGlobalActorHook(


### PR DESCRIPTION
When the concurrency library's "is current global actor" hook is not available, assume that we are already executing on the right global actor. This mimics the behavior of earlier standard libraries when faced with an isolated conformance, as well as dealing with odd configurations where the code might not load the concurrency library yet

At the moment, WebAssembly ends up in this configuration because we don't run the initialization for the concurrency library. That makes this also a workaround for issue #82682 / rdar://154762027.
