### PR TITLE
[6.2] [Runtime] Don't fail conformances when the global actor hook is missing

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -1474,8 +1474,9 @@ static bool swift_isInConformanceExecutionContextImpl(
     return true;
 
   if (context->globalActorIsolationType) {
+    // If the hook is not installed, assume we're on the right actor.
     if (!_swift_task_isCurrentGlobalActorHook)
-      return false;
+      return true;
 
     // Check whether we are running on this global actor.
     if (!_swift_task_isCurrentGlobalActorHook(


### PR DESCRIPTION
- **Explanation**: When the concurrency library's "is current global actor" hook is not available, assume that we are already executing on the right global actor. This fixes dynamic runtime conformance checking for WebAssembly with isolated conformances.
- **Scope**: Very narrow. Limited to isolated conformances in a rare configuration only currently experienced by WebAssembly.
- **Issues**: #82682 / rdar://154762027
- **Original PRs**: https://github.com/swiftlang/swift/pull/82815
- **Risk**: Very low. This code path is also never exercised, and has changed to match what earlier runtime implementations did.
- **Testing**: CI
- **Reviewers**: @ktoso 
