### PR TITLE
[cxx-interop] Allow creating Dictionary from `std::map`

### DIFF
--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -253,3 +253,18 @@ extension CxxDictionary {
     return result
   }
 }
+
+extension Dictionary {
+  @inlinable
+  public init(_ dictionary: some CxxDictionary<Key, Value>) {
+    self.init()
+
+    var it = dictionary.__beginUnsafe()
+    let endIterator = dictionary.__endUnsafe()
+    while it != endIterator {
+      self[it.pointee.first] = it.pointee.second
+      it = it.successor()
+    }
+    withExtendedLifetime(dictionary) {}
+  }
+}

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -132,6 +132,39 @@ StdMapTestSuite.test("UnorderedMap.init(grouping:by:)") {
   expectEqual(m[3]?.size(), 6)
 }
 
+StdMapTestSuite.test("Dictionary<CInt, CInt>.init(_: Map)") {
+  let cxxMap0 = Map()
+  let swiftMap0 = Dictionary<CInt, CInt>(cxxMap0)
+  expectTrue(swiftMap0.isEmpty)
+
+  let cxxMap1 = initMap()
+  let swiftMap1 = Dictionary<CInt, CInt>(cxxMap1)
+  expectEqual(swiftMap1, [1 : 3, 2 : 2, 3 : 3])
+}
+
+StdMapTestSuite.test("Dictionary<CInt, CInt>.init(_: UnorderedMap)") {
+  let cxxMap0 = UnorderedMap()
+  let swiftMap0 = Dictionary<CInt, CInt>(cxxMap0)
+  expectTrue(swiftMap0.isEmpty)
+
+  let cxxMap1 = initUnorderedMap()
+  let swiftMap1 = Dictionary<CInt, CInt>(cxxMap1)
+  expectEqual(swiftMap1, [1 : 3, 2 : 2, 3 : 3])
+}
+
+StdMapTestSuite.test("Dictionary<std.string, std.string>.init(_: MapStrings)") {
+  let cxxMap0 = MapStrings()
+  let swiftMap0 = Dictionary<std.string, std.string>(cxxMap0)
+  expectTrue(swiftMap0.isEmpty)
+
+  var cxxMap1 = MapStrings()
+  cxxMap1[std.string("abc")] = std.string("def")
+  cxxMap1[std.string("890")] = std.string("3210")
+  let swiftMap1 = Dictionary<std.string, std.string>(cxxMap1)
+  expectEqual(swiftMap1, [std.string("abc") : std.string("def"),
+                          std.string("890") : std.string("3210")])
+}
+
 StdMapTestSuite.test("Map.subscript") {
   // This relies on the `std::map` conformance to `CxxDictionary` protocol.
   var m = initMap()


### PR DESCRIPTION
This adds an initializer to `Swift.Dictionary` that takes an instance of `std::map` or `std::unordered_map`.

rdar://155050682

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
