### PR TITLE
[stdlib] Fix: Correct typo in _adHocPrint_unlocked comment

### DIFF
--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -304,7 +304,7 @@ internal func _adHocPrint_unlocked<T, TargetStream: TextOutputStream>(
     isDebugPrint: Bool
 ) {
   func printTypeName(_ type: Any.Type) {
-    // Print type names without qualification, unless we're debugPrint'ing.
+    // Print type names without qualification, unless we're debugPrinting.
     target.write(_typeName(type, qualified: isDebugPrint))
   }
 


### PR DESCRIPTION
Corrected a minor typo from 'debugPrint'ing' to 'debugPrinting' in the comment for the `printTypeName` nested function within `_adHocPrint_unlocked` in `swift/stdlib/public/core/OutputStream.swift`.