### PR TITLE
[6.2] Fix LifetimeDependenceDiagnostics: allow inout assignment to Void.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -110,6 +110,20 @@ private func analyze(dependence: LifetimeDependence, _ context: FunctionPassCont
     }
   }
 
+  // Check for immortal dependence.
+  switch dependence.scope {
+  case .global:
+    log("Immortal global dependence.")
+    return true
+  case let .unknown(value):
+    if value.type.isVoid {
+      log("Immortal void dependence.")
+      return true
+    }
+  default:
+    break
+  }
+
   // Compute this dependence scope.
   var range = dependence.computeRange(context)
   defer { range?.deinitialize() }
@@ -200,6 +214,9 @@ private struct DiagnoseDependence {
       return .continueWalk
     }
     // Check for immortal lifetime.
+    //
+    // FIXME: remove this immortal check. It should be redundant with the earlier check that bypasses dependence
+    // diagnostics.
     switch dependence.scope {
     case .global:
       return .continueWalk

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -287,3 +287,13 @@ func testSpanMayThrow(buffer: inout [Int]) {
   let bufferSpan = buffer.mutableSpan
   try! mutableSpanMayThrow(bufferSpan)
 }
+
+// =============================================================================
+// inout
+// =============================================================================
+
+@available(Span 0.1, *)
+func inoutToImmortal(_ s: inout RawSpan) {
+  let tmp = RawSpan(_unsafeBytes: UnsafeRawBufferPointer(start: nil, count: 0))
+  s = _overrideLifetime(tmp, borrowing: ())
+}


### PR DESCRIPTION
Bypess lifetime dependence diagnostics completely for immortal values. We did
not do this initially because we wanted to potentially consider a value with a missing
dependency to mean that it could not escape the current function. But now we use
`Void` as a stand-in for immortal values.

This is needed for reassigning a Span/MutableSpan to an empty, immortal
Span:

    func inoutToImmortal(_ s: inout RawSpan) {
      let tmp = RawSpan(_unsafeBytes: UnsafeRawBufferPointer(start: nil, count: 0))
      s = _overrideLifetime(tmp, borrowing: ())
    }

Fixes rdar://152572002 ([GH:#81976] Cannot reinitialize inout parameter of type
`MutableSpan<T>?`)

(cherry picked from commit ac94d7df1d99bdf83bee152185822410d6a9a442)

--- CCC ---

Explanation: Fix lifetime diagnostics to allow assigning an immortal value to an inout parameter.

Scope: This only affects adopters of experimental but supported @_lifetime syntax. The following example would incorrectly report a lifetime error:

    func inoutToImmortal(_ s: inout RawSpan) {
      let tmp = RawSpan(_unsafeBytes: UnsafeRawBufferPointer(start: nil, count: 0))
      s = _overrideLifetime(tmp, borrowing: ())
    }

Radar/SR Issue: rdar://152572002 ([GH:#81976] Cannot reinitialize inout parameter of type `MutableSpan<T>?`)

main PR: https://github.com/swiftlang/swift/pull/82831

Risk: Low. No new logic is introduced. The existing check for immortal values is moved earlier to handle inout parameters as well as return value. The risk is that diagnostics are less restrictive.

Testing: Added source-level unit test.

Reviewer: TBD

