### PR TITLE
[IDE] Make sure to clear cached CI when `CachedCIShouldBeInvalidated`

### DIFF
--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -213,8 +213,10 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
 
   // Check the invalidation first. Otherwise, in case no 'CacheCI' exists yet,
   // the flag will remain 'true' even after 'CachedCI' is populated.
-  if (CachedCIShouldBeInvalidated.exchange(false))
+  if (CachedCIShouldBeInvalidated.exchange(false)) {
+    CachedCI = nullptr;
     return false;
+  }
   if (!CachedCI)
     return false;
   if (CachedReuseCount >= Opts.MaxASTReuseCount)


### PR DESCRIPTION
`performNewOperation` may not set a new compiler instance if e.g it ends up being cancelled, so we need to make sure we reset the cached compiler instance to ensure future requests don't attempt to re-use it. Noticed by inspection.