### PR TITLE
WasmKit: allow building with the host toolchain

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmkit.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmkit.py
@@ -74,8 +74,11 @@ class WasmKit(product.Product):
 
 
 def run_swift_build(host_target, product, swiftpm_package_product_name, set_installation_rpath=False):
-    # Building with the freshly-built SwiftPM
-    swift_build = os.path.join(product.install_toolchain_path(host_target), "bin", "swift-build")
+    if product.args.build_runtime_with_host_compiler:
+      swift_build = product.toolchain.swift_build
+    else:
+      # Building with the freshly-built SwiftPM
+      swift_build = os.path.join(product.install_toolchain_path(host_target), "bin", "swift-build")
 
     if host_target.startswith('macos'):
         # Universal binary on macOS

--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -70,6 +70,7 @@ else:
     _register("ar", "ar")
 _register("sccache", "sccache")
 _register("swiftc", "swiftc")
+_register("swift_build", "swift-build")
 
 
 class Darwin(Toolchain):


### PR DESCRIPTION
For small local incremental builds that require WasmKit it's faster to build WasmKit with the host toolchain instead of waiting for a full bootstrap build to complete.