### PR TITLE
[FreeBSD] Add unsafe labels for strict memory safety

### DIFF
--- a/stdlib/public/Synchronization/Mutex/FreeBSDImpl.swift
+++ b/stdlib/public/Synchronization/Mutex/FreeBSDImpl.swift
@@ -30,20 +30,20 @@ public struct _MutexHandle: ~Copyable {
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _lock() {
-    _umtx_op(value._address, UMTX_OP_MUTEX_LOCK, 0, nil, nil)
+    unsafe _umtx_op(unsafe value._address, UMTX_OP_MUTEX_LOCK, 0, nil, nil)
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _tryLock() -> Bool {
-    _umtx_op(value._address, UMTX_OP_MUTEX_TRYLOCK, 0, nil, nil) != -1
+    unsafe _umtx_op(unsafe value._address, UMTX_OP_MUTEX_TRYLOCK, 0, nil, nil) != -1
   }
 
   @available(SwiftStdlib 6.0, *)
   @_alwaysEmitIntoClient
   @_transparent
   internal borrowing func _unlock() {
-    _umtx_op(value._address, UMTX_OP_MUTEX_UNLOCK, 0, nil, nil)
+    unsafe _umtx_op(unsafe value._address, UMTX_OP_MUTEX_UNLOCK, 0, nil, nil)
   }
 }


### PR DESCRIPTION
This Swift standard library builds with strict memory safety on, which means that the compiler issues a warning whenever unsafe C capabilities such as raw pointers are used. To silence the warning the 'unsafe' annotation must be used to acknowledge the lack of safety.

This annotation should be added to the FreeBSD implementation of the Mutex type in the Synchronization module.