### PR TITLE
[6.2] Diagnose isolated conformance to SendableMetatype-inheriting protocol

### DIFF
--- a/include/swift/AST/Concurrency.h
+++ b/include/swift/AST/Concurrency.h
@@ -19,6 +19,11 @@
 
 namespace swift {
 
+/// Find the imported module that treats the given nominal type as "preconcurrency", or return `nullptr`
+/// if there is no such module.
+ModuleDecl *moduleImportForPreconcurrency(NominalTypeDecl *nominal,
+                                          const DeclContext *fromDC);
+
 /// Determinate the appropriate diagnostic behavior to used when emitting
 /// concurrency diagnostics when referencing the given nominal type from the
 /// given declaration context.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8591,9 +8591,9 @@ GROUPED_ERROR(isolated_conformance_wrong_domain,IsolatedConformances,none,
 GROUPED_WARNING(isolated_conformance_will_become_nonisolated,IsolatedConformances,none,
       "conformance of %0 to %1 should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'",
       (const ValueDecl *, const ValueDecl *))
-GROUPED_WARNING(isolated_conformance_to_sendable_metatype,IsolatedConformances,none,
-    "%0 conformance of %1 to SendableMetatype-inheriting %kind2 can never "
-    "be used with generic code", (ActorIsolation, Type, const ValueDecl *))
+GROUPED_ERROR(isolated_conformance_to_sendable_metatype,IsolatedConformances,none,
+    "cannot form %0 conformance of %1 to SendableMetatype-inheriting %kind2",
+    (ActorIsolation, Type, const ValueDecl *))
 
 //===----------------------------------------------------------------------===//
 // MARK: @_inheritActorContext

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8591,6 +8591,9 @@ GROUPED_ERROR(isolated_conformance_wrong_domain,IsolatedConformances,none,
 GROUPED_WARNING(isolated_conformance_will_become_nonisolated,IsolatedConformances,none,
       "conformance of %0 to %1 should be marked 'nonisolated' to retain its behavior with upcoming feature 'InferIsolatedConformances'",
       (const ValueDecl *, const ValueDecl *))
+GROUPED_WARNING(isolated_conformance_to_sendable_metatype,IsolatedConformances,none,
+    "%0 conformance of %1 to SendableMetatype-inheriting %kind2 can never "
+    "be used with generic code", (ActorIsolation, Type, const ValueDecl *))
 
 //===----------------------------------------------------------------------===//
 // MARK: @_inheritActorContext

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -8299,18 +8299,20 @@ RawConformanceIsolationRequest::evaluate(
       globalActorTypeExpr->setType(MetatypeType::get(globalActorType));
     }
 
-    // Isolated conformance to a SendableMetatype-inheriting protocol can
-    // never be used generically. Warn about it.
+    // Cannot form an isolated conformance to a SendableMetatype-inheriting
+    // protocol. Diagnose it.
     if (auto sendableMetatype =
             ctx.getProtocol(KnownProtocolKind::SendableMetatype)) {
-      if (proto->inheritsFrom(sendableMetatype) &&
-          !getActorIsolation(proto).preconcurrency()) {
+      if (proto->inheritsFrom(sendableMetatype)) {
+        bool isPreconcurrency = moduleImportForPreconcurrency(
+            proto, conformance->getDeclContext()) != nullptr;
         ctx.Diags.diagnose(
             conformance->getLoc(),
             diag::isolated_conformance_to_sendable_metatype,
             ActorIsolation::forGlobalActor(globalActorType),
             conformance->getType(),
-            proto);
+            proto)
+          .limitBehaviorIf(isPreconcurrency, DiagnosticBehavior::Warning);
       }
     }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -8307,7 +8307,7 @@ RawConformanceIsolationRequest::evaluate(
         bool isPreconcurrency = moduleImportForPreconcurrency(
             proto, conformance->getDeclContext()) != nullptr;
         ctx.Diags.diagnose(
-            conformance->getLoc(),
+            rootNormal->getLoc(),
             diag::isolated_conformance_to_sendable_metatype,
             ActorIsolation::forGlobalActor(globalActorType),
             conformance->getType(),

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -151,7 +151,7 @@ protocol R: SendableMetatype {
   func f()
 }
 
-// expected-warning@+1{{main actor-isolated conformance of 'RSendableSMainActor' to SendableMetatype-inheriting protocol 'R' can never be used with generic code}}
+// expected-error@+1{{cannot form main actor-isolated conformance of 'RSendableSMainActor' to SendableMetatype-inheriting protocol 'R'}}
 @MainActor struct RSendableSMainActor: @MainActor R {
   func f() { }
 }

--- a/test/Concurrency/isolated_conformance.swift
+++ b/test/Concurrency/isolated_conformance.swift
@@ -147,6 +147,15 @@ struct PSendableS: @MainActor PSendable { // expected-note{{requirement specifie
   func f() { }
 }
 
+protocol R: SendableMetatype {
+  func f()
+}
+
+// expected-warning@+1{{main actor-isolated conformance of 'RSendableSMainActor' to SendableMetatype-inheriting protocol 'R' can never be used with generic code}}
+@MainActor struct RSendableSMainActor: @MainActor R {
+  func f() { }
+}
+
 // ----------------------------------------------------------------------------
 // Use checking of isolated conformances.
 // ----------------------------------------------------------------------------

--- a/test/Concurrency/isolated_conformance_6.swift
+++ b/test/Concurrency/isolated_conformance_6.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend -typecheck -verify -target %target-swift-5.1-abi-triple -swift-version 6 %s
+
+// REQUIRES: concurrency
+
+protocol P: SendableMetatype {
+  func f()
+}
+
+@preconcurrency
+protocol Q: SendableMetatype {
+  func f()
+}
+
+// expected-error@+1{{cannot form main actor-isolated conformance of 'PSendableSMainActor' to SendableMetatype-inheriting protocol 'P'}}
+@MainActor struct PSendableSMainActor: @MainActor P {
+  func f() { }
+}
+
+// expected-warning@+1{{cannot form main actor-isolated conformance of 'QSendableSMainActor' to SendableMetatype-inheriting protocol 'Q'}}
+@MainActor struct QSendableSMainActor: @MainActor Q {
+  func f() { }
+}


### PR DESCRIPTION
- **Explanation**: An isolated conformance to a `SendableMetatype`-inheriting protocol breaks the soundness model of isolated conformances, so produce an error on such conformances.
- **Scope**: Limited to a new feature, isolated conformances (SE-0470).
- **Issues**: Part of issue #82550 / rdar://154437489, fixes rdar://154808002.
- **Original PRs**: https://github.com/swiftlang/swift/pull/82846
- **Risk**: Low. Only affects new feature.
- **Testing**: CI
- **Reviewers**: @slavapestov 
