### PR TITLE
Update SwiftCompilerSources AllocBoxToStack to handle mark_dep.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -264,6 +264,8 @@ private struct DiagnoseDependence {
     }
     onError()
 
+    log("  Error: lifetime-dependence violation - escaping use")
+
     // Identify the escaping variable.
     let escapingVar = LifetimeVariable(usedBy: operand, context)
     if let varDecl = escapingVar.varDecl {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8964,6 +8964,21 @@ public:
     return SILValue();
   }
 
+  void setBase(SILValue newVal) {
+    if (inst) {
+      switch (inst->getKind()) {
+      case SILInstructionKind::MarkDependenceInst:
+        cast<MarkDependenceInst>(inst)->setBase(newVal);
+        break;
+      case SILInstructionKind::MarkDependenceAddrInst:
+        cast<MarkDependenceAddrInst>(inst)->setBase(newVal);
+        break;
+      default:
+        break;
+      }
+    }
+  }
+
   SILValue getDependent() const {
     if (inst) {
       switch (inst->getKind()) {

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -400,6 +400,13 @@ static SILInstruction *recursivelyFindBoxOperandsPromotableToAddress(
         isa<EndBorrowInst>(User))
       continue;
 
+    // mark_dependence base value uses will be directly converted to base
+    // address uses.
+    if (auto mdi = MarkDependenceInstruction(User)) {
+      if (Op->get() == mdi.getBase())
+        continue;
+    }
+
     // If our user instruction is a copy_value or a mark_uninitialized, visit
     // the users recursively.
     if (isa<MarkUninitializedInst>(User) || isa<CopyValueInst>(User) ||
@@ -736,6 +743,12 @@ static bool rewriteAllocBoxAsAllocStack(AllocBoxInst *ABI) {
       });
       Inst->replaceAllUsesWithUndef();
       Inst->eraseFromParent();
+      continue;
+    }
+    // mark_dependence base value uses will be directly converted to base
+    // address uses.
+    if (auto mdi = MarkDependenceInstruction(User)) {
+      mdi.setBase(StackBox);
       continue;
     }
 

--- a/test/SILOptimizer/allocbox_to_stack_ne.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ne.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -enable-experimental-feature LifetimeDependence -allocbox-to-stack %s | %FileCheck %s
+// RUN: %target-sil-opt -enable-experimental-feature LifetimeDependence -legacy-allocbox-to-stack %s | %FileCheck %s
 
 // REQUIRES: swift_feature_LifetimeDependence
 

--- a/test/SILOptimizer/allocbox_to_stack_ne.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ne.sil
@@ -1,0 +1,68 @@
+// RUN: %target-sil-opt -enable-experimental-feature LifetimeDependence -allocbox-to-stack %s | %FileCheck %s
+
+// REQUIRES: swift_feature_LifetimeDependence
+
+import Swift
+import Builtin
+
+public struct View : ~Escapable {
+  let _ptr: UnsafeRawPointer
+}
+
+sil [ossa] @initFn : $@convention(method) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @owned View
+sil [ossa] @initFnAddr : $@convention(thin) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @out View 
+
+// CHECK-LABEL:  sil [ossa] @testBoxedParam :
+// CHECK-NOT: alloc_box
+// CHECK-LABEL: } // end sil function 'testBoxedParam'
+sil [ossa] @testBoxedParam : $@convention(thin) (@owned View) -> @lifetime(copy 0) @owned View {
+bb0(%0 : @noImplicitCopy @_eagerMove @owned $View):
+  %1 = alloc_box ${ var @moveOnly View }, var, name "that"
+  %2 = begin_borrow [var_decl] %1
+  %3 = project_box %2, 0
+  %4 = moveonlywrapper_to_copyable_addr %3
+  store %0 to [init] %4
+  %6 = metatype $@thin View.Type
+  %7 = begin_access [read] [static] %3
+  %8 = mark_unresolved_non_copyable_value [no_consume_or_assign] %7
+  %9 = struct_element_addr %8, #View._ptr
+  %10 = load_borrow %9
+  %11 = moveonlywrapper_to_copyable [guaranteed] %10
+  end_borrow %10
+  end_access %7
+  %14 = function_ref @initFn : $@convention(method) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @owned View
+  %15 = apply %14(%11, %6) : $@convention(method) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @owned View
+  %16 = mark_dependence [unresolved] %15 on %2
+  end_borrow %2
+  destroy_value %1
+  return %16
+}
+
+// CHECK-LABEL:  sil [ossa] @testBoxedParamAddr :
+// CHECK-NOT: alloc_box
+// CHECK-LABEL: } // end sil function 'testBoxedParamAddr'
+sil [ossa] @testBoxedParamAddr : $@convention(thin) (@owned View) -> () {
+bb0(%0 : @noImplicitCopy @_eagerMove @owned $View):
+  %1 = alloc_box ${ var @moveOnly View }, var, name "that"
+  %2 = begin_borrow [var_decl] %1
+  %3 = project_box %2, 0
+  %4 = moveonlywrapper_to_copyable_addr %3
+  store %0 to [init] %4
+  %6 = metatype $@thin View.Type
+  %7 = begin_access [read] [static] %3
+  %8 = mark_unresolved_non_copyable_value [no_consume_or_assign] %7
+  %9 = struct_element_addr %8, #View._ptr
+  %10 = load_borrow %9
+  %11 = moveonlywrapper_to_copyable [guaranteed] %10
+  end_borrow %10
+  end_access %7
+  %14 = alloc_stack $View
+  %15 = function_ref @initFnAddr : $@convention(thin) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @out View
+  %16 = apply %15(%14, %11, %6) : $@convention(thin) (UnsafeRawPointer, @thin View.Type) -> @lifetime(borrow 0) @out View
+  mark_dependence_addr [unresolved] %14 on %2
+  dealloc_stack %14
+  end_borrow %2
+  destroy_value %1
+  %99 = tuple ()
+  return %99
+}

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.sil
@@ -52,13 +52,14 @@ sil @useNE : $@convention(thin) (@guaranteed NE) -> ()
 sil @reborrowNE : $@convention(thin) (@guaranteed NE) -> @lifetime(borrow 0) @owned NE
 
 sil @initHolder : $@convention(thin) () -> @out Holder
+sil @getHolderNE : $@convention(thin) (@guaranteed Holder) -> @lifetime(borrow 0) @owned NE
 sil @getNE : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @owned NE
 sil @getNEIndirect : $@convention(thin) (@in_guaranteed Holder) -> @lifetime(borrow address_for_deps 0) @out NE
 
 sil @initTrivialHolder : $@convention(thin) () -> @out TrivialHolder
 sil @getTrivialNE : $@convention(thin) (@in_guaranteed TrivialHolder) -> @lifetime(borrow address_for_deps 0) @owned NE
 
-sil @makeHolder: $@convention(method) (@thin Holder.Type) -> @owned Holder // user: %6
+sil @makeHolder: $@convention(thin) () -> @owned Holder
 sil @getGeneric : $@convention(thin) <τ_0_0 where τ_0_0 : ~Escapable> (@guaranteed Holder, @thick τ_0_0.Type) -> @lifetime(borrow 0) @out τ_0_0 // user: %12
 
 // Test returning a owned dependence on a trivial value
@@ -196,9 +197,8 @@ sil [ossa] @testBorrowAddress : $@convention(thin) <T where T : ~Escapable> (@th
 bb0(%0 : $*T, %1 : $@thick T.Type):
   debug_value %1, let, name "type", argno 1
   %3 = alloc_stack [lexical] [var_decl] $Holder, var, name "holder", type $Holder
-  %4 = metatype $@thin Holder.Type
 
-  %5 = function_ref @makeHolder : $@convention(method) (@thin Holder.Type) -> @owned Holder
+  %5 = function_ref @makeHolder : $@convention(thin) () -> @owned Holder
   %6 = apply %5(%4) : $@convention(method) (@thin Holder.Type) -> @owned Holder
   store %6 to [init] %3
   %8 = alloc_stack [lexical] [var_decl] $T, let, name "result"
@@ -245,4 +245,31 @@ bb0(%0 : $*NE, %1 : $*Holder):
   dealloc_stack %2
   %18 = tuple ()
   return %18
+}
+
+// Test dependence on an alloc_stack variable.
+//
+//!!!
+sil private [ossa] @testOnStackHolder : $@convention(thin) (@guaranteed Holder) -> ()  {
+bb0(%0 : @guaranteed $Holder):
+  %6 = alloc_stack [lexical] [var_decl] $Holder, let, name "c", type $Holder
+
+  %10 = function_ref @makeHolder : $@convention(thin) () -> @owned Holder
+  %11 = apply %10() : $@convention(thin) () -> @owned Holder
+  store %11 to [init] %6
+  %13 = load_borrow %6
+
+  %14 = function_ref @getHolderNE : $@convention(thin) (@guaranteed Holder) -> @lifetime(borrow 0) @owned NE
+  %15 = apply %14(%13) : $@convention(thin) (@guaranteed Holder) -> @lifetime(borrow 0) @owned NE
+  %16 = mark_dependence [unresolved] %15 on %6
+  %17 = move_value [var_decl] %16
+  end_borrow %13
+
+  %20 = function_ref @useNE : $@convention(thin) (@guaranteed NE) -> ()
+  %21 = apply %20(%17) : $@convention(thin) (@guaranteed NE) -> ()
+  destroy_value %17
+  destroy_addr %6
+  dealloc_stack %6
+  %26 = tuple ()
+  return %26
 }


### PR DESCRIPTION
- **Fix AllocBoxToStack to handle mark_dependence[_addr]**
  Handle the easy case in which the promoted box is the base operand of a
  mark_dep. This requires nothing more than setting the base operand to the new
  stack address.
  
  Required for move-only checking. Otherwise, we get an incredibly bizarre
  compiler error: noncopyable 'foo' cannot be consumed when captured by an
  escaping closure
  
  Fixes rdar://150398673 ([nonescapable] allocbox-to-stack fails causing lifetime diagnostics to fail)

- **Update SwiftCompilerSources AllocBoxToStack to handle mark_dep.**
  Handle the easy case in which the promoted box is the base operand of a
  mark_dep. This requires nothing more than setting the base operand to the new
  stack address.
  
  Required for move-only checking. Otherwise, we get an incredibly bizarre
  compiler error: noncopyable 'foo' cannot be consumed when captured by an
  escaping closure
  
  The legacy pass was updated first for 6.2.
  