### PR TITLE
[6.2][Concurrency] Remove deprecated `Task.startSynchronously` API

### DIFF
--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -33,25 +33,6 @@ import Swift
 @available(SwiftStdlib 6.2, *)
 extension Task where Failure == ${FAILURE_TYPE} {
 
-  // FIXME: This method is left in place to give adopters time to switch to `immediate` but it's going
-  // to be removed soon, since this spelling was rejected as part of SE-0472 proposal.
-  @available(SwiftStdlib 6.2, *)
-  @available(*, deprecated, renamed: "immediate")
-  // Used to preserve the symbols as originally declared without `@isolated(any)` attribute on `operation:`.
-  % if FAILURE_TYPE == "Error":
-  @_silgen_name("$sScTss5Error_pRs_rlE18startSynchronously4name8priority_ScTyxsAA_pGSSSg_ScPSgxyYaKcntFZ")
-  % elif FAILURE_TYPE == "Never":
-  @_silgen_name("$sScTss5NeverORs_rlE18startSynchronously4name8priority_ScTyxABGSSSg_ScPSgxyYaKcntFZ")
-  % end
-  @discardableResult
-  public static func startSynchronously(
-    name: String? = nil,
-    priority: TaskPriority? = nil,
-    @_implicitSelfCapture @_inheritActorContext(always) _ operation: sending @isolated(any) @escaping () async ${THROWS} -> Success
-  ) -> Task<Success, ${FAILURE_TYPE}> {
-    immediate(name: name, priority: priority, operation: operation)
-  }
-
   /// Create and immediately start running a new task in the context of the calling thread/task.
   ///
   /// This function _starts_ the created task on the calling context.

--- a/test/Concurrency/Runtime/startImmediately.swift
+++ b/test/Concurrency/Runtime/startImmediately.swift
@@ -436,11 +436,6 @@ print("call_startSynchronously_insideActor()")
 
 actor A {
   func f() {
-    Task.startSynchronously(name: "hello") { print("Task.startSynchronously (\(Task.name!))") }
-    Task.startSynchronously() { print("Task.startSynchronously") }
-  }
-
-  func f2() {
     Task.immediate(name: "hello") { print("Task.immediate (\(Task.name!))") }
     Task.immediate() { print("Task.immediate") }
 
@@ -451,12 +446,10 @@ actor A {
 
 func call_startSynchronously_insideActor() async {
   await A().f()
-  await A().f2()
 }
 
 await call_startSynchronously_insideActor()
 
 // CHECK-LABEL: call_startSynchronously_insideActor()
-// Those two definitely in this order, however the startSynchronously is not determinate
 // CHECK: Task.immediate
 // CHECK: Task.immediate { @MainActor }

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -389,10 +389,8 @@ Added: _$sScTss5NeverORszABRs_rlE4nameSSSgvgZ
 Added: _$sScTss5NeverORszABRs_rlE4nameSSSgvpZMV
 Added: _swift_task_getCurrentTaskName
 
-// startSynchronously, immediate, addImmediateTask{UnlessCancelled}
+// immediate, addImmediateTask{UnlessCancelled}
 Added: _swift_task_immediate
-Added: _$sScTss5Error_pRs_rlE18startSynchronously4name8priority_ScTyxsAA_pGSSSg_ScPSgxyYaKcntFZ
-Added: _$sScTss5NeverORs_rlE18startSynchronously4name8priority_ScTyxABGSSSg_ScPSgxyYaKcntFZ
 
 // isIsolatingCurrentContext
 Added: _swift_task_invokeSwiftIsIsolatingCurrentContext

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -389,10 +389,8 @@ Added: _$sScTss5NeverORszABRs_rlE4nameSSSgvgZ
 Added: _$sScTss5NeverORszABRs_rlE4nameSSSgvpZMV
 Added: _swift_task_getCurrentTaskName
 
-// startSynchronously, immediate, addImmediateTask{UnlessCancelled}
+// immediate, addImmediateTask{UnlessCancelled}
 Added: _swift_task_immediate
-Added: _$sScTss5Error_pRs_rlE18startSynchronously4name8priority_ScTyxsAA_pGSSSg_ScPSgxyYaKcntFZ
-Added: _$sScTss5NeverORs_rlE18startSynchronously4name8priority_ScTyxABGSSSg_ScPSgxyYaKcntFZ
 
 // isIsolatingCurrentContext
 Added: _swift_task_invokeSwiftIsIsolatingCurrentContext


### PR DESCRIPTION
- Explanation:

  This is the original spelling which was not accepted. We kept it for a bit to give adopters time to switch but it's time to remove it now.

- Main Branch PR: https://github.com/swiftlang/swift/pull/82833

- Risk: Low. This removes an API that wasn't accepted by LSG and should no longer be used.
 
- Reviewed By: @ktoso   

- Testing: Updated existing ones in the Concurrency suite.

(cherry picked from commit e108524d9852f103432ebe3887a876f8f37d6a65)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
