### PR TITLE
Fix a move-checker diagnostic message (textual change)

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -857,7 +857,8 @@ ERROR(sil_movechecking_borrowed_parameter_captured_by_closure, none,
       "parameter",
       (StringRef))
 ERROR(sil_movechecking_capture_consumed, none,
-      "noncopyable '%0' cannot be consumed when captured by an escaping closure", (StringRef))
+      "noncopyable '%0' cannot be consumed when captured by an escaping closure or borrowed by a non-Escapable type",
+      (StringRef))
 ERROR(sil_movechecking_not_reinitialized_before_end_of_function, none,
       "missing reinitialization of %select{inout parameter|closure capture}1 '%0' "
       "after consume", (StringRef, bool))

--- a/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence/verify_diagnostics.swift
@@ -121,6 +121,23 @@ struct TestDeinitCallsAddressor: ~Copyable, ~Escapable {
   }
 }
 
+struct NCBuffer: ~Copyable {
+  fileprivate let buffer: UnsafeMutableRawBufferPointer
+
+  public init() {
+    let ptr = UnsafeMutableRawPointer.init(bitPattern: 0)
+    self.buffer = UnsafeMutableRawBufferPointer(start: ptr, count: 0)
+  }
+
+  public var bytes: Span<UInt8> {
+    @_lifetime(borrow self)
+    borrowing get {
+      let span: Span<UInt8> = Span(_bytes: self.buffer.bytes)
+      return span
+    }
+  }
+}
+
 // Test a borrowed dependency on an address
 @_lifetime(immortal)
 public func testGenericDep<T: ~Escapable>(type: T.Type) -> T {
@@ -286,4 +303,16 @@ func mutableSpanMayThrow(_: borrowing MutableSpan<Int>) throws {}
 func testSpanMayThrow(buffer: inout [Int]) {
   let bufferSpan = buffer.mutableSpan
   try! mutableSpanMayThrow(bufferSpan)
+}
+
+// =============================================================================
+// Dependence on non-Copyable values
+// =============================================================================
+
+@_lifetime(immortal)
+func dependOnNonCopyable() -> NCBuffer {
+  let buffer = NCBuffer()
+  let count = buffer.bytes.count
+  _ = count
+  return buffer // expected-error {{noncopyable 'buffer' cannot be consumed when captured by an escaping closure or borrowed by a non-Escapable type}}
 }


### PR DESCRIPTION
The move-checker was assuming that any non-Copyable variable in a box must be
captured by a closure. The underlying problem is that the move-checker relies on
the best-effort AllocBoxToStack optimization to be perfect. But when
non-Escapable values depend on the variable, it remains boxed. That's good for
lifetime diagnostics but caused an incorrect move-checker diagnostic.

Fixes rdar://154519148 (Returning non-copyable type after accessing borrowed
field emits incorrect error about escaped closure capturing the noncopyable)
