### PR TITLE
[Concurrency] Use ASSERT for to also assert in release builds

### DIFF
--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -75,7 +75,7 @@ setExpectedExecutorForParameterIsolation(SILGenFunction &SGF,
   // argument.
   if (actorIsolation.getKind() == ActorIsolation::CallerIsolationInheriting) {
     auto *isolatedArg = SGF.F.maybeGetIsolatedArgument();
-    assert(isolatedArg &&
+    ASSERT(isolatedArg &&
            "Caller Isolation Inheriting without isolated parameter");
     ManagedValue isolatedMV;
     if (isolatedArg->getOwnershipKind() == OwnershipKind::Guaranteed) {


### PR DESCRIPTION
Small cleanup from code review; we'd crash either way after this line, so might be better to always ASSERT more nicely.

Thanks for pointing that out @slavapestov in https://github.com/swiftlang/swift/pull/82826