### PR TITLE
[stdlib] Default initializers for Span-family types

### DIFF
--- a/stdlib/public/core/Span/MutableRawSpan.swift
+++ b/stdlib/public/core/Span/MutableRawSpan.swift
@@ -32,6 +32,14 @@ public struct MutableRawSpan: ~Copyable & ~Escapable {
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  @lifetime(immortal)
+  public init() {
+    unsafe _pointer = nil
+    _count = 0
+  }
+
   @unsafe
   @_unsafeNonescapableResult
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/MutableSpan.swift
+++ b/stdlib/public/core/Span/MutableSpan.swift
@@ -33,6 +33,14 @@ public struct MutableSpan<Element: ~Copyable>
     unsafe _pointer._unsafelyUnwrappedUnchecked
   }
 
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  @lifetime(immortal)
+  public init() {
+    unsafe _pointer = nil
+    _count = 0
+  }
+
   @unsafe
   @_unsafeNonescapableResult
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -54,7 +54,7 @@ public struct RawSpan: ~Escapable, Copyable, BitwiseCopyable {
   @_alwaysEmitIntoClient
   @inline(__always)
   @lifetime(immortal)
-  internal init() {
+  public init() {
     unsafe _pointer = nil
     _count = 0
   }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -55,7 +55,7 @@ public struct Span<Element: ~Copyable>: ~Escapable, Copyable, BitwiseCopyable {
   @_alwaysEmitIntoClient
   @inline(__always)
   @lifetime(immortal)
-  internal init() {
+  public init() {
     unsafe _pointer = nil
     _count = 0
   }

--- a/test/stdlib/Span/MutableRawSpanTests.swift
+++ b/test/stdlib/Span/MutableRawSpanTests.swift
@@ -29,10 +29,13 @@ suite.test("Basic Initializer")
 
   var s = Array("\(#file)+\(#function)--\(Int.random(in: 1000...9999))".utf8)
   s.withUnsafeMutableBytes {
-    let b = MutableRawSpan(_unsafeBytes: $0)
+    var b = MutableRawSpan(_unsafeBytes: $0)
     expectEqual(b.byteCount, $0.count)
     expectFalse(b.isEmpty)
     expectEqual(b.byteOffsets, 0..<$0.count)
+
+    b = MutableRawSpan()
+    expectEqual(b.byteCount, 0)
   }
 }
 

--- a/test/stdlib/Span/MutableSpanTests.swift
+++ b/test/stdlib/Span/MutableSpanTests.swift
@@ -30,9 +30,11 @@ suite.test("Initialize with ordinary element")
   let capacity = 4
   var s = (0..<capacity).map({ "\(#file)+\(#function)--\($0)" })
   s.withUnsafeMutableBufferPointer {
-    let b = MutableSpan(_unsafeElements: $0)
-    let c = b.count
-    expectEqual(c, $0.count)
+    var b = MutableSpan(_unsafeElements: $0)
+    expectEqual(b.count, $0.count)
+
+    b = MutableSpan()
+    expectEqual(b.count, 0)
   }
 }
 

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -30,9 +30,12 @@ suite.test("Initialize with Span<Int>")
   let capacity = 4
   Array(0..<capacity).withUnsafeBufferPointer {
     let intSpan = Span(_unsafeElements: $0)
-    let span = RawSpan(_elements: intSpan)
+    var span = RawSpan(_elements: intSpan)
     expectEqual(span.byteCount, capacity*MemoryLayout<Int>.stride)
     expectFalse(span.isEmpty)
+
+    span = RawSpan()
+    expectTrue(span.isEmpty)
   }
 
   let a: [Int] = []

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -120,6 +120,9 @@ suite.test("Initialize with ordinary element")
     let pointer: UnsafeMutablePointer = $0.baseAddress!
     span = Span(_unsafeStart: pointer, count: $0.count)
     expectEqual(span.count, capacity)
+
+    span = Span()
+    expectEqual(span.count, 0)
   }
 }
 


### PR DESCRIPTION
Adds no-parameter initializers that return empty, immortal instances of `Span`/`RawSpan`/`MutableSpan`/`MutableRawSpan`.

These were proposed as part of [SE-0485](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0485-outputspan.md).

Addresses rdar://155275054