### PR TITLE
[CSOptimizer] Prefer logical infix operator if it has smaller overload set

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -140,6 +140,10 @@ public:
     return is("??");
   }
 
+  // Returns whether this is a standard infix logical operator,
+  // such as '&&', '||'.
+  bool isStandardInfixLogicalOperator() const { return is("&&") || is("||"); }
+
   /// isOperatorStartCodePoint - Return true if the specified code point is a
   /// valid start of an operator.
   static bool isOperatorStartCodePoint(uint32_t C) {

--- a/validation-test/Sema/type_checker_perf/fast/logical_infix_operator_chains.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/logical_infix_operator_chains.swift.gyb
@@ -1,0 +1,51 @@
+// RUN: %scale-test --begin 1 --end 20 --step 1 --select NumLeafScopes %s
+// REQUIRES: asserts,no_asan
+
+struct Predicate<T> : Equatable {}
+
+func ||<T>(_: Predicate<T>, _: Predicate<T>) -> Predicate<T> {
+  .init()
+}
+
+func !=<Value, Operand>(_: Operand, _: Operand) -> Predicate<Value> where Operand : Equatable {
+  .init()
+}
+
+func !=<Value, Operand>(_: Operand, _: KeyPath<Value, Operand>) -> Predicate<Value> where Operand : Equatable {
+  .init()
+}
+
+func !=<Value, Operand>(_: KeyPath<Value, Operand>, _: Operand) -> Predicate<Value> where Operand : Equatable {
+  .init()
+}
+
+func !=<Value, Operand>(_: KeyPath<Value, Operand>, _: KeyPath<Value, Operand>) -> Predicate<Value> where Operand : Equatable {
+  .init()
+}
+
+enum Format : UInt, Equatable {
+case simple = 0
+}
+
+struct Parameter {
+  struct Buffers {
+    struct Data {
+      let format: Format
+    }
+
+    let data: Data?
+  }
+
+  var buffers: Buffers
+}
+
+func test(arr: [Parameter]) {
+  for p in arr {
+    if (p.buffers.data != nil && p.buffers.data!.format != .simple) ||
+%for i in range(1, N):
+       (p.buffers.data != nil && p.buffers.data!.format != .simple) ||
+%end
+       (p.buffers.data != nil && p.buffers.data!.format != .simple) {
+    }
+  }
+}


### PR DESCRIPTION
Infix logical operators are usually not overloaded and don't form disjunctions,
but when they do, let's prefer them over other operators when they have fewer
choices because it helps to split operator chains.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
