### PR TITLE
build-script: flush `compiler-rt embedded builtins` logs in `llvm.py`

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -141,7 +141,7 @@ class LLVM(cmake_product.CMakeProduct):
                                                      'lib', 'darwin')
                 print('copying compiler-rt embedded builtins from {}'
                       ' into the local clang build directory {}.'.format(
-                          host_cxx_builtins_dir, dest_builtins_dir))
+                          host_cxx_builtins_dir, dest_builtins_dir), flush=True)
 
                 for _os in ['ios', 'watchos', 'tvos', 'xros']:
                     # Copy over the device .a when necessary


### PR DESCRIPTION
Current use of `print` without `flush=True` outputs these logs at the end of a `build-script` run, after the supposedly final `--- Build Script Analyzer ---` output, which is quite confusing when reading logs.