### PR TITLE
[cxx-interop] Propagate AddressableParameters enablement to dependencies

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1789,6 +1789,10 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
     genericSubInvocation.getLangOptions().enableFeature(
         Feature::LayoutPrespecialization);
   }
+  if (LangOpts.hasFeature(Feature::AddressableParameters)) {
+    genericSubInvocation.getLangOptions().enableFeature(
+        Feature::AddressableParameters);
+  }
 
   genericSubInvocation.getClangImporterOptions().DirectClangCC1ModuleBuild =
       clangImporterOpts.DirectClangCC1ModuleBuild;

--- a/test/Interop/Cxx/class/method/methods-addressable-dependency.swift
+++ b/test/Interop/Cxx/class/method/methods-addressable-dependency.swift
@@ -1,0 +1,28 @@
+// This ensures that a Swift module built without AddressableParameters can be
+// consumed by a dependency Swift module that enables AddressableParameters.
+
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift %t/library.swift -emit-module -emit-library -enable-library-evolution -cxx-interoperability-mode=upcoming-swift -module-name MyLibrary -emit-module-path %t/artifacts/MyLibrary.swiftmodule -emit-module-interface-path %t/artifacts/MyLibrary.swiftinterface -I %S/Inputs -swift-version 6 -enable-experimental-feature AssumeResilientCxxTypes
+// RUN: rm %t/artifacts/MyLibrary.swiftmodule
+// RUN: %target-build-swift %t/executable.swift -emit-irgen -cxx-interoperability-mode=default -module-name ImportsMyLibrary -I %t/artifacts -I %S/Inputs -swift-version 6 -enable-experimental-feature AssumeResilientCxxTypes -enable-experimental-feature AddressableParameters
+
+// REQUIRES: swift_feature_AddressableParameters
+
+//--- library.swift
+import Methods
+
+@inlinable // emit the body of the function into the textual interface
+public func addressableTest(_ x: borrowing NonTrivialInWrapper) {
+  let m = HasMethods()
+  m.nonTrivialTakesConstRef(x)
+}
+
+//--- executable.swift
+import MyLibrary
+import Methods
+
+let x = NonTrivialInWrapper(123)
+let m = HasMethods()
+m.nonTrivialTakesConstRef(x)


### PR DESCRIPTION
This fixes a deserialization crash when someone builds a Swift module that exposes C++ symbols without the experimental AddressableParameters feature enabled, and then consumes that Swift module from another Swift module that enables AddressableParameters.

The real use case for this is consuming CxxStdlib overlay, which is imported implicitly whenever someone uses the C++ stdlib from Swift (which most C++ interop users do), from a module that uses AddressableDependencies.

rdar://155319311

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
