### PR TITLE
Enable test for 64bit platforms only

### DIFF
--- a/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_no_bte2.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization/multi_bb_no_bte2.sil
@@ -7,6 +7,7 @@
 
 /// _ArrayBuffer is part of the ObjC runtime interop.
 // REQUIRES: objc_interop
+// REQUIRES: CPU=x86_64 || CPU=arm64
 
 sil_stage canonical
 


### PR DESCRIPTION
This test fails on 32bit platforms due to SIL mismatches.