### PR TITLE
[6.2] SILGen: Don't try to project static stored properties as addressable from their base.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3623,8 +3623,8 @@ SILGenFunction::tryEmitAddressableParameterAsAddress(ArgumentSource &&arg,
     auto vd = cast<VarDecl>(memberStorage);
     // TODO: Is it possible and/or useful for class storage to be
     // addressable?
-    if (!vd->getDeclContext()->getInnermostTypeContext()
-         ->getDeclaredTypeInContext()->getStructOrBoundGenericStruct()) {
+    if (!vd->isInstanceMember()
+        || !isa<StructDecl>(vd->getDeclContext())) {
       return notAddressable();
     }
   

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -684,7 +684,8 @@ static void deallocateAddressable(SILGenFunction &SGF,
                 const SILGenFunction::VarLoc::AddressableBuffer::State &state) {
   SGF.B.createEndBorrow(l, state.storeBorrow);
   SGF.B.createDeallocStack(l, state.allocStack);
-  if (state.reabstraction) {
+  if (state.reabstraction
+      && !state.reabstraction->getType().isTrivial(SGF.F)) {
     SGF.B.createDestroyValue(l, state.reabstraction);
   }
 }

--- a/test/SILGen/82368.swift
+++ b/test/SILGen/82368.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking -verify %s
+
+struct A {
+  static let a: InlineArray = [1]
+
+  static func foo() {
+    a.span.withUnsafeBufferPointer({ buffer in
+      print("\(buffer.baseAddress!)")
+    })
+  }
+}


### PR DESCRIPTION
Explanation: Fixes a regression introduced in #82288, which would cause the addressability logic to also be applied to static properties of structs.
Scope: Bug fix.
Issues: #82368, rdar://153837014
Original PRs: https://github.com/swiftlang/swift/pull/82855
Risk: Low. Bug fix.
Testing: Swift CI, test case from issue
Reviewers: @slavapestov 
