### PR TITLE
[cxx-interop] Class declaration order does not matter

### DIFF
--- a/test/Interop/SwiftToCxx/class/swift-class-ordering.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-ordering.swift
@@ -9,3 +9,13 @@ public class SwiftNode {
 public struct SwiftLinkedList {
   public var head: SwiftNode
 }
+
+public class B
+{
+    public init() {}
+}
+
+public class A
+{
+    public init(_ b: B) {}
+}


### PR DESCRIPTION
Looking through the old issues found one that we already fixed. Adding a a test to close the issue. Closing #70336.

rdar://119405019
