### PR TITLE
Revert "[Concurrency] Remove deprecated `Task.startSynchronously` API"

### DIFF
--- a/stdlib/public/Concurrency/Task+immediate.swift.gyb
+++ b/stdlib/public/Concurrency/Task+immediate.swift.gyb
@@ -33,6 +33,25 @@ import Swift
 @available(SwiftStdlib 6.2, *)
 extension Task where Failure == ${FAILURE_TYPE} {
 
+  // FIXME: This method is left in place to give adopters time to switch to `immediate` but it's going
+  // to be removed soon, since this spelling was rejected as part of SE-0472 proposal.
+  @available(SwiftStdlib 6.2, *)
+  @available(*, deprecated, renamed: "immediate")
+  // Used to preserve the symbols as originally declared without `@isolated(any)` attribute on `operation:`.
+  % if FAILURE_TYPE == "Error":
+  @_silgen_name("$sScTss5Error_pRs_rlE18startSynchronously4name8priority_ScTyxsAA_pGSSSg_ScPSgxyYaKcntFZ")
+  % elif FAILURE_TYPE == "Never":
+  @_silgen_name("$sScTss5NeverORs_rlE18startSynchronously4name8priority_ScTyxABGSSSg_ScPSgxyYaKcntFZ")
+  % end
+  @discardableResult
+  public static func startSynchronously(
+    name: String? = nil,
+    priority: TaskPriority? = nil,
+    @_implicitSelfCapture @_inheritActorContext(always) _ operation: sending @isolated(any) @escaping () async ${THROWS} -> Success
+  ) -> Task<Success, ${FAILURE_TYPE}> {
+    immediate(name: name, priority: priority, operation: operation)
+  }
+
   /// Create and immediately start running a new task in the context of the calling thread/task.
   ///
   /// This function _starts_ the created task on the calling context.

--- a/test/Concurrency/Runtime/startImmediately.swift
+++ b/test/Concurrency/Runtime/startImmediately.swift
@@ -436,6 +436,11 @@ print("call_startSynchronously_insideActor()")
 
 actor A {
   func f() {
+    Task.startSynchronously(name: "hello") { print("Task.startSynchronously (\(Task.name!))") }
+    Task.startSynchronously() { print("Task.startSynchronously") }
+  }
+
+  func f2() {
     Task.immediate(name: "hello") { print("Task.immediate (\(Task.name!))") }
     Task.immediate() { print("Task.immediate") }
 
@@ -446,10 +451,12 @@ actor A {
 
 func call_startSynchronously_insideActor() async {
   await A().f()
+  await A().f2()
 }
 
 await call_startSynchronously_insideActor()
 
 // CHECK-LABEL: call_startSynchronously_insideActor()
+// Those two definitely in this order, however the startSynchronously is not determinate
 // CHECK: Task.immediate
 // CHECK: Task.immediate { @MainActor }

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -389,8 +389,10 @@ Added: _$sScTss5NeverORszABRs_rlE4nameSSSgvgZ
 Added: _$sScTss5NeverORszABRs_rlE4nameSSSgvpZMV
 Added: _swift_task_getCurrentTaskName
 
-// immediate, addImmediateTask{UnlessCancelled}
+// startSynchronously, immediate, addImmediateTask{UnlessCancelled}
 Added: _swift_task_immediate
+Added: _$sScTss5Error_pRs_rlE18startSynchronously4name8priority_ScTyxsAA_pGSSSg_ScPSgxyYaKcntFZ
+Added: _$sScTss5NeverORs_rlE18startSynchronously4name8priority_ScTyxABGSSSg_ScPSgxyYaKcntFZ
 
 // isIsolatingCurrentContext
 Added: _swift_task_invokeSwiftIsIsolatingCurrentContext

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -389,8 +389,10 @@ Added: _$sScTss5NeverORszABRs_rlE4nameSSSgvgZ
 Added: _$sScTss5NeverORszABRs_rlE4nameSSSgvpZMV
 Added: _swift_task_getCurrentTaskName
 
-// immediate, addImmediateTask{UnlessCancelled}
+// startSynchronously, immediate, addImmediateTask{UnlessCancelled}
 Added: _swift_task_immediate
+Added: _$sScTss5Error_pRs_rlE18startSynchronously4name8priority_ScTyxsAA_pGSSSg_ScPSgxyYaKcntFZ
+Added: _$sScTss5NeverORs_rlE18startSynchronously4name8priority_ScTyxABGSSSg_ScPSgxyYaKcntFZ
 
 // isIsolatingCurrentContext
 Added: _swift_task_invokeSwiftIsIsolatingCurrentContext


### PR DESCRIPTION
Reverts swiftlang/swift#82833