### PR TITLE
[stdlib, 6.2] Make String.makeContiguousUTF8() strictly true

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -79,7 +79,7 @@ internal struct _SmallString {
 extension _SmallString {
   @inlinable @inline(__always)
   internal static var capacity: Int {
-#if _pointerBitWidth(_32) && os(watchOS)
+#if os(watchOS) && _pointerBitWidth(_32)
     return 10
 #elseif _pointerBitWidth(_32) || _pointerBitWidth(_16)
     // Note: changed from 10 for contiguous storage.
@@ -95,7 +95,7 @@ extension _SmallString {
 
   @_alwaysEmitIntoClient @inline(__always)
   internal static func contiguousCapacity() -> Int {
-#if _pointerBitWidth(_32) && os(watchOS)
+#if os(watchOS) && _pointerBitWidth(_32)
     return capacity &- 2
 #else
     return capacity

--- a/stdlib/public/core/StringCreate.swift
+++ b/stdlib/public/core/StringCreate.swift
@@ -316,6 +316,8 @@ extension String {
         unsafe String._uncheckedFromUTF8($0)
       }
 #if os(watchOS) && _pointerBitWidth(_32)
+      // Required for compatibility with some small strings that
+      // may be encoded in the 32-bit slice of watchOS binaries.
       if str._wholeGuts.isSmall,
          str._wholeGuts.count > _SmallString.contiguousCapacity() {
         new.reserveCapacity(_SmallString.capacity + 1)

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -185,7 +185,17 @@ extension String {
   /// Contiguous strings also benefit from fast-paths and better optimizations.
   ///
   @_alwaysEmitIntoClient
-  public var isContiguousUTF8: Bool { return _guts.isFastUTF8 }
+  public var isContiguousUTF8: Bool {
+    if _guts.isFastUTF8 {
+#if os(watchOS) && _pointerBitWidth(_32)
+      if _guts.isSmall && _guts.count > _SmallString.contiguousCapacity() {
+        return false
+      }
+#endif
+      return true
+    }
+    return false
+  }
 
   /// If this string is not contiguous, make it so. If this mutates the string,
   /// it will invalidate any pre-existing indices.

--- a/stdlib/public/core/StringProtocol.swift
+++ b/stdlib/public/core/StringProtocol.swift
@@ -177,17 +177,19 @@ extension StringProtocol {
 
 // Contiguous UTF-8 strings
 extension String {
-  /// Returns whether this string is capable of providing access to
-  /// validly-encoded UTF-8 contents in contiguous memory in O(1) time.
+  /// Returns whether this string's storage contains
+  /// validly-encoded UTF-8 contents in contiguous memory.
   ///
-  /// Contiguous strings always operate in O(1) time for withUTF8 and always
-  /// give a result for String.UTF8View.withContiguousStorageIfAvailable.
+  /// Contiguous strings always operate in O(1) time for withUTF8, always give
+  /// a result for String.UTF8View.withContiguousStorageIfAvailable, and always
+  /// return a non-nil value from `String._utf8Span` and `String.UTF8View._span`.
   /// Contiguous strings also benefit from fast-paths and better optimizations.
-  ///
   @_alwaysEmitIntoClient
   public var isContiguousUTF8: Bool {
     if _guts.isFastUTF8 {
 #if os(watchOS) && _pointerBitWidth(_32)
+      // Required for compatibility with some small strings that
+      // may be encoded in the 32-bit slice of watchOS binaries.
       if _guts.isSmall && _guts.count > _SmallString.contiguousCapacity() {
         return false
       }
@@ -233,13 +235,14 @@ extension String {
 
 // Contiguous UTF-8 strings
 extension Substring {
-  /// Returns whether this string is capable of providing access to
-  /// validly-encoded UTF-8 contents in contiguous memory in O(1) time.
+  /// Returns whether this string's storage contains
+  /// validly-encoded UTF-8 contents in contiguous memory.
   ///
-  /// Contiguous strings always operate in O(1) time for withUTF8 and always
-  /// give a result for String.UTF8View.withContiguousStorageIfAvailable.
+  /// Contiguous strings always operate in O(1) time for withUTF8, always give
+  /// a result for Substring.UTF8View.withContiguousStorageIfAvailable, and
+  /// always return a non-nil value from `Substring._utf8Span` and
+  /// `Substring.UTF8View._span`.
   /// Contiguous strings also benefit from fast-paths and better optimizations.
-  ///
   @_alwaysEmitIntoClient
   public var isContiguousUTF8: Bool { return self.base.isContiguousUTF8 }
 

--- a/test/stdlib/Span/SmallStringCompatibility.swift
+++ b/test/stdlib/Span/SmallStringCompatibility.swift
@@ -1,0 +1,67 @@
+//===--- SmallStringCompatibility.swift -----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %target-run-stdlib-swift
+
+// REQUIRES: executable_test
+// REQUIRES: CPU=wasm32 || CPU=arm64_32
+
+import StdlibUnittest
+
+var suite = TestSuite("SmallStringCompatibility")
+defer { runAllTests() }
+
+var strings = [
+  ("Small", true),
+  ("Less small", true),
+  ("Positively large.", true),
+]
+
+#if os(watchOS)
+strings[1].1 = false
+#endif
+
+strings.forEach { (string, contiguous) in
+  suite.test("Contiguous: \(string)")
+  .require(.stdlib_6_2).code {
+
+    expectEqual(string.isContiguousUTF8, contiguous)
+  }
+}
+
+strings.forEach { (string, contiguous) in
+  suite.test("Contiguous Substring: \(string)")
+  .require(.stdlib_6_2).code {
+    let substring = string[...]
+    expectEqual(substring.isContiguousUTF8, contiguous)
+  }
+}
+
+strings.forEach { (string, contiguous) in
+  suite.test("String.makeContiguousUTF8: \(string)")
+  .require(.stdlib_6_2).code {
+    var s = string
+    s.makeContiguousUTF8()
+    expectTrue(s.isContiguousUTF8)
+    expectEqual(s, string)
+  }
+}
+
+strings.forEach { (string, contiguous) in
+  suite.test("Substring.makeContiguousUTF8: \(string)")
+  .require(.stdlib_6_2).code {
+    var s: Substring = string.dropFirst().dropLast()
+    s.makeContiguousUTF8()
+    expectTrue(s.isContiguousUTF8)
+    expectEqual(s, string.dropFirst().dropLast())
+  }
+}


### PR DESCRIPTION
- Explanation:
Until now, StringProtocol.makeContiguousUTF8() only considered whether or not a String or Substring heap allocation contained contiguous UTF8, disregarding whether a stack-allocated instance was discontiguous. This is no longer tenable when these types vend UTF8Span and Span properties, so we now also consider whether the small string form contains contiguous code units. If the small form contains discontiguously-stored code units, then it is replaced by a new heap-allocated String in contiguous storage. This new code path is specific to ABI-stable, 32-bit platforms.

- Resolves: rdar://154331399

- Risk: Low. This change is only in `@_alwaysEmitIntoClient` code.

- Main branch PR: https://github.com/swiftlang/swift/pull/82851

- Review by: @kperryua 

- Testing: new test, existing tests