### PR TITLE
[Caching] Fix cache build with optimization remarks are used

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1037,7 +1037,7 @@ def save_optimization_record_EQ : Joined<["-"], "save-optimization-record=">,
            "(default: YAML)">, MetaVarName<"<format>">;
 def save_optimization_record_path :
   Separate<["-"], "save-optimization-record-path">,
-  Flags<[FrontendOption, ArgumentIsPath]>,
+  Flags<[FrontendOption, ArgumentIsPath, CacheInvariant]>,
   HelpText<"Specify the file name of any generated optimization record">;
 def save_optimization_record_passes :
   Separate<["-"], "save-optimization-record-passes">,

--- a/lib/Frontend/CASOutputBackends.cpp
+++ b/lib/Frontend/CASOutputBackends.cpp
@@ -227,6 +227,12 @@ void SwiftCASOutputBackend::Implementation::initBackend(
     Input.getPrimarySpecificPaths()
         .SupplementaryOutputs.forEachSetOutputAndType(
             [&](const std::string &Out, file_types::ID ID) {
+              // FIXME: Opt Remarks are not setup correctly to be cached and
+              // didn't go through the output backend. Do not cache them.
+              if (ID == file_types::ID::TY_YAMLOptRecord ||
+                  ID == file_types::ID::TY_BitstreamOptRecord)
+                return;
+
               if (!file_types::isProducedFromDiagnostics(ID))
                 OutputToInputMap.insert({Out, {Index, ID}});
             });

--- a/test/CAS/opt-record.swift
+++ b/test/CAS/opt-record.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
+// RUN: %swift_frontend_plain @%t/shim.cmd
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+
+// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -O \
+// RUN:   -save-optimization-record -save-optimization-record-path %t/record.yaml \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   @%t/MyApp.cmd %s -o %t/test.o -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-MISS
+
+// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -O \
+// RUN:   -save-optimization-record -save-optimization-record-path %t/record-1.yaml \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   @%t/MyApp.cmd %s -o %t/test.o -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=CACHE-HIT
+
+// RUN: %FileCheck %s --check-prefix=YAML --input-file=%t/record.yaml
+
+/// FIXME: Remarks are not produced when cache hit.
+// RUN: not %FileCheck %s --check-prefix=YAML --input-file=%t/record-1.yaml
+
+// CACHE-MISS: remark: cache miss for input
+// CACHE-HIT: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
+// CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': key 'llvmcas://{{.*}}'
+// YAML: ---
+
+var a: Int = 1
+
+func foo() {
+  a = 2
+}
+
+public func bar() {
+  foo()
+}


### PR DESCRIPTION
Temporarily disable replaying optimization remarks when cache hit. Optimization remarks file are not setup to be cached because:
* the write of such files are not going through output backend
* when optimization remarks files are requested, it produces files that are not intended to be produced in SupplementoryOutputs, which confuses compiler when storing and loading compilation results, and causes cache misses all the time when optimization remark file is reuqested.

Disable optimization remarks for cache replay so it is currently only produced when compiler actually did the compile locally.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
