### PR TITLE
[Region isolation] Factor SILIsolationInfo creation into static methods

### DIFF
--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -257,6 +257,11 @@ private:
   static SILIsolationInfo getFromConformances(
       SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
 
+  /// Determine the isolation of conformances that could be introduced by a
+  /// cast from sourceType to destType.
+  static SILIsolationInfo getForCastConformances(
+      SILValue value, CanType sourceType, CanType destType);
+
 public:
   SILIsolationInfo() : actorIsolation(), kind(Kind::Unknown), options(0) {}
 
@@ -537,11 +542,6 @@ public:
       return get(inst);
     return {};
   }
-
-  /// Determine the isolation of conformances that could be introduced by a
-  /// cast from sourceType to destType.
-  static SILIsolationInfo getForCastConformances(
-      SILValue value, CanType sourceType, CanType destType);
 
   /// Infer isolation of conformances for the given instruction.
   static SILIsolationInfo getConformanceIsolation(SILInstruction *inst);

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -229,6 +229,8 @@ private:
                  ->lookThroughAllOptionalTypes()
                  ->getAnyActor())) &&
            "actorInstance must be an actor if it is non-empty");
+    assert((getKind() != Disconnected || isolatedConformance == nullptr) &&
+        "isolated conformance cannot be introduced with disconnected region");
   }
 
   SILIsolationInfo(SILValue isolatedValue, ActorInstance actorInstance,
@@ -531,6 +533,15 @@ public:
       return get(inst);
     return {};
   }
+
+  /// Infer isolation region from the set of protocol conformances.
+  static SILIsolationInfo getFromConformances(
+      SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
+
+  /// Determine the isolation of conformances that could be introduced by a
+  /// cast from sourceType to destType.
+  static SILIsolationInfo getForCastConformances(
+      SILValue value, CanType sourceType, CanType destType);
 
   /// A helper that is used to ensure that we treat certain builtin values as
   /// non-Sendable that the AST level otherwise thinks are non-Sendable.

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -253,6 +253,10 @@ private:
   SILIsolationInfo(Kind kind, Options options = Options())
       : actorIsolation(), kind(kind), options(options.toRaw()) {}
 
+  /// Infer isolation region from the set of protocol conformances.
+  static SILIsolationInfo getFromConformances(
+      SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
+
 public:
   SILIsolationInfo() : actorIsolation(), kind(Kind::Unknown), options(0) {}
 
@@ -534,14 +538,13 @@ public:
     return {};
   }
 
-  /// Infer isolation region from the set of protocol conformances.
-  static SILIsolationInfo getFromConformances(
-      SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
-
   /// Determine the isolation of conformances that could be introduced by a
   /// cast from sourceType to destType.
   static SILIsolationInfo getForCastConformances(
       SILValue value, CanType sourceType, CanType destType);
+
+  /// Infer isolation of conformances for the given instruction.
+  static SILIsolationInfo getConformanceIsolation(SILInstruction *inst);
 
   /// A helper that is used to ensure that we treat certain builtin values as
   /// non-Sendable that the AST level otherwise thinks are non-Sendable.

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -336,10 +336,7 @@ static bool isStaticallyLookThroughInst(SILInstruction *inst) {
 
     // If this cast introduces isolation due to conformances, we cannot look
     // through it to the source.
-    if (!SILIsolationInfo::getForCastConformances(
-            llvm::cast<UnconditionalCheckedCastInst>(inst),
-            cast.getSourceFormalType(), cast.getTargetFormalType())
-              .isDisconnected())
+    if (SILIsolationInfo::getConformanceIsolation(inst))
       return false;
 
     if (cast.isRCIdentityPreserving())
@@ -3166,7 +3163,8 @@ public:
     case TranslationSemantics::Store:
       return translateSILStore(
           &inst->getAllOperands()[CopyLikeInstruction::Dest],
-          &inst->getAllOperands()[CopyLikeInstruction::Src]);
+          &inst->getAllOperands()[CopyLikeInstruction::Src],
+          SILIsolationInfo::getConformanceIsolation(inst));
 
     case TranslationSemantics::Special:
       return;
@@ -3177,7 +3175,8 @@ public:
     case TranslationSemantics::TerminatorPhi: {
       TermArgSources sources;
       sources.init(inst);
-      return translateSILPhi(sources);
+      return translateSILPhi(
+          sources, SILIsolationInfo::getConformanceIsolation(inst));
     }
 
     case TranslationSemantics::Asserting:
@@ -3480,6 +3479,7 @@ CONSTANT_TRANSLATION(StoreInst, Store)
 CONSTANT_TRANSLATION(StoreWeakInst, Store)
 CONSTANT_TRANSLATION(MarkUnresolvedMoveAddrInst, Store)
 CONSTANT_TRANSLATION(UncheckedRefCastAddrInst, Store)
+CONSTANT_TRANSLATION(UnconditionalCheckedCastAddrInst, Store)
 CONSTANT_TRANSLATION(StoreUnownedInst, Store)
 
 //===---
@@ -3554,6 +3554,7 @@ CONSTANT_TRANSLATION(YieldInst, Require)
 // Terminators that act as phis.
 CONSTANT_TRANSLATION(BranchInst, TerminatorPhi)
 CONSTANT_TRANSLATION(CondBranchInst, TerminatorPhi)
+CONSTANT_TRANSLATION(CheckedCastBranchInst, TerminatorPhi)
 CONSTANT_TRANSLATION(DynamicMethodBranchInst, TerminatorPhi)
 
 // Function exiting terminators.
@@ -3955,34 +3956,16 @@ PartitionOpTranslator::visitPointerToAddressInst(PointerToAddressInst *ptai) {
 
 TranslationSemantics PartitionOpTranslator::visitUnconditionalCheckedCastInst(
     UnconditionalCheckedCastInst *ucci) {
-  auto isolation = SILIsolationInfo::getForCastConformances(
-      ucci, ucci->getSourceFormalType(), ucci->getTargetFormalType());
+  auto isolation = SILIsolationInfo::getConformanceIsolation(ucci);
 
-  if (isolation.isDisconnected() &&
+  if (!isolation &&
       SILDynamicCastInst(ucci).isRCIdentityPreserving()) {
     assert(isStaticallyLookThroughInst(ucci) && "Out of sync");
     return TranslationSemantics::LookThrough;
   }
 
   assert(!isStaticallyLookThroughInst(ucci) && "Out of sync");
-  translateSILMultiAssign(
-      ucci->getResults(), makeOperandRefRange(ucci->getAllOperands()),
-      isolation);
-  return TranslationSemantics::Special;
-}
-
-TranslationSemantics PartitionOpTranslator::visitUnconditionalCheckedCastAddrInst(
-    UnconditionalCheckedCastAddrInst *uccai) {
-  auto isolation = SILIsolationInfo::getForCastConformances(
-      uccai->getAllOperands()[CopyLikeInstruction::Dest].get(),
-      uccai->getSourceFormalType(), uccai->getTargetFormalType());
-
-  translateSILStore(
-      &uccai->getAllOperands()[CopyLikeInstruction::Dest],
-      &uccai->getAllOperands()[CopyLikeInstruction::Src],
-      isolation);
-
-  return TranslationSemantics::Special;
+  return TranslationSemantics::Assign;
 }
 
 // RefElementAddrInst is not considered to be a lookThrough since we want to
@@ -4079,31 +4062,9 @@ PartitionOpTranslator::visitInitExistentialValueInst(InitExistentialValueInst *i
   return TranslationSemantics::Assign;
 }
 
-TranslationSemantics
-PartitionOpTranslator::visitCheckedCastBranchInst(CheckedCastBranchInst *ccbi) {
-  // Consider whether the value produced by the cast might be task-isolated.
-  auto resultValue = ccbi->getSuccessBB()->getArgument(0);
-  auto conformanceIsolation = SILIsolationInfo::getForCastConformances(
-      resultValue,
-      ccbi->getSourceFormalType(),
-      ccbi->getTargetFormalType());
-  TermArgSources sources;
-  sources.init(static_cast<SILInstruction *>(ccbi));
-  translateSILPhi(sources, conformanceIsolation);
-
-  return TranslationSemantics::Special;
-}
-
 TranslationSemantics PartitionOpTranslator::visitCheckedCastAddrBranchInst(
     CheckedCastAddrBranchInst *ccabi) {
   assert(ccabi->getSuccessBB()->getNumArguments() <= 1);
-
-  // Consider whether the value written into by the cast might be task-isolated.
-  auto resultValue = ccabi->getAllOperands().back().get();
-  auto conformanceIsolation = SILIsolationInfo::getForCastConformances(
-      resultValue,
-      ccabi->getSourceFormalType(),
-      ccabi->getTargetFormalType());
 
   // checked_cast_addr_br does not have any arguments in its resulting
   // block. We should just use a multi-assign on its operands.
@@ -4114,7 +4075,7 @@ TranslationSemantics PartitionOpTranslator::visitCheckedCastAddrBranchInst(
   // but still correct.
   translateSILMultiAssign(ArrayRef<SILValue>(),
                           makeOperandRefRange(ccabi->getAllOperands()),
-                          conformanceIsolation);
+                          SILIsolationInfo::getConformanceIsolation(ccabi));
   return TranslationSemantics::Special;
 }
 

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/SIL/AddressWalker.h"
 #include "swift/SIL/ApplySite.h"
+#include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/PatternMatch.h"
 #include "swift/SIL/SILGlobalVariable.h"
@@ -1171,6 +1172,24 @@ SILIsolationInfo SILIsolationInfo::getForCastConformances(
   return {};
 }
 
+/// Retrieve a suitable destination value for the cast instruction.
+///
+/// TODO: This should probably be SILDynamicCastInst::getDest(), but that has
+/// unimplemented TODOs.
+static SILValue destValueForDynamicCast(SILDynamicCastInst dynCast) {
+  auto inst = dynCast.getInstruction();
+  switch (dynCast.getKind()) {
+    case SILDynamicCastKind::CheckedCastAddrBranchInst:
+      return cast<CheckedCastAddrBranchInst>(inst)->getDest();
+    case SILDynamicCastKind::CheckedCastBranchInst:
+      return cast<CheckedCastBranchInst>(inst)->getSuccessBB()->getArgument(0);
+    case SILDynamicCastKind::UnconditionalCheckedCastAddrInst:
+      return cast<UnconditionalCheckedCastAddrInst>(inst)->getDest();
+    case SILDynamicCastKind::UnconditionalCheckedCastInst:
+      return cast<UnconditionalCheckedCastInst>(inst);
+  }
+}
+
 SILIsolationInfo SILIsolationInfo::getConformanceIsolation(SILInstruction *inst) {
   // Existential initialization.
   if (auto ieai = dyn_cast<InitExistentialAddrInst>(inst)) {
@@ -1181,6 +1200,14 @@ SILIsolationInfo SILIsolationInfo::getConformanceIsolation(SILInstruction *inst)
   }
   if (auto ievi = dyn_cast<InitExistentialValueInst>(inst)) {
     return getFromConformances(ievi, ievi->getConformances());
+  }
+
+  // Dynamic casts.
+  if (auto dynCast = SILDynamicCastInst::getAs(inst)) {
+    return getForCastConformances(
+        destValueForDynamicCast(dynCast),
+        dynCast.getSourceFormalType(),
+        dynCast.getTargetFormalType());
   }
 
   return {};

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1171,6 +1171,21 @@ SILIsolationInfo SILIsolationInfo::getForCastConformances(
   return {};
 }
 
+SILIsolationInfo SILIsolationInfo::getConformanceIsolation(SILInstruction *inst) {
+  // Existential initialization.
+  if (auto ieai = dyn_cast<InitExistentialAddrInst>(inst)) {
+    return getFromConformances(ieai, ieai->getConformances());
+  }
+  if (auto ieri = dyn_cast<InitExistentialRefInst>(inst)) {
+    return getFromConformances(ieri, ieri->getConformances());
+  }
+  if (auto ievi = dyn_cast<InitExistentialValueInst>(inst)) {
+    return getFromConformances(ievi, ievi->getConformances());
+  }
+
+  return {};
+}
+
 void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
   if (isolatedConformance) {
     os << "isolated-conformance-to(" << isolatedConformance->getName() << ")";

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -13,8 +13,12 @@
 #include "swift/SILOptimizer/Utils/SILIsolationInfo.h"
 
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DistributedDecl.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/PackConformance.h"
+#include "swift/AST/ProtocolConformance.h"
 #include "swift/SIL/AddressWalker.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/InstructionUtils.h"
@@ -1067,6 +1071,104 @@ SILIsolationInfo SILIsolationInfo::get(SILArgument *arg) {
   }
 
   return SILIsolationInfo::getTaskIsolated(fArg);
+}
+
+/// Infer isolation region from the set of protocol conformances.
+SILIsolationInfo SILIsolationInfo::getFromConformances(
+    SILValue value, ArrayRef<ProtocolConformanceRef> conformances) {
+  for (auto conformance: conformances) {
+    if (conformance.getProtocol()->isMarkerProtocol())
+      continue;
+
+    // If the conformance is a pack, recurse.
+    if (conformance.isPack()) {
+      auto pack = conformance.getPack();
+      for (auto innerConformance : pack->getPatternConformances()) {
+        auto isolation = getFromConformances(value, innerConformance);
+        if (isolation)
+          return isolation;
+      }
+
+      continue;
+    }
+
+    // If a concrete conformance is global-actor-isolated, then the resulting
+    // value must be.
+    if (conformance.isConcrete()) {
+      auto isolation = conformance.getConcrete()->getIsolation();
+      if (isolation.isGlobalActor()) {
+        return SILIsolationInfo::getGlobalActorIsolated(
+            value, isolation.getGlobalActor(), conformance.getProtocol());
+      }
+
+      continue;
+    }
+
+    // If an abstract conformance is for a non-SendableMetatype-conforming
+    // type, the resulting value is task-isolated.
+    if (conformance.isAbstract()) {
+      auto sendableMetatype =
+        conformance.getType()->getASTContext()
+          .getProtocol(KnownProtocolKind::SendableMetatype);
+      if (sendableMetatype &&
+          lookupConformance(conformance.getType(), sendableMetatype,
+                            /*allowMissing=*/false).isInvalid()) {
+        return SILIsolationInfo::getTaskIsolated(value,
+                                                 conformance.getProtocol());
+      }
+    }
+  }
+
+  return {};
+}
+
+SILIsolationInfo SILIsolationInfo::getForCastConformances(
+    SILValue value, CanType sourceType, CanType destType) {
+  // If the enclosing function is @concurrent, then a cast cannot pick up
+  // any isolated conformances because it's not on any actor.
+  auto function = value->getFunction();
+  auto functionIsolation = function->getActorIsolation();
+  if (functionIsolation && functionIsolation->isNonisolated())
+    return {};
+
+  auto sendableMetatype =
+    sourceType->getASTContext().getProtocol(KnownProtocolKind::SendableMetatype);
+  if (!sendableMetatype)
+    return {};
+
+  if (!destType.isAnyExistentialType())
+    return {};
+
+  const auto &destLayout = destType.getExistentialLayout();
+  for (auto proto : destLayout.getProtocols()) {
+    if (proto->isMarkerProtocol())
+      continue;
+
+    // If the source type already conforms to the protocol, we won't be looking
+    // it up dynamically.
+    if (!lookupConformance(sourceType, proto, /*allowMissing=*/false).isInvalid())
+      continue;
+
+    // If the protocol inherits SendableMetatype, it can't have isolated
+    // conformances.
+    if (proto->inheritsFrom(sendableMetatype))
+      continue;
+
+    // The cast can produce a conformance with the same isolation as this
+    // function is dynamically executing. If that's known (i.e., because we're
+    // on a global actor), the value is isolated to that global actor.
+    // Otherwise, it's task-isolated.
+    if (functionIsolation && functionIsolation->isGlobalActor()) {
+      return SILIsolationInfo::getGlobalActorIsolated(
+          value, functionIsolation->getGlobalActor(), proto);
+    }
+
+    // Consider the cast to be task-isolated, because the runtime could find
+    // a conformance that is isolated to the current context.
+    return SILIsolationInfo::getTaskIsolated(value, proto);
+  }
+
+  return {};
 }
 
 void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -192,9 +192,9 @@ bb0:
   // expected-warning @-1 {{}}
   // expected-note @-2 {{}}
 
-  %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P // expected-note {{access can happen concurrently}}
+  %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P
   %f2 = function_ref @useP : $@convention(thin) (@in_guaranteed P) -> ()
-  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> ()
+  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> () // expected-note {{access can happen concurrently}}
   destroy_value %i : $P
 
   %9999 = tuple ()


### PR DESCRIPTION
Better match the style of SILIsolationInfo by moving the code for determining SILIsolationInfo from conformances or dynamic casts to existentials into static `getXYZ` methods on SILIsolationInfo.

Centralize the logic for figuring out the conformances for the various init_existential* instructions in a SILIsolationInfo static method, and always go through that when handling "assign" / "terminator-phi" / etc. semantics. This way, we can use CONSTANT_TRANSLATION again for these instructions, or a simpler decision process between Assign and LookThrough.

The actually undoes a small change made earlier when we stopped looking
through `init_existential_value` instructions. Now we do when there are
no isolated conformances.