### PR TITLE
[ODL] Visit objc_method insts.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -241,6 +241,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(ExistentialMetatype)
   NO_UPDATE_NEEDED(Builtin)
   NO_UPDATE_NEEDED(IgnoredUse)
+  NO_UPDATE_NEEDED(ObjCMethod)
 #undef NO_UPDATE_NEEDED
 
   bool eliminateIdentityCast(SingleValueInstruction *svi) {

--- a/validation-test/SILOptimizer/rdar155059418.swift
+++ b/validation-test/SILOptimizer/rdar155059418.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend %t/Library.swift -sil-verify-all -emit-sil -import-objc-header %t/Header.h > /dev/null
+
+// REQUIRES: objc_interop
+
+//--- Header.h
+
+@import Foundation;
+
+@interface Foo : NSObject
+@property (nonatomic, readwrite) NSUInteger length;
+@end
+
+//--- Library.swift
+
+func foo(_ x: borrowing Foo) -> UInt {
+    let y = x.length
+    return y
+}
+


### PR DESCRIPTION
No update is needed for the values they produce.  This pass should really be refactored not to crash on instructions that aren't explicitly listed or at least not to compile if not every instruction is listed.

rdar://155059418
