### PR TITLE
6.2: [ODL] Visit objc_method insts.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyWrappedTypeEliminator.cpp
@@ -241,6 +241,7 @@ struct SILMoveOnlyWrappedTypeEliminatorVisitor
   NO_UPDATE_NEEDED(ExistentialMetatype)
   NO_UPDATE_NEEDED(Builtin)
   NO_UPDATE_NEEDED(IgnoredUse)
+  NO_UPDATE_NEEDED(ObjCMethod)
 #undef NO_UPDATE_NEEDED
 
   bool eliminateIdentityCast(SingleValueInstruction *svi) {

--- a/validation-test/SILOptimizer/rdar155059418.swift
+++ b/validation-test/SILOptimizer/rdar155059418.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend %t/Library.swift -sil-verify-all -emit-sil -import-objc-header %t/Header.h > /dev/null
+
+// REQUIRES: objc_interop
+
+//--- Header.h
+
+@import Foundation;
+
+@interface Foo : NSObject
+@property (nonatomic, readwrite) NSUInteger length;
+@end
+
+//--- Library.swift
+
+func foo(_ x: borrowing Foo) -> UInt {
+    let y = x.length
+    return y
+}
+


### PR DESCRIPTION
**Explanation**: Add a missing instruction visitor.

The MoveOnlyWrappedTypeEliminator crashes if it sees an instruction that hasn't been explicitly listed.  We regularly have to add instructions to it that were missed, most recently here: https://github.com/swiftlang/swift/pull/82763 .  Most of the time, as here, all that's required is to say "this pass shouldn't do anything to this instruction.
**Scope**: Affects controls using ownership controls (`borrowing`, `consuming`).
**Issue**: rdar://155059418
**Original PR**: https://github.com/swiftlang/swift/pull/82902
**Risk**: Very low.
**Testing**: Added test.
**Reviewer**: Meghana Gupta ( @meg-gupta )