### PR TITLE
[6.2] Extend region analysis to account for isolated conformances

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -1081,6 +1081,10 @@ NOTE(regionbasedisolation_typed_sendneversendable_via_arg_callee, none,
       "sending %0 value of non-Sendable type %1 to %2 %3 %4 risks causing races in between %0 and %2 uses",
       (StringRef, Type, ActorIsolation, DescriptiveDeclKind, DeclName))
 
+NOTE(regionbasedisolation_isolated_conformance_introduced, none,
+     "isolated conformance to %kind0 can be introduced here",
+     (const ValueDecl *))
+
 // Error that is only used when the send non sendable emitter cannot discover any
 // information to give a better diagnostic.
 ERROR(regionbasedisolation_task_or_actor_isolated_sent, none,

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -253,6 +253,11 @@ private:
   static SILIsolationInfo getFromConformances(
       SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
 
+  /// Determine the isolation of conformances that could be introduced by a
+  /// cast from sourceType to destType.
+  static SILIsolationInfo getForCastConformances(
+      SILValue value, CanType sourceType, CanType destType);
+
 public:
   SILIsolationInfo() : actorIsolation(), kind(Kind::Unknown), options(0) {}
 
@@ -506,11 +511,6 @@ public:
       return get(inst);
     return {};
   }
-
-  /// Determine the isolation of conformances that could be introduced by a
-  /// cast from sourceType to destType.
-  static SILIsolationInfo getForCastConformances(
-      SILValue value, CanType sourceType, CanType destType);
 
   /// Infer isolation of conformances for the given instruction.
   static SILIsolationInfo getConformanceIsolation(SILInstruction *inst);

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -225,6 +225,8 @@ private:
                  ->lookThroughAllOptionalTypes()
                  ->getAnyActor())) &&
            "actorInstance must be an actor if it is non-empty");
+    assert((getKind() != Disconnected || isolatedConformance == nullptr) &&
+        "isolated conformance cannot be introduced with disconnected region");
   }
 
   SILIsolationInfo(SILValue isolatedValue, ActorInstance actorInstance,
@@ -500,6 +502,15 @@ public:
       return get(inst);
     return {};
   }
+
+  /// Infer isolation region from the set of protocol conformances.
+  static SILIsolationInfo getFromConformances(
+      SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
+
+  /// Determine the isolation of conformances that could be introduced by a
+  /// cast from sourceType to destType.
+  static SILIsolationInfo getForCastConformances(
+      SILValue value, CanType sourceType, CanType destType);
 
   /// A helper that is used to ensure that we treat certain builtin values as
   /// non-Sendable that the AST level otherwise thinks are non-Sendable.

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -249,6 +249,10 @@ private:
   SILIsolationInfo(Kind kind, Options options = Options())
       : actorIsolation(), kind(kind), options(options.toRaw()) {}
 
+  /// Infer isolation region from the set of protocol conformances.
+  static SILIsolationInfo getFromConformances(
+      SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
+
 public:
   SILIsolationInfo() : actorIsolation(), kind(Kind::Unknown), options(0) {}
 
@@ -503,14 +507,13 @@ public:
     return {};
   }
 
-  /// Infer isolation region from the set of protocol conformances.
-  static SILIsolationInfo getFromConformances(
-      SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
-
   /// Determine the isolation of conformances that could be introduced by a
   /// cast from sourceType to destType.
   static SILIsolationInfo getForCastConformances(
       SILValue value, CanType sourceType, CanType destType);
+
+  /// Infer isolation of conformances for the given instruction.
+  static SILIsolationInfo getConformanceIsolation(SILInstruction *inst);
 
   /// A helper that is used to ensure that we treat certain builtin values as
   /// non-Sendable that the AST level otherwise thinks are non-Sendable.

--- a/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
+++ b/include/swift/SILOptimizer/Utils/SILIsolationInfo.h
@@ -186,7 +186,7 @@ public:
     UnappliedIsolatedAnyParameter = 0x2,
 
     /// The maximum number of bits used by a Flag.
-    MaxNumBits = 2,
+    MaxNumBits = 3,
   };
 
   using Options = OptionSet<Flag>;
@@ -204,13 +204,19 @@ private:
   /// derived isolatedValue from.
   ActorInstance actorInstance;
 
+  /// When the isolation is introduced due to a (potentially) isolated
+  /// conformance, the protocol whose conformance might be isolated.
+  ProtocolDecl *isolatedConformance = nullptr;
+
   unsigned kind : 8;
   unsigned options : 8;
 
   SILIsolationInfo(SILValue isolatedValue, SILValue actorInstance,
-                   ActorIsolation actorIsolation, Options options = Options())
+                   ActorIsolation actorIsolation, Options options = Options(),
+                   ProtocolDecl *isolatedConformance = nullptr)
       : actorIsolation(actorIsolation), isolatedValue(isolatedValue),
-        actorInstance(ActorInstance::getForValue(actorInstance)), kind(Actor),
+        actorInstance(ActorInstance::getForValue(actorInstance)),
+        isolatedConformance(isolatedConformance), kind(Actor),
         options(options.toRaw()) {
     assert((!actorInstance ||
             (actorIsolation.getKind() == ActorIsolation::ActorInstance &&
@@ -222,15 +228,20 @@ private:
   }
 
   SILIsolationInfo(SILValue isolatedValue, ActorInstance actorInstance,
-                   ActorIsolation actorIsolation, Options options = Options())
+                   ActorIsolation actorIsolation, Options options = Options(),
+                   ProtocolDecl *isolatedConformance = nullptr)
       : actorIsolation(actorIsolation), isolatedValue(isolatedValue),
-        actorInstance(actorInstance), kind(Actor), options(options.toRaw()) {
+        actorInstance(actorInstance), isolatedConformance(isolatedConformance),
+        kind(Actor), options(options.toRaw())
+  {
     assert(actorInstance);
     assert(actorIsolation.getKind() == ActorIsolation::ActorInstance);
   }
 
-  SILIsolationInfo(Kind kind, SILValue isolatedValue)
-      : actorIsolation(), isolatedValue(isolatedValue), kind(kind), options(0) {
+  SILIsolationInfo(Kind kind, SILValue isolatedValue,
+                   ProtocolDecl *isolatedConformance = nullptr)
+      : actorIsolation(), isolatedValue(isolatedValue),
+        isolatedConformance(isolatedConformance), kind(kind), options(0) {
   }
 
   SILIsolationInfo(Kind kind, Options options = Options())
@@ -257,6 +268,12 @@ public:
     return getOptions().contains(Flag::UnsafeNonIsolated);
   }
 
+  // Retrieve the protocol to which there is (or could be) an isolated
+  // conformance.
+  ProtocolDecl *getIsolatedConformance() const {
+    return isolatedConformance;
+  }
+
   SILIsolationInfo withUnsafeNonIsolated(bool newValue = true) const {
     assert(*this && "Cannot be unknown");
     auto self = *this;
@@ -267,6 +284,26 @@ public:
           self.getOptions().toRaw() & ~Options(Flag::UnsafeNonIsolated).toRaw();
     }
     return self;
+  }
+
+  /// Produce a new isolation info value that merges in the given isolated
+  /// conformance value.
+  ///
+  /// If both isolation infos have an isolation conformance, pick one
+  /// arbitrarily. Otherwise, the result has no isolated conformance.
+  SILIsolationInfo
+  withMergedIsolatedConformance(ProtocolDecl *newIsolatedConformance) const {
+    SILIsolationInfo result(*this);
+    if (!isolatedConformance || !newIsolatedConformance) {
+      result.isolatedConformance = nullptr;
+      return result;
+    }
+
+    result.isolatedConformance =
+      ProtocolDecl::compare(isolatedConformance, newIsolatedConformance) <= 0
+        ? isolatedConformance
+        : newIsolatedConformance;
+    return result;
   }
 
   /// Returns true if this actor isolation is derived from an unapplied
@@ -427,10 +464,13 @@ public:
             Flag::UnappliedIsolatedAnyParameter};
   }
 
-  static SILIsolationInfo getGlobalActorIsolated(SILValue value,
-                                                 Type globalActorType) {
+  static SILIsolationInfo getGlobalActorIsolated(
+      SILValue value,
+      Type globalActorType,
+      ProtocolDecl *isolatedConformance = nullptr) {
     return {value, SILValue() /*no actor instance*/,
-            ActorIsolation::forGlobalActor(globalActorType)};
+            ActorIsolation::forGlobalActor(globalActorType),
+            Options(), isolatedConformance};
   }
 
   static SILIsolationInfo getGlobalActorIsolated(SILValue value,
@@ -442,8 +482,9 @@ public:
                                                     isolation.getGlobalActor());
   }
 
-  static SILIsolationInfo getTaskIsolated(SILValue value) {
-    return {Kind::Task, value};
+  static SILIsolationInfo getTaskIsolated(
+      SILValue value, ProtocolDecl *isolatedConformance = nullptr) {
+    return {Kind::Task, value, isolatedConformance};
   }
 
   /// Attempt to infer the isolation region info for \p inst.

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -15,12 +15,8 @@
 #include "swift/SILOptimizer/Analysis/RegionAnalysis.h"
 
 #include "swift/AST/ASTWalker.h"
-#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
-#include "swift/AST/ExistentialLayout.h"
-#include "swift/AST/PackConformance.h"
-#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/FrozenMultiMap.h"
@@ -265,59 +261,6 @@ struct AddressBaseComputingVisitor
 
 } // namespace
 
-/// Determine the isolation of conformances that could be introduced by a cast from sourceType to
-/// destType.
-///
-///
-static SILIsolationInfo getIsolationForCastConformances(
-    SILValue value, CanType sourceType, CanType destType) {
-  // If the enclosing function is @concurrent, then a cast cannot pick up
-  // any isolated conformances because it's not on any actor.
-  auto function = value->getFunction();
-  auto functionIsolation = function->getActorIsolation();
-  if (functionIsolation && functionIsolation->isNonisolated())
-    return {};
-
-  auto sendableMetatype =
-    sourceType->getASTContext().getProtocol(KnownProtocolKind::SendableMetatype);
-  if (!sendableMetatype)
-    return {};
-
-  if (!destType.isAnyExistentialType())
-    return {};
-
-  const auto &destLayout = destType.getExistentialLayout();
-  for (auto proto : destLayout.getProtocols()) {
-    if (proto->isMarkerProtocol())
-      continue;
-
-    // If the source type already conforms to the protocol, we won't be looking
-    // it up dynamically.
-    if (!lookupConformance(sourceType, proto, /*allowMissing=*/false).isInvalid())
-      continue;
-
-    // If the protocol inherits SendableMetatype, it can't have isolated
-    // conformances.
-    if (proto->inheritsFrom(sendableMetatype))
-      continue;
-
-    // The cast can produce a conformance with the same isolation as this
-    // function is dynamically executing. If that's known (i.e., because we're
-    // on a global actor), the value is isolated to that global actor.
-    // Otherwise, it's task-isolated.
-    if (functionIsolation && functionIsolation->isGlobalActor()) {
-      return SILIsolationInfo::getGlobalActorIsolated(
-          value, functionIsolation->getGlobalActor(), proto);
-    }
-
-    // Consider the cast to be task-isolated, because the runtime could find
-    // a conformance that is isolated to the current context.
-    return SILIsolationInfo::getTaskIsolated(value, proto);
-  }
-
-  return {};
-}
-
 /// Classify an instructions as look through when we are looking through
 /// values. We assert that all instructions that are CONSTANT_TRANSLATION
 /// LookThrough to make sure they stay in sync.
@@ -381,7 +324,7 @@ static bool isStaticallyLookThroughInst(SILInstruction *inst) {
 
     // If this cast introduces isolation due to conformances, we cannot look
     // through it to the source.
-    if (!getIsolationForCastConformances(
+    if (!SILIsolationInfo::getForCastConformances(
             llvm::cast<UnconditionalCheckedCastInst>(inst),
             cast.getSourceFormalType(), cast.getTargetFormalType())
               .isDisconnected())
@@ -2189,13 +2132,6 @@ private:
     return valueMap.lookupValueID(value);
   }
 
-  /// Determine the isolation of a set of conformances.
-  ///
-  /// This function identifies potentially-isolated conformances that might affect the isolation of the given
-  /// value.
-  SILIsolationInfo getIsolationFromConformances(
-      SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
-
 public:
   /// Return the partition consisting of all function arguments.
   ///
@@ -3970,7 +3906,7 @@ PartitionOpTranslator::visitPointerToAddressInst(PointerToAddressInst *ptai) {
 
 TranslationSemantics PartitionOpTranslator::visitUnconditionalCheckedCastInst(
     UnconditionalCheckedCastInst *ucci) {
-  auto isolation = getIsolationForCastConformances(
+  auto isolation = SILIsolationInfo::getForCastConformances(
       ucci, ucci->getSourceFormalType(), ucci->getTargetFormalType());
 
   if (isolation.isDisconnected() &&
@@ -3988,7 +3924,7 @@ TranslationSemantics PartitionOpTranslator::visitUnconditionalCheckedCastInst(
 
 TranslationSemantics PartitionOpTranslator::visitUnconditionalCheckedCastAddrInst(
     UnconditionalCheckedCastAddrInst *uccai) {
-  auto isolation = getIsolationForCastConformances(
+  auto isolation = SILIsolationInfo::getForCastConformances(
       uccai->getAllOperands()[CopyLikeInstruction::Dest].get(),
       uccai->getSourceFormalType(), uccai->getTargetFormalType());
 
@@ -4086,58 +4022,9 @@ PartitionOpTranslator::visitPartialApplyInst(PartialApplyInst *pai) {
   return TranslationSemantics::Special;
 }
 
-SILIsolationInfo
-PartitionOpTranslator::getIsolationFromConformances(
-    SILValue value, ArrayRef<ProtocolConformanceRef> conformances) {
-  for (auto conformance: conformances) {
-    if (conformance.getProtocol()->isMarkerProtocol())
-      continue;
-
-    // If the conformance is a pack, recurse.
-    if (conformance.isPack()) {
-      auto pack = conformance.getPack();
-      for (auto innerConformance : pack->getPatternConformances()) {
-        auto isolation = getIsolationFromConformances(value, innerConformance);
-        if (isolation)
-          return isolation;
-      }
-
-      continue;
-    }
-
-    // If a concrete conformance is global-actor-isolated, then the resulting
-    // value must be.
-    if (conformance.isConcrete()) {
-      auto isolation = conformance.getConcrete()->getIsolation();
-      if (isolation.isGlobalActor()) {
-        return SILIsolationInfo::getGlobalActorIsolated(
-            value, isolation.getGlobalActor(), conformance.getProtocol());
-      }
-
-      continue;
-    }
-
-    // If an abstract conformance is for a non-SendableMetatype-conforming
-    // type, the resulting value is task-isolated.
-    if (conformance.isAbstract()) {
-      auto sendableMetatype =
-        conformance.getType()->getASTContext()
-          .getProtocol(KnownProtocolKind::SendableMetatype);
-      if (sendableMetatype &&
-          lookupConformance(conformance.getType(), sendableMetatype,
-                            /*allowMissing=*/false).isInvalid()) {
-        return SILIsolationInfo::getTaskIsolated(value,
-                                                 conformance.getProtocol());
-      }
-    }
-  }
-
-  return {};
-}
-
 TranslationSemantics
 PartitionOpTranslator::visitInitExistentialAddrInst(InitExistentialAddrInst *ieai) {
-  auto conformanceIsolationInfo = getIsolationFromConformances(
+  auto conformanceIsolationInfo = SILIsolationInfo::getFromConformances(
       ieai, ieai->getConformances());
 
   translateSILMultiAssign(ieai->getResults(),
@@ -4149,7 +4036,7 @@ PartitionOpTranslator::visitInitExistentialAddrInst(InitExistentialAddrInst *iea
 
 TranslationSemantics
 PartitionOpTranslator::visitInitExistentialRefInst(InitExistentialRefInst *ieri) {
-  auto conformanceIsolationInfo = getIsolationFromConformances(
+  auto conformanceIsolationInfo = SILIsolationInfo::getFromConformances(
       ieri, ieri->getConformances());
 
   translateSILMultiAssign(ieri->getResults(),
@@ -4161,7 +4048,7 @@ PartitionOpTranslator::visitInitExistentialRefInst(InitExistentialRefInst *ieri)
 
 TranslationSemantics
 PartitionOpTranslator::visitInitExistentialValueInst(InitExistentialValueInst *ievi) {
-  auto conformanceIsolationInfo = getIsolationFromConformances(
+  auto conformanceIsolationInfo = SILIsolationInfo::getFromConformances(
       ievi, ievi->getConformances());
 
   translateSILMultiAssign(ievi->getResults(),
@@ -4175,7 +4062,7 @@ TranslationSemantics
 PartitionOpTranslator::visitCheckedCastBranchInst(CheckedCastBranchInst *ccbi) {
   // Consider whether the value produced by the cast might be task-isolated.
   auto resultValue = ccbi->getSuccessBB()->getArgument(0);
-  auto conformanceIsolation = getIsolationForCastConformances(
+  auto conformanceIsolation = SILIsolationInfo::getForCastConformances(
       resultValue,
       ccbi->getSourceFormalType(),
       ccbi->getTargetFormalType());
@@ -4192,7 +4079,7 @@ TranslationSemantics PartitionOpTranslator::visitCheckedCastAddrBranchInst(
 
   // Consider whether the value written into by the cast might be task-isolated.
   auto resultValue = ccabi->getAllOperands().back().get();
-  auto conformanceIsolation = getIsolationForCastConformances(
+  auto conformanceIsolation = SILIsolationInfo::getForCastConformances(
       resultValue,
       ccabi->getSourceFormalType(),
       ccabi->getTargetFormalType());

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -318,6 +318,8 @@ static bool isStaticallyLookThroughInst(SILInstruction *inst) {
   case SILInstructionKind::BeginBorrowInst:
     // Look through if it isn't from a var decl.
     return !cast<BeginBorrowInst>(inst)->isFromVarDecl();
+  case SILInstructionKind::InitExistentialValueInst:
+    return !SILIsolationInfo::getConformanceIsolation(inst);
   case SILInstructionKind::UnconditionalCheckedCastInst: {
     auto cast = SILDynamicCastInst::getAs(inst);
     assert(cast);
@@ -3100,7 +3102,8 @@ public:
 
     case TranslationSemantics::Assign:
       return translateSILMultiAssign(
-          inst->getResults(), makeOperandRefRange(inst->getAllOperands()));
+          inst->getResults(), makeOperandRefRange(inst->getAllOperands()),
+          SILIsolationInfo::getConformanceIsolation(inst));
 
     case TranslationSemantics::Require:
       for (auto op : inst->getOperandValues())
@@ -3344,6 +3347,8 @@ CONSTANT_TRANSLATION(CopyBlockInst, Assign)
 CONSTANT_TRANSLATION(CopyBlockWithoutEscapingInst, Assign)
 CONSTANT_TRANSLATION(IndexAddrInst, Assign)
 CONSTANT_TRANSLATION(InitBlockStorageHeaderInst, Assign)
+CONSTANT_TRANSLATION(InitExistentialAddrInst, Assign)
+CONSTANT_TRANSLATION(InitExistentialRefInst, Assign)
 CONSTANT_TRANSLATION(OpenExistentialBoxInst, Assign)
 CONSTANT_TRANSLATION(OpenExistentialRefInst, Assign)
 CONSTANT_TRANSLATION(TailAddrInst, Assign)
@@ -4023,39 +4028,11 @@ PartitionOpTranslator::visitPartialApplyInst(PartialApplyInst *pai) {
 }
 
 TranslationSemantics
-PartitionOpTranslator::visitInitExistentialAddrInst(InitExistentialAddrInst *ieai) {
-  auto conformanceIsolationInfo = SILIsolationInfo::getFromConformances(
-      ieai, ieai->getConformances());
-
-  translateSILMultiAssign(ieai->getResults(),
-                          makeOperandRefRange(ieai->getAllOperands()),
-                          conformanceIsolationInfo);
-
-  return TranslationSemantics::Special;
-}
-
-TranslationSemantics
-PartitionOpTranslator::visitInitExistentialRefInst(InitExistentialRefInst *ieri) {
-  auto conformanceIsolationInfo = SILIsolationInfo::getFromConformances(
-      ieri, ieri->getConformances());
-
-  translateSILMultiAssign(ieri->getResults(),
-                          makeOperandRefRange(ieri->getAllOperands()),
-                          conformanceIsolationInfo);
-
-  return TranslationSemantics::Special;
-}
-
-TranslationSemantics
 PartitionOpTranslator::visitInitExistentialValueInst(InitExistentialValueInst *ievi) {
-  auto conformanceIsolationInfo = SILIsolationInfo::getFromConformances(
-      ievi, ievi->getConformances());
+  if (isStaticallyLookThroughInst(ievi))
+    return TranslationSemantics::LookThrough;
 
-  translateSILMultiAssign(ievi->getResults(),
-                          makeOperandRefRange(ievi->getAllOperands()),
-                          conformanceIsolationInfo);
-
-  return TranslationSemantics::Special;
+  return TranslationSemantics::Assign;
 }
 
 TranslationSemantics

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -15,8 +15,12 @@
 #include "swift/SILOptimizer/Analysis/RegionAnalysis.h"
 
 #include "swift/AST/ASTWalker.h"
+#include "swift/AST/ConformanceLookup.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Expr.h"
+#include "swift/AST/ExistentialLayout.h"
+#include "swift/AST/PackConformance.h"
+#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/Assertions.h"
 #include "swift/Basic/FrozenMultiMap.h"
@@ -261,6 +265,56 @@ struct AddressBaseComputingVisitor
 
 } // namespace
 
+/// Determine the isolation of conformances that could be introduced by a cast from sourceType to
+/// destType.
+///
+///
+static SILIsolationInfo getIsolationForCastConformances(
+    SILValue value, CanType sourceType, CanType destType) {
+  // If the enclosing function is @concurrent, then a cast cannot pick up
+  // any isolated conformances because it's not on any actor.
+  auto function = value->getFunction();
+  auto functionIsolation = function->getActorIsolation();
+  if (functionIsolation && functionIsolation->isNonisolated())
+    return {};
+
+  auto sendableMetatype =
+    sourceType->getASTContext().getProtocol(KnownProtocolKind::SendableMetatype);
+  if (!sendableMetatype)
+    return {};
+
+  if (!destType.isAnyExistentialType())
+    return {};
+
+  const auto &destLayout = destType.getExistentialLayout();
+  for (auto proto : destLayout.getProtocols()) {
+    // If the source type already conforms to the protocol, we won't be looking
+    // it up dynamically.
+    if (!lookupConformance(sourceType, proto, /*allowMissing=*/false).isInvalid())
+      continue;
+
+    // If the protocol inherits SendableMetatype, it can't have isolated
+    // conformances.
+    if (proto->inheritsFrom(sendableMetatype))
+      continue;
+
+    // The cast can produce a conformance with the same isolation as this
+    // function is dynamically executing. If that's known (i.e., because we're
+    // on a global actor), the value is isolated to that global actor.
+    // Otherwise, it's task-isolated.
+    if (functionIsolation && functionIsolation->isGlobalActor()) {
+      return SILIsolationInfo::getGlobalActorIsolated(
+          value, functionIsolation->getGlobalActor());
+    }
+
+    // Consider the cast to be task-isolated, because the runtime could find
+    // a conformance that is isolated to the current context.
+    return SILIsolationInfo::getTaskIsolated(value);
+  }
+
+  return {};
+}
+
 /// Classify an instructions as look through when we are looking through
 /// values. We assert that all instructions that are CONSTANT_TRANSLATION
 /// LookThrough to make sure they stay in sync.
@@ -308,7 +362,6 @@ static bool isStaticallyLookThroughInst(SILInstruction *inst) {
   case SILInstructionKind::StrongCopyUnmanagedValueInst:
   case SILInstructionKind::RefToUnmanagedInst:
   case SILInstructionKind::UnmanagedToRefInst:
-  case SILInstructionKind::InitExistentialValueInst:
   case SILInstructionKind::UncheckedEnumDataInst:
   case SILInstructionKind::StructElementAddrInst:
   case SILInstructionKind::TupleElementAddrInst:
@@ -322,6 +375,15 @@ static bool isStaticallyLookThroughInst(SILInstruction *inst) {
   case SILInstructionKind::UnconditionalCheckedCastInst: {
     auto cast = SILDynamicCastInst::getAs(inst);
     assert(cast);
+
+    // If this cast introduces isolation due to conformances, we cannot look
+    // through it to the source.
+    if (!getIsolationForCastConformances(
+            llvm::cast<UnconditionalCheckedCastInst>(inst),
+            cast.getSourceFormalType(), cast.getTargetFormalType())
+              .isDisconnected())
+      return false;
+
     if (cast.isRCIdentityPreserving())
       return true;
     return false;
@@ -2124,6 +2186,13 @@ private:
     return valueMap.lookupValueID(value);
   }
 
+  /// Determine the isolation of a set of conformances.
+  ///
+  /// This function identifies potentially-isolated conformances that might affect the isolation of the given
+  /// value.
+  SILIsolationInfo getIsolationFromConformances(
+      SILValue value, ArrayRef<ProtocolConformanceRef> conformances);
+
 public:
   /// Return the partition consisting of all function arguments.
   ///
@@ -2822,13 +2891,19 @@ public:
 
   template <typename Collection>
   void translateSILMerge(SILValue dest, Collection srcCollection,
-                         bool requireOperands = true) {
-    auto destResult = tryToTrackValue(dest);
+                         bool requireOperands,
+                         SILIsolationInfo resultIsolationInfoOverride = {}) {
+    auto destResult =  tryToTrackValue(dest);
     if (!destResult)
       return;
 
     if (requireOperands) {
       builder.addRequire(*destResult);
+
+      if (resultIsolationInfoOverride && !srcCollection.empty()) {
+        using std::begin;
+        builder.addActorIntroducingInst(dest, *begin(srcCollection), resultIsolationInfoOverride);
+      }
     }
 
     for (Operand *op : srcCollection) {
@@ -2847,17 +2922,29 @@ public:
 
   template <>
   void translateSILMerge<Operand *>(SILValue dest, Operand *src,
-                                    bool requireOperands) {
+                                    bool requireOperands,
+                                    SILIsolationInfo resultIsolationInfoOverride) {
     return translateSILMerge(dest, TinyPtrVector<Operand *>(src),
-                             requireOperands);
+                             requireOperands, resultIsolationInfoOverride);
   }
 
   void translateSILMerge(MutableArrayRef<Operand> array,
-                         bool requireOperands = true) {
+                         bool requireOperands,
+                         SILIsolationInfo resultIsolationInfoOverride = {}) {
     if (array.size() < 2)
       return;
 
-    auto destResult = tryToTrackValue(array.front().get());
+    std::optional<TrackableValueLookupResult> destResult;
+    if (resultIsolationInfoOverride) {
+      if (auto nonSendableValue = initializeTrackedValue(
+              array.front().get(), resultIsolationInfoOverride)) {
+        destResult = TrackableValueLookupResult{
+            nonSendableValue->first, std::nullopt};
+      }
+    } else {
+      destResult = tryToTrackValue(array.front().get());
+    }
+
     if (!destResult)
       return;
 
@@ -2882,7 +2969,8 @@ public:
   /// captures by applications), then these can be treated as assignments of \p
   /// dest to src. If the \p dest could be aliased, then we must instead treat
   /// them as merges, to ensure any aliases of \p dest are also updated.
-  void translateSILStore(Operand *dest, Operand *src) {
+  void translateSILStore(Operand *dest, Operand *src,
+                          SILIsolationInfo resultIsolationInfoOverride = {}) {
     SILValue destValue = dest->get();
 
     if (auto destResult = tryToTrackValue(destValue)) {
@@ -2901,11 +2989,13 @@ public:
       // TODO: Should this change if we have a Sendable address with a
       // non-Sendable base.
       if (destResult.value().value.isNoAlias() &&
+          !resultIsolationInfoOverride &&
           !isProjectedFromAggregate(destValue))
         return translateSILAssign(destValue, src);
 
       // Stores to possibly aliased storage must be treated as merges.
-      return translateSILMerge(destValue, src);
+      return translateSILMerge(destValue, src, /*requireOperand*/true,
+                               resultIsolationInfoOverride);
     }
 
     // Stores to storage of non-Sendable type can be ignored.
@@ -2935,7 +3025,8 @@ public:
 
       // Stores to possibly aliased storage must be treated as merges.
       return translateSILMerge(dest,
-                               makeOperandRefRange(inst->getElementOperands()));
+                               makeOperandRefRange(inst->getElementOperands()),
+                               /*requireOperands=*/true);
     }
 
     // Stores to storage of non-Sendable type can be ignored.
@@ -2980,10 +3071,12 @@ public:
   // and a pointer to the bb being branches to itself.
   // this is handled as assigning to each possible arg being branched to the
   // merge of all values that could be passed to it from this basic block.
-  void translateSILPhi(TermArgSources &argSources) {
+  void translateSILPhi(TermArgSources &argSources,
+                       SILIsolationInfo resultIsolationInfoOverride = {}) {
     argSources.argSources.setFrozen();
     for (auto pair : argSources.argSources.getRange()) {
-      translateSILMultiAssign(TinyPtrVector<SILValue>(pair.first), pair.second);
+      translateSILMultiAssign(TinyPtrVector<SILValue>(pair.first), pair.second,
+                              resultIsolationInfoOverride);
     }
   }
 
@@ -3312,8 +3405,6 @@ CONSTANT_TRANSLATION(CopyBlockInst, Assign)
 CONSTANT_TRANSLATION(CopyBlockWithoutEscapingInst, Assign)
 CONSTANT_TRANSLATION(IndexAddrInst, Assign)
 CONSTANT_TRANSLATION(InitBlockStorageHeaderInst, Assign)
-CONSTANT_TRANSLATION(InitExistentialAddrInst, Assign)
-CONSTANT_TRANSLATION(InitExistentialRefInst, Assign)
 CONSTANT_TRANSLATION(OpenExistentialBoxInst, Assign)
 CONSTANT_TRANSLATION(OpenExistentialRefInst, Assign)
 CONSTANT_TRANSLATION(TailAddrInst, Assign)
@@ -3382,7 +3473,6 @@ CONSTANT_TRANSLATION(StrongCopyWeakValueInst, LookThrough)
 CONSTANT_TRANSLATION(StrongCopyUnmanagedValueInst, LookThrough)
 CONSTANT_TRANSLATION(RefToUnmanagedInst, LookThrough)
 CONSTANT_TRANSLATION(UnmanagedToRefInst, LookThrough)
-CONSTANT_TRANSLATION(InitExistentialValueInst, LookThrough)
 CONSTANT_TRANSLATION(UncheckedEnumDataInst, LookThrough)
 CONSTANT_TRANSLATION(TupleElementAddrInst, LookThrough)
 CONSTANT_TRANSLATION(StructElementAddrInst, LookThrough)
@@ -3393,7 +3483,7 @@ CONSTANT_TRANSLATION(UncheckedTakeEnumDataAddrInst, LookThrough)
 //
 
 // These are treated as stores - meaning that they could write values into
-// memory. The beahvior of this depends on whether the tgt addr is aliased,
+// memory. The behavior of this depends on whether the tgt addr is aliased,
 // but conservative behavior is to treat these as merges of the regions of
 // the src value and tgt addr
 CONSTANT_TRANSLATION(CopyAddrInst, Store)
@@ -3402,7 +3492,6 @@ CONSTANT_TRANSLATION(StoreInst, Store)
 CONSTANT_TRANSLATION(StoreWeakInst, Store)
 CONSTANT_TRANSLATION(MarkUnresolvedMoveAddrInst, Store)
 CONSTANT_TRANSLATION(UncheckedRefCastAddrInst, Store)
-CONSTANT_TRANSLATION(UnconditionalCheckedCastAddrInst, Store)
 CONSTANT_TRANSLATION(StoreUnownedInst, Store)
 
 //===---
@@ -3477,7 +3566,6 @@ CONSTANT_TRANSLATION(YieldInst, Require)
 // Terminators that act as phis.
 CONSTANT_TRANSLATION(BranchInst, TerminatorPhi)
 CONSTANT_TRANSLATION(CondBranchInst, TerminatorPhi)
-CONSTANT_TRANSLATION(CheckedCastBranchInst, TerminatorPhi)
 CONSTANT_TRANSLATION(DynamicMethodBranchInst, TerminatorPhi)
 
 // Function exiting terminators.
@@ -3879,13 +3967,34 @@ PartitionOpTranslator::visitPointerToAddressInst(PointerToAddressInst *ptai) {
 
 TranslationSemantics PartitionOpTranslator::visitUnconditionalCheckedCastInst(
     UnconditionalCheckedCastInst *ucci) {
-  if (SILDynamicCastInst(ucci).isRCIdentityPreserving()) {
+  auto isolation = getIsolationForCastConformances(
+      ucci, ucci->getSourceFormalType(), ucci->getTargetFormalType());
+
+  if (isolation.isDisconnected() &&
+      SILDynamicCastInst(ucci).isRCIdentityPreserving()) {
     assert(isStaticallyLookThroughInst(ucci) && "Out of sync");
     return TranslationSemantics::LookThrough;
   }
 
   assert(!isStaticallyLookThroughInst(ucci) && "Out of sync");
-  return TranslationSemantics::Assign;
+  translateSILMultiAssign(
+      ucci->getResults(), makeOperandRefRange(ucci->getAllOperands()),
+      isolation);
+  return TranslationSemantics::Special;
+}
+
+TranslationSemantics PartitionOpTranslator::visitUnconditionalCheckedCastAddrInst(
+    UnconditionalCheckedCastAddrInst *uccai) {
+  auto isolation = getIsolationForCastConformances(
+      uccai->getAllOperands()[CopyLikeInstruction::Dest].get(),
+      uccai->getSourceFormalType(), uccai->getTargetFormalType());
+
+  translateSILStore(
+      &uccai->getAllOperands()[CopyLikeInstruction::Dest],
+      &uccai->getAllOperands()[CopyLikeInstruction::Src],
+      isolation);
+
+  return TranslationSemantics::Special;
 }
 
 // RefElementAddrInst is not considered to be a lookThrough since we want to
@@ -3974,9 +4083,112 @@ PartitionOpTranslator::visitPartialApplyInst(PartialApplyInst *pai) {
   return TranslationSemantics::Special;
 }
 
+SILIsolationInfo
+PartitionOpTranslator::getIsolationFromConformances(
+    SILValue value, ArrayRef<ProtocolConformanceRef> conformances) {
+  for (auto conformance: conformances) {
+    // If the conformance is a pack, recurse.
+    if (conformance.isPack()) {
+      auto pack = conformance.getPack();
+      for (auto innerConformance : pack->getPatternConformances()) {
+        auto isolation = getIsolationFromConformances(value, innerConformance);
+        if (isolation)
+          return isolation;
+      }
+
+      continue;
+    }
+
+    // If a concrete conformance is global-actor-isolated, then the resulting
+    // value must be.
+    if (conformance.isConcrete()) {
+      auto isolation = conformance.getConcrete()->getIsolation();
+      if (isolation.isGlobalActor()) {
+        return SILIsolationInfo::getGlobalActorIsolated(
+            value, isolation.getGlobalActor());
+      }
+
+      continue;
+    }
+
+    // If an abstract conformance is for a non-SendableMetatype-conforming
+    // type, the resulting value is task-isolated.
+    if (conformance.isAbstract()) {
+      auto sendableMetatype =
+        conformance.getType()->getASTContext()
+          .getProtocol(KnownProtocolKind::SendableMetatype);
+      if (sendableMetatype &&
+          lookupConformance(conformance.getType(), sendableMetatype,
+                            /*allowMissing=*/false).isInvalid()) {
+        return SILIsolationInfo::getTaskIsolated(value);
+      }
+    }
+  }
+
+  return {};
+}
+
+TranslationSemantics
+PartitionOpTranslator::visitInitExistentialAddrInst(InitExistentialAddrInst *ieai) {
+  auto conformanceIsolationInfo = getIsolationFromConformances(
+      ieai->getResult(0), ieai->getConformances());
+
+  translateSILMultiAssign(ieai->getResults(),
+                          makeOperandRefRange(ieai->getAllOperands()),
+                          conformanceIsolationInfo);
+
+  return TranslationSemantics::Special;
+}
+
+TranslationSemantics
+PartitionOpTranslator::visitInitExistentialRefInst(InitExistentialRefInst *ieri) {
+  auto conformanceIsolationInfo = getIsolationFromConformances(
+      ieri->getResult(0), ieri->getConformances());
+
+  translateSILMultiAssign(ieri->getResults(),
+                          makeOperandRefRange(ieri->getAllOperands()),
+                          conformanceIsolationInfo);
+
+  return TranslationSemantics::Special;
+}
+
+TranslationSemantics
+PartitionOpTranslator::visitInitExistentialValueInst(InitExistentialValueInst *ievi) {
+  auto conformanceIsolationInfo = getIsolationFromConformances(
+      ievi->getResult(0), ievi->getConformances());
+
+  translateSILMultiAssign(ievi->getResults(),
+                          makeOperandRefRange(ievi->getAllOperands()),
+                          conformanceIsolationInfo);
+
+  return TranslationSemantics::Special;
+}
+
+TranslationSemantics
+PartitionOpTranslator::visitCheckedCastBranchInst(CheckedCastBranchInst *ccbi) {
+  // Consider whether the value produced by the cast might be task-isolated.
+  auto resultValue = ccbi->getSuccessBB()->getArgument(0);
+  auto conformanceIsolation = getIsolationForCastConformances(
+      resultValue,
+      ccbi->getSourceFormalType(),
+      ccbi->getTargetFormalType());
+  TermArgSources sources;
+  sources.init(static_cast<SILInstruction *>(ccbi));
+  translateSILPhi(sources, conformanceIsolation);
+
+  return TranslationSemantics::Special;
+}
+
 TranslationSemantics PartitionOpTranslator::visitCheckedCastAddrBranchInst(
     CheckedCastAddrBranchInst *ccabi) {
   assert(ccabi->getSuccessBB()->getNumArguments() <= 1);
+
+  // Consider whether the value written into by the cast might be task-isolated.
+  auto resultValue = ccabi->getAllOperands().back().get();
+  auto conformanceIsolation = getIsolationForCastConformances(
+      resultValue,
+      ccabi->getSourceFormalType(),
+      ccabi->getTargetFormalType());
 
   // checked_cast_addr_br does not have any arguments in its resulting
   // block. We should just use a multi-assign on its operands.
@@ -3986,7 +4198,8 @@ TranslationSemantics PartitionOpTranslator::visitCheckedCastAddrBranchInst(
   // is. For now just keep the current behavior. It is more conservative,
   // but still correct.
   translateSILMultiAssign(ArrayRef<SILValue>(),
-                          makeOperandRefRange(ccabi->getAllOperands()));
+                          makeOperandRefRange(ccabi->getAllOperands()),
+                          conformanceIsolation);
   return TranslationSemantics::Special;
 }
 

--- a/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/SendNonSendable.cpp
@@ -1304,6 +1304,18 @@ public:
   ~SendNeverSentDiagnosticEmitter() {
     if (!emittedErrorDiagnostic) {
       emitUnknownPatternError();
+    } else if (auto proto = isolationRegionInfo.getIsolationInfo()
+                   .getIsolatedConformance()) {
+       // If the diagnostic comes from a (potentially) isolated conformance,
+       // add a note saying so and indicating where the isolated conformance
+       // can come in.
+       if (auto value = isolationRegionInfo.getIsolationInfo().getIsolatedValue()) {
+         if (auto loc = value.getLoc()) {
+           diagnoseNote(
+               loc, diag::regionbasedisolation_isolated_conformance_introduced,
+               proto);
+         }
+       }
     }
   }
 
@@ -1318,6 +1330,13 @@ public:
   }
 
   std::optional<DiagnosticBehavior> getBehaviorLimit() const {
+    // If the failure is due to an isolated conformance, downgrade the error
+    // to a warning prior to Swift 7.
+    if (isolationRegionInfo.getIsolationInfo().getIsolatedConformance() &&
+        !sendingOperand->get()->getType().getASTType()->getASTContext().LangOpts
+          .isSwiftVersionAtLeast(7))
+      return DiagnosticBehavior::Warning;
+
     return sendingOperand->get()->getType().getConcurrencyDiagnosticBehavior(
         getOperand()->getFunction());
   }
@@ -1595,8 +1614,7 @@ public:
     }
 
     diagnoseNote(loc, diag::regionbasedisolation_named_send_nt_asynclet_capture,
-                 name, descriptiveKindStr)
-        .limitBehaviorIf(getBehaviorLimit());
+                 name, descriptiveKindStr);
   }
 
   void emitNamedIsolation(SILLocation loc, Identifier name,

--- a/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
+++ b/lib/SILOptimizer/Utils/SILIsolationInfo.cpp
@@ -1062,6 +1062,21 @@ SILIsolationInfo SILIsolationInfo::getForCastConformances(
   return {};
 }
 
+SILIsolationInfo SILIsolationInfo::getConformanceIsolation(SILInstruction *inst) {
+  // Existential initialization.
+  if (auto ieai = dyn_cast<InitExistentialAddrInst>(inst)) {
+    return getFromConformances(ieai, ieai->getConformances());
+  }
+  if (auto ieri = dyn_cast<InitExistentialRefInst>(inst)) {
+    return getFromConformances(ieri, ieri->getConformances());
+  }
+  if (auto ievi = dyn_cast<InitExistentialValueInst>(inst)) {
+    return getFromConformances(ievi, ievi->getConformances());
+  }
+
+  return {};
+}
+
 void SILIsolationInfo::printOptions(llvm::raw_ostream &os) const {
   if (isolatedConformance) {
     os << "isolated-conformance-to(" << isolatedConformance->getName() << ")";

--- a/test/Concurrency/sendable_metatype.swift
+++ b/test/Concurrency/sendable_metatype.swift
@@ -120,20 +120,21 @@ func acceptSendingAnyObjectR(_ s: sending AnyObject & R) { }
 @MainActor func passSendingExistential<T: P, U: AnyObject & P , V: R, W: AnyObject & R>(
   t: sending T, u: sending U, v: sending V, w: sending W
 ) {
-  // FIXME: Diagnostics here should really mention that it's the main-actor-
-  // isolated conformance to P that's the problem.
-  acceptSendingP(S()) // expected-error{{sending value of non-Sendable type 'S' risks causing data races}}
+  acceptSendingP(S()) // expected-warning{{sending value of non-Sendable type 'S' risks causing data races}}
   // expected-note@-1{{Passing main actor-isolated value of non-Sendable type 'S' as a 'sending' parameter to global function 'acceptSendingP' risks causing races}}
-  acceptSendingP(SC()) // expected-error{{sending value of non-Sendable type 'SC'}}
+  // expected-note@-2{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingP(SC()) // expected-warning{{sending value of non-Sendable type 'SC'}}
   // expected-note@-1{{Passing main actor-isolated value of non-Sendable type 'SC' as a 'sending' parameter to global function 'acceptSendingP' risks causing races}}' risks causing data races}}
-  acceptSendingAnyObjectP(SC()) // expected-error{{sending value of non-Sendable type 'SC' risks causing data races}}
+  // expected-note@-2{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingAnyObjectP(SC()) // expected-warning{{sending value of non-Sendable type 'SC' risks causing data races}}
   // expected-note@-1{{Passing main actor-isolated value of non-Sendable type 'SC' as a 'sending' parameter to global function 'acceptSendingAnyObjectP' risks causing races}}' risks causing data races}}
-
-  acceptSendingP(t) // expected-error{{sending 't' risks causing data races}}
+  // expected-note@-2{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingP(t) // expected-warning{{sending 't' risks causing data races}}
   // expected-note@-1{{task-isolated 't' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
-  acceptSendingAnyObjectP(u) // expected-error{{sending value of non-Sendable type 'U' risks causing data races}}
+  // expected-note@-2{{isolated conformance to protocol 'P' can be introduced he}}
+  acceptSendingAnyObjectP(u) // expected-warning{{sending value of non-Sendable type 'U' risks causing data races}}
   // expected-note@-1{{task-isolated value of non-Sendable type 'U'}}
-
+  // expected-note@-2{{isolated conformance to protocol 'P' can be introduced here}}
   // All of these are okay, because there are no isolated conformances to R.
   acceptSendingR(S())
   acceptSendingR(SC())
@@ -146,16 +147,15 @@ func dynamicCastingExistential(
   _ s1: sending Any,
   _ s2: sending Any
 ) {
-  // TODO: Improve diagnostics due to isolated conformances.
-  if let s1p = s1 as? any P {
-    acceptSendingP(s1p) // expected-error{{sending 's1p' risks causing data races}}
+  if let s1p = s1 as? any P { // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+    acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
     // expected-note@-1{{task-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
   } else {
     print(s1)
   }
 
-  if let s2p = s2 as? any AnyObject & P {
-    acceptSendingAnyObjectP(s2p) // expected-error{{sending 's2p' risks causing data races}}
+  if let s2p = s2 as? any AnyObject & P { // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+    acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
     // expected-note@-1{{task-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
   } else {
     print(s2)
@@ -185,16 +185,15 @@ func dynamicCastingGeneric(
   _ s1: sending some Any,
   _ s2: sending some Any
 ) {
-  // TODO: Improve diagnostics due to isolated conformances.
-  if let s1p = s1 as? any P {
-    acceptSendingP(s1p) // expected-error{{sending 's1p' risks causing data races}}
+  if let s1p = s1 as? any P { // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+    acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
     // expected-note@-1{{task-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
   } else {
     print(s1)
   }
 
-  if let s2p = s2 as? any AnyObject & P {
-    acceptSendingAnyObjectP(s2p) // expected-error{{sending 's2p' risks causing data races}}
+  if let s2p = s2 as? any AnyObject & P { // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+    acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
     // expected-note@-1{{task-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
   } else {
     print(s2)
@@ -239,12 +238,12 @@ func forceCastingExistential(
   _ s1: sending Any,
   _ s2: sending AnyObject
 ) {
-  let s1p = s1 as! any P
-  acceptSendingP(s1p) // expected-error{{sending 's1p' risks causing data races}}
+  let s1p = s1 as! any P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
   // expected-note@-1{{task-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
 
-  let s2p = s2 as! any AnyObject & P
-  acceptSendingAnyObjectP(s2p) // expected-error{{sending 's2p' risks causing data races}}
+  let s2p = s2 as! any AnyObject & P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
   // expected-note@-1{{task-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
 }
 
@@ -263,12 +262,12 @@ func forceCastingGeneric(
   _ s1: sending some Any,
   _ s2: sending some AnyObject
 ) {
-  let s1p = s1 as! any P
-  acceptSendingP(s1p) // expected-error{{sending 's1p' risks causing data races}}
+  let s1p = s1 as! any P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
   // expected-note@-1{{task-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
 
-  let s2p = s2 as! any AnyObject & P
-  acceptSendingAnyObjectP(s2p) // expected-error{{sending 's2p' risks causing data races}}
+  let s2p = s2 as! any AnyObject & P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
   // expected-note@-1{{task-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later task-isolated uses}}
 }
 
@@ -276,12 +275,12 @@ func forceCastingGeneric(
   _ s1: sending some Any,
   _ s2: sending some AnyObject
 ) {
-  let s1p = s1 as! any P
-  acceptSendingP(s1p) // expected-error{{sending 's1p' risks causing data races}}
+  let s1p = s1 as! any P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingP(s1p) // expected-warning{{sending 's1p' risks causing data races}}
   // expected-note@-1{{main actor-isolated 's1p' is passed as a 'sending' parameter; Uses in callee may race with later main actor-isolated uses}}
 
-  let s2p = s2 as! any AnyObject & P
-  acceptSendingAnyObjectP(s2p) // expected-error{{sending 's2p' risks causing data races}}
+  let s2p = s2 as! any AnyObject & P // expected-note{{isolated conformance to protocol 'P' can be introduced here}}
+  acceptSendingAnyObjectP(s2p) // expected-warning{{sending 's2p' risks causing data races}}
   // expected-note@-1{{main actor-isolated 's2p' is passed as a 'sending' parameter; Uses in callee may race with later main actor-isolated uses}}
 }
 

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -192,9 +192,9 @@ bb0:
   // expected-warning @-1 {{}}
   // expected-note @-2 {{}}
 
-  %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P // expected-note {{access can happen concurrently}}
+  %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P
   %f2 = function_ref @useP : $@convention(thin) (@in_guaranteed P) -> ()
-  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> ()
+  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> () // expected-note {{access can happen concurrently}}
   destroy_value %i : $P
 
   %9999 = tuple ()

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -192,9 +192,9 @@ bb0:
   // expected-warning @-1 {{}}
   // expected-note @-2 {{}}
 
-  %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P
+  %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P // expected-note {{access can happen concurrently}}
   %f2 = function_ref @useP : $@convention(thin) (@in_guaranteed P) -> ()
-  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> () // expected-note {{access can happen concurrently}}
+  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> ()
   destroy_value %i : $P
 
   %9999 = tuple ()


### PR DESCRIPTION
- **Explanation**: Extend region-based isolation to track the introduction of isolated conformances through existentials (e.g., `any P`) and through dynamic casts (e.g., `as? any P`). This closes a concurrency soundness hole with the introduction of isolated conformances into the language, where an isolated conformance could get picked up via a `sending` parameter or return and then sent to another isolation domain, carrying the conformance with it.
- **Scope**: Limited to region analysis. Region-basic isolation is only enabled with strict concurrency, and the new diagnostic is staged in as a warning in Swift <= 6 so that it should break existing code.
- **Issues**: Issue https://github.com/swiftlang/swift/issues/82550 / rdar://154437489
- **Original PRs**: https://github.com/swiftlang/swift/pull/82814, https://github.com/swiftlang/swift/pull/82884, https://github.com/swiftlang/swift/pull/82900
- **Risk**: Low. It's plausible that a Swift 6 code base could trigger this issue in a manner that doesn't get downgraded to a warning appropriately, or triggers some other related error.
- **Testing**: CI, new tests
- **Reviewers**: @gottesmm 
