### PR TITLE
[cxx-interop] Work around errors in some tests

### DIFF
--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -13,8 +13,8 @@ config.substitutions.insert(0, ('%check-in-clang',
 config.substitutions.insert(0, ('%check-in-clang-c',
   '%%clang-no-modules -fsyntax-only -x c-header -std=c99 '
   '-Weverything -Werror -Wno-unused-macros -Wno-incomplete-module '
-  '-Wno-auto-import -Wno-poison-system-directories '
-  '-F %%clang-importer-sdk-path/frameworks '
+  '-Wno-auto-import -Wno-poison-system-directories -Wno-c++-keyword '
+  '-Wno-unknown-warning-option -F %%clang-importer-sdk-path/frameworks '
   '-I %%clang-include-dir '
   '-isysroot %r/Inputs/clang-importer-sdk' % config.test_source_root) )
 


### PR DESCRIPTION
For some reason, the new version of clang started to emit -Wc++-keyword warnings in C mode when -Weverything is enabled. This PR suppresses this warning.

rdar://155324207