### PR TITLE
[test] Tweak a couple of crasher test cases

### DIFF
--- a/validation-test/IDE/crashers/539adae64314fae.swift
+++ b/validation-test/IDE/crashers/539adae64314fae.swift
@@ -1,5 +1,8 @@
-// {"kind":"complete","signature":"void std::__1::__introsort<std::__1::_ClassicAlgPolicy, printCodeCompletionLookedupTypeNames(llvm::ArrayRef<swift::NullTerminatedStringRef>, llvm::raw_ostream&)::$_0&, swift::NullTerminatedStringRef*, false>(swift::NullTerminatedStringRef*, swift::NullTerminatedStringRef*, printCodeCompletionLookedupTypeNames(llvm::ArrayRef<swift::NullTerminatedStringRef>, llvm::raw_ostream&)::$_0&, std::__1::iterator_traits<swift::NullTerminatedStringRef*>::difference_type, bool)"}
-// RUN: not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// {"kind":"complete","signature":"void std::__1::__introsort<std::__1::_ClassicAlgPolicy, printCodeCompletionLookedupTypeNames(llvm::ArrayRef<swift::NullTerminatedStringRef>, llvm::raw_ostream&)::$_0&, swift::NullTerminatedStringRef*, false>(swift::NullTerminatedStringRef*, swift::NullTerminatedStringRef*, printCodeCompletionLookedupTypeNames(llvm::ArrayRef<swift::NullTerminatedStringRef>, llvm::raw_ostream&)::$_0&, std::__1::iterator_traits<swift::NullTerminatedStringRef*>::difference_type, bool)","useGuardMalloc":true}
+// RUN: env DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib not --crash %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+// REQUIRES: OS=macosx
+// REQUIRES: no_asan
+// REQUIRES: target-same-as-host
 struct a<each b: Collection
 {
 c: (repeat each b.Index

--- a/validation-test/compiler_crashers_2/1e4b431ffe374ef1.swift
+++ b/validation-test/compiler_crashers_2/1e4b431ffe374ef1.swift
@@ -1,8 +1,0 @@
-// {"kind":"typecheck","signature":"swift::TypeTransform<swift::Type::transformRec(llvm::function_ref<std::__1::optional<swift::Type> (swift::TypeBase*)>) const::Transform>::doIt(swift::Type, swift::TypePosition)"}
-// RUN: not --crash %target-swift-frontend -typecheck %s
-@dynamicMemberLookup struct a<b {
-  init(() -> b, subscript
-   <c>(dynamicMember d: WritableKeyPath<b, c>)
-  a<c>
-}
-let binding = a { ?? buffer ?? binding.e

--- a/validation-test/compiler_crashers_2/a5fbf4336df96867.swift
+++ b/validation-test/compiler_crashers_2/a5fbf4336df96867.swift
@@ -1,0 +1,11 @@
+// {"kind":"typecheck","signature":"swift::TypeTransform<swift::Type::transformRec(llvm::function_ref<std::__1::optional<swift::Type> (swift::TypeBase*)>) const::Transform>::doIt(swift::Type, swift::TypePosition)"}
+// The issue here is that the solver attempts to recursively apply the same
+// dynamic member lookup until eventually it overflows the stack. Make sure
+// we either timeout or crash.
+// RUN: not %{python} %S/../../test/Inputs/timeout.py 60 %target-swift-frontend -typecheck %s || \
+// RUN: not --crash %target-swift-frontend -typecheck %s
+@dynamicMemberLookup struct S<T> {
+  init(_: () -> T) {}
+  subscript<U>(dynamicMember d: WritableKeyPath<T, U>) -> S<U> {}
+}
+let x = S { x.e }


### PR DESCRIPTION
- Make `539adae64314fae.swift` macOS only and use guard malloc for it.
- Tweak `1e4b431ffe374ef1.swift` such that it succeeds if it either times out after a minute or crashes. While here, also clean up the test case a little.