### PR TITLE
[Completion] Avoid using unbound contextual type in argument completion

### DIFF
--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -148,7 +148,9 @@ void ArgumentTypeCheckCompletionCallback::sawSolutionImpl(const Solution &S) {
       ExpectedCallType = ContextualType;
     }
   }
-  if (ExpectedCallType && ExpectedCallType->hasUnresolvedType()) {
+  if (ExpectedCallType &&
+      (ExpectedCallType->hasUnresolvedType() ||
+       ExpectedCallType->hasUnboundGenericType())) {
     ExpectedCallType = Type();
   }
   

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1443,3 +1443,14 @@ struct NestedCallsWithoutClosingParen {
     _ = (foo(#^IN_TUPLE?check=NESTED_CALL_WITHOUT_TYPE_RELATION^#, 1)
   }
 }
+
+func testUnboundContextualType() {
+  struct S<T> {
+    func bar(x: Int) -> Self { self }
+  }
+
+  func foo(x: S<Int>) {
+    let _: S = x.bar(#^ARG_WITH_UNBOUND_CONTEXTUAL_TY^#
+    // ARG_WITH_UNBOUND_CONTEXTUAL_TY: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#x: Int#}[')'][#S<Int>#]; name=x:
+  }
+}

--- a/validation-test/IDE/crashers_fixed/ad7672295e2e882c.swift
+++ b/validation-test/IDE/crashers_fixed/ad7672295e2e882c.swift
@@ -1,0 +1,4 @@
+// {"kind":"complete","signature":"swift::ide::CodeCompletionResultType::calculateTypeRelation(swift::ide::ExpectedTypeContext const*, swift::DeclContext const*, swift::ide::USRBasedTypeContext const*) const"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+func b(a : Array<Int>) {
+let: Array = a.prefix( #^^#


### PR DESCRIPTION
Match the logic in `getTypeForCompletion` and avoid using an unbound generic type as the expected type for a completion.

rdar://155420395