### PR TITLE
[6.2] [Completion] Avoid using unbound contextual type in argument completion

### DIFF
--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -148,7 +148,9 @@ void ArgumentTypeCheckCompletionCallback::sawSolutionImpl(const Solution &S) {
       ExpectedCallType = ContextualType;
     }
   }
-  if (ExpectedCallType && ExpectedCallType->hasUnresolvedType()) {
+  if (ExpectedCallType &&
+      (ExpectedCallType->hasUnresolvedType() ||
+       ExpectedCallType->hasUnboundGenericType())) {
     ExpectedCallType = Type();
   }
   

--- a/lib/IDE/CodeCompletionResultType.cpp
+++ b/lib/IDE/CodeCompletionResultType.cpp
@@ -393,8 +393,14 @@ static TypeRelation calculateTypeRelation(Type Ty, Type ExpectedTy,
     return TypeRelation::Unknown;
   }
 
-  ASSERT(!Ty->hasUnboundGenericType() && !ExpectedTy->hasUnboundGenericType());
-  ASSERT(!ExpectedTy->hasTypeParameter());
+  if (Ty->hasUnboundGenericType() || ExpectedTy->hasUnboundGenericType()) {
+    CONDITIONAL_ASSERT(false && "Must not have unbound generic type here");
+    return TypeRelation::Unrelated;
+  }
+  if (ExpectedTy->hasTypeParameter()) {
+    CONDITIONAL_ASSERT(false && "Must not have generic type here");
+    return TypeRelation::Unrelated;
+  }
 
   if (Ty->isEqual(ExpectedTy))
     return TypeRelation::Convertible;

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1443,3 +1443,14 @@ struct NestedCallsWithoutClosingParen {
     _ = (foo(#^IN_TUPLE?check=NESTED_CALL_WITHOUT_TYPE_RELATION^#, 1)
   }
 }
+
+func testUnboundContextualType() {
+  struct S<T> {
+    func bar(x: Int) -> Self { self }
+  }
+
+  func foo(x: S<Int>) {
+    let _: S = x.bar(#^ARG_WITH_UNBOUND_CONTEXTUAL_TY^#
+    // ARG_WITH_UNBOUND_CONTEXTUAL_TY: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]: ['(']{#x: Int#}[')'][#S<Int>#]; name=x:
+  }
+}

--- a/validation-test/IDE/crashers_fixed/ad7672295e2e882c.swift
+++ b/validation-test/IDE/crashers_fixed/ad7672295e2e882c.swift
@@ -1,0 +1,4 @@
+// {"kind":"complete","signature":"swift::ide::CodeCompletionResultType::calculateTypeRelation(swift::ide::ExpectedTypeContext const*, swift::DeclContext const*, swift::ide::USRBasedTypeContext const*) const"}
+// RUN: %target-swift-ide-test -code-completion -batch-code-completion -skip-filecheck -code-completion-diagnostics -source-filename %s
+func b(a : Array<Int>) {
+let: Array = a.prefix( #^^#


### PR DESCRIPTION
*6.2 cherry-pick of #82910*

- Explanation: Fixes a crash that could occur when completing in a call argument where the contextual type has an unbound generic type 
- Scope: Affects code completion
- Issue: rdar://155420395
- Risk: Low, only affects code completion, and the fix is straightforward.
- Testing: Added tests to test suite
- Reviewer: Rintaro Ishizaki