### PR TITLE
[6.2] SILGen: Bitcast indirect returns that differ only in concurrency annotations.

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -754,6 +754,13 @@ public:
   SILType subst(SILModule &M, SubstitutionMap subs,
                 TypeExpansionContext context) const;
 
+  /// Strip concurrency annotations from the representation type.
+  SILType stripConcurrency(bool recursive, bool dropGlobalActor) {
+    auto strippedASTTy = getASTType()->stripConcurrency(recursive, dropGlobalActor);
+    return SILType::getPrimitiveType(strippedASTTy->getCanonicalType(),
+                                     getCategory());
+  }
+
   /// Return true if this type references a "ref" type that has a single pointer
   /// representation. Class existentials do not always qualify.
   bool isHeapObjectReferenceType() const;

--- a/test/SILGen/preconcurrency_indirect_return.swift
+++ b/test/SILGen/preconcurrency_indirect_return.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+@preconcurrency
+func test() -> (any Sendable)? { nil }
+
+// CHECK-LABEL: sil {{.*}} @$s{{.*}}callWithPreconcurrency
+func callWithPreconcurrency() {
+	// CHECK: unchecked_addr_cast {{.*}} to $*Optional<any Sendable>
+	let x = test()
+}


### PR DESCRIPTION
Explanation: Fixes a compiler crash when a function returning `any Sendable` or `(any Sendable)?` is called through a `@preconcurrency` interface.
Scope: Fixes a regression introduced by new concurrency behavior.
Issue: rdar://154240007
Original PRs: https://github.com/swiftlang/swift/pull/82901
Risk: Low. Changes behavior to fix a bug in a limited situation where `@preconcurrency` code tries to call a function returning `any Sendable` or some other indirectly-returned type.
Testing: Swift CI, test case from bug report
Reviewers: @xedin 