### PR TITLE
[SE-0466] Enable SendableProhibitsMainActorInference by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -532,10 +532,6 @@ EXPERIMENTAL_FEATURE(DefaultIsolationPerFile, false)
 /// Enable @_lifetime attribute
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
 
-/// Disable @MainActor inference when the primary definition of a type conforms
-/// to SendableMetatype (or Sendable).
-EXPERIMENTAL_FEATURE(SendableProhibitsMainActorInference, true)
-
 /// Allow macro based aliases to be imported into Swift
 EXPERIMENTAL_FEATURE(ImportMacroAliases, true)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -125,7 +125,6 @@ UNINTERESTING_FEATURE(StructLetDestructuring)
 UNINTERESTING_FEATURE(MacrosOnImports)
 UNINTERESTING_FEATURE(NonisolatedNonsendingByDefault)
 UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
-UNINTERESTING_FEATURE(SendableProhibitsMainActorInference)
 UNINTERESTING_FEATURE(ImportMacroAliases)
 
 // TODO: Return true for inlinable function bodies with module selectors in them

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -155,18 +155,6 @@ addImplicitCodingKeys(NominalTypeDecl *target,
   enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);
 
-  if (!C.LangOpts.hasFeature(Feature::SendableProhibitsMainActorInference)) {
-    switch (C.LangOpts.DefaultIsolationBehavior) {
-    case DefaultIsolation::MainActor:
-      enumDecl->getAttrs().add(NonisolatedAttr::createImplicit(C));
-      break;
-
-    case DefaultIsolation::Nonisolated:
-      // Nothing to do.
-      break;
-    }
-  }
-
   // For classes which inherit from something Encodable or Decodable, we
   // provide case `super` as the first key (to be used in encoding super).
   auto *classDecl = dyn_cast<ClassDecl>(target);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6029,9 +6029,6 @@ static void addAttributesForActorIsolation(ValueDecl *value,
 /// be nonisolated (preventing @MainActor inference).
 static bool sendableConformanceRequiresNonisolated(NominalTypeDecl *nominal) {
   ASTContext &ctx = nominal->getASTContext();
-  if (!ctx.LangOpts.hasFeature(Feature::SendableProhibitsMainActorInference))
-    return false;
-
   if (isa<ProtocolDecl>(nominal))
     return false;
 

--- a/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -swift-version 5 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift5- -enable-experimental-feature SendableProhibitsMainActorInference
-// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift6- -enable-experimental-feature SendableProhibitsMainActorInference
-
-// REQUIRES: swift_feature_SendableProhibitsMainActorInference
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift5-
+// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift6-
 
 // Ensure that a Sendable-conforming protocol suppresses @MainActor inference
 // for a type.

--- a/test/Macros/default_main_actor_nonisolated.swift
+++ b/test/Macros/default_main_actor_nonisolated.swift
@@ -4,9 +4,7 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // Check for errors
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -swift-version 6 -default-isolation MainActor -enable-experimental-feature SendableProhibitsMainActorInference
-
-// REQUIRES: swift_feature_SendableProhibitsMainActorInference
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -swift-version 6 -default-isolation MainActor
 
 @attached(extension, conformances: Sendable)
 macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableMacro")


### PR DESCRIPTION
This implements the SE-0466 amendment under discussion for all code with default main-actor isolation.

Finalizes rdar://151029300.
