### PR TITLE
[6.2] [SE-0466] Enable SendableProhibitsMainActorInference by default

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -530,10 +530,6 @@ EXPERIMENTAL_FEATURE(DefaultIsolationPerFile, false)
 /// Enable @_lifetime attribute
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(Lifetimes, true)
 
-/// Disable @MainActor inference when the primary definition of a type conforms
-/// to SendableMetatype (or Sendable).
-EXPERIMENTAL_FEATURE(SendableProhibitsMainActorInference, true)
-
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -127,7 +127,6 @@ UNINTERESTING_FEATURE(MacrosOnImports)
 UNINTERESTING_FEATURE(ExtensibleEnums)
 UNINTERESTING_FEATURE(NonisolatedNonsendingByDefault)
 UNINTERESTING_FEATURE(KeyPathWithMethodMembers)
-UNINTERESTING_FEATURE(SendableProhibitsMainActorInference)
 
 static bool usesFeatureNonescapableTypes(Decl *decl) {
   auto containsNonEscapable =

--- a/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformance/DerivedConformanceCodable.cpp
@@ -155,18 +155,6 @@ addImplicitCodingKeys(NominalTypeDecl *target,
   enumDecl->setSynthesized();
   enumDecl->setAccess(AccessLevel::Private);
 
-  if (!C.LangOpts.hasFeature(Feature::SendableProhibitsMainActorInference)) {
-    switch (C.LangOpts.DefaultIsolationBehavior) {
-    case DefaultIsolation::MainActor:
-      enumDecl->getAttrs().add(NonisolatedAttr::createImplicit(C));
-      break;
-
-    case DefaultIsolation::Nonisolated:
-      // Nothing to do.
-      break;
-    }
-  }
-
   // For classes which inherit from something Encodable or Decodable, we
   // provide case `super` as the first key (to be used in encoding super).
   auto *classDecl = dyn_cast<ClassDecl>(target);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6010,9 +6010,6 @@ static void addAttributesForActorIsolation(ValueDecl *value,
 /// be nonisolated (preventing @MainActor inference).
 static bool sendableConformanceRequiresNonisolated(NominalTypeDecl *nominal) {
   ASTContext &ctx = nominal->getASTContext();
-  if (!ctx.LangOpts.hasFeature(Feature::SendableProhibitsMainActorInference))
-    return false;
-
   if (isa<ProtocolDecl>(nominal))
     return false;
 

--- a/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
+++ b/test/Concurrency/assume_mainactor_typechecker_errors_sendablecheck.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -swift-version 5 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift5- -enable-experimental-feature SendableProhibitsMainActorInference
-// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift6- -enable-experimental-feature SendableProhibitsMainActorInference
-
-// REQUIRES: swift_feature_SendableProhibitsMainActorInference
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift5-
+// RUN: %target-swift-frontend -swift-version 6 -emit-sil -default-isolation MainActor %s -verify -verify-additional-prefix swift6-
 
 // Ensure that a Sendable-conforming protocol suppresses @MainActor inference
 // for a type.

--- a/test/Macros/default_main_actor_nonisolated.swift
+++ b/test/Macros/default_main_actor_nonisolated.swift
@@ -4,9 +4,7 @@
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // Check for errors
-// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -swift-version 6 -default-isolation MainActor -enable-experimental-feature SendableProhibitsMainActorInference
-
-// REQUIRES: swift_feature_SendableProhibitsMainActorInference
+// RUN: %target-swift-frontend -swift-version 5 -typecheck -load-plugin-library %t/%target-library-name(MacroDefinition) %s -I %t -disable-availability-checking -swift-version 6 -default-isolation MainActor
 
 @attached(extension, conformances: Sendable)
 macro AddSendable() = #externalMacro(module: "MacroDefinition", type: "SendableMacro")


### PR DESCRIPTION
- **Explanation**: Implements the [amendment to SE-0466](https://github.com/swiftlang/swift-evolution/pull/2894) currently under discussion, which prohibits `@MainActor` from being inferred for `Sendable`-conforming types in when default-main-actor-isolation is enabled.
- **Scope**: Narrow. Only applies to default main actor isolation.
- **Issues**: rdar://151029300
- **Original PRs**: https://github.com/swiftlang/swift/pull/82921
- **Risk**: Low. Enables slightly more inference rules with default main actor isolation.
- **Testing**: CI
- **Reviewers**:
 