### PR TITLE
[6.2][Concurrency] Prevent use of `nonisolated(nonsending)` and `@concurrent` on `@_inheritActorContext` parameters

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -8612,6 +8612,14 @@ ERROR(inherit_actor_context_only_on_async_or_isolation_erased_params,none,
       "asynchronous function types",
       (DeclAttribute))
 
+ERROR(inherit_actor_context_with_concurrent,none,
+      "'@_inheritActorContext' attribute cannot be used together with %0",
+      (const TypeAttribute *))
+
+ERROR(inherit_actor_context_with_nonisolated_nonsending,none,
+      "'@_inheritActorContext' attribute cannot be used together with %0",
+      (TypeRepr *))
+
 //===----------------------------------------------------------------------===//
 // MARK: @concurrent and nonisolated(nonsending) attributes
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7815,6 +7815,9 @@ void AttributeChecker::visitInheritActorContextAttr(
     return;
 
   auto paramTy = P->getInterfaceType();
+  if (paramTy->hasError())
+    return;
+
   auto *funcTy =
       paramTy->lookThroughAllOptionalTypes()->getAs<AnyFunctionType>();
   if (!funcTy) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2339,6 +2339,9 @@ static Type validateParameterType(ParamDecl *decl) {
   if (dc->isInSpecializeExtensionContext())
     options |= TypeResolutionFlags::AllowUsableFromInline;
 
+  if (decl->getAttrs().hasAttribute<InheritActorContextAttr>())
+    options |= TypeResolutionFlags::InheritsActorContext;
+
   Type Ty;
 
   auto *nestedRepr = decl->getTypeRepr();

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4234,6 +4234,11 @@ NeverNullType TypeResolver::resolveASTFunctionType(
                       attr->getAttrName());
     }
 
+    if (options.contains(TypeResolutionFlags::InheritsActorContext)) {
+      diagnoseInvalid(repr, attr->getAttrLoc(),
+                      diag::inherit_actor_context_with_concurrent, attr);
+    }
+
     switch (isolation.getKind()) {
     case FunctionTypeIsolation::Kind::NonIsolated:
       break;
@@ -4280,18 +4285,20 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     if (!repr->isInvalid())
       isolation = FunctionTypeIsolation::forNonIsolated();
   } else if (!getWithoutClaiming<CallerIsolatedTypeRepr>(attrs)) {
-    // Infer async function type as `nonisolated(nonsending)` if there is
-    // no `@concurrent` or `nonisolated(nonsending)` attribute and isolation
-    // is nonisolated.
-    if (ctx.LangOpts.hasFeature(Feature::NonisolatedNonsendingByDefault) &&
-        repr->isAsync() && isolation.isNonIsolated()) {
-      isolation = FunctionTypeIsolation::forNonIsolatedCaller();
-    } else if (ctx.LangOpts
-                   .getFeatureState(Feature::NonisolatedNonsendingByDefault)
-                   .isEnabledForMigration()) {
-      // Diagnose only in the interface stage, which is run once.
-      if (inStage(TypeResolutionStage::Interface)) {
-        warnAboutNewNonisolatedAsyncExecutionBehavior(ctx, repr, isolation);
+    if (!options.contains(TypeResolutionFlags::InheritsActorContext)) {
+      // Infer async function type as `nonisolated(nonsending)` if there is
+      // no `@concurrent` or `nonisolated(nonsending)` attribute and isolation
+      // is nonisolated.
+      if (ctx.LangOpts.hasFeature(Feature::NonisolatedNonsendingByDefault) &&
+          repr->isAsync() && isolation.isNonIsolated()) {
+        isolation = FunctionTypeIsolation::forNonIsolatedCaller();
+      } else if (ctx.LangOpts
+                     .getFeatureState(Feature::NonisolatedNonsendingByDefault)
+                     .isEnabledForMigration()) {
+        // Diagnose only in the interface stage, which is run once.
+        if (inStage(TypeResolutionStage::Interface)) {
+          warnAboutNewNonisolatedAsyncExecutionBehavior(ctx, repr, isolation);
+        }
       }
     }
   }
@@ -5339,6 +5346,12 @@ TypeResolver::resolveCallerIsolatedTypeRepr(CallerIsolatedTypeRepr *repr,
     diagnoseInvalid(repr, repr->getStartLoc(),
                     diag::nonisolated_nonsending_only_on_function_types, repr);
     return ErrorType::get(getASTContext());
+  }
+
+  if (options.contains(TypeResolutionFlags::InheritsActorContext)) {
+    diagnoseInvalid(repr, repr->getLoc(),
+                    diag::inherit_actor_context_with_nonisolated_nonsending,
+                    repr);
   }
 
   if (!fnType->isAsync()) {

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -87,6 +87,9 @@ enum class TypeResolutionFlags : uint16_t {
 
   /// Whether the immediate context has an @escaping attribute.
   DirectEscaping = 1 << 14,
+
+  /// We are in a `@_inheritActorContext` parameter declaration.
+  InheritsActorContext = 1 << 15,
 };
 
 /// Type resolution contexts that require special handling.

--- a/test/Concurrency/attr_execution/attr_execution.swift
+++ b/test/Concurrency/attr_execution/attr_execution.swift
@@ -80,3 +80,16 @@ func testClosure() {
   takesClosure {
   }
 }
+
+// CHECK-LABEL: // testInheritsActor(fn:)
+// CHECK: Isolation: global_actor. type: MainActor
+// CHECK: sil hidden [ossa] @$s14attr_execution17testInheritsActor2fnyyyYaYbXE_tYaF : $@convention(thin) @async (@guaranteed @noescape @Sendable @async @callee_guaranteed () -> ()) -> ()
+// CHECK: bb0([[FN:%.*]] : @guaranteed $@noescape @Sendable @async @callee_guaranteed () -> ()):
+// CHECK:  [[FN_COPY:%.*]] = copy_value [[FN]]
+// CHECK:  [[BORROWED_FN_COPY:%.*]] = begin_borrow [[FN_COPY]]
+// CHECK:  apply [[BORROWED_FN_COPY]]() : $@noescape @Sendable @async @callee_guaranteed () -> ()
+// CHECK: } // end sil function '$s14attr_execution17testInheritsActor2fnyyyYaYbXE_tYaF'
+@MainActor
+func testInheritsActor(@_inheritActorContext(always) fn: @Sendable () async -> Void) async {
+  await fn()
+}

--- a/test/Concurrency/attr_execution/migration_mode.swift
+++ b/test/Concurrency/attr_execution/migration_mode.swift
@@ -393,3 +393,9 @@ do {
     }
   }
 }
+
+// @_inheritActorContext prevents `nonisolated(nonsending)` inference.
+do {
+  func testInherit1(@_inheritActorContext _: @Sendable () async -> Void) {}
+  func testInherit2(@_inheritActorContext(always) _: (@Sendable () async -> Void)?) {}
+}

--- a/test/Concurrency/attr_execution/nonisolated_nonsending_by_default.swift
+++ b/test/Concurrency/attr_execution/nonisolated_nonsending_by_default.swift
@@ -8,3 +8,8 @@ func testCasts() {
   // expected-error@-1 {{cannot convert value of type '(nonisolated(nonsending) () async -> ()).Type' to type '(() async -> ()).Type' in coercion}}
   _ = defaultedType as (nonisolated(nonsending) () async -> ()).Type // Ok
 }
+
+func test(@_inheritActorContext fn: @Sendable () async -> Void) {
+  let _: Int = fn
+  // expected-error@-1 {{cannot convert value of type '@Sendable () async -> Void' to specified type 'Int'}}
+}

--- a/test/Parse/execution_behavior_attrs.swift
+++ b/test/Parse/execution_behavior_attrs.swift
@@ -84,3 +84,10 @@ do {
   nonisolated(0) // expected-warning {{result of call to 'nonisolated' is unused}}
   print("hello")
 }
+
+do {
+  func testActorInheriting1(@_inheritActorContext _: @concurrent @Sendable () async -> Void) {}
+  // expected-error@-1 {{'@_inheritActorContext' attribute cannot be used together with '@concurrent'}}
+  func testActorInheriting2(@_inheritActorContext _: nonisolated(nonsending) @Sendable () async -> Void) {}
+  // expected-error@-1 {{'@_inheritActorContext' attribute cannot be used together with 'nonisolated(nonsending)'}}
+}


### PR DESCRIPTION
- Explanation:

  This change replaces a SIL crash with a diagnostic that detect invalid combination during Sema.

  `@_inheritActorContext` is a form of isolation which precludes direct use of inference of `nonisolated(nonsending)` and `@concurrent` just like other isolation attributes/modifiers would i.e. `isolated` or `@isolated(any)`.

- Resolves: rdar://155449914

- Main branch PR: https://github.com/swiftlang/swift/pull/82857

- Risk: Low. The compiler used to crash during SIL. There are no existing uses of this combination because attempting to reference such a declaration in a call or passing a closure to it would result in a compiler crash.
 
- Reviewed By: @gottesmm @ktoso    

- Testing: Added new test-cases to the Concurrency and attribute checking suites.

(cherry picked from commit e42ac61d9f98796cae78c790879bbe37a5e34395)

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
