### PR TITLE
Sema: Opening overloads at the outer decision level, part 1

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4317,7 +4317,8 @@ public:
   /// \returns The opened type.
   Type openUnboundGenericType(GenericTypeDecl *decl, Type parentTy,
                               ConstraintLocatorBuilder locator,
-                              bool isTypeResolution);
+                              bool isTypeResolution,
+                              PreparedOverload *preparedOverload = nullptr);
 
   /// Replace placeholder types with fresh type variables, and unbound generic
   /// types with bound generic types whose generic args are fresh type
@@ -4327,7 +4328,9 @@ public:
   ///
   /// \returns The converted type.
   Type replaceInferableTypesWithTypeVars(Type type,
-                                         ConstraintLocatorBuilder locator);
+                                         ConstraintLocatorBuilder locator,
+                                         PreparedOverload *preparedOverload
+                                            = nullptr);
 
   /// "Open" the given type by replacing any occurrences of generic
   /// parameter types and dependent member types with fresh type variables.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2924,15 +2924,15 @@ private:
   SolverTrail *getTrail() const {
     return solverState ? &solverState->Trail : nullptr;
   }
-
-  /// Add a new type variable that was already created.
-  void addTypeVariable(TypeVariableType *typeVar);
   
   /// Add a constraint from the subscript base to the root of the key
   /// path literal to the constraint system.
   void addKeyPathApplicationRootConstraint(Type root, ConstraintLocatorBuilder locator);
 
 public:
+  /// Add a new type variable that was already created.
+  void addTypeVariable(TypeVariableType *typeVar);
+
   /// Lookup for a member with the given name which is in the given base type.
   ///
   /// This routine caches the results of member lookups in the top constraint
@@ -2953,7 +2953,9 @@ public:
 
   /// Create a new type variable.
   TypeVariableType *createTypeVariable(ConstraintLocator *locator,
-                                       unsigned options);
+                                       unsigned options,
+                                       PreparedOverload *preparedOverload
+                                           = nullptr);
 
   /// Retrieve the set of active type variables.
   ArrayRef<TypeVariableType *> getTypeVariables() const {
@@ -4333,7 +4335,8 @@ public:
   ///
   /// \returns The opened type, or \c type if there are no archetypes in it.
   Type openType(Type type, ArrayRef<OpenedType> replacements,
-                ConstraintLocatorBuilder locator);
+                ConstraintLocatorBuilder locator,
+                PreparedOverload *preparedOverload);
 
   /// "Open" an opaque archetype type, similar to \c openType.
   Type openOpaqueType(OpaqueTypeArchetypeType *type,
@@ -4349,7 +4352,8 @@ public:
   /// aforementioned variable via special constraints.
   Type openPackExpansionType(PackExpansionType *expansion,
                              ArrayRef<OpenedType> replacements,
-                             ConstraintLocatorBuilder locator);
+                             ConstraintLocatorBuilder locator,
+                             PreparedOverload *preparedOverload);
 
   /// Update OpenedPackExpansionTypes and record a change in the trail.
   void recordOpenedPackExpansionType(PackExpansionType *expansion,
@@ -4378,26 +4382,30 @@ public:
   FunctionType *openFunctionType(AnyFunctionType *funcType,
                                  ConstraintLocatorBuilder locator,
                                  SmallVectorImpl<OpenedType> &replacements,
-                                 DeclContext *outerDC);
+                                 DeclContext *outerDC,
+                                 PreparedOverload *preparedOverload);
 
   /// Open the generic parameter list and its requirements,
   /// creating type variables for each of the type parameters.
   void openGeneric(DeclContext *outerDC,
                    GenericSignature signature,
                    ConstraintLocatorBuilder locator,
-                   SmallVectorImpl<OpenedType> &replacements);
+                   SmallVectorImpl<OpenedType> &replacements,
+                   PreparedOverload *preparedOverload);
 
   /// Open the generic parameter list creating type variables for each of the
   /// type parameters.
   void openGenericParameters(DeclContext *outerDC,
                              GenericSignature signature,
                              SmallVectorImpl<OpenedType> &replacements,
-                             ConstraintLocatorBuilder locator);
+                             ConstraintLocatorBuilder locator,
+                             PreparedOverload *preparedOverload);
 
   /// Open a generic parameter into a type variable and record
   /// it in \c replacements.
   TypeVariableType *openGenericParameter(GenericTypeParamType *parameter,
-                                         ConstraintLocatorBuilder locator);
+                                         ConstraintLocatorBuilder locator,
+                                         PreparedOverload *preparedOverload);
 
   /// Given generic signature open its generic requirements,
   /// using substitution function, and record them in the
@@ -4436,7 +4444,8 @@ public:
   FunctionType *adjustFunctionTypeForConcurrency(
       FunctionType *fnType, Type baseType, ValueDecl *decl, DeclContext *dc,
       unsigned numApplies, bool isMainDispatchQueue,
-      ArrayRef<OpenedType> replacements, ConstraintLocatorBuilder locator);
+      ArrayRef<OpenedType> replacements, ConstraintLocatorBuilder locator,
+      PreparedOverload *preparedOverload);
 
   /// Retrieve the type of a reference to the given value declaration.
   ///

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3621,7 +3621,8 @@ public:
 
   /// Log and record the application of the fix. Return true iff any
   /// subsequent solution would be worse than the best known solution.
-  bool recordFix(ConstraintFix *fix, unsigned impact = 1);
+  bool recordFix(ConstraintFix *fix, unsigned impact = 1,
+                 PreparedOverload *preparedOverload = nullptr);
 
   void recordPotentialHole(TypeVariableType *typeVar);
   void recordAnyTypeVarAsPotentialHole(Type type);
@@ -5333,13 +5334,20 @@ public:
   /// Matches a wrapped or projected value parameter type to its backing
   /// property wrapper type by applying the property wrapper.
   TypeMatchResult applyPropertyWrapperToParameter(
-      Type wrapperType, Type paramType, ParamDecl *param, Identifier argLabel,
-      ConstraintKind matchKind, ConstraintLocator *locator,
-      ConstraintLocator *calleeLocator);
+      Type wrapperType,
+      Type paramType,
+      ParamDecl *param,
+      Identifier argLabel,
+      ConstraintKind matchKind,
+      ConstraintLocator *locator,
+      ConstraintLocator *calleeLocator,
+      PreparedOverload *preparedOverload = nullptr);
 
   /// Used by applyPropertyWrapperToParameter() to update appliedPropertyWrappers
   /// and record a change in the trail.
-  void applyPropertyWrapper(Expr *anchor, AppliedPropertyWrapper applied);
+  void applyPropertyWrapper(Expr *anchor,
+                            AppliedPropertyWrapper applied,
+                            PreparedOverload *preparedOverload = nullptr);
 
   /// Undo the above change.
   void removePropertyWrapper(Expr *anchor);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4438,7 +4438,8 @@ public:
 
   /// Update OpenedTypes and record a change in the trail.
   void recordOpenedType(
-      ConstraintLocator *locator, ArrayRef<OpenedType> openedTypes);
+      ConstraintLocator *locator, ArrayRef<OpenedType> openedTypes,
+      PreparedOverload *preparedOverload = nullptr);
 
   /// Record the set of opened types for the given locator.
   void recordOpenedTypes(

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3695,12 +3695,14 @@ public:
   /// Add a constraint to the constraint system.
   void addConstraint(ConstraintKind kind, Type first, Type second,
                      ConstraintLocatorBuilder locator,
-                     bool isFavored = false);
+                     bool isFavored = false,
+                     PreparedOverload *preparedOverload = nullptr);
 
   /// Add a requirement as a constraint to the constraint system.
   void addConstraint(Requirement req, ConstraintLocatorBuilder locator,
                      bool isFavored,
-                     bool prohibitNonisolatedConformance);
+                     bool prohibitNonisolatedConformance,
+                     PreparedOverload *preparedOverload = nullptr);
 
   void addApplicationConstraint(
       FunctionType *appliedFn, Type calleeType,
@@ -4414,7 +4416,8 @@ public:
                                GenericSignature signature,
                                bool skipProtocolSelfConstraint,
                                ConstraintLocatorBuilder locator,
-                               llvm::function_ref<Type(Type)> subst);
+                               llvm::function_ref<Type(Type)> subst,
+                               PreparedOverload *preparedOverload);
 
   // Record the given requirement in the constraint system.
   void openGenericRequirement(DeclContext *outerDC,
@@ -4423,7 +4426,8 @@ public:
                               const Requirement &requirement,
                               bool skipProtocolSelfConstraint,
                               ConstraintLocatorBuilder locator,
-                              llvm::function_ref<Type(Type)> subst);
+                              llvm::function_ref<Type(Type)> subst,
+                              PreparedOverload *preparedOverload);
 
   /// Update OpenedTypes and record a change in the trail.
   void recordOpenedType(
@@ -4432,8 +4436,9 @@ public:
   /// Record the set of opened types for the given locator.
   void recordOpenedTypes(
          ConstraintLocatorBuilder locator,
-         SmallVectorImpl<OpenedType> &replacements,
-         bool fixmeAllowDuplicates=false);
+         const SmallVectorImpl<OpenedType> &replacements,
+         PreparedOverload *preparedOverload = nullptr,
+         bool fixmeAllowDuplicates = false);
 
   /// Check whether the given type conforms to the given protocol and if
   /// so return a valid conformance reference.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4360,7 +4360,9 @@ public:
 
   /// Update OpenedPackExpansionTypes and record a change in the trail.
   void recordOpenedPackExpansionType(PackExpansionType *expansion,
-                                     TypeVariableType *expansionVar);
+                                     TypeVariableType *expansionVar,
+                                     PreparedOverload *preparedOverload
+                                        = nullptr);
 
   /// Undo the above change.
   void removeOpenedPackExpansionType(PackExpansionType *expansion) {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3413,7 +3413,8 @@ public:
 
   /// Update OpenedExistentials and record a change in the trail.
   void recordOpenedExistentialType(ConstraintLocator *locator,
-                                   ExistentialArchetypeType *opened);
+                                   ExistentialArchetypeType *opened,
+                                   PreparedOverload *preparedOverload = nullptr);
 
   /// Retrieve the generic environment for the opened element of a given pack
   /// expansion, or \c nullptr if no environment was recorded yet.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -64,6 +64,7 @@ namespace constraints {
 
 class ConstraintSystem;
 class SyntacticElementTarget;
+struct PreparedOverload;
 
 } // end namespace constraints
 
@@ -2211,6 +2212,8 @@ public:
   unsigned CountDisjunctions = 0;
 
 private:
+  bool PreparingOverload = false;
+
   /// A constraint that has failed along the current solver path.
   /// Do not set directly, call \c recordFailedConstraint instead.
   Constraint *failedConstraint = nullptr;
@@ -2752,6 +2755,7 @@ public:
   SolverState *solverState = nullptr;
 
   void recordChange(SolverTrail::Change change) {
+    ASSERT(!PreparingOverload);
     solverState->Trail.recordChange(change);
   }
 
@@ -4447,7 +4451,8 @@ public:
                           ValueDecl *decl,
                           FunctionRefInfo functionRefInfo,
                           ConstraintLocatorBuilder locator,
-                          DeclContext *useDC);
+                          DeclContext *useDC,
+                          PreparedOverload *preparedOverload);
 
   /// Return the type-of-reference of the given value.
   ///
@@ -4488,7 +4493,8 @@ public:
   DeclReferenceType getTypeOfMemberReference(
       Type baseTy, ValueDecl *decl, DeclContext *useDC, bool isDynamicLookup,
       FunctionRefInfo functionRefInfo, ConstraintLocator *locator,
-      SmallVectorImpl<OpenedType> *replacements = nullptr);
+      SmallVectorImpl<OpenedType> *replacements = nullptr,
+      PreparedOverload *preparedOverload = nullptr);
 
   /// Retrieve a list of generic parameter types solver has "opened" (replaced
   /// with a type variable) at the given location.

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -1,0 +1,31 @@
+//===--- PreparedOverload.h - A Choice from an Overload Set  ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_SEMA_PREPAREDOVERLOAD_H
+#define SWIFT_SEMA_PREPAREDOVERLOAD_H
+
+#include "swift/AST/AvailabilityRange.h"
+#include "swift/AST/FunctionRefInfo.h"
+#include "swift/AST/Types.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace swift {
+namespace constraints {
+
+struct PreparedOverload {
+
+};
+
+}
+}
+
+#endif

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -12,6 +12,7 @@
 #ifndef SWIFT_SEMA_PREPAREDOVERLOAD_H
 #define SWIFT_SEMA_PREPAREDOVERLOAD_H
 
+#include "swift/AST/PropertyWrappers.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -37,6 +38,8 @@ struct PreparedOverload {
   ExistentialArchetypeType *OpenedExistential = nullptr;
   SmallVector<std::pair<PackExpansionType *, TypeVariableType *>>
     OpenedPackExpansionTypes;
+  SmallVector<AppliedPropertyWrapper, 2> PropertyWrappers;
+  SmallVector<std::pair<ConstraintFix *, unsigned>, 2> Fixes;
 
   void discharge(ConstraintSystem &cs, ConstraintLocatorBuilder locator) const;
 };

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -35,6 +35,8 @@ struct PreparedOverload {
   SmallVector<Constraint *, 2> Constraints;
   SmallVector<OpenedType, 2> Replacements;
   ExistentialArchetypeType *OpenedExistential = nullptr;
+  SmallVector<std::pair<PackExpansionType *, TypeVariableType *>>
+    OpenedPackExpansionTypes;
 
   void discharge(ConstraintSystem &cs, ConstraintLocatorBuilder locator) const;
 };

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -17,16 +17,24 @@
 
 namespace swift {
 
+class GenericTypeParamType;
 class TypeVariableType;
 
 namespace constraints {
 
+class ConstraintLocatorBuilder;
 class ConstraintSystem;
+
+/// Describes a dependent type that has been opened to a particular type
+/// variable.
+using OpenedType = std::pair<GenericTypeParamType *, TypeVariableType *>;
 
 struct PreparedOverload {
   SmallVector<TypeVariableType *, 2> TypeVariables;
+  SmallVector<Constraint *, 2> Constraints;
+  SmallVector<OpenedType, 2> Replacements;
 
-  void discharge(ConstraintSystem &cs) const;
+  void discharge(ConstraintSystem &cs, ConstraintLocatorBuilder locator) const;
 };
 
 }

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -12,17 +12,21 @@
 #ifndef SWIFT_SEMA_PREPAREDOVERLOAD_H
 #define SWIFT_SEMA_PREPAREDOVERLOAD_H
 
-#include "swift/AST/AvailabilityRange.h"
-#include "swift/AST/FunctionRefInfo.h"
-#include "swift/AST/Types.h"
 #include "llvm/ADT/PointerIntPair.h"
-#include "llvm/Support/ErrorHandling.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace swift {
+
+class TypeVariableType;
+
 namespace constraints {
 
-struct PreparedOverload {
+class ConstraintSystem;
 
+struct PreparedOverload {
+  SmallVector<TypeVariableType *, 2> TypeVariables;
+
+  void discharge(ConstraintSystem &cs) const;
 };
 
 }

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -31,15 +31,130 @@ class ConstraintSystem;
 /// variable.
 using OpenedType = std::pair<GenericTypeParamType *, TypeVariableType *>;
 
+/// A "pre-cooked" representation of all type variables and constraints
+/// that are generated as part of an overload choice.
 struct PreparedOverload {
-  SmallVector<TypeVariableType *, 2> TypeVariables;
-  SmallVector<Constraint *, 2> Constraints;
-  SmallVector<OpenedType, 2> Replacements;
-  ExistentialArchetypeType *OpenedExistential = nullptr;
-  SmallVector<std::pair<PackExpansionType *, TypeVariableType *>>
-    OpenedPackExpansionTypes;
-  SmallVector<AppliedPropertyWrapper, 2> PropertyWrappers;
-  SmallVector<std::pair<ConstraintFix *, unsigned>, 2> Fixes;
+  /// A change to be introduced into the constraint system when this
+  /// overload choice is chosen.
+  struct Change {
+    enum ChangeKind : unsigned {
+      /// A generic parameter was opened to a type variable.
+      AddedTypeVariable,
+
+      /// A generic requirement was opened to a constraint.
+      AddedConstraint,
+
+      /// A mapping of generic parameter types to type variables
+      /// was recorded.
+      OpenedTypes,
+
+      /// An existential type was opened.
+      OpenedExistentialType,
+
+      /// A pack expansion type was opened.
+      OpenedPackExpansionType,
+
+      /// A property wrapper was applied to a parameter.
+      AppliedPropertyWrapper,
+
+      /// A fix was recorded because a property wrapper application failed.
+      AddedFix
+    };
+
+    /// The kind of change.
+    ChangeKind Kind;
+
+    union {
+      /// For ChangeKind::AddedTypeVariable.
+      TypeVariableType *TypeVar;
+
+      /// For ChangeKind::AddedConstraint.
+      Constraint *TheConstraint;
+
+      /// For ChangeKind::OpenedTypes.
+      struct {
+        const OpenedType *Data;
+        size_t Count;
+      } Replacements;
+
+      /// For ChangeKind::OpenedExistentialType.
+      ExistentialArchetypeType *TheExistential;
+
+      /// For ChangeKind::OpenedPackExpansionType.
+      struct {
+        PackExpansionType *TheExpansion;
+        TypeVariableType *TypeVar;
+      } PackExpansion;
+
+      /// For ChangeKind::AppliedPropertyWrapper.
+      struct {
+        TypeBase *WrapperType;
+        PropertyWrapperInitKind InitKind;
+      } PropertyWrapper;
+
+      /// For ChangeKind::Fix.
+      struct {
+        ConstraintFix *TheFix;
+        unsigned Impact;
+      } Fix;
+    };
+  };
+
+  SmallVector<Change, 8> Changes;
+
+  void addedTypeVariable(TypeVariableType *typeVar) {
+    Change change;
+    change.Kind = Change::AddedTypeVariable;
+    change.TypeVar = typeVar;
+    Changes.push_back(change);
+  }
+
+  void addedConstraint(Constraint *constraint) {
+    Change change;
+    change.Kind = Change::AddedConstraint;
+    change.TheConstraint = constraint;
+    Changes.push_back(change);
+  }
+
+  void openedTypes(ArrayRef<OpenedType> replacements) {
+    Change change;
+    change.Kind = Change::OpenedTypes;
+    change.Replacements.Data = replacements.data();
+    change.Replacements.Count = replacements.size();
+    Changes.push_back(change);
+  }
+
+  void openedExistentialType(ExistentialArchetypeType *openedExistential) {
+    Change change;
+    change.Kind = Change::OpenedExistentialType;
+    change.TheExistential = openedExistential;
+    Changes.push_back(change);
+  }
+
+  void openedPackExpansionType(PackExpansionType *packExpansion,
+                               TypeVariableType *typeVar) {
+    Change change;
+    change.Kind = Change::OpenedPackExpansionType;
+    change.PackExpansion.TheExpansion = packExpansion;
+    change.PackExpansion.TypeVar = typeVar;
+    Changes.push_back(change);
+  }
+
+  void appliedPropertyWrapper(AppliedPropertyWrapper wrapper) {
+    Change change;
+    change.Kind = Change::AppliedPropertyWrapper;
+    change.PropertyWrapper.WrapperType = wrapper.wrapperType.getPointer();
+    change.PropertyWrapper.InitKind = wrapper.initKind;
+    Changes.push_back(change);
+  }
+
+  void addedFix(ConstraintFix *fix, unsigned impact) {
+    Change change;
+    change.Kind = Change::AddedFix;
+    change.Fix.TheFix = fix;
+    change.Fix.Impact = impact;
+    Changes.push_back(change);
+  }
 
   void discharge(ConstraintSystem &cs, ConstraintLocatorBuilder locator) const;
 };

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -17,6 +17,7 @@
 
 namespace swift {
 
+class ExistentialArchetypeType;
 class GenericTypeParamType;
 class TypeVariableType;
 
@@ -33,6 +34,7 @@ struct PreparedOverload {
   SmallVector<TypeVariableType *, 2> TypeVariables;
   SmallVector<Constraint *, 2> Constraints;
   SmallVector<OpenedType, 2> Replacements;
+  ExistentialArchetypeType *OpenedExistential = nullptr;
 
   void discharge(ConstraintSystem &cs, ConstraintLocatorBuilder locator) const;
 };

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -5122,7 +5122,7 @@ void ConstraintSystem::applyPropertyWrapper(
     PreparedOverload *preparedOverload) {
   if (preparedOverload) {
     ASSERT(PreparingOverload);
-    preparedOverload->PropertyWrappers.push_back(applied);
+    preparedOverload->appliedPropertyWrapper(applied);
     return;
   }
 

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -423,7 +423,8 @@ static bool isProtocolExtensionAsSpecializedAs(DeclContext *dc1,
   // the second protocol extension.
   ConstraintSystem cs(dc1, std::nullopt);
   SmallVector<OpenedType, 4> replacements;
-  cs.openGeneric(dc2, sig2, ConstraintLocatorBuilder(nullptr), replacements);
+  cs.openGeneric(dc2, sig2, ConstraintLocatorBuilder(nullptr), replacements,
+                 /*preparedOverload=*/nullptr);
 
   // Bind the 'Self' type from the first extension to the type parameter from
   // opening 'Self' of the second extension.
@@ -581,13 +582,15 @@ bool CompareDeclSpecializationRequest::evaluate(
                       SmallVectorImpl<OpenedType> &replacements,
                       ConstraintLocator *locator) -> Type {
     if (auto *funcType = type->getAs<AnyFunctionType>()) {
-      return cs.openFunctionType(funcType, locator, replacements, outerDC);
+      return cs.openFunctionType(funcType, locator, replacements, outerDC,
+                                 /*preparedOverload=*/nullptr);
     }
 
     cs.openGeneric(outerDC, innerDC->getGenericSignatureOfContext(), locator,
-                   replacements);
+                   replacements, /*preparedOverload=*/nullptr);
 
-    return cs.openType(type, replacements, locator);
+    return cs.openType(type, replacements, locator,
+                       /*preparedOverload=*/nullptr);
   };
 
   bool knownNonSubtype = false;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15407,7 +15407,7 @@ bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact,
                                  PreparedOverload *preparedOverload) {
   if (preparedOverload) {
     ASSERT(PreparingOverload);
-    preparedOverload->Fixes.push_back({fix, impact});
+    preparedOverload->addedFix(fix, impact);
     return true;
   }
 
@@ -16350,7 +16350,7 @@ void ConstraintSystem::addConstraint(ConstraintKind kind, Type first,
     auto c = Constraint::create(*this, kind, first, second,
                                 getConstraintLocator(locator));
     if (isFavored) c->setFavored();
-    preparedOverload->Constraints.push_back(c);
+    preparedOverload->addedConstraint(c);
     return;
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -16013,6 +16013,8 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
                                     Type second,
                                     ConstraintLocatorBuilder locator,
                                     bool isFavored) {
+  ASSERT(!PreparingOverload);
+
   assert(first && "Missing first type");
   assert(second && "Missing second type");
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12046,8 +12046,10 @@ static Type getOpenedResultBuilderTypeFor(ConstraintSystem &cs,
     // Find the opened type for this callee and substitute in the type
     // parameters.
     auto substitutions = cs.getOpenedTypes(calleeLocator);
-    if (!substitutions.empty())
-      builderType = cs.openType(builderType, substitutions, locator);
+    if (!substitutions.empty()) {
+      builderType = cs.openType(builderType, substitutions, locator,
+                                /*preparedOverload=*/nullptr);
+    }
 
     assert(!builderType->hasTypeParameter());
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15403,7 +15403,16 @@ static bool isAugmentingFix(ConstraintFix *fix) {
   }
 }
 
-bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact) {
+bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact,
+                                 PreparedOverload *preparedOverload) {
+  if (preparedOverload) {
+    ASSERT(PreparingOverload);
+    preparedOverload->Fixes.push_back({fix, impact});
+    return true;
+  }
+
+  ASSERT(!PreparingOverload);
+
   if (isDebugMode()) {
     auto &log = llvm::errs();
     log.indent(solverState ? solverState->getCurrentIndent() : 0)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -40,6 +40,7 @@
 #include "swift/Sema/CSFix.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "swift/Sema/PreparedOverload.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Compiler.h"
 
@@ -16269,7 +16270,8 @@ ConstraintSystem::addKeyPathConstraint(
 void ConstraintSystem::addConstraint(Requirement req,
                                      ConstraintLocatorBuilder locator,
                                      bool isFavored,
-                                     bool prohibitNonisolatedConformance) {
+                                     bool prohibitNonisolatedConformance,
+                                     PreparedOverload *preparedOverload) {
   bool conformsToAnyObject = false;
   std::optional<ConstraintKind> kind;
   switch (req.getKind()) {
@@ -16277,7 +16279,8 @@ void ConstraintSystem::addConstraint(Requirement req,
     auto type1 = req.getFirstType();
     auto type2 = req.getSecondType();
 
-    addConstraint(ConstraintKind::SameShape, type1, type2, locator);
+    addConstraint(ConstraintKind::SameShape, type1, type2, locator,
+                  /*isFavored=*/false, preparedOverload);
     return;
   }
 
@@ -16318,19 +16321,32 @@ void ConstraintSystem::addConstraint(Requirement req,
   auto firstType = req.getFirstType();
   if (kind) {
     addConstraint(*kind, req.getFirstType(), req.getSecondType(), locator,
-                  isFavored);
+                  isFavored, preparedOverload);
   }
 
   if (conformsToAnyObject) {
     auto anyObject = getASTContext().getAnyObjectConstraint();
-    addConstraint(ConstraintKind::ConformsTo, firstType, anyObject, locator);
+    addConstraint(ConstraintKind::ConformsTo, firstType, anyObject, locator,
+                  /*isFavored=*/false, preparedOverload);
   }
 }
 
 void ConstraintSystem::addConstraint(ConstraintKind kind, Type first,
                                      Type second,
                                      ConstraintLocatorBuilder locator,
-                                     bool isFavored) {
+                                     bool isFavored,
+                                     PreparedOverload *preparedOverload) {
+  if (preparedOverload) {
+    ASSERT(PreparingOverload);
+    auto c = Constraint::create(*this, kind, first, second,
+                                getConstraintLocator(locator));
+    if (isFavored) c->setFavored();
+    preparedOverload->Constraints.push_back(c);
+    return;
+  }
+
+  ASSERT(!PreparingOverload);
+
   switch (addConstraintImpl(kind, first, second, locator, isFavored)) {
   case SolutionKind::Error:
     // Add a failing constraint, if needed.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -22,6 +22,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Sema/ConstraintGraph.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/PreparedOverload.h"
 #include "swift/Sema/SolutionResult.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
@@ -58,11 +59,15 @@ STATISTIC(LargestSolutionAttemptNumber, "# of the largest solution attempt");
 
 TypeVariableType *ConstraintSystem::createTypeVariable(
                                      ConstraintLocator *locator,
-                                     unsigned options) {
+                                     unsigned options,
+                                     PreparedOverload *preparedOverload) {
   ++TotalNumTypeVariables;
   auto tv = TypeVariableType::getNew(getASTContext(), assignTypeVariableID(),
                                      locator, options);
-  addTypeVariable(tv);
+  if (preparedOverload)
+    preparedOverload->TypeVariables.push_back(tv);
+  else
+    addTypeVariable(tv);
   return tv;
 }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -66,7 +66,7 @@ TypeVariableType *ConstraintSystem::createTypeVariable(
                                      locator, options);
   if (preparedOverload) {
     ASSERT(PreparingOverload);
-    preparedOverload->TypeVariables.push_back(tv);
+    preparedOverload->addedTypeVariable(tv);
   } else {
     addTypeVariable(tv);
   }

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -64,10 +64,12 @@ TypeVariableType *ConstraintSystem::createTypeVariable(
   ++TotalNumTypeVariables;
   auto tv = TypeVariableType::getNew(getASTContext(), assignTypeVariableID(),
                                      locator, options);
-  if (preparedOverload)
+  if (preparedOverload) {
+    ASSERT(PreparingOverload);
     preparedOverload->TypeVariables.push_back(tv);
-  else
+  } else {
     addTypeVariable(tv);
+  }
   return tv;
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -307,6 +307,8 @@ void ConstraintSystem::removeConversionRestriction(
 }
 
 void ConstraintSystem::addFix(ConstraintFix *fix) {
+  ASSERT(!PreparingOverload);
+
   bool inserted = Fixes.insert(fix);
   ASSERT(inserted);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -176,6 +176,8 @@ bool ConstraintSystem::hasFreeTypeVariables() {
 }
 
 void ConstraintSystem::addTypeVariable(TypeVariableType *typeVar) {
+  ASSERT(!PreparingOverload);
+
   TypeVariables.insert(typeVar);
 
   // Notify the constraint graph.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -38,6 +38,7 @@
 #include "swift/Sema/CSFix.h"
 #include "swift/Sema/ConstraintGraph.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "swift/Sema/PreparedOverload.h"
 #include "swift/Sema/SolutionResult.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallSet.h"
@@ -899,7 +900,15 @@ ConstraintSystem::openAnyExistentialType(Type type,
 }
 
 void ConstraintSystem::recordOpenedExistentialType(
-    ConstraintLocator *locator, ExistentialArchetypeType *opened) {
+    ConstraintLocator *locator,
+    ExistentialArchetypeType *opened,
+    PreparedOverload *preparedOverload) {
+  if (preparedOverload) {
+    ASSERT(!preparedOverload->OpenedExistential);
+    preparedOverload->OpenedExistential = opened;
+    return;
+  }
+
   bool inserted = OpenedExistentialTypes.insert({locator, opened}).second;
   ASSERT(inserted);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -906,8 +906,7 @@ void ConstraintSystem::recordOpenedExistentialType(
     ExistentialArchetypeType *opened,
     PreparedOverload *preparedOverload) {
   if (preparedOverload) {
-    ASSERT(!preparedOverload->OpenedExistential);
-    preparedOverload->OpenedExistential = opened;
+    preparedOverload->openedExistentialType(opened);
     return;
   }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -627,7 +627,7 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
       if (auto *typeVar = findParam(GP))
         return typeVar;
 
-      auto *typeVar = cs.openGenericParameter(GP, locator);
+      auto *typeVar = cs.openGenericParameter(GP, locator, nullptr);
       genericParameters.emplace_back(GP, typeVar);
 
       return typeVar;
@@ -720,8 +720,8 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
       cs.openGenericRequirement(DC->getParent(), signature, index, requirement,
                                 /*skipSelfProtocolConstraint=*/false, locator,
                                 [&](Type type) -> Type {
-                                  return cs.openType(type, genericParameters,
-                                                     locator);
+                                  return cs.openType(type, genericParameters, locator,
+                                                     /*preparedOverload=*/nullptr);
                                 });
     };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -722,7 +722,7 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
                                 [&](Type type) -> Type {
                                   return cs.openType(type, genericParameters, locator,
                                                      /*preparedOverload=*/nullptr);
-                                });
+                                }, /*preparedOverload=*/nullptr);
     };
 
     auto diagnoseInvalidRequirement = [&](Requirement requirement) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1224,7 +1224,7 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
       openWitnessType =
           cs->getTypeOfReference(
                 witness, FunctionRefInfo::doubleBaseNameApply(), witnessLocator,
-                /*useDC=*/nullptr)
+                /*useDC=*/nullptr, /*preparedOverload=*/nullptr)
               .adjustedReferenceType;
     }
     openWitnessType = openWitnessType->getRValueType();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1251,11 +1251,11 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
 
       reqThrownError = getThrownErrorType(reqASD);
       reqThrownError = cs->openType(reqThrownError, reqReplacements,
-                                    reqLocator);
+                                    reqLocator, /*preparedOverload=*/nullptr);
 
       witnessThrownError = getThrownErrorType(witnessASD);
       witnessThrownError = cs->openType(witnessThrownError, witnessReplacements,
-                                        witnessLocator);
+                                        witnessLocator, /*preparedOverload=*/nullptr);
     }
 
     return std::make_tuple(std::nullopt, reqType, openWitnessType,

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1753,7 +1753,8 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
   } else if (baseObjTy->isExistentialType()) {
     auto openedArchetype =
         ExistentialArchetypeType::get(baseObjTy->getCanonicalType());
-    recordOpenedExistentialType(getConstraintLocator(locator), openedArchetype);
+    recordOpenedExistentialType(getConstraintLocator(locator), openedArchetype,
+                                preparedOverload);
     baseOpenedTy = openedArchetype;
   }
 
@@ -2471,6 +2472,10 @@ void PreparedOverload::discharge(ConstraintSystem &cs,
     cs.activateConstraint(c);
   }
   cs.recordOpenedTypes(locator, Replacements);
+  if (OpenedExistential) {
+    cs.recordOpenedExistentialType(cs.getConstraintLocator(locator),
+                                   OpenedExistential);
+  }
 }
 
 void ConstraintSystem::resolveOverload(ConstraintLocator *locator,


### PR DESCRIPTION
Today, we open the type of an overload after we make the decision to bind it. The opening generates new type variables and constraints from the overload's generic signature. This results in exponential space usage in the solver arena when exploring a large search space, because we also form other structures such as function types, substitution maps, etc that involve these new type variables, but we never re-use those type variables or the structures built up from them after we backtrack. (We also don't incrementally roll back the solver arena when we backtrack, because that would require trail-recording changes to all the folding sets in the AST, which would probably not be worth the overhead.)

Instead, we're going to open the overload type when forming the disjunction, at scope N; this will generate new type variables and constraints without actually introducing them into the constraint system, and also build the opened type. The opened type, together with the type variables and constraints, will be stored in a PreparedOverloadChoice. When we attempt the disjunction, we will create scope N+1, and then introduce the prepared type variables and constraints.

This increases overhead in the case that some choices in a disjunction are never explored, because then we build the opened type and never use it. But it will pay off -- exponentially -- for expressions involving operators and other global overloads that are looked up at the outermost decision level, but are then repeatedly bound with different other combinations as we search.

This also won't help with member overloads as much, like foo.bar.baz, because the qualified lookups happen in nested decision levels, so we may still re-generate new opened types and type variables.

Preserving the "identity" of the type variables and constraints associated with an overload choice while we explore different parts of the search space should also help us implement non-chronological backtracking.