### PR TITLE
utils: build static runtime with static dispatch and closure

### DIFF
--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.cpp
@@ -103,9 +103,13 @@ static void initializeDispatchEnqueueFunc(dispatch_queue_t queue, void *obj,
   if (SWIFT_RUNTIME_WEAK_CHECK(dispatch_async_swift_job))
     func = SWIFT_RUNTIME_WEAK_USE(dispatch_async_swift_job);
 #elif defined(_WIN32)
+#if defined(dispatch_STATIC)
+  func = dispatch_async_swift_job;
+#else
   func = function_cast<dispatchEnqueueFuncType>(
       GetProcAddress(LoadLibraryW(L"dispatch.dll"),
       "dispatch_async_swift_job"));
+#endif
 #else
   func = function_cast<dispatchEnqueueFuncType>(
       dlsym(RTLD_NEXT, "dispatch_async_swift_job"));

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -2356,13 +2356,17 @@ function Build-ExperimentalRuntime {
         CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
         CMAKE_Swift_COMPILER_TARGET = (Get-ModuleTriple $Platform);
         CMAKE_Swift_COMPILER_WORKS = "YES";
+        # TODO(compnerd) enforce dynamic linking of BlocksRuntime and dispatch.
+        CMAKE_Swift_FLAGS = $(if ($Static) { @("-Xcc", "-static-libclosure", "-Xcc", "-Ddispatch_STATIC") } else { @() });
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
         CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
         CMAKE_NINJA_FORCE_RESPONSE_FILE = "YES";
 
         # NOTE(compnerd) we can get away with this currently because we only
-        # use the C portion of the dispatch build, which is always built
-        # dynamically.
+        # use the C portion of the dispatch build, which is supposed to always
+        # be built dynamically. Currently, we do not do this due to limitations
+        # of the build system, but because we are building statically, we do
+        # not link against the runtime and can get away with it.
         dispatch_DIR = (Get-ProjectCMakeModules $Platform Dispatch);
         SwiftCore_ENABLE_CONCURRENCY = "YES";
       }
@@ -2758,7 +2762,8 @@ function Build-ExperimentalSDK([Hashtable] $Platform) {
         CMAKE_FIND_PACKAGE_PREFER_CONFIG = "YES";
         CMAKE_Swift_COMPILER_TARGET = (Get-ModuleTriple $Platform);
         CMAKE_Swift_COMPILER_WORKS = "YES";
-        CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir");
+        # TODO(compnerd) enforce dynamic linking of BlocksRuntime and dispatch.
+        CMAKE_Swift_FLAGS = @("-static-stdlib", "-Xfrontend", "-use-static-resource-dir", "-Xcc", "-Ddispatch_STATIC");
         CMAKE_STATIC_LIBRARY_PREFIX_Swift = "lib";
         CMAKE_SYSTEM_NAME = $Platform.OS.ToString();
 


### PR DESCRIPTION
Although we would like these to be dynamic, we currently cannot build them properly due to limitations of the build system. Adjust the build to pass in additional flags to properly build the runtimes for that environment as a temporary measure.