### PR TITLE
[Dependency Scanning] Consider `-swift-module-file` inputs when looking for dependencies

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -211,6 +211,9 @@ ERROR(error_stdlib_module_name,none,
       "module name \"%0\" is reserved for the standard library"
       "%select{|; use -module-name flag to specify an alternate name}1",
       (StringRef, bool))
+WARNING(warn_multiple_module_inputs_same_name,none,
+        "multiple Swift module file inputs with identifier \"%0\": replacing '%1' with '%2'",
+        (StringRef, StringRef, StringRef))
 
 ERROR(error_bad_export_as_name,none,
       "export-as name \"%0\" is not a valid identifier",

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -518,11 +518,8 @@ public:
   std::string ExplicitSwiftModuleMapPath;
 
   /// Module inputs specified with -swift-module-input,
-  /// <ModuleName, Path to .swiftmodule file>
-  std::vector<std::pair<std::string, std::string>> ExplicitSwiftModuleInputs;
-
-  /// A map of placeholder Swift module dependency information.
-  std::string PlaceholderDependencyModuleMap;
+  /// ModuleName: Path to .swiftmodule file
+  llvm::StringMap<std::string> ExplicitSwiftModuleInputs;
 
   /// A file containing a list of protocols whose conformances require const value extraction.
   std::string ConstGatherProtocolListFilePath;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -176,7 +176,7 @@ public:
   create(ASTContext &ctx,
          DependencyTracker *tracker, ModuleLoadingMode loadMode,
          StringRef ExplicitSwiftModuleMap,
-         const std::vector<std::pair<std::string, std::string>> &ExplicitSwiftModuleInputs,
+         const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
          bool IgnoreSwiftSourceInfoFile);
 
   /// Append visible module names to \p names. Note that names are possibly
@@ -224,8 +224,7 @@ public:
   create(ASTContext &ctx, llvm::cas::ObjectStore &CAS,
          llvm::cas::ActionCache &cache, DependencyTracker *tracker,
          ModuleLoadingMode loadMode, StringRef ExplicitSwiftModuleMap,
-         const std::vector<std::pair<std::string, std::string>>
-             &ExplicitSwiftModuleInputs,
+         const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
          bool IgnoreSwiftSourceInfoFile);
 
   /// Append visible module names to \p names. Note that names are possibly

--- a/include/swift/Serialization/ScanningLoaders.h
+++ b/include/swift/Serialization/ScanningLoaders.h
@@ -66,6 +66,10 @@ private:
       bool SkipBuildingInterface, bool IsFramework,
       bool IsTestableDependencyLookup) override;
 
+  bool canImportModule(ImportPath::Module named, SourceLoc loc,
+                       ModuleVersionInfo *versionInfo,
+                       bool isTestableImport) override;
+
   virtual void collectVisibleTopLevelModuleNames(
       SmallVectorImpl<Identifier> &names) const override {
     llvm_unreachable("Not used");
@@ -80,6 +84,9 @@ private:
   /// Clang-specific (-Xcc) command-line flags to include on
   /// Swift module compilation commands
   std::vector<std::string> swiftModuleClangCC1CommandLineArgs;
+  /// Module inputs specified with -swift-module-input,
+  /// <ModuleName, Path to .swiftmodule file>
+  llvm::StringMap<std::string> explicitSwiftModuleInputs;
 
   /// Constituents of a result of a given Swift module query,
   /// reset at the end of every query.
@@ -91,12 +98,14 @@ public:
       ASTContext &ctx, ModuleLoadingMode LoadMode,
       InterfaceSubContextDelegate &astDelegate, StringRef moduleOutputPath,
       StringRef sdkModuleOutputPath,
-      std::vector<std::string> swiftModuleClangCC1CommandLineArgs)
+      std::vector<std::string> swiftModuleClangCC1CommandLineArgs,
+      llvm::StringMap<std::string> &explicitSwiftModuleInputs)
       : SerializedModuleLoaderBase(ctx, nullptr, LoadMode,
                                    /*IgnoreSwiftSourceInfoFile=*/true),
         astDelegate(astDelegate), moduleOutputPath(moduleOutputPath),
         sdkModuleOutputPath(sdkModuleOutputPath),
-        swiftModuleClangCC1CommandLineArgs(swiftModuleClangCC1CommandLineArgs) {
+        swiftModuleClangCC1CommandLineArgs(swiftModuleClangCC1CommandLineArgs),
+        explicitSwiftModuleInputs(explicitSwiftModuleInputs) {
   }
 
   /// Perform a filesystem search for a Swift module with a given name

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -294,7 +294,8 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
       *workerASTContext,
       workerCompilerInvocation->getSearchPathOptions().ModuleLoadMode,
       *scanningASTDelegate, moduleOutputPath, sdkModuleOutputPath,
-      swiftModuleClangCC1CommandLineArgs);
+      swiftModuleClangCC1CommandLineArgs,
+      workerCompilerInvocation->getSearchPathOptions().ExplicitSwiftModuleInputs);
 }
 
 SwiftModuleScannerQueryResult

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2310,7 +2310,15 @@ static bool validateSwiftModuleFileArgumentAndAdd(const std::string &swiftModule
     Diags.diagnose(SourceLoc(), diag::error_bad_module_name, moduleName, false);
     return true;
   }
-  ExplicitSwiftModuleInputs.insert(std::make_pair(moduleName, modulePath));
+
+  auto priorEntryIt = ExplicitSwiftModuleInputs.find(moduleName);
+  if (priorEntryIt != ExplicitSwiftModuleInputs.end()) {
+    Diags.diagnose(SourceLoc(), diag::warn_multiple_module_inputs_same_name,
+                   moduleName, priorEntryIt->getValue(), modulePath);
+    ExplicitSwiftModuleInputs[moduleName] = modulePath;
+  } else
+    ExplicitSwiftModuleInputs.insert(std::make_pair(moduleName, modulePath));
+
   return false;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2297,7 +2297,7 @@ static void ParseSymbolGraphArgs(symbolgraphgen::SymbolGraphOptions &Opts,
 
 static bool validateSwiftModuleFileArgumentAndAdd(const std::string &swiftModuleArgument,
                                                   DiagnosticEngine &Diags,
-                                                  std::vector<std::pair<std::string, std::string>> &ExplicitSwiftModuleInputs) {
+                                                  llvm::StringMap<std::string> &ExplicitSwiftModuleInputs) {
   std::size_t foundDelimeterPos = swiftModuleArgument.find_first_of("=");
   if (foundDelimeterPos == std::string::npos) {
     Diags.diagnose(SourceLoc(), diag::error_swift_module_file_requires_delimeter,
@@ -2310,7 +2310,7 @@ static bool validateSwiftModuleFileArgumentAndAdd(const std::string &swiftModule
     Diags.diagnose(SourceLoc(), diag::error_bad_module_name, moduleName, false);
     return true;
   }
-  ExplicitSwiftModuleInputs.emplace_back(std::make_pair(moduleName, modulePath));
+  ExplicitSwiftModuleInputs.insert(std::make_pair(moduleName, modulePath));
   return false;
 }
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2246,11 +2246,10 @@ struct ExplicitSwiftModuleLoader::Implementation {
   }
 
   void addCommandLineExplicitInputs(
-      const std::vector<std::pair<std::string, std::string>>
-          &commandLineExplicitInputs) {
+    const llvm::StringMap<std::string> &commandLineExplicitInputs) {
     for (const auto &moduleInput : commandLineExplicitInputs) {
-      ExplicitSwiftModuleInputInfo entry(moduleInput.second, {}, {}, {});
-      ExplicitModuleMap.try_emplace(moduleInput.first, std::move(entry));
+      ExplicitSwiftModuleInputInfo entry(moduleInput.getValue(), {}, {}, {});
+      ExplicitModuleMap.try_emplace(moduleInput.first(), std::move(entry));
     }
   }
 };
@@ -2422,7 +2421,7 @@ std::unique_ptr<ExplicitSwiftModuleLoader>
 ExplicitSwiftModuleLoader::create(ASTContext &ctx,
     DependencyTracker *tracker, ModuleLoadingMode loadMode,
     StringRef ExplicitSwiftModuleMap,
-    const std::vector<std::pair<std::string, std::string>> &ExplicitSwiftModuleInputs,
+    const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
     bool IgnoreSwiftSourceInfoFile) {
   auto result = std::unique_ptr<ExplicitSwiftModuleLoader>(
     new ExplicitSwiftModuleLoader(ctx, tracker, loadMode,
@@ -2536,11 +2535,10 @@ struct ExplicitCASModuleLoader::Implementation {
   }
 
   void addCommandLineExplicitInputs(
-      const std::vector<std::pair<std::string, std::string>>
-          &commandLineExplicitInputs) {
+      const llvm::StringMap<std::string> &commandLineExplicitInputs) {
     for (const auto &moduleInput : commandLineExplicitInputs) {
-      ExplicitSwiftModuleInputInfo entry(moduleInput.second, {}, {}, {});
-      ExplicitModuleMap.try_emplace(moduleInput.first, std::move(entry));
+      ExplicitSwiftModuleInputInfo entry(moduleInput.getValue(), {}, {}, {});
+      ExplicitModuleMap.try_emplace(moduleInput.getKey(), std::move(entry));
     }
   }
 
@@ -2777,8 +2775,7 @@ std::unique_ptr<ExplicitCASModuleLoader> ExplicitCASModuleLoader::create(
     ASTContext &ctx, llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &cache,
     DependencyTracker *tracker, ModuleLoadingMode loadMode,
     StringRef ExplicitSwiftModuleMap,
-    const std::vector<std::pair<std::string, std::string>>
-        &ExplicitSwiftModuleInputs,
+    const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
     bool IgnoreSwiftSourceInfoFile) {
   auto result =
       std::unique_ptr<ExplicitCASModuleLoader>(new ExplicitCASModuleLoader(

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -83,6 +83,30 @@ std::error_code SwiftModuleScanner::findModuleFilesInDirectory(
   return dependencyInfo.getError();
 }
 
+bool SwiftModuleScanner::canImportModule(
+    ImportPath::Module path, SourceLoc loc, ModuleVersionInfo *versionInfo,
+    bool isTestableDependencyLookup) {
+  if (path.hasSubmodule())
+    return false;
+
+  // Check explicitly-provided Swift modules with '-swift-module-file'
+  ImportPath::Element mID = path.front();
+  auto it =
+      explicitSwiftModuleInputs.find(Ctx.getRealModuleName(mID.Item).str());
+  if (it != explicitSwiftModuleInputs.end()) {
+    auto dependencyInfo = scanBinaryModuleFile(
+        mID.Item, it->getValue(), /* isFramework */ false,
+        isTestableDependencyLookup, /* isCandidateForTextualModule */ false);
+    if (dependencyInfo) {
+      this->foundDependencyInfo = std::move(dependencyInfo.get());
+      return true;
+    }
+  }
+
+  return SerializedModuleLoaderBase::canImportModule(
+      path, loc, versionInfo, isTestableDependencyLookup);
+}
+
 static std::vector<std::string> getCompiledCandidates(ASTContext &ctx,
                                                       StringRef moduleName,
                                                       StringRef interfacePath) {

--- a/test/ScanDependencies/explicit-scanner-input-can-import.swift
+++ b/test/ScanDependencies/explicit-scanner-input-can-import.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/Inputs/Foo.swiftmodule)
+// RUN: split-file %s %t
+
+// Step 1: build swift interface and swift module side by side
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -user-module-version 22
+
+// Step 2: scan dependency should give us the binary module we specify with 'swift-module-file'
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-INPUT
+
+// Step 3: ensure that versioned canImport still applies with direct -swift-module-file
+// RUN: %target-swift-frontend -scan-dependencies %t/test_too_new.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-MISSING
+
+// CHECK-INPUT: "swiftPrebuiltExternal": "Foo"
+// CHECK-MISSING-NOT: "swiftPrebuiltExternal": "Foo"
+
+//--- Foo.swift
+public func foo() {}
+
+//--- test.swift
+#if canImport(Foo)
+import Foo
+#endif
+
+//--- test_too_new.swift
+#if canImport(Foo, _version: 23)
+import Foo
+#endif

--- a/test/ScanDependencies/explicit-scanner-input.swift
+++ b/test/ScanDependencies/explicit-scanner-input.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/Inputs/Foo.swiftmodule)
+// RUN: split-file %s %t
+
+// Step 1: build swift interface and swift module side by side
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo
+
+// Step 2: scan dependency should give us the binary module we specify with 'swift-module-file'
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-INPUT
+// CHECK-INPUT: "swiftPrebuiltExternal": "Foo"
+
+// Step 3: verify that the usual invalid module candidate diagnostics apply
+// RUN: echo "Not Really a module" > %t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json  -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-INVALID-MODULE-DIAG
+// CHECK-INVALID-MODULE-DIAG: error: unable to resolve Swift module dependency to a compatible module: 'Foo'
+// CHECK-INVALID-MODULE-DIAG: note: found incompatible module '{{.*}}': malformed
+
+//--- Foo.swift
+public func foo() {}
+
+//--- test.swift
+#if canImport(Foo)
+import Foo
+#endif

--- a/test/ScanDependencies/explicit-scanner-input.swift
+++ b/test/ScanDependencies/explicit-scanner-input.swift
@@ -9,11 +9,18 @@
 // Step 2: scan dependency should give us the binary module we specify with 'swift-module-file'
 // RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
 // RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-INPUT
-// CHECK-INPUT: "swiftPrebuiltExternal": "Foo"
 
-// Step 3: verify that the usual invalid module candidate diagnostics apply
+// Step 3: ensure that if multiple inputs for the same module are specified then a warning is emitted and the latter is preferred
+// RUN: echo "Gibberish" > %t/Inputs/Foo.swiftmodule/NotAModule.swiftmodule
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/NotAModule.swiftmodule -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-WARN-MULTIPLE
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-INPUT
+
+// Step 4: verify that the usual invalid module candidate diagnostics apply
 // RUN: echo "Not Really a module" > %t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
 // RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json  -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-INVALID-MODULE-DIAG
+
+// CHECK-INPUT: "swiftPrebuiltExternal": "Foo"
+// CHECK-WARN-MULTIPLE: warning: multiple Swift module file inputs with identifier "Foo": replacing '{{.*}}NotAModule.swiftmodule'
 // CHECK-INVALID-MODULE-DIAG: error: unable to resolve Swift module dependency to a compatible module: 'Foo'
 // CHECK-INVALID-MODULE-DIAG: note: found incompatible module '{{.*}}': malformed
 


### PR DESCRIPTION
Previously this flag was only used to pass explicit dependencies to compilation tasks. This change adds support for the dependency scanner to also consider these inputs when resolving dependencies.

Resolves https://github.com/swiftlang/swift-driver/issues/1951
