### PR TITLE
ClangImporter: permit redundancy in the Generate PCM job

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -143,8 +143,6 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
     if (!ctx.CASOpts.EnableCaching) {
       auto &overlayFiles = invocation.getMutHeaderSearchOpts().VFSOverlayFiles;
       for (auto overlay : overlayFiles) {
-        if (llvm::is_contained(ctx.SearchPathOpts.VFSOverlayFiles, overlay))
-          continue;
         swiftArgs.push_back("-vfsoverlay");
         swiftArgs.push_back(overlay);
       }


### PR DESCRIPTION
`-Xcc` flags are internal to the C compiler; we have `-vfsoverlay` now which directly passes the VFS overlay. Because the VFS overlay flags are automatically passed along to the clang scanner, we need to pass along `-vfsoverlay` to the Swift frontend to ensure that any VFS overlays are honoured. Most likely this was a workaround for `-vfsoverlay` not getting propagated originally and when the restriction was lifted the exercised codepath was not heavily tested.