### PR TITLE
BuiltinFixedArray cleanup

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1773,18 +1773,10 @@ class BuiltinFixedArrayType : public BuiltinType, public llvm::FoldingSetNode {
   CanType Size;
   CanType ElementType;
   
-  static RecursiveTypeProperties
-  getRecursiveTypeProperties(CanType Size, CanType Element) {
-    RecursiveTypeProperties properties;
-    properties |= Size->getRecursiveProperties();
-    properties |= Element->getRecursiveProperties();
-    return properties;
-  }
-  
-  BuiltinFixedArrayType(CanType Size,
-                        CanType ElementType)
+  BuiltinFixedArrayType(CanType Size, CanType ElementType,
+                        RecursiveTypeProperties properties)
     : BuiltinType(TypeKind::BuiltinFixedArray, ElementType->getASTContext(),
-                  getRecursiveTypeProperties(Size, ElementType)),
+                  properties),
         Size(Size),
         ElementType(ElementType)
   {}

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6241,8 +6241,19 @@ public:
   ASTPRINTER_PRINT_BUILTINTYPE(BuiltinIntegerType)
   ASTPRINTER_PRINT_BUILTINTYPE(BuiltinFloatType)
   ASTPRINTER_PRINT_BUILTINTYPE(BuiltinUnboundGenericType)
-  ASTPRINTER_PRINT_BUILTINTYPE(BuiltinFixedArrayType)
 #undef ASTPRINTER_PRINT_BUILTINTYPE
+
+  void visitBuiltinFixedArrayType(BuiltinFixedArrayType *T,
+                                  NonRecursivePrintOptions nrOptions) {
+    SmallString<32> buffer;
+    T->getTypeName(buffer);
+    Printer << buffer;
+    Printer << "<";
+    visit(T->getSize());
+    Printer << ", ";
+    visit(T->getElementType());
+    Printer << ">";
+  }
 
   void visitSILTokenType(SILTokenType *T,
                          NonRecursivePrintOptions nrOptions) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1416,7 +1416,7 @@ public:
         abort();
       }
 
-      checkTrivialSubtype(srcTy, destTy, "MetatypeConversionExpr");
+      checkTrivialSubtype(E, srcTy, destTy, "MetatypeConversionExpr");
       verifyCheckedBase(E);
     }
     
@@ -1641,7 +1641,7 @@ public:
         abort();
       }
 
-      checkTrivialSubtype(srcTy, destTy, "DerivedToBaseExpr");
+      checkTrivialSubtype(E, srcTy, destTy, "DerivedToBaseExpr");
       verifyCheckedBase(E);
     }
 
@@ -3590,12 +3590,14 @@ public:
       abort();
     }
 
-    void checkTrivialSubtype(Type srcTy, Type destTy, const char *what) {
+    void checkTrivialSubtype(Expr *E, Type srcTy, Type destTy,
+                             const char *what) {
       if (srcTy->isEqual(destTy)) return;
 
       if (auto srcMetatype = srcTy->getAs<AnyMetatypeType>()) {
         if (auto destMetatype = destTy->getAs<AnyMetatypeType>()) {
-          return checkTrivialSubtype(srcMetatype->getInstanceType(),
+          return checkTrivialSubtype(E,
+                                     srcMetatype->getInstanceType(),
                                      destMetatype->getInstanceType(),
                                      what);
         }
@@ -3625,6 +3627,7 @@ public:
       Out << " to ";
       destTy.print(Out);
       Out << "\n";
+      E->dump(Out);
       abort();
     }
 

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -3593,16 +3593,9 @@ StringRef BuiltinType::getTypeName(SmallVectorImpl<char> &result,
     }
     break;
   }
-  case BuiltinTypeKind::BuiltinFixedArray: {
-    auto bfa = cast<BuiltinFixedArrayType>(this);
-    printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_FIXEDARRAY)
-            << '<';
-    bfa->getSize()->print(printer);
-    printer << ", ";
-    bfa->getElementType()->print(printer);
-    printer << '>';
+  case BuiltinTypeKind::BuiltinFixedArray:
+    printer << MAYBE_GET_NAMESPACED_BUILTIN(BUILTIN_TYPE_NAME_FIXEDARRAY);
     break;
-  }
   case BuiltinTypeKind::BuiltinUnboundGeneric: {
     auto bug = cast<BuiltinUnboundGenericType>(this);
     printer << MAYBE_GET_NAMESPACED_BUILTIN(bug->getBuiltinTypeName());

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -1640,14 +1640,12 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
     memberTy = replaceInferableTypesWithTypeVars(
         memberTy, locator, preparedOverload);
 
-    // Wrap it in a metatype.
-    memberTy = MetatypeType::get(memberTy);
-
-    // If this is a value generic, undo the wrapping. 'substMemberTypeWithBase'
-    // returns the underlying value type of the value generic (e.g. 'Int').
-    if (isa<GenericTypeParamDecl>(value) &&
-        cast<GenericTypeParamDecl>(value)->isValue()) {
-      memberTy = memberTy->castTo<MetatypeType>()->getInstanceType();
+    // Wrap it in a metatype, unless this is a value generic.
+    // 'substMemberTypeWithBase' returns the underlying value type
+    // of the value generic (e.g. 'Int').
+    if (!isa<GenericTypeParamDecl>(value) ||
+        !cast<GenericTypeParamDecl>(value)->isValue()) {
+      memberTy = MetatypeType::get(memberTy);
     }
 
     auto openedType = FunctionType::get({baseObjParam}, memberTy);


### PR DESCRIPTION
This type is pretty broken which made debugging another issue difficult:
- Fix allocation to use solver arena if the generic arguments contain type variables
- Fix printing to go through the normal path instead of string-ifying the generic arguments in getTypeName(), which ensures that PrintOptions are respected
- matchTypes() was not implemented