### PR TITLE
[Runtimes] handle incremental builds that have non nested swiftmodules

### DIFF
--- a/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Core/cmake/modules/EmitSwiftInterface.cmake
@@ -18,7 +18,13 @@ function(emit_swift_interface target)
   if(NOT module_name)
     set(module_name ${target})
   endif()
-  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  # Account for an existing swiftmodule file
+  # generated with the previous logic
+  if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
+     AND NOT IS_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+    message(STATUS "Removing regular file ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule to support nested swiftmodule generation")
+    file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  endif()
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftCore_MODULE_TRIPLE}.swiftmodule>")
   if(SwiftCore_VARIANT_MODULE_TRIPLE)

--- a/Runtimes/Overlay/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Overlay/cmake/modules/EmitSwiftInterface.cmake
@@ -18,7 +18,13 @@ function(emit_swift_interface target)
   if(NOT module_name)
     set(module_name ${target})
   endif()
-  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  # Account for an existing swiftmodule file
+  # generated with the previous logic
+  if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
+     AND NOT IS_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+    message(STATUS "Removing regular file ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule to support nested swiftmodule generation")
+    file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  endif()
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${SwiftOverlay_MODULE_TRIPLE}.swiftmodule>")
   if(SwiftOverlay_VARIANT_MODULE_TRIPLE)

--- a/Runtimes/Supplemental/cmake/modules/EmitSwiftInterface.cmake
+++ b/Runtimes/Supplemental/cmake/modules/EmitSwiftInterface.cmake
@@ -18,7 +18,13 @@ function(emit_swift_interface target)
   if(NOT module_name)
     set(module_name ${target})
   endif()
-  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  # Account for an existing swiftmodule file
+  # generated with the previous logic
+  if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule"
+     AND NOT IS_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+    message(STATUS "Removing regular file ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule to support nested swiftmodule generation")
+    file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule")
+  endif()
   target_compile_options(${target} PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/${module_name}.swiftmodule/${${PROJECT_NAME}_MODULE_TRIPLE}.swiftmodule>")
   if(${PROJECT_NAME}_VARIANT_MODULE_TRIPLE)


### PR DESCRIPTION
Before #82571, we would generate a binary swiftmodule file at `<build folder>/<module>.swiftmodule`, while now in the same location we generate a directory.
Trying an incremental run on top of a build folder generated with the old logic will fail during configuration with an error similar to

```
CMake Error at .../Supplemental/cmake/modules/EmitSwiftInterface.cmake:21 (file):
  file failed to create directory:

    .../StringProcessing-build/_RegexParser/_RegexParser.swiftmodule

  because: File exists
```

To reduce churn in CI and at desk, delete such remnant from the previous logic.

Addresses rdar://155466197