### PR TITLE
[6.2 🍒][Dependency Scanning] Consider `-swift-module-file` inputs when looking for dependencies

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -213,6 +213,9 @@ ERROR(error_stdlib_module_name,none,
       "module name \"%0\" is reserved for the standard library"
       "%select{|; use -module-name flag to specify an alternate name}1",
       (StringRef, bool))
+WARNING(warn_multiple_module_inputs_same_name,none,
+        "multiple Swift module file inputs with identifier \"%0\": replacing '%1' with '%2'",
+        (StringRef, StringRef, StringRef))
 
 ERROR(error_bad_export_as_name,none,
       "export-as name \"%0\" is not a valid identifier",

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -375,6 +375,7 @@ public:
                         StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
+                        const llvm::StringMap<std::string> &explicitSwiftModuleInputs,
                         InterfaceSubContextDelegate &delegate,
                         llvm::PrefixMapper *mapper = nullptr,
                         bool isTestableImport = false) = 0;

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -519,7 +519,7 @@ public:
 
   /// Module inputs specified with -swift-module-input,
   /// <ModuleName, Path to .swiftmodule file>
-  std::vector<std::pair<std::string, std::string>> ExplicitSwiftModuleInputs;
+  llvm::StringMap<std::string> ExplicitSwiftModuleInputs;
 
   /// A map of placeholder Swift module dependency information.
   std::string PlaceholderDependencyModuleMap;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -509,6 +509,7 @@ public:
   getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
+                        const llvm::StringMap<std::string> &explicitSwiftModuleInputs,
                         InterfaceSubContextDelegate &delegate,
                         llvm::PrefixMapper *mapper,
                         bool isTestableImport = false) override;

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -101,6 +101,9 @@ private:
   std::vector<std::string> swiftModuleClangCC1CommandLineArgs;
   // Working directory for clang module lookup queries
   std::string clangScanningWorkingDirectoryPath;
+  
+  /// Module inputs specified with -swift-module-input,
+  llvm::StringMap<std::string> explicitSwiftModuleInputs;
 
   // CAS instance.
   std::shared_ptr<llvm::cas::ObjectStore> CAS;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -176,7 +176,7 @@ public:
   create(ASTContext &ctx,
          DependencyTracker *tracker, ModuleLoadingMode loadMode,
          StringRef ExplicitSwiftModuleMap,
-         const std::vector<std::pair<std::string, std::string>> &ExplicitSwiftModuleInputs,
+         const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
          bool IgnoreSwiftSourceInfoFile);
 
   /// Append visible module names to \p names. Note that names are possibly
@@ -224,8 +224,7 @@ public:
   create(ASTContext &ctx, llvm::cas::ObjectStore &CAS,
          llvm::cas::ActionCache &cache, DependencyTracker *tracker,
          ModuleLoadingMode loadMode, StringRef ExplicitSwiftModuleMap,
-         const std::vector<std::pair<std::string, std::string>>
-             &ExplicitSwiftModuleInputs,
+         const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
          bool IgnoreSwiftSourceInfoFile);
 
   /// Append visible module names to \p names. Note that names are possibly

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -102,6 +102,7 @@ public:
   getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
+                        const llvm::StringMap<std::string> &explicitSwiftModuleInputs,
                         InterfaceSubContextDelegate &delegate,
                         llvm::PrefixMapper *mapper,
                         bool isTestableImport) override;

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -266,6 +266,7 @@ public:
   getModuleDependencies(Identifier moduleName, StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                         const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                         const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
+                        const llvm::StringMap<std::string> &explicitSwiftModuleInputs,
                         InterfaceSubContextDelegate &delegate,
                         llvm::PrefixMapper *mapper,
                         bool isTestableImport) override;

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -275,6 +275,7 @@ ClangImporter::getModuleDependencies(Identifier moduleName,
                                      StringRef sdkModuleOutputPath,
                                      const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                                      const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
+                                     const llvm::StringMap<std::string> &explicitSwiftModuleInputs,
                                      InterfaceSubContextDelegate &delegate,
                                      llvm::PrefixMapper *mapper,
                                      bool isTestableImport) {

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -259,6 +259,9 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
     swiftModuleClangCC1CommandLineArgs.push_back("-fno-implicit-module-maps");
   }
 
+  explicitSwiftModuleInputs =
+    workerCompilerInvocation->getSearchPathOptions().ExplicitSwiftModuleInputs;
+
   // Set up the Swift interface loader for Swift scanning.
   swiftScannerModuleLoader = ModuleInterfaceLoader::create(
       *workerASTContext,
@@ -275,8 +278,8 @@ ModuleDependencyScanningWorker::scanFilesystemForSwiftModuleDependency(
     bool isTestableImport) {
   return swiftScannerModuleLoader->getModuleDependencies(
       moduleName, moduleOutputPath, sdkModuleOutputPath,
-      {}, swiftModuleClangCC1CommandLineArgs, *scanningASTDelegate,
-      prefixMapper, isTestableImport);
+      {}, swiftModuleClangCC1CommandLineArgs, explicitSwiftModuleInputs,
+      *scanningASTDelegate, prefixMapper, isTestableImport);
 }
 
 ModuleDependencyVector
@@ -299,8 +302,7 @@ ModuleDependencyScanningWorker::scanFilesystemForClangModuleDependency(
   auto clangModuleDependencies = clangScanningTool.getModuleDependencies(
       moduleName.str(), clangScanningModuleCommandLineArgs,
       clangScanningWorkingDirectoryPath,
-      alreadySeenModules,
-      lookupModuleOutput);
+      alreadySeenModules, lookupModuleOutput);
   if (!clangModuleDependencies) {
     auto errorStr = toString(clangModuleDependencies.takeError());
     // We ignore the "module 'foo' not found" error, the Swift dependency

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2269,7 +2269,7 @@ static void ParseSymbolGraphArgs(symbolgraphgen::SymbolGraphOptions &Opts,
 
 static bool validateSwiftModuleFileArgumentAndAdd(const std::string &swiftModuleArgument,
                                                   DiagnosticEngine &Diags,
-                                                  std::vector<std::pair<std::string, std::string>> &ExplicitSwiftModuleInputs) {
+                                                  llvm::StringMap<std::string> &ExplicitSwiftModuleInputs) {
   std::size_t foundDelimeterPos = swiftModuleArgument.find_first_of("=");
   if (foundDelimeterPos == std::string::npos) {
     Diags.diagnose(SourceLoc(), diag::error_swift_module_file_requires_delimeter,
@@ -2282,7 +2282,7 @@ static bool validateSwiftModuleFileArgumentAndAdd(const std::string &swiftModule
     Diags.diagnose(SourceLoc(), diag::error_bad_module_name, moduleName, false);
     return true;
   }
-  ExplicitSwiftModuleInputs.emplace_back(std::make_pair(moduleName, modulePath));
+  ExplicitSwiftModuleInputs.insert(std::make_pair(moduleName, modulePath));
   return false;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2282,7 +2282,15 @@ static bool validateSwiftModuleFileArgumentAndAdd(const std::string &swiftModule
     Diags.diagnose(SourceLoc(), diag::error_bad_module_name, moduleName, false);
     return true;
   }
-  ExplicitSwiftModuleInputs.insert(std::make_pair(moduleName, modulePath));
+
+  auto priorEntryIt = ExplicitSwiftModuleInputs.find(moduleName);
+  if (priorEntryIt != ExplicitSwiftModuleInputs.end()) {
+    Diags.diagnose(SourceLoc(), diag::warn_multiple_module_inputs_same_name,
+                   moduleName, priorEntryIt->getValue(), modulePath);
+    ExplicitSwiftModuleInputs[moduleName] = modulePath;
+  } else
+    ExplicitSwiftModuleInputs.insert(std::make_pair(moduleName, modulePath));
+
   return false;
 }
 

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -2251,11 +2251,10 @@ struct ExplicitSwiftModuleLoader::Implementation {
   }
 
   void addCommandLineExplicitInputs(
-      const std::vector<std::pair<std::string, std::string>>
-          &commandLineExplicitInputs) {
+      const llvm::StringMap<std::string> &commandLineExplicitInputs) {
     for (const auto &moduleInput : commandLineExplicitInputs) {
-      ExplicitSwiftModuleInputInfo entry(moduleInput.second, {}, {}, {});
-      ExplicitModuleMap.try_emplace(moduleInput.first, std::move(entry));
+      ExplicitSwiftModuleInputInfo entry(moduleInput.getValue(), {}, {}, {});
+      ExplicitModuleMap.try_emplace(moduleInput.getKey(), std::move(entry));
     }
   }
 };
@@ -2427,7 +2426,7 @@ std::unique_ptr<ExplicitSwiftModuleLoader>
 ExplicitSwiftModuleLoader::create(ASTContext &ctx,
     DependencyTracker *tracker, ModuleLoadingMode loadMode,
     StringRef ExplicitSwiftModuleMap,
-    const std::vector<std::pair<std::string, std::string>> &ExplicitSwiftModuleInputs,
+    const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
     bool IgnoreSwiftSourceInfoFile) {
   auto result = std::unique_ptr<ExplicitSwiftModuleLoader>(
     new ExplicitSwiftModuleLoader(ctx, tracker, loadMode,
@@ -2541,11 +2540,10 @@ struct ExplicitCASModuleLoader::Implementation {
   }
 
   void addCommandLineExplicitInputs(
-      const std::vector<std::pair<std::string, std::string>>
-          &commandLineExplicitInputs) {
+      const llvm::StringMap<std::string> &commandLineExplicitInputs) {
     for (const auto &moduleInput : commandLineExplicitInputs) {
-      ExplicitSwiftModuleInputInfo entry(moduleInput.second, {}, {}, {});
-      ExplicitModuleMap.try_emplace(moduleInput.first, std::move(entry));
+      ExplicitSwiftModuleInputInfo entry(moduleInput.getValue(), {}, {}, {});
+      ExplicitModuleMap.try_emplace(moduleInput.getKey(), std::move(entry));
     }
   }
 
@@ -2782,8 +2780,7 @@ std::unique_ptr<ExplicitCASModuleLoader> ExplicitCASModuleLoader::create(
     ASTContext &ctx, llvm::cas::ObjectStore &CAS, llvm::cas::ActionCache &cache,
     DependencyTracker *tracker, ModuleLoadingMode loadMode,
     StringRef ExplicitSwiftModuleMap,
-    const std::vector<std::pair<std::string, std::string>>
-        &ExplicitSwiftModuleInputs,
+    const llvm::StringMap<std::string> &ExplicitSwiftModuleInputs,
     bool IgnoreSwiftSourceInfoFile) {
   auto result =
       std::unique_ptr<ExplicitCASModuleLoader>(new ExplicitCASModuleLoader(

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -159,6 +159,7 @@ SourceLoader::getModuleDependencies(Identifier moduleName,
                                     StringRef moduleOutputPath, StringRef sdkModuleOutputPath,
                                     const llvm::DenseSet<clang::tooling::dependencies::ModuleID> &alreadySeenClangModules,
                                     const std::vector<std::string> &swiftModuleClangCC1CommandLineArgs,
+                                    const llvm::StringMap<std::string> &explicitSwiftModuleInputs,
                                     InterfaceSubContextDelegate &delegate,
                                     llvm::PrefixMapper* mapper,
                                     bool isTestableImport) {

--- a/test/ScanDependencies/explicit-scanner-input-can-import.swift
+++ b/test/ScanDependencies/explicit-scanner-input-can-import.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/Inputs/Foo.swiftmodule)
+// RUN: split-file %s %t
+
+// Step 1: build swift interface and swift module side by side
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo -user-module-version 22
+
+// Step 2: scan dependency should give us the binary module we specify with 'swift-module-file'
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-INPUT
+
+// Step 3: ensure that versioned canImport still applies with direct -swift-module-file
+// RUN: %target-swift-frontend -scan-dependencies %t/test_too_new.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-MISSING
+
+// CHECK-INPUT: "swiftPrebuiltExternal": "Foo"
+// CHECK-MISSING-NOT: "swiftPrebuiltExternal": "Foo"
+
+//--- Foo.swift
+public func foo() {}
+
+//--- test.swift
+#if canImport(Foo)
+import Foo
+#endif
+
+//--- test_too_new.swift
+#if canImport(Foo, _version: 23)
+import Foo
+#endif

--- a/test/ScanDependencies/explicit-scanner-input.swift
+++ b/test/ScanDependencies/explicit-scanner-input.swift
@@ -9,12 +9,25 @@
 // Step 2: scan dependency should give us the binary module we specify with 'swift-module-file'
 // RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
 // RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-INPUT
+
+// Step 3: ensure that if multiple inputs for the same module are specified then a warning is emitted and the latter is preferred
+// RUN: echo "Gibberish" > %t/Inputs/Foo.swiftmodule/NotAModule.swiftmodule
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/NotAModule.swiftmodule -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-WARN-MULTIPLE
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-INPUT
+
+// Step 4: verify that the usual invalid module candidate diagnostics apply
+// RUN: echo "Not Really a module" > %t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json  -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -diagnostic-style llvm 2>&1 | %FileCheck %s -check-prefix=CHECK-INVALID-MODULE-DIAG
+
 // CHECK-INPUT: "swiftPrebuiltExternal": "Foo"
+// CHECK-WARN-MULTIPLE: warning: multiple Swift module file inputs with identifier "Foo": replacing '{{.*}}NotAModule.swiftmodule'
+
+// CHECK-INVALID-MODULE-DIAG: warning: module file '{{.*}}Foo.swiftmodule{{/|\\}}{{.*}}.swiftmodule' is incompatible with this Swift compiler: malformed
+// CHECK-INVALID-MODULE-DIAG: error: Unable to find module dependency: 'Foo'
+// CHECK-INVALID-MODULE-DIAG: note: a dependency of main module 'deps'
 
 //--- Foo.swift
 public func foo() {}
 
 //--- test.swift
-#if canImport(Foo)
 import Foo
-#endif

--- a/test/ScanDependencies/explicit-scanner-input.swift
+++ b/test/ScanDependencies/explicit-scanner-input.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/Inputs/Foo.swiftmodule)
+// RUN: split-file %s %t
+
+// Step 1: build swift interface and swift module side by side
+// RUN: %target-swift-frontend -emit-module %t/Foo.swift -emit-module-path %t/Inputs/Foo.swiftmodule/%target-swiftmodule-name -module-name Foo
+
+// Step 2: scan dependency should give us the binary module we specify with 'swift-module-file'
+// RUN: %target-swift-frontend -scan-dependencies %t/test.swift -o %t/deps.json -scanner-module-validation -swift-module-file=Foo=%t/Inputs/Foo.swiftmodule/%target-swiftmodule-name
+// RUN: %validate-json %t/deps.json | %FileCheck %s -check-prefix=CHECK-INPUT
+// CHECK-INPUT: "swiftPrebuiltExternal": "Foo"
+
+//--- Foo.swift
+public func foo() {}
+
+//--- test.swift
+#if canImport(Foo)
+import Foo
+#endif


### PR DESCRIPTION
`release/6.2` re-implementation of https://github.com/swiftlang/swift/pull/82934
------------------------------------------
- **Explanation**: Previously this flag was only used to pass explicit dependencies to compilation tasks. This change adds support for the dependency scanner to also consider these inputs when resolving dependencies.

- **Scope**: Builds which enable Explicitly built modules and manually specify module dependencies with `-Xfrontend -swift-module-file`.

- **Risk**: Low. These changes are largely additive to the dependency scanner and add code paths for a direct use of a frontend flag which is not generated by the driver but must be done by the user directly.

- **Problem**: rdar://152883649

- **Reviewed By**: @cachemeifyoucan 

- **Original PR**: https://github.com/swiftlang/swift/pull/82934