### PR TITLE
ClangImporter: Generate and call custom availability domain predicates

### DIFF
--- a/include/swift/AST/AvailabilityDomain.h
+++ b/include/swift/AST/AvailabilityDomain.h
@@ -34,6 +34,7 @@ class ASTContext;
 class CustomAvailabilityDomain;
 class Decl;
 class DeclContext;
+class FuncDecl;
 class ModuleDecl;
 
 /// Represents a dimension of availability (e.g. macOS platform or Swift
@@ -336,19 +337,26 @@ private:
   Kind kind;
   ModuleDecl *mod;
   Decl *decl;
+  FuncDecl *predicateFunc;
 
   CustomAvailabilityDomain(Identifier name, Kind kind, ModuleDecl *mod,
-                           Decl *decl);
+                           Decl *decl, FuncDecl *predicateFunc);
 
 public:
   static const CustomAvailabilityDomain *get(StringRef name, Kind kind,
                                              ModuleDecl *mod, Decl *decl,
+                                             FuncDecl *predicateFunc,
                                              const ASTContext &ctx);
 
   Identifier getName() const { return name; }
   Kind getKind() const { return kind; }
   ModuleDecl *getModule() const { return mod; }
   Decl *getDecl() const { return decl; }
+
+  /// Returns the function that should be called at runtime to determine whether
+  /// the domain is available, or `nullptr` if the domain's availability is not
+  /// determined at runtime.
+  FuncDecl *getPredicateFunc() const { return predicateFunc; }
 
   /// Uniquing for `ASTContext`.
   static void Profile(llvm::FoldingSetNodeID &ID, Identifier name,

--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -298,6 +298,9 @@ public:
 
   virtual FuncDecl *getDefaultArgGenerator(const clang::ParmVarDecl *param) = 0;
 
+  virtual FuncDecl *
+  getAvailabilityDomainPredicate(const clang::VarDecl *var) = 0;
+
   virtual std::optional<Type>
   importFunctionReturnType(const clang::FunctionDecl *clangDecl,
                            DeclContext *dc) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -630,6 +630,8 @@ public:
 
   FuncDecl *getDefaultArgGenerator(const clang::ParmVarDecl *param) override;
 
+  FuncDecl *getAvailabilityDomainPredicate(const clang::VarDecl *var) override;
+
   bool isAnnotatedWith(const clang::CXXMethodDecl *method, StringRef attr);
 
   /// Find the lookup table that corresponds to the given Clang module.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5899,7 +5899,8 @@ const AvailabilityContext::Storage *AvailabilityContext::Storage::get(
 
 const CustomAvailabilityDomain *
 CustomAvailabilityDomain::get(StringRef name, Kind kind, ModuleDecl *mod,
-                              Decl *decl, const ASTContext &ctx) {
+                              Decl *decl, FuncDecl *predicateFunc,
+                              const ASTContext &ctx) {
   auto identifier = ctx.getIdentifier(name);
   llvm::FoldingSetNodeID id;
   CustomAvailabilityDomain::Profile(id, identifier, mod);
@@ -5912,8 +5913,8 @@ CustomAvailabilityDomain::get(StringRef name, Kind kind, ModuleDecl *mod,
 
   void *mem = ctx.Allocate(sizeof(CustomAvailabilityDomain),
                            alignof(CustomAvailabilityDomain));
-  auto *newNode =
-      ::new (mem) CustomAvailabilityDomain(identifier, kind, mod, decl);
+  auto *newNode = ::new (mem)
+      CustomAvailabilityDomain(identifier, kind, mod, decl, predicateFunc);
   foldingSet.InsertNode(newNode, insertPos);
 
   return newNode;

--- a/lib/AST/AvailabilityQuery.cpp
+++ b/lib/AST/AvailabilityQuery.cpp
@@ -129,7 +129,8 @@ getOSAvailabilityDeclAndArguments(const AvailabilityQuery &query,
 
 FuncDecl *AvailabilityQuery::getDynamicQueryDeclAndArguments(
     llvm::SmallVectorImpl<unsigned> &arguments, ASTContext &ctx) const {
-  switch (getDomain().getKind()) {
+  auto domain = getDomain();
+  switch (domain.getKind()) {
   case AvailabilityDomain::Kind::Universal:
   case AvailabilityDomain::Kind::SwiftLanguage:
   case AvailabilityDomain::Kind::PackageDescription:
@@ -138,7 +139,9 @@ FuncDecl *AvailabilityQuery::getDynamicQueryDeclAndArguments(
   case AvailabilityDomain::Kind::Platform:
     return getOSAvailabilityDeclAndArguments(*this, arguments, ctx);
   case AvailabilityDomain::Kind::Custom:
-    // FIXME: [availability] Support custom domains.
-    return nullptr;
+    auto customDomain = domain.getCustomDomain();
+    ASSERT(customDomain);
+
+    return customDomain->getPredicateFunc();
   }
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7646,6 +7646,14 @@ ClangImporter::getDefaultArgGenerator(const clang::ParmVarDecl *param) {
   return nullptr;
 }
 
+FuncDecl *
+ClangImporter::getAvailabilityDomainPredicate(const clang::VarDecl *var) {
+  auto it = Impl.availabilityDomainPredicates.find(var);
+  if (it != Impl.availabilityDomainPredicates.end())
+    return it->second;
+  return nullptr;
+}
+
 SwiftLookupTable *
 ClangImporter::findLookupTable(const clang::Module *clangModule) {
   return Impl.findLookupTable(clangModule);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4675,6 +4675,14 @@ namespace {
       if (correctSwiftName)
         markAsVariant(result, *correctSwiftName);
 
+      // If the decl represents an availability domain, eagerly synthesize its
+      // `if #available` predicate function.
+      if (decl->hasAttrs() &&
+          llvm::any_of(decl->getAttrs(), [](clang::Attr *attr) {
+            return isa<clang::AvailabilityDomainAttr>(attr);
+          }))
+        (void)synthesizer.makeAvailabilityDomainPredicate(decl);
+
       return result;
     }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -818,6 +818,11 @@ private:
 public:
   importer::PlatformAvailability platformAvailability;
 
+  /// The synthesized predicate functions for imported `VarDecl`s that represent
+  /// availability domains.
+  llvm::DenseMap<const clang::VarDecl *, FuncDecl *>
+      availabilityDomainPredicates;
+
 private:
   /// For importing names. This is initialized by the ClangImporter::create()
   /// after having set up a suitable Clang instance.

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2747,3 +2747,107 @@ SwiftDeclSynthesizer::synthesizeStaticFactoryForCXXForeignRef(
 
   return synthesizedFactories;
 }
+
+static std::pair<BraceStmt *, bool>
+synthesizeAvailabilityDomainPredicateBody(AbstractFunctionDecl *afd,
+                                          void *context) {
+  auto clangVarDecl = static_cast<const clang::VarDecl *>(context);
+  clang::ASTContext &clangCtx = clangVarDecl->getASTContext();
+  auto domainInfo =
+      clangCtx.getFeatureAvailInfo(const_cast<clang::VarDecl *>(clangVarDecl));
+  ASSERT(domainInfo.second.Call);
+
+  auto funcDecl = cast<FuncDecl>(afd);
+  ASTContext &ctx = funcDecl->getASTContext();
+
+  // FIXME: The need for an intermediate function to call could be eliminated if
+  // Clang provided the predicate function decl directly, rather than a call
+  // expression that must be wrapped in a function.
+  // Synthesize `return {domain predicate expression}`.
+  auto clangHelperReturnStmt = clang::ReturnStmt::Create(
+      clangCtx, clang::SourceLocation(), domainInfo.second.Call, nullptr);
+
+  // Synthesize `int __XYZ_isAvailable() { return {predicate expr}; }`.
+  auto clangDeclName = clang::DeclarationName(
+      &clangCtx.Idents.get("__" + domainInfo.first.str() + "_isAvailable"));
+  auto clangDeclContext = clangCtx.getTranslationUnitDecl();
+  clang::QualType funcTy =
+      clangCtx.getFunctionType(domainInfo.second.Call->getType(), {},
+                               clang::FunctionProtoType::ExtProtoInfo());
+
+  auto clangHelperFuncDecl = clang::FunctionDecl::Create(
+      clangCtx, clangDeclContext, clang::SourceLocation(),
+      clang::SourceLocation(), clangDeclName, funcTy,
+      clangCtx.getTrivialTypeSourceInfo(funcTy),
+      clang::StorageClass::SC_Static);
+  clangHelperFuncDecl->setImplicit();
+  clangHelperFuncDecl->setImplicitlyInline();
+  clangHelperFuncDecl->setBody(clangHelperReturnStmt);
+
+  // Import `func __XYZ_isAvailable() -> Bool` into Swift.
+  auto helperFuncDecl = dyn_cast_or_null<FuncDecl>(
+      ctx.getClangModuleLoader()->importDeclDirectly(clangHelperFuncDecl));
+  if (!helperFuncDecl)
+    return {nullptr, /*isTypeChecked=*/true};
+
+  auto helperFuncRef = new (ctx) DeclRefExpr(ConcreteDeclRef(helperFuncDecl),
+                                             DeclNameLoc(), /*Implicit=*/true);
+  helperFuncRef->setType(helperFuncDecl->getInterfaceType());
+
+  // Synthesize `__XYZ_isAvailable()`.
+  auto helperCall = CallExpr::createImplicit(
+      ctx, helperFuncRef, ArgumentList::createImplicit(ctx, {}));
+  helperCall->setType(helperFuncDecl->getResultInterfaceType());
+  helperCall->setThrows(nullptr);
+
+  // Synthesize `__XYZ_isAvailable()._value`.
+  auto *memberRef =
+      UnresolvedDotExpr::createImplicit(ctx, helperCall, ctx.Id_value_);
+
+  // Synthesize `return __XYZ_isAvailable()._value`.
+  auto *returnStmt = ReturnStmt::createImplicit(ctx, memberRef);
+  auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
+                                /*implicit=*/true);
+
+  return {body, /*isTypeChecked=*/false};
+}
+
+FuncDecl *SwiftDeclSynthesizer::makeAvailabilityDomainPredicate(
+    const clang::VarDecl *var) {
+  ASTContext &ctx = ImporterImpl.SwiftContext;
+  clang::ASTContext &clangCtx = var->getASTContext();
+  auto featureInfo =
+      clangCtx.getFeatureAvailInfo(const_cast<clang::VarDecl *>(var));
+
+  // If the decl doesn't represent and availability domain, skip it.
+  if (featureInfo.first.empty())
+    return nullptr;
+
+  // Only dynamic availability domains require a predicate function.
+  if (featureInfo.second.Kind != clang::FeatureAvailKind::Dynamic)
+    return nullptr;
+
+  if (!featureInfo.second.Call)
+    return nullptr;
+
+  // Synthesize `func __swift_XYZ_isAvailable() -> Builtin.Int1 { ... }`.
+  std::string s;
+  llvm::raw_string_ostream os(s);
+  os << "__swift_" << featureInfo.first << "_isAvailable";
+  DeclName funcName(ctx, DeclBaseName(ctx.getIdentifier(s)),
+                    ParameterList::createEmpty(ctx));
+
+  auto funcDecl = FuncDecl::createImplicit(
+      ctx, StaticSpellingKind::None, funcName, SourceLoc(), /*Async=*/false,
+      /*Throws=*/false, Type(), {}, ParameterList::createEmpty(ctx),
+      BuiltinIntegerType::get(1, ctx), ImporterImpl.ImportedHeaderUnit);
+  funcDecl->setBodySynthesizer(synthesizeAvailabilityDomainPredicateBody,
+                               (void *)var);
+  funcDecl->setAccess(AccessLevel::Public);
+  funcDecl->getAttrs().add(new (ctx)
+                               AlwaysEmitIntoClientAttr(/*IsImplicit=*/true));
+
+  ImporterImpl.availabilityDomainPredicates[var] = funcDecl;
+
+  return funcDecl;
+}

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -341,6 +341,10 @@ public:
   synthesizeStaticFactoryForCXXForeignRef(
       const clang::CXXRecordDecl *cxxRecordDecl);
 
+  /// Synthesize a Swift function that calls the Clang runtime predicate
+  /// function for the availability domain represented by `var`.
+  FuncDecl *makeAvailabilityDomainPredicate(const clang::VarDecl *var);
+
 private:
   Type getConstantLiteralType(Type type, ConstantConvertKind convertKind);
 };

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1440,8 +1440,8 @@ static void configureAvailabilityDomains(const ASTContext &ctx,
   llvm::SmallDenseMap<Identifier, const CustomAvailabilityDomain *> domainMap;
   auto createAndInsertDomain = [&](const std::string &name,
                                    CustomAvailabilityDomain::Kind kind) {
-    auto *domain =
-        CustomAvailabilityDomain::get(name, kind, mainModule, nullptr, ctx);
+    auto *domain = CustomAvailabilityDomain::get(name, kind, mainModule,
+                                                 nullptr, nullptr, ctx);
     bool inserted = domainMap.insert({domain->getName(), domain}).second;
     ASSERT(inserted); // Domains must be unique.
   };

--- a/test/IRGen/Inputs/AvailabilityDomains.h
+++ b/test/IRGen/Inputs/AvailabilityDomains.h
@@ -1,0 +1,34 @@
+#include <feature-availability.h>
+
+static struct __AvailabilityDomain __EnabledDomain __attribute__((
+    availability_domain(EnabledDomain))) = {__AVAILABILITY_DOMAIN_ENABLED, 0};
+
+static struct __AvailabilityDomain __DisabledDomain __attribute__((
+    availability_domain(DisabledDomain))) = {__AVAILABILITY_DOMAIN_DISABLED, 0};
+
+int dynamic_domain_pred();
+
+static struct __AvailabilityDomain __DynamicDomain
+    __attribute__((availability_domain(DynamicDomain))) = {
+        __AVAILABILITY_DOMAIN_DYNAMIC, dynamic_domain_pred};
+
+#define AVAIL 0
+#define UNAVAIL 1
+
+__attribute__((availability(domain : EnabledDomain, AVAIL))) void
+available_in_enabled_domain(void);
+
+__attribute__((availability(domain : EnabledDomain, UNAVAIL))) void
+unavailable_in_enabled_domain(void);
+
+__attribute__((availability(domain : DisabledDomain, AVAIL))) void
+available_in_disabled_domain(void);
+
+__attribute__((availability(domain : DisabledDomain, UNAVAIL))) void
+unavailable_in_disabled_domain(void);
+
+__attribute__((availability(domain : DynamicDomain, AVAIL))) void
+available_in_dynamic_domain(void);
+
+__attribute__((availability(domain : DynamicDomain, UNAVAIL))) void
+unavailable_in_dynamic_domain(void);

--- a/test/IRGen/availability_custom_domains.swift
+++ b/test/IRGen/availability_custom_domains.swift
@@ -18,36 +18,46 @@ public func always()
 @_silgen_name("never")
 public func never()
 
-// CHECK-NOT: call swiftcc void @never()
-
+// CHECK-LABEL: define swiftcc void @"$s4Test24ifAvailableEnabledDomainyyF"()
 // CHECK: call swiftcc void @always()
 // CHECK-NOT: call swiftcc void @never()
-if #available(EnabledDomain) {
-  always()
-} else {
-  never()
+public func ifAvailableEnabledDomain() {
+  if #available(EnabledDomain) {
+    always()
+  } else {
+    never()
+  }
 }
 
-// CHECK: call swiftcc void @always()
+// CHECK-LABEL: define swiftcc void @"$s4Test25ifAvailableDisabledDomainyyF"()
 // CHECK-NOT: call swiftcc void @never()
-if #available(DisabledDomain) {
-  never()
-} else {
-  always()
+// CHECK: call swiftcc void @always()
+public func ifAvailableDisabledDomain() {
+  if #available(DisabledDomain) {
+    never()
+  } else {
+    always()
+  }
 }
 
-// CHECK: call swiftcc void @always()
+// CHECK-LABEL: define swiftcc void @"$s4Test26ifUnavailableEnabledDomainyyF"()
 // CHECK-NOT: call swiftcc void @never()
-if #unavailable(EnabledDomain) {
-  never()
-} else {
-  always()
+// CHECK: call swiftcc void @always()
+public func ifUnavailableEnabledDomain() {
+  if #unavailable(EnabledDomain) {
+    never()
+  } else {
+    always()
+  }
 }
 
+// CHECK-LABEL: define swiftcc void @"$s4Test27ifUnavailableDisabledDomainyyF"()
 // CHECK: call swiftcc void @always()
 // CHECK-NOT: call swiftcc void @never()
-if #unavailable(DisabledDomain) {
-  always()
-} else {
-  never()
+public func ifUnavailableDisabledDomain() {
+  if #unavailable(DisabledDomain) {
+    always()
+  } else {
+    never()
+  }
 }

--- a/test/IRGen/availability_custom_domains.swift
+++ b/test/IRGen/availability_custom_domains.swift
@@ -18,7 +18,7 @@ public func always()
 @_silgen_name("never")
 public func never()
 
-// CHECK-LABEL: define swiftcc void @"$s4Test24ifAvailableEnabledDomainyyF"()
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test24ifAvailableEnabledDomainyyF"()
 // CHECK: call swiftcc void @always()
 // CHECK-NOT: call swiftcc void @never()
 public func ifAvailableEnabledDomain() {
@@ -29,7 +29,7 @@ public func ifAvailableEnabledDomain() {
   }
 }
 
-// CHECK-LABEL: define swiftcc void @"$s4Test25ifAvailableDisabledDomainyyF"()
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test25ifAvailableDisabledDomainyyF"()
 // CHECK-NOT: call swiftcc void @never()
 // CHECK: call swiftcc void @always()
 public func ifAvailableDisabledDomain() {
@@ -40,7 +40,7 @@ public func ifAvailableDisabledDomain() {
   }
 }
 
-// CHECK-LABEL: define swiftcc void @"$s4Test26ifUnavailableEnabledDomainyyF"()
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test26ifUnavailableEnabledDomainyyF"()
 // CHECK-NOT: call swiftcc void @never()
 // CHECK: call swiftcc void @always()
 public func ifUnavailableEnabledDomain() {
@@ -51,7 +51,7 @@ public func ifUnavailableEnabledDomain() {
   }
 }
 
-// CHECK-LABEL: define swiftcc void @"$s4Test27ifUnavailableDisabledDomainyyF"()
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test27ifUnavailableDisabledDomainyyF"()
 // CHECK: call swiftcc void @always()
 // CHECK-NOT: call swiftcc void @never()
 public func ifUnavailableDisabledDomain() {

--- a/test/IRGen/availability_custom_domains_clang.swift
+++ b/test/IRGen/availability_custom_domains_clang.swift
@@ -1,0 +1,61 @@
+// RUN: %target-swift-emit-irgen -module-name Test %s -verify \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-bridging-header %S/Inputs/AvailabilityDomains.h \
+// RUN:   -Onone | %FileCheck %s --check-prefixes=CHECK,CHECK-O-NONE
+
+// RUN: %target-swift-emit-irgen -module-name Test %s -verify \
+// RUN:   -enable-experimental-feature CustomAvailability \
+// RUN:   -import-bridging-header %S/Inputs/AvailabilityDomains.h \
+// RUN:   -O | %FileCheck %s --check-prefixes=CHECK,CHECK-O
+
+// REQUIRES: swift_feature_CustomAvailability
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test24ifAvailableEnabledDomainyyF"()
+// CHECK: call void @available_in_enabled_domain()
+// CHECK-NOT: call void @unavailable_in_enabled_domain()
+public func ifAvailableEnabledDomain() {
+  if #available(EnabledDomain) {
+    available_in_enabled_domain()
+  } else {
+    unavailable_in_enabled_domain()
+  }
+}
+
+// CHECK-LABEL: define {{.*}}swiftcc void @"$s4Test25ifAvailableDisabledDomainyyF"()
+// CHECK-NOT: call void @available_in_disabled_domain()
+// CHECK: call void @unavailable_in_disabled_domain()
+public func ifAvailableDisabledDomain() {
+  if #available(DisabledDomain) {
+    available_in_disabled_domain()
+  } else {
+    unavailable_in_disabled_domain()
+  }
+}
+
+// CHECK-LABEL:   define {{.*}}swiftcc void @"$s4Test24ifAvailableDynamicDomainyyF"()
+// CHECK:         entry:
+// CHECK-O-NONE:    [[QUERY_RESULT:%.*]] = call swiftcc i1 @"$sSC33__swift_DynamicDomain_isAvailableBi1_yF"()
+// CHECK-O:         [[QUERY_RESULT:%.*]] = call zeroext i1 @__DynamicDomain_isAvailable()
+// CHECK:           br i1 [[QUERY_RESULT]], label %[[TRUE_LABEL:.*]], label %[[FALSE_LABEL:.*]]
+// CHECK:         [[TRUE_LABEL]]:
+// CHECK:           call void @available_in_dynamic_domain()
+// CHECK:         [[FALSE_LABEL]]:
+// CHECK:           call void @unavailable_in_dynamic_domain()
+public func ifAvailableDynamicDomain() {
+  if #available(DynamicDomain) {
+    available_in_dynamic_domain()
+  } else {
+    unavailable_in_dynamic_domain()
+  }
+}
+
+// CHECK-O-NONE-LABEL: define {{.*}}swiftcc i1 @"$sSC33__swift_DynamicDomain_isAvailableBi1_yF"()
+// CHECK-O-NONE:       entry:
+// CHECK-O-NONE:         [[CALL:%.*]] = call zeroext i1 @__DynamicDomain_isAvailable()
+// CHECK-O-NONE:         ret i1 [[CALL]]
+
+// CHECK-LABEL: define {{.*}}i1 @__DynamicDomain_isAvailable()
+// CHECK:       entry:
+// CHECK:         [[CALL:%.*]] = call i32 @dynamic_domain_pred()
+// CHECK:         [[TOBOOL:%.*]] = icmp ne i32 [[CALL]], 0
+// CHECK:         ret i1 [[TOBOOL]]

--- a/test/IRGen/availability_custom_domains_maccatalyst_zippered.swift
+++ b/test/IRGen/availability_custom_domains_maccatalyst_zippered.swift
@@ -23,36 +23,46 @@ public func always()
 @_silgen_name("never")
 public func never()
 
-// CHECK-NOT: call swiftcc void @never()
-
+// CHECK-LABEL: define swiftcc void @"$s4Test24ifAvailableEnabledDomainyyF"()
 // CHECK: call swiftcc void @always()
 // CHECK-NOT: call swiftcc void @never()
-if #available(EnabledDomain) {
-  always()
-} else {
-  never()
+public func ifAvailableEnabledDomain() {
+  if #available(EnabledDomain) {
+    always()
+  } else {
+    never()
+  }
 }
 
-// CHECK: call swiftcc void @always()
+// CHECK-LABEL: define swiftcc void @"$s4Test25ifAvailableDisabledDomainyyF"()
 // CHECK-NOT: call swiftcc void @never()
-if #available(DisabledDomain) {
-  never()
-} else {
-  always()
+// CHECK: call swiftcc void @always()
+public func ifAvailableDisabledDomain() {
+  if #available(DisabledDomain) {
+    never()
+  } else {
+    always()
+  }
 }
 
-// CHECK: call swiftcc void @always()
+// CHECK-LABEL: define swiftcc void @"$s4Test26ifUnavailableEnabledDomainyyF"()
 // CHECK-NOT: call swiftcc void @never()
-if #unavailable(EnabledDomain) {
-  never()
-} else {
-  always()
+// CHECK: call swiftcc void @always()
+public func ifUnavailableEnabledDomain() {
+  if #unavailable(EnabledDomain) {
+    never()
+  } else {
+    always()
+  }
 }
 
+// CHECK-LABEL: define swiftcc void @"$s4Test27ifUnavailableDisabledDomainyyF"()
 // CHECK: call swiftcc void @always()
 // CHECK-NOT: call swiftcc void @never()
-if #unavailable(DisabledDomain) {
-  always()
-} else {
-  never()
+public func ifUnavailableDisabledDomain() {
+  if #unavailable(DisabledDomain) {
+    always()
+  } else {
+    never()
+  }
 }

--- a/test/SILGen/availability_query_custom_domains_clang.swift
+++ b/test/SILGen/availability_query_custom_domains_clang.swift
@@ -83,10 +83,10 @@ public func testIfUnavailableDisabledDomain() {
 
 // CHECK-LABEL: sil{{.*}}$s4Test28testIfAvailableDynamicDomainyyF : $@convention(thin) () -> ()
 public func testIfAvailableDynamicDomain() {
-  // FIXME: [availability] Call dynamic domain predicate function
   // CHECK: bb0:
-  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, -1
-  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+  // CHECK:   [[QUERY_FUNC:%.*]] = function_ref @$sSC33__swift_DynamicDomain_isAvailableBi1_yF : $@convention(thin) () -> Builtin.Int1
+  // CHECK:   [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]() : $@convention(thin) () -> Builtin.Int1
+  // CHECK:   cond_br [[QUERY_RESULT]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
 
   // CHECK: [[TRUE_BB]]:
   // CHECK:   function_ref @available_in_dynamic_domain
@@ -101,12 +101,22 @@ public func testIfAvailableDynamicDomain() {
 }
 // CHECK: end sil function '$s4Test28testIfAvailableDynamicDomainyyF'
 
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$sSC33__swift_DynamicDomain_isAvailableBi1_yF : $@convention(thin) () -> Builtin.Int1
+// CHECK: bb0:
+// CHECK:   [[QUERY_FUNC:%.*]] = function_ref @__DynamicDomain_isAvailable : $@convention(c) () -> Bool
+// CHECK:   [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]() : $@convention(c) () -> Bool
+// CHECK:   [[RESULT:%.*]] = struct_extract [[QUERY_RESULT]], #Bool._value
+// CHECK:   return [[RESULT]]
+// CHECK: end sil function '$sSC33__swift_DynamicDomain_isAvailableBi1_yF'
+
 // CHECK-LABEL: sil{{.*}}$s4Test30testIfUnavailableDynamicDomainyyF : $@convention(thin) () -> ()
 public func testIfUnavailableDynamicDomain() {
-  // FIXME: [availability] Call dynamic domain predicate function
   // CHECK: bb0:
-  // CHECK:   [[PRED:%.*]] = integer_literal $Builtin.Int1, 0
-  // CHECK:   cond_br [[PRED]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
+  // CHECK:   [[QUERY_FUNC:%.*]] = function_ref @$sSC33__swift_DynamicDomain_isAvailableBi1_yF : $@convention(thin) () -> Builtin.Int1
+  // CHECK:   [[QUERY_RESULT:%.*]] = apply [[QUERY_FUNC]]() : $@convention(thin) () -> Builtin.Int1
+  // CHECK:   [[MINUSONE:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK:   [[QUERY_INVERSION:%.*]] = builtin "xor_Int1"([[QUERY_RESULT]], [[MINUSONE]]) : $Builtin.Int1
+  // CHECK:   cond_br [[QUERY_INVERSION]], [[TRUE_BB:bb[0-9]+]], [[FALSE_BB:bb[0-9]+]]
 
   // CHECK: [[TRUE_BB]]:
   // CHECK:   function_ref @unavailable_in_dynamic_domain


### PR DESCRIPTION
When importing custom availability domains with dynamic predicates from Clang modules, synthesize predicate functions for `if #available` queries and call them when generating SIL.

Resolves rdar://138441312.