### PR TITLE
[Concurrency] Correct isolation handling with default act and task exec

### DIFF
--- a/include/swift/ABI/Executor.h
+++ b/include/swift/ABI/Executor.h
@@ -105,12 +105,12 @@ public:
     return SerialExecutorRef(actor, 0);
   }
 
-  static SerialExecutorRef forSynchronousStart() {
+  static SerialExecutorRef forImmediateTask() {
     auto wtable = reinterpret_cast<uintptr_t>(nullptr) |
                   static_cast<uintptr_t>(ExecutorKind::Immediate);
     return SerialExecutorRef(nullptr, wtable);
   }
-  bool isForSynchronousStart() const {
+  bool isImmediateTask() const {
     return getIdentity() == nullptr &&
            getExecutorKind() == ExecutorKind::Immediate;
   }
@@ -139,15 +139,38 @@ public:
     return Identity;
   }
 
-  const char* getIdentityDebugName() const {
-    return isMainExecutor() ? " (MainActorExecutor)"
-           : isGeneric()    ? (isForSynchronousStart() ? " (GenericExecutor/SynchronousStart)" : " (GenericExecutor)")
-                            : "";
+  const char *getIdentityDebugName() const {
+    if (isMainExecutor()) {
+      return " (MainActorExecutor)";
+    }
+    if (isGeneric()) {
+      if (isImmediateTask()) {
+        return " (GenericExecutor/Immediate)";
+      }
+      return " (GenericExecutor)";
+    }
+    return "";
   }
 
   /// Is this the generic executor reference?
   bool isGeneric() const {
-    return Identity == 0;
+    return Identity == nullptr;
+  }
+
+  /// When a task preference is set on a task, does this serial executor allow
+  /// for it to take precedence (as thread source) over this serial executor?
+  ///
+  /// A task executor *preference* may win over a serial executor and be used
+  /// as a source of "thread" to execute a task, only if the serial executor
+  /// does not have a strong requirement that the task must be executing on
+  /// it exclusively. E.g. default actors and tasks on the generic executor
+  /// do allow for a task executor preference to be active, however if we have
+  /// a concrete serial executor requirement (e.g. main actor, or an actor with
+  /// a custom executor ("non-default actor"), then a task *must* use the
+  /// specific serial executor to enqueue the work, and the task executor
+  /// preference remains inactive.
+  bool isTaskExecutorPreferenceCompatible() const {
+    return isGeneric() || isDefaultActor();
   }
 
   ExecutorKind getExecutorKind() const {

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2828,6 +2828,7 @@ public:
     Task_IsAsyncLetTask                   = 28,
     Task_HasInitialTaskExecutorPreference = 29,
     Task_HasInitialTaskName               = 30,
+    Task_IsImmediateTask                  = 31,
   };
   // clang-format on
 
@@ -2867,6 +2868,9 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(Task_HasInitialTaskName,
                                 task_hasInitialTaskName,
                                 task_setHasInitialTaskName)
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Task_IsImmediateTask,
+                                task_isImmediateTask,
+                                task_setIsImmediateTask)
 };
 
 /// Kinds of task status record.

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -533,7 +533,7 @@ static bool swift_task_isCurrentExecutorWithFlagsImpl(
             swift_task_isIsolatingCurrentContext(expectedExecutor));
 
     SWIFT_TASK_DEBUG_LOG("executor checking mode option: UseIsIsolatingCurrentContext; invoke (%p).isIsolatingCurrentContext => %s",
-                   expectedExecutor.getIdentity(), getIsIsolatingCurrentContextDecisionNameStr(isIsolatingCurrentContextDecision));
+                   expectedExecutor.getIdentity(), getIsIsolatingCurrentContextDecisionNameStr(isIsolatingCurrentContextDecision).str().c_str());
     switch (isIsolatingCurrentContextDecision) {
       case IsIsolatingCurrentContextDecision::Isolated:
         // We know for sure that this serial executor is isolating this context, return the decision.
@@ -1555,6 +1555,9 @@ void DefaultActorImpl::scheduleActorProcessJob(
     auto taskExecutorType = swift_getObjectType(taskExecutorIdentity);
     auto taskExecutorWtable = taskExecutor.getTaskExecutorWitnessTable();
 
+    SWIFT_TASK_DEBUG_LOG(
+        "Scheduling processing job@%p for actor %p, ENQUEUE ON taskExecutor:%p",
+        job, this, taskExecutor.getIdentity());
     return _swift_task_enqueueOnTaskExecutor(
         job, taskExecutorIdentity, taskExecutorType, taskExecutorWtable);
 #endif
@@ -1592,16 +1595,15 @@ void DefaultActorImpl::enqueue(Job *job, JobPriority priority) {
       }
     }
 
-    // Fetch the task executor from the job for later use. This can be somewhat
-    // expensive, so only do it if we're likely to need it. The conditions here
-    // match the conditions of the if statements below which use `taskExecutor`.
-    TaskExecutorRef taskExecutor;
-    bool needsScheduling = !oldState.isScheduled() && newState.isScheduled();
-    bool needsStealer =
-        oldState.getMaxPriority() != newState.getMaxPriority() &&
-        newState.isRunning();
-    if (needsScheduling || needsStealer)
-      taskExecutor = TaskExecutorRef::fromTaskExecutorPreference(job);
+    // We always need the task executor preference: if the job carries a task
+    // executor, the actor must drain on that executor even if the actor was
+    // already running on something else, so the presence of a preference can
+    // change whether we need to schedule a fresh processing job.
+    TaskExecutorRef taskExecutor =
+        TaskExecutorRef::fromTaskExecutorPreference(job);
+    if (taskExecutor.isDefined()) {
+      newState = newState.withScheduled();
+    }
 
     // In some cases (we aren't scheduling the actor and priorities don't
     // match) then we need to access `this` after the enqueue. But the enqueue
@@ -1645,6 +1647,7 @@ void DefaultActorImpl::enqueue(Job *job, JobPriority priority) {
           dispatch_lock_t *lockAddr = this->drainLockAddr();
           swift_dispatch_lock_override_start_with_debounce(lockAddr, newState.currentDrainer(),
                          (qos_class_t) priority);
+          return;
         } else {
           // We are scheduling a stealer for an actor due to priority override.
           // This extra processing job has a reference on the actor. See
@@ -1656,9 +1659,19 @@ void DefaultActorImpl::enqueue(Job *job, JobPriority priority) {
               this, newState.getMaxPriority());
 
           scheduleActorProcessJob(newState.getMaxPriority(), taskExecutor);
+          return;
         }
       }
 #endif
+
+      // The actor is already running, but the just-enqueued job has a task
+      // executor preference. Schedule a processing job so that drain happens
+      // on the task executor as required, rather than on whatever thread the
+      // actor is currently draining on.
+      if (oldState.isRunning() && taskExecutor.isDefined()) {
+        scheduleActorProcessJob(newState.getMaxPriority(), taskExecutor);
+        return;
+      }
       return;
     }
   }
@@ -1764,7 +1777,11 @@ void DefaultActorImpl::processIncomingQueue() {
     if (!oldState.getFirstUnprioritizedJob()) {
       return;
     }
-    assert(oldState.isAnyRunning());
+    // Note: oldState.isAnyRunning() is intentionally not asserted here.
+    // With a task executor preference in play, DefaultActorImpl::enqueue can
+    // schedule a fresh processing job for an already-running actor; by the
+    // time that processing job reaches processIncomingQueue, the original
+    // drain may have already released the actor.
 
     auto newState = oldState;
     newState = newState.withFirstUnprioritizedJob(nullptr);
@@ -1896,7 +1913,7 @@ static void defaultActorDrain(DefaultActorImpl *actor) {
     }
 
     if (shouldYieldThread()) {
-      currentActor->unlock(true);
+      currentActor->unlock(/*forceUnlock=*/true);
       break;
     }
 
@@ -2043,7 +2060,10 @@ retry:;
 #endif
 
       // We are still in the race with other stealers to take over the actor.
-      assert(oldState.isScheduled());
+      // Note: oldState.isScheduled() is intentionally not asserted: with task
+      // executor preferences in play, multiple processing jobs can be in
+      // flight for the same actor and the state may have advanced past
+      // Scheduled by the time this thread reaches the takeover CAS.
 
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
       // We only want to self override a thread if we are taking the actor lock
@@ -2131,7 +2151,10 @@ bool DefaultActorImpl::unlock(bool forceUnlock)
 
   _swift_tsan_release(this);
   while (true) {
-    assert(oldState.isAnyRunning());
+    // Note: oldState.isAnyRunning() is intentionally not asserted here:
+    // when called with forceUnlock=false the actor may already have been
+    // released by another path (e.g. a task executor draining the actor),
+    // and we still want to handle the zombie / re-schedule cases below.
 #if SWIFT_CONCURRENCY_ENABLE_PRIORITY_ESCALATION
     assert(dispatch_lock_is_locked_by_self(*(this->drainLockAddr())));
 #endif
@@ -2237,9 +2260,8 @@ static void swift_job_runImpl(Job *job, SerialExecutorRef executor) {
     trackingInfo.disallowSwitching();
   }
 
-  auto taskExecutor = executor.isGeneric()
-                          ? TaskExecutorRef::fromTaskExecutorPreference(job)
-                          : TaskExecutorRef::undefined();
+  // If no task executor is set, this is simply "undefined" task executor.
+  auto taskExecutor = TaskExecutorRef::fromTaskExecutorPreference(job);
 
   trackingInfo.enterAndShadow(executor, taskExecutor);
 
@@ -2253,7 +2275,13 @@ static void swift_job_runImpl(Job *job, SerialExecutorRef executor) {
   // executor) and we've switched to a default actor.
   auto currentExecutor = trackingInfo.getActiveExecutor();
   if (trackingInfo.allowsSwitching() && currentExecutor.isDefaultActor()) {
-    asImpl(currentExecutor.getDefaultActor())->unlock(true);
+    // When the job carried a task executor preference, the actor's drain
+    // belongs to that task executor: force-unlocking would let any thread
+    // (e.g. the global pool) pick up the next pending job and break the
+    // preference contract. With no preference, force-unlock as before so
+    // the actor isn't left locked with nobody to drain it.
+    bool forceUnlock = taskExecutor.isUndefined();
+    asImpl(currentExecutor.getDefaultActor())->unlock(forceUnlock);
   }
 }
 
@@ -2265,11 +2293,9 @@ static void swift_job_run_on_serial_and_task_executorImpl(Job *job,
   SWIFT_TASK_DEBUG_LOG("Run job %p on serial executor %p task executor %p", job,
                        serialExecutor.getIdentity(), taskExecutor.getIdentity());
 
-  // TODO: we don't allow switching
   trackingInfo.disallowSwitching();
   trackingInfo.enterAndShadow(serialExecutor, taskExecutor);
 
-  SWIFT_TASK_DEBUG_LOG("job %p", job);
   runJobInEstablishedExecutorContext(job, serialExecutor, taskExecutor);
 
   trackingInfo.leave();
@@ -2279,7 +2305,7 @@ static void swift_job_run_on_serial_and_task_executorImpl(Job *job,
   // executor) and we've switched to a default actor.
   auto currentExecutor = trackingInfo.getActiveExecutor();
   if (trackingInfo.allowsSwitching() && currentExecutor.isDefaultActor()) {
-    asImpl(currentExecutor.getDefaultActor())->unlock(true);
+    asImpl(currentExecutor.getDefaultActor())->unlock(/*forceUnlock=*/true);
   }
 }
 
@@ -2371,7 +2397,7 @@ static bool canGiveUpThreadForSwitch(ExecutorTrackingInfo *trackingInfo,
   // We can certainly "give up" a generic executor to try to run
   // a task for an actor.
   if (currentExecutor.isGeneric()) {
-    if (currentExecutor.isForSynchronousStart()) {
+    if (currentExecutor.isImmediateTask()) {
       return false;
     }
 
@@ -2507,8 +2533,9 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
   auto currentTaskExecutor = (trackingInfo ? trackingInfo->getTaskExecutor()
                                            : TaskExecutorRef::undefined());
   auto newTaskExecutor = task->getPreferredTaskExecutor();
-  SWIFT_TASK_DEBUG_LOG("Task %p trying to switch executors: executor %p%s to "
+  SWIFT_TASK_DEBUG_LOG("task(T:%u) %p trying to switch executors: executor %p%s to "
                        "new serial executor: %p%s; task executor: from %p%s to %p%s",
+                       task->getJobId(),
                        task,
                        currentExecutor.getIdentity(),
                        currentExecutor.getIdentityDebugName(),
@@ -2524,7 +2551,9 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
   // we were passed in.
   if (!mustSwitchToRun(currentExecutor, newExecutor, currentTaskExecutor,
                        newTaskExecutor)) {
-    SWIFT_TASK_DEBUG_LOG("Task %p run inline", task);
+    SWIFT_TASK_DEBUG_LOG("task(T:%u) %p run inline (current serialExecutor %p, current taskExecutor %p)",
+      task->getJobId(), task,
+      currentExecutor.getIdentity(), currentTaskExecutor.getIdentity());
     return resumeFunction(resumeContext); // 'return' forces tail call
   }
 
@@ -2569,8 +2598,8 @@ static void swift_task_switchImpl(SWIFT_ASYNC_CONTEXT AsyncContext *resumeContex
   // Otherwise, just asynchronously enqueue the task on the given
   // executor.
   SWIFT_TASK_DEBUG_LOG(
-      "switch failed, task %p enqueued on executor %p (task executor: %p)",
-      task, newExecutor.getIdentity(), currentTaskExecutor.getIdentity());
+      "switch failed, task %p enqueued on executor %p (new task executor: %p)",
+      task, newExecutor.getIdentity(), newTaskExecutor.getIdentity());
 
   _swift_task_clearCurrent();
   task->flagAsAndEnqueueOnExecutor(newExecutor);
@@ -2580,30 +2609,57 @@ SWIFT_CC(swift)
 static void
 swift_task_immediateImpl(AsyncTask *task,
                          SerialExecutorRef targetExecutor) {
+  assert(task && task->Flags.task_isImmediateTask() && "expected 'immediate' task!");
+  SWIFT_TASK_DEBUG_LOG(
+      "try to run immediate task %p synchronously... target executor %p %s",
+      task, targetExecutor.getIdentity(), targetExecutor.getIdentityDebugName());
+
   swift_retain(task);
   if (targetExecutor.isGeneric()) {
-  // If the target is generic, it means that the closure did not specify
-  // an isolation explicitly. According to the "start synchronously" rules,
-  // we should therefore ignore the global and just start running on the
-  // caller immediately.
-  SerialExecutorRef executor = SerialExecutorRef::forSynchronousStart();
+    // If the target is generic, it means that the closure did not specify
+    // an isolation explicitly. According to the "start synchronously" rules,
+    // we should therefore ignore the global and just start running on the
+    // caller immediately.
+    SerialExecutorRef executor = SerialExecutorRef::forImmediateTask();
 
-  auto originalTask = ActiveTask::swap(task);
-  swift_job_run(task, executor);
-  _swift_task_setCurrent(originalTask);
-  } else {
-    assert(swift_task_isCurrentExecutor(targetExecutor) &&
-           "'immediate' must only be invoked when it is correctly in "
-           "the same isolation already, but wasn't!");
-
-    // We can run synchronously, we're on the expected executor so running in
-    // the caller context is going to be in the same context as the requested
-    // "caller" context.
-    AsyncTask *originalTask = _swift_task_clearCurrent();
-
-    swift_job_run(task, targetExecutor);
+    auto originalTask = ActiveTask::swap(task);
+    swift_job_run(task, executor);
     _swift_task_setCurrent(originalTask);
+    return;
   }
+
+  if (targetExecutor.isDefaultActor()) {
+    // Two cases where we must NOT start synchronously on the caller and
+    // instead route through the actor's enqueue path:
+    //
+    //  1. The task carries a task executor preference. Even if we are already
+    //     on the target actor, the preference must be honoured for the initial
+    //     run; enqueueing on the actor lets DefaultActorImpl::enqueue's
+    //     task-executor handling above schedule the drain on that executor.
+    //
+    //  2. We are not currently on the target actor at all (e.g. a closure
+    //     isolated to a default actor invoked from a different context); we
+    //     can't start synchronously without violating the actor's isolation.
+    if (task->getPreferredTaskExecutor().isDefined() ||
+        !swift_task_isCurrentExecutor(targetExecutor)) {
+      swift_defaultActor_enqueue(task, targetExecutor.getDefaultActor());
+      return;
+    }
+    // Otherwise we are already on the actor and have no executor preference;
+    // fall through to the synchronous start path.
+  }
+
+  assert(swift_task_isCurrentExecutor(targetExecutor) &&
+         "'immediate' must only be invoked when it is correctly in "
+         "the same isolation already, but wasn't!");
+
+  // We can run synchronously, we're on the expected executor so running in
+  // the caller context is going to be in the same context as the requested
+  // "caller" context.
+  AsyncTask *originalTask = _swift_task_clearCurrent();
+
+  swift_job_run(task, targetExecutor);
+  _swift_task_setCurrent(originalTask);
 }
 
 #if !SWIFT_CONCURRENCY_ACTORS_AS_LOCKS
@@ -2731,39 +2787,48 @@ extern "C" SWIFT_CC(swift) void _swift_task_makeAnyTaskExecutor(
 
 SWIFT_CC(swift)
 static void swift_task_enqueueImpl(Job *job, SerialExecutorRef serialExecutorRef) {
-#ifndef NDEBUG
-  auto _taskExecutorRef = TaskExecutorRef::undefined();
-  if (auto task = dyn_cast<AsyncTask>(job)) {
-    _taskExecutorRef = task->getPreferredTaskExecutor();
-  }
-  SWIFT_TASK_DEBUG_LOG("enqueue job %p on serial serialExecutor %p, taskExecutor = %p", job,
-                       serialExecutorRef.getIdentity(),
-                       _taskExecutorRef.getIdentity());
-#endif
-
   assert(job && "no job provided");
-  job->SchedulerPrivate[0] = NULL;
-  job->SchedulerPrivate[1] = NULL;
+
+  auto task = dyn_cast<AsyncTask>(job);
+  auto taskExecutorRef =
+      task ? task->getPreferredTaskExecutor() : TaskExecutorRef::undefined();
+  SWIFT_TASK_DEBUG_LOG("enqueue job %p on serial serialExecutor %p, taskExecutor = %p", job,
+                       serialExecutorRef.getIdentity(), taskExecutorRef.getIdentity());
+
+  job->SchedulerPrivate[0] = nullptr;
+  job->SchedulerPrivate[1] = nullptr;
 
   _swift_tsan_release(job);
 
-  if (serialExecutorRef.isGeneric()) {
-    if (auto task = dyn_cast<AsyncTask>(job)) {
-      auto taskExecutorRef = task->getPreferredTaskExecutor();
-      if (taskExecutorRef.isDefined()) {
+  // If a task executor preference is set, the job's destination depends on
+  // what kind of serial executor it is heading to:
+  //  - Default actor: enqueue on the actor; the actor's drain code reads the
+  //    job's task executor preference and dispatches the processing job
+  //    accordingly.
+  //  - Generic: enqueue directly on the task executor.
+  //  - Custom serial executor: fall through to the standard serial enqueue
+  //    path; that executor owns the dispatch, the task executor preference
+  //    only takes effect once the task suspends and resumes.
+  if (taskExecutorRef.isDefined()) {
 #if SWIFT_CONCURRENCY_EMBEDDED
-        swift_unreachable("task executors not supported in embedded Swift");
+    swift_unreachable("task executors not supported in embedded Swift");
 #else
-        auto taskExecutorIdentity = taskExecutorRef.getIdentity();
-        auto taskExecutorType = swift_getObjectType(taskExecutorIdentity);
-        auto taskExecutorWtable = taskExecutorRef.getTaskExecutorWitnessTable();
-
-        return _swift_task_enqueueOnTaskExecutor(
-            job,
-            taskExecutorIdentity, taskExecutorType, taskExecutorWtable);
-#endif // SWIFT_CONCURRENCY_EMBEDDED
-      } // else, fall-through to the default global enqueue
+    if (serialExecutorRef.isDefaultActor()) {
+      return swift_defaultActor_enqueue(job, serialExecutorRef.getDefaultActor());
     }
+
+    if (serialExecutorRef.isGeneric()) {
+      auto taskExecutorIdentity = taskExecutorRef.getIdentity();
+      auto taskExecutorType = swift_getObjectType(taskExecutorIdentity);
+      auto taskExecutorWtable = taskExecutorRef.getTaskExecutorWitnessTable();
+
+      return _swift_task_enqueueOnTaskExecutor(job,
+        taskExecutorIdentity, taskExecutorType, taskExecutorWtable);
+    }
+#endif // SWIFT_CONCURRENCY_EMBEDDED
+  }
+
+  if (serialExecutorRef.isGeneric()) {
     return swift_task_enqueueGlobal(job);
   }
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -753,6 +753,7 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
 
   // Propagate task-creation flags to job flags as appropriate.
   jobFlags.task_setIsChildTask(taskCreateFlags.isChildTask());
+  jobFlags.task_setIsImmediateTask(taskCreateFlags.isImmediateTask());
 
   ResultTypeInfo futureResultType;
   #if !SWIFT_CONCURRENCY_EMBEDDED
@@ -939,7 +940,7 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
      basePriority = JobPriority::Default;
   }
 
-  SWIFT_TASK_DEBUG_LOG("Task's base priority = %#zx", basePriority);
+  SWIFT_TASK_DEBUG_LOG("Task base priority = %#zx", basePriority);
 
   size_t headerSize, amountToAllocate;
   std::tie(headerSize, amountToAllocate) = amountToAllocateForHeaderAndTask(
@@ -1083,9 +1084,10 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
     futureAsyncContextPrefix->indirectResult = futureFragment->getStoragePtr();
   }
 
-  SWIFT_TASK_DEBUG_LOG("creating task %p ID %" PRIu64
+  SWIFT_TASK_DEBUG_LOG("creating %stask %p ID %" PRIu64
                        " with parent %p at base pri %zu",
-                       task, task->getTaskId(), parent, basePriority);
+                       task, taskCreateFlags.isImmediateTask() ? "immediate " : "",
+                       task->getTaskId(), parent, basePriority);
 
   // Configure the initial context.
 
@@ -1227,6 +1229,8 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
         serialExecutor);
   }
 
+
+  SWIFT_TASK_DEBUG_LOG("Created task(T:%u) %p", task->getJobId(), task);
   return {task, initialContext};
 }
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1816,7 +1816,7 @@ reevaluate_if_taskgroup_has_results:;
       assumed = TaskGroupStatus{assumedStatus};
       continue; // We raced with something, try again.
     }
-    SWIFT_TASK_DEBUG_LOG("poll, after CAS: %s", status.to_string().c_str());
+    SWIFT_TASK_DEBUG_LOG("poll, after CAS: %lld", status.load(std::memory_order_relaxed));
 
     // We're going back to running the task, so if we suspended before,
     // we need to flag it as running again.

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -53,10 +53,14 @@ namespace swift {
 // If this is enabled, tests with `swift_task_debug_log` requirement can run.
 #if 0
 #define SWIFT_TASK_DEBUG_LOG_ENABLED 1
+#define SWIFT_TASK_DEBUG_ID(job)                                               \
+  ((job && job->isAsyncTask()) ? dyn_cast<AsyncTask>(job)->getJobId() : 9)
+
 #define SWIFT_TASK_DEBUG_LOG(fmt, ...)                                         \
-  fprintf(stderr, "[%#lx] [%s:%d](%s) " fmt "\n",                              \
-          (unsigned long)Thread::current().platformThreadId(), __FILE__,       \
-          __LINE__, __FUNCTION__, __VA_ARGS__)
+  fprintf(stderr, "[%#lx](T:%u) [%s:%d](%s) " fmt "\n",                        \
+          (unsigned long)Thread::current().platformThreadId(),                 \
+          SWIFT_TASK_DEBUG_ID(swift_task_getCurrent()),  \
+          __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
 #else
 #define SWIFT_TASK_DEBUG_LOG_ENABLED 0
 #define SWIFT_TASK_DEBUG_LOG(fmt, ...) (void)0
@@ -71,7 +75,7 @@ class ActiveTaskStatus;
 /// done on behalf of a child task.
 void *_swift_task_alloc_specific(AsyncTask *task, size_t size);
 
-/// deallocate task-local memory on behalf of a specific task,
+/// Deallocate task-local memory on behalf of a specific task,
 /// not necessarily the current one.  Generally this should only be
 /// done on behalf of a child task.
 void _swift_task_dealloc_specific(AsyncTask *task, void *ptr);

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -521,8 +521,8 @@ swift_task_pushTaskExecutorPreferenceImpl(TaskExecutorRef taskExecutor) {
           // the executor.
           /*retainedExecutor=*/false);
   SWIFT_TASK_DEBUG_LOG("[TaskExecutorPreference] Create task executor "
-                       "preference record:%p taskExecutor:%p for task:%p",
-                       allocation, taskExecutor.getIdentity(), task);
+                       "preference record:%p taskExecutor:%p for task(%d):%p",
+                       allocation, taskExecutor.getIdentity(), SWIFT_TASK_DEBUG_ID(task), task);
 
 
   addStatusRecord(task, record,

--- a/test/Concurrency/Runtime/async_task_executor_and_serial_executor_nonisolated_async_func_swift6.swift
+++ b/test/Concurrency/Runtime/async_task_executor_and_serial_executor_nonisolated_async_func_swift6.swift
@@ -103,8 +103,16 @@ actor DefaultActor {
 
     let actor = DefaultActor()
 
+    print("Task(executorPreference:) { actorFunc { ... } }") // OK
     await Task(executorPreference: executor) {
       await actor.testWithTaskExecutorPreferenceTask(executor)
+    }.value
+
+    print("Task() { withTaskExecutorPreference { actorFunc { ... } } }") // OK
+    await Task {
+      await withTaskExecutorPreference(executor) {
+        await actor.testWithTaskExecutorPreferenceTask(executor)
+      }
     }.value
   }
 }

--- a/test/Concurrency/Runtime/startImmediately.swift
+++ b/test/Concurrency/Runtime/startImmediately.swift
@@ -77,7 +77,9 @@ final class NaiveQueueExecutor: SerialExecutor, TaskExecutor {
     let unowned = UnownedJob(job)
     print("NaiveQueueExecutor(\(self.queue.label)) enqueue [thread:\(getCurrentThreadID())]")
     queue.async {
+      print("NaiveQueueExecutor(\(self.queue.label)) enqueue, inside async [thread:\(getCurrentThreadID())]")
       unowned.runSynchronously(on: self.asUnownedSerialExecutor())
+      print("NaiveQueueExecutor(\(self.queue.label)) enqueue, after runSynchronously [thread:\(getCurrentThreadID())]")
     }
   }
 }
@@ -456,7 +458,9 @@ print("call_taskImmediate_taskExecutor()")
 @TaskLocal
 nonisolated(unsafe) var niceTaskLocalValueYouGotThere: String = ""
 
-// FIXME: rdar://155596073 Task executors execution may not always hop as expected
+// FIXME: rdar://155596073 Task.immediate(executorPreference:) called from
+// within an already-running default actor needs the drain to hop to the
+// task executor's queue, which is not yet supported.
 func call_taskImmediate_taskExecutor(taskExecutor: NaiveQueueExecutor) async {
   await Task.immediate(executorPreference: taskExecutor) {
     print("Task.immediate(executorPreference:)")
@@ -554,9 +558,5 @@ func call_taskImmediate_taskExecutor(taskExecutor: NaiveQueueExecutor) async {
     }
   }
 }
-
-// FIXME: rdar://155596073 task executors can be somewhat racy it seems and not always hop as we'd want them to
-// await call_taskImmediate_taskExecutor(
-//  taskExecutor: NaiveQueueExecutor(queue: DispatchQueue(label: "my-queue")))
 
 print("DONE!") // CHECK: DONE!


### PR DESCRIPTION
We did not properly account for default actor's isolation in our task executor forwarding and... this is quite unfortunate.

~~TODO: rebase it on top of https://github.com/swiftlang/swift/pull/82913 which does the Task.immediate changes~~ (done)

rdar://155596073
Also rdar://144382903