### PR TITLE
Add `llvm-nm` to `llvm-install-components` in `build-presets.ini`

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -19,7 +19,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;libexec;
 [preset: mixin_buildbot_install_components_with_clang]
 
 swift-install-components=autolink-driver;back-deployment;compiler;clang-resource-dir-symlink;libexec;stdlib;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers
-llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;dsymutil;LTO;clang-features-file;lld
+llvm-install-components=llvm-ar;llvm-nm;llvm-ranlib;llvm-cov;llvm-profdata;llvm-objdump;llvm-objcopy;llvm-symbolizer;IndexStore;clang;clang-resource-headers;builtins;runtimes;clangd;libclang;dsymutil;LTO;clang-features-file;lld
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.


### PR DESCRIPTION
This LLVM tool is required for cross-compiling and debugging binaries cross-compiled to non-Darwin platforms, but for some reason is currently not included unlike `llvm-ar` or `llvm-ranlib`.