### PR TITLE
[test] Work around some C interop test failures on `stable/20250601`

### DIFF
--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -65,6 +65,10 @@ config.substitutions.insert(0, (r'%check-interop-cxx-header-in-clang\(([^)]+)\)'
                                                 r'%check-cxx-header-in-clang -std=c++20 -Wno-padded -Wno-c11-extensions -D_LIBCPP_CSTDLIB ' + clang_compile_opt + r'\1')))
 
 # Test parsing of the generated C header in different C language modes.
-config.substitutions.insert(0, (r'%check-interop-c-header-in-clang\(([^)]+)\)',
-                             SubstituteCaptures(r'%check-c-header-in-clang -std=c99 -Wno-padded -Wno-c11-extensions -Wno-pre-c11-compat \1 && '
-                                                r'%check-c-header-in-clang -std=c11 -Wno-padded -Wno-pre-c11-compat \1')))
+config.substitutions.insert(0, (
+    r'%check-interop-c-header-in-clang\(([^)]+)\)',
+    SubstituteCaptures(
+        r'%check-c-header-in-clang -std=c99 -Wno-padded -Wno-c++-keyword -Wno-unknown-warning-option -Wno-c11-extensions -Wno-pre-c11-compat \1 && '
+        r'%check-c-header-in-clang -std=c11 -Wno-padded -Wno-c++-keyword -Wno-unknown-warning-option -Wno-pre-c11-compat \1'
+    )
+))


### PR DESCRIPTION
For some reason, the `stable/20250601` Clang emits `-Wc++-keyword` warnings in C mode when `-Weverything` is enabled. Suppress this warning.

This PR replays https://github.com/swiftlang/swift/pull/82907 against some outstanding analogous test failures:
```
Interop/SwiftToC/functions/swift-primitive-functions-c-bridging-long-lp64.swift
Interop/SwiftToC/functions/swift-primitive-functions-c-bridging.swift
Interop/SwiftToC/structs/large-structs-pass-return-indirect-in-c.swift
Interop/SwiftToC/structs/small-structs-64-bit-pass-return-direct-in-c.swift
Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
```