### PR TITLE
WasmLLVMRuntimeLibs: handle `args.build_runtime_with_host_compiler`

### DIFF
--- a/utils/swift_build_support/swift_build_support/toolchain.py
+++ b/utils/swift_build_support/swift_build_support/toolchain.py
@@ -68,6 +68,9 @@ if 'ANDROID_DATA' in os.environ:
 else:
     _register("ranlib", "ranlib")
     _register("ar", "ar")
+_register("llvm_ar", "llvm-ar")
+_register("llvm_nm", "llvm-nm")
+_register("llvm_ranlib", "llvm-ranlib")
 _register("sccache", "sccache")
 _register("swiftc", "swiftc")
 _register("swift_build", "swift-build")


### PR DESCRIPTION
This allows quickly building `WasmLLVMRuntimeLibs` product with the host toolchain (usually Swift nightly development snapshot toolchain) when `--skip-build-llvm --skip-build-swift --build-runtime-with-host-compiler` combination of options is passed to `build-script`.