### PR TITLE
[6.2] [SourceKit] Fix raw identifier handling for semantic tokens

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -868,11 +868,8 @@ bool SemaAnnotator::passCallAsFunctionReference(ValueDecl *D, SourceLoc Loc,
 
 bool SemaAnnotator::
 passReference(ValueDecl *D, Type Ty, DeclNameLoc Loc, ReferenceMetaData Data) {
-  SourceManager &SM = D->getASTContext().SourceMgr;
-  SourceLoc BaseStart = Loc.getBaseNameLoc(), BaseEnd = BaseStart;
-  if (BaseStart.isValid() && SM.extractText({BaseStart, 1}) == "`")
-    BaseEnd = Lexer::getLocForEndOfToken(SM, BaseStart.getAdvancedLoc(1));
-  return passReference(D, Ty, BaseStart, {BaseStart, BaseEnd}, Data);
+  SourceLoc BaseLoc = Loc.getBaseNameLoc();
+  return passReference(D, Ty, BaseLoc, BaseLoc, Data);
 }
 
 bool SemaAnnotator::

--- a/test/SourceKit/SemanticTokens/raw_identifiers.swift
+++ b/test/SourceKit/SemanticTokens/raw_identifiers.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %sourcekitd-test -req=semantic-tokens %t/main.swift -- %t/main.swift > %t/result.json
+// RUN: diff -u %t/tokens.json %t/result.json
+
+//--- main.swift
+func `foo`(x: Int) {}
+`foo`(x: 0)
+
+func `foo bar baz`() {}
+`foo bar baz`()
+
+//--- tokens.json
+{
+  key.semantic_tokens: [
+    {
+      key.kind: source.lang.swift.ref.struct,
+      key.offset: 14,
+      key.length: 3,
+      key.is_system: 1
+    },
+    {
+      key.kind: source.lang.swift.ref.function.free,
+      key.offset: 22,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.ref.function.free,
+      key.offset: 59,
+      key.length: 13
+    }
+  ]
+}


### PR DESCRIPTION
The logic here was unnecessary, the SourceRange gets converted to a CharSourceRange in the function being called, which handles raw identifiers correctly. 6.2-only since this is already fixed on main (adding test case in #82952).

---

- Explanation: Fixes raw identifier handling in the semantic tokens request, previously we could report an incorrect range if the identifier contained characters such as spaces.
- Scope: Affects the semantic tokens request
- Issue: rdar://152273926
- Risk: Low, only affects semantic tokens request, and the fix is straightforward
- Testing: Added tests to test suite
- Reviewer: Ben Barham