### PR TITLE
Disable function signature optimization on functions with lifetime dependencies

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/DeadArgumentTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/DeadArgumentTransform.cpp
@@ -28,6 +28,16 @@ bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
 
   // Did we decide we should optimize any parameter?
   SILFunction *F = TransformDescriptor.OriginalFunction;
+
+  // If a function has lifetime dependencies, disable FSO's dead param
+  // optimization.  Dead params maybe dependency sources and we should not
+  // delete them. It is also problematic to dead code params that are not
+  // dependency sources, since lifetime dependent sources are stored as indices
+  // and deleting dead parameters will require recomputation of these indices.
+  if (F->getLoweredFunctionType()->hasLifetimeDependencies()) {
+    return false;
+  }
+
   bool SignatureOptimize = false;
   auto Args = F->begin()->getSILFunctionArguments();
   auto OrigShouldModifySelfArgument =

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1,5 +1,8 @@
-// RUN: %target-sil-opt -sil-print-types -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck %s
-// RUN: %target-sil-opt -sil-print-types -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts %s | %FileCheck -check-prefix=CHECK-NEGATIVE %s
+// RUN: %target-sil-opt -sil-print-types -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts -enable-experimental-feature Lifetimes %s | %FileCheck %s
+// RUN: %target-sil-opt -sil-print-types -sil-inline-generics -enable-sil-verify-all -inline -function-signature-opts -enable-experimental-feature Lifetimes %s | %FileCheck -check-prefix=CHECK-NEGATIVE %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
 
 import Builtin
 import Swift
@@ -1830,6 +1833,28 @@ bb0(%0 : $ValueGenericType<N>):
   %1 = function_ref @value_generic_count : $@convention(thin) <let τ_0_0 : Int> (ValueGenericType<τ_0_0>) -> Int
   %2 = apply %1<N>(%0) : $@convention(thin) <let τ_0_0 : Int> (ValueGenericType<τ_0_0>) -> Int
   return %2 : $Int
+}
+
+struct NE<T> : ~Escapable where T : ~Escapable {
+  @_lifetime(copy t)
+  init(_ t: borrowing T)
+}
+
+// CHECK-NOT: sil [serialized] [signature_optimized_thunk] [always_inline] @neinit :
+sil [noinline] @neinit : $@convention(method) <T where T : ~Escapable> (@in_guaranteed T, @thin NE<T>.Type) -> @lifetime(copy 0) @owned NE<T> {
+bb0(%0 : @noImplicitCopy $*T, %1 : $@thin NE<T>.Type):
+  debug_value [moveable_value_debuginfo] %0, let, name "t", argno 1, expr op_deref
+  %3 = struct $NE<T> ()
+  return %3
+}
+
+sil hidden @neinit_caller : $@convention(thin) <T where T : ~Escapable> (@in_guaranteed T) -> @lifetime(copy 0) @owned NE<T> {
+bb0(%0 : @noImplicitCopy $*T):
+  debug_value [moveable_value_debuginfo] %0, let, name "t", argno 1, expr op_deref
+  %2 = metatype $@thin NE<T>.Type
+  %3 = function_ref @neinit : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed τ_0_0, @thin NE<τ_0_0>.Type) -> @lifetime(copy 0) @owned NE<τ_0_0>
+  %4 = apply %3<T>(%0, %2) : $@convention(method) <τ_0_0 where τ_0_0 : ~Escapable> (@in_guaranteed τ_0_0, @thin NE<τ_0_0>.Type) -> @lifetime(copy 0) @owned NE<τ_0_0>
+  return %4
 }
 
 // CHECK-LABEL: sil shared @$s36exploded_release_to_guaranteed_paramTf4gX_n

--- a/test/SILOptimizer/functionsigopts_crash.swift
+++ b/test/SILOptimizer/functionsigopts_crash.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend -module-name main -O -emit-sil -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name main -O -emit-sil -primary-file %s -enable-experimental-feature Lifetimes | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: swift_feature_Lifetimes
 
 protocol P {
   func foo()
@@ -53,3 +56,14 @@ extension Array: IP {
     }
   }
 }
+
+struct NE<T : ~Escapable> : ~Escapable {
+  @_lifetime(copy t)
+  init(_ t: borrowing T) {}
+}
+
+@_lifetime(copy t)
+func getNE<T : ~Escapable>(_ t: borrowing T) -> NE<T> {
+  return NE(t)
+}
+


### PR DESCRIPTION
If a function has lifetime dependencies, disable FSO's dead param optimization.  Dead params maybe dependency sources and we should not delete them. It is also problematic to dead code params that are not dependency sources, since lifetime dependent sources are stored as indices and deleting dead parameters will require recomputation of these indices.