### PR TITLE
test/CMakeLists.txt: fix `setup_lit_args` missing `SWIFT_LIT_ARGS`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -294,7 +294,7 @@ function(setup_lit_args ARGS_VAR_OUT tested_sdk test_results_dir resource_dir_ov
   endif()
 
 
-  set(LIT_ARGS "${swift_lit_args_result} ${SWIFT_LIT_ARGS} ${LLVM_LIT_ARGS}")
+  set(swift_lit_args_result "${swift_lit_args_result} ${SWIFT_LIT_ARGS} ${LLVM_LIT_ARGS}")
   separate_arguments(swift_lit_args_result)
 
   set(${ARGS_VAR_OUT} ${swift_lit_args_result} PARENT_SCOPE)


### PR DESCRIPTION
After https://github.com/swiftlang/swift/pull/82878 `SWIFT_LIT_ARGS` wasn't merged into correct returned variable in `setup_lit_args`, let's fix that to make sure that options like `-v --debug` are passed correctly from CLI `build-script` invocations or from presets that have these options predefined.
