### PR TITLE
[Strict memory safety] Eliminate spurious warnings with synthesized Codable

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4734,9 +4734,10 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
         (isAsync &&
          ctx.LangOpts.StrictConcurrencyLevel == StrictConcurrency::Complete)) {
       SourceLoc loc = stmt->getUnsafeLoc();
+      bool implicit = stmt->getUnsafeLoc().isInvalid();
       if (loc.isInvalid())
         loc = stmt->getForLoc();
-      nextCall = new (ctx) UnsafeExpr(loc, nextCall, Type(), /*implicit=*/true);
+      nextCall = new (ctx) UnsafeExpr(loc, nextCall, Type(), implicit);
     }
 
     // The iterator type must conform to IteratorProtocol.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -791,7 +791,7 @@ ExprPatternMatchRequest::evaluate(Evaluator &evaluator,
 
   // If there was an "unsafe", put it outside of the match call.
   if (unsafeExpr) {
-    matchCall = UnsafeExpr::createImplicit(ctx, unsafeExpr->getLoc(), matchCall);
+    matchCall = new (ctx) UnsafeExpr(unsafeExpr->getLoc(), matchCall);
   }
 
   return {matchVar, matchCall};

--- a/test/Unsafe/codable_synthesis.swift
+++ b/test/Unsafe/codable_synthesis.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -strict-memory-safety
+
+@unsafe public struct UnsafeStruct: Codable {
+  public var string: String
+}
+
+
+@unsafe public enum UnsafeEnum: Codable {
+case something(Int)
+}
+
+@safe public struct SafeStruct: Codable {
+  public var us: UnsafeStruct
+}
+
+@safe public enum SafeEnum: Codable {
+case something(UnsafeEnum)
+}
+
+@unsafe public class C1: Codable {
+  public var string: String = ""
+}
+
+@unsafe public class C2: C1 {
+  public var otherString: String = ""
+}

--- a/test/Unsafe/hashable_synthesis.swift
+++ b/test/Unsafe/hashable_synthesis.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -strict-memory-safety
+
+@unsafe public struct UnsafeStruct: Hashable {
+  public var string: String
+}
+
+
+@unsafe public enum UnsafeEnum: Hashable {
+case something(Int)
+}
+
+@safe public struct SafeStruct: Hashable {
+  public var us: UnsafeStruct
+}
+
+@safe public enum SafeEnum: Hashable {
+case something(UnsafeEnum)
+}


### PR DESCRIPTION
When synthesizing code for Codable conformances involving unsafe types, make sure to wrap the resulting expressions in "unsafe" when strict memory safety is enabled.

Tweak the warning-emission logic to suppress warnings about spurious "unsafe" expressions when the compiler generated the "unsafe" itself, so we don't spam the developer with warnings they can't fix. Also make the checking for other suppression considerations safe when there are no source locations, eliminating a potential assertion.

Fixes rdar://153665692.