### PR TITLE
[6.2] Fix spurious warnings with strict memory safety

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4692,10 +4692,15 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
     }
 
     // Wrap the 'next' call in 'unsafe', if the for..in loop has that
-    // effect.
-    if (stmt->getUnsafeLoc().isValid()) {
-      nextCall = new (ctx) UnsafeExpr(
-          stmt->getUnsafeLoc(), nextCall, Type(), /*implicit=*/true);
+    // effect or if the loop is async (in which case the iterator variable
+    // is nonisolated(unsafe).
+    if (stmt->getUnsafeLoc().isValid() ||
+        (isAsync &&
+         ctx.LangOpts.StrictConcurrencyLevel == StrictConcurrency::Complete)) {
+      SourceLoc loc = stmt->getUnsafeLoc();
+      if (loc.isInvalid())
+        loc = stmt->getForLoc();
+      nextCall = new (ctx) UnsafeExpr(loc, nextCall, Type(), /*implicit=*/true);
     }
 
     // The iterator type must conform to IteratorProtocol.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4698,9 +4698,10 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
         (isAsync &&
          ctx.LangOpts.StrictConcurrencyLevel == StrictConcurrency::Complete)) {
       SourceLoc loc = stmt->getUnsafeLoc();
+      bool implicit = stmt->getUnsafeLoc().isInvalid();
       if (loc.isInvalid())
         loc = stmt->getForLoc();
-      nextCall = new (ctx) UnsafeExpr(loc, nextCall, Type(), /*implicit=*/true);
+      nextCall = new (ctx) UnsafeExpr(loc, nextCall, Type(), implicit);
     }
 
     // The iterator type must conform to IteratorProtocol.

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2439,7 +2439,7 @@ private:
       return ShouldRecurse;
     }
     ShouldRecurse_t checkUnsafe(UnsafeExpr *E) {
-      return E->isImplicit() ? ShouldRecurse : ShouldNotRecurse;
+      return ShouldNotRecurse;
     }
     ShouldRecurse_t checkTry(TryExpr *E) {
       return ShouldRecurse;
@@ -4573,10 +4573,6 @@ private:
           diagnoseUnsafeUse(unsafeUse);
         }
       }
-    } else if (S->getUnsafeLoc().isValid()) {
-      // Extraneous "unsafe" on the sequence.
-      Ctx.Diags.diagnose(S->getUnsafeLoc(), diag::no_unsafe_in_unsafe_for)
-        .fixItRemove(S->getUnsafeLoc());
     }
 
     return ShouldRecurse;
@@ -4636,7 +4632,10 @@ private:
       return;
     }
 
-    Ctx.Diags.diagnose(E->getUnsafeLoc(), diag::no_unsafe_in_unsafe)
+    Ctx.Diags.diagnose(E->getUnsafeLoc(),
+                       forEachNextCallExprs.contains(E)
+                           ? diag::no_unsafe_in_unsafe_for
+                           : diag::no_unsafe_in_unsafe)
       .fixItRemove(E->getUnsafeLoc());
   }
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -4614,18 +4614,25 @@ private:
   }
 
   void diagnoseRedundantUnsafe(UnsafeExpr *E) const {
-    // Silence this warning in the expansion of the _SwiftifyImport macro.
-    // This is a hack because it's tricky to determine when to insert "unsafe".
-    unsigned bufferID =
-        Ctx.SourceMgr.findBufferContainingLoc(E->getUnsafeLoc());
-    if (auto sourceInfo = Ctx.SourceMgr.getGeneratedSourceInfo(bufferID)) {
-      if (sourceInfo->macroName == "_SwiftifyImport")
-        return;
+    // Ignore implicitly-generated "unsafe" expressions; they're allowed to be
+    // overly conservative.
+    if (E->isImplicit())
+      return;
+
+    SourceLoc loc = E->getUnsafeLoc();
+    if (loc.isValid()) {
+      // Silence this warning in the expansion of the _SwiftifyImport macro.
+      // This is a hack because it's tricky to determine when to insert "unsafe".
+      unsigned bufferID = Ctx.SourceMgr.findBufferContainingLoc(loc);
+      if (auto sourceInfo = Ctx.SourceMgr.getGeneratedSourceInfo(bufferID)) {
+        if (sourceInfo->macroName == "_SwiftifyImport")
+          return;
+      }
     }
 
     if (auto *SVE = SingleValueStmtExpr::tryDigOutSingleValueStmtExpr(E)) {
       // For an if/switch expression, produce a tailored warning.
-      Ctx.Diags.diagnose(E->getUnsafeLoc(),
+      Ctx.Diags.diagnose(loc,
                          diag::effect_marker_on_single_value_stmt,
                          "unsafe", SVE->getStmt()->getKind())
         .highlight(E->getUnsafeLoc());

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -786,7 +786,7 @@ ExprPatternMatchRequest::evaluate(Evaluator &evaluator,
 
   // If there was an "unsafe", put it outside of the match call.
   if (unsafeExpr) {
-    matchCall = UnsafeExpr::createImplicit(ctx, unsafeExpr->getLoc(), matchCall);
+    matchCall = new (ctx) UnsafeExpr(unsafeExpr->getLoc(), matchCall);
   }
 
   return {matchVar, matchCall};

--- a/test/Unsafe/codable_synthesis.swift
+++ b/test/Unsafe/codable_synthesis.swift
@@ -1,0 +1,26 @@
+// RUN: %target-typecheck-verify-swift -strict-memory-safety
+
+@unsafe public struct UnsafeStruct: Codable {
+  public var string: String
+}
+
+
+@unsafe public enum UnsafeEnum: Codable {
+case something(Int)
+}
+
+@safe public struct SafeStruct: Codable {
+  public var us: UnsafeStruct
+}
+
+@safe public enum SafeEnum: Codable {
+case something(UnsafeEnum)
+}
+
+@unsafe public class C1: Codable {
+  public var string: String = ""
+}
+
+@unsafe public class C2: C1 {
+  public var otherString: String = ""
+}

--- a/test/Unsafe/hashable_synthesis.swift
+++ b/test/Unsafe/hashable_synthesis.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift -strict-memory-safety
+
+@unsafe public struct UnsafeStruct: Hashable {
+  public var string: String
+}
+
+
+@unsafe public enum UnsafeEnum: Hashable {
+case something(Int)
+}
+
+@safe public struct SafeStruct: Hashable {
+  public var us: UnsafeStruct
+}
+
+@safe public enum SafeEnum: Hashable {
+case something(UnsafeEnum)
+}

--- a/test/Unsafe/safe.swift
+++ b/test/Unsafe/safe.swift
@@ -98,6 +98,8 @@ func testUnsafeAsSequenceForEach() {
   for _ in unsafe uas { } // expected-warning{{for-in loop uses unsafe constructs but is not marked with 'unsafe'}}{{documentation-file=strict-memory-safety}}{{7-7=unsafe }}
 
   for unsafe _ in unsafe uas { } // okay
+
+  for unsafe _ in [1, 2, 3] { } // expected-warning{{no unsafe operations occur within 'unsafe' for-in loop}}
 }
 
 func testForInUnsafeAmbiguity(_ integers: [Int]) {

--- a/test/Unsafe/unsafe_concurrency.swift
+++ b/test/Unsafe/unsafe_concurrency.swift
@@ -55,3 +55,10 @@ open class SyntaxVisitor {
 open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visit(_ token: TokenSyntax) { }
 }
+
+@available(SwiftStdlib 5.1, *)
+func testMemorySafetyWithForLoop() async {
+  let (stream, continuation) = AsyncStream<Int>.makeStream()
+  for await _ in stream {}
+  _ = continuation
+}


### PR DESCRIPTION
- **Explanation**: Fix two narrow places where strict memory safety was producing spurious warnings from compiler-generated code, which the user could not suppress. The first occurs in async `for..in` loops under strict concurrency checking, where the compiler-synthesized `$generator` variable is `nonisolated(unsafe)`. The second occurs in synthesized `Codable` conformances when 
- **Scope**: Limited to strict memory safety checking with these two narrow cases.
- **Issues**: rdar://154775389, rdar://153665692
- **Original PRs**: https://github.com/swiftlang/swift/pull/82938 , https://github.com/swiftlang/swift/pull/82954
- **Risk**: Very low due to narrow scope and the nature of the changes (minor AST tweaks and warning suppression).
- **Testing**: CI
- **Reviewers**: @slavapestov 
