### PR TITLE
Tests: Add missing -target clang flags in `@cdecl` Interpreter tests

### DIFF
--- a/test/Interpreter/cdecl_implementation_run.swift
+++ b/test/Interpreter/cdecl_implementation_run.swift
@@ -11,7 +11,7 @@
 // RUN: %target-codesign %t/%target-library-name(Lib)
 
 /// Build a C client against cdecl.h.
-// RUN: %clang-no-modules %t/Client.c -o %t/a.out \
+// RUN: %clang-no-modules %t/Client.c -o %t/a.out -target %target-triple \
 // RUN:   -I %clang-include-dir -Werror -isysroot %sdk \
 // RUN:   -I %t -l Lib -L %t %target-rpath(%t)
 // RUN: %target-codesign %t/a.out

--- a/test/Interpreter/cdecl_official_run.swift
+++ b/test/Interpreter/cdecl_official_run.swift
@@ -8,7 +8,7 @@
 // RUN:   -enable-experimental-feature CDecl
 
 /// Build and run a binary from Swift and C code.
-// RUN: %clang-no-modules -c %t/Client.c -o %t/Client.o \
+// RUN: %clang-no-modules -c %t/Client.c -o %t/Client.o -target %target-triple \
 // RUN:   -I %t -I %clang-include-dir -Werror -isysroot %sdk
 // RUN: %target-build-swift %t/Lib.swift %t/Client.o -O -o %t/a.out \
 // RUN:   -enable-experimental-feature CDecl -parse-as-library


### PR DESCRIPTION
These tests were failing for some devices.

rdar://155013885&155529527