### PR TITLE
[stdlib] Implementation for SE-0488

### DIFF
--- a/stdlib/public/core/Span/RawSpan.swift
+++ b/stdlib/public/core/Span/RawSpan.swift
@@ -378,13 +378,20 @@ extension RawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(_ bounds: Range<Int>) -> Self {
+  public func extracting(_ bounds: Range<Int>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
       "Byte offset range out of bounds"
     )
-    return unsafe _extracting(unchecked: bounds)
+    return unsafe extracting(unchecked: bounds)
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(_ bounds: Range<Int>) -> Self {
+    extracting(bounds)
   }
 
   /// Constructs a new span over the bytes within the supplied range of
@@ -405,12 +412,20 @@ extension RawSpan {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(unchecked bounds: Range<Int>) -> Self {
+  public func extracting(unchecked bounds: Range<Int>) -> Self {
     let newStart = unsafe _pointer?.advanced(by: bounds.lowerBound)
     let newSpan = unsafe RawSpan(_unchecked: newStart, byteCount: bounds.count)
     return unsafe _overrideLifetime(newSpan, copying: self)
   }
 
+  @unsafe
+  @available(*, deprecated, renamed: "extracting(unchecked:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(unchecked bounds: Range<Int>) -> Self {
+    unsafe extracting(unchecked: bounds)
+  }
+
   /// Constructs a new span over the bytes within the supplied range of
   /// positions within this span.
   ///
@@ -426,8 +441,15 @@ extension RawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
+  public func extracting(_ bounds: some RangeExpression<Int>) -> Self {
+    extracting(bounds.relative(to: byteOffsets))
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
   public func _extracting(_ bounds: some RangeExpression<Int>) -> Self {
-    _extracting(bounds.relative(to: byteOffsets))
+    extracting(bounds)
   }
 
   /// Constructs a new span over the bytes within the supplied range of
@@ -448,13 +470,21 @@ extension RawSpan {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(
+  public func extracting(
     unchecked bounds: ClosedRange<Int>
   ) -> Self {
     let range = unsafe Range(
       _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
     )
-    return unsafe _extracting(unchecked: range)
+    return unsafe extracting(unchecked: range)
+  }
+
+  @unsafe
+  @available(*, deprecated, renamed: "extracting(unchecked:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(unchecked bounds: ClosedRange<Int>) -> Self {
+    unsafe extracting(unchecked: bounds)
   }
 
   /// Constructs a new span over all the bytes of this span.
@@ -466,6 +496,13 @@ extension RawSpan {
   /// - Returns: A span over all the bytes of this span.
   ///
   /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   public func _extracting(_: UnboundedRange) -> Self {
@@ -708,11 +745,18 @@ extension RawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(first maxLength: Int) -> Self {
+  public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, byteCount)
     let newSpan = unsafe Self(_unchecked: _pointer, byteCount: newCount)
     return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(first:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(first maxLength: Int) -> Self {
+    extracting(first: maxLength)
   }
 
   /// Returns a span over all but the given number of trailing bytes.
@@ -731,12 +775,19 @@ extension RawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(droppingLast k: Int) -> Self {
+  public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)
     let count = byteCount &- droppedCount
     let newSpan = unsafe Self(_unchecked: _pointer, byteCount: count)
     return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(droppingLast:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(droppingLast k: Int) -> Self {
+    extracting(droppingLast: k)
   }
 
   /// Returns a span containing the trailing bytes of the span,
@@ -756,7 +807,7 @@ extension RawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(last maxLength: Int) -> Self {
+  public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
     let newCount = min(maxLength, byteCount)
     let newStart = unsafe _pointer?.advanced(by: byteCount &- newCount)
@@ -764,6 +815,13 @@ extension RawSpan {
     // As a trivial value, 'newStart' does not formally depend on the
     // lifetime of 'self'. Make the dependence explicit.
     return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(last:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(last maxLength: Int) -> Self {
+    extracting(last: maxLength)
   }
 
   /// Returns a span over all but the given number of initial bytes.
@@ -782,7 +840,7 @@ extension RawSpan {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(droppingFirst k: Int) -> Self {
+  public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of bytes")
     let droppedCount = min(k, byteCount)
     let newStart = unsafe _pointer?.advanced(by: droppedCount)
@@ -791,5 +849,12 @@ extension RawSpan {
     // As a trivial value, 'newStart' does not formally depend on the
     // lifetime of 'self'. Make the dependence explicit.
     return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(droppingFirst:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(droppingFirst k: Int) -> Self {
+    extracting(droppingFirst: k)
   }
 }

--- a/stdlib/public/core/Span/Span.swift
+++ b/stdlib/public/core/Span/Span.swift
@@ -536,13 +536,20 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(_ bounds: Range<Index>) -> Self {
+  public func extracting(_ bounds: Range<Index>) -> Self {
     _precondition(
       UInt(bitPattern: bounds.lowerBound) <= UInt(bitPattern: _count) &&
       UInt(bitPattern: bounds.upperBound) <= UInt(bitPattern: _count),
       "Index range out of bounds"
     )
-    return unsafe _extracting(unchecked: bounds)
+    return unsafe extracting(unchecked: bounds)
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(_ bounds: Range<Index>) -> Self {
+    extracting(bounds)
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -563,7 +570,7 @@ extension Span where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(unchecked bounds: Range<Index>) -> Self {
+  public func extracting(unchecked bounds: Range<Index>) -> Self {
     let delta = bounds.lowerBound &* MemoryLayout<Element>.stride
     let newStart = unsafe _pointer?.advanced(by: delta)
     let newSpan = unsafe Span(_unchecked: newStart, count: bounds.count)
@@ -572,6 +579,14 @@ extension Span where Element: ~Copyable {
     return unsafe _overrideLifetime(newSpan, copying: self)
   }
 
+  @unsafe
+  @available(*, deprecated, renamed: "extracting(unchecked:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(unchecked bounds: Range<Index>) -> Self {
+    unsafe extracting(unchecked: bounds)
+  }
+
   /// Constructs a new span over the items within the supplied range of
   /// positions within this span.
   ///
@@ -587,10 +602,17 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(
+  public func extracting(
     _ bounds: some RangeExpression<Index>
   ) -> Self {
-    _extracting(bounds.relative(to: indices))
+    extracting(bounds.relative(to: indices))
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(_ bounds: some RangeExpression<Index>) -> Self {
+    extracting(bounds)
   }
 
   /// Constructs a new span over the items within the supplied range of
@@ -611,13 +633,21 @@ extension Span where Element: ~Copyable {
   @unsafe
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(
+  public func extracting(
     unchecked bounds: ClosedRange<Index>
   ) -> Self {
     let range = unsafe Range(
       _uncheckedBounds: (bounds.lowerBound, bounds.upperBound + 1)
     )
-    return unsafe _extracting(unchecked: range)
+    return unsafe extracting(unchecked: range)
+  }
+
+  @unsafe
+  @available(*, deprecated, renamed: "extracting(unchecked:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(unchecked bounds: ClosedRange<Index>) -> Self {
+    unsafe extracting(unchecked: bounds)
   }
 
   /// Constructs a new span over all the items of this span.
@@ -629,6 +659,13 @@ extension Span where Element: ~Copyable {
   /// - Returns: A `Span` over all the items of this span.
   ///
   /// - Complexity: O(1)
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func extracting(_: UnboundedRange) -> Self {
+    self
+  }
+
+  @available(*, deprecated, renamed: "extracting(_:)")
   @_alwaysEmitIntoClient
   @lifetime(copy self)
   public func _extracting(_: UnboundedRange) -> Self {
@@ -761,11 +798,18 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(first maxLength: Int) -> Self {
+  public func extracting(first maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a prefix of negative length")
     let newCount = min(maxLength, count)
     let newSpan = unsafe Self(_unchecked: _pointer, count: newCount)
     return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(first:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(first maxLength: Int) -> Self {
+    extracting(first: maxLength)
   }
 
   /// Returns a span over all but the given number of trailing elements.
@@ -784,11 +828,18 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(droppingLast k: Int) -> Self {
+  public func extracting(droppingLast k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, count)
     let newSpan = unsafe Self(_unchecked: _pointer, count: count &- droppedCount)
     return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(droppingLast:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(droppingLast k: Int) -> Self {
+    extracting(droppingLast: k)
   }
 
   /// Returns a span containing the final elements of the span,
@@ -808,7 +859,7 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(last maxLength: Int) -> Self {
+  public func extracting(last maxLength: Int) -> Self {
     _precondition(maxLength >= 0, "Can't have a suffix of negative length")
     let newCount = min(maxLength, count)
     let offset = (count &- newCount) * MemoryLayout<Element>.stride
@@ -817,6 +868,13 @@ extension Span where Element: ~Copyable {
     // As a trivial value, 'newStart' does not formally depend on the
     // lifetime of 'buffer'. Make the dependence explicit.
     return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(last:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(last maxLength: Int) -> Self {
+    extracting(last: maxLength)
   }
 
   /// Returns a span over all but the given number of initial elements.
@@ -835,7 +893,7 @@ extension Span where Element: ~Copyable {
   /// - Complexity: O(1)
   @_alwaysEmitIntoClient
   @lifetime(copy self)
-  public func _extracting(droppingFirst k: Int) -> Self {
+  public func extracting(droppingFirst k: Int) -> Self {
     _precondition(k >= 0, "Can't drop a negative number of elements")
     let droppedCount = min(k, count)
     let offset = droppedCount &* MemoryLayout<Element>.stride
@@ -845,5 +903,12 @@ extension Span where Element: ~Copyable {
     // As a trivial value, 'newStart' does not formally depend on the
     // lifetime of 'buffer'. Make the dependence explicit.
     return unsafe _overrideLifetime(newSpan, copying: self)
+  }
+
+  @available(*, deprecated, renamed: "extracting(droppingFirst:)")
+  @_alwaysEmitIntoClient
+  @lifetime(copy self)
+  public func _extracting(droppingFirst k: Int) -> Self {
+    extracting(droppingFirst: k)
   }
 }

--- a/stdlib/public/core/Substring.swift
+++ b/stdlib/public/core/Substring.swift
@@ -760,7 +760,7 @@ extension Substring.UTF8View {
       let base: String.UTF8View = self._base
       let first = base._foreignDistance(from: base.startIndex, to: startIndex)
       let count = base._foreignDistance(from: startIndex, to: endIndex)
-      let span = base._underlyingSpan()._extracting(first..<(first &+ count))
+      let span = base._underlyingSpan().extracting(first..<(first &+ count))
       return unsafe _overrideLifetime(span, borrowing: self)
     }
 #endif // _runtime(_ObjC)
@@ -776,7 +776,7 @@ extension Substring.UTF8View {
     let isFastUTF8 = _wholeGuts.isFastUTF8
     _precondition(isFastUTF8, "Substring must be contiguous UTF8")
     var span = unsafe Span(_unsafeElements: _wholeGuts._object.fastUTF8)
-    span = span._extracting(first..<end)
+    span = span.extracting(first..<end)
     return unsafe _overrideLifetime(span, borrowing: self)
   }
 

--- a/stdlib/public/core/UTF8Span.swift
+++ b/stdlib/public/core/UTF8Span.swift
@@ -313,7 +313,7 @@ extension Substring {
       let base: String.UTF8View = _slice._base.utf8
       let first = base._foreignDistance(from: base.startIndex, to: startIndex)
       let count = base._foreignDistance(from: startIndex, to: endIndex)
-      let span = base._underlyingSpan()._extracting(first..<(first &+ count))
+      let span = base._underlyingSpan().extracting(first..<(first &+ count))
       return unsafe _overrideLifetime(span, borrowing: self)
     }
 #endif // _runtime(_ObjC)
@@ -329,7 +329,7 @@ extension Substring {
     let isFastUTF8 = _wholeGuts.isFastUTF8
     _precondition(isFastUTF8, "Substring must be contiguous UTF8")
     var span = unsafe Span(_unsafeElements: _wholeGuts._object.fastUTF8)
-    span = span._extracting(first..<end)
+    span = span.extracting(first..<end)
     return unsafe _overrideLifetime(span, borrowing: self)
   }
 

--- a/stdlib/public/core/UTF8SpanIterators.swift
+++ b/stdlib/public/core/UTF8SpanIterators.swift
@@ -174,7 +174,7 @@ extension UTF8Span {
     /// The resultant `UTF8Span` has the same lifetime constraints as `self`.
     @lifetime(copy self)
     public func prefix() -> UTF8Span {
-      let slice = codeUnits.span._extracting(0..<currentCodeUnitOffset)
+      let slice = codeUnits.span.extracting(0..<currentCodeUnitOffset)
       return UTF8Span(
         _uncheckedAssumingValidUTF8: slice,
         isKnownASCII: codeUnits.isKnownASCII,
@@ -187,7 +187,7 @@ extension UTF8Span {
     /// The resultant `UTF8Span` has the same lifetime constraints as `self`.
     @lifetime(copy self)
     public func suffix() -> UTF8Span {
-      let slice = codeUnits.span._extracting(currentCodeUnitOffset..<codeUnits.count)
+      let slice = codeUnits.span.extracting(currentCodeUnitOffset..<codeUnits.count)
       return UTF8Span(
         _uncheckedAssumingValidUTF8: slice,
         isKnownASCII: codeUnits.isKnownASCII,
@@ -368,7 +368,7 @@ extension UTF8Span {
     /// current position.
     @lifetime(copy self)
     public func prefix() -> UTF8Span {
-      let slice = codeUnits.span._extracting(0..<currentCodeUnitOffset)
+      let slice = codeUnits.span.extracting(0..<currentCodeUnitOffset)
       return UTF8Span(
         _uncheckedAssumingValidUTF8: slice,
         isKnownASCII: codeUnits.isKnownASCII,
@@ -379,7 +379,7 @@ extension UTF8Span {
     /// current position.
     @lifetime(copy self)
     public func suffix() -> UTF8Span {
-      let slice = codeUnits.span._extracting(currentCodeUnitOffset..<codeUnits.count)
+      let slice = codeUnits.span.extracting(currentCodeUnitOffset..<codeUnits.count)
       return UTF8Span(
         _uncheckedAssumingValidUTF8: slice,
         isKnownASCII: codeUnits.isKnownASCII,

--- a/test/stdlib/Span/RawSpanTests.swift
+++ b/test/stdlib/Span/RawSpanTests.swift
@@ -129,7 +129,7 @@ suite.test("unsafeLoadUnaligned(as:)")
   a.withUnsafeBytes {
     let span = RawSpan(_unsafeBytes: $0)
 
-    let suffix = span._extracting(droppingFirst: 2)
+    let suffix = span.extracting(droppingFirst: 2)
     let u0 = suffix.unsafeLoadUnaligned(as: UInt64.self)
     expectEqual(u0.littleEndian & 0xff, 2)
     expectEqual(u0.bigEndian & 0xff, 9)
@@ -139,7 +139,7 @@ suite.test("unsafeLoadUnaligned(as:)")
   }
 }
 
-suite.test("_extracting() functions")
+suite.test("extracting() functions")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -151,10 +151,10 @@ suite.test("_extracting() functions")
   let b = (0..<capacity).map(Int8.init)
   b.withUnsafeBytes {
     let span = RawSpan(_unsafeBytes: $0)
-    let sub1 = span._extracting(0..<2)
-    let sub2 = span._extracting(..<2)
-    let sub3 = span._extracting(...)
-    let sub4 = span._extracting(2...)
+    let sub1 = span.extracting(0..<2)
+    let sub2 = span.extracting(..<2)
+    let sub3 = span.extracting(...)
+    let sub4 = span.extracting(2...)
 
     sub1.withUnsafeBytes { p1 in
       sub2.withUnsafeBytes { p2 in
@@ -174,7 +174,7 @@ suite.test("_extracting() functions")
   }
 }
 
-suite.test("_extracting(unchecked:) functions")
+suite.test("extracting(unchecked:) functions")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -186,14 +186,14 @@ suite.test("_extracting(unchecked:) functions")
   let b = (0..<capacity).map(UInt8.init)
   b.withUnsafeBytes {
     let span = RawSpan(_unsafeBytes: $0)
-    let prefix = span._extracting(0..<8)
-    let beyond = prefix._extracting(unchecked: 16...23)
+    let prefix = span.extracting(0..<8)
+    let beyond = prefix.extracting(unchecked: 16...23)
     expectEqual(beyond.byteCount, 8)
     expectEqual(beyond.unsafeLoad(as: UInt8.self), 16)
   }
 }
 
-suite.test("prefix _extracting() functions")
+suite.test("prefix extracting() functions")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -206,22 +206,22 @@ suite.test("prefix _extracting() functions")
   a.withUnsafeBytes {
     let span = RawSpan(_unsafeBytes: $0)
     expectEqual(span.byteCount, capacity)
-    expectEqual(span._extracting(first: 1).unsafeLoad(as: UInt8.self), 0)
+    expectEqual(span.extracting(first: 1).unsafeLoad(as: UInt8.self), 0)
     expectEqual(
-      span._extracting(first: capacity).unsafeLoad(
+      span.extracting(first: capacity).unsafeLoad(
         fromByteOffset: capacity-1, as: UInt8.self
       ),
       UInt8(capacity-1)
     )
-    expectTrue(span._extracting(droppingLast: capacity).isEmpty)
+    expectTrue(span.extracting(droppingLast: capacity).isEmpty)
     expectEqual(
-      span._extracting(droppingLast: 1).unsafeLoad(
+      span.extracting(droppingLast: 1).unsafeLoad(
         fromByteOffset: capacity-2, as: UInt8.self
       ),
       UInt8(capacity-2)
     )
-    let emptySpan = span._extracting(first: 0)
-    let emptierSpan = emptySpan._extracting(0..<0)
+    let emptySpan = span.extracting(first: 0)
+    let emptierSpan = emptySpan.extracting(0..<0)
     expectTrue(emptySpan.isIdentical(to: emptierSpan))
   }
 
@@ -229,12 +229,12 @@ suite.test("prefix _extracting() functions")
     let b = UnsafeRawBufferPointer(start: nil, count: 0)
     let span = RawSpan(_unsafeBytes: b)
     expectEqual(span.byteCount, b.count)
-    expectEqual(span._extracting(first: 1).byteCount, b.count)
-    expectEqual(span._extracting(droppingLast: 1).byteCount, b.count)
+    expectEqual(span.extracting(first: 1).byteCount, b.count)
+    expectEqual(span.extracting(droppingLast: 1).byteCount, b.count)
   }
 }
 
-suite.test("suffix _extracting() functions")
+suite.test("suffix extracting() functions")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -247,19 +247,19 @@ suite.test("suffix _extracting() functions")
   a.withUnsafeBytes {
     let span = RawSpan(_unsafeBytes: $0)
     expectEqual(span.byteCount, capacity)
-    expectEqual(span._extracting(last: capacity).unsafeLoad(as: UInt8.self), 0)
-    expectEqual(span._extracting(last: capacity-1).unsafeLoad(as: UInt8.self), 1)
-    expectEqual(span._extracting(last: 1).unsafeLoad(as: UInt8.self), UInt8(capacity-1))
-    expectTrue(span._extracting(droppingFirst: capacity).isEmpty)
-    expectEqual(span._extracting(droppingFirst: 1).unsafeLoad(as: UInt8.self), 1)
+    expectEqual(span.extracting(last: capacity).unsafeLoad(as: UInt8.self), 0)
+    expectEqual(span.extracting(last: capacity-1).unsafeLoad(as: UInt8.self), 1)
+    expectEqual(span.extracting(last: 1).unsafeLoad(as: UInt8.self), UInt8(capacity-1))
+    expectTrue(span.extracting(droppingFirst: capacity).isEmpty)
+    expectEqual(span.extracting(droppingFirst: 1).unsafeLoad(as: UInt8.self), 1)
   }
 
   do {
     let b = UnsafeRawBufferPointer(start: nil, count: 0)
     let span = RawSpan(_unsafeBytes: b)
     expectEqual(span.byteCount, b.count)
-    expectEqual(span._extracting(last: 1).byteCount, b.count)
-    expectEqual(span._extracting(droppingFirst: 1).byteCount, b.count)
+    expectEqual(span.extracting(last: 1).byteCount, b.count)
+    expectEqual(span.extracting(droppingFirst: 1).byteCount, b.count)
   }
 }
 
@@ -304,9 +304,9 @@ suite.test("byteOffsets(of:)")
   defer { b.deallocate() }
 
   let span = RawSpan(_unsafeBytes: b)
-  let subSpan1 = span._extracting(first: 6)
-  let subSpan2 = span._extracting(last: 6)
-  let emptySpan = span._extracting(first: 0)
+  let subSpan1 = span.extracting(first: 6)
+  let subSpan2 = span.extracting(last: 6)
+  let emptySpan = span.extracting(first: 0)
   let nilBuffer = UnsafeRawBufferPointer(start: nil, count: 0)
   let nilSpan = RawSpan(_unsafeBytes: nilBuffer)
 

--- a/test/stdlib/Span/SpanTests.swift
+++ b/test/stdlib/Span/SpanTests.swift
@@ -254,10 +254,10 @@ suite.test("_elementsEqual(_: Span)")
   a.withUnsafeBufferPointer {
     let span = Span(_unsafeElements: $0)
 
-    expectEqual(span._elementsEqual(span._extracting(first: 1)), false)
-    expectEqual(span._extracting(0..<0)._elementsEqual(span._extracting(last: 0)), true)
+    expectEqual(span._elementsEqual(span.extracting(first: 1)), false)
+    expectEqual(span.extracting(0..<0)._elementsEqual(span.extracting(last: 0)), true)
     expectEqual(span._elementsEqual(span), true)
-    expectEqual(span._extracting(0..<3)._elementsEqual(span._extracting(last: 3)), false)
+    expectEqual(span.extracting(0..<3)._elementsEqual(span.extracting(last: 3)), false)
 
     let copy = span.withUnsafeBufferPointer(Array.init)
     copy.withUnsafeBufferPointer {
@@ -281,7 +281,7 @@ suite.test("_elementsEqual(_: some Collection)")
     let span = Span(_unsafeElements: $0)
 
     expectEqual(span._elementsEqual(a), true)
-    expectEqual(span._extracting(0..<0)._elementsEqual([]), true)
+    expectEqual(span.extracting(0..<0)._elementsEqual([]), true)
     expectEqual(span._elementsEqual(a.dropLast()), false)
   }
 }
@@ -301,7 +301,7 @@ suite.test("_elementsEqual(_: some Sequence")
 
     let s = AnySequence(a)
     expectEqual(span._elementsEqual(s), true)
-    expectEqual(span._extracting(0..<(capacity-1))._elementsEqual(s), false)
+    expectEqual(span.extracting(0..<(capacity-1))._elementsEqual(s), false)
     expectEqual(span._elementsEqual(s.dropFirst()), false)
   }
 }
@@ -338,7 +338,7 @@ suite.test("subscript with BitwiseCopyable element")
   }
 }
 
-suite.test("_extracting() functions")
+suite.test("extracting() functions")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -350,17 +350,17 @@ suite.test("_extracting() functions")
   let b = (0..<capacity).map(String.init)
   b.withUnsafeBufferPointer {
     let span = Span(_unsafeElements: $0)
-    let sub1 = span._extracting(0..<2)
-    let sub2 = span._extracting(..<2)
-    let sub3 = span._extracting(...)
-    let sub4 = span._extracting(2...)
+    let sub1 = span.extracting(0..<2)
+    let sub2 = span.extracting(..<2)
+    let sub3 = span.extracting(...)
+    let sub4 = span.extracting(2...)
     expectTrue(sub1._elementsEqual(sub2))
     expectTrue(sub3._elementsEqual(span))
     expectFalse(sub4._elementsEqual(sub3))
   }
 }
 
-suite.test("_extracting(unchecked:) functions")
+suite.test("extracting(unchecked:) functions")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -372,14 +372,14 @@ suite.test("_extracting(unchecked:) functions")
   let b = (0..<capacity).map(String.init)
   b.withUnsafeBufferPointer {
     let span = Span(_unsafeElements: $0)
-    let prefix = span._extracting(0..<8)
-    let beyond = prefix._extracting(unchecked: 16...23)
+    let prefix = span.extracting(0..<8)
+    let beyond = prefix.extracting(unchecked: 16...23)
     expectEqual(beyond.count, 8)
     expectEqual(beyond[0], "16")
   }
 }
 
-suite.test("prefix _extracting() functions")
+suite.test("prefix extracting() functions")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -392,22 +392,22 @@ suite.test("prefix _extracting() functions")
   a.withUnsafeBufferPointer {
     let span = Span(_unsafeElements: $0)
     expectEqual(span.count, capacity)
-    expectEqual(span._extracting(first: 1)[0], 0)
-    expectEqual(span._extracting(first: capacity)[capacity-1], capacity-1)
-    expectEqual(span._extracting(droppingLast: capacity).count, 0)
-    expectEqual(span._extracting(droppingLast: 1)[capacity-2], capacity-2)
+    expectEqual(span.extracting(first: 1)[0], 0)
+    expectEqual(span.extracting(first: capacity)[capacity-1], capacity-1)
+    expectEqual(span.extracting(droppingLast: capacity).count, 0)
+    expectEqual(span.extracting(droppingLast: 1)[capacity-2], capacity-2)
   }
 
   do {
     let b = UnsafeBufferPointer<Int>(start: nil, count: 0)
     let span = Span(_unsafeElements: b)
     expectEqual(span.count, b.count)
-    expectEqual(span._extracting(first: 1).count, b.count)
-    expectEqual(span._extracting(droppingLast: 1).count, b.count)
+    expectEqual(span.extracting(first: 1).count, b.count)
+    expectEqual(span.extracting(droppingLast: 1).count, b.count)
   }
 }
 
-suite.test("suffix _extracting() functions")
+suite.test("suffix extracting() functions")
 .skip(.custom(
   { if #available(SwiftStdlib 6.2, *) { false } else { true } },
   reason: "Requires Swift 6.2's standard library"
@@ -420,19 +420,19 @@ suite.test("suffix _extracting() functions")
   a.withUnsafeBufferPointer {
     let span = Span<Int>(_unsafeElements: $0)
     expectEqual(span.count, capacity)
-    expectEqual(span._extracting(last: capacity)[0], 0)
-    expectEqual(span._extracting(last: capacity-1)[0], 1)
-    expectEqual(span._extracting(last: 1)[0], capacity-1)
-    expectEqual(span._extracting(droppingFirst: capacity).count, 0)
-    expectEqual(span._extracting(droppingFirst: 1)[0], 1)
+    expectEqual(span.extracting(last: capacity)[0], 0)
+    expectEqual(span.extracting(last: capacity-1)[0], 1)
+    expectEqual(span.extracting(last: 1)[0], capacity-1)
+    expectEqual(span.extracting(droppingFirst: capacity).count, 0)
+    expectEqual(span.extracting(droppingFirst: 1)[0], 1)
   }
 
   do {
     let b = UnsafeBufferPointer<Int>(start: nil, count: 0)
     let span = Span(_unsafeElements: b)
     expectEqual(span.count, b.count)
-    expectEqual(span._extracting(last: 1).count, b.count)
-    expectEqual(span._extracting(droppingFirst: 1).count, b.count)
+    expectEqual(span.extracting(last: 1).count, b.count)
+    expectEqual(span.extracting(droppingFirst: 1).count, b.count)
   }
 }
 
@@ -506,8 +506,8 @@ suite.test("isIdentical(to:)")
   defer { b.deallocate() }
 
   let span = Span(_unsafeElements: b)
-  let pre = span._extracting(first: 6)
-  let suf = span._extracting(last: 6)
+  let pre = span.extracting(first: 6)
+  let suf = span.extracting(last: 6)
 
   expectFalse(
     pre.isIdentical(to: suf)
@@ -516,7 +516,7 @@ suite.test("isIdentical(to:)")
     pre.isIdentical(to: span)
   )
   expectTrue(
-    pre._extracting(last: 4).isIdentical(to: suf._extracting(first: 4))
+    pre.extracting(last: 4).isIdentical(to: suf.extracting(first: 4))
   )
 }
 
@@ -533,13 +533,13 @@ suite.test("indices(of:)")
   defer { b.deallocate() }
 
   let span = Span(_unsafeElements: b)
-  let subSpan1 = span._extracting(first: 6)
-  let subSpan2 = span._extracting(last: 6)
-  let emptySpan = span._extracting(first: 0)
+  let subSpan1 = span.extracting(first: 6)
+  let subSpan2 = span.extracting(last: 6)
+  let emptySpan = span.extracting(first: 0)
 /*  This isn't relevant until we can support unaligned spans
   let unalignedSpan = RawSpan(_unsafeSpan: span)
-                        ._extracting(droppingFirst: 6)
-                        ._extracting(droppingLast: 2)
+                        .extracting(droppingFirst: 6)
+                        .extracting(droppingLast: 2)
                         .unsafeView(as: Int.self)
 */
   let nilBuffer = UnsafeBufferPointer<Int>(start: nil, count: 0)


### PR DESCRIPTION
Makes the `extracting()` functions public for `Span` and `RawSpan`. ([SE-0488](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0488-extracting.md))

Addresses rdar://155474776