### PR TITLE
Basic: Stop enabling `NoncopyableGenerics`, `BorrowingSwitch`, and `MoveOnlyPartialConsumption`

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -51,11 +51,6 @@ LangOptions::LangOptions() {
   disableFeature(Feature::ExtensionMacros);
 #endif
 
-  // Note: Introduce default-on language options here.
-  enableFeature(Feature::NoncopyableGenerics);
-  enableFeature(Feature::BorrowingSwitch);
-  enableFeature(Feature::MoveOnlyPartialConsumption);
-
   // Enable any playground options that are enabled by default.
 #define PLAYGROUND_OPTION(OptionName, Description, DefaultOn, HighPerfOn) \
   if (DefaultOn) \

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -828,10 +828,6 @@ void DiagnosticEmitter::emitCannotPartiallyMutateError(
     return;
   }
   case PartialMutationError::Kind::HasDeinit: {
-    assert(
-        astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption) ||
-        astContext.LangOpts.hasFeature(
-            Feature::MoveOnlyPartialReinitialization));
     auto diagnostic = [&]() {
       switch (kind) {
       case PartialMutation::Kind::Consume:
@@ -851,10 +847,6 @@ void DiagnosticEmitter::emitCannotPartiallyMutateError(
     return;
   }
   case PartialMutationError::Kind::NonfrozenImportedType: {
-    assert(
-        astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption) ||
-        astContext.LangOpts.hasFeature(
-            Feature::MoveOnlyPartialReinitialization));
     auto &nominal = error.getNonfrozenImportedNominal();
     auto diagnostic = [&]() {
       switch (kind) {
@@ -870,10 +862,6 @@ void DiagnosticEmitter::emitCannotPartiallyMutateError(
     return;
   }
   case PartialMutationError::Kind::NonfrozenUsableFromInlineType: {
-    assert(
-        astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption) ||
-        astContext.LangOpts.hasFeature(
-            Feature::MoveOnlyPartialReinitialization));
     auto &nominal = error.getNonfrozenUsableFromInlineNominal();
     auto diagnostic = [&]() {
       switch (kind) {


### PR DESCRIPTION
These features are baseline features and therefore are considered to be implicitly enabled. They don't need to be explicitly enabled or queried for in any part of the compiler.
