### PR TITLE
RemoteInspection: Add AsyncTaskInfo.IsSuspended based on HasTaskDependency

### DIFF
--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -197,6 +197,7 @@ public:
     bool IsRunning;
     bool IsEnqueued;
     bool IsComplete;
+    bool IsSuspended;
 
     bool HasThreadPort;
     uint32_t ThreadPort;
@@ -1785,6 +1786,8 @@ private:
     Info.IsEscalated = TaskStatusFlags & ActiveTaskStatusFlags::IsEscalated;
     Info.IsEnqueued = TaskStatusFlags & ActiveTaskStatusFlags::IsEnqueued;
     Info.IsComplete = TaskStatusFlags & ActiveTaskStatusFlags::IsComplete;
+    Info.IsSuspended =
+        TaskStatusFlags & ActiveTaskStatusFlags::HasTaskDependency;
 
     setIsRunning(Info, AsyncTaskObj.get());
     std::tie(Info.HasThreadPort, Info.ThreadPort) =

--- a/include/swift/RemoteInspection/RuntimeInternals.h
+++ b/include/swift/RemoteInspection/RuntimeInternals.h
@@ -113,6 +113,7 @@ struct ActiveTaskStatusFlags {
   static const uint32_t IsRunning = 0x800;
   static const uint32_t IsEnqueued = 0x1000;
   static const uint32_t IsComplete = 0x2000;
+  static const uint32_t HasTaskDependency = 0x4000;
 };
 
 template <typename Runtime, typename ActiveTaskStatus>


### PR DESCRIPTION
Adds an `IsSuspended` field to `AsyncTaskInfo`, which is the same value as `HasTaskDependency`, but uses the `Is<State>` naming to match `IsEnqueued`, `IsRunning`, and `IsComplete`.

Based on the docs in Task.h:

```cpp
/// A task can have the following states:
///   * suspended: In this state, a task is considered not runnable
///   * enqueued: In this state, a task is considered runnable
///   * running on a thread
///   * completed
```

rdar://148663671