### PR TITLE
[CMake] Ensure incremental builds invoke the Runtimes build system...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1626,6 +1626,8 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
         # INSTALL_DIR "${CMAKE_BINARY_DIR}/"
 
         DEPENDS PopulateRuntimeSourceDir
+        # To ensure incremental builds work as expected
+        BUILD_ALWAYS 1
         CMAKE_ARGS
           -DCMAKE_INSTALL_LIBDIR:FILEPATH=lib
           # Compiler will see mismatched swift modules and fail initial checks
@@ -1657,6 +1659,8 @@ if(SWIFT_ENABLE_NEW_RUNTIME_BUILD)
         INSTALL_DIR "${INSTALL_DIR}"
         INSTALL_COMMAND ""
         LIST_SEPARATOR "|"
+        # To ensure incremental builds work as expected
+        BUILD_ALWAYS 1
         CMAKE_ARGS
           -DSwift_ENABLE_RUNTIMES=StringProcessing
           -DBUILD_SHARED_LIBS=YES

--- a/Runtimes/Supplemental/CMakeLists.txt
+++ b/Runtimes/Supplemental/CMakeLists.txt
@@ -51,6 +51,8 @@ if(SwiftRuntime_ENABLE_stringprocessing)
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/StringProcessing"
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     INSTALL_COMMAND ""
+    # To ensure incremental builds work as expected
+    BUILD_ALWAYS 1
     CMAKE_ARGS
       ${COMMON_OPTIONS})
 endif()
@@ -62,6 +64,8 @@ if(SwiftRuntime_ENABLE_synchronization)
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/Synchronization"
     INSTALL_DIR "${CMAKE_INSTALL_PREFIX}"
     INSTALL_COMMAND ""
+    # To ensure incremental builds work as expected
+    BUILD_ALWAYS 1
     CMAKE_ARGS
       ${COMMON_OPTIONS})
 endif()


### PR DESCRIPTION
...when using `--enable-new-runtime-build`

When building changes incrementally the runtime build system is not invoked -- the configure and build steps generated by `ExternalProject_Add` are effectively triggered only if the `CMAKE_ARGS` argument changes. We should instead delegate to the the Runtime build system to figure out if it needs to regenerate the `build.ninja` file and/or trigger any rebuild -- this can be done by passing `BUILD_ALWAYS 1` to `ExternalProject_Add`.

Addresses rdar://155559208