### PR TITLE
[RemoteMirrors] Restore stripping signed pointer when iterating the

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -622,8 +622,7 @@ public:
       return RemoteAddress();
 
     auto classMeta = cast<TargetClassMetadata>(meta);
-    return stripSignedPointer(RemoteAddress(
-        classMeta->Superclass.SignedValue, RemoteAddress::DefaultAddressSpace));
+    return stripSignedPointer(classMeta->Superclass);
   }
 
   /// Given a remote pointer to class metadata, attempt to discover its class

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -1386,8 +1386,7 @@ public:
     for (StoredSize i = 0; i < Count; i++) {
       auto &Element = ElementsData[i];
       Call(RemoteAddress(Element.Type, ConformancesPtr.getAddressSpace()),
-           RemoteAddress(Element.Proto.SignedValue,
-                         ConformancesPtr.getAddressSpace()));
+           stripSignedPointer(Element.Proto));
     }
   }
 


### PR DESCRIPTION
conformance cache

58df5534d2917ca545463b accidentally removed stripping this signed pointer.

<!--