### PR TITLE
Prepared overloads, part 2

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -49,6 +49,7 @@ namespace constraints {
 class ConstraintFix;
 class ConstraintLocator;
 class ConstraintSystem;
+class PreparedOverload;
 enum class TrailingClosureMatching;
 
 /// Describes the kind of constraint placed on one or more types.
@@ -437,6 +438,9 @@ class Constraint final : public llvm::ilist_node<Constraint>,
     struct {
       /// The first type.
       Type First;
+
+      /// The prepared overload, if any.
+      PreparedOverload *Prepared;
     } Overload;
 
     struct {
@@ -490,7 +494,9 @@ class Constraint final : public llvm::ilist_node<Constraint>,
              SmallPtrSetImpl<TypeVariableType *> &typeVars);
 
   /// Construct a new overload-binding constraint, which might have a fix.
-  Constraint(Type type, OverloadChoice choice, DeclContext *useDC,
+  Constraint(Type type, OverloadChoice choice,
+             PreparedOverload *preparedOverload,
+             DeclContext *useDC,
              ConstraintFix *fix, ConstraintLocator *locator,
              SmallPtrSetImpl<TypeVariableType *> &typeVars);
 
@@ -869,6 +875,13 @@ public:
   OverloadChoice getOverloadChoice() const {
     ASSERT(Kind == ConstraintKind::BindOverload);
     return *getTrailingObjects<OverloadChoice>();
+  }
+
+  /// Retrieve the prepared overload choice for an overload-binding
+  /// constraint.
+  PreparedOverload *getPreparedOverload() const {
+    ASSERT(Kind == ConstraintKind::BindOverload);
+    return Overload.Prepared;
   }
 
   FunctionType *getAppliedFunctionType() const {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -64,6 +64,9 @@ namespace constraints {
 
 class ConstraintSystem;
 class SyntacticElementTarget;
+
+// PreparedOverload.h
+struct DeclReferenceType;
 struct PreparedOverload;
 struct PreparedOverloadBuilder;
 
@@ -2142,34 +2145,6 @@ struct ClosureIsolatedByPreconcurrency {
   ConstraintSystem &cs;
 
   bool operator()(const ClosureExpr *expr) const;
-};
-
-/// Describes the type produced when referencing a declaration.
-struct DeclReferenceType {
-  /// The "opened" type, which is the type of the declaration where any
-  /// generic parameters have been replaced with type variables.
-  ///
-  /// The mapping from generic parameters to type variables will have been
-  /// recorded by \c recordOpenedTypes when this type is produced.
-  Type openedType;
-
-  /// The opened type, after performing contextual type adjustments such as
-  /// removing concurrency-related annotations for a `@preconcurrency`
-  /// operation.
-  Type adjustedOpenedType;
-
-  /// The type of the reference, based on the original opened type. This is the
-  /// type that the expression used to form the declaration reference would
-  /// have if no adjustments had been applied.
-  Type referenceType;
-
-  /// The type of the reference, which is the adjusted opened type after
-  /// (e.g.) applying the base of a member access. This is the type of the
-  /// expression used to form the declaration reference.
-  Type adjustedReferenceType;
-
-  /// The type that could be thrown by accessing this declaration.
-  Type thrownErrorTypeOnAccess;
 };
 
 /// Describes a system of constraints on type variables, the

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -67,7 +67,7 @@ class SyntacticElementTarget;
 
 // PreparedOverload.h
 struct DeclReferenceType;
-struct PreparedOverload;
+class PreparedOverload;
 struct PreparedOverloadBuilder;
 
 } // end namespace constraints
@@ -4906,18 +4906,23 @@ public:
   void recordResolvedOverload(ConstraintLocator *locator,
                               SelectedOverload choice);
 
+  /// Build and allocate a prepared overload in the solver arena.
+  const PreparedOverload *prepareOverload(ConstraintLocator *locator,
+                                          OverloadChoice choice,
+                                          DeclContext *useDC);
+
   /// Populate the prepared overload with all type variables and constraints
   /// that are to be introduced into the constraint system when this choice
   /// is taken.
   DeclReferenceType
-  prepareOverload(ConstraintLocator *locator,
-                  OverloadChoice choice,
-                  DeclContext *useDC,
-                  PreparedOverloadBuilder *preparedOverload);
+  prepareOverloadImpl(ConstraintLocator *locator,
+                      OverloadChoice choice,
+                      DeclContext *useDC,
+                      PreparedOverloadBuilder *preparedOverload);
 
   void replayChanges(
-      ConstraintLocatorBuilder locator,
-      PreparedOverload preparedOverload);
+      ConstraintLocator *locator,
+      const PreparedOverload *preparedOverload);
 
   /// Resolve the given overload set to the given choice.
   void resolveOverload(ConstraintLocator *locator, Type boundType,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -65,6 +65,7 @@ namespace constraints {
 class ConstraintSystem;
 class SyntacticElementTarget;
 struct PreparedOverload;
+struct PreparedOverloadBuilder;
 
 } // end namespace constraints
 
@@ -2954,7 +2955,7 @@ public:
   /// Create a new type variable.
   TypeVariableType *createTypeVariable(ConstraintLocator *locator,
                                        unsigned options,
-                                       PreparedOverload *preparedOverload
+                                       PreparedOverloadBuilder *preparedOverload
                                            = nullptr);
 
   /// Retrieve the set of active type variables.
@@ -3414,7 +3415,8 @@ public:
   /// Update OpenedExistentials and record a change in the trail.
   void recordOpenedExistentialType(ConstraintLocator *locator,
                                    ExistentialArchetypeType *opened,
-                                   PreparedOverload *preparedOverload = nullptr);
+                                   PreparedOverloadBuilder *preparedOverload
+                                      = nullptr);
 
   /// Retrieve the generic environment for the opened element of a given pack
   /// expansion, or \c nullptr if no environment was recorded yet.
@@ -3622,7 +3624,7 @@ public:
   /// Log and record the application of the fix. Return true iff any
   /// subsequent solution would be worse than the best known solution.
   bool recordFix(ConstraintFix *fix, unsigned impact = 1,
-                 PreparedOverload *preparedOverload = nullptr);
+                 PreparedOverloadBuilder *preparedOverload = nullptr);
 
   void recordPotentialHole(TypeVariableType *typeVar);
   void recordAnyTypeVarAsPotentialHole(Type type);
@@ -3698,13 +3700,13 @@ public:
   void addConstraint(ConstraintKind kind, Type first, Type second,
                      ConstraintLocatorBuilder locator,
                      bool isFavored = false,
-                     PreparedOverload *preparedOverload = nullptr);
+                     PreparedOverloadBuilder *preparedOverload = nullptr);
 
   /// Add a requirement as a constraint to the constraint system.
   void addConstraint(Requirement req, ConstraintLocatorBuilder locator,
                      bool isFavored,
                      bool prohibitNonisolatedConformance,
-                     PreparedOverload *preparedOverload = nullptr);
+                     PreparedOverloadBuilder *preparedOverload = nullptr);
 
   void addApplicationConstraint(
       FunctionType *appliedFn, Type calleeType,
@@ -4319,7 +4321,7 @@ public:
   Type openUnboundGenericType(GenericTypeDecl *decl, Type parentTy,
                               ConstraintLocatorBuilder locator,
                               bool isTypeResolution,
-                              PreparedOverload *preparedOverload = nullptr);
+                              PreparedOverloadBuilder *preparedOverload = nullptr);
 
   /// Replace placeholder types with fresh type variables, and unbound generic
   /// types with bound generic types whose generic args are fresh type
@@ -4330,7 +4332,7 @@ public:
   /// \returns The converted type.
   Type replaceInferableTypesWithTypeVars(Type type,
                                          ConstraintLocatorBuilder locator,
-                                         PreparedOverload *preparedOverload
+                                         PreparedOverloadBuilder *preparedOverload
                                             = nullptr);
 
   /// "Open" the given type by replacing any occurrences of generic
@@ -4343,7 +4345,7 @@ public:
   /// \returns The opened type, or \c type if there are no archetypes in it.
   Type openType(Type type, ArrayRef<OpenedType> replacements,
                 ConstraintLocatorBuilder locator,
-                PreparedOverload *preparedOverload);
+                PreparedOverloadBuilder *preparedOverload);
 
   /// "Open" an opaque archetype type, similar to \c openType.
   Type openOpaqueType(OpaqueTypeArchetypeType *type,
@@ -4360,12 +4362,12 @@ public:
   Type openPackExpansionType(PackExpansionType *expansion,
                              ArrayRef<OpenedType> replacements,
                              ConstraintLocatorBuilder locator,
-                             PreparedOverload *preparedOverload);
+                             PreparedOverloadBuilder *preparedOverload);
 
   /// Update OpenedPackExpansionTypes and record a change in the trail.
   void recordOpenedPackExpansionType(PackExpansionType *expansion,
                                      TypeVariableType *expansionVar,
-                                     PreparedOverload *preparedOverload
+                                     PreparedOverloadBuilder *preparedOverload
                                         = nullptr);
 
   /// Undo the above change.
@@ -4392,7 +4394,7 @@ public:
                                  ConstraintLocatorBuilder locator,
                                  SmallVectorImpl<OpenedType> &replacements,
                                  DeclContext *outerDC,
-                                 PreparedOverload *preparedOverload);
+                                 PreparedOverloadBuilder *preparedOverload);
 
   /// Open the generic parameter list and its requirements,
   /// creating type variables for each of the type parameters.
@@ -4400,7 +4402,7 @@ public:
                    GenericSignature signature,
                    ConstraintLocatorBuilder locator,
                    SmallVectorImpl<OpenedType> &replacements,
-                   PreparedOverload *preparedOverload);
+                   PreparedOverloadBuilder *preparedOverload);
 
   /// Open the generic parameter list creating type variables for each of the
   /// type parameters.
@@ -4408,13 +4410,13 @@ public:
                              GenericSignature signature,
                              SmallVectorImpl<OpenedType> &replacements,
                              ConstraintLocatorBuilder locator,
-                             PreparedOverload *preparedOverload);
+                             PreparedOverloadBuilder *preparedOverload);
 
   /// Open a generic parameter into a type variable and record
   /// it in \c replacements.
   TypeVariableType *openGenericParameter(GenericTypeParamType *parameter,
                                          ConstraintLocatorBuilder locator,
-                                         PreparedOverload *preparedOverload);
+                                         PreparedOverloadBuilder *preparedOverload);
 
   /// Given generic signature open its generic requirements,
   /// using substitution function, and record them in the
@@ -4424,7 +4426,7 @@ public:
                                bool skipProtocolSelfConstraint,
                                ConstraintLocatorBuilder locator,
                                llvm::function_ref<Type(Type)> subst,
-                               PreparedOverload *preparedOverload);
+                               PreparedOverloadBuilder *preparedOverload);
 
   // Record the given requirement in the constraint system.
   void openGenericRequirement(DeclContext *outerDC,
@@ -4434,18 +4436,18 @@ public:
                               bool skipProtocolSelfConstraint,
                               ConstraintLocatorBuilder locator,
                               llvm::function_ref<Type(Type)> subst,
-                              PreparedOverload *preparedOverload);
+                              PreparedOverloadBuilder *preparedOverload);
 
   /// Update OpenedTypes and record a change in the trail.
   void recordOpenedType(
       ConstraintLocator *locator, ArrayRef<OpenedType> openedTypes,
-      PreparedOverload *preparedOverload = nullptr);
+      PreparedOverloadBuilder *preparedOverload = nullptr);
 
   /// Record the set of opened types for the given locator.
   void recordOpenedTypes(
          ConstraintLocatorBuilder locator,
          const SmallVectorImpl<OpenedType> &replacements,
-         PreparedOverload *preparedOverload = nullptr,
+         PreparedOverloadBuilder *preparedOverload = nullptr,
          bool fixmeAllowDuplicates = false);
 
   /// Check whether the given type conforms to the given protocol and if
@@ -4458,7 +4460,7 @@ public:
       FunctionType *fnType, Type baseType, ValueDecl *decl, DeclContext *dc,
       unsigned numApplies, bool isMainDispatchQueue,
       ArrayRef<OpenedType> replacements, ConstraintLocatorBuilder locator,
-      PreparedOverload *preparedOverload);
+      PreparedOverloadBuilder *preparedOverload);
 
   /// Retrieve the type of a reference to the given value declaration.
   ///
@@ -4474,7 +4476,7 @@ public:
                           FunctionRefInfo functionRefInfo,
                           ConstraintLocatorBuilder locator,
                           DeclContext *useDC,
-                          PreparedOverload *preparedOverload);
+                          PreparedOverloadBuilder *preparedOverload);
 
   /// Return the type-of-reference of the given value.
   ///
@@ -4516,7 +4518,7 @@ public:
       Type baseTy, ValueDecl *decl, DeclContext *useDC, bool isDynamicLookup,
       FunctionRefInfo functionRefInfo, ConstraintLocator *locator,
       SmallVectorImpl<OpenedType> *replacements = nullptr,
-      PreparedOverload *preparedOverload = nullptr);
+      PreparedOverloadBuilder *preparedOverload = nullptr);
 
   /// Retrieve a list of generic parameter types solver has "opened" (replaced
   /// with a type variable) at the given location.
@@ -4936,7 +4938,11 @@ public:
   prepareOverload(ConstraintLocator *locator,
                   OverloadChoice choice,
                   DeclContext *useDC,
-                  PreparedOverload *preparedOverload);
+                  PreparedOverloadBuilder *preparedOverload);
+
+  void replayChanges(
+      ConstraintLocatorBuilder locator,
+      PreparedOverload preparedOverload);
 
   /// Resolve the given overload set to the given choice.
   void resolveOverload(ConstraintLocator *locator, Type boundType,
@@ -5351,13 +5357,13 @@ public:
       ConstraintKind matchKind,
       ConstraintLocator *locator,
       ConstraintLocator *calleeLocator,
-      PreparedOverload *preparedOverload = nullptr);
+      PreparedOverloadBuilder *preparedOverload = nullptr);
 
   /// Used by applyPropertyWrapperToParameter() to update appliedPropertyWrappers
   /// and record a change in the trail.
   void applyPropertyWrapper(Expr *anchor,
                             AppliedPropertyWrapper applied,
-                            PreparedOverload *preparedOverload = nullptr);
+                            PreparedOverloadBuilder *preparedOverload = nullptr);
 
   /// Undo the above change.
   void removePropertyWrapper(Expr *anchor);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4929,6 +4929,15 @@ public:
   void recordResolvedOverload(ConstraintLocator *locator,
                               SelectedOverload choice);
 
+  /// Populate the prepared overload with all type variables and constraints
+  /// that are to be introduced into the constraint system when this choice
+  /// is taken.
+  DeclReferenceType
+  prepareOverload(ConstraintLocator *locator,
+                  OverloadChoice choice,
+                  DeclContext *useDC,
+                  PreparedOverload *preparedOverload);
+
   /// Resolve the given overload set to the given choice.
   void resolveOverload(ConstraintLocator *locator, Type boundType,
                        OverloadChoice choice, DeclContext *useDC);

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3791,9 +3791,9 @@ public:
 
   /// Add a constraint that binds an overload set to a specific choice.
   void addBindOverloadConstraint(Type boundTy, OverloadChoice choice,
-                                 ConstraintLocator *locator,
-                                 DeclContext *useDC) {
-    resolveOverload(locator, boundTy, choice, useDC);
+                                 ConstraintLocator *locator, DeclContext *useDC) {
+    resolveOverload(locator, boundTy, choice, useDC,
+                    /*preparedOverload=*/nullptr);
   }
 
   /// Add a value member constraint to the constraint system.
@@ -4907,9 +4907,9 @@ public:
                               SelectedOverload choice);
 
   /// Build and allocate a prepared overload in the solver arena.
-  const PreparedOverload *prepareOverload(ConstraintLocator *locator,
-                                          OverloadChoice choice,
-                                          DeclContext *useDC);
+  PreparedOverload *prepareOverload(ConstraintLocator *locator,
+                                    OverloadChoice choice,
+                                    DeclContext *useDC);
 
   /// Populate the prepared overload with all type variables and constraints
   /// that are to be introduced into the constraint system when this choice
@@ -4922,11 +4922,12 @@ public:
 
   void replayChanges(
       ConstraintLocator *locator,
-      const PreparedOverload *preparedOverload);
+      PreparedOverload *preparedOverload);
 
   /// Resolve the given overload set to the given choice.
   void resolveOverload(ConstraintLocator *locator, Type boundType,
-                       OverloadChoice choice, DeclContext *useDC);
+                       OverloadChoice choice, DeclContext *useDC,
+                       PreparedOverload *preparedOverload);
 
   /// Simplify a type, by replacing type variables with either their
   /// fixed types (if available) or their representatives.

--- a/include/swift/Sema/OverloadChoice.h
+++ b/include/swift/Sema/OverloadChoice.h
@@ -250,6 +250,23 @@ public:
     return (OverloadChoiceKind)kind;
   }
 
+  bool canBePrepared() const {
+    switch (getKind()) {
+    case OverloadChoiceKind::Decl:
+    case OverloadChoiceKind::DeclViaBridge:
+    case OverloadChoiceKind::DeclViaDynamic:
+    case OverloadChoiceKind::DeclViaUnwrappedOptional:
+    case OverloadChoiceKind::DynamicMemberLookup:
+    case OverloadChoiceKind::KeyPathDynamicMemberLookup:
+      return true;
+    case OverloadChoiceKind::TupleIndex:
+    case OverloadChoiceKind::MaterializePack:
+    case OverloadChoiceKind::ExtractFunctionIsolation:
+    case OverloadChoiceKind::KeyPathApplication:
+      return false;
+    }
+  }
+
   /// Determine whether this choice is for a declaration.
   bool isDecl() const {
     return DeclOrKind.is<ValueDecl*>();

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -27,6 +27,34 @@ namespace constraints {
 class ConstraintLocatorBuilder;
 class ConstraintSystem;
 
+/// Describes the type produced when referencing a declaration.
+struct DeclReferenceType {
+  /// The "opened" type, which is the type of the declaration where any
+  /// generic parameters have been replaced with type variables.
+  ///
+  /// The mapping from generic parameters to type variables will have been
+  /// recorded by \c recordOpenedTypes when this type is produced.
+  Type openedType;
+
+  /// The opened type, after performing contextual type adjustments such as
+  /// removing concurrency-related annotations for a `@preconcurrency`
+  /// operation.
+  Type adjustedOpenedType;
+
+  /// The type of the reference, based on the original opened type. This is the
+  /// type that the expression used to form the declaration reference would
+  /// have if no adjustments had been applied.
+  Type referenceType;
+
+  /// The type of the reference, which is the adjusted opened type after
+  /// (e.g.) applying the base of a member access. This is the type of the
+  /// expression used to form the declaration reference.
+  Type adjustedReferenceType;
+
+  /// The type that could be thrown by accessing this declaration.
+  Type thrownErrorTypeOnAccess;
+};
+
 /// Describes a dependent type that has been opened to a particular type
 /// variable.
 using OpenedType = std::pair<GenericTypeParamType *, TypeVariableType *>;
@@ -101,6 +129,7 @@ struct PreparedOverload {
   };
 
   ArrayRef<Change> Changes;
+  DeclReferenceType DeclType;
 };
 
 struct PreparedOverloadBuilder {

--- a/include/swift/Sema/PreparedOverload.h
+++ b/include/swift/Sema/PreparedOverload.h
@@ -100,66 +100,68 @@ struct PreparedOverload {
     };
   };
 
-  SmallVector<Change, 8> Changes;
+  ArrayRef<Change> Changes;
+};
+
+struct PreparedOverloadBuilder {
+  SmallVector<PreparedOverload::Change, 8> Changes;
 
   void addedTypeVariable(TypeVariableType *typeVar) {
-    Change change;
-    change.Kind = Change::AddedTypeVariable;
+    PreparedOverload::Change change;
+    change.Kind = PreparedOverload::Change::AddedTypeVariable;
     change.TypeVar = typeVar;
     Changes.push_back(change);
   }
 
   void addedConstraint(Constraint *constraint) {
-    Change change;
-    change.Kind = Change::AddedConstraint;
+    PreparedOverload::Change change;
+    change.Kind = PreparedOverload::Change::AddedConstraint;
     change.TheConstraint = constraint;
     Changes.push_back(change);
   }
 
   void openedTypes(ArrayRef<OpenedType> replacements) {
-    Change change;
-    change.Kind = Change::OpenedTypes;
+    PreparedOverload::Change change;
+    change.Kind = PreparedOverload::Change::OpenedTypes;
     change.Replacements.Data = replacements.data();
     change.Replacements.Count = replacements.size();
     Changes.push_back(change);
   }
 
   void openedExistentialType(ExistentialArchetypeType *openedExistential) {
-    Change change;
-    change.Kind = Change::OpenedExistentialType;
+    PreparedOverload::Change change;
+    change.Kind = PreparedOverload::Change::OpenedExistentialType;
     change.TheExistential = openedExistential;
     Changes.push_back(change);
   }
 
   void openedPackExpansionType(PackExpansionType *packExpansion,
                                TypeVariableType *typeVar) {
-    Change change;
-    change.Kind = Change::OpenedPackExpansionType;
+    PreparedOverload::Change change;
+    change.Kind = PreparedOverload::Change::OpenedPackExpansionType;
     change.PackExpansion.TheExpansion = packExpansion;
     change.PackExpansion.TypeVar = typeVar;
     Changes.push_back(change);
   }
 
   void appliedPropertyWrapper(AppliedPropertyWrapper wrapper) {
-    Change change;
-    change.Kind = Change::AppliedPropertyWrapper;
+    PreparedOverload::Change change;
+    change.Kind = PreparedOverload::Change::AppliedPropertyWrapper;
     change.PropertyWrapper.WrapperType = wrapper.wrapperType.getPointer();
     change.PropertyWrapper.InitKind = wrapper.initKind;
     Changes.push_back(change);
   }
 
   void addedFix(ConstraintFix *fix, unsigned impact) {
-    Change change;
-    change.Kind = Change::AddedFix;
+    PreparedOverload::Change change;
+    change.Kind = PreparedOverload::Change::AddedFix;
     change.Fix.TheFix = fix;
     change.Fix.Impact = impact;
     Changes.push_back(change);
   }
-
-  void discharge(ConstraintSystem &cs, ConstraintLocatorBuilder locator) const;
 };
 
-}
-}
+}  // end namespace constraints
+}  // end namespace swift
 
 #endif

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -5124,7 +5124,7 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
 
 void ConstraintSystem::applyPropertyWrapper(
     Expr *anchor, AppliedPropertyWrapper applied,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   if (preparedOverload) {
     ASSERT(PreparingOverload);
     preparedOverload->appliedPropertyWrapper(applied);
@@ -5160,7 +5160,7 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     ConstraintKind matchKind,
     ConstraintLocator *locator,
     ConstraintLocator *calleeLocator,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   Expr *anchor = getAsExpr(calleeLocator->getAnchor());
 
   auto recordPropertyWrapperFix = [&](ConstraintFix *fix) -> TypeMatchResult {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1660,7 +1660,7 @@ namespace {
 
       OverloadChoice choice =
           OverloadChoice(Type(), E->getDecl(), E->getFunctionRefInfo());
-      CS.resolveOverload(locator, tv, choice, CurDC);
+      CS.addBindOverloadConstraint(tv, choice, locator, CurDC);
       return tv;
     }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11834,8 +11834,8 @@ ConstraintSystem::simplifyValueWitnessConstraint(
     return fail();
 
   auto choice = OverloadChoice(resolvedBaseType, witness.getDecl(), functionRefInfo);
-  resolveOverload(getConstraintLocator(locator), memberType, choice,
-                  useDC);
+  addBindOverloadConstraint(memberType, choice, getConstraintLocator(locator),
+                            useDC);
   return SolutionKind::Solved;
 }
 
@@ -16661,7 +16661,8 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
 
     resolveOverload(constraint.getLocator(), constraint.getFirstType(),
                     constraint.getOverloadChoice(),
-                    constraint.getDeclContext());
+                    constraint.getDeclContext(),
+                    constraint.getPreparedOverload());
     return SolutionKind::Solved;
 
   case ConstraintKind::SubclassOf:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -15422,7 +15422,7 @@ static bool isAugmentingFix(ConstraintFix *fix) {
 }
 
 bool ConstraintSystem::recordFix(ConstraintFix *fix, unsigned impact,
-                                 PreparedOverload *preparedOverload) {
+                                 PreparedOverloadBuilder *preparedOverload) {
   if (preparedOverload) {
     ASSERT(PreparingOverload);
     preparedOverload->addedFix(fix, impact);
@@ -16298,7 +16298,7 @@ void ConstraintSystem::addConstraint(Requirement req,
                                      ConstraintLocatorBuilder locator,
                                      bool isFavored,
                                      bool prohibitNonisolatedConformance,
-                                     PreparedOverload *preparedOverload) {
+                                     PreparedOverloadBuilder *preparedOverload) {
   bool conformsToAnyObject = false;
   std::optional<ConstraintKind> kind;
   switch (req.getKind()) {
@@ -16362,7 +16362,7 @@ void ConstraintSystem::addConstraint(ConstraintKind kind, Type first,
                                      Type second,
                                      ConstraintLocatorBuilder locator,
                                      bool isFavored,
-                                     PreparedOverload *preparedOverload) {
+                                     PreparedOverloadBuilder *preparedOverload) {
   if (preparedOverload) {
     ASSERT(PreparingOverload);
     auto c = Constraint::create(*this, kind, first, second,

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -60,7 +60,7 @@ STATISTIC(LargestSolutionAttemptNumber, "# of the largest solution attempt");
 TypeVariableType *ConstraintSystem::createTypeVariable(
                                      ConstraintLocator *locator,
                                      unsigned options,
-                                     PreparedOverload *preparedOverload) {
+                                     PreparedOverloadBuilder *preparedOverload) {
   ++TotalNumTypeVariables;
   auto tv = TypeVariableType::getNew(getASTContext(), assignTypeVariableID(),
                                      locator, options);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -904,7 +904,7 @@ ConstraintSystem::openAnyExistentialType(Type type,
 void ConstraintSystem::recordOpenedExistentialType(
     ConstraintLocator *locator,
     ExistentialArchetypeType *opened,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   if (preparedOverload) {
     preparedOverload->openedExistentialType(opened);
     return;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -62,6 +62,7 @@
 #include "swift/Basic/StringExtras.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Sema/IDETypeChecking.h"
+#include "swift/Sema/PreparedOverload.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Statistic.h"

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -46,7 +46,7 @@ Type ConstraintSystem::openUnboundGenericType(GenericTypeDecl *decl,
                                               Type parentTy,
                                               ConstraintLocatorBuilder locator,
                                               bool isTypeResolution,
-                                              PreparedOverload *preparedOverload) {
+                                              PreparedOverloadBuilder *preparedOverload) {
   if (parentTy) {
     parentTy = replaceInferableTypesWithTypeVars(
         parentTy, locator, preparedOverload);
@@ -121,7 +121,7 @@ Type ConstraintSystem::openUnboundGenericType(GenericTypeDecl *decl,
 
 static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
                                        ConstraintLocatorBuilder locator,
-                                       PreparedOverload *preparedOverload) {
+                                       PreparedOverloadBuilder *preparedOverload) {
   // If this is a type defined inside of constrained extension, let's add all
   // of the generic requirements to the constraint system to make sure that it's
   // something we can use.
@@ -200,7 +200,7 @@ static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
 
 Type ConstraintSystem::replaceInferableTypesWithTypeVars(
     Type type, ConstraintLocatorBuilder locator,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   if (!type->hasUnboundGenericType() && !type->hasPlaceholder())
     return type;
 
@@ -246,12 +246,12 @@ namespace {
 struct TypeOpener : public TypeTransform<TypeOpener> {
   ArrayRef<OpenedType> replacements;
   ConstraintLocatorBuilder locator;
-  PreparedOverload *preparedOverload;
+  PreparedOverloadBuilder *preparedOverload;
   ConstraintSystem &cs;
 
   TypeOpener(ArrayRef<OpenedType> replacements,
              ConstraintLocatorBuilder locator,
-             PreparedOverload *preparedOverload,
+             PreparedOverloadBuilder *preparedOverload,
              ConstraintSystem &cs)
       : TypeTransform<TypeOpener>(cs.getASTContext()),
         replacements(replacements), locator(locator),
@@ -295,7 +295,7 @@ struct TypeOpener : public TypeTransform<TypeOpener> {
 
 Type ConstraintSystem::openType(Type type, ArrayRef<OpenedType> replacements,
                                 ConstraintLocatorBuilder locator,
-                                PreparedOverload *preparedOverload) {
+                                PreparedOverloadBuilder *preparedOverload) {
   assert(!type->hasUnboundGenericType());
 
   if (!type->hasTypeParameter())
@@ -308,7 +308,7 @@ Type ConstraintSystem::openType(Type type, ArrayRef<OpenedType> replacements,
 Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
                                              ArrayRef<OpenedType> replacements,
                                              ConstraintLocatorBuilder locator,
-                                             PreparedOverload *preparedOverload) {
+                                             PreparedOverloadBuilder *preparedOverload) {
   auto patternType =
       openType(expansion->getPatternType(), replacements, locator,
                preparedOverload);
@@ -357,7 +357,7 @@ Type ConstraintSystem::openPackExpansionType(PackExpansionType *expansion,
 
 void ConstraintSystem::recordOpenedPackExpansionType(PackExpansionType *expansion,
                                                      TypeVariableType *expansionVar,
-                                                     PreparedOverload *preparedOverload) {
+                                                     PreparedOverloadBuilder *preparedOverload) {
   if (preparedOverload) {
     ASSERT(PreparingOverload);
     preparedOverload->openedPackExpansionType(expansion, expansionVar);
@@ -477,7 +477,7 @@ FunctionType *ConstraintSystem::openFunctionType(
        ConstraintLocatorBuilder locator,
        SmallVectorImpl<OpenedType> &replacements,
        DeclContext *outerDC,
-       PreparedOverload *preparedOverload) {
+       PreparedOverloadBuilder *preparedOverload) {
   if (auto *genericFn = funcType->getAs<GenericFunctionType>()) {
     auto signature = genericFn->getGenericSignature();
     openGenericParameters(outerDC, signature, replacements, locator,
@@ -701,7 +701,7 @@ Type ConstraintSystem::getUnopenedTypeOfReference(
 
 void ConstraintSystem::recordOpenedType(
     ConstraintLocator *locator, ArrayRef<OpenedType> replacements,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   if (preparedOverload) {
     ASSERT(PreparingOverload);
     preparedOverload->openedTypes(replacements);
@@ -720,7 +720,7 @@ void ConstraintSystem::recordOpenedType(
 void ConstraintSystem::recordOpenedTypes(
        ConstraintLocatorBuilder locator,
        const SmallVectorImpl<OpenedType> &replacements,
-       PreparedOverload *preparedOverload,
+       PreparedOverloadBuilder *preparedOverload,
        bool fixmeAllowDuplicates) {
   if (replacements.empty())
     return;
@@ -810,7 +810,7 @@ unwrapPropertyWrapperParameterTypes(ConstraintSystem &cs,
                                     FunctionRefInfo functionRefInfo,
                                     FunctionType *functionType,
                                     ConstraintLocatorBuilder locator,
-                                    PreparedOverload *preparedOverload) {
+                                    PreparedOverloadBuilder *preparedOverload) {
   // Only apply property wrappers to unapplied references to functions.
   if (!functionRefInfo.isUnapplied())
     return functionType;
@@ -870,7 +870,7 @@ static bool isRequirementOrWitness(const ConstraintLocatorBuilder &locator) {
 FunctionType *ConstraintSystem::adjustFunctionTypeForConcurrency(
     FunctionType *fnType, Type baseType, ValueDecl *decl, DeclContext *dc,
     unsigned numApplies, bool isMainDispatchQueue, ArrayRef<OpenedType> replacements,
-    ConstraintLocatorBuilder locator, PreparedOverload *preparedOverload) {
+    ConstraintLocatorBuilder locator, PreparedOverloadBuilder *preparedOverload) {
 
   auto *adjustedTy = swift::adjustFunctionTypeForConcurrency(
       fnType, decl, dc, numApplies, isMainDispatchQueue, GetClosureType{*this},
@@ -997,7 +997,7 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
                                      FunctionRefInfo functionRefInfo,
                                      ConstraintLocatorBuilder locator,
                                      DeclContext *useDC,
-                                     PreparedOverload *preparedOverload) {
+                                     PreparedOverloadBuilder *preparedOverload) {
   ASSERT(!!preparedOverload == PreparingOverload);
 
   if (value->getDeclContext()->isTypeContext() && isa<FuncDecl>(value)) {
@@ -1181,7 +1181,7 @@ static void bindArchetypesFromContext(
     DeclContext *outerDC,
     ConstraintLocator *locatorPtr,
     ArrayRef<OpenedType> replacements,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
 
   auto bindPrimaryArchetype = [&](Type paramTy, Type contextTy) {
     // We might not have a type variable for this generic parameter
@@ -1227,7 +1227,7 @@ void ConstraintSystem::openGeneric(
        GenericSignature sig,
        ConstraintLocatorBuilder locator,
        SmallVectorImpl<OpenedType> &replacements,
-       PreparedOverload *preparedOverload) {
+       PreparedOverloadBuilder *preparedOverload) {
   if (!sig)
     return;
 
@@ -1245,7 +1245,7 @@ void ConstraintSystem::openGenericParameters(DeclContext *outerDC,
                                              GenericSignature sig,
                                              SmallVectorImpl<OpenedType> &replacements,
                                              ConstraintLocatorBuilder locator,
-                                             PreparedOverload *preparedOverload) {
+                                             PreparedOverloadBuilder *preparedOverload) {
   ASSERT(sig);
   ASSERT(replacements.empty());
 
@@ -1263,7 +1263,7 @@ void ConstraintSystem::openGenericParameters(DeclContext *outerDC,
 
 TypeVariableType *ConstraintSystem::openGenericParameter(GenericTypeParamType *parameter,
                                                          ConstraintLocatorBuilder locator,
-                                                         PreparedOverload *preparedOverload) {
+                                                         PreparedOverloadBuilder *preparedOverload) {
   auto *paramLocator = getConstraintLocator(
       locator.withPathElement(LocatorPathElt::GenericParameter(parameter)));
 
@@ -1282,7 +1282,7 @@ void ConstraintSystem::openGenericRequirements(
     DeclContext *outerDC, GenericSignature signature,
     bool skipProtocolSelfConstraint, ConstraintLocatorBuilder locator,
     llvm::function_ref<Type(Type)> substFn,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   auto requirements = signature.getRequirements();
   for (unsigned pos = 0, n = requirements.size(); pos != n; ++pos) {
     auto openedGenericLoc =
@@ -1298,7 +1298,7 @@ void ConstraintSystem::openGenericRequirement(
     unsigned index, const Requirement &req,
     bool skipProtocolSelfConstraint, ConstraintLocatorBuilder locator,
     llvm::function_ref<Type(Type)> substFn,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   std::optional<Requirement> openedReq;
   auto openedFirst = substFn(req.getFirstType());
 
@@ -1351,7 +1351,7 @@ void ConstraintSystem::openGenericRequirement(
 /// declared.
 static void addSelfConstraint(ConstraintSystem &cs, Type objectTy, Type selfTy,
                               ConstraintLocatorBuilder locator,
-                              PreparedOverload *preparedOverload) {
+                              PreparedOverloadBuilder *preparedOverload) {
   assert(!selfTy->is<ProtocolType>());
 
   // Otherwise, use a subtype constraint for classes to cope with inheritance.
@@ -1590,7 +1590,7 @@ DeclReferenceType ConstraintSystem::getTypeOfMemberReference(
     Type baseTy, ValueDecl *value, DeclContext *useDC, bool isDynamicLookup,
     FunctionRefInfo functionRefInfo, ConstraintLocator *locator,
     SmallVectorImpl<OpenedType> *replacementsPtr,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   ASSERT(!!preparedOverload == PreparingOverload);
 
   // Figure out the instance type used for the base.
@@ -2378,7 +2378,7 @@ isInvalidPartialApplication(ConstraintSystem &cs,
 static DeclReferenceType getTypeOfReferenceWithSpecialTypeCheckingSemantics(
     ConstraintSystem &CS, ConstraintLocator *locator,
     DeclTypeCheckingSemantics semantics,
-    PreparedOverload *preparedOverload) {
+    PreparedOverloadBuilder *preparedOverload) {
   switch (semantics) {
   case DeclTypeCheckingSemantics::Normal:
     llvm_unreachable("Decl does not have special type checking semantics!");
@@ -2497,54 +2497,55 @@ void ConstraintSystem::recordResolvedOverload(ConstraintLocator *locator,
     recordChange(SolverTrail::Change::ResolvedOverload(locator));
 }
 
-void PreparedOverload::discharge(ConstraintSystem &cs,
-                                 ConstraintLocatorBuilder locator) const {
-  for (auto change : Changes) {
+void ConstraintSystem::replayChanges(
+    ConstraintLocatorBuilder locator,
+    PreparedOverload preparedOverload) {
+  for (auto change : preparedOverload.Changes) {
     switch (change.Kind) {
     case PreparedOverload::Change::AddedTypeVariable:
-      cs.addTypeVariable(change.TypeVar);
+      addTypeVariable(change.TypeVar);
       break;
 
     case PreparedOverload::Change::AddedConstraint:
-      cs.simplifyDisjunctionChoice(change.TheConstraint);
+      simplifyDisjunctionChoice(change.TheConstraint);
       break;
 
     case PreparedOverload::Change::OpenedTypes: {
-      auto *locatorPtr = cs.getConstraintLocator(locator);
+      auto *locatorPtr = getConstraintLocator(locator);
       ArrayRef<OpenedType> replacements(
           change.Replacements.Data,
           change.Replacements.Count);
 
       // FIXME: Get rid of this conditional.
-      if (cs.getOpenedTypes(locatorPtr).empty())
-        cs.recordOpenedType(locatorPtr, replacements);
+      if (getOpenedTypes(locatorPtr).empty())
+        recordOpenedType(locatorPtr, replacements);
       break;
     }
 
     case PreparedOverload::Change::OpenedExistentialType: {
-      auto *locatorPtr = cs.getConstraintLocator(locator);
-      cs.recordOpenedExistentialType(locatorPtr,
-                                     change.TheExistential);
+      auto *locatorPtr = getConstraintLocator(locator);
+      recordOpenedExistentialType(locatorPtr,
+                                  change.TheExistential);
       break;
     }
 
     case PreparedOverload::Change::OpenedPackExpansionType:
-      cs.recordOpenedPackExpansionType(
+      recordOpenedPackExpansionType(
           change.PackExpansion.TheExpansion,
           change.PackExpansion.TypeVar);
       break;
 
     case PreparedOverload::Change::AppliedPropertyWrapper: {
-      auto *locatorPtr = cs.getConstraintLocator(locator);
+      auto *locatorPtr = getConstraintLocator(locator);
       Expr *anchor = getAsExpr(locatorPtr->getAnchor());
-      cs.applyPropertyWrapper(anchor,
+      applyPropertyWrapper(anchor,
           { Type(change.PropertyWrapper.WrapperType),
             change.PropertyWrapper.InitKind });
       break;
     }
 
     case PreparedOverload::Change::AddedFix:
-      cs.recordFix(change.Fix.TheFix, change.Fix.Impact);
+      recordFix(change.Fix.TheFix, change.Fix.Impact);
       break;
     }
   }
@@ -2560,7 +2561,7 @@ DeclReferenceType
 ConstraintSystem::prepareOverload(ConstraintLocator *locator,
                                   OverloadChoice choice,
                                   DeclContext *useDC,
-                                  PreparedOverload *preparedOverload) {
+                                  PreparedOverloadBuilder *preparedOverload) {
   // If we refer to a top-level decl with special type-checking semantics,
   // handle it now.
   auto semantics =
@@ -2600,9 +2601,10 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
   case OverloadChoiceKind::DeclViaUnwrappedOptional:
   case OverloadChoiceKind::DynamicMemberLookup:
   case OverloadChoiceKind::KeyPathDynamicMemberLookup: {
+    // FIXME: Transitional hack
     bool enablePreparedOverloads = false;
 
-    PreparedOverload preparedOverload;
+    PreparedOverloadBuilder preparedOverload;
     if (enablePreparedOverloads) {
       ASSERT(!PreparingOverload);
       PreparingOverload = true;
@@ -2615,7 +2617,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
 
     if (enablePreparedOverloads) {
       PreparingOverload = false;
-      preparedOverload.discharge(*this, locator);
+      PreparedOverload result{preparedOverload.Changes};
+      replayChanges(locator, result);
     }
 
     openedType = declRefType.openedType;

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2617,7 +2617,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
 
     if (enablePreparedOverloads) {
       PreparingOverload = false;
-      PreparedOverload result{preparedOverload.Changes};
+      PreparedOverload result{preparedOverload.Changes, declRefType};
       replayChanges(locator, result);
     }
 

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2502,8 +2502,7 @@ void PreparedOverload::discharge(ConstraintSystem &cs,
       break;
 
     case PreparedOverload::Change::AddedConstraint:
-      cs.addUnsolvedConstraint(change.TheConstraint);
-      cs.activateConstraint(change.TheConstraint);
+      cs.simplifyDisjunctionChoice(change.TheConstraint);
       break;
 
     case PreparedOverload::Change::OpenedTypes: {

--- a/lib/Sema/TypeOfReference.cpp
+++ b/lib/Sema/TypeOfReference.cpp
@@ -2499,7 +2499,7 @@ void ConstraintSystem::recordResolvedOverload(ConstraintLocator *locator,
 
 void ConstraintSystem::replayChanges(
     ConstraintLocator *locator,
-    const PreparedOverload *preparedOverload) {
+    PreparedOverload *preparedOverload) {
   for (auto change : preparedOverload->getChanges()) {
     switch (change.Kind) {
     case PreparedOverload::Change::AddedTypeVariable:
@@ -2581,10 +2581,9 @@ ConstraintSystem::prepareOverloadImpl(ConstraintLocator *locator,
   }
 }
 
-const PreparedOverload *
-ConstraintSystem::prepareOverload(ConstraintLocator *locator,
-                                  OverloadChoice choice,
-                                  DeclContext *useDC) {
+PreparedOverload *ConstraintSystem::prepareOverload(ConstraintLocator *locator,
+                                                    OverloadChoice choice,
+                                                    DeclContext *useDC) {
   ASSERT(!PreparingOverload);
   PreparingOverload = true;
 
@@ -2602,7 +2601,8 @@ ConstraintSystem::prepareOverload(ConstraintLocator *locator,
 
 void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
                                        Type boundType, OverloadChoice choice,
-                                       DeclContext *useDC) {
+                                       DeclContext *useDC,
+                                       PreparedOverload *preparedOverload) {
   // Determine the type to which we'll bind the overload set's type.
   Type openedType;
   Type adjustedOpenedType;
@@ -2617,11 +2617,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
   case OverloadChoiceKind::DeclViaUnwrappedOptional:
   case OverloadChoiceKind::DynamicMemberLookup:
   case OverloadChoiceKind::KeyPathDynamicMemberLookup: {
-    // FIXME: Transitional hack
-    bool enablePreparedOverloads = true;
-
-    if (enablePreparedOverloads) {
-      auto *preparedOverload = prepareOverload(locator, choice, useDC);
+    if (preparedOverload) {
       replayChanges(locator, preparedOverload);
 
       openedType = preparedOverload->getOpenedType();


### PR DESCRIPTION
This is a follow-up to https://github.com/swiftlang/swift/pull/82928. This is all still completely disabled by default, so other than passing around nullptrs in various places this should have no functional effect.