### PR TITLE
Fix SILCombine of inject_enum_addr when the enum is non-trivial but payload is trivial

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1059,7 +1059,7 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
         Builder.getBuilderContext(), /*noUndef*/ true);
   } else {
     auto loadQual = !func->hasOwnership() ? LoadOwnershipQualifier::Unqualified
-                    : DataAddrInst->getOperand()->getType().isTrivial(*func)
+                    : DataAddrInst->getType().isTrivial(*func)
                         ? LoadOwnershipQualifier::Trivial
                         : LoadOwnershipQualifier::Take;
     enumValue =

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -5508,3 +5508,25 @@ bb0(%1 : @owned $Cr):
   return %49
 }
 
+enum NT {
+  case inline(InlineArray<1, Int>)
+  case klass(Klass)
+}
+
+sil @get_inlinearray : $@convention(thin) () -> @out InlineArray<1, Int>
+
+// CHECK-LABEL: sil shared [ossa] @testTrivialPayloadInNonTrivialEnum :
+// CHECK-NOT: inject_enum_addr
+// CHECK-LABEL: } // end sil function 'testTrivialPayloadInNonTrivialEnum'
+sil shared [ossa] @testTrivialPayloadInNonTrivialEnum : $@convention(thin) () -> @owned NT {
+bb0:
+  %0 = alloc_stack $NT
+  %1 = init_enum_data_addr %0, #NT.inline!enumelt
+  %3 = function_ref @get_inlinearray : $@convention(thin) () -> @out InlineArray<1, Int>
+  %4 = apply %3(%1) : $@convention(thin) () -> @out InlineArray<1, Int>
+  inject_enum_addr %0, #NT.inline!enumelt
+  %6 = load [take] %0
+  dealloc_stack %0
+  return %6
+}
+


### PR DESCRIPTION
The SILCombine was using the type of `inject_enum_data_addr `'s operand instead of its result leading to creating of `load` instruction with invalid qualifier triggering ownership error.

Fixes https://github.com/swiftlang/swift/issues/82813 