### PR TITLE
AST: consume newValue in synthesized setters

### DIFF
--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1827,9 +1827,13 @@ synthesizeTrivialSetterBodyWithStorage(AccessorDecl *setter,
     new (ctx) DeclRefExpr(valueParamDecl, DeclNameLoc(), /*IsImplicit=*/true);
   valueDRE->setType(valueParamDecl->getTypeInContext());
 
+  /// Consume the newValue, as this is the only use in this setter.
+  auto *consumedValue =
+    ConsumeExpr::createImplicit(ctx, loc, valueDRE, valueDRE->getType());
+
   SmallVector<ASTNode, 1> setterBody;
 
-  createPropertyStoreOrCallSuperclassSetter(setter, valueDRE, storageToUse,
+  createPropertyStoreOrCallSuperclassSetter(setter, consumedValue, storageToUse,
                                             target, setterBody, ctx);
   return { BraceStmt::create(ctx, loc, setterBody, loc, true),
            /*isTypeChecked=*/true };


### PR DESCRIPTION
The `newValue` is an owned value whose only use is to be stored, so we can synthesize this instead:
```
 set { prop = consume newValue }
```
which improves -Onone code quality by avoiding a copy/destroy pair.