### PR TITLE
[RemoteMirrors] Fix losing the remote address on StaticMirror

### DIFF
--- a/include/swift/StaticMirror/ObjectFileContext.h
+++ b/include/swift/StaticMirror/ObjectFileContext.h
@@ -39,8 +39,12 @@ private:
   uint64_t HeaderAddress;
   std::vector<Segment> Segments;
   struct DynamicRelocation {
+    /// The symbol name that the pointer refers to. Empty if only an absolute
+    /// address is available.
     StringRef Symbol;
-    uint64_t Offset;
+    // The offset (if the symbol is available), or the resolved remote address
+    // if the symbol is empty.
+    uint64_t OffsetOrAddress;
   };
   llvm::DenseMap<uint64_t, DynamicRelocation> DynamicRelocations;
 

--- a/lib/StaticMirror/ObjectFileContext.cpp
+++ b/lib/StaticMirror/ObjectFileContext.cpp
@@ -333,8 +333,13 @@ remote::RemoteAbsolutePointer Image::getDynamicSymbol(uint64_t Addr) const {
   auto found = DynamicRelocations.find(Addr);
   if (found == DynamicRelocations.end())
     return nullptr;
+  if (!found->second.Symbol.empty())
+    return remote::RemoteAbsolutePointer(found->second.Symbol,
+                                         found->second.OffsetOrAddress,
+                                         remote::RemoteAddress());
   return remote::RemoteAbsolutePointer(
-      found->second.Symbol, found->second.Offset, remote::RemoteAddress());
+      remote::RemoteAddress(found->second.OffsetOrAddress,
+                            remote::RemoteAddress::DefaultAddressSpace));
 }
 
 std::pair<const Image *, uint64_t>

--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -5,7 +5,6 @@
 //
 // Temporarily disable on AArch64 Linux (rdar://88451721)
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-// XFAIL: OS=linux-android
 
 // rdar://100558042
 // UNSUPPORTED: CPU=arm64e

--- a/test/Reflection/typeref_decoding.swift
+++ b/test/Reflection/typeref_decoding.swift
@@ -10,7 +10,6 @@
 
 // FIXME: rdar://127796117
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
-// XFAIL: OS=linux-android
 
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift -parse-as-library -emit-module -emit-library %no-fixup-chains -module-name TypesToReflect -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-build-swift -target %target-swift-5.2-abi-triple -Xfrontend -enable-anonymous-context-mangled-names %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/main.swift -emit-module -emit-executable %no-fixup-chains -module-name TypesToReflect -o %t/TypesToReflect


### PR DESCRIPTION
The Offset field of a DynamicRelocation is either an offset or a remote address, but was being treated only as a remote address on getDynamicSymbol.

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
