### PR TITLE
Tests: Adjust `CHECK`s in `IRGen/availability_custom_domains_clang.swift`

### DIFF
--- a/test/IRGen/availability_custom_domains_clang.swift
+++ b/test/IRGen/availability_custom_domains_clang.swift
@@ -35,7 +35,7 @@ public func ifAvailableDisabledDomain() {
 // CHECK-LABEL:   define {{.*}}swiftcc void @"$s4Test24ifAvailableDynamicDomainyyF"()
 // CHECK:         entry:
 // CHECK-O-NONE:    [[QUERY_RESULT:%.*]] = call swiftcc i1 @"$sSC33__swift_DynamicDomain_isAvailableBi1_yF"()
-// CHECK-O:         [[QUERY_RESULT:%.*]] = call zeroext i1 @__DynamicDomain_isAvailable()
+// CHECK-O:         [[QUERY_RESULT:%.*]] = call {{.*}}i1 @__DynamicDomain_isAvailable()
 // CHECK:           br i1 [[QUERY_RESULT]], label %[[TRUE_LABEL:.*]], label %[[FALSE_LABEL:.*]]
 // CHECK:         [[TRUE_LABEL]]:
 // CHECK:           call void @available_in_dynamic_domain()
@@ -51,7 +51,7 @@ public func ifAvailableDynamicDomain() {
 
 // CHECK-O-NONE-LABEL: define {{.*}}swiftcc i1 @"$sSC33__swift_DynamicDomain_isAvailableBi1_yF"()
 // CHECK-O-NONE:       entry:
-// CHECK-O-NONE:         [[CALL:%.*]] = call zeroext i1 @__DynamicDomain_isAvailable()
+// CHECK-O-NONE:         [[CALL:%.*]] = call {{.*}}i1 @__DynamicDomain_isAvailable()
 // CHECK-O-NONE:         ret i1 [[CALL]]
 
 // CHECK-LABEL: define {{.*}}i1 @__DynamicDomain_isAvailable()

--- a/test/IRGen/availability_custom_domains_clang.swift
+++ b/test/IRGen/availability_custom_domains_clang.swift
@@ -56,6 +56,6 @@ public func ifAvailableDynamicDomain() {
 
 // CHECK-LABEL: define {{.*}}i1 @__DynamicDomain_isAvailable()
 // CHECK:       entry:
-// CHECK:         [[CALL:%.*]] = call i32 @dynamic_domain_pred()
+// CHECK:         [[CALL:%.*]] = call i32 @dynamic_domain_pred{{(.ptrauth)?}}()
 // CHECK:         [[TOBOOL:%.*]] = icmp ne i32 [[CALL]], 0
 // CHECK:         ret i1 [[TOBOOL]]


### PR DESCRIPTION
Resolves rdar://155588692 and rdar://155596071.