### PR TITLE
[test] Remove duplicate test case

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/af9b33175dd868bc.swift
+++ b/validation-test/compiler_crashers_2_fixed/af9b33175dd868bc.swift
@@ -1,5 +1,0 @@
-// {"kind":"typecheck","signature":"(anonymous namespace)::SyntacticElementConstraintGenerator::visitBraceStmt(swift::BraceStmt*)"}
-// RUN: not %target-swift-frontend -typecheck %s
-[ switch {
-  case (let a)
-    print(


### PR DESCRIPTION
This is effectively the same as `eb61865acc77c50.swift`.