### PR TITLE
[RemoteAddress] Handle comparison of addresses in different spaces

### DIFF
--- a/include/swift/Remote/RemoteAddress.h
+++ b/include/swift/Remote/RemoteAddress.h
@@ -55,16 +55,42 @@ public:
     return !operator==(other);
   }
 
+  bool inRange(const RemoteAddress &begin, const RemoteAddress &end) const {
+    assert(begin.AddressSpace != end.AddressSpace &&
+           "Unexpected address spaces");
+    if (AddressSpace != begin.AddressSpace)
+      return false;
+    return begin <= *this && *this < end;
+  }
+
   bool operator<(const RemoteAddress rhs) const {
     assert(AddressSpace == rhs.AddressSpace &&
            "Comparing remote addresses of different address spaces");
     return Data < rhs.Data;
   }
 
+  /// Less than operator to be used for ordering purposes. The default less than
+  /// operator asserts if the address spaces are different, this one takes it
+  /// into account to determine the order of the addresses.
+  bool orderedLessThan(const RemoteAddress rhs) const {
+    if (AddressSpace == rhs.AddressSpace)
+      return Data < rhs.Data;
+    return AddressSpace < rhs.AddressSpace;
+  }
+
   bool operator<=(const RemoteAddress rhs) const {
     assert(AddressSpace == rhs.AddressSpace &&
            "Comparing remote addresses of different address spaces");
     return Data <= rhs.Data;
+  }
+
+  /// Less than or equal operator to be used for ordering purposes. The default
+  /// less than or equal operator asserts if the address spaces are different,
+  /// this one takes it into account to determine the order of the addresses.
+  bool orderedLessThanOrEqual(const RemoteAddress rhs) const {
+    if (AddressSpace == rhs.AddressSpace)
+      return Data <= rhs.Data;
+    return AddressSpace <= rhs.AddressSpace;
   }
 
   bool operator>(const RemoteAddress &rhs) const {

--- a/include/swift/RemoteInspection/ReflectionContext.h
+++ b/include/swift/RemoteInspection/ReflectionContext.h
@@ -907,7 +907,7 @@ public:
     for (auto Range : ranges) {
       auto Start = std::get<0>(Range);
       auto End = std::get<1>(Range);
-      if (Start <= Address && Address < End)
+      if (Address.inRange(Start, End))
         return true;
     }
 

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -65,6 +65,10 @@ public:
 
   bool containsRemoteAddress(remote::RemoteAddress remoteAddr,
                              uint64_t size) const {
+    if (Start.getRemoteAddress().getAddressSpace() !=
+        remoteAddr.getAddressSpace())
+      return false;
+
     return Start.getRemoteAddress() <= remoteAddr &&
            remoteAddr + size <= Start.getRemoteAddress() + Size;
   }

--- a/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
+++ b/stdlib/public/RemoteInspection/TypeRefBuilder.cpp
@@ -64,7 +64,7 @@ TypeRefBuilder::ReflectionTypeDescriptorFinder::
                   .TypeReference.startAddress()
                   .getRemoteAddress();
 
-          return typeReferenceAStart < typeReferenceBStart;
+          return typeReferenceAStart.orderedLessThan(typeReferenceBStart);
         });
   }
 
@@ -75,9 +75,11 @@ TypeRefBuilder::ReflectionTypeDescriptorFinder::
       ReflectionInfoIndexesSortedByTypeReferenceRange.begin(),
       ReflectionInfoIndexesSortedByTypeReferenceRange.end(), remoteAddr,
       [&](uint32_t ReflectionInfoIndex, remote::RemoteAddress remoteAddr) {
-        return ReflectionInfos[ReflectionInfoIndex]
-                   .TypeReference.endAddress()
-                   .getRemoteAddress() <= remoteAddr;
+        auto reflectionInfoAddress = ReflectionInfos[ReflectionInfoIndex]
+                                         .TypeReference.endAddress()
+                                         .getRemoteAddress();
+
+        return reflectionInfoAddress.orderedLessThanOrEqual(remoteAddr);
       });
 
   if (possiblyMatchingReflectionInfoIndex ==


### PR DESCRIPTION
Sometimes it makes sense to compares addresses from different address spaces.

rdar://148361743

<!--
If this pull request is targeting a release branch, please fill out the
following form:
https://github.com/swiftlang/.github/blob/main/PULL_REQUEST_TEMPLATE/release.md?plain=1

Otherwise, replace this comment with a description of your changes and
rationale. Provide links to external references/discussions if appropriate.
If this pull request resolves any GitHub issues, link them like so:

  Resolves <link to issue>, resolves <link to another issue>.

For more information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
